### PR TITLE
feat(data-warehouse): row filters + column selection for clickhouse

### DIFF
--- a/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -1024,7 +1024,7 @@ def _build_query(
     if not should_use_incremental_field:
         if filter_conditions:
             return f"SELECT {select_list} FROM {qualified} WHERE {' AND '.join(filter_conditions)}", filter_params
-        return f"SELECT {select_list} FROM {qualified}", {}
+        return f"SELECT {select_list} FROM {qualified}", filter_params
 
     if incremental_field is None:
         raise ValueError("incremental_field can't be None when should_use_incremental_field is True")

--- a/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -26,6 +26,8 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     build_pyarrow_decimal_type,
 )
 from posthog.temporal.data_imports.sources.common.sql import Column, Table
+from posthog.temporal.data_imports.sources.common.sql.identifiers import BacktickIdentifierQuoter
+from posthog.temporal.data_imports.sources.common.sql.predicates import ValidatedRowFilter, render_named_conditions
 
 from products.data_warehouse.backend.types import IncrementalFieldType, PartitionSettings
 
@@ -49,6 +51,11 @@ DATA_QUERY_TIMEOUT_SECONDS = 60 * 60  # 1 hour
 # concat and yield a single pa.Table to the pipeline.
 YIELD_TARGET_BYTES = 200 * 1024 * 1024  # 200 MiB, matches pipeline partition target
 YIELD_TARGET_ROWS = 100_000
+
+# Quoter for user-supplied row-filter column names — the allowlist-validated
+# safety rail the shared predicate renderer expects. Trusted internal
+# identifiers (table/incremental columns) keep using `_quote_identifier`.
+_ROW_FILTER_IDENTIFIER_QUOTER = BacktickIdentifierQuoter()
 
 
 class ClickHouseConnectionError(Exception):
@@ -975,25 +982,34 @@ def _build_query(
     columns: list[ClickHouseColumn],
     should_use_incremental_field: bool,
     incremental_field: Optional[str],
-) -> str:
-    """Build the data extraction query.
+    row_filters: Optional[list[ValidatedRowFilter]] = None,
+) -> tuple[str, dict[str, Any]]:
+    """Build the data extraction query and its bound parameters.
 
-    Returns the SQL string. We never interpolate the incremental cursor
-    value directly — only identifiers (which are validated) end up in the
-    SQL string. Column types ClickHouse can't emit as Arrow (UUID, IPv4,
-    enums, arrays, ...) are wrapped in toString() to avoid error 50.
+    Returns the SQL string plus the row-filter params dict. We never
+    interpolate values — only identifiers (which are validated) end up in the
+    SQL string; the incremental cursor and every row-filter value bind as
+    parameters. Row filters are ANDed onto the WHERE clause. Column types
+    ClickHouse can't emit as Arrow (UUID, IPv4, enums, arrays, ...) are
+    wrapped in toString() to avoid error 50.
     """
     qualified = _qualified_table(database, table_name)
     select_list = _build_select_list(columns)
 
+    filter_conditions, filter_params = render_named_conditions(row_filters or [], _ROW_FILTER_IDENTIFIER_QUOTER)
+
     if not should_use_incremental_field:
-        return f"SELECT {select_list} FROM {qualified}"
+        if filter_conditions:
+            return f"SELECT {select_list} FROM {qualified} WHERE {' AND '.join(filter_conditions)}", filter_params
+        return f"SELECT {select_list} FROM {qualified}", {}
 
     if incremental_field is None:
         raise ValueError("incremental_field can't be None when should_use_incremental_field is True")
 
     quoted_field = _quote_identifier(incremental_field)
-    return f"SELECT {select_list} FROM {qualified} WHERE {quoted_field} > %(last_value)s ORDER BY {quoted_field} ASC"
+    conditions = [f"{quoted_field} > %(last_value)s", *filter_conditions]
+    query = f"SELECT {select_list} FROM {qualified} WHERE {' AND '.join(conditions)} ORDER BY {quoted_field} ASC"
+    return query, filter_params
 
 
 def _query_settings(chunk_size: int) -> dict[str, Any]:
@@ -1043,6 +1059,7 @@ def clickhouse_source(
     chunk_size_override: Optional[int] = None,
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
+    row_filters: Optional[list[ValidatedRowFilter]] = None,
 ) -> SourceResponse:
     """Build a SourceResponse that pulls a single ClickHouse table.
 
@@ -1147,15 +1164,16 @@ def clickhouse_source(
             )
 
             try:
-                query = _build_query(
+                query, filter_params = _build_query(
                     database=database,
                     table_name=table_name,
                     columns=list(table.columns),
                     should_use_incremental_field=should_use_incremental_field,
                     incremental_field=incremental_field,
+                    row_filters=row_filters,
                 )
 
-                parameters: dict[str, Any] = {}
+                parameters: dict[str, Any] = dict(filter_params)
                 if should_use_incremental_field:
                     last_value = db_incremental_field_last_value
                     if last_value is None and incremental_field_type is not None:

--- a/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/clickhouse.py
@@ -25,7 +25,7 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     DEFAULT_PARTITION_TARGET_SIZE_IN_BYTES,
     build_pyarrow_decimal_type,
 )
-from posthog.temporal.data_imports.sources.common.sql import Column, Table
+from posthog.temporal.data_imports.sources.common.sql import Column, Table, compute_projected_columns
 from posthog.temporal.data_imports.sources.common.sql.identifiers import BacktickIdentifierQuoter
 from posthog.temporal.data_imports.sources.common.sql.predicates import ValidatedRowFilter, render_named_conditions
 
@@ -975,6 +975,29 @@ def _build_select_list(columns: list[ClickHouseColumn]) -> str:
     return ", ".join(parts)
 
 
+def _project_columns(
+    columns: list[ClickHouseColumn],
+    enabled_columns: Optional[list[str]],
+    primary_keys: Optional[list[str]],
+    incremental_field: Optional[str],
+) -> list[ClickHouseColumn]:
+    """Restrict the SELECT to the user-enabled columns.
+
+    `enabled_columns is None` syncs every column. Otherwise we project to the
+    enabled set plus the primary keys and incremental cursor (always synced),
+    reusing the shared `compute_projected_columns` ordering and mapping the
+    names back to typed `ClickHouseColumn`s so toString casting is preserved.
+    Falls back to all columns if nothing resolves, so a sync never selects zero
+    columns.
+    """
+    projected_names = compute_projected_columns(enabled_columns, primary_keys, incremental_field)
+    if projected_names is None:
+        return columns
+    by_name = {column.name: column for column in columns}
+    projected = [by_name[name] for name in projected_names if name in by_name]
+    return projected or columns
+
+
 def _build_query(
     *,
     database: str,
@@ -1060,6 +1083,7 @@ def clickhouse_source(
     incremental_field: Optional[str] = None,
     incremental_field_type: Optional[IncrementalFieldType] = None,
     row_filters: Optional[list[ValidatedRowFilter]] = None,
+    enabled_columns: Optional[list[str]] = None,
 ) -> SourceResponse:
     """Build a SourceResponse that pulls a single ClickHouse table.
 
@@ -1092,6 +1116,9 @@ def clickhouse_source(
             primary_keys = _get_primary_keys(client, database, table_name)
             if primary_keys:
                 logger.debug(f"Found primary keys (sorting key): {primary_keys}")
+
+            # Project to the user-selected columns (always keeping PK + cursor).
+            projected_columns = _project_columns(list(table.columns), enabled_columns, primary_keys, incremental_field)
 
             # Warn when the incremental cursor isn't the sorting-key prefix.
             # ClickHouse can only skip the sort if the ORDER BY column leads
@@ -1167,7 +1194,7 @@ def clickhouse_source(
                 query, filter_params = _build_query(
                     database=database,
                     table_name=table_name,
-                    columns=list(table.columns),
+                    columns=projected_columns,
                     should_use_incremental_field=should_use_incremental_field,
                     incremental_field=incremental_field,
                     row_filters=row_filters,

--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -1,4 +1,4 @@
-from typing import Optional, cast
+from typing import TYPE_CHECKING, Optional, cast
 
 from clickhouse_connect.driver.exceptions import ClickHouseError, DatabaseError, OperationalError
 from sshtunnel import BaseSSHTunnelForwarderError
@@ -30,9 +30,13 @@ from posthog.temporal.data_imports.sources.common.base import FieldType, SimpleS
 from posthog.temporal.data_imports.sources.common.mixins import SSHTunnelMixin, ValidateDatabaseHostMixin
 from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.common.sql.base import reconcile_source_schema_metadata
 from posthog.temporal.data_imports.sources.generated_configs import ClickHouseSourceConfig
 
 from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalField
+
+if TYPE_CHECKING:
+    from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 # Error message → user-friendly translation. Matched as a substring of the
 # exception string. Patterns are lowercase-matched.
@@ -348,4 +352,16 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             incremental_field_type=inputs.incremental_field_type,
             db_incremental_field_last_value=inputs.db_incremental_field_last_value,
             chunk_size_override=schema.chunk_size_override,
+            row_filters=inputs.row_filters,
         )
+
+    def reconcile_schema_metadata(
+        self,
+        source: "ExternalDataSource",
+        source_schemas: list[SourceSchema],
+        team_id: int,
+    ) -> list[str]:
+        """Persist per-schema column metadata so row filters validate and the
+        column picker populates. ClickHouse isn't a `SQLSource`, but the
+        reconcile step is driver-agnostic, so we reuse the shared helper."""
+        return reconcile_source_schema_metadata(source, source_schemas, team_id)

--- a/posthog/temporal/data_imports/sources/clickhouse/source.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/source.py
@@ -57,6 +57,10 @@ ClickHouseErrors: dict[str, str] = {
 
 @SourceRegistry.register
 class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
+    # Lets users pick which columns to sync (and, in the wizard, surfaces the
+    # row-filter editor that shares the same column-selection modal).
+    supports_column_selection: bool = True
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.CLICKHOUSE
@@ -353,6 +357,7 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             db_incremental_field_last_value=inputs.db_incremental_field_last_value,
             chunk_size_override=schema.chunk_size_override,
             row_filters=inputs.row_filters,
+            enabled_columns=inputs.enabled_columns,
         )
 
     def reconcile_schema_metadata(

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -18,6 +18,7 @@ from posthog.temporal.data_imports.sources.clickhouse.clickhouse import (
     _has_duplicate_primary_keys,
     _is_transient_connect_drop,
     _parse_mv_target,
+    _project_columns,
     _quote_identifier,
     _strip_type_modifiers,
     filter_clickhouse_incremental_fields,
@@ -256,6 +257,43 @@ class TestBuildQuery:
         )
         assert "WHERE `country` IN (%(row_filter_0_0)s, %(row_filter_0_1)s)" in query
         assert params == {"row_filter_0_0": "US", "row_filter_0_1": "CA"}
+
+
+class TestProjectColumns:
+    @staticmethod
+    def _cols(*names: str) -> list[ClickHouseColumn]:
+        return [ClickHouseColumn(name=n, data_type="String", nullable=False) for n in names]
+
+    @staticmethod
+    def _names(cols: list[ClickHouseColumn]) -> list[str]:
+        return [c.name for c in cols]
+
+    def test_none_enabled_returns_all_columns(self):
+        cols = self._cols("a", "b", "c")
+        assert _project_columns(cols, None, ["a"], "b") == cols
+
+    def test_subset_keeps_only_enabled(self):
+        cols = self._cols("a", "b", "c", "d")
+        assert self._names(_project_columns(cols, ["b", "c"], None, None)) == ["b", "c"]
+
+    def test_always_includes_primary_keys_and_incremental(self):
+        cols = self._cols("id", "name", "created_at", "extra")
+        result = _project_columns(cols, ["name"], ["id"], "created_at")
+        assert set(self._names(result)) == {"name", "id", "created_at"}
+
+    def test_empty_enabled_selects_pk_and_incremental_only(self):
+        cols = self._cols("id", "name", "created_at")
+        result = _project_columns(cols, [], ["id"], "created_at")
+        assert set(self._names(result)) == {"id", "created_at"}
+
+    def test_unknown_enabled_names_are_ignored(self):
+        cols = self._cols("a", "b")
+        assert self._names(_project_columns(cols, ["a", "does_not_exist"], None, None)) == ["a"]
+
+    def test_empty_projection_falls_back_to_all_columns(self):
+        cols = self._cols("a", "b")
+        # enabled=[] with no PK/cursor resolves to nothing — never select zero columns.
+        assert _project_columns(cols, [], None, None) == cols
 
 
 class TestParseMvTarget:

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterable
 
 import pytest
+from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
 import pyarrow as pa
@@ -25,9 +26,12 @@ from posthog.temporal.data_imports.sources.clickhouse.clickhouse import (
     get_primary_keys_for_schemas,
 )
 from posthog.temporal.data_imports.sources.clickhouse.source import ClickHouseSource
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.common.sql.predicates import ColumnTypeCategory, ValidatedRowFilter
 
-from products.data_warehouse.backend.types import IncrementalFieldType
+from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalFieldType
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 
 class TestQuoteIdentifier:
@@ -231,7 +235,8 @@ class TestBuildQuery:
             "SELECT `id`, `name` FROM `default`.`events` WHERE `id` > %(row_filter_0)s AND `name` = %(row_filter_1)s"
         )
         assert params == {"row_filter_0": 21, "row_filter_1": "x'; DROP TABLE y; --"}
-        assert "DROP TABLE" not in query.replace("%(row_filter_1)s", "")
+        # The value binds as a param, so the injection payload never reaches the SQL string.
+        assert "DROP TABLE" not in query
 
     def test_incremental_ands_row_filters_after_cursor(self):
         query, params = _build_query(
@@ -1065,3 +1070,30 @@ class TestGetRowsBatching:
 
     def test_empty_stream_yields_nothing(self):
         assert self._run_get_rows([]) == []
+
+
+class TestClickHouseReconcileSchemaMetadata(BaseTest):
+    """The ClickHouse-specific override that routes through the shared reconcile helper."""
+
+    def test_persists_schema_metadata_for_clickhouse_source(self) -> None:
+        source = ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSourceType.CLICKHOUSE)
+        schema = ExternalDataSchema.objects.create(team=self.team, source=source, name="events")
+
+        result = ClickHouseSource().reconcile_schema_metadata(
+            source=source,
+            source_schemas=[
+                SourceSchema(
+                    name="events",
+                    supports_incremental=False,
+                    supports_append=False,
+                    columns=[("uuid", "UUID", False), ("timestamp", "DateTime64(6)", False)],
+                )
+            ],
+            team_id=self.team.pk,
+        )
+
+        assert result == []
+        schema.refresh_from_db()
+        metadata = schema.schema_metadata
+        assert metadata is not None
+        assert [column["name"] for column in metadata["columns"]] == ["uuid", "timestamp"]

--- a/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/posthog/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -24,6 +24,7 @@ from posthog.temporal.data_imports.sources.clickhouse.clickhouse import (
     get_primary_keys_for_schemas,
 )
 from posthog.temporal.data_imports.sources.clickhouse.source import ClickHouseSource
+from posthog.temporal.data_imports.sources.common.sql.predicates import ColumnTypeCategory, ValidatedRowFilter
 
 from products.data_warehouse.backend.types import IncrementalFieldType
 
@@ -144,8 +145,12 @@ class TestBuildQuery:
     def _cols(*specs: tuple[str, str]) -> list[ClickHouseColumn]:
         return [ClickHouseColumn(name=n, data_type=t, nullable=False) for n, t in specs]
 
+    @staticmethod
+    def _filter(column: str, operator: str, value: object, category: ColumnTypeCategory) -> ValidatedRowFilter:
+        return ValidatedRowFilter(column=column, operator=operator, value=value, category=category)
+
     def test_full_refresh(self):
-        query = _build_query(
+        query, params = _build_query(
             database="default",
             table_name="events",
             columns=self._cols(("id", "Int64"), ("name", "String")),
@@ -153,9 +158,10 @@ class TestBuildQuery:
             incremental_field=None,
         )
         assert query == "SELECT `id`, `name` FROM `default`.`events`"
+        assert params == {}
 
     def test_incremental(self):
-        query = _build_query(
+        query, params = _build_query(
             database="default",
             table_name="events",
             columns=self._cols(("id", "Int64"), ("created_at", "DateTime64(6)")),
@@ -165,9 +171,10 @@ class TestBuildQuery:
         assert "SELECT `id`, `created_at` FROM `default`.`events`" in query
         assert "WHERE `created_at` > %(last_value)s" in query
         assert "ORDER BY `created_at` ASC" in query
+        assert params == {}
 
     def test_incremental_quotes_field_with_special_chars(self):
-        query = _build_query(
+        query, _ = _build_query(
             database="my-db",
             table_name="weird table",
             columns=self._cols(("event time", "DateTime")),
@@ -188,7 +195,7 @@ class TestBuildQuery:
             )
 
     def test_wraps_arrow_unsupported_types_in_to_string(self):
-        query = _build_query(
+        query, _ = _build_query(
             database="default",
             table_name="events",
             columns=[
@@ -206,6 +213,49 @@ class TestBuildQuery:
         assert "toString(`ip`) AS `ip`" in query
         assert "toString(`tags`) AS `tags`" in query
         assert "toString(`status`) AS `status`" in query
+
+    def test_full_refresh_with_row_filters_binds_values_as_params(self):
+        query, params = _build_query(
+            database="default",
+            table_name="events",
+            columns=self._cols(("id", "Int64"), ("name", "String")),
+            should_use_incremental_field=False,
+            incremental_field=None,
+            row_filters=[
+                self._filter("id", ">", 21, ColumnTypeCategory.INTEGER),
+                self._filter("name", "=", "x'; DROP TABLE y; --", ColumnTypeCategory.STRING),
+            ],
+        )
+        assert query == (
+            "SELECT `id`, `name` FROM `default`.`events` WHERE `id` > %(row_filter_0)s AND `name` = %(row_filter_1)s"
+        )
+        assert params == {"row_filter_0": 21, "row_filter_1": "x'; DROP TABLE y; --"}
+        assert "DROP TABLE" not in query.replace("%(row_filter_1)s", "")
+
+    def test_incremental_ands_row_filters_after_cursor(self):
+        query, params = _build_query(
+            database="default",
+            table_name="events",
+            columns=self._cols(("id", "Int64"), ("created_at", "DateTime64(6)")),
+            should_use_incremental_field=True,
+            incremental_field="created_at",
+            row_filters=[self._filter("id", ">=", 100, ColumnTypeCategory.INTEGER)],
+        )
+        assert "WHERE `created_at` > %(last_value)s AND `id` >= %(row_filter_0)s" in query
+        assert "ORDER BY `created_at` ASC" in query
+        assert params == {"row_filter_0": 100}
+
+    def test_row_filter_in_operator_expands_to_placeholders(self):
+        query, params = _build_query(
+            database="default",
+            table_name="events",
+            columns=self._cols(("country", "String")),
+            should_use_incremental_field=False,
+            incremental_field=None,
+            row_filters=[self._filter("country", "IN", ["US", "CA"], ColumnTypeCategory.STRING)],
+        )
+        assert "WHERE `country` IN (%(row_filter_0_0)s, %(row_filter_0_1)s)" in query
+        assert params == {"row_filter_0_0": "US", "row_filter_0_1": "CA"}
 
 
 class TestParseMvTarget:

--- a/posthog/temporal/data_imports/sources/common/sql/base.py
+++ b/posthog/temporal/data_imports/sources/common/sql/base.py
@@ -161,39 +161,52 @@ class SQLSource(SimpleSource[ConfigType], Generic[ConfigType]):
         Returns schema names this hook soft-deleted (default impl never does;
         override to handle direct-query table cleanup).
         """
-        schemas_by_name: dict[str, SourceSchema] = {s.name: s for s in source_schemas}
-        rows = ExternalDataSchema.objects.filter(team_id=team_id, source_id=source.id, deleted=False)
-        for row in rows:
-            source_schema = schemas_by_name.get(row.name)
-            if source_schema is None:
-                continue
-            new_metadata = sql_schema_metadata(
-                source_schema.columns,
-                source_schema.foreign_keys,
-                source_catalog=source_schema.source_catalog,
-                source_schema=source_schema.source_schema,
-                source_table_name=source_schema.source_table_name,
+        return reconcile_source_schema_metadata(source, source_schemas, team_id)
+
+
+def reconcile_source_schema_metadata(
+    source: ExternalDataSource,
+    source_schemas: list[SourceSchema],
+    team_id: int,
+) -> list[str]:
+    """Persist `schema_metadata` per schema row and prune stale `enabled_columns`.
+
+    Generic over the source driver — it reads only `SourceSchema` fields and the
+    `ExternalDataSchema` rows — so non-`SQLSource` sources (e.g. ClickHouse) can
+    reuse it to surface column metadata for row filters and the column picker.
+    Returns schema names soft-deleted by this hook (currently none).
+    """
+    schemas_by_name: dict[str, SourceSchema] = {s.name: s for s in source_schemas}
+    rows = ExternalDataSchema.objects.filter(team_id=team_id, source_id=source.id, deleted=False)
+    for row in rows:
+        source_schema = schemas_by_name.get(row.name)
+        if source_schema is None:
+            continue
+        new_metadata = sql_schema_metadata(
+            source_schema.columns,
+            source_schema.foreign_keys,
+            source_catalog=source_schema.source_catalog,
+            source_schema=source_schema.source_schema,
+            source_table_name=source_schema.source_table_name,
+        )
+        existing_config: dict[str, Any] = dict(row.sync_type_config) if isinstance(row.sync_type_config, dict) else {}
+        existing_config["schema_metadata"] = new_metadata
+
+        available_names = extract_available_column_names(new_metadata)
+        pruned_enabled_columns, removed_columns = prune_enabled_columns(row.enabled_columns, available_names)
+        update_fields = ["sync_type_config", "updated_at"]
+        if removed_columns:
+            log.info(
+                "sql_source.reconcile_schema_metadata.pruned_enabled_columns",
+                source_id=str(source.id),
+                schema_id=str(row.id),
+                schema_name=row.name,
+                removed_columns=removed_columns,
             )
-            existing_config: dict[str, Any] = (
-                dict(row.sync_type_config) if isinstance(row.sync_type_config, dict) else {}
-            )
-            existing_config["schema_metadata"] = new_metadata
+            row.enabled_columns = pruned_enabled_columns
+            update_fields.append("enabled_columns")
 
-            available_names = extract_available_column_names(new_metadata)
-            pruned_enabled_columns, removed_columns = prune_enabled_columns(row.enabled_columns, available_names)
-            update_fields = ["sync_type_config", "updated_at"]
-            if removed_columns:
-                log.info(
-                    "sql_source.reconcile_schema_metadata.pruned_enabled_columns",
-                    source_id=str(source.id),
-                    schema_id=str(row.id),
-                    schema_name=row.name,
-                    removed_columns=removed_columns,
-                )
-                row.enabled_columns = pruned_enabled_columns
-                update_fields.append("enabled_columns")
+        row.sync_type_config = existing_config
+        row.save(update_fields=update_fields)
 
-            row.sync_type_config = existing_config
-            row.save(update_fields=update_fields)
-
-        return []
+    return []

--- a/posthog/temporal/data_imports/sources/common/sql/tests/test_base.py
+++ b/posthog/temporal/data_imports/sources/common/sql/tests/test_base.py
@@ -5,17 +5,21 @@ from contextlib import contextmanager
 from typing import Any
 
 import pytest
+from posthog.test.base import BaseTest
 from unittest.mock import MagicMock
 
 from posthog.schema import SourceConfig
 
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceInputs, SourceResponse
 from posthog.temporal.data_imports.sources.common.config import Config
-from posthog.temporal.data_imports.sources.common.sql.base import SQLSource
+from posthog.temporal.data_imports.sources.common.schema import SourceSchema
+from posthog.temporal.data_imports.sources.common.sql.base import SQLSource, reconcile_source_schema_metadata
 from posthog.temporal.data_imports.sources.common.sql.implementation import SourceMetadata, SQLSourceImplementation
 from posthog.temporal.data_imports.sources.common.sql.incremental import IncrementalFieldFilter
 
 from products.data_warehouse.backend.types import ExternalDataSourceType, IncrementalFieldType
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 
 @dataclasses.dataclass
@@ -241,3 +245,103 @@ class TestDefaultNonRetryableErrors:
         errors = SQLSource.default_non_retryable_errors()
         assert isinstance(errors, dict)
         assert len(errors) == 2
+
+
+class TestReconcileSourceSchemaMetadata(BaseTest):
+    """The driver-agnostic reconcile helper that `SQLSource` and `ClickHouseSource` share."""
+
+    def _source(self) -> ExternalDataSource:
+        return ExternalDataSource.objects.create(team=self.team, source_type=ExternalDataSourceType.CLICKHOUSE)
+
+    def _schema(self, source: ExternalDataSource, name: str = "messages", **kwargs: Any) -> ExternalDataSchema:
+        return ExternalDataSchema.objects.create(team=self.team, source=source, name=name, **kwargs)
+
+    @staticmethod
+    def _source_schema(name: str = "messages", **kwargs: Any) -> SourceSchema:
+        return SourceSchema(name=name, supports_incremental=False, supports_append=False, **kwargs)
+
+    def test_persists_columns_foreign_keys_and_source_fields(self) -> None:
+        source = self._source()
+        schema = self._schema(source)
+
+        result = reconcile_source_schema_metadata(
+            source,
+            [
+                self._source_schema(
+                    columns=[("id", "Int64", False), ("ts", "DateTime", True)],
+                    foreign_keys=[("author_id", "users", "id")],
+                    source_catalog="default",
+                    source_schema="public",
+                    source_table_name="messages",
+                )
+            ],
+            self.team.pk,
+        )
+
+        assert result == []
+        schema.refresh_from_db()
+        metadata = schema.sync_type_config["schema_metadata"]
+        assert metadata["columns"] == [
+            {"name": "id", "data_type": "Int64", "is_nullable": False},
+            {"name": "ts", "data_type": "DateTime", "is_nullable": True},
+        ]
+        assert metadata["foreign_keys"] == [{"column": "author_id", "target_table": "users", "target_column": "id"}]
+        assert metadata["source_catalog"] == "default"
+        assert metadata["source_schema"] == "public"
+        assert metadata["source_table_name"] == "messages"
+
+    def test_merges_into_existing_sync_type_config(self) -> None:
+        source = self._source()
+        schema = self._schema(source, sync_type_config={"incremental_field": "ts", "chunk_size_override": 5})
+
+        reconcile_source_schema_metadata(source, [self._source_schema(columns=[("id", "Int64", False)])], self.team.pk)
+
+        schema.refresh_from_db()
+        assert schema.sync_type_config["incremental_field"] == "ts"
+        assert schema.sync_type_config["chunk_size_override"] == 5
+        assert "schema_metadata" in schema.sync_type_config
+
+    def test_prunes_enabled_columns_missing_from_source(self) -> None:
+        source = self._source()
+        schema = self._schema(source, enabled_columns=["id", "dropped"])
+
+        reconcile_source_schema_metadata(
+            source, [self._source_schema(columns=[("id", "Int64", False), ("ts", "DateTime", True)])], self.team.pk
+        )
+
+        schema.refresh_from_db()
+        assert schema.enabled_columns == ["id"]
+
+    def test_keeps_enabled_columns_when_all_present(self) -> None:
+        source = self._source()
+        schema = self._schema(source, enabled_columns=["id", "ts"])
+
+        reconcile_source_schema_metadata(
+            source, [self._source_schema(columns=[("id", "Int64", False), ("ts", "DateTime", True)])], self.team.pk
+        )
+
+        schema.refresh_from_db()
+        assert schema.enabled_columns == ["id", "ts"]
+
+    def test_skips_schema_without_a_matching_source_schema(self) -> None:
+        source = self._source()
+        schema = self._schema(source, name="messages")
+
+        reconcile_source_schema_metadata(
+            source, [self._source_schema(name="other", columns=[("id", "Int64", False)])], self.team.pk
+        )
+
+        schema.refresh_from_db()
+        assert schema.schema_metadata is None
+
+    def test_does_not_touch_schemas_on_a_different_source(self) -> None:
+        source = self._source()
+        other_source = self._source()
+        schema = self._schema(other_source, name="messages")
+
+        reconcile_source_schema_metadata(
+            source, [self._source_schema(name="messages", columns=[("id", "Int64", False)])], self.team.pk
+        )
+
+        schema.refresh_from_db()
+        assert schema.schema_metadata is None

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -2189,11 +2189,9 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 )
                 if reconciled_deleted_schemas:
                     schemas_deleted = list({*schemas_deleted, *reconciled_deleted_schemas})
-            elif isinstance(source, SQLSource) and source.supports_column_selection:
-                source.reconcile_schema_metadata(source=instance, source_schemas=schemas, team_id=self.team_id)
-            elif isinstance(source, ClickHouseSource):
-                # ClickHouse isn't a SQLSource but exposes the same reconcile hook so
-                # row filters validate and the column picker populates.
+            elif isinstance(source, (SQLSource, ClickHouseSource)) and source.supports_column_selection:
+                # ClickHouse isn't a SQLSource but exposes the same column-selection
+                # capability and reconcile hook, so it reuses this path.
                 source.reconcile_schema_metadata(source=instance, source_schemas=schemas, team_id=self.team_id)
         logger.debug(
             "refresh_schemas completed",

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -44,6 +44,7 @@ from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.temporal.data_imports.cdc.adapters import CDCSourceAdapter, get_cdc_adapter, source_type_supports_cdc
 from posthog.temporal.data_imports.sources import SourceRegistry
+from posthog.temporal.data_imports.sources.clickhouse.source import ClickHouseSource
 from posthog.temporal.data_imports.sources.common.base import AnySource, ExternalWebhookInfo, FieldType, WebhookSource
 from posthog.temporal.data_imports.sources.common.config import Config
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema, build_default_schemas
@@ -2189,6 +2190,10 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 if reconciled_deleted_schemas:
                     schemas_deleted = list({*schemas_deleted, *reconciled_deleted_schemas})
             elif isinstance(source, SQLSource) and source.supports_column_selection:
+                source.reconcile_schema_metadata(source=instance, source_schemas=schemas, team_id=self.team_id)
+            elif isinstance(source, ClickHouseSource):
+                # ClickHouse isn't a SQLSource but exposes the same reconcile hook so
+                # row filters validate and the column picker populates.
                 source.reconcile_schema_metadata(source=instance, source_schemas=schemas, team_id=self.team_id)
         logger.debug(
             "refresh_schemas completed",

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -2797,6 +2797,8 @@ class TestAvailableColumnsAcrossSqlSources(APIBaseTest):
             (ExternalDataSourceType.BIGQUERY, True),
             (ExternalDataSourceType.SNOWFLAKE, True),
             (ExternalDataSourceType.REDSHIFT, True),
+            # ClickHouse isn't a SQLSource but opts into column selection.
+            (ExternalDataSourceType.CLICKHOUSE, True),
             # Non-SQL sources stay False
             (ExternalDataSourceType.STRIPE, False),
         ]


### PR DESCRIPTION
## Problem

ClickHouse warehouse sources lacked two table-scoping controls every other SQL source already had:

- **Row filters** — `{column, operator, value}` predicates ANDed onto the extraction query so a sync only pulls matching rows.
- **Column selection** — picking which columns to sync.

Both matter beyond convenience for ClickHouse specifically: scoping a sync down (a `timestamp` window that prunes partitions, or dropping a fat `properties` column) reduces how much the source server has to read, which is the lever for the large-table syncs that otherwise read everything.

## Changes

Brings ClickHouse to parity on both, backend-only (the frontend surfaces are capability-driven, so no UI changes were needed).

**Row filters**
- `_build_query` ANDs validated filters onto the `WHERE` clause via the shared `render_named_conditions` helper. Column names go through the allowlist-validated backtick quoter; values bind as named params (`%(row_filter_n)s`) — never interpolated — matching the existing incremental-cursor binding. Composes with incremental syncs (cursor predicate first, then filters).
- Filter validation and the column picker both read `ExternalDataSchema.schema_metadata`, which only `SQLSource` subclasses populated. ClickHouse is a `SimpleSource`, so its metadata was never persisted. The reconcile logic is driver-agnostic, so it's extracted into a shared `reconcile_source_schema_metadata` helper and reused for ClickHouse on schema refresh.

**Column selection**
- ClickHouse opts in via `supports_column_selection = True`. The source projects the `SELECT` to the enabled columns through the shared `compute_projected_columns` helper, **always** keeping primary-key and incremental-cursor columns and preserving the `toString()` casting for Arrow-unsupported types.
- **Sync-time data behavior** (worth calling out): once enabled, column selection changes which columns ClickHouse actually syncs. `enabled_columns is None` → `SELECT *` (so **existing schemas are unaffected** — the model field defaults to `None`); a non-empty list → those columns plus PK + cursor; `enabled_columns == []` → **PK + incremental cursor only**.
- This also fixes a gap in the **new-source wizard**: the row-filter editor lives inside the same modal as the column picker, which only opens for sources reporting `supportsColumnSelection`. ClickHouse reported false, so neither showed during setup — flipping the flag lights up both.

ClickHouse intentionally **stays a `SimpleSource`** rather than converting to `SQLSource`: its Arrow-streaming read path doesn't fit the cursor-based `SQLSourceImplementation` that `SQLSource` mandates, and a full conversion would rewrite a working, memory-bounded source for no functional gain. Reusing just the shared helpers (`reconcile_source_schema_metadata`, `compute_projected_columns`, the predicate renderer) gets the features without the rewrite.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing claimed.

- `_build_query` unit tests: full-refresh + filters, incremental + filters (AND order), `IN` expansion, and an injection assertion that a malicious value binds as a param and never reaches the SQL string.
- `_project_columns` unit tests: `None` → all, enabled subset, `[]` → PK + cursor only, unknown names ignored, empty-projection fallback to all.
- `reconcile_source_schema_metadata` (the shared base-source helper) tests: persists columns/foreign-keys/source fields, merges into existing `sync_type_config`, prunes stale `enabled_columns`, ignores non-matching/other-source schemas.
- A direct test that `ClickHouseSource.reconcile_schema_metadata` persists `schema_metadata`, plus the `supports_column_selection` capability flag.
- Local runs green: full `test_clickhouse.py` (172), `test_base.py` (22), and the data-warehouse column-selection / reconcile API tests (27). `ty` type check passes in pre-commit.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Skills invoked: `/implementing-warehouse-sources` (warehouse-source changes) and `dc-review-pr` (an async PostHog cloud review of this PR, whose findings are addressed below).

Key decisions:
- **Skipped the full `SQLSource` conversion** (explicitly considered) — incompatible with ClickHouse's Arrow-streaming reader; reused only the shared helpers instead, keeping ClickHouse specifics out of generic layers.
- **Column selection unlocks wizard row filters** — the two share one modal gated by `supportsColumnSelection`, so the single flag fixes both setup surfaces with zero frontend code.

`dc-review-pr` findings addressed: owned the column-selection feature in this title/description (incl. the `[]` → PK+cursor-only behavior); added a direct test for the ClickHouse `reconcile_schema_metadata` override; collapsed the duplicate reconcile dispatch branch; unified `_build_query`'s no-filter return; removed a no-op assertion. No blockers were raised.

No new env vars, migrations, or generated-type changes (`row_filters`, `enabled_columns`, and `schema_metadata` already exist on the model). Agent-authored — requires human review.
