### PR TITLE
feat(charts): clean, lightly-curved styling for SQL line/area charts

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -551,9 +551,17 @@ describe('sqlLineGraphAdapter', () => {
             expect(config.yAxis).toMatchObject({ label: 'Count', scale: 'log', showGrid: false, hide: true })
         })
 
-        it('defaults to a linear scale with grid shown', () => {
+        it('defaults to a linear scale with the grid off and clean axis lines drawn', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC' })
-            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: true })
+            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: false })
+            expect(config.showAxisLines).toBe(true)
+            expect(config.showTickMarks).toBe(true)
+        })
+
+        it('shows the grid when the user explicitly enables grid lines', () => {
+            const chartSettings: ChartSettings = { leftYAxisSettings: { showGridLines: true } }
+            const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC' })
+            expect(config.yAxis).toMatchObject({ showGrid: true })
         })
 
         it('keeps a single-object yAxis when no series targets the right axis', () => {
@@ -571,7 +579,8 @@ describe('sqlLineGraphAdapter', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC', ySeriesData })
             expect(config.yAxis).toEqual([
                 // Left is logarithmic, so startAtZero is omitted (no zero baseline on a log scale).
-                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: true, hide: false },
+                // Grid defaults off on the line path (no explicit showGridLines on the left axis).
+                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: false, hide: false },
                 {
                     id: 'right',
                     position: 'right',

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -325,7 +325,12 @@ function buildYAxisConfig(
     yAxis: YAxisSettings | undefined,
     axisSeries: SqlLineYSeries[],
     yAxisAtZero: boolean | undefined,
-    { forceLinear = false, id, position }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right' } = {}
+    {
+        forceLinear = false,
+        id,
+        position,
+        gridDefault = true,
+    }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right'; gridDefault?: boolean } = {}
 ): YAxisConfig {
     const isLog = !forceLinear && yAxis?.scale === 'logarithmic'
     const tickSettings = axisSeries[0]?.settings
@@ -339,7 +344,7 @@ function buildYAxisConfig(
         ...(position ? { position } : {}),
         label: yAxis?.label,
         scale: isLog ? 'log' : 'linear',
-        showGrid: yAxis?.showGridLines ?? true,
+        showGrid: yAxis?.showGridLines ?? gridDefault,
         hide: yAxis?.showTicks === false,
         tickFormatter,
         // Quill ignores startAtZero on a log scale; floatBaseline (the false case) is line-only, so
@@ -393,13 +398,23 @@ export function buildLineChartConfig({
                       buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
                           id: 'left',
                           position: 'left',
+                          gridDefault: false,
                       }),
                       buildYAxisConfig(chartSettings.rightYAxisSettings, rightSeries, chartSettings.yAxisAtZero, {
                           id: 'right',
                           position: 'right',
+                          gridDefault: false,
                       }),
                   ]
-                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero),
+                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
+                      gridDefault: false,
+                  }),
+        // Grid off by default for a cleaner plot; draw a crisp L-shaped axis with tick marks instead
+        // of the full frame. An explicit `showGridLines` still wins (drawGrid takes over when on).
+        showAxisLines: true,
+        showTickMarks: true,
+        // Soften the line with a monotone-cubic curve (no overshoot — peaks stay accurate).
+        curve: 'monotone',
         goalLines: schemaGoalLinesToConfigs(goalLines),
         trendLines: buildTrendLineConfigs(ySeriesData),
         legend: buildLegendConfig(chartSettings),
@@ -456,5 +471,7 @@ export function buildComboChartConfig({
         legend: buildLegendConfig(chartSettings),
         valueLabels: buildValueLabelsConfig(chartSettings, ySeriesData),
         tooltip: buildSqlTooltipConfig(chartSettings, ySeriesData),
+        // Smooth the line/area series (bars are unaffected) to match the line chart.
+        curve: 'monotone',
     }
 }

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -118,14 +118,14 @@ export function drawBarChartStatic(
         labels: drawLabels,
     }
 
+    // Grid sits behind the bars; the L-axis is drawn after them (below) so a bar doesn't paint over
+    // the baseline where it meets the axis.
     if (showGrid) {
         drawGrid(baseDrawCtx, {
             gridColor: theme.gridColor,
             orientation: isHorizontal ? 'horizontal' : 'vertical',
             categoryTicks: computeGridTicks(d3Scales, drawLabels, isHorizontal, xTickFormatter),
         })
-    } else if (showAxisLines) {
-        drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
     }
 
     const seriesBars = buildBarLayers({
@@ -174,6 +174,10 @@ export function drawBarChartStatic(
             ctx.restore()
         }
     })
+
+    if (!showGrid && showAxisLines) {
+        drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+    }
 }
 
 export interface DrawBarHoverArgs {

--- a/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
@@ -87,7 +87,9 @@ function ComboChartInner<Meta = unknown>({
         defaultSeriesType = DEFAULT_SERIES_TYPE,
         xTickFormatter,
         valueDomain,
+        curve,
     } = config ?? {}
+    const smooth = curve === 'monotone'
 
     const seriesTypeOf = useCallback(
         (s: Pick<Series, 'type'>): SeriesType => resolveSeriesType(s, defaultSeriesType),
@@ -177,6 +179,8 @@ function ComboChartInner<Meta = unknown>({
                 labels: drawLabels,
             }
 
+            // Grid sits behind the data; the L-axis is drawn after the series (below) so neither bars
+            // nor lines paint over the baseline where they meet the axis.
             if (showGrid) {
                 const categoryTicks = computeVisibleXLabels(
                     drawLabels,
@@ -184,8 +188,6 @@ function ComboChartInner<Meta = unknown>({
                     xTickFormatter
                 ).map((entry) => entry.x)
                 drawGrid(baseDrawCtx, { gridColor: theme.gridColor, categoryTicks })
-            } else if (showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
             }
 
             // ── 1. Bars ──────────────────────────────────────────────────────────────────────
@@ -217,7 +219,12 @@ function ComboChartInner<Meta = unknown>({
                 shouldFill: (s) => seriesTypeOf(s) === 'area' || !!s.fill,
                 bottomFor: (s) => s.fill?.lowerData,
                 zOrder: 'areas-first',
+                smooth,
             })
+
+            if (!showGrid && showAxisLines) {
+                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+            }
         },
         [
             seriesTypeOf,
@@ -228,6 +235,7 @@ function ComboChartInner<Meta = unknown>({
             barStackedData,
             topStackedKeyByAxis,
             barCornerRadius,
+            smooth,
         ]
     )
 

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -81,7 +81,9 @@ function LineChartInner<Meta = unknown>({
         valueDomain,
         floatBaseline = false,
         yAxes,
+        curve,
     } = config ?? {}
+    const smooth = curve === 'monotone'
 
     const { visibleSeries, legendProps } = useChartLegend(series, theme, config?.legend)
 
@@ -176,10 +178,10 @@ function LineChartInner<Meta = unknown>({
                 labels: drawLabels,
             }
 
+            // Grid sits behind the data; the L-axis is drawn after the series (below) so the line
+            // doesn't paint over the baseline where it meets the axis.
             if (showGrid) {
                 drawGrid(baseDrawCtx, { gridColor: theme.gridColor })
-            } else if (showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
             }
 
             // Area then line+points per series, clipped vertically (shared with ComboChart). Areas use
@@ -195,9 +197,14 @@ function LineChartInner<Meta = unknown>({
                 bottomFor: (s) => s.fill?.lowerData ?? stackedData?.get(s.key)?.bottom,
                 shouldFill: (s) => !!s.fill,
                 zOrder: 'per-series',
+                smooth,
             })
+
+            if (!showGrid && showAxisLines) {
+                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+            }
         },
-        [showGrid, showAxisLines, stackedData]
+        [showGrid, showAxisLines, stackedData, smooth]
     )
 
     const drawHover = useCallback(

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -44,6 +44,8 @@ export interface TimeSeriesComboChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Line interpolation for line/area series: `linear` (default) or `monotone` (smooth curve). */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
     /** Built-in legend with click-to-toggle series visibility. Hidden by default. */
@@ -88,6 +90,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         barCornerRadius,
         showCrosshair,
         showAxisLines,
+        curve,
         tooltip: tooltipConfig,
         legend,
     } = config ?? {}
@@ -121,6 +124,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         yAxisLabel: yAxis?.label,
         showGrid: yAxis?.showGrid,
         showAxisLines,
+        curve,
         showCrosshair,
         defaultSeriesType,
         barLayout,

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -60,6 +60,10 @@ export interface TimeSeriesLineChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Draw short tick marks next to each visible axis label. Pairs with `showAxisLines`. */
+    showTickMarks?: boolean
+    /** Line interpolation: `linear` (default) or `monotone` (smooth curve through every point). */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
     /** Built-in legend with click-to-toggle series visibility. Hidden by default. */
@@ -105,6 +109,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
         percentStackView,
         showCrosshair,
         showAxisLines,
+        showTickMarks,
+        curve,
         tooltip: tooltipConfig,
         legend,
     } = config ?? {}
@@ -159,6 +165,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
         yAxisLabel: primaryYAxis?.label,
         showGrid: primaryYAxis?.showGrid,
         showAxisLines,
+        showTickMarks,
+        curve,
         percentStackView,
         showCrosshair,
         tooltip: tooltipConfig,

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -120,6 +120,7 @@ export function Chart<Meta = unknown>({
         yAxisLabel,
         tooltip: tooltipConfig,
         showCrosshair = false,
+        showTickMarks = false,
         axisOrientation = 'vertical',
         isPercent = false,
         animateHover,
@@ -319,6 +320,7 @@ export function Chart<Meta = unknown>({
                         orientation={axisOrientation}
                         labelToCoord={labelToCoord}
                         maxCategoryLabelWidth={maxCategoryLabelWidth}
+                        showTickMarks={showTickMarks}
                     />
                     <AxisTitles
                         xAxisLabel={xAxisLabel}

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -10,6 +10,8 @@ export interface DrawContext {
     xScale: (label: string) => number | undefined
     yScale: ScaleLinear<number, number> | ScaleLogarithmic<number, number>
     labels: string[]
+    /** Smooth the line/area with monotone-cubic interpolation instead of straight segments. */
+    smooth?: boolean
 }
 
 export function drawLine(drawCtx: DrawContext, series: ResolvedSeries, yValues?: number[]): void {
@@ -122,25 +124,118 @@ function planLineStrokes(series: ResolvedSeries, length: number): Stroke[] {
     return strokes
 }
 
-/** Walks data from [start, end] inclusive, emitting moveTo/lineTo. Caller owns beginPath/stroke. */
+/** Walks data from [start, end] inclusive. Emits straight segments, or monotone-cubic curves when
+ *  `drawCtx.smooth` is set. NaN/out-of-domain points break the line into separate subpaths. Caller
+ *  owns beginPath/stroke. */
 function tracePath(drawCtx: DrawContext, data: number[], start: number, end: number): void {
-    const { ctx, xScale, yScale, labels } = drawCtx
-    let started = false
+    const { ctx, xScale, yScale, labels, smooth } = drawCtx
+    let xs: number[] = []
+    let ys: number[] = []
+    const flush = (): void => {
+        if (xs.length === 0) {
+            return
+        }
+        ctx.moveTo(xs[0], ys[0])
+        if (smooth && xs.length > 1) {
+            curveForward(ctx, xs, ys)
+        } else {
+            for (let k = 1; k < xs.length; k++) {
+                ctx.lineTo(xs[k], ys[k])
+            }
+        }
+        xs = []
+        ys = []
+    }
     for (let i = start; i <= end; i++) {
         const x = xScale(labels[i])
         const y = yScale(data[i])
         if (x == null || !isFinite(y)) {
-            // Reset so the next valid point starts a fresh subpath rather than
+            // A gap ends the current subpath so the next valid point starts fresh rather than
             // connecting straight across the NaN gap.
-            started = false
+            flush()
             continue
         }
-        if (!started) {
-            ctx.moveTo(x, y)
-            started = true
+        xs.push(x)
+        ys.push(y)
+    }
+    flush()
+}
+
+/** Monotone-cubic (Fritsch–Carlson) tangents for points with strictly increasing x. Matches d3's
+ *  `curveMonotoneX`: preserves monotonicity between points, so the curve never overshoots the data
+ *  (no spurious wiggles or dips past a peak/trough). */
+function monotoneTangents(xs: number[], ys: number[]): number[] {
+    const n = xs.length
+    const h: number[] = new Array(n - 1)
+    const s: number[] = new Array(n - 1)
+    for (let i = 0; i < n - 1; i++) {
+        h[i] = xs[i + 1] - xs[i]
+        s[i] = h[i] !== 0 ? (ys[i + 1] - ys[i]) / h[i] : 0
+    }
+    const m: number[] = new Array(n)
+    if (n === 2) {
+        m[0] = s[0]
+        m[1] = s[0]
+        return m
+    }
+    for (let i = 1; i < n - 1; i++) {
+        const s0 = s[i - 1]
+        const s1 = s[i]
+        if (s0 * s1 <= 0) {
+            m[i] = 0
         } else {
-            ctx.lineTo(x, y)
+            const p = (s0 * h[i] + s1 * h[i - 1]) / (h[i - 1] + h[i])
+            m[i] = (Math.sign(s0) + Math.sign(s1)) * Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p))
         }
+    }
+    m[0] = (3 * s[0] - m[1]) / 2
+    m[n - 1] = (3 * s[n - 2] - m[n - 2]) / 2
+    return m
+}
+
+interface CurveSegment {
+    cp1x: number
+    cp1y: number
+    cp2x: number
+    cp2y: number
+}
+
+// Control-arm length as a fraction of the segment width. 1/3 is the standard monotone-cubic arm
+// (full curve); shortening it pulls the curve closer to the straight chord between points for a
+// gentler bend. Crucially this keeps the *same* tangent direction at each point, so adjacent
+// segments still meet smoothly there — the data points stay rounded, only the mid-segment bow shrinks.
+const SMOOTH_ARM = 1 / 6
+
+function monotoneSegments(xs: number[], ys: number[]): CurveSegment[] {
+    const m = monotoneTangents(xs, ys)
+    const segs: CurveSegment[] = []
+    for (let i = 0; i < xs.length - 1; i++) {
+        const arm = (xs[i + 1] - xs[i]) * SMOOTH_ARM
+        segs.push({
+            cp1x: xs[i] + arm,
+            cp1y: ys[i] + m[i] * arm,
+            cp2x: xs[i + 1] - arm,
+            cp2y: ys[i + 1] - m[i + 1] * arm,
+        })
+    }
+    return segs
+}
+
+/** Emit monotone bezier segments from the first point forward. Assumes the current path point is
+ *  already at (xs[0], ys[0]). */
+function curveForward(ctx: CanvasRenderingContext2D, xs: number[], ys: number[]): void {
+    const segs = monotoneSegments(xs, ys)
+    for (let i = 0; i < segs.length; i++) {
+        ctx.bezierCurveTo(segs[i].cp1x, segs[i].cp1y, segs[i].cp2x, segs[i].cp2y, xs[i + 1], ys[i + 1])
+    }
+}
+
+/** Emit the same monotone curve traversed last→first (control points swapped). Assumes the current
+ *  path point is already at (xs[n-1], ys[n-1]). Used for an area's bottom edge. */
+function curveReverse(ctx: CanvasRenderingContext2D, xs: number[], ys: number[]): void {
+    const segs = monotoneSegments(xs, ys)
+    for (let i = segs.length - 1; i >= 0; i--) {
+        ctx.bezierCurveTo(segs[i].cp2x, segs[i].cp2y, segs[i].cp1x, segs[i].cp1y, xs[i], ys[i])
     }
 }
 
@@ -202,7 +297,7 @@ export function drawArea(
     yValues?: number[],
     bottomValues?: number[]
 ): void {
-    const { ctx, xScale, yScale, labels, dimensions } = drawCtx
+    const { ctx, xScale, yScale, labels, dimensions, smooth } = drawCtx
     const data = yValues ?? series.data
     const opacity = series.fill?.opacity ?? 0.5
     const baseline = dimensions.plotTop + dimensions.plotHeight
@@ -262,7 +357,7 @@ export function drawArea(
 
         if (useGradient || (dashedFrom === null && dashedTo === null)) {
             ctx.fillStyle = gradient ?? series.color
-            fillAreaPath(ctx, top, bottom)
+            fillAreaPath(ctx, top, bottom, smooth)
             continue
         }
 
@@ -276,14 +371,14 @@ export function drawArea(
 
         if (wholeSegmentLeading || wholeSegmentTrailing) {
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top, bottom)
+            fillAreaPath(ctx, top, bottom, smooth)
             continue
         }
 
         if (dashedTo !== null && toSplit > 0) {
             const leadingEnd = Math.min(top.length, toSplit + 1)
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top.slice(0, leadingEnd), bottom.slice(0, leadingEnd))
+            fillAreaPath(ctx, top.slice(0, leadingEnd), bottom.slice(0, leadingEnd), smooth)
         }
 
         const solidStart = toSplit === -1 ? 0 : toSplit
@@ -294,13 +389,13 @@ export function drawArea(
         // segment and the shaded region stops a step past where the line turns dashed.
         if (solidEnd - solidStart >= 2) {
             ctx.fillStyle = series.color
-            fillAreaPath(ctx, top.slice(solidStart, solidEnd), bottom.slice(solidStart, solidEnd))
+            fillAreaPath(ctx, top.slice(solidStart, solidEnd), bottom.slice(solidStart, solidEnd), smooth)
         }
 
         if (dashedFrom !== null && fromSplit > 0) {
             const hatchStart = Math.max(0, fromSplit - 1)
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top.slice(hatchStart), bottom.slice(hatchStart))
+            fillAreaPath(ctx, top.slice(hatchStart), bottom.slice(hatchStart), smooth)
         }
     }
 
@@ -310,15 +405,26 @@ export function drawArea(
 function fillAreaPath(
     ctx: CanvasRenderingContext2D,
     top: { x: number; y: number }[],
-    bottom: { x: number; y: number }[]
+    bottom: { x: number; y: number }[],
+    smooth?: boolean
 ): void {
     ctx.beginPath()
     ctx.moveTo(top[0].x, top[0].y)
-    for (let i = 1; i < top.length; i++) {
-        ctx.lineTo(top[i].x, top[i].y)
+    if (smooth && top.length > 1) {
+        curveForward(ctx, top.map((p) => p.x), top.map((p) => p.y))
+    } else {
+        for (let i = 1; i < top.length; i++) {
+            ctx.lineTo(top[i].x, top[i].y)
+        }
     }
-    for (let i = bottom.length - 1; i >= 0; i--) {
-        ctx.lineTo(bottom[i].x, bottom[i].y)
+    // Down the right edge, then back along the bottom to close the band.
+    ctx.lineTo(bottom[bottom.length - 1].x, bottom[bottom.length - 1].y)
+    if (smooth && bottom.length > 1) {
+        curveReverse(ctx, bottom.map((p) => p.x), bottom.map((p) => p.y))
+    } else {
+        for (let i = bottom.length - 2; i >= 0; i--) {
+            ctx.lineTo(bottom[i].x, bottom[i].y)
+        }
     }
     ctx.closePath()
     ctx.fill()
@@ -358,9 +464,10 @@ export function drawAxes(drawCtx: DrawContext, options: DrawAxesOptions = {}): v
     ctx.strokeStyle = options.axisColor ?? 'rgba(0, 0, 0, 0.15)'
     ctx.lineWidth = 1
     ctx.setLineDash([])
-    // +0.5 / -0.5 pixel snapping keeps the 1px strokes crisp and inside the plot rect (see drawGrid).
-    const axisX = Math.round(dimensions.plotLeft) + 0.5
-    const axisY = Math.round(dimensions.plotTop + dimensions.plotHeight) - 0.5
+    // Snap the corner to the rounded plot edge so the L lines up with the zero baseline and the first
+    // tick mark (which anchor to the plot edge) rather than sitting a pixel inside it.
+    const axisX = Math.round(dimensions.plotLeft)
+    const axisY = Math.round(dimensions.plotTop + dimensions.plotHeight)
     // Route both strokes through the shared, snapped corner (axisX, axisY) so the L meets cleanly
     // even when plotLeft/plotHeight are fractional.
     ctx.beginPath()
@@ -593,13 +700,15 @@ export interface LineSeriesLayerOptions {
     /** `per-series`: area then line+points per series (LineChart). `areas-first`: every area, then
      *  every line+points (ComboChart) so a later area can't paint over an earlier line. */
     zOrder?: 'per-series' | 'areas-first'
+    /** Smooth lines/areas with monotone-cubic interpolation instead of straight segments. */
+    smooth?: boolean
 }
 
 /** Draw a line/area layer (clipped vertically) — the per-series area/line/points orchestration shared
  *  by LineChart and ComboChart. Callers supply the y-value source (raw vs stacked tops), the fill
  *  predicate, and the z-order; the loop, clip, and primitive calls live here. */
 export function drawLineSeriesLayer(options: LineSeriesLayerOptions): void {
-    const { ctx, dimensions, labels, series, xScale, resolveYScale } = options
+    const { ctx, dimensions, labels, series, xScale, resolveYScale, smooth } = options
     const yValuesFor = options.yValuesFor ?? (() => undefined)
     const bottomFor = options.bottomFor ?? ((s: ResolvedSeries) => s.fill?.lowerData)
     const shouldFill = options.shouldFill ?? ((s: ResolvedSeries) => !!s.fill)
@@ -610,13 +719,13 @@ export function drawLineSeriesLayer(options: LineSeriesLayerOptions): void {
         if (!shouldFill(s)) {
             return
         }
-        drawArea({ ctx, dimensions, labels, xScale, yScale: resolveYScale(s) }, s, yValuesFor(s), bottomFor(s))
+        drawArea({ ctx, dimensions, labels, xScale, yScale: resolveYScale(s), smooth }, s, yValuesFor(s), bottomFor(s))
     }
     const paintLine = (s: ResolvedSeries): void => {
         if (s.fill?.lowerData) {
             return
         }
-        const drawCtx: DrawContext = { ctx, dimensions, labels, xScale, yScale: resolveYScale(s) }
+        const drawCtx: DrawContext = { ctx, dimensions, labels, xScale, yScale: resolveYScale(s), smooth }
         drawLine(drawCtx, s, yValuesFor(s))
         drawPoints(drawCtx, s, yValuesFor(s))
     }

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -216,6 +216,12 @@ export interface ChartConfig {
     /** Draw only the L-shaped axis baselines (left + bottom) without interior grid lines. Ignored
      *  when `showGrid` is true, since the grid already frames the plot. */
     showAxisLines?: boolean
+    /** Draw short tick marks on the axes next to each visible tick label. Pairs with
+     *  `showAxisLines` for a clean, grid-free axis that still reads precisely. */
+    showTickMarks?: boolean
+    /** Line/area interpolation. `linear` (default) draws straight segments; `monotone` smooths the
+     *  line with monotone-cubic curves that pass through every point without overshooting. */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour. Defaults to enabled with no pinning and `follow-data` placement. */
     tooltip?: TooltipConfig
     /** Show a vertical crosshair line that follows the cursor. */

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -17,6 +17,8 @@ interface AxisLabelsProps {
     /** When set, truncate category tick labels wider than this (px) with an ellipsis and reveal
      *  the full value on hover. Omitted (default) renders labels untruncated. */
     maxCategoryLabelWidth?: number
+    /** Draw a short tick mark on the axis next to each visible label. */
+    showTickMarks?: boolean
 }
 
 // Minimum gap (px) required between adjacent kept labels. Category labels are often words and get
@@ -265,6 +267,70 @@ function XTickLabel({
     )
 }
 
+// Length (px) of a tick mark measured outward from the plot edge.
+const TICK_MARK_LENGTH = 4
+// The axis line is canvas-drawn while ticks are DOM overlays, so subpixel rounding can leave a hairline
+// gap between them. The axis line is 1px wide, so extending each tick this far past the plot edge makes
+// it reach the line's far side — closing the gap — without poking visibly into the plot.
+const TICK_MARK_AXIS_OVERLAP = 1
+
+const TICK_MARK_STYLE_BASE: React.CSSProperties = { position: 'absolute', pointerEvents: 'none' }
+
+/** Short mark crossing a value/category axis line, aligned to a label, so the two stay visually joined. */
+function YTickMark({
+    y,
+    side,
+    box,
+    color,
+    offset = 0,
+}: {
+    y: number
+    side: 'left' | 'right'
+    box: ChartBox
+    color: string
+    offset?: number
+}): React.ReactElement {
+    // Pull the inner edge `TICK_MARK_AXIS_OVERLAP` px past the plot edge so the tick crosses the axis line.
+    const edge =
+        side === 'left'
+            ? { right: box.width - box.plotLeft + offset - TICK_MARK_AXIS_OVERLAP }
+            : { left: box.plotLeft + box.plotWidth + offset - TICK_MARK_AXIS_OVERLAP }
+    return (
+        <div
+            aria-hidden
+            data-attr={side === 'left' ? 'hog-chart-axis-tickmark-y' : 'hog-chart-axis-tickmark-yr'}
+            style={{
+                ...TICK_MARK_STYLE_BASE,
+                ...edge,
+                top: y,
+                width: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
+                height: 1,
+                transform: 'translateY(-50%)',
+                background: color,
+            }}
+        />
+    )
+}
+
+function XTickMark({ x, box, color }: { x: number; box: ChartBox; color: string }): React.ReactElement {
+    return (
+        <div
+            aria-hidden
+            data-attr="hog-chart-axis-tickmark-x"
+            style={{
+                ...TICK_MARK_STYLE_BASE,
+                left: x,
+                // Start `TICK_MARK_AXIS_OVERLAP` px above the plot's bottom edge so the tick crosses the axis line.
+                top: box.plotTop + box.plotHeight - TICK_MARK_AXIS_OVERLAP,
+                width: 1,
+                height: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
+                transform: 'translateX(-50%)',
+                background: color,
+            }}
+        />
+    )
+}
+
 export const AxisLabels = React.memo(function AxisLabels({
     xTickFormatter,
     yTickFormatter,
@@ -274,6 +340,7 @@ export const AxisLabels = React.memo(function AxisLabels({
     orientation = 'vertical',
     labelToCoord,
     maxCategoryLabelWidth = 0,
+    showTickMarks = false,
 }: AxisLabelsProps): React.ReactElement | null {
     const { scales, dimensions, labels, yGutters } = useChartLayout()
     const yTicks = scales.yTicks()
@@ -312,27 +379,25 @@ export const AxisLabels = React.memo(function AxisLabels({
                         }
                         const { text, title } = truncateWithTitle(fullText, maxCategoryLabelWidth)
                         return (
-                            <YTickLabel
-                                key={`y-cat-${i}`}
-                                y={y}
-                                side="left"
-                                box={dimensions}
-                                text={text}
-                                title={title}
-                                color={axisColor}
-                                dataAttr="hog-chart-axis-tick-y"
-                            />
+                            <React.Fragment key={`y-cat-${i}`}>
+                                <YTickLabel
+                                    y={y}
+                                    side="left"
+                                    box={dimensions}
+                                    text={text}
+                                    title={title}
+                                    color={axisColor}
+                                    dataAttr="hog-chart-axis-tick-y"
+                                />
+                                {showTickMarks && <YTickMark y={y} side="left" box={dimensions} color={axisColor} />}
+                            </React.Fragment>
                         )
                     })}
                 {visibleValueTicks.map(({ tick, text, x }) => (
-                    <XTickLabel
-                        key={`x-val-${tick}`}
-                        x={x}
-                        box={dimensions}
-                        text={text}
-                        color={axisColor}
-                        dataAttr="hog-chart-axis-tick-x"
-                    />
+                    <React.Fragment key={`x-val-${tick}`}>
+                        <XTickLabel x={x} box={dimensions} text={text} color={axisColor} dataAttr="hog-chart-axis-tick-x" />
+                        {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
+                    </React.Fragment>
                 ))}
             </>
         )
@@ -347,30 +412,42 @@ export const AxisLabels = React.memo(function AxisLabels({
                         return null
                     }
                     return (
-                        <YTickLabel
-                            key={`${gutter.key}-${tick}`}
-                            y={y}
-                            side={gutter.side}
-                            offset={gutter.offset}
-                            box={dimensions}
-                            text={gutter.formatter(tick)}
-                            color={axisColor}
-                            dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
-                        />
+                        <React.Fragment key={`${gutter.key}-${tick}`}>
+                            <YTickLabel
+                                y={y}
+                                side={gutter.side}
+                                offset={gutter.offset}
+                                box={dimensions}
+                                text={gutter.formatter(tick)}
+                                color={axisColor}
+                                dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
+                            />
+                            {showTickMarks && (
+                                <YTickMark
+                                    y={y}
+                                    side={gutter.side}
+                                    offset={gutter.offset}
+                                    box={dimensions}
+                                    color={axisColor}
+                                />
+                            )}
+                        </React.Fragment>
                     )
                 })
             )}
 
             {visibleXLabels.map(({ index, text, title, x }) => (
-                <XTickLabel
-                    key={`x-${index}`}
-                    x={x}
-                    box={dimensions}
-                    text={text}
-                    title={title}
-                    color={axisColor}
-                    dataAttr="hog-chart-axis-tick-x"
-                />
+                <React.Fragment key={`x-${index}`}>
+                    <XTickLabel
+                        x={x}
+                        box={dimensions}
+                        text={text}
+                        title={title}
+                        color={axisColor}
+                        dataAttr="hog-chart-axis-tick-x"
+                    />
+                    {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
+                </React.Fragment>
             ))}
         </>
     )


### PR DESCRIPTION
## Problem

The quill-rendered SQL insight line/area charts (behind the `product-analytics-quill-sql-charts` flag) looked heavy and a bit rough: a full background grid with a boxed frame, sharp zig-zag lines, and a faint axis that didn't line up cleanly with the data. This is a visual polish pass on that renderer.

## Changes

Restyle the SQL line/area charts for a cleaner look, with the building blocks added as opt-in chart config so other quill consumers (trends, web analytics) are unaffected.

- **New chart config**, default off:
  - `showTickMarks` — short tick marks next to each visible axis label
  - `curve: 'linear' | 'monotone'` — monotone-cubic line/area smoothing
- **SQL line/area adapter**: grid off by default, draw a crisp L-shaped axis + tick marks, and a light monotone curve. An explicit "show grid lines" setting still wins (the full grid takes over).
- **Renderer**:
  - Monotone-cubic interpolation — passes through every data point and never overshoots; a shortened control arm keeps the bend gentle and the data points smoothly rounded.
  - Axis line now uses the tick/label colour, snaps to the rounded plot edge so the corner lines up with the zero point, and is drawn **on top** of the series so the line no longer paints over the baseline.
  - Tick marks cross the 1px axis line so there's no subpixel gap between them.
- Applied consistently across `LineChart`, `ComboChart`, and `BarChart` (bars are never curved).

Stacked conceptually on the separate y-axis fix in #65312, but independent — this branch is cut from `master` and touches different files.

## How did you test this code?

I'm an agent (Claude Code). Verified visually in the local dev app against a SQL line chart (grid removed, clean L-axis, rounded points, gentle curve, axis-on-top), including reading back canvas pixels to confirm axis/zero-point alignment and z-order.

Automated: ran the full `@posthog/quill-charts` jest suite + the SQL adapter tests — 1586 pass. The only failure is a pre-existing `PieChart` tooltip-hover flake that also fails on clean `master` (canvas/jsdom timing, unrelated — PieChart has no axis/line).

Not yet done (happy to add before un-drafting): unit/story coverage for the new `curve` and `showTickMarks` options, and the `packages/quill/packages/charts/AGENTS.md` guide update.

## Automatic notifications

- [ ] Publish to changelog?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8), driven interactively by @sam through a series of visual tweaks: remove gridlines → clearer axis → tick marks → match axis colour to ticks → align the corner to the zero point → draw axis over the line → curve the line → dampen the curve. Each step was applied to the quill-charts renderer, rebuilt, and checked in the live app.

Notable decisions:
- Monotone-cubic over a Catmull-Rom/cardinal spline so spikes don't overshoot into invented peaks/dips — values stay truthful.
- First curve-dampening attempt blended each segment toward its own secant, which broke slope continuity and put a corner at every data point; fixed by keeping one monotone tangent per point and shortening the control arm instead (smoothness lives at the points, the arm length controls the bend).
- Styling building blocks are opt-in config rather than new defaults, to keep blast radius to the SQL charts behind the flag.