### PR TITLE
feat(data-warehouse): enforce read-only Snowflake queries our side

### DIFF
--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -326,6 +326,18 @@ def ensure_read_only_raw_snowflake_statement(sql: str) -> str:
     statements = [statement for statement in sqlparse.parse(sql) if str(statement).strip(" \t\r\n;")]
     if len(statements) != 1 or statements[0].get_type() != "SELECT":
         raise ExposedHogQLError(RAW_SNOWFLAKE_READ_ONLY_ERROR)
+    # Snowflake has no read-only session/transaction switch — the Postgres path sets
+    # default_transaction_read_only on the connection, but Snowflake offers no equivalent.
+    # So this single-read-only-SELECT gate is the enforcement boundary (backed at runtime
+    # by the MULTI_STATEMENT_COUNT=1 session pin). As defense in depth, reject any DDL, or
+    # any DML keyword other than SELECT, appearing anywhere in the statement — e.g. a write
+    # smuggled into a subquery. String values and quoted identifiers aren't tagged DML/DDL,
+    # so a literal or alias like 'DELETE' is unaffected.
+    for token in statements[0].flatten():
+        if token.ttype in sqlparse_tokens.DDL:
+            raise ExposedHogQLError(RAW_SNOWFLAKE_READ_ONLY_ERROR)
+        if token.ttype in sqlparse_tokens.DML and token.value.upper() != "SELECT":
+            raise ExposedHogQLError(RAW_SNOWFLAKE_READ_ONLY_ERROR)
     return sql
 
 
@@ -923,12 +935,14 @@ class HogQLQueryExecutor:
     def _execute_direct_snowflake_query(self) -> None:
         """Execute a single read-only statement against the source's Snowflake account.
 
-        Write safety has two layers. The statement is parsed and rejected unless it is a
-        single SELECT (`ensure_read_only_raw_snowflake_statement`), and HogQL-authored
-        queries only ever emit SELECT. Snowflake has no read-only transaction mode (the
-        backstop the Postgres/MySQL paths use), so the configured connection role MUST be
-        granted SELECT-only on the queried objects — that least-privilege role is the
-        authoritative guard if the parser is ever bypassed.
+        Snowflake has no read-only session/transaction switch — the Postgres path sets
+        default_transaction_read_only on the connection, but Snowflake offers no equivalent.
+        So PostHog enforces read-only itself rather than trusting the connection's role:
+        the statement is rejected unless it is a single read-only SELECT
+        (`ensure_read_only_raw_snowflake_statement`), HogQL-authored queries only ever emit
+        SELECT, and the session pins MULTI_STATEMENT_COUNT=1 so the server refuses any
+        stacked statement. A least-privilege SELECT-only role is still recommended as
+        defense in depth, but is not the boundary we rely on.
         """
         assert self.direct_sql is not None
         assert self.direct_source_id is not None
@@ -952,6 +966,9 @@ class HogQLQueryExecutor:
             with self.timings.measure("snowflake_execute"), observe_direct_query("snowflake"):
                 with snowflake_implementation.connect(source_config) as connection:
                     with connection.cursor() as cursor:
+                        # Server-side backstop: refuse stacked statements regardless of what the
+                        # connector default is, so the single-statement parse gate can't be bypassed.
+                        cursor.execute("ALTER SESSION SET MULTI_STATEMENT_COUNT = 1")
                         cursor.execute(f"ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = {statement_timeout_seconds}")
                         cursor.execute(self.direct_sql, self.direct_values or None)
                         results = self._fetch_capped_snowflake_rows(cursor)

--- a/posthog/hogql/test/test_direct_snowflake_query.py
+++ b/posthog/hogql/test/test_direct_snowflake_query.py
@@ -166,7 +166,10 @@ class TestDirectSnowflakeQuery(APIBaseTest):
                 response = executor.execute()
 
         executed_statements = [call.args[0] for call in cursor.execute.call_args_list]
-        self.assertTrue(executed_statements[0].startswith("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS"))
+        # Read-only is enforced our side: pin single-statement and the statement timeout
+        # on the session before the query runs.
+        self.assertEqual(executed_statements[0], "ALTER SESSION SET MULTI_STATEMENT_COUNT = 1")
+        self.assertTrue(executed_statements[1].startswith("ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS"))
         self.assertEqual(executor.direct_dialect, "snowflake")
         self.assertEqual(response.results, [(1, "100.50")])
         # FIXED with scale 0 → Int64; scale 2 → Decimal (the bug that showed C_ACCTBAL as String).
@@ -200,12 +203,26 @@ class TestDirectSnowflakeQuery(APIBaseTest):
 
     @parameterized.expand(
         [
+            # Leading-keyword writes (rejected by the SELECT classification).
             ("delete", "DELETE FROM CUSTOMER WHERE C_ID = 1"),
             ("insert", "INSERT INTO CUSTOMER VALUES (1)"),
             ("update", "UPDATE CUSTOMER SET C_NAME = 'x'"),
             ("drop", "DROP TABLE CUSTOMER"),
+            ("create", "CREATE TABLE t (c int)"),
+            ("alter", "ALTER TABLE CUSTOMER ADD COLUMN c int"),
+            ("truncate", "TRUNCATE TABLE CUSTOMER"),
             ("multiple_statements", "SELECT 1; DROP TABLE CUSTOMER"),
             ("merge", "MERGE INTO CUSTOMER USING staging ON CUSTOMER.C_ID = staging.id WHEN MATCHED THEN DELETE"),
+            # Snowflake side-effecting statements that classify as UNKNOWN, not SELECT.
+            ("call_procedure", "CALL my_writing_proc()"),
+            ("copy_into", "COPY INTO CUSTOMER FROM @my_stage"),
+            ("put_file", "PUT file:///tmp/x @my_stage"),
+            ("get_file", "GET @my_stage file:///tmp/x"),
+            ("grant", "GRANT SELECT ON CUSTOMER TO ROLE reporting"),
+            ("use_database", "USE DATABASE other_db"),
+            # Writes smuggled into an otherwise SELECT-classified statement.
+            ("write_in_subquery", "SELECT * FROM (DELETE FROM CUSTOMER RETURNING C_ID)"),
+            ("write_in_cte", "WITH x AS (INSERT INTO CUSTOMER VALUES (1) RETURNING C_ID) SELECT * FROM x"),
         ]
     )
     def test_raw_query_rejects_non_select(self, _name: str, query: str):
@@ -225,3 +242,38 @@ class TestDirectSnowflakeQuery(APIBaseTest):
         # The statement is rejected before any connection is opened.
         mock_validate.assert_not_called()
         self.assertIsNone(executor.direct_sql)
+
+    @parameterized.expand(
+        [
+            ("plain_select", "SELECT C_ID FROM CUSTOMER"),
+            ("cte_select", "WITH x AS (SELECT 1 AS v) SELECT v FROM x"),
+            # UDFs are read-only in Snowflake; a function call in a SELECT is fine.
+            ("udf_call", "SELECT my_udf(C_ID) FROM CUSTOMER"),
+            # A write keyword inside a string literal must not trip the token scan.
+            ("write_word_in_string", "SELECT C_ID FROM CUSTOMER WHERE C_STATUS = 'DELETE'"),
+        ]
+    )
+    def test_raw_query_allows_read_only_selects(self, _name: str, query: str):
+        source = self._create_source()
+
+        executor = HogQLQueryExecutor(
+            query=query,
+            team=self.team,
+            connection_id=str(source.id),
+            send_raw_query=True,
+        )
+
+        implementation, _cursor = self._mock_snowflake_connection(
+            rows=[(1,)],
+            description=[("C_ID", FIXED, None, None, None, 0, None)],
+        )
+
+        with patch(
+            "posthog.hogql.query.validate_direct_snowflake_source_config",
+            return_value=(implementation, MagicMock()),
+        ):
+            with patch.object(HogQLQueryExecutor, "_capture_send_raw_query_translation_error"):
+                executor.execute()
+
+        # The statement passed the read-only gate and reached execution unchanged.
+        self.assertEqual(executor.direct_sql, query)


### PR DESCRIPTION
## Problem

Stacked on #65259.

The direct Snowflake path enforced read-only with a single-`SELECT` parse check, and leaned on the customer configuring a least-privilege role as the real backstop. That's weaker than the other direct sources: Postgres sets `default_transaction_read_only=on` on the connection and MySQL uses `START TRANSACTION READ ONLY` — both enforce read-only *server-side regardless of the user's grants*. Snowflake has no equivalent switch, so we were trusting the customer's role config. We should enforce read-only ourselves instead.

## Changes

Snowflake genuinely has no read-only session/transaction parameter (verified against the docs — read-only there is only achievable via role privileges or reactive alert/auto-kill). So the enforcement boundary is the statement gate, and this PR makes it the thing we actually rely on:

- **Pin `MULTI_STATEMENT_COUNT = 1`** on the session before running the query, so the server refuses any stacked statement independent of the connector default.
- **Harden the raw-statement gate** (`ensure_read_only_raw_snowflake_statement`): beyond the existing single-`SELECT` classification, reject any DDL — or any DML keyword other than `SELECT` — appearing *anywhere* in the statement, catching a write smuggled into a subquery or CTE. The scan keys on sqlparse's `DML`/`DDL` token types, so string values and quoted identifiers (e.g. `WHERE status = 'DELETE'`) are unaffected.

A least-privilege SELECT-only role is still **recommended as defense in depth**, but is no longer the boundary we depend on — and we don't block a customer from connecting with broader privileges.

## How did you test this code?

I'm an agent (Claude Code); no manual Snowflake testing. Automated: **60 passed** in `test_direct_snowflake_query`, including new rejections for `CALL`/`COPY`/`PUT`/`GET`/`GRANT`/`USE`/`CREATE`/`ALTER`/`TRUNCATE` and writes smuggled into a subquery/CTE, plus positive cases proving plain/CTE/UDF selects and a write keyword inside a string literal still pass. `ruff` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tool:** Claude Code (Opus 4.8).
- **Key decision:** enforce read-only on our side rather than blocking connections that use an over-privileged role (per maintainer direction). Confirmed via Snowflake docs that there is no read-only session parameter to mirror the Postgres mechanism, so the parser gate + `MULTI_STATEMENT_COUNT=1` is the enforcement, and the least-privilege role becomes defense-in-depth.
- **Why the token scan keys on DML/DDL types:** `SELECT` is itself tagged `Keyword.DML` by sqlparse, and reserved words inside string literals or quoted identifiers aren't tagged — so matching on token type (rejecting non-`SELECT` DML and all DDL) avoids false-positives on column names and string values.
