### PR TITLE
fix(devex): disable app OTEL SDK during backend tests

### DIFF
--- a/posthog/otel_instrumentation.py
+++ b/posthog/otel_instrumentation.py
@@ -36,6 +36,17 @@ def _otel_django_response_hook(span, request, response):
 
 
 def initialize_otel():
+    # App tracing targets a real OTLP collector (dev/prod). In tests, booting the app
+    # (e.g. posthog/test/test_asgi_lifespan.py imports posthog.asgi) would otherwise arm a
+    # process-wide span exporter to the SDK default localhost:4317 with no collector there,
+    # so the flush at pytest shutdown retries with exponential backoff and stalls the run by
+    # minutes. Skip app instrumentation in tests WITHOUT touching OTEL_SDK_DISABLED, so tests
+    # that build their own in-memory TracerProvider still record spans (test_auth_spans,
+    # test_celery_span_team_id, test_routing). TEST is forced on by settings/overrides.py
+    # before any app import runs.
+    if os.environ.get("TEST") == "1":
+        return
+
     # --- BEGIN FORCED OTEL DEBUG LOGGING ---
     otel_python_log_level_env = os.environ.get("OTEL_PYTHON_LOG_LEVEL", "info").lower()
     effective_log_level = logging.DEBUG if otel_python_log_level_env == "debug" else logging.INFO

--- a/posthog/settings/overrides.py
+++ b/posthog/settings/overrides.py
@@ -36,11 +36,3 @@ if runner:
         print("Running in test mode. Setting DEBUG and TEST environment variables.")  # noqa: T201
         os.environ["DEBUG"] = "1"
         os.environ["TEST"] = "1"
-        # Keep the app OpenTelemetry SDK off in tests. Anything that boots the real
-        # ASGI/WSGI app (e.g. posthog/test/test_asgi_lifespan.py) runs initialize_otel(),
-        # which otherwise arms a process-wide span exporter to the SDK default
-        # localhost:4317. CI runs no collector there, so the flush at pytest shutdown
-        # retries with exponential backoff and adds minutes to whichever shard imported
-        # the app. setdefault, so a dev with a running collector can still opt back in
-        # via OTEL_SDK_DISABLED=false.
-        os.environ.setdefault("OTEL_SDK_DISABLED", "true")

--- a/posthog/settings/overrides.py
+++ b/posthog/settings/overrides.py
@@ -36,3 +36,11 @@ if runner:
         print("Running in test mode. Setting DEBUG and TEST environment variables.")  # noqa: T201
         os.environ["DEBUG"] = "1"
         os.environ["TEST"] = "1"
+        # Keep the app OpenTelemetry SDK off in tests. Anything that boots the real
+        # ASGI/WSGI app (e.g. posthog/test/test_asgi_lifespan.py) runs initialize_otel(),
+        # which otherwise arms a process-wide span exporter to the SDK default
+        # localhost:4317. CI runs no collector there, so the flush at pytest shutdown
+        # retries with exponential backoff and adds minutes to whichever shard imported
+        # the app. setdefault, so a dev with a running collector can still opt back in
+        # via OTEL_SDK_DISABLED=false.
+        os.environ.setdefault("OTEL_SDK_DISABLED", "true")


### PR DESCRIPTION
**What** Disable the app OpenTelemetry SDK while running tests (`OTEL_SDK_DISABLED` in `posthog/settings/overrides.py`).

**Why** `posthog/test/test_asgi_lifespan.py` boots the real ASGI app, which runs `initialize_otel()` on import and arms a process-wide span exporter to the SDK default `localhost:4317`. Tests run no collector there, so the flush at pytest shutdown retries with exponential backoff (16s, 32s, …) and adds 3-5 min to whichever shard imported the app. That shard sets the job makespan, so a random Django backend shard is minutes-slow on every CI run — it's the bulk of the backend CI tail.

**Where** `overrides.py` is the test-mode env hook, imported before anything else, next to where `DEBUG`/`TEST` get forced. Putting it there (vs scoping to one CI job) covers every test invocation — pytest, `/bin/tests`, mypy, local or CI — and survives someone adding or moving an app-booting test. `setdefault` keeps an escape hatch: a dev with a running collector can still trace tests via `OTEL_SDK_DISABLED=false`.

**Scope** App APM is for dev/prod with a real collector, not unit tests. The deliberate per-test trace observability (the separate "Report per-test traces" job) uses its own remote endpoint and is untouched. Only the one shard running `test_asgi_lifespan` arms the SDK today; the others already run the full suite with it off and pass, so this can't regress currently-green tests.
