### PR TITLE
feat(warehouse_sources): add skill for building a Custom REST source

### DIFF
--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -116,8 +116,10 @@ fan-out example. Keep it to one level of nesting.
 
 ### Step 3 — Validate and list resources
 
-Call `external-data-sources-db-schema` with `{ source_type: "Custom", manifest_json: "<stringified manifest>", auth_*:
-"<credential>" }`. It validates the manifest structure, the fan-out graph, and the credential (a bounded live probe),
+Call `external-data-sources-db-schema` with `{ source_type: "Custom", manifest_json: "<stringified manifest>",
+auth_token: "<credential>" }`. The credential key is **not literally `auth_*`** — use the one for your auth type:
+`auth_token` (bearer), `auth_api_key` (api_key), or `auth_password` (http_basic). It validates the manifest structure,
+the fan-out graph, and the credential (a bounded live probe),
 then returns one table entry per resource with `detected_primary_keys` and `incremental_fields`. If it returns a 400,
 the `message` is plain English (e.g. `resources[0].endpoint.path: must not be empty`) — fix the manifest and retry.
 Loop here until it validates.
@@ -125,7 +127,8 @@ Loop here until it validates.
 ### Step 4 — Test-read each resource
 
 For each resource, call `external-data-sources-preview-resource` with `{ source_type: "Custom", payload: {
-manifest_json, auth_* }, resource_name: "<name>", limit: 10 }`. It returns up to `limit` real rows plus the inferred
+manifest_json, auth_token }, resource_name: "<name>", limit: 10 }` (the `auth_token` key varies by auth type, as in
+Step 3). It returns up to `limit` real rows plus the inferred
 `columns`. Check that:
 
 - **`data_selector` is right** — `rows` are the records you expect, not a wrapper object. If `rows` looks like
@@ -138,8 +141,8 @@ and retry. Iterate Steps 2–4 until the sample looks right.
 
 ### Step 5 — Create the source
 
-Call `data-warehouse-source-setup` with `{ source_type: "Custom", payload: { manifest_json, auth_* }, prefix:
-"<short_name>" }`. It enables **every** resource in the manifest with sensible sync defaults (incremental where the
+Call `data-warehouse-source-setup` with `{ source_type: "Custom", payload: { manifest_json, auth_token }, prefix:
+"<short_name>" }` (the `auth_token` key varies by auth type, as in Step 3). It enables **every** resource in the manifest with sensible sync defaults (incremental where the
 manifest declares a cursor, else full refresh) and creates the source. If the user only wants a subset of resources,
 use `external-data-sources-create` with a `schemas` array instead (see `setting-up-a-data-warehouse-source` for the
 schemas shape). Pick a short lowercase `prefix` — tables become `{prefix}_{resource_name}` in HogQL.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -28,10 +28,10 @@ This is an **alpha** capability. Caps: at most 50 resources per manifest, and at
 - The user explicitly asks for a "custom REST source", "custom source manifest", or to "build a connector from docs".
 
 A Custom source is the **fallback** — only correct when no native connector fits. PostHog ships **hundreds** of native
-connectors (Postgres, MySQL, Stripe, Hubspot, Zendesk, BigQuery, GitHub, Salesforce, …), far more than any list here
-can name, so **never infer "no built-in exists" from a name's absence in these examples** — that misroutes well-known
-APIs into a hand-authored manifest that duplicates a battle-tested connector. Step 0 below makes you check the registry
-before drafting anything; if a native connector matches, hand off to `setting-up-a-data-warehouse-source` instead.
+connectors, far more than could be listed here, so **never assume an API has no built-in** — most well-known SaaS apps
+and databases do, and guessing wrong misroutes them into a hand-authored manifest that duplicates a battle-tested
+connector. Step 0 below makes you check the registry before drafting anything; if a native connector matches, hand off
+to `setting-up-a-data-warehouse-source` instead.
 
 ## The grammar
 
@@ -83,9 +83,8 @@ response. Putting a token inline is rejected at validation.
 ### Step 0 — Check for a native connector first
 
 Before drafting anything, call `external-data-sources-wizard` to list the native source types and check whether the
-target API is among them (match on the service name — GitHub, Stripe, Salesforce, Postgres, …). A Custom source is the
-fallback for APIs with **no** native connector; do not skip this check on the assumption that a well-known API isn't
-supported — most are.
+target API is among them, matching on the service name. A Custom source is the fallback for APIs with **no** native
+connector; do not skip this check on the assumption that a well-known API isn't supported — most are.
 
 If a native connector matches, **stop and tell the user** the built-in path is simpler and battle-tested (it handles
 auth, pagination, schema, and incremental sync for you), and hand off to `setting-up-a-data-warehouse-source`. Only

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -26,8 +26,11 @@ This is an **alpha** capability. Caps: at most 50 resources per manifest, and at
   API — and can give you its docs URL or describe its endpoints.
 - The user explicitly asks for a "custom REST source", "custom source manifest", or to "build a connector from docs".
 
-If a built-in connector exists for the source (Postgres, MySQL, Stripe, Hubspot, Zendesk, BigQuery, …), use
-`setting-up-a-data-warehouse-source` — it's simpler and battle-tested. Only fall back to a Custom source when none fits.
+A Custom source is the **fallback** — only correct when no native connector fits. PostHog ships **hundreds** of native
+connectors (Postgres, MySQL, Stripe, Hubspot, Zendesk, BigQuery, GitHub, Salesforce, …), far more than any list here
+can name, so **never infer "no built-in exists" from a name's absence in these examples** — that misroutes well-known
+APIs into a hand-authored manifest that duplicates a battle-tested connector. Step 0 below makes you check the registry
+before drafting anything; if a native connector matches, hand off to `setting-up-a-data-warehouse-source` instead.
 
 ## The grammar
 
@@ -65,15 +68,28 @@ response. Putting a token inline is rejected at validation.
 
 ## Available tools
 
-| Tool                                     | Purpose                                                                                                                                                                |
-| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `external-data-sources-db-schema`        | Validate the manifest + credential and list the resources (tables) it exposes, with detected primary keys and incremental cursors. This is the validate-and-list step. |
-| `external-data-sources-preview-resource` | Read a small live sample of rows for one resource — verify `data_selector` / `primary_key` / `cursor_path` against real data before creating anything.                 |
-| `data-warehouse-source-setup`            | Create the source. Enables **all** manifest resources with sync defaults in one call.                                                                                  |
-| `external-data-sources-create`           | Advanced create — lets the user hand-pick which resources sync via a `schemas` array.                                                                                  |
-| `external-data-schemas-list`             | After creation, watch per-table sync status.                                                                                                                           |
+| Tool                                     | Purpose                                                                                                                                                                  |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `external-data-sources-wizard`           | List every native source type PostHog supports. Run this **first** (Step 0) to check whether the target API already has a built-in connector before drafting a manifest. |
+| `external-data-sources-db-schema`        | Validate the manifest + credential and list the resources (tables) it exposes, with detected primary keys and incremental cursors. This is the validate-and-list step.   |
+| `external-data-sources-preview-resource` | Read a small live sample of rows for one resource — verify `data_selector` / `primary_key` / `cursor_path` against real data before creating anything.                   |
+| `data-warehouse-source-setup`            | Create the source. Enables **all** manifest resources with sync defaults in one call.                                                                                    |
+| `external-data-sources-create`           | Advanced create — lets the user hand-pick which resources sync via a `schemas` array.                                                                                    |
+| `external-data-schemas-list`             | After creation, watch per-table sync status.                                                                                                                             |
 
 ## Workflow
+
+### Step 0 — Check for a native connector first
+
+Before drafting anything, call `external-data-sources-wizard` to list the native source types and check whether the
+target API is among them (match on the service name — GitHub, Stripe, Salesforce, Postgres, …). A Custom source is the
+fallback for APIs with **no** native connector; do not skip this check on the assumption that a well-known API isn't
+supported — most are.
+
+If a native connector matches, **stop and tell the user** the built-in path is simpler and battle-tested (it handles
+auth, pagination, schema, and incremental sync for you), and hand off to `setting-up-a-data-warehouse-source`. Only
+continue with this skill when the user has no matching native connector, or explicitly wants to exercise the custom
+REST path despite one existing.
 
 ### Step 1 — Gather the API shape
 

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -6,8 +6,9 @@ description: >
   REST API", "sync my internal API", "connect this API from its docs", "build a custom data warehouse source" — and
   gives a docs URL or a natural-language description of the endpoints. Walks through drafting the RESTAPIConfig manifest
   (auth, pagination, record path, incremental cursor, parent/child fan-out), validating it, test-reading live rows to
-  verify the field mappings, and creating the source. For sources that already have a built-in connector (Postgres,
-  Stripe, Hubspot, etc.), use setting-up-a-data-warehouse-source instead.
+  verify the field mappings, and creating the source. If the API already has a native PostHog connector, use
+  setting-up-a-data-warehouse-source instead — this skill checks the connector registry first and only handles APIs
+  with no native connector.
 ---
 
 # Setting up a Custom REST source

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: setting-up-a-custom-rest-source
+description: >
+  Connect an arbitrary REST API to the PostHog data warehouse as a Custom source by authoring a JSON manifest, with no
+  per-source code. Use when the user points at an API that has no built-in PostHog connector — "import data from this
+  REST API", "sync my internal API", "connect this API from its docs", "build a custom data warehouse source" — and
+  gives a docs URL or a natural-language description of the endpoints. Walks through drafting the RESTAPIConfig manifest
+  (auth, pagination, record path, incremental cursor, parent/child fan-out), validating it, test-reading live rows to
+  verify the field mappings, and creating the source. For sources that already have a built-in connector (Postgres,
+  Stripe, Hubspot, etc.), use setting-up-a-data-warehouse-source instead.
+---
+
+# Setting up a Custom REST source
+
+A **Custom source** imports any HTTP REST API into queryable warehouse tables from a JSON **manifest** — no
+per-source Python. The manifest is a `RESTAPIConfig`: the same shape that powers PostHog's built-in REST connectors
+(Intercom, Attio, Sentry, …), so the generic REST engine handles auth, pagination, JSONPath record extraction, and
+incremental cursors for you. Your job is to author a correct manifest and prove it against live data before creating
+the source.
+
+This is an **alpha** capability. Caps: at most 50 resources per manifest, and at most 5 Custom sources per project.
+
+## When to use this skill
+
+- The user wants to import an API that has **no built-in connector** — an internal service, a niche SaaS, a public
+  API — and can give you its docs URL or describe its endpoints.
+- The user explicitly asks for a "custom REST source", "custom source manifest", or to "build a connector from docs".
+
+If a built-in connector exists for the source (Postgres, MySQL, Stripe, Hubspot, Zendesk, BigQuery, …), use
+`setting-up-a-data-warehouse-source` — it's simpler and battle-tested. Only fall back to a Custom source when none fits.
+
+## The grammar
+
+Read [references/manifest-reference.md](references/manifest-reference.md) before drafting — it is the full
+`RESTAPIConfig` field reference (auth types, the six paginators, incremental cursors, parent/child fan-out) with worked
+examples for each. Draft the manifest from that grammar; don't guess field names.
+
+The skeleton:
+
+```json
+{
+  "client": {
+    "base_url": "https://api.example.com/v1",
+    "auth": { "type": "bearer" }
+  },
+  "resources": [
+    {
+      "name": "users",
+      "primary_key": "id",
+      "endpoint": {
+        "path": "/users",
+        "data_selector": "data",
+        "paginator": { "type": "json_response", "next_url_path": "next" },
+        "incremental": { "cursor_path": "updated_at", "start_param": "since" }
+      }
+    }
+  ]
+}
+```
+
+**Secrets never go inline in the manifest.** `manifest_json` holds only the non-secret structure. The credential
+travels in a separate payload key chosen by the manifest's `client.auth.type`: `auth_token` (bearer), `auth_api_key`
+(api_key), or `auth_password` (http_basic). The engine injects it at run time, and PostHog redacts it from every
+response. Putting a token inline is rejected at validation.
+
+## Available tools
+
+| Tool                                     | Purpose                                                                                                                                                                |
+| ---------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `external-data-sources-db-schema`        | Validate the manifest + credential and list the resources (tables) it exposes, with detected primary keys and incremental cursors. This is the validate-and-list step. |
+| `external-data-sources-preview-resource` | Read a small live sample of rows for one resource — verify `data_selector` / `primary_key` / `cursor_path` against real data before creating anything.                 |
+| `data-warehouse-source-setup`            | Create the source. Enables **all** manifest resources with sync defaults in one call.                                                                                  |
+| `external-data-sources-create`           | Advanced create — lets the user hand-pick which resources sync via a `schemas` array.                                                                                  |
+| `external-data-schemas-list`             | After creation, watch per-table sync status.                                                                                                                           |
+
+## Workflow
+
+### Step 1 — Gather the API shape
+
+Get either a **docs URL** (fetch it and read the auth scheme, the list endpoints, their response envelopes, and any
+pagination) or a **natural-language description** of the endpoints. You need, per resource you'll import:
+
+- the **path** (relative to a common `base_url`) and method (GET, or POST for query-style read endpoints),
+- the **auth scheme** (bearer token / API key in header or query / HTTP basic),
+- the **record path** — where the array of records sits in the JSON response (e.g. `data`, `results`, `items`),
+- how the API **paginates** (next-URL, link header, cursor, offset, page number, or single page),
+- a **primary key** field, and
+- optionally an **incremental cursor** field (`updated_at`-style) so re-syncs only fetch new/changed rows.
+
+Ask the user for the credential value, but tell them you'll only ever place it in the `auth_*` payload key, never in
+the manifest.
+
+### Step 2 — Draft the manifest
+
+Author the `RESTAPIConfig` from [references/manifest-reference.md](references/manifest-reference.md). Match the auth
+block to the scheme, pick the paginator that matches the docs, set `data_selector` to the record path, and add an
+`incremental` block when the API has an `updated_at`-style cursor and a matching query param. For an endpoint whose
+rows must be fetched per parent (e.g. `/forms/{form_id}/responses`), use a parent/child **resolve** param — see the
+fan-out example. Keep it to one level of nesting.
+
+### Step 3 — Validate and list resources
+
+Call `external-data-sources-db-schema` with `{ source_type: "Custom", manifest_json: "<stringified manifest>", auth_*:
+"<credential>" }`. It validates the manifest structure, the fan-out graph, and the credential (a bounded live probe),
+then returns one table entry per resource with `detected_primary_keys` and `incremental_fields`. If it returns a 400,
+the `message` is plain English (e.g. `resources[0].endpoint.path: must not be empty`) — fix the manifest and retry.
+Loop here until it validates.
+
+### Step 4 — Test-read each resource
+
+For each resource, call `external-data-sources-preview-resource` with `{ source_type: "Custom", payload: {
+manifest_json, auth_* }, resource_name: "<name>", limit: 10 }`. It returns up to `limit` real rows plus the inferred
+`columns`. Check that:
+
+- **`data_selector` is right** — `rows` are the records you expect, not a wrapper object. If `rows` looks like
+  `[{ "data": [...] }]` you pointed at the envelope, not the array; fix `data_selector`.
+- **`primary_key` exists** in the rows and is unique.
+- **the incremental `cursor_path` field is present** in the rows and looks like a sortable timestamp/id.
+
+A live failure (unreachable host, auth rejected) comes back as `error` with empty `rows` — fix credentials or the URL
+and retry. Iterate Steps 2–4 until the sample looks right.
+
+### Step 5 — Create the source
+
+Call `data-warehouse-source-setup` with `{ source_type: "Custom", payload: { manifest_json, auth_* }, prefix:
+"<short_name>" }`. It enables **every** resource in the manifest with sensible sync defaults (incremental where the
+manifest declares a cursor, else full refresh) and creates the source. If the user only wants a subset of resources,
+use `external-data-sources-create` with a `schemas` array instead (see `setting-up-a-data-warehouse-source` for the
+schemas shape). Pick a short lowercase `prefix` — tables become `{prefix}_{resource_name}` in HogQL.
+
+After creation, call `external-data-schemas-list` to show the user the initial sync status, and tell them how to query:
+`SELECT * FROM {prefix}_{resource_name} LIMIT 10`.
+
+## Important notes
+
+- **Always preview before creating.** db-schema proves the manifest parses and the credential works; preview proves the
+  field mappings (`data_selector` / `primary_key` / `cursor_path`) against real rows. Skipping preview is the most
+  common way to create a source that syncs zero or malformed rows.
+- **Secrets only in `auth_*`.** Never inline a token/key/password in `manifest_json` — it's rejected, and the manifest
+  is non-secret (it round-trips to the client).
+- **One level of fan-out.** A child resource may depend on a top-level parent; a parent can't itself be a child.
+- **GET and POST only.** The engine reads upstream data; PUT/PATCH/DELETE are rejected so a manifest can't mutate the
+  source API.
+- **Pick the cursor carefully.** Prefer an `updated_at`-style field over `created_at` (it catches edits), and set
+  `cursor_type` when the cursor isn't a datetime (e.g. an integer id) so it's compared with the right type.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
@@ -59,7 +59,8 @@ an API with no auth, omit `auth` entirely.
 - **`json`** — request body (for POST query endpoints).
 - **`data_selector`** — JSONPath to the array of records inside the response. For `{ "data": [ ... ] }` use `"data"`;
   for `{ "results": { "items": [ ... ] } }` use `"results.items"`. Omit only if the response body **is** the array.
-- **`paginator`** — see below. Omit to let the engine auto-detect (`{ "type": "auto" }`).
+- **`paginator`** — see below. **Required for any paginated endpoint.** Omitting it (or `{ "type": "auto" }`) fetches
+  only the first response — there is no auto-detection — so a paginated API would silently import just page one.
 - **`incremental`** — see below.
 
 `primary_key` sits on the **resource**, not the endpoint: `"primary_key": "id"` or `"primary_key": ["org_id", "id"]`.
@@ -68,15 +69,15 @@ an API with no auth, omit `auth` entirely.
 
 Set `endpoint.paginator` (or `client.paginator`) to one of:
 
-| Type            | Config keys                                                            | Use when                                                         |
-| --------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
-| `json_response` | `next_url_path` (JSONPath to the next-page URL in the body)            | response carries a next-page URL/path                            |
-| `header_link`   | `links_next_key` (rel, default `next`)                                 | pagination via the `Link` response header                        |
-| `cursor`        | `cursor_path` (JSONPath to the next cursor), `cursor_param`            | response returns an opaque cursor you pass back as a query param |
-| `offset`        | `limit`, `offset_param`, `limit_param`, `total_path`, `maximum_offset` | classic `?offset=&limit=` pagination                             |
-| `page_number`   | `initial_page`, `page_param`, `total_path`, `maximum_page`             | classic `?page=N` pagination                                     |
-| `single_page`   | —                                                                      | endpoint returns everything in one response                      |
-| `auto`          | —                                                                      | let the engine guess (default)                                   |
+| Type            | Config keys                                                                                  | Use when                                                                        |
+| --------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `json_response` | `next_url_path` (JSONPath to the next-page URL in the body)                                  | response carries a next-page URL/path                                           |
+| `header_link`   | `links_next_key` (rel, default `next`)                                                       | pagination via the `Link` response header                                       |
+| `cursor`        | `cursor_path` (JSONPath to the next cursor), `cursor_param`                                  | response returns an opaque cursor you pass back as a query param                |
+| `offset`        | `limit`, `offset_param`, `limit_param`, `total_path`, `maximum_offset`                       | classic `?offset=&limit=` pagination                                            |
+| `page_number`   | `base_page` (first page number, e.g. `0` or `1`), `page_param`, `total_path`, `maximum_page` | classic `?page=N` pagination                                                    |
+| `single_page`   | —                                                                                            | endpoint returns everything in one response                                     |
+| `auto`          | —                                                                                            | fetches only the first response — no auto-detection; single-page endpoints only |
 
 ## Incremental sync
 

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
@@ -1,0 +1,196 @@
+# Custom REST source manifest reference
+
+The manifest is a JSON `RESTAPIConfig`. The generic REST engine consumes it directly, so every field below maps to a
+real engine behavior. Only the fields the engine reads are documented here; unknown keys are ignored.
+
+## Top-level shape
+
+```json
+{
+    "client": { "base_url": "...", "auth": { ... }, "headers": { ... }, "paginator": { ... } },
+    "resource_defaults": { "endpoint": { ... } },
+    "resources": [ { "name": "...", "primary_key": "...", "endpoint": { ... } } ]
+}
+```
+
+- **`client.base_url`** (required) — every resource path resolves against this. On PostHog Cloud it must be `https://`.
+  Internal/private hosts are rejected (SSRF guard).
+- **`client.headers`** (optional) — static headers sent on every request.
+- **`client.paginator`** (optional) — a default paginator for all resources; override per resource on the endpoint.
+- **`resource_defaults.endpoint`** (optional) — endpoint fields merged into every resource (e.g. a shared paginator or
+  `data_selector`).
+- **`resources`** (required, 1–50) — one entry per table you want to import. Each has a unique `name` (becomes the
+  table name) and an `endpoint`.
+
+## Auth
+
+The auth **type** lives in the manifest; the secret value travels in a separate payload key and is injected at run
+time. Never put the secret in the manifest.
+
+| `client.auth` block                                                | Secret payload key | Sends                                         |
+| ------------------------------------------------------------------ | ------------------ | --------------------------------------------- |
+| `{ "type": "bearer" }`                                             | `auth_token`       | `Authorization: Bearer <token>`               |
+| `{ "type": "api_key", "name": "X-Api-Key", "location": "header" }` | `auth_api_key`     | the key in header / query param `name`        |
+| `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`     | `?api_key=<key>`                              |
+| `{ "type": "http_basic", "username": "user" }`                     | `auth_password`    | HTTP Basic with the given username + password |
+
+`location` is one of `header`, `query`, `param`, `cookie`. For an API with no auth, omit `auth` entirely.
+
+## Endpoint fields
+
+```json
+{
+    "path": "/users",
+    "method": "GET",
+    "params": { "status": "active" },
+    "json": { ... },
+    "data_selector": "data",
+    "paginator": { "type": "json_response", "next_url_path": "next" },
+    "incremental": { "cursor_path": "updated_at", "start_param": "since" }
+}
+```
+
+- **`path`** (required) — appended to `base_url`.
+- **`method`** — `GET` (default) or `POST`. POST is for read/query-style endpoints; `PUT`/`PATCH`/`DELETE` are
+  rejected.
+- **`params`** — static query params, or the engine's incremental/resolve specs (see below).
+- **`json`** — request body (for POST query endpoints).
+- **`data_selector`** — JSONPath to the array of records inside the response. For `{ "data": [ ... ] }` use `"data"`;
+  for `{ "results": { "items": [ ... ] } }` use `"results.items"`. Omit only if the response body **is** the array.
+- **`paginator`** — see below. Omit to let the engine auto-detect (`{ "type": "auto" }`).
+- **`incremental`** — see below.
+
+`primary_key` sits on the **resource**, not the endpoint: `"primary_key": "id"` or `"primary_key": ["org_id", "id"]`.
+
+## Paginators
+
+Set `endpoint.paginator` (or `client.paginator`) to one of:
+
+| Type            | Config keys                                                            | Use when                                                         |
+| --------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------------- |
+| `json_response` | `next_url_path` (JSONPath to the next-page URL in the body)            | response carries a next-page URL/path                            |
+| `header_link`   | `links_next_key` (rel, default `next`)                                 | pagination via the `Link` response header                        |
+| `cursor`        | `cursor_path` (JSONPath to the next cursor), `cursor_param`            | response returns an opaque cursor you pass back as a query param |
+| `offset`        | `limit`, `offset_param`, `limit_param`, `total_path`, `maximum_offset` | classic `?offset=&limit=` pagination                             |
+| `page_number`   | `initial_page`, `page_param`, `total_path`, `maximum_page`             | classic `?page=N` pagination                                     |
+| `single_page`   | —                                                                      | endpoint returns everything in one response                      |
+| `auto`          | —                                                                      | let the engine guess (default)                                   |
+
+## Incremental sync
+
+`endpoint.incremental` makes re-syncs fetch only new/changed rows:
+
+```json
+{
+  "cursor_path": "updated_at",
+  "start_param": "since",
+  "end_param": "until",
+  "cursor_type": "datetime",
+  "datetime_format": "%Y-%m-%dT%H:%M:%SZ"
+}
+```
+
+- **`cursor_path`** — JSONPath to the cursor field on each record (the high-watermark).
+- **`start_param`** — query param the engine sets to the last-seen cursor value on the next sync.
+- **`end_param`** (optional) — upper-bound param if the API supports a window.
+- **`cursor_type`** (optional) — `datetime` (default), `date`, `timestamp`, `integer`, `numeric`, or `objectid`. Set
+  it when the cursor is not a datetime (e.g. an autoincrement id) so it's stored and compared correctly.
+- **`datetime_format`** (optional) — strftime pattern for how the watermark is serialized into `start_param`. Defaults
+  to ISO-8601. Set it for strict APIs that reject the default.
+
+Prefer an `updated_at`-style cursor over `created_at`: `created_at` misses edits to existing rows.
+
+## Parent/child fan-out
+
+When a resource's rows must be fetched per parent row (`/forms/{form_id}/responses`), bind the parent field into the
+child path with a `resolve` param:
+
+```json
+{
+  "resources": [
+    { "name": "forms", "primary_key": "id", "endpoint": { "path": "/forms", "data_selector": "items" } },
+    {
+      "name": "responses",
+      "primary_key": "token",
+      "endpoint": {
+        "path": "/forms/{form_id}/responses",
+        "data_selector": "items",
+        "params": { "form_id": { "type": "resolve", "resource": "forms", "field": "id" } }
+      }
+    }
+  ]
+}
+```
+
+Rules: the `{form_id}` placeholder must sit **within** the path (not start it, so a parent value can't redirect the
+request off `base_url`); the parent must be a **top-level** resource; only **one level** of nesting is supported; and a
+resource may have at most one resolve param.
+
+## Worked examples
+
+### Bearer + next-URL pagination + incremental
+
+```json
+{
+  "client": { "base_url": "https://api.acme.com/v2", "auth": { "type": "bearer" } },
+  "resources": [
+    {
+      "name": "orders",
+      "primary_key": "id",
+      "endpoint": {
+        "path": "/orders",
+        "data_selector": "data",
+        "paginator": { "type": "json_response", "next_url_path": "links.next" },
+        "incremental": { "cursor_path": "updated_at", "start_param": "updated_since" }
+      }
+    }
+  ]
+}
+```
+
+Credential: `auth_token`.
+
+### API key in query + offset pagination + integer cursor
+
+```json
+{
+  "client": {
+    "base_url": "https://data.example.org",
+    "auth": { "type": "api_key", "name": "api_key", "location": "query" }
+  },
+  "resources": [
+    {
+      "name": "events",
+      "primary_key": "event_id",
+      "endpoint": {
+        "path": "/events",
+        "data_selector": "results",
+        "paginator": { "type": "offset", "limit": 200, "total_path": "meta.total" },
+        "incremental": { "cursor_path": "sequence", "start_param": "after_id", "cursor_type": "integer" }
+      }
+    }
+  ]
+}
+```
+
+Credential: `auth_api_key`.
+
+### HTTP basic + single page
+
+```json
+{
+  "client": {
+    "base_url": "https://reports.example.net",
+    "auth": { "type": "http_basic", "username": "svc_account" }
+  },
+  "resources": [
+    {
+      "name": "daily_summary",
+      "primary_key": "date",
+      "endpoint": { "path": "/summary/today", "data_selector": "rows", "paginator": { "type": "single_page" } }
+    }
+  ]
+}
+```
+
+Credential: `auth_password`.

--- a/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
+++ b/products/warehouse_sources/skills/setting-up-a-custom-rest-source/references/manifest-reference.md
@@ -34,7 +34,9 @@ time. Never put the secret in the manifest.
 | `{ "type": "api_key", "name": "api_key", "location": "query" }`    | `auth_api_key`     | `?api_key=<key>`                              |
 | `{ "type": "http_basic", "username": "user" }`                     | `auth_password`    | HTTP Basic with the given username + password |
 
-`location` is one of `header`, `query`, `param`, `cookie`. For an API with no auth, omit `auth` entirely.
+`location` is one of `header`, `query`, `param`, `cookie`. `query` and `param` are **synonyms** — both append
+`name=<key>` to the URL query string, so use either (prefer `query`); they differ only in spelling, not behavior. For
+an API with no auth, omit `auth` entirely.
 
 ## Endpoint fields
 
@@ -194,3 +196,29 @@ Credential: `auth_api_key`.
 ```
 
 Credential: `auth_password`.
+
+### Bearer + cursor pagination + incremental
+
+`paginator.cursor_path` and `incremental.cursor_path` are independent and easily confused: the **paginator's**
+`cursor_path` reads the _next-page cursor_ from the response envelope (drives pagination within a sync); the
+**incremental's** `cursor_path` reads the _watermark_ from each record (drives what a re-sync re-fetches).
+
+```json
+{
+  "client": { "base_url": "https://api.acme.com/v1", "auth": { "type": "bearer" } },
+  "resources": [
+    {
+      "name": "tickets",
+      "primary_key": "id",
+      "endpoint": {
+        "path": "/tickets",
+        "data_selector": "data",
+        "paginator": { "type": "cursor", "cursor_path": "meta.next_cursor", "cursor_param": "cursor" },
+        "incremental": { "cursor_path": "updated_at", "start_param": "since" }
+      }
+    }
+  ]
+}
+```
+
+Credential: `auth_token`.


### PR DESCRIPTION
## Problem

With the preview endpoint in place, the pieces exist to build a Custom REST source from an API's docs entirely over MCP — but an agent still needs a grounded approach: how to translate a docs page or a natural-language description into a correct `RESTAPIConfig` manifest, and how to prove it before creating the source.

## Changes

Add the `setting-up-a-custom-rest-source` skill: an agent-driven loop that turns a docs URL or NL API description into a working Custom source.

- `SKILL.md` is the workflow — gather the API shape → draft the manifest → validate and list resources (`external-data-sources-db-schema`) → test-read live rows (`external-data-sources-preview-resource`) → create (`data-warehouse-source-setup`).
- `references/manifest-reference.md` is the grounded grammar: the full `RESTAPIConfig` field reference (auth types, the six paginators, incremental cursors, parent/child fan-out) with a worked example per auth scheme. The agent drafts from this rather than guessing field names.
- Routes built-in connectors (Postgres, Stripe, …) back to `setting-up-a-data-warehouse-source`; this skill is only for APIs with no connector.

## How did you test this code?

I'm an agent (Claude Code). `hogli lint:skills` passes (94 skills, including this one). `hogli build:skills` is currently blocked on my machine by an unrelated local Postgres migration drift (a missing `posthog_team` column) in the shared Django-booting harness — this skill has no `.j2` templates, so it does not depend on that path and builds in CI against a migrated DB.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code. Skill invoked: `/writing-skills` (required before authoring the skill).
- Modeled on the existing `setting-up-a-data-warehouse-source` skill (frontmatter, tools table, numbered workflow). Grammar/examples split into `references/` for progressive disclosure, keeping `SKILL.md` focused on the loop.
