### PR TITLE
fix(tasks): unbreak modal vm and network-allowlist agent startup

### DIFF
--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -42,6 +42,7 @@ from products.tasks.backend.logic.services.agentsh import (
     ENV_FILE,
     ENV_WRAPPER_SCRIPT,
     SESSION_ID_FILE,
+    _hostname_from_url,
     build_exec_prefix,
     build_setup_script,
     generate_bash_env_script,
@@ -85,6 +86,13 @@ SANDBOX_IMAGE = SANDBOX_BASE_IMAGE
 AGENT_SERVER_PORT = 8080  # Modal connect tokens require port 8080
 AGENT_SERVER_HEALTH_MAX_ATTEMPTS = 240
 
+SESSION_INIT_PROBE_HOSTS = (
+    "gateway.us.posthog.com",
+    "gateway.eu.posthog.com",
+    "api.anthropic.com",
+    "mcp.posthog.com",
+)
+
 # Modal region mapping based on cloud deployment
 MODAL_REGION_BY_DEPLOYMENT: dict[str | None, str] = {
     "EU": "eu-west",
@@ -112,8 +120,12 @@ def _resource_create_kwargs(config: SandboxConfig) -> dict[str, object]:
     memory_limit_mb = int(config.memory_gb * 1024)
     if not config.burstable_resources:
         return {"cpu": cpu_limit, "memory": memory_limit_mb}
+
+    cpu_value = (min(float(config.cpu_request_cores), cpu_limit), cpu_limit)
+    if config.is_vm:
+        return {"cpu": cpu_value, "memory": memory_limit_mb}
     return {
-        "cpu": (min(float(config.cpu_request_cores), cpu_limit), cpu_limit),
+        "cpu": cpu_value,
         "memory": (min(int(config.memory_request_mb), memory_limit_mb), memory_limit_mb),
     }
 
@@ -398,7 +410,7 @@ class ModalSandbox(SandboxBase):
                 "verbose": True,
             }
 
-            if config.vm_runtime or config.template == SandboxTemplate.VM_BASE:
+            if config.is_vm:
                 create_kwargs["experimental_options"] = {"vm_runtime": True}
 
             if config.outbound_domain_allowlist:
@@ -698,6 +710,53 @@ class ModalSandbox(SandboxBase):
             return False
         return self._wait_for_health_check()
 
+    def _diagnose_startup_failure(self, allowed_domains: list[str] | None) -> dict[str, str]:
+        diagnostics: dict[str, str] = {}
+        try:
+            if not self.is_running():
+                poll = self._sandbox.poll()
+                diagnostics["sandbox_terminated"] = "true"
+                diagnostics["failure_reason"] = (
+                    f"sandbox terminated before becoming healthy (poll={poll}); "
+                    "the VM/container exited (OOM, init exit, or reaping) rather than egress being blocked"
+                )
+                return diagnostics
+
+            diagnostics["sandbox_terminated"] = "false"
+            log_result = self.execute("cat /tmp/agent-server.log 2>/dev/null || echo 'No log file'", timeout_seconds=5)
+            diagnostics["log"] = log_result.stdout
+            health_result = self.execute(
+                f"curl -s --max-time 3 http://localhost:{AGENT_SERVER_PORT}/health || echo 'no-health-response'",
+                timeout_seconds=5,
+            )
+            diagnostics["health_response"] = health_result.stdout.strip()[:500]
+
+            egress = self._probe_session_init_egress()
+            diagnostics["egress_probe"] = egress
+            blocked = [line for line in egress.splitlines() if "http_code=000" in line or line.endswith("FAILED")]
+            if blocked:
+                diagnostics["failure_reason"] = "egress blocked to required session-init host(s): " + "; ".join(blocked)
+            else:
+                diagnostics["failure_reason"] = (
+                    "agent server alive but never reported hasSession=true; no egress block detected, "
+                    "inspect agent-server log"
+                )
+        except Exception as e:
+            diagnostics.setdefault("failure_reason", f"health check failed; diagnostics unavailable: {e}")
+        return diagnostics
+
+    def _probe_session_init_egress(self) -> str:
+        hosts = list(SESSION_INIT_PROBE_HOSTS)
+        gateway_host = _hostname_from_url(getattr(settings, "SANDBOX_LLM_GATEWAY_URL", None))
+        if gateway_host and gateway_host not in hosts:
+            hosts.insert(0, gateway_host)
+        checks = "; ".join(
+            f"printf '%s ' {shlex.quote(host)}; "
+            f"curl -sS --max-time 3 -o /dev/null -w 'http_code=%{{http_code}}\\n' https://{host}/ 2>/dev/null || echo FAILED"
+            for host in hosts
+        )
+        return self.execute(checks, timeout_seconds=30).stdout.strip()
+
     def start_agent_server(
         self,
         repository: str | None,
@@ -763,11 +822,11 @@ class ModalSandbox(SandboxBase):
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
         if not self._launch_and_check(command):
-            log_result = self.execute("cat /tmp/agent-server.log 2>/dev/null || echo 'No log file'", timeout_seconds=5)
+            diagnostics = self._diagnose_startup_failure(allowed_domains)
             raise SandboxExecutionError(
                 "Agent-server failed to start",
-                {"sandbox_id": self.id, "log": log_result.stdout},
-                cause=RuntimeError("Health check failed after retries"),
+                {"sandbox_id": self.id, **diagnostics},
+                cause=RuntimeError(diagnostics.get("failure_reason", "Health check failed after retries")),
             )
 
         logger.info(f"Agent-server started in sandbox {self.id}")

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -103,6 +103,10 @@ class SandboxConfig(BaseModel):
     # gVisor only — Modal rejects this under vm_runtime.
     outbound_domain_allowlist: list[str] | None = None
 
+    @property
+    def is_vm(self) -> bool:
+        return self.vm_runtime or self.template == SandboxTemplate.VM_BASE
+
 
 WORKING_DIR = "/tmp/workspace"
 

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -21,7 +21,12 @@ from products.tasks.backend.logic.services.modal_sandbox import (
     _image_ref_cache,
     _resource_create_kwargs,
 )
-from products.tasks.backend.logic.services.sandbox import AgentServerResult, ExecutionResult, SandboxConfig
+from products.tasks.backend.logic.services.sandbox import (
+    AgentServerResult,
+    ExecutionResult,
+    SandboxConfig,
+    SandboxTemplate,
+)
 
 
 def _agent_server_launch_command(mock_execute: Any) -> str:
@@ -741,6 +746,108 @@ class TestModalSandboxAgentServerStartupHelpers:
         assert "pkill -KILL -f agent-server" in command
 
 
+class TestStartupFailureDiagnostics:
+    def _sandbox(self) -> Any:
+        sandbox = ModalSandbox.__new__(ModalSandbox)
+        sandbox.id = "sb-diag"
+        sandbox.config = SandboxConfig(name="t")
+        sandbox._sandbox = MagicMock()
+        return sandbox
+
+    def test_reports_termination_when_sandbox_gone(self):
+        sandbox = self._sandbox()
+        sandbox._sandbox.poll.return_value = 137
+
+        with patch.object(sandbox, "is_running", return_value=False):
+            diagnostics = sandbox._diagnose_startup_failure(allowed_domains=None)
+
+        assert diagnostics["sandbox_terminated"] == "true"
+        assert "poll=137" in diagnostics["failure_reason"]
+        sandbox._sandbox.exec.assert_not_called()
+
+    def test_reports_blocked_egress_host(self):
+        sandbox = self._sandbox()
+
+        def _exec(command: str, timeout_seconds: Any = None) -> ExecutionResult:
+            if "printf" in command:
+                return ExecutionResult(
+                    stdout="api.anthropic.com code=200\nmcp.posthog.com http_code=000",
+                    stderr="",
+                    exit_code=0,
+                    error=None,
+                )
+            if "agent-server.log" in command:
+                return ExecutionResult(stdout="agent log tail", stderr="", exit_code=0, error=None)
+            return ExecutionResult(stdout='{"status":"ok","hasSession":false}', stderr="", exit_code=0, error=None)
+
+        with (
+            patch.object(sandbox, "is_running", return_value=True),
+            patch.object(sandbox, "execute", side_effect=_exec),
+        ):
+            diagnostics = sandbox._diagnose_startup_failure(allowed_domains=["github.com"])
+
+        assert diagnostics["sandbox_terminated"] == "false"
+        assert "egress blocked" in diagnostics["failure_reason"]
+        assert "mcp.posthog.com" in diagnostics["failure_reason"]
+
+    def test_reports_alive_without_session_when_no_block(self):
+        sandbox = self._sandbox()
+
+        def _exec(command: str, timeout_seconds: Any = None) -> ExecutionResult:
+            if "printf" in command:
+                return ExecutionResult(
+                    stdout="gateway.us.posthog.com http_code=200", stderr="", exit_code=0, error=None
+                )
+            return ExecutionResult(stdout="ok", stderr="", exit_code=0, error=None)
+
+        with (
+            patch.object(sandbox, "is_running", return_value=True),
+            patch.object(sandbox, "execute", side_effect=_exec),
+        ):
+            diagnostics = sandbox._diagnose_startup_failure(allowed_domains=None)
+
+        assert diagnostics["sandbox_terminated"] == "false"
+        assert "never reported hasSession=true" in diagnostics["failure_reason"]
+
+
+class TestModalSandboxCreateAllowlist:
+    def _create_with_config(self, config: SandboxConfig) -> Any:
+        mock_sb = MagicMock()
+        mock_sb.object_id = "sb-created"
+        with (
+            patch("products.tasks.backend.logic.services.modal_sandbox.modal.enable_output"),
+            patch.object(ModalSandbox, "_get_app_for_template", return_value=MagicMock()),
+            patch("products.tasks.backend.logic.services.modal_sandbox._get_template_image", return_value=MagicMock()),
+            patch(
+                "products.tasks.backend.logic.services.modal_sandbox.modal.Sandbox.create", return_value=mock_sb
+            ) as mock_create,
+        ):
+            ModalSandbox.create(config)
+        return mock_create
+
+    def test_create_forwards_exact_outbound_domain_allowlist(self):
+        domains = ["github.com", "api.github.com", "example.com", "*.posthog.com", "api.anthropic.com"]
+        config = SandboxConfig(name="t", outbound_domain_allowlist=domains)
+
+        mock_create = self._create_with_config(config)
+
+        assert mock_create.call_args.kwargs["outbound_domain_allowlist"] == domains
+
+    def test_create_omits_allowlist_when_unset(self):
+        config = SandboxConfig(name="t")
+
+        mock_create = self._create_with_config(config)
+
+        assert "outbound_domain_allowlist" not in mock_create.call_args.kwargs
+
+    def test_create_sets_vm_runtime_experimental_option(self):
+        config = SandboxConfig(name="t", vm_runtime=True)
+
+        mock_create = self._create_with_config(config)
+
+        assert mock_create.call_args.kwargs["experimental_options"] == {"vm_runtime": True}
+
+
 class TestResourceCreateKwargs:
     def test_flat_scalars_when_not_burstable(self):
         config = SandboxConfig(name="t", cpu_cores=4, memory_gb=16)
@@ -781,6 +888,26 @@ class TestResourceCreateKwargs:
 
         # Reserve the explicitly requested floor, burst up to the configured limit.
         assert kwargs == {"cpu": (2.0, 8.0), "memory": (4096, 16384)}
+
+    def test_vm_runtime_pins_memory_but_keeps_cpu_elastic(self):
+        config = SandboxConfig(name="t", cpu_cores=4, memory_gb=16, burstable_resources=True, vm_runtime=True)
+
+        kwargs = _resource_create_kwargs(config)
+
+        assert kwargs == {"cpu": (0.5, 4.0), "memory": 16384}
+
+    def test_vm_template_pins_memory_but_keeps_cpu_elastic(self):
+        config = SandboxConfig(
+            name="t",
+            cpu_cores=4,
+            memory_gb=16,
+            burstable_resources=True,
+            template=SandboxTemplate.VM_BASE,
+        )
+
+        kwargs = _resource_create_kwargs(config)
+
+        assert kwargs == {"cpu": (0.5, 4.0), "memory": 16384}
 
     def test_explicit_request_floor_is_clamped_to_limit(self):
         # A request floor above the configured limit is clamped down to the limit.

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -231,13 +232,35 @@ def _is_sandbox_event_ingest_enabled(
     return enabled
 
 
+def _vm_sandbox_allowed_origin_products(payload: object) -> set[str]:
+    if isinstance(payload, str):
+        try:
+            payload = json.loads(payload)
+        except (ValueError, TypeError):
+            payload = None
+    value = payload.get("origin_products") if isinstance(payload, dict) else payload
+    if isinstance(value, list) and all(isinstance(item, str) for item in value):
+        return {item for item in value if isinstance(item, str)}
+    return set()
+
+
 def _is_modal_vm_sandbox_enabled(
     *,
     distinct_id: str,
     organization_id: str,
     run_id: str,
+    origin_product: str | None,
+    allowed_domains: list[str] | None,
     state: dict | None = None,
 ) -> bool:
+    if allowed_domains is not None:
+        log_with_activity_context(
+            "modal_vm_sandbox_skipped_restricted_egress",
+            run_id=run_id,
+            use_modal_vm_sandbox=False,
+        )
+        return False
+
     state_override = (state or {}).get("use_modal_vm_sandbox")
     if isinstance(state_override, bool):
         log_with_activity_context(
@@ -258,16 +281,30 @@ def _is_modal_vm_sandbox_enabled(
                 send_feature_flag_events=False,
             )
         )
+        allowed_origins: set[str] = set()
+        if enabled:
+            payload = posthoganalytics.get_feature_flag_payload(
+                MODAL_VM_SANDBOX_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+            )
+            allowed_origins = _vm_sandbox_allowed_origin_products(payload)
     except Exception as e:
         log_with_activity_context("modal_vm_sandbox_flag_check_failed", run_id=run_id, error=str(e))
         return False
 
+    result = enabled and origin_product in allowed_origins
     log_with_activity_context(
         "modal_vm_sandbox_flag_checked",
         run_id=run_id,
-        use_modal_vm_sandbox=enabled,
+        flag_enabled=enabled,
+        origin_product=origin_product,
+        allowed_origin_products=sorted(allowed_origins),
+        use_modal_vm_sandbox=result,
     )
-    return enabled
+    return result
 
 
 def _is_burstable_sandbox_resources_enabled(
@@ -452,6 +489,8 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         distinct_id=distinct_id,
         organization_id=organization_id,
         run_id=run_id,
+        origin_product=task.origin_product,
+        allowed_domains=allowed_domains,
         state=state,
     )
     emit_agent_log(

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -43,6 +43,15 @@ RESERVED_SANDBOX_ENVIRONMENT_VARIABLE_KEYS = {
     "LLM_GATEWAY_URL",
     "POSTHOG_RESUME_RUN_ID",
     "BASH_ENV",
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+    "DISABLE_TELEMETRY",
+    "DISABLE_ERROR_REPORTING",
+}
+
+NETWORK_RESTRICTED_AGENT_ENV = {
+    "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC": "1",
+    "DISABLE_TELEMETRY": "1",
+    "DISABLE_ERROR_REPORTING": "1",
 }
 
 
@@ -107,11 +116,23 @@ class InjectFreshTokensOnResumeInput:
     repository: str | None
 
 
+def _is_covered_by_wildcard(host: str, wildcard_bases: set[str]) -> bool:
+    base = host[2:] if host.startswith("*.") else host
+    for wildcard_base in wildcard_bases:
+        if host.startswith("*.") and base == wildcard_base:
+            continue
+        if base == wildcard_base or base.endswith("." + wildcard_base):
+            return True
+    return False
+
+
 def _to_modal_domain_allowlist(allowed_domains: list[str]) -> list[str]:
     """Translate the agentsh allowlist into Modal's outbound_domain_allowlist.
 
-    Modal fences the whole sandbox, so union in the infra (and local tunnel) domains
-    the agent needs, and drop loopback aliases Modal rejects as invalid domains.
+    Modal fences the whole sandbox and supports `*.` wildcards that match the
+    apex and any subdomain, so union in the infra (and local tunnel) domains the
+    agent needs, drop loopback aliases Modal rejects as invalid domains, and
+    collapse entries already covered by a wildcard.
     """
     domains = list(allowed_domains)
     extra = list(INFRASTRUCTURE_DOMAINS)
@@ -120,7 +141,18 @@ def _to_modal_domain_allowlist(allowed_domains: list[str]) -> list[str]:
     for domain in extra:
         if domain not in domains:
             domains.append(domain)
-    return [d for d in domains if "." in d and d != "host.docker.internal"]
+
+    fqdns = [d for d in domains if "." in d and d != "host.docker.internal"]
+    wildcard_bases = {d[2:] for d in fqdns if d.startswith("*.")}
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for domain in fqdns:
+        if domain in seen or _is_covered_by_wildcard(domain, wildcard_bases):
+            continue
+        seen.add(domain)
+        result.append(domain)
+    return result
 
 
 def _load_task(ctx: TaskProcessingContext) -> Task:
@@ -204,6 +236,9 @@ def _build_environment_variables(
 
     if settings.SANDBOX_LLM_GATEWAY_URL:
         environment_variables["LLM_GATEWAY_URL"] = settings.SANDBOX_LLM_GATEWAY_URL
+
+    if ctx.allowed_domains is not None:
+        environment_variables.update(NETWORK_RESTRICTED_AGENT_ENV)
 
     environment_variables.update(get_git_identity_env_vars(task, ctx.state))
 

--- a/products/tasks/backend/temporal/process_task/activities/read_sandbox_logs.py
+++ b/products/tasks/backend/temporal/process_task/activities/read_sandbox_logs.py
@@ -6,6 +6,7 @@ from temporalio import activity
 
 from posthog.temporal.common.utils import asyncify
 
+from products.tasks.backend.exceptions import SandboxNotRunningError
 from products.tasks.backend.logic.services.sandbox import Sandbox
 from products.tasks.backend.temporal.observability import log_activity_execution
 
@@ -20,6 +21,9 @@ class ReadSandboxLogsInput:
     run_id: str | None = None
 
 
+SANDBOX_TERMINATED_MESSAGE = "Sandbox terminated before logs could be captured; no agent-server logs available."
+
+
 @activity.defn
 @asyncify
 def read_sandbox_logs(input: ReadSandboxLogsInput) -> str:
@@ -30,6 +34,9 @@ def read_sandbox_logs(input: ReadSandboxLogsInput) -> str:
     ):
         try:
             sandbox = Sandbox.get_by_id(input.sandbox_id)
+            if not sandbox.is_running():
+                logger.info(f"Sandbox {input.sandbox_id} already terminated; skipping log capture")
+                return SANDBOX_TERMINATED_MESSAGE
             result = sandbox.execute(
                 f"tail -c {MAX_LOG_SIZE} /tmp/agent-server.log 2>/dev/null || echo 'No log file found'",
                 timeout_seconds=10,
@@ -75,6 +82,9 @@ def read_sandbox_logs(input: ReadSandboxLogsInput) -> str:
                 logger.debug("agentsh audit query failed for sandbox %s", input.sandbox_id, exc_info=True)
 
             return logs
+        except SandboxNotRunningError:
+            logger.info(f"Sandbox {input.sandbox_id} terminated mid-capture; no logs available")
+            return SANDBOX_TERMINATED_MESSAGE
         except Exception as e:
             logger.warning(f"Failed to read sandbox logs: {e}")
             return f"Failed to read logs: {e}"

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -21,6 +21,7 @@ from products.tasks.backend.temporal.process_task.activities.get_task_processing
     _is_burstable_sandbox_resources_enabled,
     _is_modal_vm_sandbox_enabled,
     _is_sandbox_event_ingest_enabled,
+    _vm_sandbox_allowed_origin_products,
     get_task_processing_context,
 )
 
@@ -339,15 +340,23 @@ class TestGetTaskProcessingContextActivity:
         ],
     )
     def test_modal_vm_sandbox_flag_uses_organization_rollout(self, flag_value, expected):
-        with patch(
-            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-            return_value=flag_value,
-        ) as feature_enabled_mock:
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+                return_value=flag_value,
+            ) as feature_enabled_mock,
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.get_feature_flag_payload",
+                return_value=["user_created"],
+            ),
+        ):
             assert (
                 _is_modal_vm_sandbox_enabled(
                     distinct_id="distinct-id",
                     organization_id="organization-id",
                     run_id="run-id",
+                    origin_product="user_created",
+                    allowed_domains=None,
                 )
                 is expected
             )
@@ -371,6 +380,8 @@ class TestGetTaskProcessingContextActivity:
                     distinct_id="distinct-id",
                     organization_id="organization-id",
                     run_id="run-id",
+                    origin_product="user_created",
+                    allowed_domains=None,
                 )
                 is False
             )
@@ -385,12 +396,99 @@ class TestGetTaskProcessingContextActivity:
                     distinct_id="distinct-id",
                     organization_id="organization-id",
                     run_id="run-id",
+                    origin_product="user_created",
+                    allowed_domains=None,
                     state={"use_modal_vm_sandbox": True},
                 )
                 is True
             )
 
         feature_enabled_mock.assert_not_called()
+
+    def test_modal_vm_sandbox_restricted_egress_forces_gvisor(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=True,
+        ) as feature_enabled_mock:
+            assert (
+                _is_modal_vm_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product="user_created",
+                    allowed_domains=["github.com"],
+                )
+                is False
+            )
+
+        feature_enabled_mock.assert_not_called()
+
+    def test_modal_vm_sandbox_restricted_egress_overrides_state_override(self):
+        with patch(
+            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+            return_value=True,
+        ) as feature_enabled_mock:
+            assert (
+                _is_modal_vm_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product="user_created",
+                    allowed_domains=["github.com"],
+                    state={"use_modal_vm_sandbox": True},
+                )
+                is False
+            )
+
+        feature_enabled_mock.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "origin_product, payload, expected",
+        [
+            ("user_created", None, False),
+            ("signals_scout", None, False),
+            ("signals_scout", {"origin_products": ["signals_scout"]}, True),
+            ("signals_scout", ["signals_scout", "user_created"], True),
+            ("user_created", {"origin_products": ["signals_scout"]}, False),
+            ("user_created", '{"origin_products": ["user_created"]}', True),
+        ],
+    )
+    def test_modal_vm_sandbox_origin_product_gating(self, origin_product, payload, expected):
+        with (
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
+                return_value=True,
+            ),
+            patch(
+                "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.get_feature_flag_payload",
+                return_value=payload,
+            ),
+        ):
+            assert (
+                _is_modal_vm_sandbox_enabled(
+                    distinct_id="distinct-id",
+                    organization_id="organization-id",
+                    run_id="run-id",
+                    origin_product=origin_product,
+                    allowed_domains=None,
+                )
+                is expected
+            )
+
+    @pytest.mark.parametrize(
+        "payload, expected",
+        [
+            (None, set()),
+            (["a", "b"], {"a", "b"}),
+            ({"origin_products": ["x"]}, {"x"}),
+            ('{"origin_products": ["y", "z"]}', {"y", "z"}),
+            ("not-json", set()),
+            ({"other": 1}, set()),
+            ([1, 2], set()),
+        ],
+    )
+    def test_vm_sandbox_allowed_origin_products_parsing(self, payload, expected):
+        assert _vm_sandbox_allowed_origin_products(payload) == expected
 
     @pytest.mark.parametrize(
         "flag_value,expected",

--- a/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_provision_sandbox.py
@@ -1,12 +1,19 @@
 from typing import Any
 
 import pytest
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
 
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import TaskProcessingContext
 from products.tasks.backend.temporal.process_task.activities.provision_sandbox import (
     PrepareSandboxForRepositoryOutput,
+    _build_environment_variables,
     _build_sandbox_tags,
+    _to_modal_domain_allowlist,
 )
+
+_PROVISION = "products.tasks.backend.temporal.process_task.activities.provision_sandbox"
 
 
 def _context(**overrides) -> TaskProcessingContext:
@@ -78,3 +85,58 @@ def test_build_sandbox_tags_drops_none_values():
 
     assert "origin_product" not in tags
     assert all(isinstance(value, str) for value in tags.values())
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.parametrize(
+    "allowed_domains, expected",
+    [
+        (
+            ["github.com", "api.github.com", "posthog.com", "us.posthog.com", "example.com"],
+            ["github.com", "api.github.com", "example.com", "*.posthog.com", "api.anthropic.com"],
+        ),
+        (
+            [],
+            ["*.posthog.com", "api.anthropic.com"],
+        ),
+        (
+            ["github.com", "localhost", "host.docker.internal", "registry.npmjs.org"],
+            ["github.com", "registry.npmjs.org", "*.posthog.com", "api.anthropic.com"],
+        ),
+        (
+            ["*.posthog.com", "*.us.posthog.com", "gateway.us.posthog.com", "github.com"],
+            ["*.posthog.com", "github.com", "api.anthropic.com"],
+        ),
+        (
+            ["github.com", "github.com", "api.anthropic.com"],
+            ["github.com", "api.anthropic.com", "*.posthog.com"],
+        ),
+    ],
+)
+def test_to_modal_domain_allowlist_resolves_exact_list(allowed_domains, expected):
+    assert _to_modal_domain_allowlist(allowed_domains) == expected
+
+
+@patch(f"{_PROVISION}.get_git_identity_env_vars", return_value={})
+@patch(f"{_PROVISION}.get_sandbox_jwt_public_key", return_value="pub")
+@patch(f"{_PROVISION}.get_sandbox_api_url", return_value="https://api.example")
+@pytest.mark.parametrize(
+    "allowed_domains, telemetry_disabled",
+    [
+        (["github.com"], True),
+        ([], True),
+        (None, False),
+    ],
+)
+def test_build_environment_variables_disables_telemetry_when_restricted(
+    _api, _jwt, _git, allowed_domains, telemetry_disabled
+):
+    ctx = _context(allowed_domains=allowed_domains)
+
+    env = _build_environment_variables(ctx, MagicMock(), "", "access-token")
+
+    keys = {"CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC", "DISABLE_TELEMETRY", "DISABLE_ERROR_REPORTING"}
+    if telemetry_disabled:
+        assert all(env.get(k) == "1" for k in keys)
+    else:
+        assert not (keys & env.keys())

--- a/products/tasks/backend/temporal/process_task/tests/test_read_sandbox_logs.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_read_sandbox_logs.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock, patch
+
+from products.tasks.backend.exceptions import SandboxNotRunningError
+from products.tasks.backend.temporal.process_task.activities.read_sandbox_logs import (
+    SANDBOX_TERMINATED_MESSAGE,
+    ReadSandboxLogsInput,
+    read_sandbox_logs,
+)
+
+_SANDBOX_PATH = "products.tasks.backend.temporal.process_task.activities.read_sandbox_logs.Sandbox"
+
+
+def _run(sandbox_id: str, run_id: str | None = None) -> str:
+    return read_sandbox_logs.__wrapped__(ReadSandboxLogsInput(sandbox_id=sandbox_id, run_id=run_id))  # type: ignore[attr-defined]
+
+
+def test_returns_terminated_message_when_sandbox_not_running():
+    sandbox = MagicMock()
+    sandbox.is_running.return_value = False
+
+    with patch(_SANDBOX_PATH) as mock_sandbox_cls:
+        mock_sandbox_cls.get_by_id.return_value = sandbox
+        result = _run("sb-gone")
+
+    assert result == SANDBOX_TERMINATED_MESSAGE
+    sandbox.execute.assert_not_called()
+
+
+def test_returns_logs_when_running():
+    sandbox = MagicMock()
+    sandbox.is_running.return_value = True
+    sandbox.execute.return_value = MagicMock(stdout="agent server log line")
+
+    with patch(_SANDBOX_PATH) as mock_sandbox_cls:
+        mock_sandbox_cls.get_by_id.return_value = sandbox
+        result = _run("sb-running")
+
+    assert "agent server log line" in result
+
+
+def test_returns_terminated_message_on_mid_capture_termination():
+    sandbox = MagicMock()
+    sandbox.is_running.return_value = True
+    sandbox.execute.side_effect = SandboxNotRunningError("gone", {"sandbox_id": "sb-race"}, cause=RuntimeError("gone"))
+
+    with patch(_SANDBOX_PATH) as mock_sandbox_cls:
+        mock_sandbox_cls.get_by_id.return_value = sandbox
+        result = _run("sb-race")
+
+    assert result == SANDBOX_TERMINATED_MESSAGE


### PR DESCRIPTION
## Problem

Two recently rolled-out tasks features each broke `process_task`'s `start_agent_server` step (both flags were disabled as mitigation):

- **`tasks-modal-vm-sandbox`**: VM sandboxes died right after the agent server started, then `read_sandbox_logs` raised `Sandbox … is not running`.
- **`tasks-modal-network-allowlist`**: sandboxes booted but never reached `hasSession=true`, failing with `Agent-server failed to start` / `Health check failed after retries`.

## Changes

- Handle restricted-egress sandboxes by disabling agent telemetry instead of expanding allowlists. Modal's `outbound_domain_allowlist` already supports wildcard domains and covers required service endpoints. The only blocked traffic is the Claude SDK's telemetry, which Modal correctly enforces. When network restrictions are enabled, set `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, and `DISABLE_ERROR_REPORTING` rather than adding telemetry domains to allowlists.

- Gate VM sandboxes by origin product. `tasks-modal-vm-sandbox` only routes origins listed in its dynamic payload (`{"origin_products": [...]}`) to VMs; there is no hardcoded default, so without a payload nothing is routed to a VM. Other origins remain on gVisor, where Modal's network allowlist enforcement applies. The eligible origin list can be updated without a deploy

- Force custom-domain workloads onto gVisor. Runs using a restricted/custom domain allowlist always use gVisor because Modal's domain allowlist enforcement is only available there. VMs are reserved for unrestricted network access.

- Resulting routing:
  - Scouts/signals/automation → gVisor + Modal allowlist
  - User-created (full network) → VM
  - User-created with custom domains → gVisor + Modal allowlist

