### PR TITLE
fix(custom): treat missing manifest resource as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -563,6 +563,10 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
         return {
             "401 Client Error": "The upstream API rejected the request with HTTP 401. Check that the configured auth credentials are correct.",
             "403 Client Error": "The upstream API rejected the request with HTTP 403. The configured credentials may lack the required permissions.",
+            # A schema points to a resource the manifest no longer defines (renamed or removed
+            # in an edit while the table's sync stayed scheduled). Permanent until the config is
+            # fixed — match the stable suffix, not the variable resource name in the message.
+            "not found in config": "A table in this sync points to a resource that no longer exists in the source's manifest. Re-add the resource to the manifest, or remove the table from the sync, then try again.",
         }
 
     def _assemble_manifest(self, config: CustomSourceConfig) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -848,12 +848,13 @@ class TestCustomSourceNonRetryableErrors(SimpleTestCase):
         # The message `source_for_pipeline` raises when a schema points to a resource
         # the manifest no longer defines must be recognized by the source's classifier,
         # so `_handle_import_error` stops the job instead of capturing + retrying it.
+        # Pin the specific substring on both ends — the raised message and the dict key —
+        # so the guard breaks if either the wording or the key drifts.
         with self.assertRaises(ValueError) as ctx:
             _fanout_chain(_minimal_manifest(), "nonexistent")
-        error_msg = str(ctx.exception)
 
-        non_retryable = CustomSource().get_non_retryable_errors()
-        assert any(pattern in error_msg for pattern in non_retryable)
+        assert "not found in config" in str(ctx.exception)
+        assert "not found in config" in CustomSource().get_non_retryable_errors()
 
 
 def _fanout_manifest() -> dict:

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -843,6 +843,19 @@ class TestCustomSourceSourceForPipeline(SimpleTestCase):
         assert threaded_incremental == {"cursor_path": "updated_at", "start_param": "since"}
 
 
+class TestCustomSourceNonRetryableErrors(SimpleTestCase):
+    def test_missing_resource_message_is_classified_non_retryable(self):
+        # The message `source_for_pipeline` raises when a schema points to a resource
+        # the manifest no longer defines must be recognized by the source's classifier,
+        # so `_handle_import_error` stops the job instead of capturing + retrying it.
+        with self.assertRaises(ValueError) as ctx:
+            _fanout_chain(_minimal_manifest(), "nonexistent")
+        error_msg = str(ctx.exception)
+
+        non_retryable = CustomSource().get_non_retryable_errors()
+        assert any(pattern in error_msg for pattern in non_retryable)
+
+
 def _fanout_manifest() -> dict:
     """A parent (`forms`) + fan-out child (`responses`) that binds the parent's
     `id` into its path via a `type: "resolve"` param."""


### PR DESCRIPTION
## Problem

The `custom` data-warehouse source surfaced a recurring error in error tracking:

```
ValueError: Resource '<redacted>' not found in config
```

This happens when a schema (table) still references a resource name that the customer removed or renamed in their manifest, while the table's sync stayed scheduled. It's a permanent config mismatch — retrying can never make the resource reappear in a manifest that doesn't define it.

`source_for_pipeline` already classifies this correctly: `_fanout_chain` raises a `ValueError`, and the `except ValueError` block re-raises it as `NonRetryableException`. But the import activity's `_handle_import_error` decides whether to stop or retry by substring-matching the message against the source's `get_non_retryable_errors()`, which only listed `401`/`403`. With no match, it took the `else` branch — `logger.aexception(...)` (which captures the error to error tracking) followed by re-raising — instead of the graceful `handle_non_retryable_error` path. That's the source of the noise.

## Changes

Add the stable `"not found in config"` substring to the custom source's `get_non_retryable_errors()`, with a user-facing message pointing at the config fix. The match is on the stable suffix only, never the variable resource name embedded in the message, to avoid false positives. The only other occurrence of this phrase in the repo is an unrelated test assertion.

## How did you test this code?

I'm an agent. I added a regression test (`TestCustomSourceNonRetryableErrors`) that raises the real missing-resource message via `_fanout_chain` and asserts the classifier recognizes it — so the test breaks if the raised message and the matched substring ever drift apart. Automated tests run:

- `pytest posthog/temporal/data_imports/sources/custom/test_custom_source.py` — 152 passed
- `ruff check` + `ruff format --check` on both changed files — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `custom` source. Confirmed the stack genuinely originates in `posthog/temporal/data_imports/sources/custom/source.py` (`source_for_pipeline` → `_fanout_chain`), then traced the retry-vs-stop decision into `import_data_sync._handle_import_error` and `extract.handle_non_retryable_error`.

Decision: this is a user/config error (the resource no longer exists in the manifest), so the fix extends `NonRetryableErrors` rather than changing pipeline logic — mirroring the Stripe source's `get_non_retryable_errors` pattern. Kept scoped to the observed message; deliberately did not also add the rarer "was not produced by the REST engine" message. Checked open PRs (including the maintainer's) for a duplicate — none touch the custom source for this error.
