### PR TITLE
fix(pinterest_ads): retry transient chunked-encoding connection drops

### DIFF
--- a/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_ads.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_ads.py
@@ -295,6 +295,37 @@ class TestMakeRequestErrorHandling:
         result = _make_request(mock_session, "https://api.pinterest.com/v5/test")
         assert result == {"items": []}
 
+    def test_chunked_encoding_error_is_retried(self):
+        # A mid-stream connection drop while reading the body raises ChunkedEncodingError, which must
+        # be retried so a single dropped connection doesn't fail the whole import.
+        good_response = mock.MagicMock()
+        good_response.raise_for_status.return_value = None
+        good_response.json.return_value = {"items": []}
+
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = [
+            requests.exceptions.ChunkedEncodingError(
+                "Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"
+            ),
+            good_response,
+        ]
+
+        with mock.patch("tenacity.nap.time.sleep"):
+            result = _make_request(mock_session, "https://api.pinterest.com/v5/test")
+
+        assert result == {"items": []}
+        assert mock_session.get.call_count == 2
+
+    def test_chunked_encoding_error_eventually_reraises(self):
+        mock_session = mock.MagicMock()
+        mock_session.get.side_effect = requests.exceptions.ChunkedEncodingError("Connection broken")
+
+        with mock.patch("tenacity.nap.time.sleep"):
+            with pytest.raises(requests.exceptions.ChunkedEncodingError):
+                _make_request(mock_session, "https://api.pinterest.com/v5/test")
+
+        assert mock_session.get.call_count == 5
+
 
 class TestPinterestAdsSource:
     def test_unknown_endpoint(self):

--- a/posthog/temporal/data_imports/sources/pinterest_ads/utils.py
+++ b/posthog/temporal/data_imports/sources/pinterest_ads/utils.py
@@ -4,6 +4,8 @@ from typing import Any, Optional
 import requests
 import structlog
 from dateutil import parser
+from requests.exceptions import ChunkedEncodingError
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
 from posthog.temporal.data_imports.sources.common.http import make_tracked_session
 from posthog.temporal.data_imports.sources.pinterest_ads.settings import (
@@ -85,6 +87,17 @@ def _chunk_date_range(start_date: str, end_date: str) -> list[tuple[str, str]]:
     return chunks
 
 
+@retry(
+    # ChunkedEncodingError is a transient mid-stream connection drop while reading the response
+    # body ("Connection broken: InvalidChunkLength"). It subclasses RequestException directly, not
+    # ConnectionError, so it must be listed explicitly to be retried rather than failing the whole
+    # import on a single dropped connection. The tracked session only retries on status codes during
+    # the initial request, not on a broken body stream.
+    retry=retry_if_exception_type((requests.ReadTimeout, requests.ConnectionError, ChunkedEncodingError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=60),
+    reraise=True,
+)
 def _make_request(session: requests.Session, url: str, params: Optional[dict] = None) -> Any:
     response = session.get(url, params=params, timeout=30)
     response.raise_for_status()


### PR DESCRIPTION
## Problem

Pinterest Ads imports surfaced a `ValueError: invalid literal for int() with base 16: b'\r\n'`, the inner cause of a `requests.ChunkedEncodingError` ("Connection broken: InvalidChunkLength"). Error tracking: https://us.posthog.com/project/2/error_tracking/019ef37d-c865-7971-ad5f-293fe64d1f15

The stack confirms the failure originates in this source: `analytics_items` → `_iter_analytics_rows` → `fetch_entity_ids` → `fetch_entities` → `_make_request` → `session.get(...)`, raised while reading the chunked response body (`requests.models.content → generate → read_chunked`).

This is a transient connection break — the upstream connection dropped mid-stream. The shared tracked session already retries on status codes (429/5xx) during the initial request, but that retry only governs `urlopen`; a connection broken while streaming the body happens *after* the response is returned, so it isn't retried and fails the whole sync.

## Changes

Wrap `_make_request` in a `tenacity` retry on `ChunkedEncodingError`, `ConnectionError`, and `ReadTimeout` with exponential backoff (5 attempts, reraise). `ChunkedEncodingError` subclasses `RequestException` directly — not `ConnectionError` — so it has to be listed explicitly.

This mirrors the established pattern in the mailerlite, notion, and mixpanel sources, which retry the exact same transient errors in-process for the same reason. Scoped to the single shared HTTP helper every Pinterest request flows through; nothing else changes. The error is left retryable (not added to `NonRetryableErrors`) since it's a transient connection failure, not a credential/config problem.

## How did you test this code?

I'm an agent. I added and ran automated unit tests — no manual testing.

- `test_chunked_encoding_error_is_retried` — a single `ChunkedEncodingError` followed by a good response succeeds after a retry (2 calls).
- `test_chunked_encoding_error_eventually_reraises` — a persistent `ChunkedEncodingError` reraises after exhausting 5 attempts.
- Full file: `pytest posthog/temporal/data_imports/sources/pinterest_ads/tests/test_pinterest_ads.py` → 57 passed. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to pull the full exception chain and confirm the frame was genuinely in `pinterest_ads/`, not just in serialized log context. Decision was fixable-bug vs `NonRetryableErrors`: the error is a transient connection drop, so it must stay retryable — the fix is to retry it in-process rather than letting one dropped connection fail the sync. Chose to mirror the existing mailerlite/notion/mixpanel convention rather than invent a new abstraction. No skills were required for this change.