### PR TITLE
fix(ingestion): align overflow replenish rate with capture (100/sec)

### DIFF
--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -272,8 +272,10 @@ export function getDefaultIngestionConsumerConfig(): IngestionConsumerConfig {
         GROUP_BATCH_WRITING_OPTIMISTIC_UPDATE_RETRY_INTERVAL_MS: 50,
 
         // Event overflow config
+        // Mirrors capture's OverflowLimiter (rust/common/limiters/src/overflow.rs):
+        // burst = overflow_burst_limit (1000), replenish rate = overflow_per_second_limit (100/sec).
         EVENT_OVERFLOW_BUCKET_CAPACITY: 1000,
-        EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: 1.0,
+        EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: 100.0,
 
         // Stateful overflow config
         INGESTION_STATEFUL_OVERFLOW_ENABLED: false,


### PR DESCRIPTION
## Problem

The Node.js analytics ingestion consumer rate-limits events to the overflow topic with a per `token:distinct_id` token bucket. It is meant to mirror capture's `OverflowLimiter` (`rust/common/limiters/src/overflow.rs`), which keys identically on `token:distinct_id` and is configured in production with:

- `overflow_burst_limit = 1000` (bucket capacity)
- `overflow_per_second_limit = 100` (sustained refill rate)

The Node port matched the burst (`EVENT_OVERFLOW_BUCKET_CAPACITY = 1000`) but set the replenish rate to `EVENT_OVERFLOW_BUCKET_REPLENISH_RATE = 1.0` — **100× lower** than capture. In a token bucket the refill rate *is* the sustained ceiling, so the consumer was overflowing any key sustaining more than **60 events/min**, versus the intended **6000 events/min**.

### Why this matters (the computation)

For a key sending a steady `λ` events/sec, the bucket changes by `(refill − λ)` tokens/sec. With capacity `C = 1000`:

- It only overflows once the bucket drains, after `C / (λ − refill)` seconds of continuous traffic.
- A key is safe forever whenever `λ ≤ refill`.

Comparing the two refill rates:

| Sustained input `λ` | refill = 1/sec (before) | refill = 100/sec (after, capture parity) |
| --- | --- | --- |
| 5 events/sec | drains `5−1=4`/sec → overflows after `1000/4 ≈ 250s` (~4 min), then stays flagged | `5 ≤ 100` → **never overflows** |
| 2 events/sec | drains `1`/sec → overflows after ~17 min | never overflows |
| 50 events/sec | overflows after `1000/49 ≈ 20s` | `50 ≤ 100` → never overflows |
| 150 events/sec | overflows after ~7s | drains `50`/sec → overflows after ~20s (correct hot-key behavior) |

Capture already reroutes genuinely hot keys (`> 100/sec`) upstream, so at parity the consumer-side limiter adds almost nothing. At `1/sec` it instead re-overflowed the entire `1–100/sec` band that capture intentionally passes through — modest, sustained senders that should never have been flagged. Because stateful overflow is enabled and the overflow lane refreshes the Redis TTL on every batch, a key that tripped once stayed pinned to overflow for as long as it kept sending.

This change sets `EVENT_OVERFLOW_BUCKET_REPLENISH_RATE` to `100.0` to restore parity with capture (capacity was already correct at 1000).

## Changes

- Set the default `EVENT_OVERFLOW_BUCKET_REPLENISH_RATE` from `1.0` to `100.0` in the ingestion consumer config, mirroring capture's `overflow_per_second_limit`.
- Add a comment documenting the capture-parity relationship between burst/replenish and `overflow_burst_limit`/`overflow_per_second_limit`.

A matching production override (`EVENT_OVERFLOW_BUCKET_REPLENISH_RATE: "100"`) is being added to the charts analytics config so the fix can roll out without waiting on a code deploy.

## How did you test this code?

I'm an agent (Claude Code). No new automated tests were added — this is a config default value change. The existing ingestion consumer config test that asserts `EVENT_OVERFLOW_BUCKET_CAPACITY` was checked and is unaffected. The numeric env override path (`overrideWithEnv`) was verified to coerce the string chart value `"100"` to a number via `parseFloat`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a single `token:distinct_id` that was sitting in overflow despite a low event rate. Traced the consumer overflow path (`rate-limit-to-overflow-step` → `MainLaneOverflowRedirect` → `MemoryRateLimiter`), confirmed the token-bucket semantics, and compared against capture's `OverflowLimiter` to find the 100× refill-rate discrepancy. Confirmed the keys are identical (`token:distinct_id`), the burst already matched, and only the sustained rate diverged. Chose to fix the code default and pair it with a charts override for fast rollout. No skills were invoked.
