### PR TITLE
chore(insights): extract and simplify the insight display options menu

### DIFF
--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -1,0 +1,262 @@
+import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
+import { useDebouncedCallback } from 'use-debounce'
+
+import { IconInfo } from '@posthog/icons'
+import { LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
+
+import { SmoothingFilter } from 'lib/components/SmoothingFilter/SmoothingFilter'
+import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
+import { LemonMenuItem } from 'lib/lemon-ui/LemonMenu'
+import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
+import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
+import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
+import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
+import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
+import { LifecyclePercentagesFilter } from 'scenes/insights/EditorFilters/LifecyclePercentagesFilter'
+import { LifecycleStackingFilter } from 'scenes/insights/EditorFilters/LifecycleStackingFilter'
+import {
+    MetricColorFilter,
+    MetricShowChangeFilter,
+    MetricSummaryFilter,
+} from 'scenes/insights/EditorFilters/MetricFilters'
+import { PercentStackViewFilter } from 'scenes/insights/EditorFilters/PercentStackViewFilter'
+import { ResultCustomizationByPicker } from 'scenes/insights/EditorFilters/ResultCustomizationByPicker'
+import { ScalePicker } from 'scenes/insights/EditorFilters/ScalePicker'
+import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
+import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
+import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
+import { ShowLegendFilter } from 'scenes/insights/EditorFilters/ShowLegendFilter'
+import { ShowMultipleYAxesFilter } from 'scenes/insights/EditorFilters/ShowMultipleYAxesFilter'
+import { ShowPieTotalFilter } from 'scenes/insights/EditorFilters/ShowPieTotalFilter'
+import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
+import { StackBreakdownFilter } from 'scenes/insights/EditorFilters/StackBreakdownFilter'
+import { ValueOnSeriesFilter } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
+import { RetentionCohortLabelStartIndexPicker } from 'scenes/insights/filters/RetentionCohortLabelStartIndexPicker'
+import { RetentionDashboardDisplayPicker } from 'scenes/insights/filters/RetentionDashboardDisplayPicker'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { ConfidenceLevelInput } from 'scenes/insights/views/LineGraph/ConfidenceLevelInput'
+import { MovingAverageIntervalsInput } from 'scenes/insights/views/LineGraph/MovingAverageIntervalsInput'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { isTrendsQuery } from '~/queries/utils'
+import { ChartDisplayType } from '~/types'
+
+export const LINE_DISPLAYS = [
+    ChartDisplayType.ActionsLineGraph,
+    ChartDisplayType.ActionsLineGraphCumulative,
+    ChartDisplayType.ActionsAreaGraph,
+] as const
+export const BAR_DISPLAYS = [
+    ChartDisplayType.ActionsBar,
+    ChartDisplayType.ActionsUnstackedBar,
+    ChartDisplayType.ActionsBarValue,
+] as const
+
+export function displayMatches(
+    display: ChartDisplayType | null | undefined,
+    displays: readonly ChartDisplayType[]
+): boolean {
+    return !!display && displays.includes(display)
+}
+
+export function isDefaultTrendsLineDisplay(
+    display: ChartDisplayType | null | undefined,
+    querySource: Parameters<typeof isTrendsQuery>[0]
+): boolean {
+    return !display && isTrendsQuery(querySource)
+}
+
+function useLineGraphState(): { isLineGraph: boolean; isLinearScale: boolean } {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, display, yAxisScaleType } = useValues(insightVizDataLogic(insightProps))
+    const isLineDisplay = isDefaultTrendsLineDisplay(display, querySource) || displayMatches(display, LINE_DISPLAYS)
+    const isCumulativeLineDisplay = display === ChartDisplayType.ActionsLineGraphCumulative
+    return {
+        isLineGraph: isLineDisplay && !isCumulativeLineDisplay,
+        isLinearScale: !yAxisScaleType || yAxisScaleType === 'linear',
+    }
+}
+
+function Smoothing(): JSX.Element {
+    return (
+        <div className="px-2 pb-1.5 w-full">
+            <SmoothingFilter />
+        </div>
+    )
+}
+
+function ExcludeOutliers(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+
+    return (
+        <LemonCheckbox
+            label={
+                <span className="font-normal">
+                    Exclude outliers{' '}
+                    <Tooltip title="When enabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles. When disabled, the y-axis extends to show the full range including extreme values.">
+                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                    </Tooltip>
+                </span>
+            }
+            className="p-1 px-2"
+            size="small"
+            checked={trendsFilter?.excludeBoxPlotOutliers !== false}
+            onChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    const newQuery = { ...querySource }
+                    newQuery.trendsFilter = { ...trendsFilter, excludeBoxPlotOutliers: checked }
+                    updateQuerySource(newQuery)
+                }
+            }}
+        />
+    )
+}
+
+function PercentStack(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { display } = useValues(insightVizDataLogic(insightProps))
+    const { showValuesOnSeries } = useValues(trendsDataLogic(insightProps))
+
+    return (
+        <PercentStackViewFilter
+            // On a pie chart the percentage is rendered through the series value labels, so it has no
+            // effect while those labels are hidden.
+            disabledReason={
+                display === ChartDisplayType.ActionsPie && showValuesOnSeries === false
+                    ? "Enable 'Show values on series' to use this option"
+                    : undefined
+            }
+        />
+    )
+}
+
+function ConfidenceInterval(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { showConfidenceIntervals } = useValues(trendsDataLogic(insightProps))
+    const { isLineGraph, isLinearScale } = useLineGraphState()
+
+    return (
+        <LemonSwitch
+            label="Show confidence intervals"
+            className="pb-2"
+            fullWidth
+            checked={showConfidenceIntervals}
+            disabledReason={
+                !isLineGraph
+                    ? 'Confidence intervals are only available for line graphs'
+                    : !isLinearScale
+                      ? 'Confidence intervals are only supported for linear scale.'
+                      : undefined
+            }
+            onChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    const newQuery = { ...querySource }
+                    newQuery.trendsFilter = { ...trendsFilter, showConfidenceIntervals: checked }
+                    updateQuerySource(newQuery)
+                }
+            }}
+        />
+    )
+}
+
+function MovingAverage(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { querySource, trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateQuerySource } = useActions(insightVizDataLogic(insightProps))
+    const { showMovingAverage } = useValues(trendsDataLogic(insightProps))
+    const { isLineGraph, isLinearScale } = useLineGraphState()
+
+    return (
+        <LemonSwitch
+            label="Show moving average"
+            className="pb-2"
+            fullWidth
+            checked={showMovingAverage}
+            disabledReason={
+                !isLineGraph
+                    ? 'Moving average is only available for line and area graphs'
+                    : !isLinearScale
+                      ? 'Moving average is only supported for linear scale.'
+                      : undefined
+            }
+            onChange={(checked) => {
+                if (isTrendsQuery(querySource)) {
+                    const newQuery = { ...querySource }
+                    newQuery.trendsFilter = { ...trendsFilter, showMovingAverage: checked }
+                    updateQuerySource(newQuery)
+                }
+            }}
+        />
+    )
+}
+
+function DecimalPrecision(): JSX.Element {
+    const { insightProps } = useValues(insightLogic)
+    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
+    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
+
+    const reportChange = useDebouncedCallback(() => {
+        posthog.capture('decimal places changed', {
+            decimal_places: trendsFilter?.decimalPlaces,
+        })
+    }, 500)
+
+    return (
+        <LemonInput
+            type="number"
+            size="small"
+            step={1}
+            min={0}
+            max={9}
+            defaultValue={DEFAULT_DECIMAL_PLACES}
+            value={trendsFilter?.decimalPlaces}
+            onChange={(value) => {
+                updateInsightFilter({ decimalPlaces: value })
+                reportChange()
+            }}
+            className="mx-2 mb-1.5"
+        />
+    )
+}
+
+// Every insight display toggle as a ready-to-use menu item, so callers assemble the Options menu by
+// referencing `DisplayOptions.X` instead of repeating `{ label: () => <X /> }` for each one.
+export const DisplayOptions = {
+    Smoothing: { label: () => <Smoothing /> },
+    Legend: { label: () => <ShowLegendFilter /> },
+    LegendOptions: { label: () => <LegendOptionsFilter /> },
+    ExcludeOutliers: { label: () => <ExcludeOutliers /> },
+    MetricSummary: { label: () => <MetricSummaryFilter /> },
+    MetricShowChange: { label: () => <MetricShowChangeFilter /> },
+    MetricColor: { label: () => <MetricColorFilter /> },
+    LifecycleStacking: { label: () => <LifecycleStackingFilter /> },
+    LifecyclePercentages: { label: () => <LifecyclePercentagesFilter /> },
+    ValueLabels: { label: () => <ValueOnSeriesFilter /> },
+    PercentStack: { label: () => <PercentStack /> },
+    StackBreakdown: { label: () => <StackBreakdownFilter /> },
+    PieTotal: { label: () => <ShowPieTotalFilter /> },
+    AlertThresholdLines: { label: () => <ShowAlertThresholdLinesFilter /> },
+    AlertAnomalyPoints: { label: () => <ShowAlertAnomalyPointsFilter /> },
+    MultipleYAxes: { label: () => <ShowMultipleYAxesFilter /> },
+    TrendLines: { label: () => <ShowTrendLinesFilter /> },
+    HideIncompleteFunnelPeriods: { label: () => <HideIncompleteConversionWindowPeriodsFilter /> },
+    HideWeekends: { label: () => <HideWeekendsFilter /> },
+    Annotations: { label: () => <ShowAnnotationsFilter /> },
+    ResultCustomizationBy: { label: () => <ResultCustomizationByPicker /> },
+    Unit: { label: () => <UnitPicker /> },
+    Scale: { label: () => <ScalePicker /> },
+    ConfidenceInterval: { label: () => <ConfidenceInterval /> },
+    ConfidenceLevel: { label: () => <ConfidenceLevelInput /> },
+    MovingAverage: { label: () => <MovingAverage /> },
+    MovingAverageIntervals: { label: () => <MovingAverageIntervalsInput /> },
+    AxisLabels: { label: () => <AxisLabelsFilter /> },
+    DecimalPrecision: { label: () => <DecimalPrecision /> },
+    RetentionDashboardDisplay: { label: () => <RetentionDashboardDisplayPicker /> },
+    RetentionCohortLabelStart: { label: () => <RetentionCohortLabelStartIndexPicker /> },
+} satisfies Record<string, LemonMenuItem>

--- a/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/DisplayOptions.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
+import { ReactNode } from 'react'
 import { useDebouncedCallback } from 'use-debounce'
 
 import { IconInfo } from '@posthog/icons'
@@ -222,6 +223,30 @@ function DecimalPrecision(): JSX.Element {
             }}
             className="mx-2 mb-1.5"
         />
+    )
+}
+
+export function SectionHeader({
+    children,
+    tooltip,
+    dataAttr,
+}: {
+    children: ReactNode
+    tooltip?: string
+    dataAttr?: string
+}): JSX.Element {
+    return (
+        <h5 className="mx-2 my-1" data-attr={dataAttr}>
+            {children}
+            {tooltip && (
+                <>
+                    {' '}
+                    <Tooltip title={tooltip}>
+                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                    </Tooltip>
+                </>
+            )}
+        </h5>
     )
 }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -10,7 +10,14 @@ import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 
 import { useMocks } from '~/mocks/jest'
-import { NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
+import {
+    InsightQueryNode,
+    LifecycleQuery,
+    NodeKind,
+    RetentionQuery,
+    StickinessQuery,
+    TrendsQuery,
+} from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { BaseMathType, ChartDisplayType, InsightShortId } from '~/types'
 
@@ -19,25 +26,43 @@ import { InsightDisplayConfig } from './InsightDisplayConfig'
 const Insight123 = '123' as InsightShortId
 const insightProps = { dashboardItemId: Insight123 }
 
+const pageviewSeries = [
+    {
+        kind: NodeKind.EventsNode,
+        name: '$pageview',
+        event: '$pageview',
+        math: BaseMathType.TotalCount,
+    },
+] as const
+
 function makeTrendsQuery(
     display?: ChartDisplayType,
     trendsFilter: NonNullable<TrendsQuery['trendsFilter']> = {}
 ): TrendsQuery {
     return {
         kind: NodeKind.TrendsQuery,
-        series: [
-            {
-                kind: NodeKind.EventsNode,
-                name: '$pageview',
-                event: '$pageview',
-                math: BaseMathType.TotalCount,
-            },
-        ],
+        series: [...pageviewSeries],
         trendsFilter: {
             display,
             ...trendsFilter,
         },
     }
+}
+
+function makeRetentionQuery(): RetentionQuery {
+    return { kind: NodeKind.RetentionQuery, retentionFilter: {} }
+}
+
+function makeStickinessQuery(): StickinessQuery {
+    return { kind: NodeKind.StickinessQuery, series: [...pageviewSeries] }
+}
+
+function makeLifecycleQuery(): LifecycleQuery {
+    return { kind: NodeKind.LifecycleQuery, series: [...pageviewSeries] }
+}
+
+function getSectionTitles(): string[] {
+    return screen.getAllByRole('heading', { level: 5 }).map((h) => h.textContent?.replace(/\s+/g, ' ').trim() ?? '')
 }
 
 async function openOptionsMenu(): Promise<void> {
@@ -67,7 +92,7 @@ describe('InsightDisplayConfig', () => {
         cleanup()
     })
 
-    function setupAndRender(query: TrendsQuery): void {
+    function setupAndRender(query: InsightQueryNode): void {
         insightLogic(insightProps).mount()
         insightDataLogic(insightProps).mount()
         const vizDataLogic = insightVizDataLogic(insightProps)
@@ -82,6 +107,67 @@ describe('InsightDisplayConfig', () => {
             </Provider>
         )
     }
+
+    describe('Options menu sections per insight/chart type', () => {
+        const cases: [string, InsightQueryNode, string[]][] = [
+            [
+                'trends line graph',
+                makeTrendsQuery(ChartDisplayType.ActionsLineGraph),
+                [
+                    'Display',
+                    'Color customization by',
+                    'Y-axis unit',
+                    'Y-axis scale',
+                    'Statistical analysis',
+                    'Axis labels',
+                ],
+            ],
+            [
+                'trends bar chart',
+                makeTrendsQuery(ChartDisplayType.ActionsBar),
+                ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+            ],
+            [
+                'trends area graph',
+                makeTrendsQuery(ChartDisplayType.ActionsAreaGraph),
+                ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+            ],
+            ['trends number', makeTrendsQuery(ChartDisplayType.BoldNumber), ['Display', 'Unit']],
+            ['trends pie', makeTrendsQuery(ChartDisplayType.ActionsPie), ['Display', 'Unit']],
+            ['trends table', makeTrendsQuery(ChartDisplayType.ActionsTable), ['Display', 'Unit']],
+            [
+                'trends bar value (horizontal)',
+                makeTrendsQuery(ChartDisplayType.ActionsBarValue),
+                ['Display', 'X-axis unit', 'Axis labels'],
+            ],
+            ['trends world map', makeTrendsQuery(ChartDisplayType.WorldMap), ['Display', 'Unit']],
+            ['box plot', makeTrendsQuery(ChartDisplayType.BoxPlot), ['Display', 'Unit', 'Y-axis scale']],
+            ['slope graph', makeTrendsQuery(ChartDisplayType.SlopeGraph), ['Display', 'Unit']],
+            ['retention', makeRetentionQuery(), ['Display', 'On dashboards', 'Cohort labels start at']],
+            ['stickiness', makeStickinessQuery(), ['Display']],
+            ['lifecycle', makeLifecycleQuery(), ['Display']],
+        ]
+
+        it.each(cases)('%s shows the expected sections', async (_name, query, expectedSections) => {
+            setupAndRender(query)
+            await openOptionsMenu()
+
+            expect(getSectionTitles()).toEqual(expectedSections)
+        })
+    })
+
+    describe('section header tooltips', () => {
+        it('renders an info tooltip on tooltip-backed headers but not on plain ones', async () => {
+            setupAndRender(makeRetentionQuery())
+            await openOptionsMenu()
+
+            const tooltipHeader = screen.getByText('Cohort labels start at').closest('h5')!
+            expect(tooltipHeader.querySelector('svg')).toBeInTheDocument()
+
+            const plainHeader = screen.getByText('On dashboards').closest('h5')!
+            expect(plainHeader.querySelector('svg')).not.toBeInTheDocument()
+        })
+    })
 
     describe('box plot display options', () => {
         it('only shows "Show legend" in the Display section', async () => {

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.test.tsx
@@ -72,8 +72,8 @@ async function openOptionsMenu(): Promise<void> {
 
 function getDisplaySectionItems(): string[] {
     const displaySection = screen.getByTestId('options-display-section').closest('section')!
-    const listItems = within(displaySection).getAllByRole('listitem')
-    return listItems.map((li) => li.textContent?.trim() || '')
+    const listItems = within(displaySection).queryAllByRole('listitem')
+    return listItems.map((li) => li.textContent?.trim() || '').filter(Boolean)
 }
 
 describe('InsightDisplayConfig', () => {
@@ -109,50 +109,138 @@ describe('InsightDisplayConfig', () => {
     }
 
     describe('Options menu sections per insight/chart type', () => {
-        const cases: [string, InsightQueryNode, string[]][] = [
+        // For each type: the section headers in the Options menu, and the toggles inside the "Display"
+        // section. Empty `displayItems` means the Display header renders with no options under it.
+        const cases: [string, InsightQueryNode, { sections: string[]; displayItems: string[] }][] = [
             [
                 'trends line graph',
                 makeTrendsQuery(ChartDisplayType.ActionsLineGraph),
-                [
-                    'Display',
-                    'Color customization by',
-                    'Y-axis unit',
-                    'Y-axis scale',
-                    'Statistical analysis',
-                    'Axis labels',
-                ],
+                {
+                    sections: [
+                        'Display',
+                        'Color customization by',
+                        'Y-axis unit',
+                        'Y-axis scale',
+                        'Statistical analysis',
+                        'Axis labels',
+                    ],
+                    displayItems: [
+                        'Show values on series',
+                        'Show legend',
+                        'Show alert threshold lines',
+                        'Show multiple Y-axes',
+                        'Show trend lines',
+                        'Show annotations',
+                    ],
+                },
             ],
             [
                 'trends bar chart',
                 makeTrendsQuery(ChartDisplayType.ActionsBar),
-                ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+                {
+                    sections: ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+                    displayItems: [
+                        'Show values on series',
+                        'Show as % of total',
+                        'Show legend',
+                        'Show alert threshold lines',
+                        'Show multiple Y-axes',
+                        'Show trend lines',
+                        'Show annotations',
+                    ],
+                },
             ],
             [
                 'trends area graph',
                 makeTrendsQuery(ChartDisplayType.ActionsAreaGraph),
-                ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+                {
+                    sections: ['Display', 'Y-axis unit', 'Y-axis scale', 'Statistical analysis', 'Axis labels'],
+                    displayItems: [
+                        'Show values on series',
+                        'Show as % of total',
+                        'Show legend',
+                        'Show alert threshold lines',
+                        'Show multiple Y-axes',
+                        'Show trend lines',
+                        'Show annotations',
+                    ],
+                },
             ],
-            ['trends number', makeTrendsQuery(ChartDisplayType.BoldNumber), ['Display', 'Unit']],
-            ['trends pie', makeTrendsQuery(ChartDisplayType.ActionsPie), ['Display', 'Unit']],
-            ['trends table', makeTrendsQuery(ChartDisplayType.ActionsTable), ['Display', 'Unit']],
+            [
+                'trends number',
+                makeTrendsQuery(ChartDisplayType.BoldNumber),
+                { sections: ['Display', 'Unit'], displayItems: [] },
+            ],
+            [
+                'trends pie',
+                makeTrendsQuery(ChartDisplayType.ActionsPie),
+                {
+                    sections: ['Display', 'Unit'],
+                    displayItems: [
+                        'Show values on series',
+                        'Show as % of total',
+                        'Show legend',
+                        'Show total below chart',
+                    ],
+                },
+            ],
+            [
+                'trends table',
+                makeTrendsQuery(ChartDisplayType.ActionsTable),
+                { sections: ['Display', 'Unit'], displayItems: [] },
+            ],
             [
                 'trends bar value (horizontal)',
                 makeTrendsQuery(ChartDisplayType.ActionsBarValue),
-                ['Display', 'X-axis unit', 'Axis labels'],
+                { sections: ['Display', 'X-axis unit', 'Axis labels'], displayItems: ['Show values on series'] },
             ],
-            ['trends world map', makeTrendsQuery(ChartDisplayType.WorldMap), ['Display', 'Unit']],
-            ['box plot', makeTrendsQuery(ChartDisplayType.BoxPlot), ['Display', 'Unit', 'Y-axis scale']],
-            ['slope graph', makeTrendsQuery(ChartDisplayType.SlopeGraph), ['Display', 'Unit']],
-            ['retention', makeRetentionQuery(), ['Display', 'On dashboards', 'Cohort labels start at']],
-            ['stickiness', makeStickinessQuery(), ['Display']],
-            ['lifecycle', makeLifecycleQuery(), ['Display']],
+            [
+                'trends world map',
+                makeTrendsQuery(ChartDisplayType.WorldMap),
+                { sections: ['Display', 'Unit'], displayItems: [] },
+            ],
+            [
+                'box plot',
+                makeTrendsQuery(ChartDisplayType.BoxPlot),
+                { sections: ['Display', 'Unit', 'Y-axis scale'], displayItems: ['Show legend', 'Exclude outliers'] },
+            ],
+            [
+                'slope graph',
+                makeTrendsQuery(ChartDisplayType.SlopeGraph),
+                { sections: ['Display', 'Unit'], displayItems: ['Show legend'] },
+            ],
+            [
+                'retention',
+                makeRetentionQuery(),
+                {
+                    sections: ['Display', 'On dashboards', 'Cohort labels start at'],
+                    displayItems: ['Show trend lines'],
+                },
+            ],
+            [
+                'stickiness',
+                makeStickinessQuery(),
+                {
+                    sections: ['Display'],
+                    displayItems: ['Show values on series', 'Show legend', 'Show multiple Y-axes'],
+                },
+            ],
+            [
+                'lifecycle',
+                makeLifecycleQuery(),
+                {
+                    sections: ['Display'],
+                    displayItems: ['Stack bars', 'Show values on series', 'Show percentages on series', 'Show legend'],
+                },
+            ],
         ]
 
-        it.each(cases)('%s shows the expected sections', async (_name, query, expectedSections) => {
+        it.each(cases)('%s shows the expected sections and display options', async (_name, query, expected) => {
             setupAndRender(query)
             await openOptionsMenu()
 
-            expect(getSectionTitles()).toEqual(expectedSections)
+            expect(getSectionTitles()).toEqual(expected.sections)
+            expect(getDisplaySectionItems()).toEqual(expected.displayItems)
         })
     })
 

--- a/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
+++ b/frontend/src/queries/nodes/InsightViz/InsightDisplayConfig.tsx
@@ -1,88 +1,31 @@
 import { useActions, useValues } from 'kea'
-import posthog from 'posthog-js'
 import { ReactNode } from 'react'
-import { useDebouncedCallback } from 'use-debounce'
 
-import { IconEllipsis, IconInfo } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput, LemonSwitch, Tooltip } from '@posthog/lemon-ui'
-import { normalizeAxisLabel } from '@posthog/quill-charts'
+import { IconEllipsis } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
 
 import { ChartFilter } from 'lib/components/ChartFilter'
 import { CompareFilter } from 'lib/components/CompareFilter/CompareFilter'
 import { IntervalFilter } from 'lib/components/IntervalFilter'
-import { SmoothingFilter } from 'lib/components/SmoothingFilter/SmoothingFilter'
-import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
-import { UnitPicker } from 'lib/components/UnitPicker/UnitPicker'
 import { FEATURE_FLAGS, NON_TIME_SERIES_DISPLAY_TYPES } from 'lib/constants'
-import { LemonMenu, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
+import { LemonMenu } from 'lib/lemon-ui/LemonMenu'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { alignResolvedDateRangeToInterval, formatResolvedDateRange } from 'lib/utils/datetime'
-import { DEFAULT_DECIMAL_PLACES } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
-import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
-import { AxisLabelsFilter } from 'scenes/insights/EditorFilters/AxisLabelsFilter'
-import { HideIncompleteConversionWindowPeriodsFilter } from 'scenes/insights/EditorFilters/HideIncompleteConversionWindowPeriodsFilter'
-import { HideWeekendsFilter } from 'scenes/insights/EditorFilters/HideWeekendsFilter'
-import { LegendOptionsFilter } from 'scenes/insights/EditorFilters/LegendOptionsFilter'
-import { LifecyclePercentagesFilter } from 'scenes/insights/EditorFilters/LifecyclePercentagesFilter'
-import { LifecycleStackingFilter } from 'scenes/insights/EditorFilters/LifecycleStackingFilter'
-import {
-    MetricColorFilter,
-    MetricShowChangeFilter,
-    MetricSummaryFilter,
-} from 'scenes/insights/EditorFilters/MetricFilters'
-import { PercentStackViewFilter } from 'scenes/insights/EditorFilters/PercentStackViewFilter'
-import { ResultCustomizationByPicker } from 'scenes/insights/EditorFilters/ResultCustomizationByPicker'
-import { ScalePicker } from 'scenes/insights/EditorFilters/ScalePicker'
-import { ShowAlertAnomalyPointsFilter } from 'scenes/insights/EditorFilters/ShowAlertAnomalyPointsFilter'
-import { ShowAlertThresholdLinesFilter } from 'scenes/insights/EditorFilters/ShowAlertThresholdLinesFilter'
-import { ShowAnnotationsFilter } from 'scenes/insights/EditorFilters/ShowAnnotationsFilter'
-import { ShowLegendFilter } from 'scenes/insights/EditorFilters/ShowLegendFilter'
-import { ShowMultipleYAxesFilter } from 'scenes/insights/EditorFilters/ShowMultipleYAxesFilter'
-import { ShowPieTotalFilter } from 'scenes/insights/EditorFilters/ShowPieTotalFilter'
-import { ShowTrendLinesFilter } from 'scenes/insights/EditorFilters/ShowTrendLinesFilter'
-import { StackBreakdownFilter } from 'scenes/insights/EditorFilters/StackBreakdownFilter'
-import { ValueOnSeriesFilter } from 'scenes/insights/EditorFilters/ValueOnSeriesFilter'
 import { InsightDateFilter } from 'scenes/insights/filters/InsightDateFilter'
 import { RetentionChartPicker } from 'scenes/insights/filters/RetentionChartPicker'
-import { RetentionCohortLabelStartIndexPicker } from 'scenes/insights/filters/RetentionCohortLabelStartIndexPicker'
-import { RetentionDashboardDisplayPicker } from 'scenes/insights/filters/RetentionDashboardDisplayPicker'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
 import { RetentionDatePicker } from 'scenes/insights/RetentionDatePicker'
 import { FunnelBinsPicker } from 'scenes/insights/views/Funnels/FunnelBinsPicker'
 import { FunnelDisplayLayoutPicker } from 'scenes/insights/views/Funnels/FunnelDisplayLayoutPicker'
-import { ConfidenceLevelInput } from 'scenes/insights/views/LineGraph/ConfidenceLevelInput'
-import { MovingAverageIntervalsInput } from 'scenes/insights/views/LineGraph/MovingAverageIntervalsInput'
 import { PathStepPicker } from 'scenes/insights/views/Paths/PathStepPicker'
 import { RetentionBreakdownFilter } from 'scenes/retention/RetentionBreakdownFilter'
-import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 
 import { hasBreakdownFilter, isWebAnalyticsInsightQuery } from '~/queries/utils'
-import { isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
-const LINE_DISPLAYS = [
-    ChartDisplayType.ActionsLineGraph,
-    ChartDisplayType.ActionsLineGraphCumulative,
-    ChartDisplayType.ActionsAreaGraph,
-] as const
-const BAR_DISPLAYS = [
-    ChartDisplayType.ActionsBar,
-    ChartDisplayType.ActionsUnstackedBar,
-    ChartDisplayType.ActionsBarValue,
-] as const
-
-function displayMatches(display: ChartDisplayType | null | undefined, displays: readonly ChartDisplayType[]): boolean {
-    return !!display && displays.includes(display)
-}
-
-function isDefaultTrendsLineDisplay(
-    display: ChartDisplayType | null | undefined,
-    querySource: Parameters<typeof isTrendsQuery>[0]
-): boolean {
-    return !display && isTrendsQuery(querySource)
-}
+import { useInsightDisplayOptions } from './insightDisplayOptions'
 
 export function InsightDisplayConfig(): JSX.Element {
     const { insightProps, canEditInsight, editingDisabledReason } = useValues(insightLogic)
@@ -98,39 +41,22 @@ export function InsightDisplayConfig(): JSX.Element {
         supportsDisplay,
         display,
         breakdownFilter,
-        trendsFilter,
-        hasLegend,
-        showLegend,
-        supportsValueOnSeries,
-        showPercentStackView,
-        supportsPercentStackView,
-        supportsBarValueStacking,
-        supportsResultCustomizationBy,
-        yAxisScaleType,
-        showMultipleYAxes,
-        showAnnotations,
-        isNonTimeSeriesDisplay,
         compareFilter,
         supportsCompare,
         interval,
         insightData,
     } = useValues(insightVizDataLogic(insightProps))
-    const { updateQuerySource, updateCompareFilter } = useActions(insightVizDataLogic(insightProps))
+    const { updateCompareFilter } = useActions(insightVizDataLogic(insightProps))
     const { isTrendsFunnel, isStepsFunnel, isTimeToConvertFunnel, isEmptyFunnel } = useValues(
         funnelDataLogic(insightProps)
     )
     const { featureFlags } = useValues(featureFlagLogic)
-    const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
-    const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
-    // The slope graph shows the first vs last interval, so it keeps the group-by interval picker but
-    // drops the options that need the points between them (compare, smoothing, multiple axes,
-    // alert/annotation overlays, statistical analysis).
-    const isSlopeGraph = display === ChartDisplayType.SlopeGraph
-
     const funnelsCompareEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE]
 
     const isMetric = display === ChartDisplayType.Metric
-    const hideContinuousChartOptions = isNonTimeSeriesDisplay || isMetric || isSlopeGraph
+    // The slope graph shows the first vs last interval, so it drops the options that need the points
+    // between them (compare, smoothing, multiple axes, alert/annotation overlays, statistical analysis).
+    const isSlopeGraph = display === ChartDisplayType.SlopeGraph
     const showCompare =
         (isTrends &&
             display !== ChartDisplayType.ActionsAreaGraph &&
@@ -145,327 +71,8 @@ export function InsightDisplayConfig(): JSX.Element {
         isTrendsFunnel ||
         isLifecycle ||
         ((isTrends || isStickiness) && !(display && NON_TIME_SERIES_DISPLAY_TYPES.includes(display)))
-    const showSmoothing =
-        isTrends &&
-        !hasBreakdownFilter(breakdownFilter) &&
-        (!display || display === ChartDisplayType.ActionsLineGraph || display === ChartDisplayType.ActionsAreaGraph) &&
-        !!interval &&
-        (smoothingOptions[interval]?.length ?? 0) > 0
-    const showMultipleYAxesConfig = (isTrends || isStickiness) && !hideContinuousChartOptions
-    const showAlertThresholdLinesConfig = isTrends && !hideContinuousChartOptions
-    const showAnnotationsConfig = (isTrends && !hideContinuousChartOptions) || isTrendsFunnel
-    const isLineDisplay = isDefaultTrendsLineDisplay(display, querySource) || displayMatches(display, LINE_DISPLAYS)
-    const isBarDisplay = displayMatches(display, BAR_DISPLAYS)
-    const isCumulativeLineDisplay = display === ChartDisplayType.ActionsLineGraphCumulative
-    const showAxisLabelsConfig = isTrends && (isLineDisplay || isBarDisplay)
-    const showFunnelLegendConfig = isTrendsFunnel && hasBreakdownFilter(breakdownFilter)
-    const isLineGraph = isLineDisplay && !isCumulativeLineDisplay
-    const isLinearScale = !yAxisScaleType || yAxisScaleType === 'linear'
-    // The in-chart quill legend supports placement, so it gets a single "Legend" select
-    // (Hide + position) instead of the legacy show/hide checkbox.
-    const useQuillLegendOptions = quillLegendEnabled && isTrends && isLineDisplay
 
-    const {
-        showValuesOnSeries,
-        showPercentagesOnSeries,
-        mightContainFractionalNumbers,
-        showConfidenceIntervals,
-        showMovingAverage,
-    } = useValues(trendsDataLogic(insightProps))
-
-    const isBoxPlot = display === ChartDisplayType.BoxPlot
-    const advancedOptions: LemonMenuItems = [
-        ...(showSmoothing
-            ? [
-                  {
-                      title: 'Smoothing',
-                      items: [
-                          {
-                              label: () => (
-                                  <div className="px-2 pb-1.5 w-full">
-                                      <SmoothingFilter />
-                                  </div>
-                              ),
-                          },
-                      ],
-                  },
-              ]
-            : []),
-        ...((isTrends && display !== ChartDisplayType.CalendarHeatmap) ||
-        isRetention ||
-        isTrendsFunnel ||
-        isStickiness ||
-        isLifecycle
-            ? [
-                  {
-                      title: (
-                          <h5 className="mx-2 my-1" data-attr="options-display-section">
-                              Display
-                          </h5>
-                      ),
-                      items: isBoxPlot
-                          ? [
-                                ...(hasLegend ? [{ label: () => <ShowLegendFilter /> }] : []),
-                                {
-                                    label: () => (
-                                        <LemonCheckbox
-                                            label={
-                                                <span className="font-normal">
-                                                    Exclude outliers{' '}
-                                                    <Tooltip title="When enabled, whiskers are clipped to 1.5x the interquartile range, making it easier to see differences between the quartiles. When disabled, the y-axis extends to show the full range including extreme values.">
-                                                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                                                    </Tooltip>
-                                                </span>
-                                            }
-                                            className="p-1 px-2"
-                                            size="small"
-                                            checked={trendsFilter?.excludeBoxPlotOutliers !== false}
-                                            onChange={(checked) => {
-                                                if (isTrendsQuery(querySource)) {
-                                                    const newQuery = { ...querySource }
-                                                    newQuery.trendsFilter = {
-                                                        ...trendsFilter,
-                                                        excludeBoxPlotOutliers: checked,
-                                                    }
-                                                    updateQuerySource(newQuery)
-                                                }
-                                            }}
-                                        />
-                                    ),
-                                },
-                            ]
-                          : isSlopeGraph
-                            ? // A slope only shows the first vs last interval of each series — the
-                              // legend (when there are multiple series) is the only display option that applies.
-                              hasLegend
-                                ? [{ label: () => <ShowLegendFilter /> }]
-                                : []
-                            : [
-                                  ...(isMetric
-                                      ? [
-                                            { label: () => <MetricSummaryFilter /> },
-                                            { label: () => <MetricShowChangeFilter /> },
-                                            { label: () => <MetricColorFilter /> },
-                                        ]
-                                      : []),
-                                  ...(isLifecycle ? [{ label: () => <LifecycleStackingFilter /> }] : []),
-                                  ...(supportsValueOnSeries ? [{ label: () => <ValueOnSeriesFilter /> }] : []),
-                                  ...(isLifecycle ? [{ label: () => <LifecyclePercentagesFilter /> }] : []),
-                                  ...(supportsPercentStackView
-                                      ? [
-                                            {
-                                                label: () => (
-                                                    <PercentStackViewFilter
-                                                        // On a pie chart the percentage is rendered through the
-                                                        // series value labels, so it has no effect while those
-                                                        // labels are hidden.
-                                                        disabledReason={
-                                                            display === ChartDisplayType.ActionsPie &&
-                                                            showValuesOnSeries === false
-                                                                ? "Enable 'Show values on series' to use this option"
-                                                                : undefined
-                                                        }
-                                                    />
-                                                ),
-                                            },
-                                        ]
-                                      : []),
-                                  ...(supportsBarValueStacking ? [{ label: () => <StackBreakdownFilter /> }] : []),
-                                  ...((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions
-                                      ? [{ label: () => <ShowLegendFilter /> }]
-                                      : []),
-                                  ...(display === ChartDisplayType.ActionsPie
-                                      ? [{ label: () => <ShowPieTotalFilter /> }]
-                                      : []),
-                                  ...(showAlertThresholdLinesConfig
-                                      ? [
-                                            { label: () => <ShowAlertThresholdLinesFilter /> },
-                                            { label: () => <ShowAlertAnomalyPointsFilter /> },
-                                        ]
-                                      : []),
-                                  ...(showMultipleYAxesConfig ? [{ label: () => <ShowMultipleYAxesFilter /> }] : []),
-                                  ...((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions
-                                      ? [{ label: () => <ShowTrendLinesFilter /> }]
-                                      : []),
-                                  ...(isTrendsFunnel && !hideContinuousChartOptions
-                                      ? [{ label: () => <HideIncompleteConversionWindowPeriodsFilter /> }]
-                                      : []),
-                                  ...(isTrends && !hideContinuousChartOptions && hideWeekendsEnabled
-                                      ? [{ label: () => <HideWeekendsFilter /> }]
-                                      : []),
-                                  ...(showAnnotationsConfig ? [{ label: () => <ShowAnnotationsFilter /> }] : []),
-                                  ...(useQuillLegendOptions ? [{ label: () => <LegendOptionsFilter /> }] : []),
-                              ],
-                  },
-              ]
-            : []),
-        ...(supportsResultCustomizationBy
-            ? [
-                  {
-                      title: (
-                          <>
-                              <h5 className="mx-2 my-1">
-                                  Color customization by{' '}
-                                  <Tooltip title="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
-                                      <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                                  </Tooltip>
-                              </h5>
-                          </>
-                      ),
-                      items: [{ label: () => <ResultCustomizationByPicker /> }],
-                  },
-              ]
-            : []),
-        ...(!showPercentStackView && isTrends && display !== ChartDisplayType.CalendarHeatmap
-            ? [
-                  {
-                      title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
-                      items: [{ label: () => <UnitPicker /> }],
-                  },
-              ]
-            : []),
-        ...(!hideContinuousChartOptions && isTrends && display !== ChartDisplayType.CalendarHeatmap
-            ? [
-                  {
-                      title: 'Y-axis scale',
-                      items: [{ label: () => <ScalePicker /> }],
-                  },
-                  ...(display === ChartDisplayType.BoxPlot
-                      ? []
-                      : [
-                            {
-                                title: 'Statistical analysis',
-                                items: [
-                                    {
-                                        label: () => (
-                                            <LemonSwitch
-                                                label="Show confidence intervals"
-                                                className="pb-2"
-                                                fullWidth
-                                                checked={showConfidenceIntervals}
-                                                disabledReason={
-                                                    !isLineGraph
-                                                        ? 'Confidence intervals are only available for line graphs'
-                                                        : !isLinearScale
-                                                          ? 'Confidence intervals are only supported for linear scale.'
-                                                          : undefined
-                                                }
-                                                onChange={(checked) => {
-                                                    if (isTrendsQuery(querySource)) {
-                                                        const newQuery = { ...querySource }
-                                                        newQuery.trendsFilter = {
-                                                            ...trendsFilter,
-                                                            showConfidenceIntervals: checked,
-                                                        }
-                                                        updateQuerySource(newQuery)
-                                                    }
-                                                }}
-                                            />
-                                        ),
-                                    },
-                                    ...(showConfidenceIntervals
-                                        ? [
-                                              {
-                                                  label: () => <ConfidenceLevelInput />,
-                                              },
-                                          ]
-                                        : []),
-                                    {
-                                        label: () => (
-                                            <LemonSwitch
-                                                label="Show moving average"
-                                                className="pb-2"
-                                                fullWidth
-                                                checked={showMovingAverage}
-                                                disabledReason={
-                                                    !isLineGraph
-                                                        ? 'Moving average is only available for line and area graphs'
-                                                        : !isLinearScale
-                                                          ? 'Moving average is only supported for linear scale.'
-                                                          : undefined
-                                                }
-                                                onChange={(checked) => {
-                                                    if (isTrendsQuery(querySource)) {
-                                                        const newQuery = { ...querySource }
-                                                        newQuery.trendsFilter = {
-                                                            ...trendsFilter,
-                                                            showMovingAverage: checked,
-                                                        }
-                                                        updateQuerySource(newQuery)
-                                                    }
-                                                }}
-                                            />
-                                        ),
-                                    },
-                                    ...(showMovingAverage
-                                        ? [
-                                              {
-                                                  label: () => <MovingAverageIntervalsInput />,
-                                              },
-                                          ]
-                                        : []),
-                                ],
-                            },
-                        ]),
-              ]
-            : []),
-        ...(showAxisLabelsConfig
-            ? [
-                  {
-                      title: 'Axis labels',
-                      items: [{ label: () => <AxisLabelsFilter /> }],
-                  },
-              ]
-            : []),
-        ...(mightContainFractionalNumbers && isTrends && display !== ChartDisplayType.CalendarHeatmap
-            ? [
-                  {
-                      title: 'Decimal places',
-                      items: [{ label: () => <DecimalPrecisionInput /> }],
-                  },
-              ]
-            : []),
-        ...(isRetention
-            ? [
-                  {
-                      title: 'On dashboards',
-                      items: [{ label: () => <RetentionDashboardDisplayPicker /> }],
-                  },
-                  {
-                      title: (
-                          <h5 className="mx-2 my-1">
-                              Cohort labels start at{' '}
-                              <Tooltip title="Controls the starting index used to label cohort columns. Display only, does not affect the calculations.">
-                                  <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                              </Tooltip>
-                          </h5>
-                      ),
-                      items: [{ label: () => <RetentionCohortLabelStartIndexPicker /> }],
-                  },
-              ]
-            : []),
-    ]
-    const advancedOptionsCount: number =
-        (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
-        (supportsValueOnSeries && showValuesOnSeries ? 1 : 0) +
-        (isLifecycle && showPercentagesOnSeries ? 1 : 0) +
-        (showPercentStackView ? 1 : 0) +
-        (!showPercentStackView &&
-        isTrends &&
-        trendsFilter?.aggregationAxisFormat &&
-        trendsFilter.aggregationAxisFormat !== 'numeric'
-            ? 1
-            : 0) +
-        ((hasLegend || showFunnelLegendConfig) && showLegend ? 1 : 0) +
-        (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
-        (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
-        (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
-        (showMultipleYAxes ? 1 : 0) +
-        (trendsFilter?.hideWeekends && hideWeekendsEnabled ? 1 : 0) +
-        (showAnnotationsConfig && showAnnotations === false ? 1 : 0) +
-        (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
-        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
-        (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)
+    const { items: advancedOptions, count: advancedOptionsCount } = useInsightDisplayOptions()
 
     return (
         <div
@@ -570,35 +177,4 @@ export function InsightDisplayConfig(): JSX.Element {
 
 function ConfigFilter({ children }: { children: ReactNode }): JSX.Element {
     return <span className="deprecated-space-x-2 flex items-center text-sm">{children}</span>
-}
-
-function DecimalPrecisionInput(): JSX.Element {
-    const { insightProps } = useValues(insightLogic)
-    const { trendsFilter } = useValues(insightVizDataLogic(insightProps))
-    const { updateInsightFilter } = useActions(insightVizDataLogic(insightProps))
-
-    const reportChange = useDebouncedCallback(() => {
-        posthog.capture('decimal places changed', {
-            decimal_places: trendsFilter?.decimalPlaces,
-        })
-    }, 500)
-
-    return (
-        <LemonInput
-            type="number"
-            size="small"
-            step={1}
-            min={0}
-            max={9}
-            defaultValue={DEFAULT_DECIMAL_PLACES}
-            value={trendsFilter?.decimalPlaces}
-            onChange={(value) => {
-                updateInsightFilter({
-                    decimalPlaces: value,
-                })
-                reportChange()
-            }}
-            className="mx-2 mb-1.5"
-        />
-    )
 }

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -1,4 +1,5 @@
 import { useValues } from 'kea'
+import { ReactNode } from 'react'
 
 import { IconInfo } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
@@ -24,6 +25,30 @@ import {
     isDefaultTrendsLineDisplay,
     LINE_DISPLAYS,
 } from './DisplayOptions'
+
+function SectionHeader({
+    children,
+    tooltip,
+    dataAttr,
+}: {
+    children: ReactNode
+    tooltip?: string
+    dataAttr?: string
+}): JSX.Element {
+    return (
+        <h5 className="mx-2 my-1" data-attr={dataAttr}>
+            {children}
+            {tooltip && (
+                <>
+                    {' '}
+                    <Tooltip title={tooltip}>
+                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                    </Tooltip>
+                </>
+            )}
+        </h5>
+    )
+}
 
 // The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
 // active options, badged on the Options button.
@@ -169,11 +194,7 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
 
     if (showDisplaySection) {
         items.push({
-            title: (
-                <h5 className="mx-2 my-1" data-attr="options-display-section">
-                    Display
-                </h5>
-            ),
+            title: <SectionHeader dataAttr="options-display-section">Display</SectionHeader>,
             items: getDisplayItems(),
         })
     }
@@ -181,12 +202,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
     if (supportsResultCustomizationBy) {
         items.push({
             title: (
-                <h5 className="mx-2 my-1">
-                    Color customization by{' '}
-                    <Tooltip title="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
-                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                    </Tooltip>
-                </h5>
+                <SectionHeader tooltip="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
+                    Color customization by
+                </SectionHeader>
             ),
             items: [DisplayOptions.ResultCustomizationBy],
         })
@@ -227,12 +245,9 @@ export function useInsightDisplayOptions(): { items: LemonMenuItems; count: numb
         items.push({ title: 'On dashboards', items: [DisplayOptions.RetentionDashboardDisplay] })
         items.push({
             title: (
-                <h5 className="mx-2 my-1">
-                    Cohort labels start at{' '}
-                    <Tooltip title="Controls the starting index used to label cohort columns. Display only, does not affect the calculations.">
-                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                    </Tooltip>
-                </h5>
+                <SectionHeader tooltip="Controls the starting index used to label cohort columns. Display only, does not affect the calculations.">
+                    Cohort labels start at
+                </SectionHeader>
             ),
             items: [DisplayOptions.RetentionCohortLabelStart],
         })

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -1,0 +1,264 @@
+import { useValues } from 'kea'
+
+import { IconInfo } from '@posthog/icons'
+import { Tooltip } from '@posthog/lemon-ui'
+import { normalizeAxisLabel } from '@posthog/quill-charts'
+
+import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { LemonMenuItem, LemonMenuItems } from 'lib/lemon-ui/LemonMenu'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
+import { axisLabel } from 'scenes/insights/aggregationAxisFormat'
+import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
+import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
+
+import { hasBreakdownFilter } from '~/queries/utils'
+import { ChartDisplayType } from '~/types'
+
+import {
+    BAR_DISPLAYS,
+    displayMatches,
+    DisplayOptions,
+    isDefaultTrendsLineDisplay,
+    LINE_DISPLAYS,
+} from './DisplayOptions'
+
+// The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
+// active options, badged on the Options button.
+export function useInsightDisplayOptions(): { items: LemonMenuItems; count: number } {
+    const { insightProps } = useValues(insightLogic)
+    const {
+        querySource,
+        isTrends,
+        isRetention,
+        isStickiness,
+        isLifecycle,
+        display,
+        breakdownFilter,
+        trendsFilter,
+        hasLegend,
+        showLegend,
+        supportsValueOnSeries,
+        showPercentStackView,
+        supportsPercentStackView,
+        supportsBarValueStacking,
+        supportsResultCustomizationBy,
+        yAxisScaleType,
+        showMultipleYAxes,
+        showAnnotations,
+        isNonTimeSeriesDisplay,
+        interval,
+    } = useValues(insightVizDataLogic(insightProps))
+    const { isTrendsFunnel } = useValues(funnelDataLogic(insightProps))
+    const {
+        showValuesOnSeries,
+        showPercentagesOnSeries,
+        mightContainFractionalNumbers,
+        showConfidenceIntervals,
+        showMovingAverage,
+    } = useValues(trendsDataLogic(insightProps))
+    const { featureFlags } = useValues(featureFlagLogic)
+    const hideWeekendsEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_HIDE_WEEKENDS]
+    const quillLegendEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_QUILL_LEGEND]
+
+    // The slope graph shows the first vs last interval, so it drops the options that need the points
+    // between them (smoothing, multiple axes, alert/annotation overlays, statistical analysis).
+    const isSlopeGraph = display === ChartDisplayType.SlopeGraph
+    const isMetric = display === ChartDisplayType.Metric
+    const hideContinuousChartOptions = isNonTimeSeriesDisplay || isMetric || isSlopeGraph
+    const showSmoothing =
+        isTrends &&
+        !hasBreakdownFilter(breakdownFilter) &&
+        (!display || display === ChartDisplayType.ActionsLineGraph || display === ChartDisplayType.ActionsAreaGraph) &&
+        !!interval &&
+        (smoothingOptions[interval]?.length ?? 0) > 0
+    const showMultipleYAxesConfig = (isTrends || isStickiness) && !hideContinuousChartOptions
+    const showAlertThresholdLinesConfig = isTrends && !hideContinuousChartOptions
+    const showAnnotationsConfig = (isTrends && !hideContinuousChartOptions) || isTrendsFunnel
+    const isLineDisplay = isDefaultTrendsLineDisplay(display, querySource) || displayMatches(display, LINE_DISPLAYS)
+    const isBarDisplay = displayMatches(display, BAR_DISPLAYS)
+    const showAxisLabelsConfig = isTrends && (isLineDisplay || isBarDisplay)
+    const showFunnelLegendConfig = isTrendsFunnel && hasBreakdownFilter(breakdownFilter)
+    const isBoxPlot = display === ChartDisplayType.BoxPlot
+    const isCalendarHeatmap = display === ChartDisplayType.CalendarHeatmap
+    // The in-chart quill legend supports placement, so it gets a single "Legend" select (Hide +
+    // position) instead of the legacy show/hide checkbox.
+    const useQuillLegendOptions = quillLegendEnabled && isTrends && isLineDisplay
+
+    const showDisplaySection =
+        (isTrends && !isCalendarHeatmap) || isRetention || isTrendsFunnel || isStickiness || isLifecycle
+    const showYAxisScale = !hideContinuousChartOptions && isTrends && !isCalendarHeatmap
+
+    // The box plot and slope graph only show a couple of options each; everything else falls
+    // through to the full shared list.
+    const getDisplayItems = (): LemonMenuItem[] => {
+        const displayItems: LemonMenuItem[] = []
+
+        if (isBoxPlot) {
+            if (hasLegend) {
+                displayItems.push(DisplayOptions.Legend)
+            }
+            displayItems.push(DisplayOptions.ExcludeOutliers)
+            return displayItems
+        }
+
+        if (isSlopeGraph) {
+            // A slope only shows the first vs last interval of each series — the legend (when there
+            // are multiple series) is the only display option that applies.
+            if (hasLegend) {
+                displayItems.push(DisplayOptions.Legend)
+            }
+            return displayItems
+        }
+
+        if (isMetric) {
+            displayItems.push(DisplayOptions.MetricSummary, DisplayOptions.MetricShowChange, DisplayOptions.MetricColor)
+        }
+        if (isLifecycle) {
+            displayItems.push(DisplayOptions.LifecycleStacking)
+        }
+        if (supportsValueOnSeries) {
+            displayItems.push(DisplayOptions.ValueLabels)
+        }
+        if (isLifecycle) {
+            displayItems.push(DisplayOptions.LifecyclePercentages)
+        }
+        if (supportsPercentStackView) {
+            displayItems.push(DisplayOptions.PercentStack)
+        }
+        if (supportsBarValueStacking) {
+            displayItems.push(DisplayOptions.StackBreakdown)
+        }
+        if ((hasLegend || showFunnelLegendConfig) && !useQuillLegendOptions) {
+            displayItems.push(DisplayOptions.Legend)
+        }
+        if (display === ChartDisplayType.ActionsPie) {
+            displayItems.push(DisplayOptions.PieTotal)
+        }
+        if (showAlertThresholdLinesConfig) {
+            displayItems.push(DisplayOptions.AlertThresholdLines, DisplayOptions.AlertAnomalyPoints)
+        }
+        if (showMultipleYAxesConfig) {
+            displayItems.push(DisplayOptions.MultipleYAxes)
+        }
+        if ((isTrends || isRetention || isTrendsFunnel) && !hideContinuousChartOptions) {
+            displayItems.push(DisplayOptions.TrendLines)
+        }
+        if (isTrendsFunnel && !hideContinuousChartOptions) {
+            displayItems.push(DisplayOptions.HideIncompleteFunnelPeriods)
+        }
+        if (isTrends && !hideContinuousChartOptions && hideWeekendsEnabled) {
+            displayItems.push(DisplayOptions.HideWeekends)
+        }
+        if (showAnnotationsConfig) {
+            displayItems.push(DisplayOptions.Annotations)
+        }
+        if (useQuillLegendOptions) {
+            displayItems.push(DisplayOptions.LegendOptions)
+        }
+        return displayItems
+    }
+
+    const items: LemonMenuItems = []
+
+    if (showSmoothing) {
+        items.push({ title: 'Smoothing', items: [DisplayOptions.Smoothing] })
+    }
+
+    if (showDisplaySection) {
+        items.push({
+            title: (
+                <h5 className="mx-2 my-1" data-attr="options-display-section">
+                    Display
+                </h5>
+            ),
+            items: getDisplayItems(),
+        })
+    }
+
+    if (supportsResultCustomizationBy) {
+        items.push({
+            title: (
+                <h5 className="mx-2 my-1">
+                    Color customization by{' '}
+                    <Tooltip title="You can customize the appearance of individual results in your insights. This can be done based on the result's name (e.g., customize the breakdown value 'pizza' for the first series) or based on the result's rank (e.g., customize the first dataset in the results).">
+                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                    </Tooltip>
+                </h5>
+            ),
+            items: [DisplayOptions.ResultCustomizationBy],
+        })
+    }
+
+    if (!showPercentStackView && isTrends && !isCalendarHeatmap) {
+        items.push({
+            title: axisLabel(display || ChartDisplayType.ActionsLineGraph),
+            items: [DisplayOptions.Unit],
+        })
+    }
+
+    if (showYAxisScale) {
+        items.push({ title: 'Y-axis scale', items: [DisplayOptions.Scale] })
+    }
+
+    if (showYAxisScale && !isBoxPlot) {
+        const statisticalItems: LemonMenuItem[] = [DisplayOptions.ConfidenceInterval]
+        if (showConfidenceIntervals) {
+            statisticalItems.push(DisplayOptions.ConfidenceLevel)
+        }
+        statisticalItems.push(DisplayOptions.MovingAverage)
+        if (showMovingAverage) {
+            statisticalItems.push(DisplayOptions.MovingAverageIntervals)
+        }
+        items.push({ title: 'Statistical analysis', items: statisticalItems })
+    }
+
+    if (showAxisLabelsConfig) {
+        items.push({ title: 'Axis labels', items: [DisplayOptions.AxisLabels] })
+    }
+
+    if (mightContainFractionalNumbers && isTrends && !isCalendarHeatmap) {
+        items.push({ title: 'Decimal places', items: [DisplayOptions.DecimalPrecision] })
+    }
+
+    if (isRetention) {
+        items.push({ title: 'On dashboards', items: [DisplayOptions.RetentionDashboardDisplay] })
+        items.push({
+            title: (
+                <h5 className="mx-2 my-1">
+                    Cohort labels start at{' '}
+                    <Tooltip title="Controls the starting index used to label cohort columns. Display only, does not affect the calculations.">
+                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
+                    </Tooltip>
+                </h5>
+            ),
+            items: [DisplayOptions.RetentionCohortLabelStart],
+        })
+    }
+
+    const count: number =
+        (showSmoothing && (trendsFilter?.smoothingIntervals ?? 1) !== 1 ? 1 : 0) +
+        (supportsValueOnSeries && showValuesOnSeries ? 1 : 0) +
+        (isLifecycle && showPercentagesOnSeries ? 1 : 0) +
+        (showPercentStackView ? 1 : 0) +
+        (!showPercentStackView &&
+        isTrends &&
+        trendsFilter?.aggregationAxisFormat &&
+        trendsFilter.aggregationAxisFormat !== 'numeric'
+            ? 1
+            : 0) +
+        ((hasLegend || showFunnelLegendConfig) && showLegend ? 1 : 0) +
+        (!!yAxisScaleType && yAxisScaleType !== 'linear' ? 1 : 0) +
+        (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.xAxisLabel) ? 1 : 0) +
+        (showAxisLabelsConfig && normalizeAxisLabel(trendsFilter?.yAxisLabel) ? 1 : 0) +
+        (showMultipleYAxes ? 1 : 0) +
+        (trendsFilter?.hideWeekends && hideWeekendsEnabled ? 1 : 0) +
+        (showAnnotationsConfig && showAnnotations === false ? 1 : 0) +
+        (isMetric && trendsFilter?.metricShowChange === false ? 1 : 0) +
+        (isMetric && trendsFilter?.metricColorByDirection ? 1 : 0) +
+        (isMetric && !!trendsFilter?.metricSummary && trendsFilter.metricSummary !== 'total' ? 1 : 0)
+
+    return { items, count }
+}

--- a/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
+++ b/frontend/src/queries/nodes/InsightViz/insightDisplayOptions.tsx
@@ -1,8 +1,5 @@
 import { useValues } from 'kea'
-import { ReactNode } from 'react'
 
-import { IconInfo } from '@posthog/icons'
-import { Tooltip } from '@posthog/lemon-ui'
 import { normalizeAxisLabel } from '@posthog/quill-charts'
 
 import { smoothingOptions } from 'lib/components/SmoothingFilter/smoothings'
@@ -24,31 +21,8 @@ import {
     DisplayOptions,
     isDefaultTrendsLineDisplay,
     LINE_DISPLAYS,
+    SectionHeader,
 } from './DisplayOptions'
-
-function SectionHeader({
-    children,
-    tooltip,
-    dataAttr,
-}: {
-    children: ReactNode
-    tooltip?: string
-    dataAttr?: string
-}): JSX.Element {
-    return (
-        <h5 className="mx-2 my-1" data-attr={dataAttr}>
-            {children}
-            {tooltip && (
-                <>
-                    {' '}
-                    <Tooltip title={tooltip}>
-                        <IconInfo className="relative top-0.5 text-lg text-secondary" />
-                    </Tooltip>
-                </>
-            )}
-        </h5>
-    )
-}
 
 // The "Options" menu in the insight editor's display config bar. `count` is the number of non-default
 // active options, badged on the Options button.


### PR DESCRIPTION
## Problem

The insight editor's "Options" menu was a ~300-line `LemonMenuItems` literal built inside `InsightDisplayConfig.tsx` out of deeply nested ternaries, array spreads (`...(cond ? [x] : [])`), and an inline `{ label: () => <X /> }` wrapper around every single option. It was hard to read and hard to change.

## Changes

Pure refactor, no behaviour change — the same options render under the same conditions.

- **`DisplayOptions.tsx`** (new): a single home for the display toggles. Exposes a `DisplayOptions` namespace of ready-to-use menu items, so callers reference `DisplayOptions.MetricColor` instead of repeating `{ label: () => <MetricColorFilter /> }`. The three previously parametrized controls (percent-stack `disabledReason`, confidence-interval / moving-average enablement) became self-contained components so every entry is a plain static item.
- **`insightDisplayOptions.tsx`** (new): the `useInsightDisplayOptions` hook that assembles the menu. The giant nested-ternary literal is now flat `if (cond) { items.push(...) }` blocks; the box-plot / slope-graph special cases are guard-clause early returns.
- **`InsightDisplayConfig.tsx`**: now just consumes the hook.

The legend handling matches what's currently on master (unified `LegendOptionsFilter` behind the quill-legend flag, from #65208).

## How did you test this code?

I'm an agent (Claude Code, driven by @sampennington). Automated only:

- `InsightDisplayConfig.test.tsx` — all 10 tests pass (box plot / slope / line-graph display sections, option counts).
- oxlint + oxfmt clean on the three files; IDE TypeScript diagnostics clean.

No manual UI testing performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tooling: Claude Code (Opus 4.8). No repo skills were needed for the refactor itself.

Decisions along the way:
- Iterated through a few styles for de-nesting (helper wrappers that lean on the menu's falsy-filtering, a data-driven section table) before settling on plain `if`/`push` — least clever, easiest to read.
- Consolidated the option controls behind a `DisplayOptions` namespace specifically to kill the repetitive `{ label: () => <X /> }` boilerplate at every call site.
- The ~23 leaf filter components (used only by this menu) are imported into `DisplayOptions.tsx` rather than physically inlined, to keep the diff reviewable; they can be pulled in later if we want a literal single file.
- Built off current master and reconciled the legend section with #65208 (which had landed since this work began), so the menu's legend behaviour is unchanged relative to master.
