### PR TITLE
fix(onboarding): point no-events settings link to project-details

### DIFF
--- a/frontend/src/layout/navigation/projectNoticeLogic.tsx
+++ b/frontend/src/layout/navigation/projectNoticeLogic.tsx
@@ -385,7 +385,7 @@ export const projectNoticeLogic = kea<projectNoticeLogicType>([
                                     </Link>{' '}
                                     or grab your project API key/HTML snippet from{' '}
                                     <Link
-                                        to={urls.settings('environment-details', 'variables')}
+                                        to={urls.settings('project-details', 'variables')}
                                         data-attr="real_project_with_no_events-settings"
                                     >
                                         Project Settings


### PR DESCRIPTION
## Problem

A user going through onboarding who clicks "grab your project API key" from the "this project has no events yet" notice lands on `/settings/environment-details#variables` instead of `/settings/project-details#variables`. The `#variables` anchor (where the project token/ID lives) never resolves, so they don't get scrolled to their API key.

## Changes

The notice's settings link in `projectNoticeLogic.tsx` used `urls.settings('environment-details', 'variables')`. The settings logic remaps every `environment-*` section to `project-*` when rendering, so the rendered section is `project-details` and a link to `environment-details` can't find the `variables` anchor. Changed the link to `urls.settings('project-details', 'variables')` to match the section as it's actually exposed.

## How did you test this code?

I'm an agent. This is a one-line URL fix; no automated tests were added. The target section (`project-details`) matches what `settingsSceneLogic` canonicalizes to and what existing settings scene tests assert as the project-level details section.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced the bad link from the reported URL: the "no events yet" banner (`real_project_with_no_events` case in `frontend/src/layout/navigation/projectNoticeLogic.tsx`) was the only place constructing `settings('environment-details', 'variables')`. The settings section remapping (`settingsLogic.ts` / `settingsSceneLogic.ts`) keeps `environment-details` un-remapped due to a `-details` backwards-compat exception, but the rendered sections array always exposes it as `project-details`, so the anchor lookup failed. Fix aligns the link with the rendered section ID.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BAB645UBA/p1782189455258439)*
