### PR TITLE
fix(logs): force OPTIMIZED property groups for logs-cluster queries

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -1,6 +1,6 @@
 from typing import TYPE_CHECKING, cast
 
-from posthog.schema_enums import InCohortVia
+from posthog.schema_enums import InCohortVia, PropertyGroupsMode
 
 if TYPE_CHECKING:
     from posthog.schema import HogQLQueryModifiers
@@ -169,6 +169,13 @@ def prepare_ast_for_printing(
         collector = WorkloadCollector(default_workload=Workload.DEFAULT)
         collector.visit(node)
         context.workload = collector.get_workload()
+
+    # LOGS-cluster tables (logs, spans, metrics) store attributes in `*_map_str/_float` Map columns, not JSON blobs.
+    # Property reads only resolve to those Map columns under OPTIMIZED; otherwise they fall back to JSONExtract, which
+    # errors on a Map. Force OPTIMIZED here — after workload detection, before property resolution reads the modifier —
+    # so every caller (SQL panel, alerts, runners) is correct without each having to set it.
+    if context.workload == Workload.LOGS and context.modifiers.propertyGroupsMode is None:
+        context.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
 
     if context.modifiers.optimizeProjections:
         with context.timings.measure("projection_pushdown"):

--- a/products/logs/backend/test/test_alert_check_query.py
+++ b/products/logs/backend/test/test_alert_check_query.py
@@ -243,6 +243,35 @@ class TestAlertCheckQuery(ClickhouseTestMixin, APIBaseTest):
         assert result.count > 0
 
     @freeze_time("2025-12-16T10:33:00Z")
+    def test_raw_scan_path_log_attribute_filter(self):
+        # log_attribute filters read the `attributes_map_str` Map column. This only happens with
+        # propertyGroupsMode=OPTIMIZED; without it the read falls back to JSONExtract, which is
+        # illegal on a Map and the query errors at execution time.
+        alert = self._make_alert(
+            filters={
+                "filterGroup": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {
+                                    "key": "log.iostream",
+                                    "value": "stderr",
+                                    "operator": "exact",
+                                    "type": "log_attribute",
+                                }
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = self._make_query(alert).execute()
+        assert isinstance(result, AlertCheckCountResult)
+        assert result.count > 0
+
+    @freeze_time("2025-12-16T10:33:00Z")
     def test_empty_results_return_zero(self):
         alert = self._make_alert(
             filters={

--- a/products/logs/backend/test/test_logs_sql_panel.py
+++ b/products/logs/backend/test/test_logs_sql_panel.py
@@ -1,0 +1,20 @@
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+
+from posthog.schema import HogQLQuery
+
+from posthog.hogql_queries.hogql_query_runner import HogQLQueryRunner
+
+
+class TestLogsSqlPanel(ClickhouseTestMixin, APIBaseTest):
+    def test_attribute_filter_uses_map_not_json(self):
+        # Arbitrary HogQL from the SQL panel reads logs attributes via the `attributes_map_str` Map column.
+        # This relies on the LOGS workload forcing propertyGroupsMode=OPTIMIZED; without it the read falls
+        # back to JSONExtract, which is illegal on a Map and errors at execution time.
+        runner = HogQLQueryRunner(
+            query=HogQLQuery(query="SELECT count() FROM logs WHERE attributes.`log.iostream__str` = 'stderr'"),
+            team=self.team,
+        )
+        response = runner.calculate()
+        sql = response.clickhouse or ""
+        assert "JSONExtract" not in sql
+        assert "attributes_map_str" in sql


### PR DESCRIPTION
## Problem

Querying the logs (or spans/metrics) tables by attribute fails with a ClickHouse error whenever the query isn't running with `propertyGroupsMode=OPTIMIZED`:

```
DB::Exception: The first argument of function JSONExtractRaw should be a string containing JSON
or a JSON object, illegal type: Map(String, String) ... on arguments attributes Map(...)
```

These tables store attributes in `attributes_map_str` / `attributes_map_float` ClickHouse `Map` columns, but HogQL declares `attributes` as a JSON blob field. Attribute reads only resolve to the Map columns under `OPTIMIZED`; otherwise the printer emits `JSONExtract`, which is illegal on a `Map`. `OPTIMIZED` was only auto-enabled on cloud, so any caller that didn't set it explicitly broke — notably **log alert checks** and **arbitrary HogQL from the SQL panel** (off-cloud, and anywhere the modifier wasn't forced).

The main logs list runner already worked because it sets `OPTIMIZED` explicitly, which masked the gap.

## Changes

Force `propertyGroupsMode=OPTIMIZED` in `prepare_ast_for_printing`, right after workload detection and before property resolution reads the modifier, when the query's workload is `LOGS`:

```python
if context.workload == Workload.LOGS and context.modifiers.propertyGroupsMode is None:
    context.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
```

This is the correct layer: workload is already detected here (from the resolved table types — `logs`, spans, and metrics all carry `Workload.LOGS`), and it fixes **every** caller at once (SQL panel, alerts, all product runners) rather than scattering the modifier across each call site. It respects an explicitly-set `propertyGroupsMode` via the `is None` guard, and only changes behavior for LOGS-cluster queries — which otherwise error.

## How did you test this code?

I'm an agent (PostHog Code). I added two regression tests and confirmed each **fails without the fix** (with the exact `JSONExtractRaw ... Map` error) and **passes with it**:

- `products/logs/backend/test/test_logs_sql_panel.py` — SQL-panel `HogQLQuery` against logs with an attribute filter.
- `test_alert_check_query.py::...test_raw_scan_path_log_attribute_filter` — the alert path.

Automated suites run locally (against local Postgres + ClickHouse):

- Logs runners + alerts + SQL panel: 149 passed
- Core HogQL printer + workload: 744 passed
- Spans + metrics (shared `Workload.LOGS`): 95 passed
- ruff clean

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Diagnosis: traced the HogQL property-resolution pipeline to find that `logs.attributes` is a `StringJSONDatabaseField` over a physical `Map`, so `JSONExtract` is never valid for it — the optimization is a correctness requirement, not just a perf win. First localized the failure to the alert check query path, then the follow-up requirement (SQL panel) made it clear the right fix is one workload-driven gate in the printer rather than per-caller modifier setting; the alert-specific patch was reverted in favor of the central fix. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
