### PR TITLE
fix(experiments): metric recalculation workflow should store the CH query id

### DIFF
--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -326,6 +326,7 @@ def _store_result(
     status: str,
     result: dict | None,
     error_message: str | None,
+    query_id: str | None = None,
 ) -> None:
     ExperimentMetricResult.objects.update_or_create(
         experiment_id=experiment_id,
@@ -336,7 +337,7 @@ def _store_result(
             "query_from": query_from,
             "status": status,
             "result": result,
-            "query_id": None,
+            "query_id": query_id,
             "completed_at": timezone.now() if status == ExperimentMetricResult.Status.COMPLETED else None,
             "error_message": error_message,
         },
@@ -482,6 +483,12 @@ def _calculate_experiment_metric_for_recalculation_sync(
         )
         recalc_fp = compute_recalc_fingerprint(config_fp, recalculation_id)
 
+        # Deterministic per-metric-per-run id. ClickHouse stamps it into the query_id as
+        # `{team_id}_{client_query_id}_{random}`, so the stored value is a greppable prefix for
+        # `system.query_log` (covers every attempt, including Temporal retries). Bound before the try so the
+        # failure paths can always persist it.
+        client_query_id = f"experiment_metric_recalc_{recalculation_id}_{metric_uuid}"
+
         calc_started_at = time.perf_counter()
         try:
             # Metric build + query live inside the try so unexpected shapes surface as a calculation-step failure.
@@ -497,6 +504,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 # warehouse HogQL access control is enforced against an accountable user instead of bypassed.
                 user=experiment.created_by,
             )
+
             # Attribute CH load back to this team + product so query_log analysis can tell whose recalc is
             # expensive without reverse-engineering the trigger string.
             tag_queries(
@@ -504,6 +512,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 team_id=state.team_id,
                 product=Product.EXPERIMENTS,
                 feature=Feature.CACHE_WARMUP,
+                client_query_id=client_query_id,
             )
             result = runner.run(execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
             result_dict = result.model_dump(mode="json")
@@ -517,6 +526,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 status=ExperimentMetricResult.Status.COMPLETED,
                 result=result_dict,
                 error_message=None,
+                query_id=client_query_id,
             )
             _capture_experiment_metric_event(
                 experiment,
@@ -540,6 +550,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 status=ExperimentMetricResult.Status.FAILED,
                 result=None,
                 error_message=message,
+                query_id=client_query_id,
             )
             logger.warning(
                 "Experiment metric recalculation failed due to insufficient data",
@@ -584,6 +595,7 @@ def _calculate_experiment_metric_for_recalculation_sync(
                 status=ExperimentMetricResult.Status.FAILED,
                 result=None,
                 error_message=message,
+                query_id=client_query_id,
             )
             _record_failure(recalculation_id, metric_uuid, "calculation", message)
             logger.exception(

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -453,6 +453,19 @@ class TestCalculateActivity(BaseTest):
         row = ExperimentMetricResult.objects.get(experiment=exp, metric_uuid="m1")
         assert row.query_from == exp.start_date
 
+    def test_query_id_is_persisted_on_result_row(self):
+        # The deterministic client_query_id is stamped into ClickHouse's query_id and stored on the row so a
+        # metric's executions are greppable in system.query_log by the `{team}_{client_query_id}_` prefix.
+        exp = self._experiment(flag_key="calc-query-id", metrics=[_mean_metric("m1")])
+        recalc = self._recalc(exp, metric_uuids=["m1"])
+
+        with patch("products.experiments.backend.temporal.recalculation_logic.ExperimentQueryRunner") as mock_runner:
+            mock_runner.return_value.run.return_value.model_dump.return_value = {}
+            _calculate(exp.id, "m1", str(recalc.id), _QUERY_TO)
+
+        row = ExperimentMetricResult.objects.get(experiment=exp, metric_uuid="m1")
+        assert row.query_id == f"experiment_metric_recalc_{recalc.id}_m1"
+
     def test_multiple_failures_accumulate_in_metric_errors(self):
         # Two metrics fail in sequence (not in parallel — that would need threads + a real Postgres). Pins the
         # merge-into-dict behavior: each failure writes its own entry keyed by metric_uuid, no overwriting.


### PR DESCRIPTION
## Problem

The metrics recalculation workflow runs a ClickHouse query per metric but hardcoded `ExperimentMetricResult.query_id` to `None`, so a result row can't be correlated back to its execution in `system.query_log` when debugging a slow or failed recalc.

## Changes

The calc activity builds a `client_query_id` of the form `experiment_metric_recalc_{recalculation_id}_{metric_uuid}`, passes it to the existing `tag_queries(...)` call, and stores it on the result row. ClickHouse stamps it into the real `query_id` as `{team_id}_{client_query_id}_{random}`, so the stored value is a greppable prefix that matches every execution for that metric, including retries. We store this prefix, not the exact `query_id`, whose random suffix is generated inside `sync_execute` and never returned.

- `products/experiments/backend/temporal/recalculation_logic.py`

## How did you test this code?

Validated end to end against local ClickHouse: confirmed the stored `query_id` is a prefix of the real `system.query_log` `query_id` for a recalc run, and that the prefix matches all per-metric executions.

```bash
pnpm turbo run backend:test --filter=@posthog/products-experiments
```

![cat-type-small](https://github.com/user-attachments/assets/7d1e57f8-299a-4ae7-9bc2-3a72a0619e28)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 (1M context)
Manually refactored: **no**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Stored the deterministic `client_query_id` (`experiment_metric_recalc_{recalc_id}_{metric_uuid}`), not the exact ClickHouse `query_id`. The real id's random suffix is generated inside `sync_execute` and never returned, so it's unrecoverable; the prefix is greppable in `system.query_log` and matches all attempts.
- Reused the existing `query_id` column and the existing `tag_queries(...)` call site rather than adding a migration or new plumbing. ClickHouse derives the full id from the `client_query_id` tag, so no execute-path signature changes were needed.
- Bound `client_query_id` before the `try` so both failure paths persist it and runner-construction errors can't trigger `UnboundLocalError`.