### PR TITLE
fix(postgres): recognize read-replica timeout QueryTimeoutException at activity layer

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -440,6 +440,15 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "max_standby_streaming_delay on the replica, enable hot_standby_feedback, or point the "
                 "connection at the primary database, then re-enable the sync."
             ),
+            # Activity-layer twin of the `QueryTimeoutException` key above, for the read-replica path:
+            # when a recovery conflict forces the offset-chunking fallback and a chunk then hits the
+            # 10-minute statement_timeout, `get_rows` raises `QueryTimeoutException` with this message.
+            # The class-name key only matches once Temporal wraps the failure; the activity-level check
+            # sees the raw `str(e)`, which is the bare message with no class name. Without a message key
+            # the timeout goes unrecognised there and the activity burns its full retry budget re-reading
+            # from the start into the same conflicting, overloaded replica before the workflow gives up.
+            # Match the stable leading phrase of our own crafted message.
+            "Reading from your read replica timed out": None,
             "DiskFull": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
             "No space left on device": "Source database ran out of disk space. Free up disk space on your database server or add an index on your incremental field to reduce temp file usage.",
             # The source server itself ran out of memory (PostgreSQL SQLSTATE 53200, psycopg's

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -626,6 +626,26 @@ class TestPostgresSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw activity-level message (what `_handle_import_error` sees via str(e)) — no class name.
+            # Raised by get_rows when a recovery conflict forces offset chunking and a chunk then hits
+            # the 10-minute statement timeout.
+            "Reading from your read replica timed out: Postgres canceled the initial read with a "
+            "recovery conflict, and the chunked fallback read still couldn't finish within the 10 "
+            "minute statement timeout. Increase max_standby_streaming_delay or enable "
+            "hot_standby_feedback on the replica, or sync from the primary database instead.",
+            # Temporal-wrapped message (what the workflow-level check sees) — carries the class name.
+            "QueryTimeoutException: Reading from your read replica timed out: Postgres canceled the "
+            "initial read with a recovery conflict",
+        ],
+    )
+    def test_read_replica_timeout_query_timeout_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Read-replica timeout error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # Raw psycopg message (what the activity-level check sees via str(e)) — no class name.
             "permission denied for table brand",
             "permission denied for view posthog_areas",


### PR DESCRIPTION
## Problem

Error tracking surfaced a `SerializationFailure: canceling statement due to conflict with recovery` for the Postgres data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ef207-40a3-7181-a93c-10bf7df295f0)). The stack genuinely originates in the source: the top in-app frame is `postgres.py:offset_chunking`, and the captured event is a chained exception ending in a `QueryTimeoutException`.

The flow:

1. The server-cursor read in `get_rows` hits a recovery conflict on the customer's read replica (`SerializationFailure: ...conflict with recovery`). This is **correctly** recognised and routes into the in-process offset-chunking fallback.
2. A chunk in that fallback then exhausts the 10-minute `statement_timeout` (`QueryCanceled`), and — because we only reached chunking via a recovery conflict — `get_rows` re-raises a non-retryable `QueryTimeoutException` with actionable guidance ("Increase max_standby_streaming_delay or enable hot_standby_feedback on the replica, or sync from the primary database instead").

`QueryTimeoutException` is meant to be non-retryable, and it is listed in `PostgresSource.get_non_retryable_errors` — but only by **class name**. The non-retryable check runs at two layers:

- **Workflow layer** sees Temporal's wrapped failure string, which carries the class name (`QueryTimeoutException: ...`), so the class-name key matches there.
- **Activity layer** (`_handle_import_error`) matches against `str(e)` — the bare message, with no class name. So the class-name key does **not** match here.

The bare read-replica message starts with `Reading from your read replica timed out:` and carries no class name, so no key matches it at the activity layer. The activity re-raises a plain `QueryTimeoutException` instead of routing through `handle_non_retryable_error`, and Temporal retries the whole activity to its full budget — re-reading from the start into the same conflicting, overloaded replica each attempt (the exact thing the message tells the user to stop doing) and re-capturing the exception each time — before the workflow-layer check finally disables the sync.

This is the same dual-layer split the existing `XminUnsupportedError` (+ `xmin replication`) and `InsufficientPrivilege` (+ `permission denied for`) entries already document and solve by adding a message fragment. It is also the read-replica sibling of #65151, which adds the `has an appropriate index` fragment for the *incremental-index* statement-timeout `QueryTimeoutException`; that message and this one are different, so the two fixes are complementary and don't overlap.

## Changes

Add the `"Reading from your read replica timed out"` message fragment to `PostgresSource.get_non_retryable_errors`. This is the stable leading phrase of our own crafted message — no host/IP/port/timestamp/id in it — so it's low-false-positive and only matches the read-replica timeout the source has **already** classified as non-retryable. The timeout is now recognised at the activity layer too, capping retries via `handle_non_retryable_error` instead of burning the full budget re-reading into the overloaded replica.

The value is `None` (surface the raw message), consistent with the sibling `QueryTimeoutException` entry — the raised message is already an actionable, user-facing string.

## How did you test this code?

I'm an agent. Added a regression test to `TestPostgresSourceNonRetryableErrors`:
- `test_read_replica_timeout_query_timeout_is_non_retryable` — asserts both the raw activity-level message and the Temporal-wrapped (class-name-carrying) message are recognised as non-retryable. Verified the raw message matched **no** pre-existing key before the change, so the test genuinely covers the gap.

Ran locally (`uv run python -m pytest`): `TestPostgresSourceNonRetryableErrors` — 74 passed. `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres import source. Confirmed via the PostHog error-tracking MCP tools that the surfaced exception is a `QueryTimeoutException` whose stack originates in `postgres.py:offset_chunking` (not in serialized log context), then traced the activity- vs workflow-layer non-retryable checks to find the gap. Checked open PRs (including the maintainer's) and confirmed #65151 fixes the *incremental-index* variant and #65349 fixes connect-timeout-during-reconnect — neither covers the read-replica timeout message, so this is a non-duplicate, complementary fix.

Decision: a sustained read-replica recovery conflict whose chunked fallback also times out is an upstream/config condition (replica `max_standby_streaming_delay`/`hot_standby_feedback`, or read from primary) — nothing for us to do but stop retrying — so this extends the activity-layer non-retryable recognition rather than changing retry/backoff behaviour.
