### PR TITLE
fix(ci): treat cancelled frontend jobs as non-failing in gate

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -671,23 +671,27 @@ jobs:
         steps:
             - run: exit 0
             - name: Check outcomes
+              # A cancelled run (e.g. concurrency cancel-in-progress on a superseded commit) leaves
+              # upstream jobs as `cancelled`; treat that as non-failing so the gate doesn't report a
+              # red failure. A genuine job failure still aggregates to `failure` and fails the gate.
+              if: ${{ !cancelled() }}
               run: |
-                  if [[ "${{ needs.jest.result }}" != "success" && "${{ needs.jest.result }}" != "skipped" ]]; then
+                  if [[ "${{ needs.jest.result }}" != "success" && "${{ needs.jest.result }}" != "skipped" && "${{ needs.jest.result }}" != "cancelled" ]]; then
                     echo "Frontend jest tests failed."
                     exit 1
                   fi
                   echo "Frontend jest tests passed."
-                  if [[ "${{ needs.frontend-format.result }}" != "success" && "${{ needs.frontend-format.result }}" != "skipped" ]]; then
+                  if [[ "${{ needs.frontend-format.result }}" != "success" && "${{ needs.frontend-format.result }}" != "skipped" && "${{ needs.frontend-format.result }}" != "cancelled" ]]; then
                     echo "Frontend linting failed."
                     exit 1
                   fi
                   echo "Frontend linting passed."
-                  if [[ "${{ needs.frontend-bundle-size.result }}" != "success" && "${{ needs.frontend-bundle-size.result }}" != "skipped" ]]; then
+                  if [[ "${{ needs.frontend-bundle-size.result }}" != "success" && "${{ needs.frontend-bundle-size.result }}" != "skipped" && "${{ needs.frontend-bundle-size.result }}" != "cancelled" ]]; then
                     echo "Frontend bundle size checks failed."
                     exit 1
                   fi
                   echo "Frontend bundle size checks passed."
-                  if [[ "${{ needs.frontend-typescript-checks.result }}" != "success" && "${{ needs.frontend-typescript-checks.result }}" != "skipped" ]]; then
+                  if [[ "${{ needs.frontend-typescript-checks.result }}" != "success" && "${{ needs.frontend-typescript-checks.result }}" != "skipped" && "${{ needs.frontend-typescript-checks.result }}" != "cancelled" ]]; then
                     echo "Frontend TypeScript checks failed."
                     exit 1
                   fi


### PR DESCRIPTION
## Problem

The `Frontend Tests Pass` gate job in `ci-frontend.yml` runs with `if: always()`, so it executes even when the whole workflow run is cancelled — e.g. concurrency `cancel-in-progress` superseding a run when a newer commit is pushed.

Its outcome check treated **anything that isn't `success` or `skipped` as a failure**, which includes `cancelled`. So when every upstream job was cancelled, the gate exited 1 and reported a red `failure` instead of being a harmless no-op. [Example run](https://github.com/PostHog/posthog/actions/runs/28008107250/job/82894631799): all frontend jobs `cancelled`, gate reported `failure`.

## Changes

- Added `if: ${{ !cancelled() }}` to the gate's "Check outcomes" step, so a cancelled run skips the check entirely.
- Added `&& != 'cancelled'` to each of the four per-job conditions (jest, format, bundle-size, typescript), so a `cancelled` upstream result no longer trips the gate.

Genuine failures are unaffected: in a matrix, `failure` takes precedence over `cancelled` in the aggregated `needs.<job>.result`, so a real test failure still surfaces as `failure` and correctly fails the gate. Only collateral cancellations (superseded runs, fail-fast siblings) stop producing false reds.

## How did you test this code?

I'm an agent. I validated the workflow YAML parses cleanly after the edit. No CI run was triggered specifically to exercise the cancelled path. The logic change is a guard-condition widening with no new dependencies.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a CI run flagged by Tom where the `Frontend Tests Pass` gate reported a failure while every upstream frontend job was `cancelled`. Root cause: the gate's `if: always()` + "not success and not skipped = fail" logic counts `cancelled` as a failure. Fix widens the allowlist to include `cancelled` and short-circuits the check when the run itself is cancelled. Considered relying solely on `!cancelled()` but kept the explicit per-job `!= 'cancelled'` checks too, since they also cover fail-fast sibling cancellations where the run as a whole is not cancelled. Checked other workflow gate jobs (`ci-backend.yml` and siblings) — the only similar `!= 'success' && != 'skipped'` matches are a conservative "run job on detection failure" trigger, not a pass/fail gate, so no change needed there.
