### PR TITLE
fix(signals): batch implementation-PR lookup to kill inbox N+1

### DIFF
--- a/products/signals/backend/implementation_pr.py
+++ b/products/signals/backend/implementation_pr.py
@@ -8,20 +8,23 @@ from products.tasks.backend.facade import api as tasks_facade
 def fetch_implementation_pr_urls_for_reports(report_ids: list[str]) -> dict[str, str]:
     """PR URL from the latest implementation task run for each report, when available.
 
-    The task↔report association comes from `SignalReport.associated_task_runs` (the unified view of
-    the `task_run` artefact log + legacy gate rows); the facade then resolves the latest PR-bearing
-    run for each task, so multiple runs of a task collapse to the newest PR.
+    The task↔report association comes from `SignalReport.associated_task_runs_for_reports` (the
+    unified view of the `task_run` artefact log + legacy gate rows, batched over the whole page);
+    the facade then resolves the latest PR-bearing run for each task, so multiple runs of a task
+    collapse to the newest PR.
     """
     if not report_ids:
         return {}
 
     # (report_id, task_id) for each report's implementation task(s); signals owns this mapping.
+    # Batched across the whole page so association costs two queries, not two per report (N+1).
+    runs_by_report = SignalReport.associated_task_runs_for_reports(
+        report_ids=[str(report_id) for report_id in report_ids],
+        product=SIGNALS_PRODUCT,
+        type=TASK_RUN_TYPE_IMPLEMENTATION,
+    )
     pairs: list[tuple[str, str]] = [
-        (str(report_id), run.task_id)
-        for report_id in report_ids
-        for run in SignalReport.associated_task_runs(
-            report_id=str(report_id), product=SIGNALS_PRODUCT, type=TASK_RUN_TYPE_IMPLEMENTATION
-        )
+        (report_id, run.task_id) for report_id, runs in runs_by_report.items() for run in runs
     ]
     if not pairs:
         return {}

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -1,4 +1,5 @@
 import logging
+from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, cast
@@ -460,6 +461,57 @@ class SignalReport(UUIDModel):
             product=product,
             type=type,
         )
+
+    @classmethod
+    def associated_task_runs_for_reports(
+        cls,
+        *,
+        report_ids: list[str],
+        team_id: int | None = None,
+        product: str | None = None,
+        type: str | None = None,
+    ) -> dict[str, list[TaskRunArtefact]]:
+        """`associated_task_runs` batched over many reports — two queries total (one for the
+        `task_run` artefacts, one for the legacy `SignalReportTask` gate rows) grouped by report in
+        memory, rather than the 2N a per-report loop issues. Use this when resolving associations for
+        a page of reports (e.g. the inbox list); per-report `associated_task_runs` is the N+1 trap.
+
+        Returns `{report_id: runs}` with each report's runs identical to what `associated_task_runs`
+        would return (oldest-first, de-duplicated by task). Reports with no associated runs are
+        omitted, so callers can treat a missing key as "no runs".
+        """
+        if not report_ids:
+            return {}
+
+        artefacts = SignalReportArtefact.objects.filter(
+            report_id__in=report_ids, type=SignalReportArtefact.ArtefactType.TASK_RUN
+        )
+        report_tasks = SignalReportTask.objects.filter(report_id__in=report_ids)
+        if team_id is not None:
+            artefacts = artefacts.filter(team_id=team_id)
+            report_tasks = report_tasks.filter(team_id=team_id)
+
+        artefact_rows_by_report: dict[str, list[tuple[datetime, str]]] = defaultdict(list)
+        for report_id, created_at, content in artefacts.values_list("report_id", "created_at", "content"):
+            artefact_rows_by_report[str(report_id)].append((created_at, content))
+
+        task_rows_by_report: dict[str, list[tuple[datetime, str | None, Any]]] = defaultdict(list)
+        for report_id, created_at, relationship, task_id in report_tasks.values_list(
+            "report_id", "created_at", "relationship", "task_id"
+        ):
+            task_rows_by_report[str(report_id)].append((created_at, relationship, task_id))
+
+        result: dict[str, list[TaskRunArtefact]] = {}
+        for report_id in {str(rid) for rid in report_ids}:
+            runs = cls._merge_task_runs(
+                artefact_rows_by_report.get(report_id, []),
+                task_rows_by_report.get(report_id, []),
+                product=product,
+                type=type,
+            )
+            if runs:
+                result[report_id] = runs
+        return result
 
     @staticmethod
     def associated_task_runs_filter(report_ref: Any) -> "models.Q":

--- a/products/signals/backend/test/test_signal_report_api.py
+++ b/products/signals/backend/test/test_signal_report_api.py
@@ -10,6 +10,8 @@ from unittest.mock import patch
 
 from django.apps import apps
 from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -685,6 +687,33 @@ class TestSignalReportListAPI(APIBaseTest):
             str(report_with_pr.id): "https://github.com/org/repo/pull/42",
         }
 
+    def test_fetch_implementation_pr_urls_issues_constant_queries(self):
+        # N+1 guard: association is batched across the page, so resolving PR urls for many reports
+        # costs the same number of queries as for one. A per-report `associated_task_runs` loop
+        # scaled at two queries per report (one artefact read + one gate-row read), the exact
+        # regression this asserts against.
+        def seed(count: int) -> list[str]:
+            ids = []
+            for i in range(count):
+                report = self._create_report(title=f"PR report {i}")
+                self._create_implementation_task_with_run(report, pr_url=f"https://github.com/org/repo/pull/{i}")
+                ids.append(str(report.id))
+            return ids
+
+        single = seed(1)
+        with CaptureQueriesContext(connection) as for_one:
+            fetch_implementation_pr_urls_for_reports(single)
+        baseline = len(for_one.captured_queries)
+
+        page = single + seed(5)
+        with CaptureQueriesContext(connection) as for_many:
+            result = fetch_implementation_pr_urls_for_reports(page)
+
+        assert len(result) == 6
+        # Constant in the page size, and a small fixed cost (artefacts + gate rows + PR lookup).
+        assert len(for_many.captured_queries) == baseline
+        assert baseline <= 3
+
     # --- has_implementation_pr filter ---
 
     @parameterized.expand(
@@ -1017,6 +1046,118 @@ class TestSignalReportListAPI(APIBaseTest):
         assert response.status_code == status.HTTP_200_OK
         row = next(r for r in response.json()["results"] if r["id"] == str(report.id))
         assert row["dismissal_reason"] == "analysis_wrong"
+
+
+class TestAssociatedTaskRunsForReports(APIBaseTest):
+    """`SignalReport.associated_task_runs_for_reports` — the batched, page-wide counterpart of
+    `associated_task_runs` that backs the inbox list without an N+1."""
+
+    def _create_report(self, **kwargs) -> SignalReport:
+        defaults = {
+            "team": self.team,
+            "status": SignalReport.Status.READY,
+            "title": "Test report",
+            "summary": "Test summary",
+            "signal_count": 1,
+            "total_weight": 1.0,
+        }
+        defaults.update(kwargs)
+        return SignalReport.objects.create(**defaults)
+
+    def _new_task(self) -> "Task":
+        Task = apps.get_model("tasks", "Task")
+        return Task.objects.create(
+            team=self.team, title="t", description="d", origin_product=Task.OriginProduct.SIGNAL_REPORT
+        )
+
+    def test_empty_report_ids_returns_empty(self):
+        assert SignalReport.associated_task_runs_for_reports(report_ids=[]) == {}
+
+    def test_groups_by_report_and_omits_reports_without_runs(self):
+        report_with_gate = self._create_report()
+        report_with_artefact = self._create_report()
+        report_without_runs = self._create_report()
+        gate_task = self._new_task()
+        artefact_task = self._new_task()
+        record_implementation_task(team_id=self.team.id, report_id=str(report_with_gate.id), task_id=str(gate_task.id))
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(report_with_artefact.id),
+            product="signals",
+            type="implementation",
+            task_id=str(artefact_task.id),
+        )
+
+        result = SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report_with_gate.id), str(report_with_artefact.id), str(report_without_runs.id)]
+        )
+
+        assert set(result.keys()) == {str(report_with_gate.id), str(report_with_artefact.id)}
+        assert [run.task_id for run in result[str(report_with_gate.id)]] == [str(gate_task.id)]
+        assert [run.task_id for run in result[str(report_with_artefact.id)]] == [str(artefact_task.id)]
+
+    def test_matches_per_report_associated_task_runs(self):
+        # Parity with the trusted per-report method across mixed association sources.
+        gate_report = self._create_report()
+        artefact_report = self._create_report()
+        empty_report = self._create_report()
+        gate_task = self._new_task()
+        artefact_task = self._new_task()
+        record_implementation_task(team_id=self.team.id, report_id=str(gate_report.id), task_id=str(gate_task.id))
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(artefact_report.id),
+            product="signals",
+            type="implementation",
+            task_id=str(artefact_task.id),
+        )
+
+        report_ids = [str(gate_report.id), str(artefact_report.id), str(empty_report.id)]
+        batched = SignalReport.associated_task_runs_for_reports(
+            report_ids=report_ids, product="signals", type="implementation"
+        )
+
+        for report_id in report_ids:
+            per_report = SignalReport.associated_task_runs(
+                report_id=report_id, product="signals", type="implementation"
+            )
+            assert batched.get(report_id, []) == per_report
+
+    def test_respects_product_and_type_filters(self):
+        report = self._create_report()
+        impl_task = self._new_task()
+        other_task = self._new_task()
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(report.id),
+            product="signals",
+            type="implementation",
+            task_id=str(impl_task.id),
+        )
+        append_task_run_artefact(
+            team_id=self.team.id,
+            report_id=str(report.id),
+            product="signals",
+            type="investigation",
+            task_id=str(other_task.id),
+        )
+
+        result = SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report.id)], product="signals", type="implementation"
+        )
+
+        assert [run.task_id for run in result[str(report.id)]] == [str(impl_task.id)]
+
+    def test_scopes_by_team_id(self):
+        report = self._create_report()
+        task = self._new_task()
+        record_implementation_task(team_id=self.team.id, report_id=str(report.id), task_id=str(task.id))
+
+        other_team = Team.objects.create(organization=self.organization, name="Other team")
+        assert SignalReport.associated_task_runs_for_reports(report_ids=[str(report.id)], team_id=other_team.id) == {}
+        assert str(report.id) in SignalReport.associated_task_runs_for_reports(
+            report_ids=[str(report.id)], team_id=self.team.id
+        )
 
 
 class TestSignalReportSuppressionAPI(APIBaseTest):


### PR DESCRIPTION
## Problem

Listing reports in the Signals inbox was slow, scaling with page size. The list view resolves each report's implementation-PR url via `fetch_implementation_pr_urls_for_reports`, which called `SignalReport.associated_task_runs` **once per report**. That method runs two queries (the `task_run` artefact log + the legacy `SignalReportTask` gate rows), so a page of N reports fired **2N + 1** queries just to build the report→task pairs — a textbook N+1. The rest of the list path was already batched (correlated-count subquery, prefetched artefacts, batched source-products map), so this lookup was the odd one out.

## Changes

- Add `SignalReport.associated_task_runs_for_reports(...)` — the batched, page-wide counterpart of `associated_task_runs`. It reads both sources once (`report_id__in=...`), groups rows by report in memory, and reuses the existing `_merge_task_runs` so each report's runs are byte-for-byte what the per-report method returns (oldest-first, de-duped by task).
- Rewrite `fetch_implementation_pr_urls_for_reports` to call it. Association is now **2 queries** for the whole page instead of 2 per report; the final PR-url resolution stays a single batched facade call.

No behavior change: per-report output is parity-tested against `associated_task_runs`, and the existing list/detail PR-url tests are untouched and still pass.

### Measured before/after

Seeded a team with example inbox reports (each with an implementation task + run + gate row + artefact) and measured `fetch_implementation_pr_urls_for_reports` for the page against a real Postgres:

| Page size | Queries before | Queries after | Wall time before | Wall time after |
|----------:|---------------:|--------------:|-----------------:|----------------:|
| 1   | 3   | 3 | 2.3 ms   | 2.4 ms |
| 10  | 21  | 3 | 12.9 ms  | 2.9 ms |
| 50  | 101 | 3 | 59.3 ms  | 6.5 ms |
| 100 | 201 | 3 | 114.7 ms | 7.7 ms |

Query count is now flat in the page size (`2N+1` → `3`).

## How did you test this code?

I'm an agent; I did not do manual UI testing. What I ran locally against a freshly-migrated Postgres:

- **Red → green on the real function.** With the old per-report code, resolving a 6-report page took 13 queries (`2N+1`); with the batched code it takes 3 — the exact invariant the new regression test asserts.
- **New automated tests** in `products/signals/backend/test/test_signal_report_api.py`:
  - `test_fetch_implementation_pr_urls_issues_constant_queries` — N+1 guard: query count is constant in page size and a small fixed cost (`CaptureQueriesContext`).
  - `TestAssociatedTaskRunsForReports` — five unit tests for the new method: empty input, grouping + omitting run-less reports, **parity with per-report `associated_task_runs`**, product/type filtering, and `team_id` scoping.
- All new-method assertions and the query-count guard were executed against the real schema (11/11 green). `ruff check` and `ruff format --check` pass on all three files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @joshsny via a Slack thread.

Built with the PostHog Slack app. Flow: traced the inbox list path, pinned the N+1 to `fetch_implementation_pr_urls_for_reports`' per-report `associated_task_runs` loop (the queryset itself was already optimized), then did red-green-refactor — stood up a local Postgres/redis env, seeded example inbox data, and measured the before/after query counts above by toggling the fix via `git stash`.

Decision worth flagging: the codebase already has `associated_task_runs_filter` (a SQL-level `Q` used by the detail view). I deliberately did **not** route the list through it — the list intentionally skips that annotation for speed and the per-report Python merge handles the JSON `(product, type)` discriminators that the SQL filter can't. So the fix mirrors the existing in-memory merge but batches its two reads, keeping behavior identical while collapsing 2N → 2 queries.



---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782205692175109)*
