### PR TITLE
fix(klaviyo): cap Get Lists page size at Klaviyo's documented max

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -246,6 +246,19 @@ class TestListProfilesFanOut:
         assert list_profiles.supports_append is False
         assert list_profiles.should_sync_default is False
 
+    def test_lists_request_stays_within_klaviyo_page_size_cap(self, monkeypatch: Any) -> None:
+        # Klaviyo's Get Lists endpoint caps page[size] at 10; a larger value 400s the whole fan-out.
+        fetched_urls: list[str] = []
+
+        def fake_fetch(session: Any, url: str, headers: dict[str, str], logger: Any) -> dict:
+            fetched_urls.append(url)
+            return {"data": [], "links": {"next": None}}
+
+        monkeypatch.setattr(klaviyo, "_fetch_page", fake_fetch)
+        list(klaviyo._iter_list_ids(MagicMock(), {}, MagicMock()))
+
+        assert fetched_urls == ["https://a.klaviyo.com/api/lists?page[size]=10"]
+
     def test_fans_out_over_every_list_into_membership_rows(self, monkeypatch: Any) -> None:
         pages = {
             "https://a.klaviyo.com/api/lists?page[size]=10": {


### PR DESCRIPTION
## Problem

The Klaviyo data-warehouse import source surfaced a recurring `HTTPError` in error tracking, originating in `posthog/temporal/data_imports/sources/klaviyo/klaviyo.py`:

> `400 Client Error: Bad Request for url: https://a.klaviyo.com/api/lists?page[size]=100`

The `list_profiles` table fans out over every Klaviyo list, enumerating them via `_iter_list_ids`, which requested `/lists` with `page[size]=100`. Klaviyo's [Get Lists endpoint](https://developers.klaviyo.com/en/reference/get_lists) caps `page[size]` at **10** (default 10, min 1, max 10) and rejects larger values with a `400`, failing the whole fan-out sync before any list membership could be read.

The standalone `lists` table is unaffected because its config sends no `page[size]` (defaulting to Klaviyo's 10); only the fan-out path hardcoded the out-of-range value.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ef3d0-1ce3-7de2-8476-e6e02e6a2298

## Changes

- `_iter_list_ids` now requests `/lists` with `page[size]=10`, the endpoint's documented maximum, so pagination stays valid while still pulling the largest allowed page.

This is a code bug (an out-of-range request parameter we always sent), not an upstream/credential problem, so it's fixed in the source rather than added to `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I ran the source's existing unit tests plus a new regression test:

- Added `test_lists_request_stays_within_klaviyo_page_size_cap`, which asserts `_iter_list_ids` builds `/lists?page[size]=10` — it would have caught the original `page[size]=100`.
- Updated the existing fan-out tests to the corrected list URL.
- `pytest posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py` → 33 passed.
- `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the stack trace genuinely originates in `klaviyo.py` (`_fetch_page` → `_iter_list_ids` → `_get_list_profile_rows`, the `fan_out_over_lists` path) and cross-checked Klaviyo's Get Lists API docs to confirm the `page[size]` max is 10. Verified no existing open PR addresses this (the only other Klaviyo PR concerns the CDP *destination* revision, not this import source). Scoped strictly to the one out-of-range parameter; left the relationships/profiles `page[size]=1000` request untouched as it targets a different endpoint and is not implicated in the failure.