### PR TITLE
fix(llma): stop eval reports firing after evaluation is deleted

### DIFF
--- a/posthog/temporal/ai_observability/eval_reports/activities.py
+++ b/posthog/temporal/ai_observability/eval_reports/activities.py
@@ -41,10 +41,9 @@ async def fetch_due_eval_reports_activity(
 
         return [
             str(pk)
-            for pk in EvaluationReport.objects.filter(
+            for pk in EvaluationReport.objects.deliverable()
+            .filter(
                 next_delivery_date__lte=now_with_buffer,
-                enabled=True,
-                deleted=False,
                 evaluation__output_type="boolean",
             )
             .exclude(frequency=EvaluationReport.Frequency.EVERY_N)
@@ -84,13 +83,13 @@ async def fetch_count_triggered_eval_reports_activity(
         skipped_daily_cap = 0
 
         reports = list(
-            EvaluationReport.objects.filter(
+            EvaluationReport.objects.deliverable()
+            .filter(
                 frequency=EvaluationReport.Frequency.EVERY_N,
-                enabled=True,
-                deleted=False,
                 trigger_threshold__isnull=False,
                 evaluation__output_type="boolean",
-            ).select_related("evaluation")
+            )
+            .select_related("evaluation")
         )
         total_checked = len(reports)
 

--- a/products/ai_observability/backend/migrations/0007_retire_reports_for_deleted_evaluations.py
+++ b/products/ai_observability/backend/migrations/0007_retire_reports_for_deleted_evaluations.py
@@ -1,0 +1,23 @@
+from django.db import migrations
+
+
+def retire_reports_for_deleted_evaluations(apps, schema_editor):
+    # Safe to run synchronously and unbatched: at PR time the affected set was tiny —
+    # 180 orphaned rows of 936 total (US) and 69 of 361 (EU), 249 rows across 88 teams.
+    # A single UPDATE over a few hundred rows holds locks only momentarily.
+    EvaluationReport = apps.get_model("ai_observability", "EvaluationReport")
+    EvaluationReport.objects.filter(evaluation__deleted=True, deleted=False).update(deleted=True, enabled=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai_observability", "0006_alter_evaluation_evaluation_type_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            retire_reports_for_deleted_evaluations,
+            migrations.RunPython.noop,
+            elidable=True,
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0006_alter_evaluation_evaluation_type_and_more
+0007_retire_reports_for_deleted_evaluations

--- a/products/ai_observability/backend/models/evaluation_reports.py
+++ b/products/ai_observability/backend/models/evaluation_reports.py
@@ -10,7 +10,14 @@ from posthog.models.utils import UUIDTModel
 from products.workflows.backend.utils.rrule_utils import compute_next_occurrences, validate_rrule
 
 
+class EvaluationReportQuerySet(models.QuerySet):
+    def deliverable(self) -> "EvaluationReportQuerySet":
+        return self.filter(enabled=True, deleted=False, evaluation__deleted=False)
+
+
 class EvaluationReport(UUIDTModel):
+    objects = EvaluationReportQuerySet.as_manager()
+
     class Frequency(models.TextChoices):
         # Time-based, driven by the `rrule` string (e.g. "FREQ=WEEKLY;BYDAY=MO,FR").
         SCHEDULED = "scheduled"

--- a/products/ai_observability/backend/models/evaluations.py
+++ b/products/ai_observability/backend/models/evaluations.py
@@ -211,6 +211,11 @@ class Evaluation(ModelActivityMixin, UUIDTModel):
 def evaluation_saved(sender, instance, created, **kwargs):
     from posthog.plugins.plugin_server_api import reload_evaluations_on_workers
 
+    from .evaluation_reports import EvaluationReport
+
+    if instance.deleted:
+        EvaluationReport.objects.filter(evaluation_id=instance.id, deleted=False).update(deleted=True, enabled=False)
+
     # Defer publishing to workers until the surrounding transaction commits — otherwise
     # workers can fire before the row is visible, especially now that perform_create wraps
     # the save + EvaluationReport create in transaction.atomic(). In auto-commit mode

--- a/products/ai_observability/backend/models/test/test_evaluation_reports.py
+++ b/products/ai_observability/backend/models/test/test_evaluation_reports.py
@@ -120,6 +120,86 @@ class TestEvaluationReportModel(BaseTest):
         assert report.next_delivery_date is not None
 
 
+class TestEvaluationReportDeletionCascade(BaseTest):
+    def _create_evaluation(self) -> Evaluation:
+        return Evaluation.objects.create(
+            team=self.team,
+            name="Test Eval",
+            evaluation_type="llm_judge",
+            evaluation_config={"prompt": "test"},
+            output_type="boolean",
+            output_config={},
+            enabled=True,
+            created_by=self.user,
+            conditions=[{"id": "c1", "rollout_percentage": 100, "properties": []}],
+        )
+
+    def _report_for(self, evaluation: Evaluation, **overrides) -> EvaluationReport:
+        defaults = {
+            "team": self.team,
+            "evaluation": evaluation,
+            "frequency": EvaluationReport.Frequency.SCHEDULED,
+            "rrule": "FREQ=HOURLY",
+            "starts_at": timezone.now() - dt.timedelta(hours=5),
+            "delivery_targets": [],
+        }
+        defaults.update(overrides)
+        return EvaluationReport.objects.create(**defaults)
+
+    def test_deliverable_excludes_reports_for_deleted_evaluations(self):
+        live = self._report_for(self._create_evaluation())
+        deleted_eval = self._create_evaluation()
+        orphaned = self._report_for(deleted_eval)
+        # Bypass the cascade signal so deliverable() is tested as an independent guard.
+        Evaluation.objects.filter(pk=deleted_eval.pk).update(deleted=True)
+
+        deliverable_ids = set(EvaluationReport.objects.deliverable().values_list("id", flat=True))
+        self.assertIn(live.id, deliverable_ids)
+        self.assertNotIn(orphaned.id, deliverable_ids)
+
+    def test_deliverable_excludes_disabled_and_deleted_reports(self):
+        evaluation = self._create_evaluation()
+        disabled = self._report_for(evaluation, enabled=False)
+        deleted = self._report_for(evaluation, deleted=True)
+        live = self._report_for(evaluation)
+
+        deliverable_ids = set(EvaluationReport.objects.deliverable().values_list("id", flat=True))
+        self.assertEqual(deliverable_ids, {live.id})
+        self.assertNotIn(disabled.id, deliverable_ids)
+        self.assertNotIn(deleted.id, deliverable_ids)
+
+    def test_deleting_evaluation_retires_its_reports(self):
+        evaluation = self._create_evaluation()
+        scheduled = self._report_for(evaluation)
+        count_triggered = self._report_for(
+            evaluation,
+            frequency=EvaluationReport.Frequency.EVERY_N,
+            trigger_threshold=100,
+            rrule="",
+            starts_at=None,
+        )
+
+        evaluation.deleted = True
+        evaluation.save()
+
+        for report in (scheduled, count_triggered):
+            report.refresh_from_db()
+            self.assertTrue(report.deleted)
+            self.assertFalse(report.enabled)
+
+    def test_deleting_evaluation_leaves_other_evaluations_reports_alone(self):
+        keep = self._report_for(self._create_evaluation())
+        doomed_eval = self._create_evaluation()
+        self._report_for(doomed_eval)
+
+        doomed_eval.deleted = True
+        doomed_eval.save()
+
+        keep.refresh_from_db()
+        self.assertFalse(keep.deleted)
+        self.assertTrue(keep.enabled)
+
+
 class TestEvaluationReportRunModel(BaseTest):
     def test_create_report_run(self):
         now = timezone.now()


### PR DESCRIPTION
## Problem

Deleting an LLM evaluation does not stop its scheduled Slack/email reports. Users who delete an evaluation keep receiving reports for it indefinitely, with no way to turn them off (the report is only reachable through the now-deleted evaluation).

## Changes

Delete reports when deleting evaluations, check for deliverability when delivering them, and fix existing records in the DB.

## How did you test this code?

I'm an agent (PostHog Code); Carlos directed and reviewed the work. Automated tests only — no manual UI testing:

- Added 4 regression tests in `models/test/test_evaluation_reports.py`: `deliverable()` excludes reports for deleted evaluations, excludes disabled/deleted reports, the soft-delete cascade retires both scheduled and count-triggered reports, and it leaves other evaluations' reports untouched.
- `hogli test products/ai_observability/backend/models/test/test_evaluation_reports.py` — 13 passed (4 new + 9 existing).
- `makemigrations --dry-run` reports no model state drift from the new manager (no schema migration needed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Carlos is the DRI (assign `carlos-marchal-ph`).

Built with PostHog Code (Claude Opus). Skills invoked: `/django-migrations` (migration safety workflow) and `/query-clickhouse-via-metabase` (used here to query the prod app Postgres via Metabase, not ClickHouse).

The bug was confirmed empirically before any code: the reporting customer's two deleted evaluations had reports still `enabled=True, deleted=False` with daily `delivered` runs continuing for days after deletion. To decide whether the backfill could run as a synchronous, unbatched migration, I counted the affected rows in both regions at PR time — US: 180 orphaned of 936 total reports (60 teams); EU: 69 of 361 (28 teams); 249 rows across 88 teams. A single `UPDATE` over a few hundred rows holds locks only momentarily, so the migration is plain synchronous `RunPython` (elidable, noop reverse), not batched.

Design decision: the runtime guard is the primary fix, not the cascade. The cascade alone (write-time only) would fail open — it leaves already-orphaned rows broken and depends on every present and future deletion path remembering to cascade. The guard fails safe and retroactively neutralizes every orphan the moment it deploys. Both are included because the cascade keeps the data truthful for all other readers, but the guard is what stops the deliveries. Note Django has no built-in cascade for soft-deletes (`on_delete` only fires on real row deletion), so the propagation is necessarily manual.

A one-off ops backfill snippet exists to disable orphans immediately ahead of deploy; it's intentionally kept out of this PR.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
