### PR TITLE
fix(cohorts): preserve the persons search when creating a static cohort

### DIFF
--- a/posthog/api/test/test_cohort.py
+++ b/posthog/api/test/test_cohort.py
@@ -2962,6 +2962,55 @@ email@example.org,
         self.assertEqual(1, len(response.json()["results"]))
 
     @patch("posthog.api.cohort.report_user_action")
+    def test_static_cohort_from_persons_query_honors_search_term(self, patch_capture):
+        # Regression test for #65303: when a static cohort is created from the persons
+        # list with a free-text `search`, only the persons matching that search should be
+        # added — not every person. The frontend "Save as static cohort" sends the same
+        # ActorsQuery the persons list uses, including its `search` term.
+        _create_person(
+            distinct_ids=["alice@example.com"],
+            team_id=self.team.pk,
+            properties={"email": "alice@example.com", "name": "Alice"},
+        )
+        _create_person(
+            distinct_ids=["bob@example.com"],
+            team_id=self.team.pk,
+            properties={"email": "bob@example.com", "name": "Bob"},
+        )
+        _create_person(
+            distinct_ids=["carol@example.com"],
+            team_id=self.team.pk,
+            properties={"email": "carol@example.com", "name": "Carol"},
+        )
+
+        flush_persons_and_events()
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/cohorts",
+            data={
+                "name": "searched cohort",
+                "is_static": True,
+                "query": {
+                    "kind": "ActorsQuery",
+                    "search": "alice",
+                },
+            },
+        )
+        self.assertEqual(response.status_code, 201, response.content)
+
+        cohort_id = response.json()["id"]
+
+        while response.json()["is_calculating"]:
+            response = self.client.get(f"/api/projects/{self.team.id}/cohorts/{cohort_id}")
+
+        response = self.client.get(f"/api/projects/{self.team.id}/cohorts/{cohort_id}/persons/?cohort={cohort_id}")
+        self.assertEqual(response.status_code, 200, response.content)
+        results = response.json()["results"]
+        # Only Alice matches the search term — not all three persons.
+        self.assertEqual(1, len(results), results)
+        self.assertEqual("alice@example.com", results[0]["distinct_ids"][0])
+
+    @patch("posthog.api.cohort.report_user_action")
     def test_creating_update_and_calculating_with_new_cohort_query_dynamic_error(self, patch_capture):
         response = self.client.post(
             f"/api/projects/{self.team.id}/cohorts",

--- a/products/cohorts/backend/models/util.py
+++ b/products/cohorts/backend/models/util.py
@@ -297,8 +297,14 @@ def _sanitize_query_for_cohort(query_dict: dict) -> dict:
 
     Cohort population only needs person IDs, so we remove recordings data
     (which can use complex UDFs like aggregate_funnel_array that may not
-    be available or are needlessly expensive) and search terms (the cohort
-    should include all matching persons, not just those matching a search).
+    be available or are needlessly expensive).
+
+    The ``search`` term is deliberately preserved: when a static cohort is
+    created from the persons list ("Save as static cohort"), the user expects
+    only the persons matching their free-text search to be added — not every
+    person (see issue #65303). The search term is part of the ActorsQuery and
+    is applied by ActorsQueryRunner/PersonStrategy exactly as it is on the live
+    persons list, so leaving it in place keeps the two paths consistent.
     """
     query_dict = copy.deepcopy(query_dict)
 
@@ -307,10 +313,6 @@ def _sanitize_query_for_cohort(query_dict: dict) -> dict:
         query_dict["select"] = [s for s in select if s != "matched_recordings"]
         if not query_dict["select"]:
             query_dict["select"] = ["actor"]
-
-        # Intentionally strip search: the cohort should capture all persons matching
-        # the query, not just those matching an ad-hoc search in the persons modal.
-        query_dict.pop("search", None)
 
         source = query_dict.get("source", {})
         if isinstance(source, dict) and source.get("includeRecordings"):

--- a/products/cohorts/backend/models/util.py
+++ b/products/cohorts/backend/models/util.py
@@ -301,7 +301,7 @@ def _sanitize_query_for_cohort(query_dict: dict) -> dict:
 
     The ``search`` term is deliberately preserved: when a static cohort is
     created from the persons list ("Save as static cohort"), the user expects
-    only the persons matching their free-text search to be added — not every
+    only the persons matching their free-text search to be added, not every
     person (see issue #65303). The search term is part of the ActorsQuery and
     is applied by ActorsQueryRunner/PersonStrategy exactly as it is on the live
     persons list, so leaving it in place keeps the two paths consistent.


### PR DESCRIPTION
## Problem

Fixes #65303. On the Persons page, filtering with the free-text search and then **Save as static cohort** adds *every* person to the cohort instead of the searched subset. Property `+ Filter` conditions are honored, but the search term is lost.

## Root cause

"Save as static cohort" sends the persons `ActorsQuery` — including its `search` term — to `api/cohort` (`is_static: true`). The static-cohort population runs the query through `_sanitize_query_for_cohort` (`products/cohorts/backend/models/util.py`), which explicitly stripped `search` before compiling the ClickHouse query, so the resulting `WHERE` matched all persons.

That strip was deliberate (there was a comment to that effect), but `search` is a real persons-list filter applied by `ActorsQueryRunner` → `PersonStrategy` (email/name `ilike`), and a cohort created *from the results of a search* should match what the user was looking at. This PR preserves `search` (recordings data is still stripped). Because the sanitized query is run through the same `ActorsQueryRunner`, the cohort now applies search identically to the live persons list — no search logic is re-implemented. Flagging the prior intentional strip in case the team prefers a different direction.

## Tests

Added `test_static_cohort_from_persons_query_honors_search_term` to `posthog/api/test/test_cohort.py`: three persons, a static cohort created with `search: "alice"`, asserts the cohort contains only the matching person. (Backend cohort tests need ClickHouse, so this runs in CI.)
