### PR TITLE
fix(onboarding): make AI/LLM usage explicit in setup wizard copy

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6875,9 +6875,9 @@ snapshots:
     scenes-other-login--sso-error--light:
         hash: v1.k794b7964.bf726aafab909db5abef95ba50728a484226b67a14df698563c5b9c5cdd6be53.uxC2xUEzUsarK6a8Ryr0pQf2IqTCz0vb5y6e7jo2_nY
     scenes-other-onboarding--ai-observability-sdk-install--dark:
-        hash: v1.k794b7964.7d236ef1181b0bfbc0cbf75d2ecd195cbb3ee7abcf30754fe1eca213bae30ded.owzvzjtP7YutlIt1_EJC7SROtdK3U5VQnWF4te51UP0
+        hash: v1.k794b7964.1b9bae7eb0e6a9af3c557646a05556795385ec5f6d6b73005234ec03ccac60e6.Vc-B4IVQxY_pFMpVeKebIYcXdCTn5hpCfvYZmBPdy7g
     scenes-other-onboarding--ai-observability-sdk-install--light:
-        hash: v1.k794b7964.4fec6955c9dbcd235a0fa044aa021e89793c0e7cc82edfaa9a52ff7ee8caa210.SiNAsUZiNtcozpiE60JFSKHxY-ditx2lEQ7u8W6fOvw
+        hash: v1.k794b7964.df3aa5330ee0572e60becf84e6258e7b38b9df3587a850b2719938fcfac54143.BZksO3bQ0K2C-_ZnYcEhWXsfgKWKqrS9t55hsukdpEc
     scenes-other-onboarding--alerts--dark:
         hash: v1.k794b7964.d66fb935e8f6fcf6d71031d9a59bf76501c90d29e5e5bae324b2cb2bbcd15ed7.4Cvshejpp_prXnrtkj5xZMl08OoFB6I6RreTrsQ4Hno
     scenes-other-onboarding--alerts--light:
@@ -6903,9 +6903,9 @@ snapshots:
     scenes-other-onboarding--product-analytics-configuration--light:
         hash: v1.k794b7964.4a2bcedebc129a67058f79b95c15dda9797691ce565f44d529cbf83e6948d10e.w_sFYsVPreMbVJO-APEJlFdnbCBsuFN6pADVErDgyj8
     scenes-other-onboarding--sdk-install--dark:
-        hash: v1.k794b7964.da85532719e44b390eb702a9bf4df7dd327fa9ee48f9fa756975dee8f0687c4b.qpGppQPiMG-9wsUnVVq0FRbrr6fYeeryRpFsep97KSE
+        hash: v1.k794b7964.2d9944b6993285774e2391d202ac96e127c5713430f75f3729bbb3b3ef093135.Ose5ZOSd-DfxLy6jutTlo0lW8spFf_BAI-7KJkZJoOM
     scenes-other-onboarding--sdk-install--light:
-        hash: v1.k794b7964.2d6f443a2e6c77162dacf2899843981bd0207c93d37927bfceb3c9573933ec10.54MggCDONQwkQoksbjMxaf5OyBQvL0lP4hWhoz4Tumo
+        hash: v1.k794b7964.512d51cd8b5eb08cb5fc108e28b444ff0e0b95fc765d68c06bf942739810a84e.0mJauXE8tjKPGqh7quOm5W60x8ceoRKuQRFJ-vU8cSI
     scenes-other-onboarding--session-replay-configuration--dark:
         hash: v1.k794b7964.32c694b9a586f8a71c1e309f5e13ee180c2ad0381560c5477cce901849c2e261.7Sv88LFiRZHddXLdspU3d-YHb1JB7YTWR22w_UYwfRE
     scenes-other-onboarding--session-replay-configuration--light:
@@ -6919,9 +6919,9 @@ snapshots:
     scenes-other-onboarding--source-maps--light:
         hash: v1.k794b7964.d7f5f7d7e2ddbe8b8cbe30e329b25da19e21ecc003a0f6d88f35c5456e2f4f4e.HpQSGkki7Sc6J5ofaU0VKqy7sF_LEHpVdmLW1HHs788
     scenes-other-onboarding--workflows-custom-installation-instructions--dark:
-        hash: v1.k794b7964.bd21410f269643405bb2f99f2b0066ce3408145099281f511e9605506bfd0fa2.tfN8yRpyJiBf7AkJyTdE90xgSuRnpIi2OO7vN_ebiKo
+        hash: v1.k794b7964.2cae8f97936488b4d626de3e1f450d814b51fa8f9a9e3b5c5bc133d789e05815.72pG3x8wdbbAvjhEOT1N0MIkbHVG2i-DqQptSAUA4L8
     scenes-other-onboarding--workflows-custom-installation-instructions--light:
-        hash: v1.k794b7964.2b86fc1172428acff28f9a1c1bf41bd403a91b6f867f5e3c9624c8dc282b214b.h5ITntLgMUja78FgDkd3_5BxiQiryXLqYxsubvU8w-w
+        hash: v1.k794b7964.85aed7f823d7888b1689838692b5da11889a12e594fca7cdfd0398bf7e7b9643.uvlfFhNFKByGcPYUWt7drUVp8I3opVLJy_PNyUUhdTM
     scenes-other-onboarding-product-selection--base--dark:
         hash: v1.k794b7964.98c8c237be42cdff687a4d0e17288cf9b87c0ecfd0d45f6fb7038b1c08343afc._0bNgtLiKO3hf65SU97DiFQ1mjUjgeIIbWy7qQl3MwY
     scenes-other-onboarding-product-selection--base--light:

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
@@ -79,7 +79,8 @@ export function WizardCommandBlock(): JSX.Element {
                     />
 
                     <p className="text-xs text-muted mb-0">
-                        Auto-detects your framework, installs the SDK, and sets up event capture.
+                        Starts an AI agent that reads your codebase to auto-detect your framework, installs the SDK,
+                        and sets up event capture.
                     </p>
 
                     <div className="flex flex-wrap gap-1.5 items-center">

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock.tsx
@@ -79,8 +79,8 @@ export function WizardCommandBlock(): JSX.Element {
                     />
 
                     <p className="text-xs text-muted mb-0">
-                        Starts an AI agent that reads your codebase to auto-detect your framework, installs the SDK,
-                        and sets up event capture.
+                        Starts an AI agent that reads your codebase to auto-detect your framework, installs the SDK, and
+                        sets up event capture.
                     </p>
 
                     <div className="flex flex-wrap gap-1.5 items-center">

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/WizardInstallIntro.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/WizardInstallIntro.tsx
@@ -3,13 +3,13 @@ export function WizardInstallIntro(): JSX.Element {
         <div className="text-center max-w-xl mx-auto space-y-3">
             <h2 className="text-2xl font-bold">Skip the install. Get 10–20 minutes back.</h2>
             <p className="text-muted">
-                Run this command from your project&apos;s root directory. It starts an AI agent that reads your
-                codebase to detect your framework, then installs the right SDK, configures your environment variables,
-                and wires up event capture automatically.
+                Run this command from your project&apos;s root directory. It starts an AI agent that reads your codebase
+                to detect your framework, then installs the right SDK, configures your environment variables, and wires
+                up event capture automatically.
             </p>
             <p className="text-muted text-xs">
-                The AI agent runs locally on your machine and will ask before making changes. LLM inference is on us,
-                no API key needed.
+                The AI agent runs locally on your machine and will ask before making changes. LLM inference is on us, no
+                API key needed.
             </p>
         </div>
     )

--- a/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/WizardInstallIntro.tsx
+++ b/frontend/src/scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardInstallStep/WizardInstallIntro.tsx
@@ -3,10 +3,14 @@ export function WizardInstallIntro(): JSX.Element {
         <div className="text-center max-w-xl mx-auto space-y-3">
             <h2 className="text-2xl font-bold">Skip the install. Get 10–20 minutes back.</h2>
             <p className="text-muted">
-                Run this command from your project&apos;s root directory. The wizard detects your framework, installs
-                the right SDK, configures your environment variables, and wires up event capture automatically.
+                Run this command from your project&apos;s root directory. It starts an AI agent that reads your
+                codebase to detect your framework, then installs the right SDK, configures your environment variables,
+                and wires up event capture automatically.
             </p>
-            <p className="text-muted text-xs">LLM inference is on us, no API key needed.</p>
+            <p className="text-muted text-xs">
+                The AI agent runs locally on your machine and will ask before making changes. LLM inference is on us,
+                no API key needed.
+            </p>
         </div>
     )
 }

--- a/frontend/src/scenes/onboarding/shared/SetupWizardBanner.tsx
+++ b/frontend/src/scenes/onboarding/shared/SetupWizardBanner.tsx
@@ -37,7 +37,10 @@ const SetupWizardBanner = ({
             <LemonBanner type="info" hideIcon={true}>
                 <h3 className="pb-1">AI setup wizard</h3>
                 <div className="flex flex-col p-2">
-                    <p className="font-normal pb-1">Try using the AI setup wizard to automatically install PostHog.</p>
+                    <p className="font-normal pb-1">
+                        Try using the AI setup wizard to automatically install PostHog. It runs an AI agent in your
+                        terminal that reads your codebase to set things up, and asks before making changes.
+                    </p>
                     <p className="font-normal pb-2">
                         Run the following command from the root of your {integrationName} project.
                     </p>

--- a/frontend/src/scenes/wizard/Wizard.tsx
+++ b/frontend/src/scenes/wizard/Wizard.tsx
@@ -23,9 +23,10 @@ export function Wizard(): JSX.Element {
                 {view === 'project' && (
                     <div className="max-w-xs">
                         <div className="mb-8">
-                            <h1 className="text-3xl font-bold mb-3">AI wizard</h1>
+                            <h1 className="text-3xl font-bold mb-3">AI setup wizard</h1>
                             <p className="text-muted-alt">
-                                Select which project the wizard should use to install PostHog.
+                                Select which project the AI agent should use to install PostHog. The agent runs in your
+                                terminal, reads your codebase to set things up, and asks before making changes.
                             </p>
                         </div>
 


### PR DESCRIPTION
## Problem

Users are kicking off the setup wizard's AI agent against their own codebase without realizing AI is involved. A support ticket reported the wizard launched an AI agent and began analyzing the project before the user understood AI was part of it — eroding trust at the very first onboarding touchpoint.

## Changes

Made AI/LLM usage explicit on the web-app onboarding screens that lead into the wizard, so users know what the command does before they run it:

- **Install intro** (`WizardInstallIntro.tsx`) — states the command starts an AI agent that reads your codebase, runs locally, and asks before making changes.
- **Command block descriptor** (`WizardCommandBlock.tsx`) — same framing on the copyable command card.
- **`/wizard` auth screen** (`Wizard.tsx`) — retitled "AI wizard" → "AI setup wizard" and explains the agent reads your codebase and asks before changing anything before you pick a project.
- **SDK-instructions banner** (`SetupWizardBanner.tsx`) — the "AI setup wizard" banner now spells out that an AI agent runs in your terminal and reads your codebase.

Copy-only changes, no behavior change.

## How did you test this code?

I'm an agent — no manual testing performed. Changes are text-only edits to existing JSX with no logic changes. No automated tests were run (frontend tooling/`node_modules` not available in this environment); reviewer should eyeball the rendered copy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack from a Zendesk inbox item: the original ticket was filed against `posthog/wizard`, but the human clarified the unclear language lives in the posthog/posthog web-app onboarding flow, so the fix targets this repo. An Explore agent mapped the wizard onboarding journey (intro → command block → `/wizard` auth/project-select → SDK-instructions banner); copy was added at each step rather than a single screen so the disclosure can't be missed. No skills were applicable (copy-only, no DRF/migrations/API-type changes).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B8ZE81ZT7/p1782162010128039?thread_ts=1782162010.128039&cid=C0B8ZE81ZT7)*
