### PR TITLE
chore(tasks): remove feature flag gating for /tasks routes

### DIFF
--- a/products/tasks/frontend/TaskDetailScene.tsx
+++ b/products/tasks/frontend/TaskDetailScene.tsx
@@ -1,6 +1,4 @@
 import { AllowTrainingCallout } from 'lib/components/AllowTrainingCallout/AllowTrainingCallout'
-import { NotFound } from 'lib/components/NotFound'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { SceneExport } from 'scenes/sceneTypes'
 
 import { ProductKey } from '~/queries/schema/schema-general'
@@ -18,12 +16,6 @@ export const scene: SceneExport<TaskDetailSceneLogicProps> = {
 }
 
 export function TaskDetailScene({ taskId }: TaskDetailSceneLogicProps): JSX.Element {
-    const isEnabled = useFeatureFlag('TASKS')
-
-    if (!isEnabled) {
-        return <NotFound object="Tasks" caption="This feature is not enabled for your project." />
-    }
-
     return (
         <>
             <AllowTrainingCallout featureName="PostHog Code" />

--- a/products/tasks/frontend/TaskTracker.tsx
+++ b/products/tasks/frontend/TaskTracker.tsx
@@ -1,6 +1,4 @@
 import { AllowTrainingCallout } from 'lib/components/AllowTrainingCallout/AllowTrainingCallout'
-import { NotFound } from 'lib/components/NotFound'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene, SceneExport } from 'scenes/sceneTypes'
 
@@ -18,12 +16,6 @@ export const scene: SceneExport = {
 }
 
 export function TaskTracker(): JSX.Element {
-    const isEnabled = useFeatureFlag('TASKS')
-
-    if (!isEnabled) {
-        return <NotFound object="Tasks" caption="This feature is not enabled for your project." />
-    }
-
     return (
         <SceneContent>
             <SceneTitleSection


### PR DESCRIPTION
## Problem

The `/tasks` and `/tasks/:taskId` scenes were gated behind the `TASKS` feature flag at render time — without the flag, both routes rendered a "not enabled" NotFound page. We want these routes accessible without the flag.

## Changes

Removed the `useFeatureFlag('TASKS')` guard (and the now-unused `NotFound` / `useFeatureFlag` imports) from `TaskTracker.tsx` and `TaskDetailScene.tsx`. The routes themselves were never flag-gated in the manifest; the gating lived entirely in these render-time guards. The `fileSystemTypes` flag in the manifest (which controls project-tree/nav visibility, not route access) is left untouched.

## How did you test this code?

I'm an agent. Frontend lint/format and typecheck tooling wasn't installed in this environment, so I did not run them. The change is a pure removal of a guard block plus its now-unused imports; remaining imports are still used. No automated tests were run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: remove feature flag gating for the `/tasks` and `/tasks/{run_id}` routes. Used the PostHog Slack app agent. Explored the tasks product to locate the gate, found it was a render-time `useFeatureFlag('TASKS')` check in each scene (not a router-level redirect), and removed it along with the imports that became unused. No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782206942905429)*
