### PR TITLE
chore(replay-vision): lower default summary sample rate and monthly cap

### DIFF
--- a/posthog/session_recordings/ai_summary_cap.py
+++ b/posthog/session_recordings/ai_summary_cap.py
@@ -24,7 +24,7 @@ from posthog.redis import get_client
 logger = structlog.get_logger(__name__)
 
 # Bump in a deploy. Per-team lowering is allowed via SignalSourceConfig.
-DEFAULT_MAX_SUMMARIES_PER_PERIOD = 4 * 1000
+DEFAULT_MAX_SUMMARIES_PER_PERIOD = 2500
 
 # JSON key on SignalSourceConfig.config.
 CONFIG_KEY = "max_summaries_per_period"

--- a/posthog/temporal/session_replay/summarization_sweep/constants.py
+++ b/posthog/temporal/session_replay/summarization_sweep/constants.py
@@ -14,7 +14,7 @@ SCHEDULE_INTERVAL = timedelta(minutes=5)
 SESSION_LOOKBACK_MINUTES = 30
 
 SAMPLE_RATE_PRECISION = 10_000
-DEFAULT_SAMPLE_RATE = 0.1
+DEFAULT_SAMPLE_RATE = 0.05
 
 # Caps in-flight `start_child_workflow` calls per tick to keep the dispatch loop within
 # WORKFLOW_EXECUTION_TIMEOUT.


### PR DESCRIPTION
## Problem

The autonomous Replay Vision summarization sweep generates summaries for sampled sessions on a per-team Temporal schedule. The two defaults that govern total summary volume — and therefore LLM cost — were set higher than we want for steady-state operation. We're dialing both down.

## Changes

Two default constants lowered:

| Constant | File | Before | After |
| --- | --- | --- | --- |
| `DEFAULT_SAMPLE_RATE` | `posthog/temporal/session_replay/summarization_sweep/constants.py` | `0.1` (10%) | `0.05` (5%) |
| `DEFAULT_MAX_SUMMARIES_PER_PERIOD` | `posthog/session_recordings/ai_summary_cap.py` | `4000` | `2500` |

- The sample rate is the fraction of eligible sessions the sweep picks up each tick. Halving it roughly halves the candidate volume feeding the summarize path.
- The monthly cap is the per-team hard backstop (a Redis counter, resets on the 1st). Both remain overridable **downward** per team via `SignalSourceConfig.config` — this only moves the defaults; the override-can-only-lower semantics are unchanged.

No behavioral/logic changes — only the default values.

## How did you test this code?

I'm an agent (Claude Code). No manual testing. The pre-commit hook ran Python lint, format, and `ty` typecheck on the two changed files — all passed. No existing tests assert the prior literal values (both constants are referenced everywhere via their names), so none needed updating.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tue asked to lower the two summarization defaults. Scope is deliberately just the two constant values — no logic, no test changes — since the cap and sample-rate are both read through their named constants throughout the sweep and DRF paths. Branch cut fresh off `master`.
