### PR TITLE
fix(data-warehouse): use Klaviyo per-endpoint max page sizes for list_profiles

### DIFF
--- a/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -184,7 +184,8 @@ def _fetch_page(
 
 def _iter_list_ids(session: requests.Session, headers: dict[str, str], logger: FilteringBoundLogger) -> Iterator[str]:
     """Page through /lists and yield each list's id, following the cursor links."""
-    url = _build_url(f"{KLAVIYO_BASE_URL}/lists", {"page[size]": 100})
+    # Klaviyo caps the /lists endpoint at a page size of 10 (larger values 400).
+    url = _build_url(f"{KLAVIYO_BASE_URL}/lists", {"page[size]": 10})
     while True:
         data = _fetch_page(session, url, headers, logger)
         for item in data.get("data", []):
@@ -224,8 +225,9 @@ def _get_list_profile_rows(
         logger.debug(f"Klaviyo: resuming list_profiles from list_id={resume.list_id}, url={resume_url}")
 
     for index, list_id in enumerate(remaining):
+        # The relationships endpoint caps page size at 100 (larger values 400).
         url = resume_url or _build_url(
-            f"{KLAVIYO_BASE_URL}/lists/{list_id}/relationships/profiles", {"page[size]": 1000}
+            f"{KLAVIYO_BASE_URL}/lists/{list_id}/relationships/profiles", {"page[size]": 100}
         )
         resume_url = None  # only the resumed-into list uses the saved URL; the rest start fresh
 

--- a/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/posthog/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -248,15 +248,15 @@ class TestListProfilesFanOut:
 
     def test_fans_out_over_every_list_into_membership_rows(self, monkeypatch: Any) -> None:
         pages = {
-            "https://a.klaviyo.com/api/lists?page[size]=100": {
+            "https://a.klaviyo.com/api/lists?page[size]=10": {
                 "data": [{"id": "L1"}, {"id": "L2"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P1"}, {"type": "profile", "id": "P2"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L2/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/L2/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P3"}],
                 "links": {"next": None},
             },
@@ -271,11 +271,11 @@ class TestListProfilesFanOut:
     def test_follows_membership_pagination(self, monkeypatch: Any) -> None:
         next_url = "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[cursor]=abc"
         pages = {
-            "https://a.klaviyo.com/api/lists?page[size]=100": {
+            "https://a.klaviyo.com/api/lists?page[size]=10": {
                 "data": [{"id": "L1"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P1"}],
                 "links": {"next": next_url},
             },
@@ -292,11 +292,11 @@ class TestListProfilesFanOut:
 
     def test_resume_from_deleted_list_restarts_from_first(self, monkeypatch: Any) -> None:
         pages = {
-            "https://a.klaviyo.com/api/lists?page[size]=100": {
+            "https://a.klaviyo.com/api/lists?page[size]=10": {
                 "data": [{"id": "L1"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P1"}],
                 "links": {"next": None},
             },
@@ -308,16 +308,16 @@ class TestListProfilesFanOut:
     def test_list_deleted_mid_fan_out_is_skipped(self, monkeypatch: Any) -> None:
         not_found = requests.HTTPError(response=_response_with_status(404))
         pages = {
-            "https://a.klaviyo.com/api/lists?page[size]=100": {
+            "https://a.klaviyo.com/api/lists?page[size]=10": {
                 "data": [{"id": "L1"}, {"id": "GONE"}, {"id": "L2"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P1"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/GONE/relationships/profiles?page[size]=1000": not_found,
-            "https://a.klaviyo.com/api/lists/L2/relationships/profiles?page[size]=1000": {
+            "https://a.klaviyo.com/api/lists/GONE/relationships/profiles?page[size]=100": not_found,
+            "https://a.klaviyo.com/api/lists/L2/relationships/profiles?page[size]=100": {
                 "data": [{"type": "profile", "id": "P2"}],
                 "links": {"next": None},
             },
@@ -331,11 +331,11 @@ class TestListProfilesFanOut:
     def test_non_404_http_error_propagates(self, monkeypatch: Any) -> None:
         server_error = requests.HTTPError(response=_response_with_status(500))
         pages = {
-            "https://a.klaviyo.com/api/lists?page[size]=100": {
+            "https://a.klaviyo.com/api/lists?page[size]=10": {
                 "data": [{"id": "L1"}],
                 "links": {"next": None},
             },
-            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=1000": server_error,
+            "https://a.klaviyo.com/api/lists/L1/relationships/profiles?page[size]=100": server_error,
         }
         with pytest.raises(requests.HTTPError):
             self._collect(_FakeResumableManager(), monkeypatch, pages)


### PR DESCRIPTION
## Problem

The opt-in Klaviyo `list_profiles` table (shipped in #65150) 400s on every sync: it requested `page[size]=100` on [`/lists`](https://developers.klaviyo.com/en/reference/get_lists) (caps at 10) and `page[size]=1000` on the [relationships endpoint](https://developers.klaviyo.com/en/reference/get_list_relationships_profiles) (caps at 100). It fails on the first `/lists` call. Caught on a customer's prod resync.

## Changes

Use each endpoint's documented max page size (`/lists` → 10, relationships → 100). Cursor pagination handles the rest. Caps per the `2024-10-15` revision the source pins:

- [Get Lists](https://developers.klaviyo.com/en/reference/get_lists) — page size max 10
- [Get Profile IDs for List](https://developers.klaviyo.com/en/reference/get_list_relationships_profiles) — page size max 100

## How did you test this code?

Agent-authored. Existing `test_klaviyo.py` passes (32) with fixtures updated to the corrected page sizes; not run against a live Klaviyo account. Follow-up to the merged #65150.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
