### PR TITLE
fix(postgres): keep PostHog DB connection failures retryable in source setup

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/exceptions.py
+++ b/posthog/temporal/data_imports/sources/postgres/exceptions.py
@@ -16,3 +16,15 @@ class XminUnsupportedError(Exception):
     is listed in `PostgresSource.get_non_retryable_errors` to stop Temporal
     retrying into the same wall.
     """
+
+
+class PostHogDatabaseConnectionError(Exception):
+    """Raised when loading sync metadata from PostHog's own database fails to connect.
+
+    This is a PostHog-side infrastructure blip (e.g. a transient DNS failure resolving our
+    database host), not a problem with the customer's Postgres. Its message intentionally
+    avoids the connection-error substrings in `PostgresSource.get_non_retryable_errors`: a
+    failure reaching our database stringifies the same as a customer misconfiguration (e.g.
+    "Name or service not known"), and must stay retryable rather than be misclassified as
+    non-retryable and stop a healthy sync.
+    """

--- a/posthog/temporal/data_imports/sources/postgres/source.py
+++ b/posthog/temporal/data_imports/sources/postgres/source.py
@@ -1,6 +1,8 @@
 import logging
 from typing import TYPE_CHECKING, Optional, cast
 
+from django.db import OperationalError as DjangoOperationalError
+
 import structlog
 from psycopg import OperationalError
 from sshtunnel import BaseSSHTunnelForwarderError
@@ -802,13 +804,24 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 conn.close()
 
     def source_for_pipeline(self, config: PostgresSourceConfig, inputs: SourceInputs) -> SourceResponse:
-        from posthog.temporal.data_imports.sources.postgres.exceptions import CDCHandledExternally
+        from posthog.temporal.data_imports.sources.postgres.exceptions import (
+            CDCHandledExternally,
+            PostHogDatabaseConnectionError,
+        )
 
         from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
         ssh_tunnel = self.make_ssh_tunnel_func(config)
 
-        schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
+        # This reads sync metadata from PostHog's own database, not the customer's Postgres. A
+        # transient failure reaching our database here (e.g. a DNS blip resolving our host) raises
+        # the same "Name or service not known" wording a customer host misconfig would, which
+        # `get_non_retryable_errors` would misclassify as non-retryable and permanently stop a
+        # healthy sync. Re-raise as a retryable error whose message doesn't collide with those.
+        try:
+            schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
+        except DjangoOperationalError as e:
+            raise PostHogDatabaseConnectionError("Failed to load sync metadata from PostHog's database") from e
         schema_metadata = schema.schema_metadata or {}
         source_schema = (
             schema_metadata.get("source_schema") if isinstance(schema_metadata.get("source_schema"), str) else None

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -8,7 +8,10 @@ from freezegun import freeze_time
 from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from django.db import connection as django_connection
+from django.db import (
+    OperationalError as DjangoOperationalError,
+    connection as django_connection,
+)
 
 import psycopg
 import pyarrow as pa
@@ -24,7 +27,10 @@ from posthog.temporal.data_imports.pipelines.pipeline.utils import (
     TemporaryFileSizeExceedsLimitException,
 )
 from posthog.temporal.data_imports.sources.common.sql.predicates import ColumnTypeCategory, ValidatedRowFilter
-from posthog.temporal.data_imports.sources.postgres.exceptions import XminUnsupportedError
+from posthog.temporal.data_imports.sources.postgres.exceptions import (
+    PostHogDatabaseConnectionError,
+    XminUnsupportedError,
+)
 from posthog.temporal.data_imports.sources.postgres.partitioned_tables import (
     WINDOW_MAX_QUERY_CANCELED_RETRIES,
     WINDOW_MAX_SERIALIZATION_RETRIES,
@@ -237,6 +243,33 @@ class TestPostgresImplementationWiring:
     def test_get_incremental_filter_returns_filter_postgres_incremental_fields(self):
         impl = PostgresSource().get_implementation
         assert impl.get_incremental_filter() is filter_postgres_incremental_fields
+
+
+class TestPostgresSourceMetadataConnectionErrors:
+    def test_posthog_database_connection_failure_stays_retryable(self):
+        # `source_for_pipeline` first reads sync metadata from PostHog's own database. A transient
+        # connection failure there (e.g. a DNS blip resolving our host) surfaces the same
+        # "Name or service not known" wording a customer host misconfig would, so it must be
+        # re-raised as PostHogDatabaseConnectionError to avoid being misclassified as non-retryable.
+        source = PostgresSource()
+        source.make_ssh_tunnel_func = MagicMock(return_value=None)  # type: ignore[method-assign]
+
+        config = MagicMock()
+        inputs = MagicMock()
+
+        with patch(
+            "products.warehouse_sources.backend.models.external_data_schema.ExternalDataSchema"
+        ) as mock_schema_model:
+            mock_schema_model.objects.select_related.return_value.get.side_effect = DjangoOperationalError(
+                "[Errno -2] Name or service not known"
+            )
+            with pytest.raises(PostHogDatabaseConnectionError) as exc_info:
+                source.source_for_pipeline(config, inputs)
+
+        non_retryable = source.get_non_retryable_errors()
+        error_msg = str(exc_info.value)
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert not is_non_retryable, f"A PostHog-side DB connection failure must stay retryable: {error_msg}"
 
 
 class TestPostgresSourceNonRetryableErrors:

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -252,14 +252,15 @@ class TestPostgresSourceMetadataConnectionErrors:
         # "Name or service not known" wording a customer host misconfig would, so it must be
         # re-raised as PostHogDatabaseConnectionError to avoid being misclassified as non-retryable.
         source = PostgresSource()
-        source.make_ssh_tunnel_func = MagicMock(return_value=None)  # type: ignore[method-assign]
-
         config = MagicMock()
         inputs = MagicMock()
 
-        with patch(
-            "products.warehouse_sources.backend.models.external_data_schema.ExternalDataSchema"
-        ) as mock_schema_model:
+        with (
+            patch.object(PostgresSource, "make_ssh_tunnel_func", return_value=None),
+            patch(
+                "products.warehouse_sources.backend.models.external_data_schema.ExternalDataSchema"
+            ) as mock_schema_model,
+        ):
             mock_schema_model.objects.select_related.return_value.get.side_effect = DjangoOperationalError(
                 "[Errno -2] Name or service not known"
             )


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `OperationalError` from the Postgres data-warehouse import source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef347-8dfe-7f62-ac72-dc3d50ce7d7e)):

```
OperationalError: [Errno -2] Name or service not known
```

The top in-app frame is `source_for_pipeline` in `posthog/temporal/data_imports/sources/postgres/source.py`. That function starts by reading sync metadata from **PostHog's own application database**:

```python
schema = ExternalDataSchema.objects.select_related("source").get(id=inputs.schema_id)
```

This is a Django ORM query against our database, not the customer's Postgres (the customer connection happens later, via `psycopg`, inside `postgres_source(...)`). The stack confirms it: the failure is raised through `django.db.models.query` → `django.db.backends.postgresql.base` → `psycopg`, i.e. Django connecting to our DB. A transient blip resolving our host (`Name or service not known` is a DNS/getaddrinfo failure) surfaces here as `django.db.OperationalError`.

The bug is in how that error is classified. The caller (`import_data_activity_sync` → `_handle_import_error`) substring-matches `str(e)` against `PostgresSource.get_non_retryable_errors()`, which already lists `"Name or service not known"` — correct for the customer-DB path, where a host that doesn't resolve is a user misconfiguration that won't fix itself. But a PostHog-side infra blip stringifies identically, so it was being misclassified as a customer error and routed through `handle_non_retryable_error`, which permanently stops a perfectly healthy sync after a few attempts. A retry would have succeeded once DNS recovered.

## Changes

Wrap the metadata read in `source_for_pipeline` and re-raise Django connection failures as a new `PostHogDatabaseConnectionError`, whose message intentionally avoids the connection-error substrings in `get_non_retryable_errors`. The error no longer matches a customer pattern, so it's re-raised for Temporal to retry — the right behavior for a transient infrastructure failure.

The customer-DB path is deliberately untouched: a customer host that doesn't resolve still raises `psycopg.OperationalError("... Name or service not known")` from `postgres_source(...)` and remains correctly non-retryable. The distinction is the exception type and origin (our Django ORM vs. the customer's psycopg connection), not the message text.

## How did you test this code?

I'm an agent. I added a regression test (`TestPostgresSourceMetadataConnectionErrors`) that mocks the ORM `.get()` to raise `django.db.OperationalError("[Errno -2] Name or service not known")`, asserts `source_for_pipeline` re-raises `PostHogDatabaseConnectionError`, and asserts the resulting message is **not** matched by `get_non_retryable_errors` (i.e. stays retryable). I ran it together with the existing `TestPostgresSourceNonRetryableErrors` suite (which still asserts the raw customer-side message stays non-retryable) — 73 passed. `ruff check` and `ruff format --check` are clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres warehouse source. Read the live stack trace, confirmed the failing frame was a Django ORM read of PostHog's own DB (not the customer's Postgres), and traced the classification path through `_handle_import_error` → `get_non_retryable_errors`. Decision: this is a fixable bug (a transient infra error being misclassified as a permanent customer error), not a case for extending `NonRetryableErrors`. Rejected the alternative of narrowing the `"Name or service not known"` pattern, since it's correct for the customer-DB path; instead isolated our own DB failures by exception type at the source. Checked open PRs (including the maintainer's) — 65068 and 65054 touch nearby DNS/connection territory but different code paths and root causes; no duplicate.