### PR TITLE
fix(insights): show breakdown values in multi-series tooltip

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1057,9 +1057,9 @@ snapshots:
     components-insighttooltip--long-names--light:
         hash: v1.k794b7964.a3cbff5e9d93637e541ee21344030f75fc32adb6edd2a363f7553ffb8d8fc407.VzgJ4zJ-yb9ZtDGxqQQZGPlH8D7diG9ufmZiyFOKwP4
     components-insighttooltip--math-tags--dark:
-        hash: v1.k794b7964.b87b215e58ae9082942943f8c2bed491f7bfdcf5df2d275a710de44883f3a199.o-tywVFQU6WUpyZNTXjAUntyMC0I_JuzmnKAfaoGQoc
+        hash: v1.k794b7964.3c78a732db4eac6e6ea9afd535245b0538dcc4564ac9c81dfedae6255fbf92ea.c5MmyDD0IP4c3rahv19WpupyN4TFbxRKEbLSX63WHSI
     components-insighttooltip--math-tags--light:
-        hash: v1.k794b7964.d80c1aacf5b19ce4014ba8b4bebdaaf66482114898a40e5ca2e2ae0da1be5639.KsOoqiHIM-ow9rXvH6B62y01_DTuzzeqzojkiW0DuIA
+        hash: v1.k794b7964.d1e89fa880800f96ac8e71fe9c9b543b8fb8d9218e8067526df447a9406d5aa5.6hbIqsXuDoBw7ufqPDVvTHkR95kBj6ybJeVg-2Hkf0s
     components-insighttooltip--math-tags-as-rows--dark:
         hash: v1.k794b7964.504670d1745189ec8c8e7ace729965b33d9a1944942f4698927f0ab28bd3bd02.HBJCzAuy852iKeKJQwoz3IXMLuhgirZN__OmGb1M5uo
     components-insighttooltip--math-tags-as-rows--light:

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.test.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.test.tsx
@@ -1,0 +1,89 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render } from '@testing-library/react'
+
+import { BreakdownFilter } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+
+import { InsightTooltip } from './InsightTooltip'
+import { SeriesDatum } from './insightTooltipUtils'
+
+const EN_DASH = '–'
+
+const eventBreakdown: BreakdownFilter = { breakdown: '$event', breakdown_type: 'event_metadata' }
+
+function renderTooltip(seriesData: SeriesDatum[], breakdownFilter: BreakdownFilter): HTMLElement {
+    const { container } = render(
+        <InsightTooltip
+            date="2024-05-29"
+            timezone="UTC"
+            seriesData={seriesData}
+            breakdownFilter={breakdownFilter}
+            renderCount={(value) => `${value}`}
+            renderSeries={(value) => value}
+        />
+    )
+    return container
+}
+
+describe('InsightTooltip column layout', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    // Regression: each breakdown row holds one series with its own `order`; the single value column
+    // used to be keyed off one row's `order`, blanking every other row to an en-dash.
+    it('shows each breakdown value when every row holds a single distinct series', () => {
+        const seriesData: SeriesDatum[] = [
+            {
+                id: 0,
+                dataIndex: 0,
+                datasetIndex: 0,
+                order: 0,
+                breakdown_value: '$pageview',
+                label: '$pageview',
+                color: '#1d4aff',
+                count: 94,
+            },
+            {
+                id: 1,
+                dataIndex: 0,
+                datasetIndex: 1,
+                order: 2,
+                breakdown_value: '$rageclick',
+                label: '$rageclick',
+                color: '#621da6',
+                count: 5,
+            },
+        ]
+
+        const container = renderTooltip(seriesData, eventBreakdown)
+
+        expect(container.textContent).toContain('94')
+        expect(container.textContent).toContain('5')
+        expect(container.textContent).not.toContain(EN_DASH)
+    })
+
+    // Regression: columns were seeded from the longest row only, so an `order` absent from it
+    // (here order 2, present only in the Safari row) was dropped to an en-dash.
+    it('renders a column for every series order across breakdown rows', () => {
+        const seriesData: SeriesDatum[] = [
+            { id: 0, dataIndex: 0, datasetIndex: 0, order: 0, breakdown_value: 'Chrome', label: 'A', count: 10 },
+            { id: 1, dataIndex: 0, datasetIndex: 1, order: 1, breakdown_value: 'Chrome', label: 'B', count: 20 },
+            { id: 2, dataIndex: 0, datasetIndex: 2, order: 1, breakdown_value: 'Safari', label: 'B', count: 5 },
+            { id: 3, dataIndex: 0, datasetIndex: 3, order: 2, breakdown_value: 'Safari', label: 'C', count: 7 },
+        ]
+
+        const container = renderTooltip(seriesData, eventBreakdown)
+
+        // The previously-dropped value (Safari / order 2) is now rendered.
+        expect(container.textContent).toContain('7')
+        expect(container.textContent).toContain('10')
+        expect(container.textContent).toContain('20')
+        expect(container.textContent).toContain('5')
+    })
+})

--- a/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
+++ b/frontend/src/scenes/insights/InsightTooltip/InsightTooltip.tsx
@@ -183,10 +183,38 @@ export function InsightTooltip({
         ]
         const numDataPoints = Math.max(...dataSource.map((ds) => ds?.seriesData?.length ?? 0))
 
-        if (numDataPoints > 0) {
-            const indexOfLongestSeries = dataSource.findIndex((ds) => ds?.seriesData?.length === numDataPoints)
-            const longestSeriesData = dataSource?.[indexOfLongestSeries !== -1 ? indexOfLongestSeries : 0].seriesData
-            const truncatedCols = colCutoff !== undefined ? longestSeriesData.slice(0, colCutoff) : longestSeriesData
+        if (numDataPoints === 1) {
+            // Each row holds one series; breaking multiple series down by event name gives them
+            // distinct `order`s, so an order-keyed column would blank every non-matching row.
+            columns.push({
+                key: 'value',
+                className: 'datum-counts-column',
+                align: 'right',
+                title: <span className="whitespace-nowrap">{rightTitle ?? undefined}</span>,
+                render: function renderSingleSeriesValue(_, datum) {
+                    const seriesColumnData = datum.seriesData[0]
+                    return renderDatumToTableCell(
+                        seriesColumnData?.action?.math_property,
+                        seriesColumnData?.count,
+                        formatPropertyValueForDisplay,
+                        renderCount,
+                        seriesColumnData?.color
+                    )
+                },
+            })
+        } else if (numDataPoints > 1) {
+            // Key columns off the union of orders across all rows, not just the longest one, so a
+            // series present in only some rows still gets a column instead of a dash.
+            const seriesByOrder = new Map<number, SeriesDatum>()
+            for (const ds of dataSource) {
+                for (const s of ds?.seriesData ?? []) {
+                    if (!seriesByOrder.has(s.order)) {
+                        seriesByOrder.set(s.order, s)
+                    }
+                }
+            }
+            const sortedColumnSeries = [...seriesByOrder.values()].sort((a, b) => a.order - b.order)
+            const truncatedCols = colCutoff !== undefined ? sortedColumnSeries.slice(0, colCutoff) : sortedColumnSeries
             const dataColumns: LemonTableColumn<InvertedSeriesDatum, keyof InvertedSeriesDatum | undefined>[] = []
             truncatedCols.forEach((seriesColumn) => {
                 const colIdx = seriesColumn.order
@@ -197,7 +225,6 @@ export function InsightTooltip({
                     title:
                         (colIdx === 0 ? rightTitle : undefined) ||
                         (!concreteTooltipTitle &&
-                            numDataPoints > 1 &&
                             renderSeries(
                                 <InsightLabel
                                     action={seriesColumn.action}
@@ -221,7 +248,7 @@ export function InsightTooltip({
                             renderCount,
                             seriesColumnData?.color
                         )
-                        if (onRowClick && seriesColumnData && numDataPoints > 1) {
+                        if (onRowClick && seriesColumnData) {
                             return (
                                 <div
                                     className="cursor-pointer hover:bg-accent-highlight-secondary -mx-2 px-2 -my-1 py-1"
@@ -234,12 +261,6 @@ export function InsightTooltip({
                         return cell
                     },
                 })
-            })
-            dataColumns.sort((a, b) => {
-                const itemA = truncatedCols?.find((s) => s.order === parseInt(a.key as string))
-                const itemB = truncatedCols?.find((s) => s.order === parseInt(b.key as string))
-
-                return (itemA?.order || 0) - (itemB?.order || 0)
             })
             columns.push(...dataColumns)
         }


### PR DESCRIPTION
## Problem

On a trends insight with multiple series and a breakdown, the tooltip shows `–` for series that actually have data. The worst case is breaking multiple event series down by event name — most rows render `–` instead of their value.

## Changes

The tooltip uses an inverted "columns" layout when there are multiple series and a breakdown: breakdown values become rows, series become value columns keyed by each series' `order`. The columns were seeded from a **single** row's series, so any series whose `order` wasn't present in that one row fell through to the `–` placeholder — even though the value existed.

This is acute with an event-name breakdown: each breakdown value maps to exactly one series, and those series carry **different** `order`s (`$pageview` → 0, `$rageclick` → 2, etc.). The layout built one column keyed to `order 0`, so only the first row resolved and the rest showed `–`.

The fix:

- When every breakdown row holds a single series, render one value column that shows each row's own series — no order matching, nothing gets blanked.
- When rows hold multiple series, build columns from the **union of orders across all rows** (not just the longest one), so a series present in only some breakdown rows still gets its column.

## How did you test this code?

I'm an agent (PostHog Code), Sam directed the work. I did not do manual click-through testing in the running app — the dev server in this environment runs from a different checkout, so HMR didn't reflect the worktree change. Instead:

- Reproduced the bug live in the dev app by creating the exact insight shape (3 event series + breakdown by event name) and inspecting the rendered tooltip via Playwright — confirmed `$pageview ● 94`, `$rageclick –`, matching the report.
- Added `InsightTooltip.test.tsx` with two regression tests. Verified they **fail against the unfixed code** (reproducing `$pageview ●94 $rageclick –` and a dropped order-2 value) and **pass with the fix**.
- Ran the surrounding suites — TrendsLineChart, TrendsBarChart, stickiness, retention — 205 tests pass, no regressions.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code. No repo skills were required for this change (frontend tooltip rendering only).

Root-causing: confirmed via the real backend response that breakdown-by-event series share no `order` — each series keeps its series-index order regardless of breakdown value — which is what made the order-keyed single column drop every non-matching row. Considered widening to a sparse N×N matrix (union of orders for the single-series case too) but that produces an ugly diagonal of mostly-`–` cells; chose the single-value-column path for the one-series-per-row case and reserved the union approach for genuinely multi-series rows.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
