### PR TITLE
feat(signals): teach general scout to discover project surfaces

### DIFF
--- a/products/signals/skills/signals-scout-general/SKILL.md
+++ b/products/signals/skills/signals-scout-general/SKILL.md
@@ -24,31 +24,59 @@ a real outcome — re-emitting a known issue is worse than emitting nothing.
 
 ## Orient
 
-Three cheap reads cold-start a run:
+Cheap reads cold-start a run:
 
 - `signals-scout-project-profile-get` — deterministic snapshot of products in use,
   recent activity, integrations, top events with reach + burst metrics, inbox
-  report counts.
-- `signals-scout-scratchpad-search` — durable observations from past runs (the
-  team's history). Search with `text=<keyword>` (ILIKE on key + content).
+  report counts. A fast hint, not the whole truth: it leans toward configured
+  entities (dashboards, flags, experiments, pipelines…) and lags products that
+  shipped recently, so treat it as a starting point, not a complete map.
+- `signals-scout-scratchpad-search` — durable observations from past runs. Read
+  `pattern:general:coverage-map` first (see "Map the project") — it's your running
+  inventory of which products actually have live data on this team. Search with
+  `text=<keyword>` (ILIKE on key + content).
 - `signals-scout-runs-list` — recent summaries from this scout and siblings. Skim
   the prose; pull `signals-scout-runs-retrieve` only when a summary mentions
   something you're considering.
 
+## Map the project
+
+The profile and `top_events` only see so much — they're blind to whole products
+(session replay, logs, tracing, revenue, the _state_ of error tracking) whose data
+the profile doesn't enumerate, and they lag products that shipped recently. Don't
+trust them to be complete. Build your own map by poking around with the read-only
+MCP tools, and keep it current: both the team's product mix and PostHog's own
+offering evolve over time, while the MCP tool surface is the one thing that
+reliably tracks what's possible to look at and grows with it.
+
+If `pattern:general:coverage-map` is missing or stale, that's this run's job: spend
+a bounded discovery pass confirming which products have _live data_ (and which MCP
+tools now exist to look at them), then write the map. `references/discovery.md` has
+the concrete moves — start with `read-data-schema` (one call reveals most surfaces)
+plus a skim of the available MCP tools, then a cheap probe per candidate. Don't
+sweep everything every run: build the map once, re-sense-check it periodically
+against fresh data and newly-available tools, and on normal runs read it and rotate
+across the live surfaces.
+
+If `signals-scout-runs-list` shows no sibling specialists running, you are the only
+scout on this project — the map should cover every live product, not just the gaps
+between specialists.
+
 ## Explore
 
-Pick what looks interesting and follow it. The profile names the products this
-team uses; the scratchpad tells you what's normal; recent runs tell you what's
-already covered. Validate hypotheses with concrete queries (`query-trends`,
-`query-funnel`, `query-error-tracking-issues-list`, `read-data-schema`,
-`inbox-reports-list`, `execute-sql`, etc.) before emitting.
+Pick what looks interesting and follow it. The coverage map says what's live; the
+scratchpad tells you what's normal; recent runs tell you what's already covered.
+Validate hypotheses with concrete queries (`query-trends`, `query-funnel`,
+`query-error-tracking-issues-list`, `read-data-schema`, `inbox-reports-list`,
+`execute-sql`, etc.) before emitting.
 
-If a sibling specialist already covers a surface in depth, leave the deep dive to it
-on a future tick — the `skill_name`s on recent runs in `signals-scout-runs-list` show
-the live roster (specialists exist for most product surfaces: error tracking, logs, AI
-observability, experiments, feature flags, session replay, web analytics, surveys, and
-more). Spend your time on **cross-product correlations** or on **surfaces no
-specialist covers**.
+When sibling specialists are running, leave a surface they cover in depth to them on
+a future tick — the `skill_name`s on recent runs in `signals-scout-runs-list` show
+the live roster (specialists exist for most product surfaces: error tracking, logs,
+AI observability, experiments, feature flags, session replay, web analytics, surveys,
+and more) — and spend your time on **cross-product correlations** or **surfaces no
+specialist covers**. When no specialists are running, the whole coverage map is your
+beat: work across it instead of narrowing to one corner.
 
 ## Decide
 

--- a/products/signals/skills/signals-scout-general/references/discovery.md
+++ b/products/signals/skills/signals-scout-general/references/discovery.md
@@ -1,0 +1,100 @@
+# Discovery: mapping what a project actually uses
+
+The profile and `top_events` are a starting point, not the whole picture. They
+enumerate configured entities and the busiest events, but whole products are
+invisible to them — session replay, logs, tracing/APM, revenue, and the _state_ of
+error tracking all live in data the profile doesn't carry — and the profile lags
+products that shipped recently. On a project with no specialist scouts, you're the
+only thing watching those surfaces, so confirm what's live yourself.
+
+Two things evolve under you: the **team's** product mix (they adopt new products,
+turn others off) and **PostHog's** own offering (new products ship with new MCP
+tools). The reliable substrate through both is the **MCP tool surface** — it tracks
+what's possible to look at and grows over time. Lean on it: a tool family that
+wasn't there last time is a strong hint of a product worth folding into the map.
+
+## One cheap pass, then a durable map you keep current
+
+Discovery is amortized, not repeated every run:
+
+- **No `pattern:general:coverage-map` yet (early runs):** spend this run building
+  it. Run the breadth pass below, then write the map.
+- **Map exists and is recent:** skip discovery. Read it, pick a live surface, and
+  investigate — rotating across surfaces over successive runs.
+- **Map is stale (~weekly, or the project clearly changed):** re-sense-check it.
+  Re-run the breadth pass, skim the MCP tools for capabilities new since last time,
+  and update the parts that drifted. Don't assume last week's map is still complete
+  — products appear on both sides.
+
+Stay bounded — discovery is orientation, not investigation. A handful of cheap reads
+is enough; you have future runs to go deep.
+
+## Breadth pass: event taxonomy + tool surface
+
+Two cheap reads do most of the work.
+
+**1. The event taxonomy.** `read-data-schema` (events) returns the event names this
+team captures — and the names alone reveal which products are live:
+
+| Signal in the event taxonomy               | Product that's live              |
+| ------------------------------------------ | -------------------------------- |
+| `$exception`                               | Error tracking                   |
+| `$ai_generation` / `$ai_span` / `$ai_*`    | LLM analytics (AI observability) |
+| `$pageview` / `$pageleave` / `$web_vitals` | Web analytics                    |
+| `$snapshot` / session activity             | Session replay                   |
+| `$feature_flag_called`                     | Feature flags                    |
+| `$csp_violation`                           | CSP reporting                    |
+| high-volume custom events                  | Product analytics                |
+
+**2. The MCP tool surface.** Skim the available tools (the MCP's own `search` /
+`tools` discovery). New `query-*` or product tool families that weren't there before
+are how you notice PostHog shipped a product you don't yet have a lens for — pick it
+up and probe whether this team uses it.
+
+Pair both with the profile's configured-entity sections (dashboards, flags,
+experiments, surveys, pipelines, warehouse sources, cohorts): together they tell you
+what's "configured," what's "emitting," and what's "now possible to query."
+
+## Confirm the surfaces the taxonomy can't show
+
+A few products don't announce themselves cleanly in the event list — probe them
+directly when the breadth pass hints they might be present, one cheap read each:
+
+- **Error tracking** — `query-error-tracking-issues-list` (issue count + recent
+  activity; `$exception` volume alone doesn't tell you issue state).
+- **Session replay** — `query-session-recordings-list` (are sessions recording, and
+  how recently?).
+- **Logs** — `query-logs` (any volume, by service / severity).
+- **Tracing / APM** — `query-apm-spans` (OTel spans present?).
+- **LLM analytics** — `query-llm-traces-list` (live traces, not just `$ai_*` counts).
+- **Revenue** — revenue events in the taxonomy, or warehouse Stripe sources in the
+  profile.
+- **Data warehouse** — the profile's `external_data_sources`; deeper structure via
+  `read-data-warehouse-schema`.
+
+When you hit a surface no tool seems to cover, that's worth a `mcp-gap:` scratchpad
+note (see [conventions.md](conventions.md)) — a capability the fleet may want later.
+
+## Write the coverage map
+
+Persist what you found as a single durable entry, overwriting it in place
+(`pattern:general:coverage-map`). Make it future-run actionable: each live product
+with a rough volume / last-seen and a one-line "what's worth watching here," an
+explicit list of products that are _absent_ so future runs don't re-probe them, and
+the date you last sense-checked it. Example shape:
+
+```text
+key:     pattern:general:coverage-map
+content: "2026-06-22 discovery (team has NO specialist scouts — general owns all).
+         LIVE: error_tracking (~12k $exception/day, 40 issues, watch new-issue
+         bursts); web_analytics ($pageview ~80k/day, 3 channels); session_replay
+         (recording, ~1.5k/day); feature_flags (22 active). ABSENT (skip until a
+         refresh): llm_analytics (no $ai_*), apm (no spans), revenue (no Stripe
+         source), surveys, csp. Last full sense-check 2026-06-22; re-check ~weekly
+         or on a visible project change / new MCP tool family."
+```
+
+Future runs read this first, skip the absent products, and rotate attention across
+the live ones — that's what turns a once-a-day generalist into something that covers
+the whole project over a week instead of re-checking one corner, and keeps up as
+both the team and PostHog change.


### PR DESCRIPTION
## Problem

The general Signals scout is becoming the **once-a-day default** for customer projects, with the specialist fleet disabled by default. That makes solo-general's coverage the whole game — but the scout oriented almost entirely off the deterministic **project profile**, and the profile has structural blind spots:

- It's **entity-config heavy** — great at "what has this team built" (dashboards, flags, experiments, pipelines, cohorts) but largely blind to the behavioral/observability products (session replay, logs, tracing/APM, revenue, and the *state* of error tracking) whose data it doesn't enumerate.
- It **lags newly-shipped products** — the inventory schema is `extra="forbid"` with a manual version bump, so a new product is invisible to the profile until someone adds a builder section. "Covers new products" is false by default.

On a project with no specialist fleet, that left whole products unwatched and pushed the scout toward lens-lock (re-checking the same narrow surfaces). Dogfooding on project 2 masks this, because there the ~26 specialists own every product surface and general is deliberately squeezed into the residual.

## Changes

Rather than chase profile completeness (a perpetual maintenance treadmill), push discovery into the scout, which already has the full read-only PostHog MCP toolset.

Edits to `signals-scout-general` (skill content only — no backend change):

- **New `## Map the project` section in `SKILL.md`** — a bounded, amortized discovery behavior. On early or stale runs the scout pokes around with the read-only MCP tools to confirm which products have *live data*, then writes a durable `pattern:general:coverage-map`. Normal runs read the map and rotate across live surfaces instead of re-treading one corner.
- **New `references/discovery.md`** (progressively disclosed) — the concrete moves: start with `read-data-schema` (one call's event taxonomy reveals most surfaces) plus a skim of the MCP tool surface, then a cheap per-surface probe (`query-error-tracking-issues-list`, `query-session-recordings-list`, `query-logs`, `query-apm-spans`, `query-llm-traces-list`, …), and the coverage-map entry shape.
- **Reframed the profile as a fast hint, not the whole truth** in `## Orient`, and made `## Explore` solo-aware: when no sibling specialists are running, the whole coverage map is general's beat.

Two properties this buys us:

- **Self-updating** — a new product (the team's *or* PostHog's) that emits data or ships an MCP tool is discoverable the day it lands, with no profile PR. The scout periodically re-sense-checks against fresh data and the evolving tool surface.
- **Profile is no longer load-bearing** — a thin or unbuilt profile (e.g. the cold-start 404 on a fresh project) no longer blocks coverage.

The profile remains a useful cheap cold-start; this just stops treating it as a complete map.

## How did you test this code?

I'm an agent (Claude Code). This is a skill-content change (Markdown only — no Python touched). Automated test actually run:

- `hogli test products/signals/backend/test/test_scout_harness_lazy_seed.py` — **48 passed**. This exercises `discover_canonical_skills()` over the real on-disk skills, confirming the new `references/discovery.md` bundles and parses cleanly and the canonical skill still loads. The harness auto-bundles `references/` recursively, so no manifest needed updating.

No manual/agent-loop testing of live scout runs was performed; behavior change will surface through dogfooding once synced.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tooling: Claude Code (Opus 4.8). Skills invoked: `/exploring-signals-scouts` (to assess how the live general scout was behaving on project 2 before deciding the fix).

Decision trail: started by assessing the general scout's health/coverage on project 2 — found it healthy and well-calibrated but narrowed to an HTTP-error-log watcher, because the full specialist fleet + shared scratchpad squeeze general into the residual surface, and the profile it orients off is behavior-light and lags new products. First considered expanding the profile builder (new `builders.py`/`schema.py` sections + version bump), but rejected it as a maintenance treadmill that can never keep up with new products. Chose instead to teach the scout to discover the project itself via MCP tools, with the coverage map made durable and periodically re-sense-checked against both live data and the evolving MCP tool surface (the one substrate we can rely on to track PostHog's growing product offering). Kept the body lean and pushed the concrete discovery moves into a progressively-disclosed reference, matching the rest of the fleet's shape.
