### PR TITLE
fix(postgres): re-raise connection drops from the child-partition PK fallback

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -1759,6 +1759,13 @@ def _get_primary_keys(
         cursor.execute(child_partition_pk_query)
         child_pk_rows = cursor.fetchall()
     except Exception as e:
+        # A transient connection drop here means the fallback never ran — swallowing it would
+        # capture noise and wrongly report "no primary key" off a dead cursor. Re-raise so the
+        # setup retry loop reconnects (mirrors the unwrapped primary query above and the
+        # duplicate-PK probe). Genuine query-incompatibility errors (e.g. an engine that can't
+        # bind this pg_catalog query) still degrade to best-effort.
+        if _is_connection_dropped_error(e):
+            raise
         capture_exception(e)
         logger.warning(f"Child-partition fallback query failed for {table_name}: {e}")
     if len(child_pk_rows) > 0:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3871,6 +3871,39 @@ class TestGetPrimaryKeys:
             result = _get_primary_keys(cast(Any, dj_cursor), "public", "test_partitioned_inconsistent_pk", logger)
             assert result is None
 
+    def test_reraises_connection_drop_during_child_partition_fallback(self):
+        logger = structlog.get_logger()
+        cursor = MagicMock()
+        # Primary PK query returns no rows, so the child-partition fallback runs.
+        cursor.fetchall.return_value = []
+        # The fallback query then hits a transient connection drop. It must propagate to the setup
+        # retry loop (stays retryable), not be swallowed as "no primary key" + captured as noise.
+        cursor.execute.side_effect = [None, psycopg.OperationalError("the connection is lost")]
+        module = "posthog.temporal.data_imports.sources.postgres.postgres"
+        with (
+            patch(f"{module}._explain_query"),
+            patch(f"{module}.capture_exception") as mock_capture,
+        ):
+            with pytest.raises(psycopg.OperationalError, match="the connection is lost"):
+                _get_primary_keys(cast(Any, cursor), "public", "events", logger)
+        mock_capture.assert_not_called()
+
+    def test_captures_and_degrades_on_non_connection_error_in_child_partition_fallback(self):
+        logger = structlog.get_logger()
+        cursor = MagicMock()
+        cursor.fetchall.return_value = []
+        # A genuine query-incompatibility error in the best-effort fallback still degrades to
+        # "no primary key" and is captured — only transient drops are re-raised.
+        cursor.execute.side_effect = [None, psycopg.errors.UndefinedColumn("boom")]
+        module = "posthog.temporal.data_imports.sources.postgres.postgres"
+        with (
+            patch(f"{module}._explain_query"),
+            patch(f"{module}.capture_exception") as mock_capture,
+        ):
+            result = _get_primary_keys(cast(Any, cursor), "public", "events", logger)
+        assert result is None
+        mock_capture.assert_called_once()
+
 
 class TestGetLeadingIndexColumns:
     """Unit tests for the leading-index-column helper used to flag unindexed


### PR DESCRIPTION
## Problem

Error tracking surfaced a handled `OperationalError: the connection is lost` (psycopg) originating in `_get_primary_keys` at `posthog/temporal/data_imports/sources/postgres/postgres.py` (the `cursor.execute` of the child-partition PK fallback query).

The child-partition fallback wraps its query in `try/except Exception`, calls `capture_exception(e)`, logs a warning, and degrades to "no primary key". That is the right behavior for a query an engine can't run (e.g. a Postgres-wire-compatible backend that can't bind the `pg_catalog` query) — but it's wrong for a transient connection drop:

- The drop is a transient infra blip, so it should stay retryable. The surrounding setup path already reconnects and retries on `_CONNECTION_DROPPED_ERROR_TYPES`, and the primary PK query a few lines above is deliberately left unwrapped so drops propagate there. The fallback swallowed them instead.
- Swallowing the drop returns a false "no primary key" off a now-dead cursor, and floods error tracking with handled-exception noise — exactly what other best-effort metadata lookups in this file avoid.

## Changes

In the child-partition fallback's `except` block, re-raise when `_is_connection_dropped_error(e)` is true so the drop propagates to the setup retry loop (reconnect on a fresh connection). Genuine query-incompatibility errors still degrade to best-effort and are captured as before.

This mirrors the fix for the sibling duplicate-PK probe (#65068), but targets the different function (`_get_primary_keys`) that this issue's stack trace points at.

## Decision: fixable bug, not user/upstream

`the connection is lost` is a transient connection drop — already listed in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`. It is **not** added to `NonRetryableErrors`: it must stay retryable. The bug was that our best-effort `except` was too broad and swallowed a transient that the retry machinery is designed to handle.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing.

Added two unit tests to `TestGetPrimaryKeys`:
- a transient connection drop in the fallback re-raises and is **not** captured
- a non-connection query error still degrades to `None` and is captured

```
.venv/bin/python -m pytest \
  posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestGetPrimaryKeys::test_reraises_connection_drop_during_child_partition_fallback \
  posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestGetPrimaryKeys::test_captures_and_degrades_on_non_connection_error_in_child_partition_fallback \
  posthog/temporal/data_imports/sources/postgres/test_postgres.py::TestIsConnectionDroppedError
# 24 passed
```

The remaining `TestGetPrimaryKeys` cases are `@pytest.mark.django_db` and need a live Postgres, unavailable in this sandbox. `ruff check` and `ruff format --check` pass on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres data-warehouse import source. Confirmed the issue in PostHog error tracking (stack trace points at `_get_primary_keys` → `psycopg.cursor.execute`, mechanism handled), read the source and its retry machinery, and judged this a fixable bug (too-broad `except` swallowing a transient) rather than a `NonRetryableErrors` candidate. Checked open PRs (including the maintainer's) and confirmed #65068 fixes the sibling duplicate-PK probe but not this function. No skills were applicable to this change.