### PR TITLE
chore(mcp): disable UI app bundle caching in local dev

### DIFF
--- a/services/mcp/src/hono/public-routes.ts
+++ b/services/mcp/src/hono/public-routes.ts
@@ -1,6 +1,7 @@
 import { serveStatic } from '@hono/node-server/serve-static'
 import type { Hono } from 'hono'
 
+import { isLocalApi } from '@/lib/constants'
 import { buildRedirectUrl, getPublicUrl, matchAuthServerRedirect } from '@/lib/routing'
 import { getAdvertisedOAuthScopes } from '@/tools/toolDefinitions'
 
@@ -80,6 +81,17 @@ const authRedirectHandler = (c: HonoCtx): Response => {
  * resource metadata, MCP UI app static assets, and auth-server fallback redirects.
  */
 export function registerPublicRoutes(app: Hono, redis: RedisWithPing, lifecycle: Lifecycle): void {
+    // The client (e.g. Claude Desktop) caches UI app bundles, so after rebuilding them
+    // locally it can keep serving the old version and your changes won't show up.
+    // Disable caching in dev so rebuilds are always reflected.
+    // Prod keeps its default caching.
+    app.use('/ui-apps/*', async (c, next) => {
+        await next()
+        if (isLocalApi()) {
+            c.header('Cache-Control', 'no-store')
+        }
+    })
+
     // MCP UI app static assets. The CF runtime serves these via the Workers
     // Static Assets binding (`wrangler.jsonc`'s `assets.directory: ./public/`);
     // here we serve them from disk so the same `${MCP_APPS_BASE_URL}/ui-apps/...`


### PR DESCRIPTION
## Problem

MCP UI app bundles are served at a stable, unhashed URL (`/ui-apps/<app>/main.js`). Clients — notably Claude Desktop's webview — cache them, so after rebuilding a UI app locally the client keeps serving the old bundle and your changes don't show up, even across server restarts, until you manually clear the client cache.

## Changes

Send `Cache-Control: no-store` for `/ui-apps/*` in local dev (gated on `isLocalApi()`), so a `build:ui-apps` is always reflected in the client.

Production is unaffected: its Cloudflare Workers Assets path already serves these with `max-age=0, must-revalidate` + ETag, and the middleware is both gated on `isLocalApi()` and bypassed by the CF edge serving `/ui-apps/*` before the Worker.

## How did you test this code?

I'm an agent. The human reviewer verified locally that, after the change, rebuilt UI app bundles are reflected in the client without clearing its cache. `tsgo` typecheck passes. No automated tests added (single dev-only response header).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 4.8). Diagnosed a stale-UI issue where local UI-app rebuilds weren't reflected in Claude Desktop and traced it to client-side caching of the stable bundle URL. Considered content-hashed filenames and tuning `Cache-Control`; chose the smallest dev-only fix since prod already revalidates via ETag. Content-hashing remains a possible future optimization to drop prod's per-load revalidation round-trip.
