### PR TITLE
fix(temporalio): retry namespace rate-limit RPCs with backoff

### DIFF
--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -3,14 +3,14 @@ import asyncio
 import datetime
 import threading
 import dataclasses
-from collections.abc import Iterable
+from collections.abc import Awaitable, Callable, Iterable
 from enum import StrEnum
 from queue import Queue
-from typing import Any, Optional
+from typing import Any, Optional, TypeVar
 
 from structlog.types import FilteringBoundLogger
 from temporalio.client import Client
-from temporalio.service import RPCError
+from temporalio.service import RPCError, RPCStatusCode
 
 from posthog.temporal.common.client import connect
 from posthog.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
@@ -51,6 +51,35 @@ INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
 @dataclasses.dataclass
 class TemporalIOResumeConfig:
     next_page_token: str  # Base64-encoded bytes for JSON serialization
+
+
+T = TypeVar("T")
+
+# Temporal Cloud throttles per-namespace RPCs (RPS / concurrency / overload) with a gRPC
+# RESOURCE_EXHAUSTED status — e.g. "namespace rate limit exceeded". It's transient: a short backoff
+# usually clears the window. Riding it out in-process keeps a brief throttle from failing the whole
+# import activity (which would rebuild the client and restart pagination) and avoids error-tracking
+# noise. Persistent throttling re-raises so Temporal's activity retry still applies.
+_MAX_RATE_LIMIT_ATTEMPTS = 6
+
+
+async def _with_rate_limit_retry(
+    operation: Callable[[], Awaitable[T]],
+    logger: FilteringBoundLogger,
+    *,
+    max_attempts: int = _MAX_RATE_LIMIT_ATTEMPTS,
+) -> T:
+    attempt = 0
+    while True:
+        try:
+            return await operation()
+        except RPCError as e:
+            attempt += 1
+            if attempt >= max_attempts or e.status != RPCStatusCode.RESOURCE_EXHAUSTED:
+                raise
+            backoff = min(2 * attempt, 30)
+            logger.debug(f"TemporalIO: namespace rate limited, backing off {backoff}s (attempt {attempt})")
+            await asyncio.sleep(backoff)
 
 
 def _async_iter_to_sync(async_iter):
@@ -177,7 +206,7 @@ async def _get_workflows(
         # Save the token that will be used to fetch this page *before* fetching.
         # On resume we re-fetch this same page — duplicates are safe thanks to primary keys.
         pre_fetch_token = workflows.next_page_token
-        await workflows.fetch_next_page()
+        await _with_rate_limit_retry(workflows.fetch_next_page, logger)
         page = workflows.current_page
         if not page:
             break
@@ -228,7 +257,7 @@ async def _get_workflow_histories(
         # Save the token that will be used to fetch this page *before* fetching.
         # On resume we re-fetch this same page — duplicates are safe thanks to primary keys.
         pre_fetch_token = workflows.next_page_token
-        await workflows.fetch_next_page()
+        await _with_rate_limit_retry(workflows.fetch_next_page, logger)
         page = workflows.current_page
         if not page:
             break
@@ -244,7 +273,10 @@ async def _get_workflow_histories(
 
         for item in page:
             try:
-                history = await client.get_workflow_handle(item.id, run_id=item.run_id).fetch_history()
+                history = await _with_rate_limit_retry(
+                    lambda item=item: client.get_workflow_handle(item.id, run_id=item.run_id).fetch_history(),
+                    logger,
+                )
                 history_dict = history.to_json_dict()
                 events = history_dict["events"]
                 for event in events:

--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -273,10 +273,8 @@ async def _get_workflow_histories(
 
         for item in page:
             try:
-                history = await _with_rate_limit_retry(
-                    lambda item=item: client.get_workflow_handle(item.id, run_id=item.run_id).fetch_history(),
-                    logger,
-                )
+                handle = client.get_workflow_handle(item.id, run_id=item.run_id)
+                history = await _with_rate_limit_retry(handle.fetch_history, logger)
                 history_dict = history.to_json_dict()
                 events = history_dict["events"]
                 for event in events:

--- a/posthog/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/temporalio.py
@@ -78,7 +78,7 @@ async def _with_rate_limit_retry(
             if attempt >= max_attempts or e.status != RPCStatusCode.RESOURCE_EXHAUSTED:
                 raise
             backoff = min(2 * attempt, 30)
-            logger.debug(f"TemporalIO: namespace rate limited, backing off {backoff}s (attempt {attempt})")
+            logger.debug("TemporalIO: namespace rate limited", backoff_seconds=backoff, attempt=attempt)
             await asyncio.sleep(backoff)
 
 

--- a/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/posthog/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -1,12 +1,21 @@
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from temporalio.client import Client
+from temporalio.service import RPCError, RPCStatusCode
 
 from posthog.temporal.common.codec import EncryptionCodec
 from posthog.temporal.data_imports.sources.generated_configs import TemporalIOSourceConfig
 from posthog.temporal.data_imports.sources.temporalio.source import TemporalIOSource
-from posthog.temporal.data_imports.sources.temporalio.temporalio import FakeSettings, _get_temporal_client
+from posthog.temporal.data_imports.sources.temporalio.temporalio import (
+    FakeSettings,
+    _get_temporal_client,
+    _with_rate_limit_retry,
+)
+
+
+def _rpc_error(message: str, status: RPCStatusCode) -> RPCError:
+    return RPCError(message, status, b"")
 
 
 class TestTemporalIOClient:
@@ -93,3 +102,43 @@ class TestTemporalIONonRetryableErrors:
         assert not any(pattern in error_message for pattern in non_retryable_errors), (
             f"'{error_message}' must not match a non-retryable pattern"
         )
+
+
+class TestRateLimitRetry:
+    @patch("posthog.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep", new_callable=AsyncMock)
+    async def test_rides_out_transient_rate_limit(self, sleep):
+        calls = {"n": 0}
+
+        async def operation():
+            calls["n"] += 1
+            if calls["n"] <= 2:
+                raise _rpc_error("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED)
+            return "ok"
+
+        result = await _with_rate_limit_retry(operation, MagicMock())
+
+        assert result == "ok"
+        assert calls["n"] == 3
+        # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.await_args_list == [call(2), call(4)]
+
+    @patch("posthog.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep", new_callable=AsyncMock)
+    async def test_persistent_rate_limit_is_reraised(self, sleep):
+        async def operation():
+            raise _rpc_error("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED)
+
+        with pytest.raises(RPCError):
+            await _with_rate_limit_retry(operation, MagicMock(), max_attempts=4)
+
+        # Bounded attempts leave Temporal to retry; backs off between attempts but not after the last.
+        assert sleep.await_args_list == [call(2), call(4), call(6)]
+
+    @patch("posthog.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep", new_callable=AsyncMock)
+    async def test_non_rate_limit_rpc_error_is_not_retried(self, sleep):
+        async def operation():
+            raise _rpc_error("workflow execution not found for", RPCStatusCode.NOT_FOUND)
+
+        with pytest.raises(RPCError):
+            await _with_rate_limit_retry(operation, MagicMock())
+
+        assert sleep.await_count == 0


### PR DESCRIPTION
## Problem

The Temporal.io data-warehouse import source surfaced an `RPCError` in error tracking:

```
RPCError: (8, 'namespace rate limit exceeded', <ResourceExhaustedFailure>)
```

gRPC status `8` is `RESOURCE_EXHAUSTED` — Temporal Cloud throttling per-namespace RPCs (RPS / concurrency / overload). The stack originates in this source's pagination loop (`_get_workflows` → `fetch_next_page` → Temporal's `_rpc_call`). The throttle is **transient**: a short backoff clears the window. But today a single throttled RPC raises straight out of the source, failing the whole import activity (which then rebuilds the client and restarts pagination) and generating error-tracking noise — when riding the blip out in-process would have let the sync continue.

Error-tracking issue: <https://us.posthog.com/project/2/error_tracking/019ef144-8708-7da0-9b25-4d0d98d155ad>

## Changes

Added a small bounded retry-with-backoff helper around the namespace RPC calls in the source (workflow list pagination and workflow-history fetches). Mirrors the existing pattern used elsewhere for transient warehouse-source errors (e.g. the Google Ads gRPC `UNAVAILABLE` and Paddle rate-limit retries).

- Retries only on the `RESOURCE_EXHAUSTED` status — the canonical "retry me with backoff" signal — with growing backoff (`min(2 * attempt, 30)`), capped at a few attempts.
- Re-raises on persistent throttling so Temporal's activity-level retry still applies as the backstop. **Not** added to `NonRetryableErrors` — a transient rate limit must stay retryable.
- Non-throttle `RPCError`s (e.g. `NOT_FOUND` for a workflow execution deleted mid-sync) fall through to the existing handling unchanged.
- Pagination retries before any page is yielded/checkpointed, so there's no partial state to reconcile; the existing resumable page-token state is untouched.

## How did you test this code?

I'm an agent. I added unit tests at the helper layer and ran them:

- `test_rides_out_transient_rate_limit` — two `RESOURCE_EXHAUSTED` failures are retried (2s, 4s backoff), then succeeds.
- `test_persistent_rate_limit_is_reraised` — gives up after bounded attempts and re-raises for Temporal to retry.
- `test_non_rate_limit_rpc_error_is_not_retried` — a non-throttle status propagates immediately with no backoff.

`uv run python -m pytest posthog/temporal/data_imports/sources/temporalio/test_temporalio.py` → 19 passed. `ruff check` / `ruff format` clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Temporal.io import source. Decision path: confirmed the failure genuinely originates in the source's pagination code (not just serialized log context), identified the error as a transient gRPC `RESOURCE_EXHAUSTED` throttle, and ruled out `NonRetryableErrors` (that would permanently fail syncs on a temporary rate limit). Chose in-process retry-with-backoff to match the maintainer's established convention for transient warehouse-source errors, re-raising on persistence so the outer Temporal retry remains the backstop. Detection keys on the status code rather than the message string so it also covers other throttle variants (concurrency / overload) without matching unrelated errors. Confirmed no existing open PR addresses this in the temporalio source.

Tools: Claude Code with the PostHog error-tracking MCP.
