### PR TITLE
feat(data-warehouse): enable QUALIFY for Snowflake

### DIFF
--- a/posthog/hogql/printer/hogql.py
+++ b/posthog/hogql/printer/hogql.py
@@ -15,6 +15,13 @@ class HogQLPrinter(BasePrinter):
 
     DIALECT_NAME: ClassVar[HogQLDialect] = "hogql"
 
+    def _assert_qualify_supported(self) -> None:
+        # QUALIFY is valid HogQL (the grammar and resolver support it), so the canonical
+        # round-trip must print it back rather than reject — otherwise any query carrying a
+        # QUALIFY clause fails when `query.py` renders `self.hogql` for the response, before
+        # the target dialect ever runs.
+        return
+
     def visit_cte(self, node: ast.CTE) -> str:
         materialization_hint = (
             "" if node.materialized is None else ("MATERIALIZED " if node.materialized else "NOT MATERIALIZED ")

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -7165,3 +7165,9 @@ class TestSnowflakePrinter(BaseTest):
         with self.assertRaises(QueryError) as ctx:
             self._select(query)
         self.assertIn(error_substring, str(ctx.exception))
+
+    def test_snowflake_qualify_emits_natively(self):
+        # QUALIFY parses and resolves but the base/HogQL printers rejected it; Snowflake supports
+        # it natively, so it should print straight through.
+        sql = self._select("SELECT event FROM events QUALIFY row_number() OVER (ORDER BY timestamp) = 1")
+        self.assertIn("QUALIFY", sql)


### PR DESCRIPTION
## Problem

Stacked on #65425.

The grammar-differential triage flagged a "Tier 1" class: SELECT constructs that the HogQL grammar parses *and* the resolver handles, but which were rejected before printing — even though Snowflake supports them natively. This PR enables `QUALIFY`.

## Changes

- **QUALIFY.** It was rejected by the HogQL round-trip printer (`query.py` renders `self.hogql` via `dialect="hogql"` for the response, *before* the target dialect runs). QUALIFY is valid HogQL — grammar, AST, and resolver all support it — so the round-trip printer now prints it back instead of raising. The Snowflake printer already permits it (inherited from Postgres), so it emits `QUALIFY <expr>` natively. The ClickHouse execution path is unchanged (still rejected there).

## Validated against a live Snowflake source

Verified end-to-end through the local MCP against a real Snowflake direct-query source (TPC-H sample data):

```sql
SELECT N_NAME, N_REGIONKEY, row_number() OVER (PARTITION BY N_REGIONKEY ORDER BY N_NAME) AS rn
FROM TPCH_SF1.NATION QUALIFY rn = 1
```

returned one nation per region, correctly filtered.

## PIVOT / UNPIVOT deferred

This PR originally also enabled PIVOT/UNPIVOT (via a resolver dialect gate). Live validation showed that's **not** Snowflake-correct yet — two issues:

1. the base printer emits **table-qualified columns inside the `PIVOT(...)` clause**, which Snowflake rejects (`000904` invalid identifier), and
2. the post-pivot `SELECT *` column projection is wrong (expands to the source columns, not the pivoted output).

Both need a Snowflake-specific implementation with live iteration, so PIVOT/UNPIVOT were pulled from this PR and remain cleanly rejected at resolution. Tracking as a follow-up.

## How did you test this code?

I'm an agent (Claude Code); the QUALIFY behavior was validated against a live Snowflake source via the local MCP (above). Automated: **1052 passed, 1 xfailed** across the full printer suite (all dialects — the shared HogQL-printer change), `test_resolver`, and `test_direct_snowflake_query`. `ruff` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Tool:** Claude Code (Opus 4.8).
- **Scope change mid-review:** PIVOT/UNPIVOT were dropped after live Snowflake validation proved them broken (qualified columns + wrong column projection); shipping them would have emitted invalid SQL. QUALIFY is the validated, working half.
- **Blast radius:** the QUALIFY change touches only the canonical HogQL round-trip printer (display) and dialects that already permit QUALIFY at their own printer; ClickHouse still rejects it. Full-suite regression confirms no dialect broke.
