### PR TITLE
feat(quill): add Table size, Card flush, and Avatar primitives

### DIFF
--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -27,6 +27,7 @@ const columns: ColumnDef<Person>[] = [
   pageSizeOptions={[10, 25, 50]} // renders the per-page selector
   stickyHeader                   // or "page" to stick to document scroll
   fullWidth
+  size="sm"                      // tighten cell padding; pair with Card size="sm"
 />
 ```
 

--- a/packages/quill/packages/components/src/data-table.tsx
+++ b/packages/quill/packages/components/src/data-table.tsx
@@ -67,6 +67,12 @@ export interface DataTableProps<TData, TValue> {
      */
     fullWidth?: boolean
     /**
+     * Cell density, forwarded to the Table primitive. `'sm'` tightens head/cell
+     * inline padding to `0.75rem` — pair with a `Card size="sm"` so edge columns
+     * align with the card's inline padding.
+     */
+    size?: 'default' | 'sm'
+    /**
      * Rendered in place of rows when `data` is empty. Defaults to a minimal
      * "No results" Empty; pass a richer node (custom copy, actions) to override.
      */
@@ -190,6 +196,7 @@ function DataTable<TData, TValue>({
     className,
     stickyHeader,
     fullWidth,
+    size,
     empty = DEFAULT_EMPTY,
     pageSize,
     pageSizeOptions,
@@ -217,7 +224,7 @@ function DataTable<TData, TValue>({
     const rows = table.getRowModel().rows
 
     const tableElement = (
-        <Table className={className} stickyHeader={stickyHeader} fullWidth={fullWidth}>
+        <Table className={className} stickyHeader={stickyHeader} fullWidth={fullWidth} size={size}>
             <TableHeader>
                 {table.getHeaderGroups().map((headerGroup) => (
                     <TableRow key={headerGroup.id}>

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -142,8 +142,8 @@ Don't hand-roll `<p className="text-xs text-muted-foreground">` when `<Text size
 | SkeletonText | —                                                        | —                                                    | lines, minWidth, maxWidth                                                                                              |
 | Progress     | —                                                        | —                                                    | value: 0-100                                                                                                           |
 | Slider       | —                                                        | —                                                    | value, min, max                                                                                                        |
-| Avatar       | —                                                        | default, sm                                          | Compose `Avatar > AvatarImage + AvatarFallback`; image errors fall back to initials/icon                               |
-| AvatarGroup  | —                                                        | default, sm                                          | Row of Avatars; `stacked` overlaps + spreads on hover (no reflow), `reverse` spreads left; `size` forwards to children |
+| Avatar       | —                                                        | default, sm, xs                                      | Compose `Avatar > AvatarImage + AvatarFallback`; image errors fall back to initials/icon                               |
+| AvatarGroup  | —                                                        | default, sm, xs                                      | Row of Avatars; `stacked` overlaps + spreads on hover (no reflow), `reverse` spreads left; `size` forwards to children |
 
 ---
 
@@ -681,7 +681,7 @@ Item sizes: default, sm, xs
 
 ### Avatar
 
-Compose `Avatar > AvatarImage + AvatarFallback`. The fallback (initials or a bare lucide icon — don't `size-*` it) shows when there's no image or the image errors. `size="sm"` (1.5rem) or default (2rem).
+Compose `Avatar > AvatarImage + AvatarFallback`. The fallback (initials or a bare lucide icon — don't `size-*` it) shows when there's no image or the image errors. `size="xs"` (1.25rem), `"sm"` (1.5rem), or default (2rem).
 
 ```tsx
 <Avatar>

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -130,18 +130,20 @@ Don't hand-roll `<p className="text-xs text-muted-foreground">` when `<Text size
 
 ## Component Catalog
 
-| Component    | Variants                                                 | Sizes                                                | Notes                                                                              |
-| ------------ | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------- |
-| Button       | default, primary, outline, destructive, link, link-muted | default, xs, sm, lg, icon, icon-xs, icon-sm, icon-lg | `loading` overlays a centered spinner and disables the button (width stays stable) |
-| Badge        | default, info, destructive, warning, success             | —                                                    | Semantic status                                                                    |
-| Toggle       | default, outline                                         | default, sm, lg, icon                                |                                                                                    |
-| Chip         | outline                                                  | sm                                                   | Use with ChipClose                                                                 |
-| Separator    | —                                                        | —                                                    | orientation: horizontal/vertical                                                   |
-| Spinner      | —                                                        | —                                                    | SVG, accepts svg props                                                             |
-| Skeleton     | —                                                        | —                                                    | Pulsing placeholder div                                                            |
-| SkeletonText | —                                                        | —                                                    | lines, minWidth, maxWidth                                                          |
-| Progress     | —                                                        | —                                                    | value: 0-100                                                                       |
-| Slider       | —                                                        | —                                                    | value, min, max                                                                    |
+| Component    | Variants                                                 | Sizes                                                | Notes                                                                                                                  |
+| ------------ | -------------------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Button       | default, primary, outline, destructive, link, link-muted | default, xs, sm, lg, icon, icon-xs, icon-sm, icon-lg | `loading` overlays a centered spinner and disables the button (width stays stable)                                     |
+| Badge        | default, info, destructive, warning, success             | —                                                    | Semantic status                                                                                                        |
+| Toggle       | default, outline                                         | default, sm, lg, icon                                |                                                                                                                        |
+| Chip         | outline                                                  | sm                                                   | Use with ChipClose                                                                                                     |
+| Separator    | —                                                        | —                                                    | orientation: horizontal/vertical                                                                                       |
+| Spinner      | —                                                        | —                                                    | SVG, accepts svg props                                                                                                 |
+| Skeleton     | —                                                        | —                                                    | Pulsing placeholder div                                                                                                |
+| SkeletonText | —                                                        | —                                                    | lines, minWidth, maxWidth                                                                                              |
+| Progress     | —                                                        | —                                                    | value: 0-100                                                                                                           |
+| Slider       | —                                                        | —                                                    | value, min, max                                                                                                        |
+| Avatar       | —                                                        | default, sm                                          | Compose `Avatar > AvatarImage + AvatarFallback`; image errors fall back to initials/icon                               |
+| AvatarGroup  | —                                                        | default, sm                                          | Row of Avatars; `stacked` overlaps + spreads on hover (no reflow), `reverse` spreads left; `size` forwards to children |
 
 ---
 
@@ -676,6 +678,30 @@ Vertical: `<ButtonGroup orientation="vertical">`
 
 Item variants: default, outline, pressable, muted, menuItem
 Item sizes: default, sm, xs
+
+### Avatar
+
+Compose `Avatar > AvatarImage + AvatarFallback`. The fallback (initials or a bare lucide icon — don't `size-*` it) shows when there's no image or the image errors. `size="sm"` (1.5rem) or default (2rem).
+
+```tsx
+<Avatar>
+  <AvatarImage src={user.avatarUrl} alt={user.name} />
+  <AvatarFallback>{initials}</AvatarFallback>
+</Avatar>
+```
+
+`AvatarGroup` lays Avatars out in a row — gapped by default, or `stacked` to overlap them. The leftmost avatar sits on top (so a leading `+N` count reads in front). Hovering (or focusing) a stacked group spreads it back to the inline gap; the spread is a `transform`, so the container box never changes and nothing reflows — the avatars slide out over the space beside them. `reverse` mirrors it: the pile anchors to its right edge, the rightmost avatar sits on top, and it spreads left (use it at the right end of a row so it grows inward). `size` on the group forwards to bare Avatar children and tunes the overlap; a non-Avatar child (a `+N` count built from a styled `AvatarFallback`) passes through untouched — put it first (default) or last (`reverse`) so it sits on top. The stacked ring defaults to the app background; on a different surface (a `Card`), override `--quill-avatar-ring` so it matches, e.g. `className="[--quill-avatar-ring:var(--card)]"`.
+
+```tsx
+<AvatarGroup stacked size="sm">
+  {members.map((m) => (
+    <Avatar key={m.id}>
+      <AvatarImage src={m.avatarUrl} alt={m.name} />
+      <AvatarFallback>{m.initials}</AvatarFallback>
+    </Avatar>
+  ))}
+</AvatarGroup>
+```
 
 ### Keyboard Shortcuts
 

--- a/packages/quill/packages/primitives/AGENTS.md
+++ b/packages/quill/packages/primitives/AGENTS.md
@@ -236,6 +236,17 @@ Stack cards with merged borders:
 </CardGroup>
 ```
 
+`size="sm"` tightens the card's gap + block padding (`0.75rem`). `flush` lets a full-bleed child (a `Table`, a chart) run corner to corner: it drops the card's section gap + bottom padding and the `CardContent`'s inline padding, while the header keeps its own padding + divider. Use it instead of hand-writing `gap-0 pb-0` on the Card and `p-0` on the CardContent.
+
+```tsx
+<Card flush>
+  <CardHeader>
+    <CardTitle>Revenue</CardTitle>
+  </CardHeader>
+  <CardContent>{/* Table / chart runs to the card edges */}</CardContent>
+</Card>
+```
+
 ### Field (forms)
 
 Always use Field for form controls, not raw Label + Input:
@@ -732,7 +743,7 @@ const range = getPaginationRange(pageCount, pageIndex)
 
 ### Table
 
-Compose `Table > TableHeader/TableBody/TableFooter > TableRow > TableHead/TableCell`. Per-cell options on `TableHead`/`TableCell`: `sticky="left" | "right"` (frozen column), `align="left" | "center" | "right"` (horizontal), `valign="top" | "middle" | "bottom"` (vertical), `expand` (absorb leftover width). `align` also positions an inline-flex header Button. On `Table`: `stickyHeader` (or `"page"`) for a sticky header, `fullWidth` to fill the container — pair `fullWidth` with `expand` on one column to choose which one stretches.
+Compose `Table > TableHeader/TableBody/TableFooter > TableRow > TableHead/TableCell`. Per-cell options on `TableHead`/`TableCell`: `sticky="left" | "right"` (frozen column), `align="left" | "center" | "right"` (horizontal), `valign="top" | "middle" | "bottom"` (vertical), `expand` (absorb leftover width). `align` also positions an inline-flex header Button. On `Table`: `stickyHeader` (or `"page"`) for a sticky header, `fullWidth` to fill the container — pair `fullWidth` with `expand` on one column to choose which one stretches, `size="sm"` to tighten head/cell inline padding to `0.75rem` (from `1rem`) for dense tables and to align edge columns with a `Card size="sm"`.
 
 **Backgrounds: transparent by default, opaque when sticky.** Plain cells and headers are transparent, so a `Table` inherits whatever surface it sits on (inside a `Card`, a tinted panel). Sticky parts (`stickyHeader`, `stickyHeader="page"`, `sticky="left"/"right"`) get an opaque background automatically — they'd otherwise bleed scrolled-under content — so you don't add `bg-background` yourself. It defaults to the app background; if the table sits on a different surface, override the inherited `--quill-table-sticky-bg` custom property on the `Table` so the frozen cells match — e.g. inside a `Card`, `className="[--quill-table-sticky-bg:var(--card)]"`.
 
@@ -758,15 +769,17 @@ Compose `Table > TableHeader/TableBody/TableFooter > TableRow > TableHead/TableC
 </Table>
 ```
 
-**Table in a Card — let the table own the edges.** A `Table` sits flush inside a `Card` because its cells are transparent (they inherit the card surface). Put `gap-0 pb-0` on the `Card` and `p-0` on the `CardContent` so the table reaches the card's rounded edges with no double padding, and use `fullWidth` on the `Table`. For an empty/loading table that should fill a tall card, build the height chain `Card min-h-* → CardContent flex-1 → Table h-full` so `TableEmpty` stretches to the body area.
+**Table in a Card — let the table own the edges.** A `Table` sits flush inside a `Card` because its cells are transparent (they inherit the card surface). Pass `flush` on the `Card` so the table reaches the card's rounded edges with no double padding (it drops the card's section gap + bottom padding and the `CardContent`'s inline padding — no `className` needed on either), and use `fullWidth` on the `Table`. For an empty/loading table that should fill a tall card, build the height chain `Card min-h-* → CardContent flex-1 → Table h-full` so `TableEmpty` stretches to the body area. Inside a `Card size="sm"`, also pass `size="sm"` on the `Table` so its edge columns line up with the card's tighter `0.75rem` inline padding (header title, footer).
 
 ```tsx
-<Card className="gap-0 pb-0">
+<Card size="sm" flush>
   <CardHeader>
     <CardTitle>Members</CardTitle>
   </CardHeader>
-  <CardContent className="p-0">
-    <Table fullWidth>{/* … */}</Table>
+  <CardContent>
+    <Table size="sm" fullWidth>
+      {/* … */}
+    </Table>
   </CardContent>
 </Card>
 ```

--- a/packages/quill/packages/primitives/src/avatar.css
+++ b/packages/quill/packages/primitives/src/avatar.css
@@ -1,0 +1,157 @@
+/* stylelint-disable selector-class-pattern -- descendant/attr selectors fall outside strict BEM */
+@layer components {
+    /* =========================================================================
+       Avatar — a circular image with an initials/icon fallback. Size is driven by
+       a single custom property so the image, fallback, and circle all track it.
+       ========================================================================= */
+    .quill-avatar {
+        --avatar-size: 2rem;
+
+        position: relative;
+        display: inline-flex;
+        flex-shrink: 0;
+        align-items: center;
+        justify-content: center;
+        width: var(--avatar-size);
+        height: var(--avatar-size);
+        overflow: hidden;
+        font-size: var(--text-xs, 0.75rem);
+        line-height: 1;
+        color: var(--muted-foreground);
+        user-select: none;
+        background-color: var(--muted);
+        border-radius: 9999px;
+    }
+
+    .quill-avatar[data-size='sm'] {
+        --avatar-size: 1.5rem;
+
+        font-size: var(--text-xxs, 0.625rem);
+    }
+
+    .quill-avatar__image {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        border-radius: inherit;
+    }
+
+    .quill-avatar__fallback {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 100%;
+        height: 100%;
+        font-weight: 500;
+        text-transform: uppercase;
+    }
+
+    /* Fallback icons (a bare lucide glyph) size to ~60% of the circle. */
+    .quill-avatar__fallback > svg:not([class*='size-']) {
+        width: 60%;
+        height: 60%;
+    }
+
+    /* =========================================================================
+       AvatarGroup — inline by default; `stacked` overlaps and spreads on hover.
+       ========================================================================= */
+    .quill-avatar-group {
+        /* Magnitude each stacked avatar overlaps the previous one. */
+        --avatar-overlap: 0.625rem;
+
+        /* Gap between avatars when inline, and the gap the stack spreads back to. */
+        --avatar-gap: 0.5rem;
+
+        position: relative;
+        display: inline-flex;
+        align-items: center;
+        width: max-content;
+    }
+
+    .quill-avatar-group[data-size='sm'] {
+        --avatar-overlap: 0.5rem;
+    }
+
+    .quill-avatar-group__item {
+        /* Default spread: anchor the left edge, fan right by index × (overlap + gap),
+           which cancels the negative margins and lands the avatars `--avatar-gap`
+           apart. `reverse` overrides this below. */
+        --avatar-spread: calc(var(--avatar-index) * (var(--avatar-overlap) + var(--avatar-gap)));
+
+        position: relative;
+
+        /* Leftmost on top by default: a leading `+N` count and each avatar's left
+           edge sit above the next. `reverse` flips this to rightmost-on-top. */
+        z-index: calc(var(--avatar-count, 0) - var(--avatar-index));
+        display: inline-flex;
+    }
+
+    /* Reverse: anchor the right edge, fan left, and put the rightmost avatar on top. */
+    .quill-avatar-group[data-reverse] .quill-avatar-group__item {
+        --avatar-spread: calc(
+            -1 * (var(--avatar-count) - 1 - var(--avatar-index)) * (var(--avatar-overlap) + var(--avatar-gap))
+        );
+
+        z-index: calc(var(--avatar-index) + 1);
+    }
+
+    /* Inline (default): plain gap, no overlap. */
+    .quill-avatar-group:not([data-stacked]) {
+        gap: var(--avatar-gap);
+    }
+
+    /* Stacked: pull each avatar (bar the first) back over the previous one. A ring in
+       the surface colour separates the overlaps; it defaults to the app background —
+       override `--quill-avatar-ring` (e.g. to `var(--card)`) when the group sits on a
+       different surface so the ring matches. */
+    .quill-avatar-group[data-stacked] .quill-avatar-group__item:not(:first-child) {
+        margin-left: calc(-1 * var(--avatar-overlap));
+    }
+
+    .quill-avatar-group[data-stacked] [data-slot='avatar'] {
+        box-shadow: 0 0 0 2px var(--quill-avatar-ring, var(--background));
+    }
+
+    /* Invisible hit bridge. When spread, the avatars are `--avatar-gap` apart and
+       the gaps fall outside the group's (un-reflowed) box — hovering one would drop
+       `:hover` and the pile would flicker shut. Each item extends its hit area half
+       a gap on either side so neighbours meet, giving one continuous hover surface.
+       It sits behind the avatar (z-index: -1), so clicks still reach the avatar. */
+    .quill-avatar-group[data-stacked] .quill-avatar-group__item::after {
+        position: absolute;
+        inset-block: 0;
+
+        /* Half the gap, plus 1px so adjacent bridges overlap instead of meeting at a seam. */
+        inset-inline: calc(-0.5 * var(--avatar-gap) - 1px);
+        z-index: -1;
+        content: '';
+    }
+
+    /* On-screen elements repositioning → ease-in-out (cubic). will-change keeps the
+       transform on the GPU for the small, bounded set of avatars in a group. */
+    .quill-avatar-group[data-stacked] .quill-avatar-group__item {
+        transition: transform 200ms cubic-bezier(0.645, 0.045, 0.355, 1);
+        will-change: transform;
+    }
+
+    .quill-avatar-group[data-stacked]:focus-within .quill-avatar-group__item {
+        transform: translateX(var(--avatar-spread));
+    }
+
+    /* Hover/focus spreads the stack to the inline gap WITHOUT reflow: only
+       `transform` moves, so the container's box stays put and nothing around it
+       reflows — the avatars slide out over whatever sits beside them. The hover
+       trigger is gated to real pointers so a touch tap doesn't leave the pile stuck
+       open; focus-within stays ungated for keyboard users with focusable avatars. */
+    @media (hover: hover) and (pointer: fine) {
+        .quill-avatar-group[data-stacked]:hover .quill-avatar-group__item {
+            transform: translateX(var(--avatar-spread));
+        }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .quill-avatar-group[data-stacked] .quill-avatar-group__item {
+            transition: none;
+        }
+    }
+}

--- a/packages/quill/packages/primitives/src/avatar.css
+++ b/packages/quill/packages/primitives/src/avatar.css
@@ -29,6 +29,12 @@
         font-size: var(--text-xxs, 0.625rem);
     }
 
+    .quill-avatar[data-size='xs'] {
+        --avatar-size: 1.25rem;
+
+        font-size: var(--text-xxs, 0.625rem);
+    }
+
     .quill-avatar__image {
         width: 100%;
         height: 100%;
@@ -70,6 +76,10 @@
 
     .quill-avatar-group[data-size='sm'] {
         --avatar-overlap: 0.5rem;
+    }
+
+    .quill-avatar-group[data-size='xs'] {
+        --avatar-overlap: 0.4375rem;
     }
 
     .quill-avatar-group__item {

--- a/packages/quill/packages/primitives/src/avatar.stories.tsx
+++ b/packages/quill/packages/primitives/src/avatar.stories.tsx
@@ -136,8 +136,9 @@ export const GroupStackedReverse: Story = {
     ),
 } satisfies Story
 
-// A stacked group led by an overflow count (styled fallback). It sits first, so it
-// reads behind the faces; on hover the whole pile spreads.
+// A stacked group led by an overflow count (styled fallback). It sits first, so —
+// with the default leftmost-on-top stacking — it reads in front of the faces; on
+// hover the whole pile spreads.
 export const GroupStackedWithCount: Story = {
     render: () => (
         <AvatarGroup stacked>

--- a/packages/quill/packages/primitives/src/avatar.stories.tsx
+++ b/packages/quill/packages/primitives/src/avatar.stories.tsx
@@ -1,0 +1,240 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { UserIcon } from 'lucide-react'
+
+import { Avatar, AvatarFallback, AvatarGroup, AvatarImage } from './avatar'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
+
+const meta = {
+    title: 'Primitives/Avatar',
+    component: Avatar,
+    tags: ['autodocs'],
+} satisfies Meta<typeof Avatar>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+// A few stable portraits + names for the image stories.
+const MEMBERS = [
+    { src: 'https://i.pravatar.cc/96?img=12', name: 'Ada Lovelace', initials: 'AL' },
+    { src: 'https://i.pravatar.cc/96?img=32', name: 'Grace Hopper', initials: 'GH' },
+    { src: 'https://i.pravatar.cc/96?img=45', name: 'Alan Turing', initials: 'AT' },
+    { src: 'https://i.pravatar.cc/96?img=5', name: 'Katherine Johnson', initials: 'KJ' },
+    { src: 'https://i.pravatar.cc/96?img=68', name: 'Edsger Dijkstra', initials: 'ED' },
+]
+const FACES = MEMBERS.map((m) => m.src)
+
+export const Default: Story = {
+    render: () => (
+        <Avatar>
+            <AvatarImage src={FACES[0]} alt="Ada Lovelace" />
+            <AvatarFallback>AL</AvatarFallback>
+        </Avatar>
+    ),
+} satisfies Story
+
+// `size="sm"` (1.5rem) next to the default (2rem). The fallback text and any icon
+// track the circle size automatically.
+export const Sizes: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <Avatar size="sm">
+                <AvatarImage src={FACES[1]} alt="Grace Hopper" />
+                <AvatarFallback>GH</AvatarFallback>
+            </Avatar>
+            <Avatar size="default">
+                <AvatarImage src={FACES[1]} alt="Grace Hopper" />
+                <AvatarFallback>GH</AvatarFallback>
+            </Avatar>
+        </div>
+    ),
+} satisfies Story
+
+// Fallbacks render when there's no image: initials, or a bare lucide icon (sized
+// to ~60% of the circle by the component, so don't add a `size-*` class).
+export const Fallback: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <Avatar>
+                <AvatarFallback>JS</AvatarFallback>
+            </Avatar>
+            <Avatar>
+                <AvatarFallback>
+                    <UserIcon />
+                </AvatarFallback>
+            </Avatar>
+            <Avatar size="sm">
+                <AvatarFallback>
+                    <UserIcon />
+                </AvatarFallback>
+            </Avatar>
+        </div>
+    ),
+} satisfies Story
+
+// A broken `src` falls back to the initials. (Base UI swaps to the fallback once
+// the image errors.)
+export const BrokenImage: Story = {
+    render: () => (
+        <Avatar>
+            <AvatarImage src="https://example.com/does-not-exist.png" alt="Missing" />
+            <AvatarFallback>MK</AvatarFallback>
+        </Avatar>
+    ),
+} satisfies Story
+
+// AvatarGroup, inline (default): a simple gapped row.
+export const Group: Story = {
+    render: () => (
+        <AvatarGroup>
+            {FACES.slice(0, 4).map((src, i) => (
+                <Avatar key={src}>
+                    <AvatarImage src={src} alt={`Member ${i + 1}`} />
+                    <AvatarFallback>M{i + 1}</AvatarFallback>
+                </Avatar>
+            ))}
+        </AvatarGroup>
+    ),
+} satisfies Story
+
+// `stacked` overlaps the avatars. Hover (or focus) the group: they spread back to
+// the inline gap via a pure `transform`, so the surrounding layout never reflows —
+// the avatars slide out over the space to their right.
+export const GroupStacked: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <span>Team</span>
+            <AvatarGroup stacked>
+                {FACES.map((src, i) => (
+                    <Avatar key={src}>
+                        <AvatarImage src={src} alt={`Member ${i + 1}`} />
+                        <AvatarFallback>M{i + 1}</AvatarFallback>
+                    </Avatar>
+                ))}
+            </AvatarGroup>
+            <span>(hover the avatars)</span>
+        </div>
+    ),
+} satisfies Story
+
+// Same layout as GroupStacked, but `reverse` anchors the pile to its right edge
+// and spreads left on hover — so the avatars slide out over the "Team" label to
+// their left instead of the text on their right. The rightmost avatar sits on top.
+export const GroupStackedReverse: Story = {
+    render: () => (
+        <div className="flex items-center gap-4">
+            <span>Team</span>
+            <AvatarGroup stacked reverse>
+                {FACES.map((src, i) => (
+                    <Avatar key={src}>
+                        <AvatarImage src={src} alt={`Member ${i + 1}`} />
+                        <AvatarFallback>M{i + 1}</AvatarFallback>
+                    </Avatar>
+                ))}
+            </AvatarGroup>
+            <span>(hover the avatars)</span>
+        </div>
+    ),
+} satisfies Story
+
+// A stacked group led by an overflow count (styled fallback). It sits first, so it
+// reads behind the faces; on hover the whole pile spreads.
+export const GroupStackedWithCount: Story = {
+    render: () => (
+        <AvatarGroup stacked>
+            <Avatar>
+                <AvatarFallback className="bg-primary/15 text-primary normal-case">+3</AvatarFallback>
+            </Avatar>
+            {FACES.slice(0, 3).map((src, i) => (
+                <Avatar key={src}>
+                    <AvatarImage src={src} alt={`Member ${i + 1}`} />
+                    <AvatarFallback>M{i + 1}</AvatarFallback>
+                </Avatar>
+            ))}
+        </AvatarGroup>
+    ),
+} satisfies Story
+
+// `size` on the group forwards to every Avatar child and tightens the stacked
+// overlap to match the smaller circles.
+export const GroupStackedSmall: Story = {
+    render: () => (
+        <AvatarGroup stacked size="sm">
+            {FACES.map((src, i) => (
+                <Avatar key={src}>
+                    <AvatarImage src={src} alt={`Member ${i + 1}`} />
+                    <AvatarFallback>M{i + 1}</AvatarFallback>
+                </Avatar>
+            ))}
+        </AvatarGroup>
+    ),
+} satisfies Story
+
+// Inline group where each avatar is a tooltip trigger. Wrap the group (or the app)
+// in a single TooltipProvider. The Avatar is the trigger via `render`, so it stays
+// hoverable and focusable.
+export const GroupWithTooltips: Story = {
+    render: () => (
+        <TooltipProvider>
+            <AvatarGroup>
+                {MEMBERS.slice(0, 4).map((m) => (
+                    <Tooltip key={m.src}>
+                        <TooltipTrigger
+                            render={
+                                <Avatar>
+                                    <AvatarImage src={m.src} alt={m.name} />
+                                    <AvatarFallback>{m.initials}</AvatarFallback>
+                                </Avatar>
+                            }
+                        />
+                        <TooltipContent>{m.name}</TooltipContent>
+                    </Tooltip>
+                ))}
+            </AvatarGroup>
+        </TooltipProvider>
+    ),
+} satisfies Story
+
+// Same, stacked: hovering an avatar both spreads the pile and shows its tooltip.
+export const GroupStackedWithTooltips: Story = {
+    render: () => (
+        <TooltipProvider>
+            <AvatarGroup stacked>
+                {MEMBERS.map((m) => (
+                    <Tooltip key={m.src}>
+                        <TooltipTrigger
+                            render={
+                                <Avatar>
+                                    <AvatarImage src={m.src} alt={m.name} />
+                                    <AvatarFallback>{m.initials}</AvatarFallback>
+                                </Avatar>
+                            }
+                        />
+                        <TooltipContent>{m.name}</TooltipContent>
+                    </Tooltip>
+                ))}
+            </AvatarGroup>
+        </TooltipProvider>
+    ),
+} satisfies Story
+
+// An avatar that links somewhere: `render` makes the Avatar an anchor, so it's
+// focusable (keyboard focus also triggers the stacked spread via `:focus-within`).
+export const GroupStackedWithLink: Story = {
+    render: () => (
+        <AvatarGroup stacked>
+            <Avatar
+                // eslint-disable-next-line react/forbid-elements
+                render={<a href="https://posthog.com" target="_blank" rel="noreferrer" aria-label={MEMBERS[0].name} />}
+            >
+                <AvatarImage src={MEMBERS[0].src} alt={MEMBERS[0].name} />
+                <AvatarFallback>{MEMBERS[0].initials}</AvatarFallback>
+            </Avatar>
+            {MEMBERS.slice(1).map((m) => (
+                <Avatar key={m.src}>
+                    <AvatarImage src={m.src} alt={m.name} />
+                    <AvatarFallback>{m.initials}</AvatarFallback>
+                </Avatar>
+            ))}
+        </AvatarGroup>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/avatar.stories.tsx
+++ b/packages/quill/packages/primitives/src/avatar.stories.tsx
@@ -32,11 +32,15 @@ export const Default: Story = {
     ),
 } satisfies Story
 
-// `size="sm"` (1.5rem) next to the default (2rem). The fallback text and any icon
-// track the circle size automatically.
+// `size="xs"` (1.25rem) and `"sm"` (1.5rem) next to the default (2rem). The
+// fallback text and any icon track the circle size automatically.
 export const Sizes: Story = {
     render: () => (
         <div className="flex items-center gap-4">
+            <Avatar size="xs">
+                <AvatarImage src={FACES[1]} alt="Grace Hopper" />
+                <AvatarFallback>GH</AvatarFallback>
+            </Avatar>
             <Avatar size="sm">
                 <AvatarImage src={FACES[1]} alt="Grace Hopper" />
                 <AvatarFallback>GH</AvatarFallback>

--- a/packages/quill/packages/primitives/src/avatar.stories.tsx
+++ b/packages/quill/packages/primitives/src/avatar.stories.tsx
@@ -196,9 +196,11 @@ export const GroupWithTooltips: Story = {
 } satisfies Story
 
 // Same, stacked: hovering an avatar both spreads the pile and shows its tooltip.
+// The tooltip delay matches the 200ms spread duration, so it appears once the
+// avatars have finished expanding rather than over a still-moving pile.
 export const GroupStackedWithTooltips: Story = {
     render: () => (
-        <TooltipProvider>
+        <TooltipProvider delay={200}>
             <AvatarGroup stacked>
                 {MEMBERS.map((m) => (
                     <Tooltip key={m.src}>

--- a/packages/quill/packages/primitives/src/avatar.stories.tsx
+++ b/packages/quill/packages/primitives/src/avatar.stories.tsx
@@ -218,20 +218,25 @@ export const GroupStackedWithTooltips: Story = {
     ),
 } satisfies Story
 
-// An avatar that links somewhere: `render` makes the Avatar an anchor, so it's
-// focusable (keyboard focus also triggers the stacked spread via `:focus-within`).
-export const GroupStackedWithLink: Story = {
+// Each avatar links to its member: `render` makes the Avatar's root an anchor, so
+// every one is focusable (keyboard focus also triggers the stacked spread via
+// `:focus-within`).
+export const GroupStackedWithLinks: Story = {
     render: () => (
         <AvatarGroup stacked>
-            <Avatar
-                // eslint-disable-next-line react/forbid-elements
-                render={<a href="https://posthog.com" target="_blank" rel="noreferrer" aria-label={MEMBERS[0].name} />}
-            >
-                <AvatarImage src={MEMBERS[0].src} alt={MEMBERS[0].name} />
-                <AvatarFallback>{MEMBERS[0].initials}</AvatarFallback>
-            </Avatar>
-            {MEMBERS.slice(1).map((m) => (
-                <Avatar key={m.src}>
+            {MEMBERS.map((m) => (
+                <Avatar
+                    key={m.src}
+                    render={
+                        // eslint-disable-next-line react/forbid-elements
+                        <a
+                            href={`https://posthog.com/${m.initials.toLowerCase()}`}
+                            target="_blank"
+                            rel="noreferrer"
+                            aria-label={m.name}
+                        />
+                    }
+                >
                     <AvatarImage src={m.src} alt={m.name} />
                     <AvatarFallback>{m.initials}</AvatarFallback>
                 </Avatar>

--- a/packages/quill/packages/primitives/src/avatar.tsx
+++ b/packages/quill/packages/primitives/src/avatar.tsx
@@ -5,7 +5,7 @@ import * as React from 'react'
 
 import { cn } from './lib/utils'
 
-type AvatarSize = 'default' | 'sm'
+type AvatarSize = 'default' | 'sm' | 'xs'
 
 const Avatar = React.forwardRef<
     HTMLSpanElement,

--- a/packages/quill/packages/primitives/src/avatar.tsx
+++ b/packages/quill/packages/primitives/src/avatar.tsx
@@ -1,0 +1,111 @@
+import './avatar.css'
+
+import { Avatar as AvatarPrimitive } from '@base-ui/react/avatar'
+import * as React from 'react'
+
+import { cn } from './lib/utils'
+
+type AvatarSize = 'default' | 'sm'
+
+const Avatar = React.forwardRef<
+    HTMLSpanElement,
+    React.ComponentProps<typeof AvatarPrimitive.Root> & { size?: AvatarSize }
+>(function Avatar({ className, size = 'default', ...props }, ref) {
+    return (
+        <AvatarPrimitive.Root
+            ref={ref}
+            data-quill
+            data-slot="avatar"
+            data-size={size}
+            className={cn('quill-avatar', className)}
+            {...props}
+        />
+    )
+})
+
+const AvatarImage = React.forwardRef<HTMLImageElement, React.ComponentProps<typeof AvatarPrimitive.Image>>(
+    function AvatarImage({ className, ...props }, ref) {
+        return (
+            <AvatarPrimitive.Image
+                ref={ref}
+                data-slot="avatar-image"
+                className={cn('quill-avatar__image', className)}
+                {...props}
+            />
+        )
+    }
+)
+
+const AvatarFallback = React.forwardRef<HTMLSpanElement, React.ComponentProps<typeof AvatarPrimitive.Fallback>>(
+    function AvatarFallback({ className, ...props }, ref) {
+        return (
+            <AvatarPrimitive.Fallback
+                ref={ref}
+                data-slot="avatar-fallback"
+                className={cn('quill-avatar__fallback', className)}
+                {...props}
+            />
+        )
+    }
+)
+
+// Overlapping pile of avatars. Inline (gapped) by default; `stacked` overlaps
+// them and, on hover/focus, spreads them back to the inline gap. The spread is a
+// `transform` (not margin/width), so the container box never changes — siblings
+// don't reflow, the avatars just slide out over whatever sits beside them.
+// `reverse` anchors the pile to its right edge and spreads left instead (and puts
+// the rightmost avatar on top). `size` forwards to any Avatar child that doesn't
+// set its own, and tunes the stacked overlap so small and default piles look right.
+function AvatarGroup({
+    className,
+    stacked = false,
+    reverse = false,
+    size = 'default',
+    children,
+    style,
+    ...props
+}: React.ComponentProps<'div'> & { stacked?: boolean; reverse?: boolean; size?: AvatarSize }): React.ReactElement {
+    const items = React.Children.toArray(children)
+    return (
+        <div
+            data-quill
+            data-slot="avatar-group"
+            data-stacked={stacked ? '' : undefined}
+            data-reverse={reverse ? '' : undefined}
+            data-size={size}
+            className={cn('quill-avatar-group', className)}
+            // Count drives the z-order and the reverse spread math; declared last so
+            // a caller's `style` can't clobber it.
+            style={{ ...style, '--avatar-count': items.length } as React.CSSProperties}
+            {...props}
+        >
+            {items.map((child, index) => {
+                // Forward the group size to bare Avatar children (those without an
+                // explicit size); leave anything else (a count chip, etc.) untouched.
+                const content =
+                    React.isValidElement<{ size?: AvatarSize }>(child) &&
+                    child.type === Avatar &&
+                    child.props.size === undefined
+                        ? React.cloneElement(child, { size })
+                        : child
+                return (
+                    <span
+                        // The index drives the per-avatar hover translate; order is stable, so the index key is fine.
+                        key={index}
+                        data-slot="avatar-group-item"
+                        className="quill-avatar-group__item"
+                        style={{ '--avatar-index': index } as React.CSSProperties}
+                    >
+                        {content}
+                    </span>
+                )
+            })}
+        </div>
+    )
+}
+
+Avatar.displayName = 'Avatar'
+AvatarImage.displayName = 'AvatarImage'
+AvatarFallback.displayName = 'AvatarFallback'
+
+export { Avatar, AvatarImage, AvatarFallback, AvatarGroup }

--- a/packages/quill/packages/primitives/src/card.css
+++ b/packages/quill/packages/primitives/src/card.css
@@ -104,6 +104,21 @@
         padding-inline: 0.75rem;
     }
 
+    /* `flush`: let a full-bleed child (Table, chart) reach the card's edges. Drops
+       the inter-section gap and bottom block padding on the card, and the inline
+       padding on its CardContent — so the header keeps its own padding + divider
+       while the content below runs corner to corner. Replaces the
+       `gap-0 pb-0` (Card) + `p-0` (CardContent) className combo. Declared after the
+       size rules above so it wins at equal specificity for a `size="sm" flush` card. */
+    .quill-card[data-flush] {
+        gap: 0;
+        padding-bottom: 0;
+    }
+
+    .quill-card[data-flush] > [data-slot='card-content'] {
+        padding-inline: 0;
+    }
+
     .quill-card__footer {
         display: flex;
         align-items: center;

--- a/packages/quill/packages/primitives/src/card.stories.tsx
+++ b/packages/quill/packages/primitives/src/card.stories.tsx
@@ -39,12 +39,14 @@ export const Default: Story = {
 export const Sizes: Story = {
     render: () => (
         <div className="flex flex-col gap-4 max-w-sm">
-            <Card size='sm'>
+            <Card size="sm">
                 <CardHeader>
                     <CardTitle>Small size</CardTitle>
                     <CardDescription>Card Description</CardDescription>
                     <CardAction>
-                        <Button size="icon"><MoreVertical /></Button>
+                        <Button size="icon">
+                            <MoreVertical />
+                        </Button>
                     </CardAction>
                 </CardHeader>
                 <CardFooter className="flex-col gap-2">
@@ -56,12 +58,14 @@ export const Sizes: Story = {
                     </Button>
                 </CardFooter>
             </Card>
-            <Card size='sm'>
+            <Card size="sm">
                 <CardHeader>
                     <CardTitle>Small size</CardTitle>
                     <CardDescription>Card Description</CardDescription>
                     <CardAction>
-                        <Button size="icon"><MoreVertical /></Button>
+                        <Button size="icon">
+                            <MoreVertical />
+                        </Button>
                     </CardAction>
                 </CardHeader>
                 <CardContent>
@@ -81,7 +85,9 @@ export const Sizes: Story = {
                     <CardTitle>Default size</CardTitle>
                     <CardDescription>Card Description</CardDescription>
                     <CardAction>
-                        <Button size="icon"><MoreVertical /></Button>
+                        <Button size="icon">
+                            <MoreVertical />
+                        </Button>
                     </CardAction>
                 </CardHeader>
                 <CardFooter className="flex-col gap-2">
@@ -98,7 +104,9 @@ export const Sizes: Story = {
                     <CardTitle>Default size</CardTitle>
                     <CardDescription>Card Description</CardDescription>
                     <CardAction>
-                        <Button size="icon"><MoreVertical /></Button>
+                        <Button size="icon">
+                            <MoreVertical />
+                        </Button>
                     </CardAction>
                 </CardHeader>
                 <CardContent>
@@ -114,6 +122,25 @@ export const Sizes: Story = {
                 </CardFooter>
             </Card>
         </div>
+    ),
+} satisfies Story
+
+// `flush` lets a full-bleed child (here a tinted block standing in for a Table or
+// chart) run to the card's rounded edges: the card drops its section gap + bottom
+// padding and the CardContent its inline padding, while the header keeps its own.
+export const Flush: Story = {
+    render: () => (
+        <Card flush className="max-w-sm">
+            <CardHeader>
+                <CardTitle>Revenue</CardTitle>
+                <CardDescription>Last 30 days</CardDescription>
+            </CardHeader>
+            <CardContent>
+                <div className="flex h-40 items-center justify-center bg-muted text-muted-foreground">
+                    Full-bleed content (Table / chart)
+                </div>
+            </CardContent>
+        </Card>
     ),
 } satisfies Story
 
@@ -168,38 +195,38 @@ export const CardWithItems: Story = {
                 <CardTitle>Team members</CardTitle>
             </CardHeader>
             <CardContent className="py-0">
-                    <ItemGroup>
-                        <Item
-                            variant="pressable"
-                            render={
-                                // eslint-disable-next-line react/forbid-elements
-                                <a href="#">
-                                    <ItemMedia variant="icon">
-                                        <UserIcon />
-                                    </ItemMedia>
-                                    <ItemContent>
-                                        <ItemTitle>Alice</ItemTitle>
-                                        <ItemDescription>Admin</ItemDescription>
-                                    </ItemContent>
-                                </a>
-                            }
-                        />
-                        <Item
-                            variant="pressable"
-                            render={
-                                // eslint-disable-next-line react/forbid-elements
-                                <a href="#">
-                                    <ItemMedia variant="icon">
-                                        <UserIcon />
-                                    </ItemMedia>
-                                    <ItemContent>
-                                        <ItemTitle>Bob</ItemTitle>
-                                        <ItemDescription>Member</ItemDescription>
-                                    </ItemContent>
-                                </a>
-                            }
-                        />
-                    </ItemGroup>
+                <ItemGroup>
+                    <Item
+                        variant="pressable"
+                        render={
+                            // eslint-disable-next-line react/forbid-elements
+                            <a href="#">
+                                <ItemMedia variant="icon">
+                                    <UserIcon />
+                                </ItemMedia>
+                                <ItemContent>
+                                    <ItemTitle>Alice</ItemTitle>
+                                    <ItemDescription>Admin</ItemDescription>
+                                </ItemContent>
+                            </a>
+                        }
+                    />
+                    <Item
+                        variant="pressable"
+                        render={
+                            // eslint-disable-next-line react/forbid-elements
+                            <a href="#">
+                                <ItemMedia variant="icon">
+                                    <UserIcon />
+                                </ItemMedia>
+                                <ItemContent>
+                                    <ItemTitle>Bob</ItemTitle>
+                                    <ItemDescription>Member</ItemDescription>
+                                </ItemContent>
+                            </a>
+                        }
+                    />
+                </ItemGroup>
             </CardContent>
         </Card>
     ),

--- a/packages/quill/packages/primitives/src/card.tsx
+++ b/packages/quill/packages/primitives/src/card.tsx
@@ -1,18 +1,21 @@
+import './card.css'
+
 import * as React from 'react'
 
-import './card.css'
 import { cn } from './lib/utils'
 
 function Card({
     className,
     size = 'default',
+    flush = false,
     ...props
-}: React.ComponentProps<'div'> & { size?: 'default' | 'sm' }): React.ReactElement {
+}: React.ComponentProps<'div'> & { size?: 'default' | 'sm'; flush?: boolean }): React.ReactElement {
     return (
         <div
             data-quill
             data-slot="card"
             data-size={size}
+            data-flush={flush ? '' : undefined}
             className={cn('quill-card group/card flex flex-col', className)}
             {...props}
         />
@@ -20,13 +23,7 @@ function Card({
 }
 
 function CardHeader({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
-    return (
-        <div
-            data-slot="card-header"
-            className={cn('quill-card__header group/card-header', className)}
-            {...props}
-        />
-    )
+    return <div data-slot="card-header" className={cn('quill-card__header group/card-header', className)} {...props} />
 }
 
 const CardTitle = React.forwardRef<HTMLDivElement, React.ComponentProps<'div'>>(({ className, ...props }, ref) => (

--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -30,6 +30,7 @@ export {
     AutocompleteValue,
     useAutocompleteAnchor,
 } from './autocomplete'
+export { Avatar, AvatarImage, AvatarFallback, AvatarGroup } from './avatar'
 export { Badge, badgeVariants } from './badge'
 export { Button, buttonVariants, type ButtonProps } from './button'
 export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants } from './button-group'

--- a/packages/quill/packages/primitives/src/table.css
+++ b/packages/quill/packages/primitives/src/table.css
@@ -145,6 +145,14 @@
         border-bottom: none;
     }
 
+    /* `size="sm"`: tighten head/cell inline padding so the edge columns align with
+       a `Card size="sm"` (0.75rem inline). Block padding and the header's negative
+       button margin are unchanged. */
+    .quill-table[data-size='sm'] .quill-table__head,
+    .quill-table[data-size='sm'] .quill-table__cell {
+        padding-inline: 0.75rem;
+    }
+
     /* Full-span empty cell. height:100% claims the lone body row's height (which
        fills a height-bounded Table), and the inner flex column resolves that
        height so children — including Empty's own flex-1 — stretch and center.

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { ChevronsUpDown, Inbox, MoreHorizontal, Plus } from 'lucide-react'
 import * as React from 'react'
 
+import { Avatar, AvatarFallback, AvatarGroup, AvatarImage } from './avatar'
 import { Badge } from './badge'
 import { Button } from './button'
 import { Card, CardContent, CardHeader, CardTitle } from './card'
@@ -25,6 +26,7 @@ import {
     TableHeader,
     TableRow,
 } from './table'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './tooltip'
 
 const meta = {
     title: 'Primitives/Table',
@@ -258,6 +260,60 @@ const manyRows = Array.from({ length: 40 }, (_, i) => ({
     role: i % 3 === 0 ? 'Admin' : 'Member',
     status: i % 4 === 0 ? 'Invited' : 'Active',
 }))
+
+const TEAM = ['Ada', 'Grace', 'Alan', 'Katherine', 'Edsger', 'Linus', 'Margaret', 'Donald', 'Barbara']
+
+// Avatars inside table cells: a stacked `size="xs"` AvatarGroup "Team" column
+// (last, so its hover spread runs into empty space), each avatar a tooltip trigger.
+// One TooltipProvider wraps the table; its delay matches the 200ms spread so a name
+// shows once the pile has finished expanding. The avatars sit on the table surface,
+// so the group's ring keeps its default (app background) here.
+export const WithAvatars: Story = {
+    render: () => (
+        <TooltipProvider delay={200}>
+            <Table className="max-w-2xl">
+                <TableHeader>
+                    <TableRow>
+                        <TableHead expand>Member</TableHead>
+                        <TableHead>Role</TableHead>
+                        <TableHead>Team</TableHead>
+                    </TableRow>
+                </TableHeader>
+                <TableBody>
+                    {manyRows.slice(0, 6).map((row, i) => (
+                        <TableRow key={row.id}>
+                            <TableCell className="font-medium">{row.name}</TableCell>
+                            <TableCell>{row.role}</TableCell>
+                            <TableCell>
+                                <AvatarGroup stacked size="xs" reverse>
+                                    {Array.from({ length: 3 }, (_, j) => {
+                                        const name = TEAM[(i * 3 + j) % TEAM.length]
+                                        return (
+                                            <Tooltip key={j}>
+                                                <TooltipTrigger
+                                                    render={
+                                                        <Avatar size="xs">
+                                                            <AvatarImage
+                                                                src={`https://i.pravatar.cc/48?img=${i * 3 + j + 20}`}
+                                                                alt={name}
+                                                            />
+                                                            <AvatarFallback>{name[0]}</AvatarFallback>
+                                                        </Avatar>
+                                                    }
+                                                />
+                                                <TooltipContent>{name}</TooltipContent>
+                                            </Tooltip>
+                                        )
+                                    })}
+                                </AvatarGroup>
+                            </TableCell>
+                        </TableRow>
+                    ))}
+                </TableBody>
+            </Table>
+        </TooltipProvider>
+    ),
+} satisfies Story
 
 export const StickyHeader: Story = {
     render: () => (

--- a/packages/quill/packages/primitives/src/table.stories.tsx
+++ b/packages/quill/packages/primitives/src/table.stories.tsx
@@ -4,7 +4,7 @@ import * as React from 'react'
 
 import { Badge } from './badge'
 import { Button } from './button'
-import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './empty'
+import { Card, CardContent, CardHeader, CardTitle } from './card'
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -12,6 +12,7 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from './dropdown-menu'
+import { Empty, EmptyContent, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from './empty'
 import { ItemContent, ItemDescription, ItemTitle } from './item'
 import {
     Table,
@@ -24,7 +25,6 @@ import {
     TableHeader,
     TableRow,
 } from './table'
-import { Card, CardContent, CardHeader, CardTitle } from './card'
 
 const meta = {
     title: 'Primitives/Table',
@@ -595,40 +595,79 @@ export const EmptyState: Story = {
     ),
 } satisfies Story
 
-// Table flush inside a Card: `gap-0 pb-0` on the Card + `p-0` on CardContent let
-// the transparent cells reach the card's rounded edges with no double padding.
+// Table flush inside a Card: the `flush` prop drops the card's section gap +
+// bottom padding and the CardContent inline padding, so the transparent cells
+// reach the card's rounded edges with no double padding.
 export const InCard: Story = {
     render: () => (
-        <Card className="gap-0 pb-0">
+        <Card flush>
             <CardHeader>
                 <CardTitle>Table in Card</CardTitle>
             </CardHeader>
-            <CardContent className="p-0">
-
-            <Table fullWidth>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead>Name</TableHead>
-                        <TableHead>Email</TableHead>
-                        <TableHead>Role</TableHead>
-                        <TableHead className="w-0">
-                            <span className="sr-only">Actions</span>
-                        </TableHead>
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {manyRows.slice(0, 6).map((row) => (
-                        <TableRow key={row.id} className="group/row">
-                            <TableCell className="font-medium">{row.name}</TableCell>
-                            <TableCell>{row.email}</TableCell>
-                            <TableCell>{row.role}</TableCell>
-                            <TableCell className="w-0 text-right">
-                                <ActionsMenu label={`Actions for ${row.name}`} />
-                            </TableCell>
+            <CardContent>
+                <Table fullWidth>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Email</TableHead>
+                            <TableHead>Role</TableHead>
+                            <TableHead className="w-0">
+                                <span className="sr-only">Actions</span>
+                            </TableHead>
                         </TableRow>
-                    ))}
-                </TableBody>
-            </Table>
+                    </TableHeader>
+                    <TableBody>
+                        {manyRows.slice(0, 6).map((row) => (
+                            <TableRow key={row.id} className="group/row">
+                                <TableCell className="font-medium">{row.name}</TableCell>
+                                <TableCell>{row.email}</TableCell>
+                                <TableCell>{row.role}</TableCell>
+                                <TableCell className="w-0 text-right">
+                                    <ActionsMenu label={`Actions for ${row.name}`} />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
+            </CardContent>
+        </Card>
+    ),
+} satisfies Story
+
+// Dense table flush inside a `Card size="sm"`: `size="sm"` on the Table tightens
+// its head/cell inline padding to 0.75rem so the edge columns line up with the
+// card header title (also 0.75rem at `size="sm"`).
+export const InCardSmall: Story = {
+    render: () => (
+        <Card size="sm" flush>
+            <CardHeader>
+                <CardTitle>Table in small Card</CardTitle>
+            </CardHeader>
+            <CardContent>
+                <Table size="sm" fullWidth>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Email</TableHead>
+                            <TableHead>Role</TableHead>
+                            <TableHead className="w-0">
+                                <span className="sr-only">Actions</span>
+                            </TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        {manyRows.slice(0, 6).map((row) => (
+                            <TableRow key={row.id} className="group/row">
+                                <TableCell className="font-medium">{row.name}</TableCell>
+                                <TableCell>{row.email}</TableCell>
+                                <TableCell>{row.role}</TableCell>
+                                <TableCell className="w-0 text-right">
+                                    <ActionsMenu label={`Actions for ${row.name}`} />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
             </CardContent>
         </Card>
     ),
@@ -638,41 +677,39 @@ export const InCard: Story = {
 // short table still fills a taller card body.
 export const InCardMinHeight: Story = {
     render: () => (
-        <Card className="gap-0 pb-0 min-h-120">
+        <Card flush className="min-h-120">
             <CardHeader>
                 <CardTitle>Table in Card</CardTitle>
             </CardHeader>
-            <CardContent className="p-0">
-
-            <Table fullWidth>
-                <TableHeader>
-                    <TableRow>
-                        <TableHead>Name</TableHead>
-                        <TableHead>Email</TableHead>
-                        <TableHead>Role</TableHead>
-                        <TableHead className="w-0">
-                            <span className="sr-only">Actions</span>
-                        </TableHead>
-                    </TableRow>
-                </TableHeader>
-                <TableBody>
-                    {manyRows.slice(0, 6).map((row) => (
-                        <TableRow key={row.id} className="group/row">
-                            <TableCell className="font-medium">{row.name}</TableCell>
-                            <TableCell>{row.email}</TableCell>
-                            <TableCell>{row.role}</TableCell>
-                            <TableCell className="w-0 text-right">
-                                <ActionsMenu label={`Actions for ${row.name}`} />
-                            </TableCell>
+            <CardContent>
+                <Table fullWidth>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead>Name</TableHead>
+                            <TableHead>Email</TableHead>
+                            <TableHead>Role</TableHead>
+                            <TableHead className="w-0">
+                                <span className="sr-only">Actions</span>
+                            </TableHead>
                         </TableRow>
-                    ))}
-                </TableBody>
-            </Table>
+                    </TableHeader>
+                    <TableBody>
+                        {manyRows.slice(0, 6).map((row) => (
+                            <TableRow key={row.id} className="group/row">
+                                <TableCell className="font-medium">{row.name}</TableCell>
+                                <TableCell>{row.email}</TableCell>
+                                <TableCell>{row.role}</TableCell>
+                                <TableCell className="w-0 text-right">
+                                    <ActionsMenu label={`Actions for ${row.name}`} />
+                                </TableCell>
+                            </TableRow>
+                        ))}
+                    </TableBody>
+                </Table>
             </CardContent>
         </Card>
     ),
 } satisfies Story
-
 
 // Sticky header inside a Card: a definite height (`h-96`, not `max-h-*` — the
 // scroll viewport needs a resolved height) makes the body scroll, and
@@ -681,11 +718,11 @@ export const InCardMinHeight: Story = {
 // so the frozen header matches — here via a Tailwind arbitrary property.
 export const InCardStickyHeader: Story = {
     render: () => (
-        <Card className="gap-0 pb-0">
+        <Card flush>
             <CardHeader>
                 <CardTitle>Table in Card</CardTitle>
             </CardHeader>
-            <CardContent className="p-0">
+            <CardContent>
                 <Table fullWidth stickyHeader className="h-96 [--quill-table-sticky-bg:var(--card)]">
                     <TableHeader>
                         <TableRow>
@@ -713,11 +750,11 @@ export const InCardStickyHeader: Story = {
 // min-h → CardContent flex-1 → Table h-full. Simplest form is just muted text.
 export const InCardEmptyText: Story = {
     render: () => (
-        <Card className="min-h-120 gap-0 pb-0">
+        <Card flush className="min-h-120">
             <CardHeader>
                 <CardTitle>Table in Card Empty Text</CardTitle>
             </CardHeader>
-            <CardContent className="flex-1 p-0">
+            <CardContent className="flex-1">
                 <Table fullWidth className="h-full">
                     <TableHeader>
                         <TableRow>
@@ -743,11 +780,11 @@ export const InCardEmptyText: Story = {
 // TableEmpty — same primitive, richer content, still centered and stretched.
 export const InCardEmptyBlock: Story = {
     render: () => (
-        <Card className="min-h-120 gap-0 pb-0">
+        <Card flush className="min-h-120">
             <CardHeader>
                 <CardTitle>Members</CardTitle>
             </CardHeader>
-            <CardContent className="flex-1 p-0">
+            <CardContent className="flex-1">
                 <Table fullWidth className="h-full">
                     <TableHeader>
                         <TableRow>

--- a/packages/quill/packages/primitives/src/table.tsx
+++ b/packages/quill/packages/primitives/src/table.tsx
@@ -85,6 +85,12 @@ type TableProps = React.ComponentProps<'table'> & {
      * one soaks up the slack; otherwise the extra width spreads across columns.
      */
     fullWidth?: boolean
+    /**
+     * Cell density. `'sm'` tightens the head/cell inline padding to `0.75rem`
+     * (from `1rem`) so the table's edge columns line up with a `Card size="sm"`'s
+     * `0.75rem` inline padding. Pair with `Card size="sm" flush`.
+     */
+    size?: 'default' | 'sm'
     /** Classes for the inner `<table>`. Size/scroll go on the container via `className`. */
     tableClassName?: string
     /** Ref to the scrolling viewport — for scroll-to-row, virtualization, IntersectionObservers, etc. */
@@ -94,7 +100,7 @@ type TableProps = React.ComponentProps<'table'> & {
 // The forwarded ref points at the `<table>` element (consistent with `...props`,
 // which also land there). The scroll container is reached via `viewportRef`.
 const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
-    { className, tableClassName, stickyHeader = false, fullWidth = false, viewportRef, ...props },
+    { className, tableClassName, stickyHeader = false, fullWidth = false, size = 'default', viewportRef, ...props },
     ref
 ) {
     const rootRef = React.useRef<HTMLDivElement | null>(null)
@@ -121,6 +127,7 @@ const Table = React.forwardRef<HTMLTableElement, TableProps>(function Table(
                     data-slot="table"
                     data-sticky-header={stickyHeader ? '' : undefined}
                     data-full-width={fullWidth ? '' : undefined}
+                    data-size={size}
                     className={cn('quill-table', tableClassName)}
                     {...props}
                 />
@@ -198,19 +205,20 @@ const TableCell = React.forwardRef<HTMLTableCellElement, React.ComponentProps<'t
 // browsers clamp it to the real column count, so callers rarely set it. The cell
 // stretches to the table's body height (give the Table a height to fill it) and
 // centers its content — drop in `<Empty>` or plain text, no `h-full` needed.
-const TableEmpty = React.forwardRef<HTMLTableCellElement, React.ComponentProps<'td'>>(
-    function TableEmpty({ className, colSpan = 1000, children, ...props }, ref) {
-        return (
-            <tbody data-slot="table-empty">
-                <tr>
-                    <td ref={ref} colSpan={colSpan} className={cn('quill-table__empty', className)} {...props}>
-                        <div className="quill-table__empty-inner">{children}</div>
-                    </td>
-                </tr>
-            </tbody>
-        )
-    }
-)
+const TableEmpty = React.forwardRef<HTMLTableCellElement, React.ComponentProps<'td'>>(function TableEmpty(
+    { className, colSpan = 1000, children, ...props },
+    ref
+) {
+    return (
+        <tbody data-slot="table-empty">
+            <tr>
+                <td ref={ref} colSpan={colSpan} className={cn('quill-table__empty', className)} {...props}>
+                    <div className="quill-table__empty-inner">{children}</div>
+                </td>
+            </tr>
+        </tbody>
+    )
+})
 
 const TableCaption = React.forwardRef<HTMLTableCaptionElement, React.ComponentProps<'caption'>>(function TableCaption(
     { className, ...props },


### PR DESCRIPTION
## Problem

Building flush data-viz cards in quill meant repeating the same className combo on every card (`gap-0 pb-0` on the Card, `p-0` on the CardContent), and a `Table` inside a `Card size="sm"` didn't align — its cells hardcoded `1rem` inline padding against the card's `0.75rem`. Separately, quill had no avatar primitive, so member/owner lists were hand-rolled.

<img width="602" height="244" alt="2026-06-23 13 44 23" src="https://github.com/user-attachments/assets/e178d934-21d4-4cdd-8f75-b2279f6f6931" />


<img width="1684" height="752" alt="2026-06-23 13 45 28" src="https://github.com/user-attachments/assets/9d3b8ddb-91cd-432e-b3da-d56865464b96" />


## Changes

Three quill primitives changes, all additive.

**Table** — new `size="sm"` tightens head/cell inline padding to `0.75rem` (from `1rem`) for dense tables and to line edge columns up with a `Card size="sm"`. `DataTable` forwards `size` through.

**Card** — new `flush` boolean. It drops the card's section gap + bottom padding and the `CardContent`'s inline padding so a full-bleed child (a `Table`, a chart) runs to the card's rounded edges. Replaces the `gap-0 pb-0` + `p-0` className combo with one prop; the header keeps its own padding + divider.

**Avatar / AvatarGroup** — wraps Base UI Avatar as `Avatar` / `AvatarImage` / `AvatarFallback` with a `size` (default | sm). `AvatarGroup` is inline by default, `stacked` to overlap; on hover/focus a stacked group spreads back to the inline gap using `transform` only, so the container never reflows and the avatars slide out over whatever sits beside them. `reverse` anchors the pile to its right edge and spreads left. `size` forwards to bare Avatar children and tunes the overlap. A leading (or trailing, in reverse) `+N` count built from a styled `AvatarFallback` reads on top.

Stories cover every variant; AGENTS.md catalog + composition guides updated in the same PR.

## How did you test this code?

I'm an agent (Claude Code). I did not manually test in a browser. Automated checks run:

- `pnpm --filter @posthog/quill-primitives build` and `--filter @posthog/quill-components build` — both green (includes the vite-dts type check).
- `oxlint` on the changed `.tsx` files — 0 warnings, 0 errors.
- `oxfmt` on changed sources.

Visual behavior (flush card alignment, stacked spread, hover hit-bridge, tooltips, link focus spread) is exercised by the Storybook stories but not yet eyeballed by a human — worth a quick Storybook pass on `Primitives/Avatar`, `Primitives/Card`, and `Primitives/Table`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by @adamleithp.

Built with Claude Code over an iterative session. Notable decisions:

- **Table density: prop, not contextual CSS.** Considered a descendant selector that auto-aligns a `Table` inside `Card size="sm"`, but that couples table CSS to card and only works in cards. Chose an explicit `size="sm"` prop — decoupled, reusable for any dense table.
- **Flush as a Card prop.** The bleed adjustments span both Card and CardContent, so a single `flush` boolean on Card that cascades via CSS (no className on the content) was the cleanest headless API. Hit and fixed an equal-specificity collision where the `size="sm"` content padding rule beat `flush`; resolved by ordering the flush rules after the size rules.
- **Avatar group spread is transform-only.** The hover spread had to expand the pile without reflowing neighbors, so it animates `transform: translateX` (per-item, driven by a CSS index var) rather than margins/width — the container box is unchanged. Added invisible per-item hit bridges so the gaps in a spread pile stay hoverable (no flicker), gated `:hover` behind `(hover: hover) and (pointer: fine)` so touch taps don't stick it open, and kept `:focus-within` for keyboard users.
- **Animation review** via the public `/web-animation-design` skill: switched the spread easing from `ease` to `ease-in-out-cubic` (on-screen reposition, not a hover-color change), 160ms → 200ms, added `will-change` and `prefers-reduced-motion`.

Agent-authored; requires human review.
