### PR TITLE
chore(observability): instrument legacy raw-clickhouse reads

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -26,6 +26,7 @@ from posthog.api.utils import action
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.kafka_engine import trim_quotes_expr
 from posthog.clickhouse.query_tagging import Feature, tag_queries
+from posthog.event_usage import report_legacy_endpoint_usage
 from posthog.helpers.dashboard_templates import create_group_type_mapping_detail_dashboard
 from posthog.models import GroupUsageMetric, PropertyDefinition
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
@@ -790,11 +791,28 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         if not actor_id:
             raise ValidationError({"id": ["This query parameter is required."]})
 
+        report_legacy_endpoint_usage(
+            "legacy groups endpoint called",
+            "groups_related_actors",
+            team=self.team,
+            removal_type="endpoint_deprecation",
+            user=request.user,
+            request=request,
+        )
+
         results = RelatedActorsQuery(self.team, group_type_index, actor_id).run()
         return response.Response(results)
 
     @action(methods=["GET"], detail=False, required_scopes=["group:read"])
     def property_definitions(self, request: request.Request, **kw):
+        report_legacy_endpoint_usage(
+            "legacy groups endpoint called",
+            "groups_property_definitions",
+            team=self.team,
+            removal_type="endpoint_deprecation",
+            user=request.user,
+            request=request,
+        )
         tag_queries(product=ProductKey.GROUP_ANALYTICS, feature=Feature.QUERY)
         rows = sync_execute(
             f"""
@@ -816,6 +834,14 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
 
     @action(methods=["GET"], detail=False, required_scopes=["group:read"])
     def property_values(self, request: request.Request, **kw):
+        report_legacy_endpoint_usage(
+            "legacy groups endpoint called",
+            "groups_property_values",
+            team=self.team,
+            removal_type="endpoint_deprecation",
+            user=request.user,
+            request=request,
+        )
         with (
             PROPERTY_VALUES_DURATION.labels(endpoint_type="group").time(),
             tracer.start_as_current_span("groups_api_property_values") as span,

--- a/ee/tasks/auto_rollback_feature_flag.py
+++ b/ee/tasks/auto_rollback_feature_flag.py
@@ -4,6 +4,7 @@ from zoneinfo import ZoneInfo
 from celery import shared_task
 
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.event_usage import report_legacy_endpoint_usage
 from posthog.models.filters.filter import Filter
 from posthog.models.team import Team
 from posthog.queries.trends.trends import Trends
@@ -53,6 +54,13 @@ def calculate_rolling_average(threshold_metric: dict, team: Team, timezone: str)
         },
         team=team,
     )
+    report_legacy_endpoint_usage(
+        "legacy feature flag rollback evaluated",
+        "feature_flag_auto_rollback_trends",
+        team=team,
+        removal_type="internal",
+    )
+
     trends_query = Trends()
     result = trends_query.run(filter, team)
 

--- a/posthog/api/cohort.py
+++ b/posthog/api/cohort.py
@@ -44,7 +44,7 @@ from posthog.cdp.filters import build_behavioral_event_expr
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.constants import LIMIT, OFFSET
-from posthog.event_usage import report_user_action
+from posthog.event_usage import report_legacy_endpoint_usage, report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import User
@@ -1533,6 +1533,15 @@ class CohortViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, viewsets.ModelVi
         team = self.team
         filter = Filter(request=request, team=self.team)
         assert request.user.is_authenticated
+
+        report_legacy_endpoint_usage(
+            "legacy persons endpoint called",
+            "cohort_persons",
+            team=team,
+            removal_type="impl_swap",
+            user=request.user,
+            request=request,
+        )
 
         is_csv_request = self.request.accepted_renderer.format == "csv" or request.GET.get("is_csv_export")
         if is_csv_request and not filter.limit:

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -39,7 +39,7 @@ from posthog.auth import PersonalAPIKeyAuthentication
 from posthog.clickhouse.query_tagging import Feature, tag_queries
 from posthog.constants import INSIGHT_FUNNELS, LIMIT, OFFSET, FunnelVizType
 from posthog.decorators import cached_by_filters
-from posthog.event_usage import get_request_analytics_properties
+from posthog.event_usage import get_request_analytics_properties, report_legacy_endpoint_usage
 from posthog.metrics import LABEL_TEAM_ID
 from posthog.models import Filter, Person, Team, User
 from posthog.models.activity_logging.activity_log import Change, Detail, load_activity, log_activity
@@ -536,6 +536,15 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         filter = Filter(request=request, team=self.team)
 
         assert request.user.is_authenticated
+
+        report_legacy_endpoint_usage(
+            "legacy persons endpoint called",
+            "persons_list",
+            team=team,
+            removal_type="impl_swap",
+            user=request.user,
+            request=request,
+        )
 
         is_csv_request = self.request.accepted_renderer.format == "csv"
         if is_csv_request:
@@ -1259,6 +1268,15 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         if request.user.is_anonymous or not self.team:
             return response.Response(data=[])
 
+        report_legacy_endpoint_usage(
+            "legacy persons endpoint called",
+            "persons_properties_timeline",
+            team=self.team,
+            removal_type="impl_swap",
+            user=request.user,
+            request=request,
+        )
+
         person = self.get_object()
         filter = PropertiesTimelineFilter(request=request, team=self.team)
 
@@ -1296,6 +1314,15 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                 },
                 status=400,
             )
+
+        report_legacy_endpoint_usage(
+            "legacy insight endpoint called",
+            "persons_lifecycle_actors",
+            team=team,
+            removal_type="endpoint_deprecation",
+            user=request.user,
+            request=request,
+        )
 
         filter = LifecycleFilter(request=request, data=request.GET.dict(), team=self.team)
         filter = prepare_actor_query_filter(filter)

--- a/posthog/event_usage.py
+++ b/posthog/event_usage.py
@@ -9,6 +9,7 @@ from urllib.parse import urlparse
 
 from django.contrib.auth.models import AnonymousUser
 
+import structlog
 import posthoganalytics
 from opentelemetry import trace
 from rest_framework.authentication import SessionAuthentication
@@ -391,6 +392,7 @@ def get_request_analytics_properties(request) -> AnalyticsProps:
 
 
 _tracer = trace.get_tracer(__name__)
+logger = structlog.get_logger(__name__)
 
 
 def report_user_action(
@@ -438,6 +440,57 @@ def report_user_action(
             groups=groups(organization or user.current_organization, team or user.current_team),
             send_feature_flags=send_feature_flags,
         )
+
+
+def report_legacy_endpoint_usage(
+    event: str,
+    reader: str,
+    *,
+    team: Team,
+    removal_type: str,
+    user: Optional[User | AnonymousUser | SyntheticUser] = None,
+    request: Optional["Request"] = None,
+    extra: Optional[dict] = None,
+) -> None:
+    """Best-effort, non-throwing telemetry that a legacy raw-ClickHouse reader was hit.
+
+    Measures, per team, which raw-ClickHouse code paths still receive traffic before we delete them
+    (these are being routed through HogQL). Pure measurement: never raises and never blocks the request.
+
+    `removal_type` is one of:
+    - "endpoint_deprecation" — the endpoint itself goes away (replaced by /query); direct callers need migration
+    - "impl_swap" — the endpoint stays, only its raw-ClickHouse internals are swapped for HogQL (transparent)
+    - "internal" — no endpoint, internal raw-ClickHouse code
+
+    Pass `user`+`request` from request handlers (enriches with access_method/user_agent). Omit both in
+    Celery/worker contexts so the event is captured team-scoped via a flushing client — the global
+    posthoganalytics client's background flush may never run there.
+    """
+    try:
+        properties: dict = {"reader": reader, "removal_type": removal_type}
+        if request is not None:
+            properties["path"] = request._request.path
+            properties["method"] = request._request.method
+        if extra:
+            properties.update(extra)
+
+        real_user = user if isinstance(user, User | SyntheticUser) and getattr(user, "distinct_id", None) else None
+        if real_user is not None:
+            report_user_action(real_user, event, properties, team=team, organization=team.organization, request=request)
+            return
+
+        # No request user (Celery task / Temporal worker): capture team-scoped via a client that flushes.
+        from posthog.ph_client import ph_scoped_capture
+
+        with ph_scoped_capture() as capture_ph_event:
+            capture_ph_event(
+                distinct_id=str(team.uuid),
+                event=event,
+                properties=properties,
+                groups=groups(team.organization, team),
+            )
+    except Exception:
+        logger.exception("legacy_endpoint_usage_capture_failed", reader=reader, event=event)
 
 
 def report_user_or_team_action(

--- a/products/experiments/backend/presentation/views.py
+++ b/products/experiments/backend/presentation/views.py
@@ -31,6 +31,7 @@ from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
 from posthog.approvals.mixins import ApprovalHandlingMixin
 from posthog.auth import IDJagAccessTokenAuthentication, OAuthAccessTokenAuthentication, PersonalAPIKeyAuthentication
+from posthog.event_usage import report_legacy_endpoint_usage
 from posthog.models.filters.filter import Filter
 from posthog.models.organization import OrganizationMembership
 from posthog.models.team.team import Team
@@ -408,6 +409,15 @@ class EnterpriseExperimentsViewSet(
     @action(methods=["GET"], detail=False, required_scopes=["experiment:read"])
     def requires_flag_implementation(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         filter = Filter(request=request, team=self.team).shallow_clone({"date_from": "-7d", "date_to": ""})
+
+        report_legacy_endpoint_usage(
+            "legacy experiment endpoint called",
+            "experiment_requires_flag",
+            team=self.team,
+            removal_type="impl_swap",
+            user=request.user,
+            request=request,
+        )
 
         warning = requires_flag_warning(filter, self.team)
 


### PR DESCRIPTION
## Problem

We want to drop raw ClickHouse reads entirely and route them through HogQL (see #65348). Before deleting any of those legacy paths we need to know which ones still get traffic — and for the ones that genuinely go away (vs. ones whose internals just swap), which teams still call them so we can migrate them.

There's no per-reader signal for this today. APM tracing can't answer it (it's head-sampled and doesn't record per-endpoint request volume), so this adds purpose-built usage events instead.

## Changes

Adds a small non-throwing helper `report_legacy_endpoint_usage(...)` in `posthog/event_usage.py` and wires it into the raw-ClickHouse readers that #65348 routes through HogQL. Each call emits a per-area product-analytics event carrying:

- `reader` — stable id for the specific code path
- `removal_type` — `endpoint_deprecation` (endpoint goes away, replaced by `/query`), `impl_swap` (endpoint stays, only internals change), or `internal` (no endpoint)
- for HTTP calls: `path`, `method`, plus `access_method` / `user_agent`, so we can tell app vs API-key callers apart

| Event | Readers | `removal_type` |
|---|---|---|
| `legacy persons endpoint called` | persons-list, cohort-persons, properties-timeline | `impl_swap` |
| `legacy insight endpoint called` | persons lifecycle actors | `endpoint_deprecation` |
| `legacy groups endpoint called` | related-actors, property-definitions, property-values | `endpoint_deprecation` |
| `legacy experiment endpoint called` | requires-flag-implementation | `impl_swap` |
| `legacy feature flag rollback evaluated` | auto-rollback metric (Celery) | `internal` |

Persons funnel/trends already emit `legacy insight endpoint called` via the existing `capture_legacy_api_call`, so they're left as-is; this adds lifecycle to keep the three actor endpoints in one event.

Request handlers route through `report_user_action`; the auto-rollback Celery task routes through `ph_scoped_capture` so its event isn't dropped when the worker exits. The helper never raises and never blocks the request — pure measurement. It's a precursor to #65348: land it, gather data, then delete what's unused.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated checks only: ruff lint + format and the local `ty` type check, all via the pre-commit hooks. No runtime verification of event emission and no new unit test yet — CI runs the full suite and mypy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Invoked the `/improving-drf-endpoints` skill before touching the viewsets — the edits only add telemetry side-effects (no serializer/schema changes), so most of that skill didn't apply, but it confirmed existing annotations were left intact.

Decisions worth flagging for review:

- **Product-analytics events over APM or Prometheus.** APM here is head-sampled and has no per-endpoint request counts, so it can't answer "how often / which teams." A team-labelled Prometheus counter (like the existing cohort-persons one) suits dashboards but is weak for per-customer migration lists and historical analysis.
- **A `removal_type` tag** so one query separates true endpoint deprecations (need customer migration) from transparent internal swaps.
- **Dropped the web-analytics property-values reader.** Its HogQL replacement (`PropertyValuesQueryRunner`) still uses raw SQL for the person path by design (perf), so there's no raw-CH removal to gate on it — instrumenting it would measure a path that isn't going away.

Follow-ups: a unit test for the helper, and optionally a "blocked attempt" signal for endpoints gated behind the legacy-insight flag.
