### PR TITLE
fix(signals): let multi-workspace users enable inbox Slack pings

### DIFF
--- a/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/SlackNotificationsSection.tsx
@@ -56,8 +56,8 @@ export function SlackNotificationsSection(): JSX.Element {
     useMountedLogic(integrationsLogic)
     useMountedLogic(userAutonomyLogic)
     const { slackIntegrations, integrationsLoading } = useValues(integrationsLogic)
-    const { autonomyConfig, autonomyConfigLoading } = useValues(userAutonomyLogic)
-    const { updateSlackNotifications } = useActions(userAutonomyLogic)
+    const { autonomyConfig, autonomyConfigLoading, slackPickersExpanded } = useValues(userAutonomyLogic)
+    const { updateSlackNotifications, setSlackPickersExpanded } = useActions(userAutonomyLogic)
 
     if (integrationsLoading && slackIntegrations === undefined) {
         return <LemonSkeleton className="h-20 w-full" />
@@ -79,12 +79,16 @@ export function SlackNotificationsSection(): JSX.Element {
     const onToggleEnabled = (enabled: boolean): void => {
         if (enabled) {
             // Turning on just opens the workspace/channel pickers – the actual enable
-            // happens once a channel is chosen. Persist the workspace if it's unambiguous.
+            // happens once a channel is chosen. Reveal them even when the workspace is
+            // ambiguous (multiple connected) so the user can pick one; persist it now
+            // only when it's unambiguous.
+            setSlackPickersExpanded(true)
             if (effectiveIntegration && selectedIntegrationId === null) {
                 updateSlackNotifications({ integrationId: effectiveIntegration.id })
             }
         } else {
-            // Disable by clearing the target.
+            // Disable by clearing the target and collapsing the pickers.
+            setSlackPickersExpanded(false)
             updateSlackNotifications({ integrationId: null, channel: null })
         }
     }
@@ -111,8 +115,9 @@ export function SlackNotificationsSection(): JSX.Element {
         })
     }
 
-    // "On" means the pickers are visible; either an integration is explicitly selected or a channel is set.
-    const showPickers = selectedIntegrationId !== null || !!channel
+    // "On" means the pickers are visible: the user expanded them, or a saved integration/channel
+    // already implies an enabled state.
+    const showPickers = slackPickersExpanded || selectedIntegrationId !== null || !!channel
 
     return (
         <div className="flex flex-col gap-3 rounded border bg-bg-light px-3 py-2.5">

--- a/frontend/src/scenes/inbox/logics/userAutonomyLogic.ts
+++ b/frontend/src/scenes/inbox/logics/userAutonomyLogic.ts
@@ -24,6 +24,9 @@ export const userAutonomyLogic = kea<userAutonomyLogicType>([
             channel?: string | null
             minPriority?: SignalReportPriority | null
         }) => ({ updates }),
+        // Ephemeral view state: whether the workspace/channel pickers are revealed. Lets a user
+        // with multiple workspaces (and nothing saved yet) open the pickers to pick one.
+        setSlackPickersExpanded: (expanded: boolean) => ({ expanded }),
     }),
     loaders({
         autonomyConfig: [
@@ -52,6 +55,12 @@ export const userAutonomyLogic = kea<userAutonomyLogicType>([
                 ...('minPriority' in updates ? { slack_notification_min_priority: updates.minPriority ?? null } : {}),
             }),
         },
+        slackPickersExpanded: [
+            false,
+            {
+                setSlackPickersExpanded: (_, { expanded }) => expanded,
+            },
+        ],
     }),
     listeners(({ actions }) => ({
         setAutostartPriority: async ({ priority }) => {


### PR DESCRIPTION
## Problem

The "Notify me directly" toggle in the Signals inbox config (per-user Slack pings when you're a suggested reviewer) was impossible to turn on for anyone with more than one Slack workspace connected. Clicking it did nothing and the switch snapped straight back off.

The toggle is a controlled switch whose "on" state was derived purely from a saved integration/channel. Turning on only persisted a workspace when it was *unambiguous* (exactly one connected), and the workspace picker was itself gated behind that same saved state — so with multiple workspaces and nothing saved yet, the enable handler fired no action, the switch reverted, and the picker that would let you choose a workspace never rendered.

## Changes

Added an ephemeral `slackPickersExpanded` view-state flag (action + reducer) to `userAutonomyLogic`. Toggling on now always reveals the workspace/channel pickers — even when the workspace is ambiguous — so a multi-workspace user can pick one and then a channel to actually enable notifications. Toggling off collapses the pickers and clears the saved target as before. Single-workspace behavior is unchanged (it still auto-persists the lone workspace).

## How did you test this code?

I'm an agent. I ran `kea-typegen` to regenerate the logic types and confirmed the new action/value wired through. I did not run the full TS check or manual UI testing — the frontend toolchain (oxlint/oxfmt/tsc) wasn't installed in my environment, so CI covers typecheck/lint.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The user reported they couldn't turn the toggle on and confirmed they have multiple Slack integrations connected, which pinpointed the dead-end in the enable path. Diagnosed the controlled-switch logic in `SlackNotificationsSection.tsx`, traced the no-op enable handler, and chose to fix it by adding ephemeral expand state in the kea logic (per repo convention of keeping view state in logics rather than React `useState`) rather than reworking the derived-state model. No skills were required for this frontend-only change.
