### PR TITLE
feat(data-warehouse): cache direct Snowflake connections per thread

### DIFF
--- a/posthog/hogql/direct_query_metrics.py
+++ b/posthog/hogql/direct_query_metrics.py
@@ -37,6 +37,11 @@ DIRECT_QUERY_ROW_CAP_EXCEEDED_TOTAL = PromCounter(
     "Direct queries rejected for exceeding the result-row cap, by dialect.",
     labelnames=["dialect"],
 )
+SNOWFLAKE_CONNECTION_CACHE_TOTAL = PromCounter(
+    "hogql_snowflake_connection_cache_total",
+    "Direct Snowflake connection-cache lookups by result (reused vs opened).",
+    labelnames=["result"],
+)
 
 
 @contextmanager

--- a/posthog/hogql/query.py
+++ b/posthog/hogql/query.py
@@ -59,6 +59,7 @@ from posthog.hogql.placeholders import find_placeholders, replace_placeholders
 from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.resolver import Resolver
 from posthog.hogql.resolver_utils import extract_base_table_types, extract_select_queries
+from posthog.hogql.snowflake_connection_cache import cached_snowflake_connection
 from posthog.hogql.timings import HogQLTimings
 from posthog.hogql.transforms.preaggregated_table_transformation import do_preaggregated_table_transforms
 from posthog.hogql.variables import replace_variables
@@ -964,7 +965,9 @@ class HogQLQueryExecutor:
 
         try:
             with self.timings.measure("snowflake_execute"), observe_direct_query("snowflake"):
-                with snowflake_implementation.connect(source_config) as connection:
+                # Reuse a per-thread connection across queries — the auth handshake is the
+                # dominant cost for interactive use.
+                with cached_snowflake_connection(snowflake_implementation, source_config) as connection:
                     with connection.cursor() as cursor:
                         # Server-side backstop: refuse stacked statements regardless of what the
                         # connector default is, so the single-statement parse gate can't be bypassed.

--- a/posthog/hogql/snowflake_connection_cache.py
+++ b/posthog/hogql/snowflake_connection_cache.py
@@ -142,8 +142,8 @@ def cached_snowflake_connection(
         # we reuse its auth/keypair logic without closing the connection on block exit.
         cm = implementation.connect(config)
         connection = cm.__enter__()
+        # A fresh key lands at the tail (LRU-newest) already, so no move_to_end needed here.
         cache[key] = _Entry(cm=cm, connection=connection, opened_at=now)
-        cache.move_to_end(key)
         SNOWFLAKE_CONNECTION_CACHE_TOTAL.labels(result="opened").inc()
         while len(cache) > SNOWFLAKE_CONNECTION_CACHE_MAX_PER_THREAD:
             _old_key, old_entry = cache.popitem(last=False)

--- a/posthog/hogql/snowflake_connection_cache.py
+++ b/posthog/hogql/snowflake_connection_cache.py
@@ -1,0 +1,164 @@
+"""Thread-local connection cache for direct Snowflake queries.
+
+Opening a Snowflake connection runs a full auth handshake (often hundreds of ms or
+more), which dominates latency for the interactive SQL editor where a user issues
+many small queries in sequence. This caches one open connection per
+(credentials + target) per worker thread, reusing it across queries and reopening
+lazily when it expires, dies, or is evicted.
+
+Two deliberate scope choices:
+
+- Direct-query path only. The data-import pipeline opens its own short-lived
+  connections per sync and must not share these.
+- Thread-local. A ``SnowflakeConnection`` is not safe to use from multiple threads
+  concurrently, and the web app runs blocking DB work in a threadpool — so each
+  thread keeps its own connection and never shares it, no locking required.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import threading
+from collections import OrderedDict
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from dataclasses import dataclass
+from time import monotonic
+from typing import TYPE_CHECKING
+
+import snowflake.connector
+
+from posthog.hogql.direct_query_metrics import SNOWFLAKE_CONNECTION_CACHE_TOTAL
+
+if TYPE_CHECKING:
+    from posthog.temporal.data_imports.sources.generated_configs import SnowflakeSourceConfig
+    from posthog.temporal.data_imports.sources.snowflake.snowflake import SnowflakeImplementation
+
+# Refresh well before Snowflake's session/token expiry so a cached connection is
+# replaced proactively rather than failing mid-query.
+SNOWFLAKE_CONNECTION_CACHE_TTL_SECONDS = 1800
+# Bound per-thread connection count so a worker that touches many distinct sources
+# can't accumulate open sessions without limit.
+SNOWFLAKE_CONNECTION_CACHE_MAX_PER_THREAD = 8
+
+# Transport/connection-level failures mean the cached session is suspect; SQL-level
+# errors (ProgrammingError, IntegrityError) leave the connection healthy.
+_CONNECTION_LEVEL_ERRORS = (
+    snowflake.connector.errors.OperationalError,
+    snowflake.connector.errors.InterfaceError,
+)
+
+
+@dataclass
+class _Entry:
+    cm: AbstractContextManager[snowflake.connector.SnowflakeConnection]
+    connection: snowflake.connector.SnowflakeConnection
+    opened_at: float
+
+
+_thread_local = threading.local()
+
+
+def _cache() -> OrderedDict[str, _Entry]:
+    cache = getattr(_thread_local, "cache", None)
+    if cache is None:
+        cache = OrderedDict()
+        _thread_local.cache = cache
+    return cache
+
+
+def _config_key(config: SnowflakeSourceConfig) -> str:
+    auth = config.auth_type
+    selection = auth.selection
+    secret = auth.private_key if selection == "keypair" else auth.password
+
+    def text(value: object) -> str:
+        return str(value) if value else ""
+
+    # Hash the secret rather than carry it in the key. Keying on the credentials means
+    # a rotation routes to a fresh connection automatically (old entry just expires).
+    secret_digest = hashlib.sha256(text(secret).encode("utf-8")).hexdigest()
+    passphrase_digest = hashlib.sha256(text(getattr(auth, "passphrase", None)).encode("utf-8")).hexdigest()
+    parts = [
+        text(config.account_id),
+        text(auth.user),
+        text(config.warehouse),
+        text(config.database),
+        text(config.role),
+        text(config.schema),
+        text(selection),
+        secret_digest,
+        passphrase_digest,
+    ]
+    return hashlib.sha256("\x00".join(parts).encode("utf-8")).hexdigest()
+
+
+def _close_entry(entry: _Entry) -> None:
+    try:
+        entry.cm.__exit__(None, None, None)
+    except Exception:
+        pass
+
+
+def _evict(key: str) -> None:
+    entry = _cache().pop(key, None)
+    if entry is not None:
+        _close_entry(entry)
+
+
+def _is_reusable(entry: _Entry, now: float) -> bool:
+    if now - entry.opened_at >= SNOWFLAKE_CONNECTION_CACHE_TTL_SECONDS:
+        return False
+    try:
+        return not entry.connection.is_closed()
+    except Exception:
+        return False
+
+
+@contextmanager
+def cached_snowflake_connection(
+    implementation: SnowflakeImplementation,
+    config: SnowflakeSourceConfig,
+) -> Iterator[snowflake.connector.SnowflakeConnection]:
+    """Yield a cached open Snowflake connection for this thread, opening one if needed.
+
+    The connection is kept open after the block exits so the next query on the same
+    thread can reuse it. It is dropped (and reopened next time) on expiry, when found
+    closed, on LRU eviction, or when the block raises a connection-level error.
+    """
+    key = _config_key(config)
+    cache = _cache()
+    now = monotonic()
+
+    entry = cache.get(key)
+    if entry is not None and _is_reusable(entry, now):
+        cache.move_to_end(key)
+        connection = entry.connection
+        SNOWFLAKE_CONNECTION_CACHE_TOTAL.labels(result="reused").inc()
+    else:
+        if entry is not None:
+            _evict(key)
+        # Drive the implementation's own connect() contextmanager but keep it entered, so
+        # we reuse its auth/keypair logic without closing the connection on block exit.
+        cm = implementation.connect(config)
+        connection = cm.__enter__()
+        cache[key] = _Entry(cm=cm, connection=connection, opened_at=now)
+        cache.move_to_end(key)
+        SNOWFLAKE_CONNECTION_CACHE_TOTAL.labels(result="opened").inc()
+        while len(cache) > SNOWFLAKE_CONNECTION_CACHE_MAX_PER_THREAD:
+            _old_key, old_entry = cache.popitem(last=False)
+            _close_entry(old_entry)
+
+    try:
+        yield connection
+    except _CONNECTION_LEVEL_ERRORS:
+        _evict(key)
+        raise
+
+
+def clear_thread_local_snowflake_connections() -> None:
+    """Close and drop every cached connection for the current thread (tests, shutdown)."""
+    cache = _cache()
+    for entry in list(cache.values()):
+        _close_entry(entry)
+    cache.clear()

--- a/posthog/hogql/test/test_direct_snowflake_query.py
+++ b/posthog/hogql/test/test_direct_snowflake_query.py
@@ -1,5 +1,7 @@
+from types import SimpleNamespace
 from uuid import uuid4
 
+import unittest
 from posthog.test.base import APIBaseTest
 from unittest.mock import MagicMock, patch
 
@@ -9,6 +11,10 @@ from parameterized import parameterized
 from posthog.hogql.direct_connection import validate_snowflake_account_id
 from posthog.hogql.errors import ExposedHogQLError
 from posthog.hogql.query import HogQLQueryExecutor, snowflake_error_to_message, snowflake_field_type_to_clickhouse_type
+from posthog.hogql.snowflake_connection_cache import (
+    cached_snowflake_connection,
+    clear_thread_local_snowflake_connections,
+)
 
 from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
@@ -35,6 +41,12 @@ MAP = 17
 
 
 class TestDirectSnowflakeQuery(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        # The connection cache is thread-local module state; isolate each test.
+        clear_thread_local_snowflake_connections()
+        self.addCleanup(clear_thread_local_snowflake_connections)
+
     def _create_source(self, prefix: str = "wh") -> ExternalDataSource:
         return ExternalDataSource.objects.create(
             team=self.team,
@@ -132,6 +144,7 @@ class TestDirectSnowflakeQuery(APIBaseTest):
         cursor.fetchmany.return_value = rows
         cursor.description = description
         connection = MagicMock()
+        connection.is_closed.return_value = False
         connection.cursor.return_value.__enter__.return_value = cursor
         connection.cursor.return_value.__exit__.return_value = False
 
@@ -277,3 +290,92 @@ class TestDirectSnowflakeQuery(APIBaseTest):
 
         # The statement passed the read-only gate and reached execution unchanged.
         self.assertEqual(executor.direct_sql, query)
+
+
+class TestSnowflakeConnectionCache(unittest.TestCase):
+    def setUp(self):
+        clear_thread_local_snowflake_connections()
+        self.addCleanup(clear_thread_local_snowflake_connections)
+
+    def _impl_and_config(
+        self, secret: str = "pw", account: str = "acme-prod"
+    ) -> tuple[MagicMock, SimpleNamespace, MagicMock]:
+        connection = MagicMock()
+        connection.is_closed.return_value = False
+        cm = MagicMock()
+        cm.__enter__.return_value = connection
+        cm.__exit__.return_value = False
+        implementation = MagicMock()
+        implementation.connect.return_value = cm
+        auth = SimpleNamespace(selection="password", user="svc", password=secret, private_key=None, passphrase=None)
+        config = SimpleNamespace(
+            account_id=account, warehouse="WH", database="DB", role="R", schema="PUBLIC", auth_type=auth
+        )
+        return implementation, config, connection
+
+    def test_reuses_connection_across_calls(self):
+        implementation, config, connection = self._impl_and_config()
+
+        with cached_snowflake_connection(implementation, config) as first:
+            self.assertIs(first, connection)
+        with cached_snowflake_connection(implementation, config) as second:
+            self.assertIs(second, connection)
+
+        implementation.connect.assert_called_once()
+
+    def test_reopens_after_ttl(self):
+        implementation, config, _connection = self._impl_and_config()
+
+        with patch("posthog.hogql.snowflake_connection_cache.SNOWFLAKE_CONNECTION_CACHE_TTL_SECONDS", 0):
+            with cached_snowflake_connection(implementation, config):
+                pass
+            with cached_snowflake_connection(implementation, config):
+                pass
+
+        self.assertEqual(implementation.connect.call_count, 2)
+
+    def test_reopens_when_connection_reports_closed(self):
+        implementation, config, connection = self._impl_and_config()
+
+        with cached_snowflake_connection(implementation, config):
+            pass
+        connection.is_closed.return_value = True
+        with cached_snowflake_connection(implementation, config):
+            pass
+
+        self.assertEqual(implementation.connect.call_count, 2)
+
+    def test_evicts_on_connection_level_error(self):
+        implementation, config, _connection = self._impl_and_config()
+
+        with self.assertRaises(snowflake.connector.errors.OperationalError):
+            with cached_snowflake_connection(implementation, config):
+                raise snowflake.connector.errors.OperationalError(msg="connection dropped")
+        with cached_snowflake_connection(implementation, config):
+            pass
+
+        # The suspect connection was dropped, so the next call reopens.
+        self.assertEqual(implementation.connect.call_count, 2)
+
+    def test_keeps_connection_on_sql_error(self):
+        implementation, config, _connection = self._impl_and_config()
+
+        with self.assertRaises(snowflake.connector.errors.ProgrammingError):
+            with cached_snowflake_connection(implementation, config):
+                raise snowflake.connector.errors.ProgrammingError(msg="bad sql")
+        with cached_snowflake_connection(implementation, config):
+            pass
+
+        # A SQL error leaves the connection healthy, so it's reused.
+        implementation.connect.assert_called_once()
+
+    def test_different_credentials_use_separate_connections(self):
+        implementation, config_a, _connection = self._impl_and_config(secret="pw-a")
+        _implementation_b, config_b, _connection_b = self._impl_and_config(secret="pw-b")
+
+        with cached_snowflake_connection(implementation, config_a):
+            pass
+        with cached_snowflake_connection(implementation, config_b):
+            pass
+
+        self.assertEqual(implementation.connect.call_count, 2)


### PR DESCRIPTION
## Problem

Stacked on #65359.

Opening a Snowflake connection runs a full auth handshake (often hundreds of ms or more) — far heavier than the TCP connect the Postgres/MySQL direct paths pay. The direct Snowflake path opened a fresh connection per query, so that handshake landed on *every* query. For the interactive SQL editor — where a user fires many small queries in sequence — that's the dominant latency, and it's the one place being pool-less hurts Snowflake more than the other direct sources.

## Changes

Cache one open connection per (credentials + target) **per worker thread**, reuse it across queries, and reopen lazily when it expires, is found closed, is LRU-evicted, or the block raises a connection-level error.

- **Thread-local, no locking.** A `SnowflakeConnection` isn't safe to use from multiple threads concurrently, and the web app runs blocking DB work in a threadpool — so each thread keeps its own connection and never shares it. This sidesteps the pool/locking complexity of a shared cache while still capturing the win for the common sequential-query case.
- **Keyed on a hash of the credentials + target** (account/user/warehouse/db/role/schema/auth + a hashed secret), so a credential rotation routes to a fresh connection automatically and the stale one just expires. The raw secret is never used as a key.
- **Lazy invalidation:** TTL (well under Snowflake's session/token expiry), an `is_closed()` check on checkout, LRU cap per thread, and eviction on `OperationalError`/`InterfaceError` (SQL-level errors leave the connection healthy and reused).
- **Scope:** direct-query path only. The data-import pipeline keeps its own short-lived per-sync connections and is untouched. The per-query session pins (`MULTI_STATEMENT_COUNT`, statement timeout) are still re-applied on every query, so reuse can't carry stale session state.
- Adds a `hogql_snowflake_connection_cache_total{result}` metric (reused vs opened) for hit-rate visibility.

This is the thread-local first step; if the hit rate turns out low in practice (threads spread across requests), a shared bounded pool is the follow-up — but it carries real concurrency complexity, so this ships the safe win first.

## How did you test this code?

I'm an agent (Claude Code); no manual Snowflake testing. Automated: **66 passed** in `test_direct_snowflake_query`, including 6 new cache unit tests — reuse across calls, reopen after TTL, reopen when the connection reports closed, evict on connection-level error, keep on SQL error, and separate connections per credentials. `ruff` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tool:** Claude Code (Opus 4.8).
- **Why thread-local over a shared pool:** confirmed the web app serves blocking DB work via an ASGI threadpool (granian/Nginx Unit), so a connection can land on different threads and can't be shared concurrently. Thread-local is correct-by-construction and captures the sequential-editor win without locking; a shared pool is a possible follow-up if profiling shows a low hit rate.
- **Driving the implementation's own `connect()` contextmanager but keeping it entered** lets the cache reuse the existing password/keypair auth logic without duplicating it or closing the connection on block exit.
