### PR TITLE
fix(data-warehouse): stop emitting invalid Snowflake SQL for ClickHouse-isms

### DIFF
--- a/posthog/hogql/printer/snowflake.py
+++ b/posthog/hogql/printer/snowflake.py
@@ -18,6 +18,40 @@ _SNOWFLAKE_DATE_PARTS: frozenset[str] = frozenset(
     {"second", "minute", "hour", "day", "week", "month", "quarter", "year"}
 )
 
+# HogQL type names accepted by a `::` cast, mapped to Snowflake types. Mirrors the cast
+# function handlers (toString → VARCHAR, toInt → BIGINT, …) so `x::String` and
+# `toString(x)` agree. Unmapped names are rejected rather than emitted verbatim.
+_SNOWFLAKE_CAST_TYPES: dict[str, str] = {
+    "int": "BIGINT",
+    "integer": "BIGINT",
+    "int8": "BIGINT",
+    "int16": "BIGINT",
+    "int32": "BIGINT",
+    "int64": "BIGINT",
+    "uint8": "BIGINT",
+    "uint16": "BIGINT",
+    "uint32": "BIGINT",
+    "uint64": "BIGINT",
+    "float": "DOUBLE",
+    "float32": "DOUBLE",
+    "float64": "DOUBLE",
+    "double": "DOUBLE",
+    "real": "DOUBLE",
+    "decimal": "DECIMAL",
+    "numeric": "DECIMAL",
+    "string": "VARCHAR",
+    "text": "VARCHAR",
+    "varchar": "VARCHAR",
+    "char": "VARCHAR",
+    "bool": "BOOLEAN",
+    "boolean": "BOOLEAN",
+    "date": "DATE",
+    "datetime": "TIMESTAMP",
+    "datetime64": "TIMESTAMP",
+    "timestamp": "TIMESTAMP",
+    "uuid": "VARCHAR",
+}
+
 # ClickHouse/strftime format specifier → Snowflake TO_CHAR format element.
 _STRFTIME_TO_SNOWFLAKE: dict[str, str] = {
     "Y": "YYYY",
@@ -61,6 +95,69 @@ class SnowflakePrinter(PostgresPrinter):
 
     def _get_passthrough_functions(self) -> frozenset[str]:
         return SNOWFLAKE_PASSTHROUGH_FUNCTIONS
+
+    # --- ClickHouse-only SELECT clauses
+    #
+    # The inherited (base) visit_select_query emits these verbatim; Snowflake has no
+    # equivalent, so reject loudly rather than emit SQL Snowflake can't run.
+
+    def visit_select_query(self, node: ast.SelectQuery) -> str:
+        if node.array_join_op is not None:
+            raise QueryError(f"ARRAY JOIN is not supported {self._dialect_error_suffix()}.")
+        if node.prewhere is not None:
+            raise QueryError(f"PREWHERE is not supported {self._dialect_error_suffix()}.")
+        if node.limit_by is not None:
+            raise QueryError(f"LIMIT BY is not supported {self._dialect_error_suffix()}; use QUALIFY ROW_NUMBER().")
+        return super().visit_select_query(node)
+
+    def visit_sample_expr(self, node: ast.SampleExpr) -> str:
+        # SAMPLE hangs off the table (JoinExpr), so reject it here rather than in the select query.
+        raise QueryError(f"SAMPLE is not supported {self._dialect_error_suffix()}.")
+
+    # --- Operators and literals
+    #
+    # Snowflake has no `~` regex operators, `[...]` array / `{...}` object literals, scalar
+    # tuples, or `[a:b]` slices — translate the ones with a clean equivalent and reject the rest.
+
+    def _get_compare_op(self, op: ast.CompareOperationOp, left: str, right: str) -> str:
+        # match()-style "found anywhere" semantics (REGEXP_INSTR != 0), consistent with the
+        # `match` function handler. The 6th arg 'i' makes the case-insensitive variants ignore case.
+        if op == ast.CompareOperationOp.Regex:
+            return f"(REGEXP_INSTR({left}, {right}) != 0)"
+        if op == ast.CompareOperationOp.NotRegex:
+            return f"(REGEXP_INSTR({left}, {right}) = 0)"
+        if op == ast.CompareOperationOp.IRegex:
+            return f"(REGEXP_INSTR({left}, {right}, 1, 1, 0, 'i') != 0)"
+        if op == ast.CompareOperationOp.NotIRegex:
+            return f"(REGEXP_INSTR({left}, {right}, 1, 1, 0, 'i') = 0)"
+        return super()._get_compare_op(op, left, right)
+
+    def visit_type_cast(self, node: ast.TypeCast) -> str:
+        target = _SNOWFLAKE_CAST_TYPES.get(node.type_name.lower())
+        if target is None:
+            raise QueryError(f"Unsupported cast to type '{node.type_name}' {self._dialect_error_suffix()}.")
+        return f"CAST({self.visit(node.expr)} AS {target})"
+
+    def visit_array(self, node: ast.Array) -> str:
+        return f"ARRAY_CONSTRUCT({', '.join(self.visit(expr) for expr in node.exprs)})"
+
+    def visit_tuple(self, node: ast.Tuple) -> str:
+        # HogQL lowers `{...}` object literals to a tagged tuple
+        # (`'__hx_tag', '__hx_obj', key, value, …`) before printing — emit those as a
+        # Snowflake OBJECT. Genuine scalar tuples have no Snowflake type, so reject them.
+        exprs = node.exprs
+        if (
+            len(exprs) >= 2
+            and isinstance(exprs[0], ast.Constant)
+            and exprs[0].value == "__hx_tag"
+            and isinstance(exprs[1], ast.Constant)
+            and exprs[1].value == "__hx_obj"
+        ):
+            return f"OBJECT_CONSTRUCT({', '.join(self.visit(expr) for expr in exprs[2:])})"
+        raise QueryError(f"Tuple expressions are not supported {self._dialect_error_suffix()}.")
+
+    def visit_array_slice(self, node: ast.ArraySlice) -> str:
+        raise QueryError(f"Array slices are not supported {self._dialect_error_suffix()}; use ARRAY_SLICE().")
 
     def visit_call(self, node: ast.Call) -> str:
         # dateDiff / formatDateTime can't be plain handlers: their first argument

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -7041,6 +7041,18 @@ SNOWFLAKE_EMIT_CASES: list[tuple[str, str, str]] = [
     # Conditional / null
     ("if", "if(1, 2, 3)", "CASE WHEN 1 THEN 2 ELSE 3 END"),
     ("isNull", "isNull(1)", "(1 IS NULL)"),
+    # Regex operators → REGEXP_INSTR (match()-style "found anywhere"); 'i' = case-insensitive
+    ("regex_match", "'h' =~ 'h.*o'", "(REGEXP_INSTR(%(hogql_val_0)s, %(hogql_val_1)s) != 0)"),
+    ("regex_not_match", "'h' !~ 'h.*o'", "(REGEXP_INSTR(%(hogql_val_0)s, %(hogql_val_1)s) = 0)"),
+    ("regex_imatch", "'h' =~* 'h.*o'", "(REGEXP_INSTR(%(hogql_val_0)s, %(hogql_val_1)s, 1, 1, 0, 'i') != 0)"),
+    ("regex_not_imatch", "'h' !~* 'h.*o'", "(REGEXP_INSTR(%(hogql_val_0)s, %(hogql_val_1)s, 1, 1, 0, 'i') = 0)"),
+    # `::` casts map HogQL type names to Snowflake types (consistent with toString/toInt/...)
+    ("cast_string", "1::String", "CAST(1 AS VARCHAR)"),
+    ("cast_int", "1.5::Int", "CAST(1.5 AS BIGINT)"),
+    ("cast_bool", "1::Bool", "CAST(1 AS BOOLEAN)"),
+    # Array / object literals → constructors
+    ("array_literal", "[1, 2, 3]", "ARRAY_CONSTRUCT(1, 2, 3)"),
+    ("object_literal", "{'a': 1}", "OBJECT_CONSTRUCT(%(hogql_val_0)s, 1)"),
     # JSON (PARSE_JSON + bracket path; chained keys for nested access)
     (
         "JSONExtractString",
@@ -7126,9 +7138,30 @@ class TestSnowflakePrinter(BaseTest):
                 "Unsupported formatDateTime specifier '%Q'",
             ),
             ("unsupported_function", "argMax(1, 2)", "not supported in the Snowflake dialect"),
+            # Tier 0: constructs with no safe Snowflake equivalent reject loudly
+            ("tuple", "(1, 2)", "Tuple expressions are not supported"),
+            ("array_slice", "[1, 2, 3][1:2]", "Array slices are not"),
+            ("unsupported_cast", "1::Nonsense", "Unsupported cast to type 'nonsense'"),
         ]
     )
     def test_snowflake_errors(self, _name: str, hogql_expr: str, error_substring: str):
         with self.assertRaises(QueryError) as ctx:
             self._expr(hogql_expr)
+        self.assertIn(error_substring, str(ctx.exception))
+
+    def _select(self, query: str) -> str:
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        return prepare_and_print_ast(parse_select(query, backend="cpp-json"), context, "snowflake")[0]
+
+    @parameterized.expand(
+        [
+            ("array_join", "SELECT x FROM events ARRAY JOIN [1, 2] AS x", "ARRAY JOIN is not supported"),
+            ("prewhere", "SELECT event FROM events PREWHERE event = 'x'", "PREWHERE is not supported"),
+            ("sample", "SELECT event FROM events SAMPLE 0.1", "SAMPLE is not supported"),
+            ("limit_by", "SELECT event FROM events LIMIT 1 BY event", "LIMIT BY is not supported"),
+        ]
+    )
+    def test_snowflake_clause_errors(self, _name: str, query: str, error_substring: str):
+        with self.assertRaises(QueryError) as ctx:
+            self._select(query)
         self.assertIn(error_substring, str(ctx.exception))


### PR DESCRIPTION
## Problem

Stacked on #65410.

A grammar-level differential (HogQL grammar vs Snowflake's SELECT grammar) surfaced a class of "Tier 0" deviations: constructs the Snowflake printer inherited from the Postgres/base printer and emitted as ClickHouse SQL verbatim, even though Snowflake can't run them. These failed at execution with cryptic Snowflake errors — or worse, silently returned wrong results — instead of translating or failing loudly in HogQL.

Verified empirically by round-tripping each construct through the real Snowflake emission path (`generate_clickhouse_sql` on a direct-Snowflake source).

## Changes

**Translate** (clean Snowflake equivalent exists):
- Regex compare operators `=~` `!~` `=~*` `!~*` → `REGEXP_INSTR(...)` with `match()`-style "found anywhere" semantics (`'i'` parameter for the case-insensitive variants), consistent with the existing `match` function handler. Previously emitted Postgres `~`/`!~`/`~*`, which Snowflake has no equivalent for.
- `::` casts → map HogQL type names to Snowflake types (`String`→`VARCHAR`, `Int`→`BIGINT`, `Float`→`DOUBLE`, …), mirroring the `toString`/`toInt`/… function handlers. Previously emitted `CAST(x AS string)` with a non-existent lowercase type.
- `[...]` array literals → `ARRAY_CONSTRUCT(...)`; `{...}` object literals → `OBJECT_CONSTRUCT(...)` (HogQL lowers objects to a tagged tuple, which is detected and rebuilt).

**Reject loudly** (no safe Snowflake equivalent — better a clear error than invalid SQL):
- `ARRAY JOIN`, `PREWHERE`, `SAMPLE`, `LIMIT BY` — ClickHouse-only clauses (the `LIMIT BY` message points at `QUALIFY ROW_NUMBER()`).
- Scalar tuples (no Snowflake tuple type), array slices (`use ARRAY_SLICE()`), and casts to unknown types.

**Known gap:** `WITH TOTALS` is dropped at parse time and has no AST representation, so it can't be rejected in the printer yet — it produces valid-but-incomplete SQL. Flagged for a parser-level follow-up rather than fixed here.

## How did you test this code?

I'm an agent (Claude Code); no manual Snowflake testing. Automated: **80 passed** in `TestSnowflakePrinter` (+16 new cases — translate emits for each operator/cast/literal, plus expression- and clause-level rejection tests) and **66 passed** in `test_direct_snowflake_query` (regression). `ruff` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tool:** Claude Code (Opus 4.8).
- **Scope:** this is the "Tier 0" slice of a larger grammar-differential triage (silent-wrong-output deviations). Tier 1 (enable `QUALIFY`/`PIVOT`, which parse but are rejected pre-print) and Tier 2 (Snowflake-only syntax the grammar can't parse, e.g. `FLATTEN(x => …)`) are deliberately out of scope here.
- **Translate-vs-reject calls:** translated where the Snowflake equivalent is unambiguous; rejected where semantics differ enough that a silent translation would be a data bug (e.g. array-slice index base, scalar tuples) or where there's no equivalent (CH execution-model clauses).
