### PR TITLE
feat(insights): track shift-to-highlight bar usage

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/LineGraph.tsx
@@ -7,6 +7,7 @@ import ChartjsPluginStacked100 from 'chartjs-plugin-stacked100'
 import chartTrendline from 'chartjs-plugin-trendline'
 import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 import { useEffect, useMemo } from 'react'
 
 import { IconX } from '@posthog/icons'
@@ -176,6 +177,20 @@ const LegacyLineGraph = ({
     const isStackedBarChart = visualizationType === ChartDisplayType.ActionsStackedBar
     const isAreaChart = visualizationType === ChartDisplayType.ActionsAreaGraph
     const isHighlightBarMode = isBarChart && isStackedBarChart && isShiftPressed
+
+    // Track engagement with the (undocumented) shift-to-highlight gesture so we can gauge whether it's
+    // worth carrying into the quill-charts rebuild. Keyed on isHighlightBarMode alone so it fires once
+    // per engagement (the rising edge), not on every re-render while shift stays held.
+    useEffect(() => {
+        if (isHighlightBarMode) {
+            posthog.capture('insight bar shift-highlight used', {
+                visualization_type: visualizationType,
+                series_count: yData?.length ?? 0,
+                on_dashboard: !!dashboardId,
+            })
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [isHighlightBarMode])
 
     useEffect(() => {
         if (exceedsMaxSeries(yData, dashboardId)) {


### PR DESCRIPTION
## Problem

Stacked-bar SQL/DataVisualization charts support an undocumented "hold Shift to highlight an individual bar" gesture (the small "Hold Shift (⇧) to highlight individual bars" hint in the tooltip is the only affordance). We're rebuilding these charts on quill-charts, which has no equivalent gesture — porting it would be a non-trivial amount of work in the shared quill package. But the feature is completely uninstrumented, so we have **no idea whether anyone actually uses it**, and can't justify the investment blind.

## Changes

Capture an `insight bar shift-highlight used` event on the rising edge of each engagement (when Shift is held over a stacked bar chart), with a few properties to slice by:

- `visualization_type`
- `series_count`
- `on_dashboard`

The effect keys on `isHighlightBarMode` alone so it fires once per engagement, not on every re-render while Shift stays held. No behavior change to the chart itself.

Once this has run for a couple of weeks we can check the count and decide whether the gesture is worth carrying into the quill-charts rebuild (or keeping at all).

## How did you test this code?

I'm an agent (PostHog Code). I made a small, self-contained instrumentation change and relied on the per-file formatter/lint that ran at commit. I did not run the app manually. The capture is a standard `posthog.capture` call in an existing `useEffect`; no automated test was added for a one-shot analytics event.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of a discussion about the quill-charts SQL-insights tooltip rebuild. While scoping whether to reimplement the legacy chart.js shift-to-highlight gesture, we checked and found it has zero analytics. Rather than port a feature with unknown usage, we chose to instrument the legacy path first and decide later. Fires on the `isHighlightBarMode` rising edge to avoid over-counting re-renders. No repo skills were invoked for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
