### PR TITLE
fix(google_ads): retry transient OAuth token-refresh timeout at client init

### DIFF
--- a/posthog/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/posthog/temporal/data_imports/sources/google_ads/google_ads.py
@@ -1,3 +1,4 @@
+import time
 import typing
 import datetime as dt
 import collections.abc
@@ -14,6 +15,7 @@ from google.ads.googleads.v23.enums import types as ga_enums
 from google.ads.googleads.v23.resources import types as ga_resources
 from google.ads.googleads.v23.services import types as ga_services
 from google.ads.googleads.v23.services.services.google_ads_service import GoogleAdsServiceClient
+from google.auth import exceptions as google_auth_exceptions
 from google.oauth2 import service_account
 from google.protobuf.json_format import MessageToJson
 
@@ -64,6 +66,37 @@ def _ensure_grpc_receive_limit() -> None:
     options.append((_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_KEY, GRPC_MAX_RECEIVE_MESSAGE_LENGTH))
 
 
+# ``GoogleAdsClient`` performs an OAuth token refresh at construction, reaching Google's token
+# endpoint over the network. A transient hiccup on that hop (e.g. a proxy connection timeout)
+# surfaces as ``google.auth.exceptions.TransportError`` — the stored credential is fine, only the
+# request failed, so a short backoff usually clears it. Riding it out here avoids failing (and
+# re-capturing) the whole import activity before a single row is fetched. Auth rejections surface
+# as ``RefreshError`` (handled as non-retryable elsewhere), not ``TransportError``, so retrying
+# here never masks bad credentials.
+_MAX_CLIENT_INIT_ATTEMPTS = 4
+
+
+def _load_client_with_transient_retry(
+    config_dict: dict[str, object],
+    *,
+    max_attempts: int = _MAX_CLIENT_INIT_ATTEMPTS,
+) -> GoogleAdsClient:
+    """Build a ``GoogleAdsClient`` from a config dict, retrying a transient transport failure.
+
+    Only the token-refresh network hop is retried; a ``RefreshError`` (revoked/expired credential)
+    or any other error re-raises immediately so the caller's non-retryable handling still applies.
+    """
+    attempt = 0
+    while True:
+        try:
+            return GoogleAdsClient.load_from_dict(config_dict)
+        except google_auth_exceptions.TransportError:
+            attempt += 1
+            if attempt >= max_attempts:
+                raise
+            time.sleep(min(2 * attempt, 30))
+
+
 def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> GoogleAdsClient:
     """Initialize a `GoogleAdsClient` with provided config."""
     _ensure_grpc_receive_limit()
@@ -90,7 +123,7 @@ def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> Googl
         if login_customer_id is not None:
             config_dict["login_customer_id"] = login_customer_id
 
-        client = GoogleAdsClient.load_from_dict(config_dict)
+        client = _load_client_with_transient_retry(config_dict)
     else:
         credentials = service_account.Credentials.from_service_account_info(
             {

--- a/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -7,6 +7,7 @@ from google.ads.googleads.errors import GoogleAdsException
 from google.ads.googleads.v23.enums import types as ga_enums
 from google.ads.googleads.v23.errors.types.errors import ErrorCode, GoogleAdsError, GoogleAdsFailure
 from google.ads.googleads.v23.errors.types.request_error import RequestErrorEnum
+from google.auth import exceptions as google_auth_exceptions
 
 from posthog.models.integration import Integration
 from posthog.temporal.data_imports.sources.generated_configs import GoogleAdsSourceConfig
@@ -15,6 +16,7 @@ from posthog.temporal.data_imports.sources.google_ads.google_ads import (
     GoogleAdsColumn,
     GoogleAdsTable,
     _is_invalid_page_token_error,
+    _load_client_with_transient_retry,
     _search_as_arrow_tables,
 )
 from posthog.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
@@ -443,3 +445,60 @@ class TestSearchPageTokenResumption:
 
         assert always_failing.calls == [""]
         assert manager.saved_states == []
+
+
+_CLIENT_PATH = "posthog.temporal.data_imports.sources.google_ads.google_ads.GoogleAdsClient"
+_SLEEP_PATH = "posthog.temporal.data_imports.sources.google_ads.google_ads.time.sleep"
+
+
+class TestLoadClientTransientRetry:
+    def test_retries_transport_error_then_succeeds(self):
+        client = object()
+        load = mock.Mock(
+            side_effect=[
+                google_auth_exceptions.TransportError("timed out"),
+                google_auth_exceptions.TransportError("timed out"),
+                client,
+            ]
+        )
+
+        with mock.patch(_CLIENT_PATH) as ga_client, mock.patch(_SLEEP_PATH) as sleep:
+            ga_client.load_from_dict = load
+            result = _load_client_with_transient_retry({"refresh_token": "x"})
+
+        assert result is client
+        assert load.call_count == 3
+        # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_reraises_after_exhausting_attempts(self):
+        load = mock.Mock(side_effect=google_auth_exceptions.TransportError("timed out"))
+
+        with mock.patch(_CLIENT_PATH) as ga_client, mock.patch(_SLEEP_PATH) as sleep:
+            ga_client.load_from_dict = load
+            with pytest.raises(google_auth_exceptions.TransportError):
+                _load_client_with_transient_retry({"refresh_token": "x"}, max_attempts=3)
+
+        assert load.call_count == 3
+        # One sleep fewer than attempts — no backoff after the final failure.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            # A revoked/expired credential surfaces as RefreshError, not TransportError — it must
+            # not be retried as if it were transient (it's handled as non-retryable elsewhere).
+            google_auth_exceptions.RefreshError("invalid_grant"),
+            ValueError("boom"),
+        ],
+    )
+    def test_non_transient_error_is_not_retried(self, error):
+        load = mock.Mock(side_effect=error)
+
+        with mock.patch(_CLIENT_PATH) as ga_client, mock.patch(_SLEEP_PATH) as sleep:
+            ga_client.load_from_dict = load
+            with pytest.raises(type(error)):
+                _load_client_with_transient_retry({"refresh_token": "x"})
+
+        assert load.call_count == 1
+        assert sleep.call_args_list == []


### PR DESCRIPTION
## Problem

Google Ads imports intermittently fail with `TimeoutError: timed out` originating in `posthog/temporal/data_imports/sources/google_ads/google_ads.py` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef330-c1c3-7ac0-9281-0756ab0357fd)).

The captured chain is `TimeoutError` → `MaxRetryError` → `ProxyError('Cannot connect to proxy.', TimeoutError('timed out'))` → `google.auth.exceptions.TransportError`, with the message shape:

```
HTTPSConnectionPool(host='accounts.google.com', port=443): Max retries exceeded with url: <redacted token endpoint> (Caused by ProxyError('Cannot connect to proxy.', TimeoutError('timed out')))
```

The in-app frames are `get_rows` → `google_ads_client` → `GoogleAdsClient.load_from_dict`. `load_from_dict` performs an OAuth token refresh at client construction, which makes an HTTP request to Google's token endpoint. When the network hop to that endpoint times out, the whole import activity fails before a single row is fetched.

This is a **transient infrastructure error**, not a user/upstream config problem — the stored credential is valid, only the network request failed. So it stays retryable (it is *not* added to `NonRetryableErrors`). Today it is retried at the Temporal activity level, but that means a full activity restart (re-fetch schemas, rebuild the client, restart pagination) and one captured error per blip.

## Changes

Wrap the client construction in `_load_client_with_transient_retry`, which retries `google.auth.exceptions.TransportError` with bounded backoff (`min(2 * attempt, 30)`, up to 4 attempts) before giving up. This rides out a transient token-endpoint hiccup in-process instead of failing the activity.

- Only `TransportError` (google-auth's transport/network failure signal) is retried. Credential rejections surface as `RefreshError` — a sibling, already classified non-retryable — so this never masks bad credentials.
- After attempts are exhausted, the error re-raises and Temporal's activity retry still applies. Nothing becomes non-retryable.
- Scope is deliberately narrow: it mirrors the existing in-process transient-retry pattern for this source (#65293 covers transient gRPC `UNAVAILABLE` during `search`); this covers the distinct, previously-uncovered token-refresh call site at client init.

## How did you test this code?

I'm an agent (Claude Code). I added unit tests at the same layer as the fix and ran them; I did not perform manual testing.

`pytest posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py` — 63 passed, including the new `TestLoadClientTransientRetry`:
- retries a `TransportError` then succeeds, asserting the backoff schedule
- re-raises after exhausting attempts
- does **not** retry non-transient errors (`RefreshError`, `ValueError`)

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `google_ads` source. Pulled the issue's full stack trace via the error-tracking MCP tools, traced the call path into `google_ads.py`, and classified the failure: a transient proxy/connection timeout during the OAuth token refresh at client construction.

Decision: not a user/upstream error (so not added to `NonRetryableErrors`) and not a code bug — a transient infra blip. Rather than leaving it to rely solely on full-activity Temporal retries, I added a scoped in-process retry with backoff, matching the team's established pattern for this source (#65293, and similar transient connect/timeout retries across other sources). Checked open PRs (including the maintainer's) to confirm no existing PR covers this token-refresh call site.

No skills were applicable to this change.
