### PR TITLE
fix(insights): dim compare-previous series in stickiness charts

### DIFF
--- a/frontend/src/test/insight-testing/mocks.ts
+++ b/frontend/src/test/insight-testing/mocks.ts
@@ -113,12 +113,14 @@ function buildStickinessResponse(series: SeriesData[]): TrendsQueryResponse {
     return {
         results: series.map((s, i) => {
             const buckets = s.data.length
+            // Compare current/previous share one series identity (order 0), mirroring the real runner.
+            const seriesOrder = s.compare || s.breakdown_value != null ? 0 : i
             return {
                 action: {
                     id: `$${s.label.toLowerCase().replace(/\s+/g, '_')}`,
                     type: 'events',
                     name: s.label,
-                    order: i,
+                    order: seriesOrder,
                 },
                 label: s.label,
                 count: s.data.reduce((a, b) => a + b, 0),
@@ -127,6 +129,8 @@ function buildStickinessResponse(series: SeriesData[]): TrendsQueryResponse {
                 labels: Array.from({ length: buckets }, (_, j) => `${j + 1} day${j === 0 ? '' : 's'}`),
                 days: Array.from({ length: buckets }, (_, j) => j + 1),
                 breakdown_value: s.breakdown_value,
+                compare: s.compare,
+                compare_label: s.compare_label,
             }
         }),
     } as TrendsQueryResponse

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.compare.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.compare.test.tsx
@@ -1,0 +1,72 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, waitFor } from '@testing-library/react'
+
+import type { Series } from '@posthog/quill-charts'
+import { setupJsdom, setupSyncRaf } from '@posthog/quill-charts/testing'
+
+import { buildStickinessQuery, renderInsight } from '~/test/insight-testing'
+import { ChartDisplayType } from '~/types'
+
+import type { TrendsSeriesMeta } from '../../trends/shared/trendsSeriesMeta'
+
+// Capture the series the component hands to the quill bar chart so we can assert the resolved
+// colors end-to-end (indexedResults → getTrendsColor → dimming) without poking at the canvas.
+const mockCapturedSeries: Series<TrendsSeriesMeta>[][] = []
+jest.mock('@posthog/quill-charts', () => {
+    const actual = jest.requireActual('@posthog/quill-charts')
+    return {
+        __esModule: true,
+        ...actual,
+        TimeSeriesBarChart: (props: { series: Series<TrendsSeriesMeta>[] }) => {
+            mockCapturedSeries.push(props.series)
+            return null
+        },
+    }
+})
+
+let cleanupJsdom: () => void
+let cleanupRaf: () => void
+
+beforeEach(() => {
+    mockCapturedSeries.length = 0
+    cleanupJsdom = setupJsdom()
+    cleanupRaf = setupSyncRaf()
+})
+
+afterEach(() => {
+    cleanupRaf()
+    cleanupJsdom()
+    cleanup()
+})
+
+describe('StickinessBarChart compare-against-previous', () => {
+    it('dims the previous-period series to 0.5 alpha while the current period keeps its full color', async () => {
+        renderInsight({
+            query: buildStickinessQuery({
+                stickinessFilter: { display: ChartDisplayType.ActionsBar },
+                compareFilter: { compare: true },
+            }),
+        })
+
+        await waitFor(
+            () => {
+                const latest = mockCapturedSeries[mockCapturedSeries.length - 1] ?? []
+                if (!latest.some((s) => s.meta?.compare_label === 'previous')) {
+                    throw new Error('compare series not captured yet')
+                }
+            },
+            { timeout: 5000 }
+        )
+
+        const series = mockCapturedSeries[mockCapturedSeries.length - 1]
+        const previous = series.find((s) => s.meta?.compare_label === 'previous')
+        const current = series.find((s) => s.meta?.compare_label === 'current')
+
+        expect(previous).not.toBeUndefined()
+        expect(current).not.toBeUndefined()
+        // Previous period is dimmed via rgba(...) at half opacity; current keeps the opaque palette color.
+        expect(previous!.color).toMatch(/^rgba\(.+,\s*0?\.5\)$/)
+        expect(current!.color).not.toMatch(/^rgba\(/)
+    })
+})

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.test.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
 import type { TooltipConfig, YAxisConfig } from '@posthog/quill-charts'
 
+import { hexToRGBA } from 'lib/utils/colors'
+
 import { ChartDisplayType } from '~/types'
 
 import {
@@ -58,6 +60,18 @@ describe('stickinessChartTransforms', () => {
             expect(series.fill).toBeUndefined()
             expect(series.visibility).toBeUndefined()
         })
+
+        it.each([
+            { compare_label: undefined, expectedColor: RED },
+            { compare_label: 'current' as const, expectedColor: RED },
+            { compare_label: 'previous' as const, expectedColor: hexToRGBA(RED, 0.5) },
+        ])(
+            'dims the compare-against-previous series to 0.5 alpha, leaving others full color (compare_label=$compare_label)',
+            ({ compare_label, expectedColor }) => {
+                const series = buildStickinessMainSeries(makeResult({ compare_label }), 0, { getColor: () => RED })
+                expect(series.color).toBe(expectedColor)
+            }
+        )
 
         it('never sets a partial-stroke / in-progress tail (stickiness has no incomplete buckets)', () => {
             const series = buildStickinessMainSeries(makeResult({ data: [1, 2, 3, 4, 5] }), 0, { getColor: () => RED })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -14,7 +14,6 @@ export interface StickinessResultLike {
     data: number[]
     count: number
     days?: Array<string | number>
-    compare?: boolean
     compare_label?: string | null
     action?: { order?: number } | null
     breakdown_value?: unknown

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -5,6 +5,8 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 
 import { ChartDisplayType } from '~/types'
 
+import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../../trends/shared/compareDimming'
+
 // Shape both IndexedTrendResult (kea) and StickinessResultItem (MCP) satisfy.
 export interface StickinessResultLike {
     id?: string | number
@@ -12,6 +14,8 @@ export interface StickinessResultLike {
     data: number[]
     count: number
     days?: Array<string | number>
+    compare?: boolean
+    compare_label?: string | null
     action?: { order?: number } | null
     breakdown_value?: unknown
     filter?: unknown
@@ -47,11 +51,14 @@ export function buildStickinessMainSeries<R extends StickinessResultLike, M = un
     const yAxisId = opts.showMultipleYAxes && index > 0 ? `y${index}` : DEFAULT_Y_AXIS_ID
     const excluded = opts.getHidden ? opts.getHidden(r, index) : false
     const meta: M | undefined = opts.buildMeta ? opts.buildMeta(r, index) : undefined
+    // Dim the compare-against-previous series so it recedes behind the current period, matching trends.
+    const baseColor = opts.getColor(r, index)
+    const color = r.compare_label === 'previous' ? dimHexColor(baseColor, COMPARE_PREVIOUS_DIM_OPACITY) : baseColor
     return {
         key: String(r.id),
         label: r.label ?? '',
         data: toPercentData(r.data, r.count),
-        color: opts.getColor(r, index),
+        color,
         yAxisId,
         meta,
         fill: opts.display === ChartDisplayType.ActionsAreaGraph ? {} : undefined,

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.test.ts
@@ -41,7 +41,7 @@ describe('buildTrendsBarTimeSeries', () => {
         }
     )
 
-    // The inlined hex dimming must match lib/utils' hexToRGBA for valid hex (incl. 3-digit shorthand);
+    // The shared dimHexColor must match lib/utils' hexToRGBA for valid hex (incl. 3-digit shorthand);
     // a non-hex color is passed through unchanged (the one intentional divergence from hexToRGBA).
     it.each([
         { base: '#ff0000', expected: hexToRGBA('#ff0000', 0.5) },

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/trendsBarChartTransforms.ts
@@ -1,32 +1,10 @@
 import { DEFAULT_Y_AXIS_ID, normalizeAxisLabel } from '@posthog/quill-charts'
 import type { Series, TimeInterval, TimeSeriesBarChartConfig } from '@posthog/quill-charts'
 
+import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../shared/compareDimming'
 import { schemaGoalLinesToConfigs } from '../shared/goalLinesAdapter'
 import { buildTrendsYAxisConfig } from '../shared/trendsAxisFormat'
 import type { GoalLineLike, YFormatterFields } from '../shared/trendsChartDisplayOptions'
-
-// Compare-against-previous bars render at half opacity so they recede behind the current period.
-const COMPARE_PREVIOUS_DIM_OPACITY = 0.5
-
-// Inlined from `lib/utils` so this module stays free of `lib/`/`~/`/`scenes/` deps and compiles in
-// the MCP Vite bundle, which only resolves `products/*` and `@posthog/*`. Returns the input unchanged
-// if it isn't a 3/6/8-digit hex (callers always pass palette hexes).
-function dimHexColor(hex: string, alpha: number): string {
-    let h = hex.replace(/^#/, '')
-    if (h.length === 3 || h.length === 4) {
-        h = h
-            .split('')
-            .map((char) => char + char)
-            .join('')
-    }
-    if (h.length !== 6 && h.length !== 8) {
-        return hex
-    }
-    const r = parseInt(h.slice(0, 2), 16)
-    const g = parseInt(h.slice(2, 4), 16)
-    const b = parseInt(h.slice(4, 6), 16)
-    return `rgba(${r},${g},${b},${alpha})`
-}
 
 // Shape both IndexedTrendResult (kea) and TrendsResultItem (MCP) satisfy.
 export interface TrendsBarResultLike {

--- a/products/product_analytics/frontend/insights/trends/shared/compareDimming.test.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/compareDimming.test.ts
@@ -1,0 +1,25 @@
+import { hexToRGBA } from 'lib/utils/colors'
+
+import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from './compareDimming'
+
+describe('compareDimming', () => {
+    it('COMPARE_PREVIOUS_DIM_OPACITY is half opacity', () => {
+        expect(COMPARE_PREVIOUS_DIM_OPACITY).toBe(0.5)
+    })
+
+    // Must match lib/utils' hexToRGBA for valid hex (incl. 3/8-digit forms); the one intentional
+    // divergence is that a non-hex string is returned unchanged rather than producing rgba(NaN,...).
+    it.each([
+        { base: '#ff0000', expected: hexToRGBA('#ff0000', 0.5) },
+        { base: '#f00', expected: hexToRGBA('#f00', 0.5) },
+        { base: '#ff000080', expected: hexToRGBA('#ff000080', 0.5) },
+        { base: 'var(--color-1)', expected: 'var(--color-1)' },
+        { base: 'not-a-hex', expected: 'not-a-hex' },
+    ])('dimHexColor($base) -> $expected', ({ base, expected }) => {
+        expect(dimHexColor(base, 0.5)).toBe(expected)
+    })
+
+    it('respects the requested alpha', () => {
+        expect(dimHexColor('#ffffff', 0.25)).toBe('rgba(255,255,255,0.25)')
+    })
+})

--- a/products/product_analytics/frontend/insights/trends/shared/compareDimming.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/compareDimming.ts
@@ -2,8 +2,9 @@
 export const COMPARE_PREVIOUS_DIM_OPACITY = 0.5
 
 // Inlined hex math (mirrors `lib/utils` `hexToRGBA`) so this module stays free of `lib/`/`~/`/`scenes/`
-// deps and compiles in the MCP Vite bundle, which only resolves `products/*` and `@posthog/*`. Returns
-// the input unchanged if it isn't a 3/6/8-digit hex (callers always pass palette hexes).
+// deps and compiles in the MCP Vite bundle, which only resolves `products/*` and `@posthog/*`. 3/4-digit
+// shorthand is expanded to 6/8-digit first; anything that isn't ultimately a 6- or 8-digit hex is returned
+// unchanged (callers always pass palette hexes). Note an 8-digit input's alpha byte is dropped in favor of `alpha`.
 export function dimHexColor(hex: string, alpha: number): string {
     let h = hex.replace(/^#/, '')
     if (h.length === 3 || h.length === 4) {

--- a/products/product_analytics/frontend/insights/trends/shared/compareDimming.ts
+++ b/products/product_analytics/frontend/insights/trends/shared/compareDimming.ts
@@ -1,0 +1,22 @@
+// Compare-against-previous series render at half opacity so they recede behind the current period.
+export const COMPARE_PREVIOUS_DIM_OPACITY = 0.5
+
+// Inlined hex math (mirrors `lib/utils` `hexToRGBA`) so this module stays free of `lib/`/`~/`/`scenes/`
+// deps and compiles in the MCP Vite bundle, which only resolves `products/*` and `@posthog/*`. Returns
+// the input unchanged if it isn't a 3/6/8-digit hex (callers always pass palette hexes).
+export function dimHexColor(hex: string, alpha: number): string {
+    let h = hex.replace(/^#/, '')
+    if (h.length === 3 || h.length === 4) {
+        h = h
+            .split('')
+            .map((char) => char + char)
+            .join('')
+    }
+    if (h.length !== 6 && h.length !== 8) {
+        return hex
+    }
+    const r = parseInt(h.slice(0, 2), 16)
+    const g = parseInt(h.slice(2, 4), 16)
+    const b = parseInt(h.slice(4, 6), 16)
+    return `rgba(${r},${g},${b},${alpha})`
+}


### PR DESCRIPTION
## Problem

Enabling "Compare to previous period" on a **stickiness** insight renders the previous-period series at full opacity — visually identical to the current period. Every other trends insight dims the previous period to half opacity so it recedes behind the current one. This regressed when stickiness charts migrated to the new quill-charts renderer.

## Changes

The stickiness chart transforms were ported to quill-charts without the compare-against-previous dimming step the trends transforms carry — `StickinessResultLike` had dropped the `compare`/`compare_label` fields and `buildStickinessMainSeries` applied the series color raw.

- Add `compare`/`compare_label` back to `StickinessResultLike` and dim the previous-period series to `0.5` alpha in `buildStickinessMainSeries`. This single change covers **both** the stickiness bar and line charts (they share the builder), and the area-graph fill inherits the dimmed color.
- Extract the `dimHexColor` + `COMPARE_PREVIOUS_DIM_OPACITY` helper out of `trendsBarChartTransforms` into a shared, dependency-free `trends/shared/compareDimming.ts` so both call sites reuse it (kept free of `lib/`/`~/`/`scenes/` deps so it still compiles in the MCP Vite bundle).

Incomplete-period dashing is intentionally **not** added: stickiness's x-axis is interval counts ("Day 0, Day 1…"), not calendar time, so there is no in-progress final period to dash — the existing `!isStickiness` guard is correct.

~_No screenshots: this was authored by an agent without a running UI. The change flips the previous-period series color from the palette hex to `rgba(r,g,b,0.5)`._~

<img width="1711" height="653" alt="Screenshot 2026-06-23 at 14 04 24" src="https://github.com/user-attachments/assets/ee7e7c8b-15b1-4619-afae-fcccf2b220b6" />

## How did you test this code?

Authored by an agent — I did not manually exercise the UI. Automated tests run locally:

- `stickinessChartTransforms.test.ts` — new parameterized case asserting `compare_label: 'previous'` dims to `0.5` alpha while `current`/absent stay full color.
- `compareDimming.test.ts` — new unit test for the extracted helper (hex parity with `lib/utils` `hexToRGBA`, non-hex pass-through).
- `trendsBarChartTransforms.test.ts` — existing dimming tests still pass after the import move.
- Full stickiness + `TrendsBarChart` suites: 156 tests across 9 suites pass.
- `oxfmt` + `oxlint` clean on the changed files (the single remaining `oxlint` warning is pre-existing, on untouched code).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by the requesting engineer (please self-assign as DRI).

Investigated a reported regression in the stickiness "Compare against" visualization using Claude Code. Traced the chart pipeline (`trendsDataLogic` → stickiness transforms → quill-charts) and found the previous-period dimming was dropped during the quill-charts migration, while the trends bar/line charts still dim via `resolveBarColor` / `applyComparisonDimming`.

Decisions along the way:

- Dim the series color directly in the shared stickiness builder rather than mirror the trends *line* `comparisonOf` + `applyComparisonDimming` path — stickiness has no derived series (confidence intervals / moving averages / trend lines), so color-level dimming is simpler and covers both bar and line in one place.
- Extracted the dimming helper into a shared module instead of duplicating the inlined hex math a third time, keeping it MCP-bundle-safe.
- Confirmed with the requester that incomplete-period dashing is out of scope for stickiness.

No repo skills were required (no DRF / migrations / generated-API-type / taxonomic-filter surfaces touched).
