### PR TITLE
feat(tracing): add p99 to operations aggregate

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -576,6 +576,9 @@
                 "p95_duration_nano": {
                     "type": "number"
                 },
+                "p99_duration_nano": {
+                    "type": "number"
+                },
                 "service_name": {
                     "type": "string"
                 },
@@ -591,6 +594,7 @@
                 "avg_duration_nano",
                 "p50_duration_nano",
                 "p95_duration_nano",
+                "p99_duration_nano",
                 "error_count"
             ],
             "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -3295,6 +3295,7 @@ export interface AggregatedSpanRow {
     avg_duration_nano: number
     p50_duration_nano: number
     p95_duration_nano: number
+    p99_duration_nano: number
     error_count: integer
 }
 

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -3104,6 +3104,7 @@ class AggregatedSpanRow(BaseModel):
     name: str
     p50_duration_nano: float
     p95_duration_nano: float
+    p99_duration_nano: float
     service_name: str
     total_duration_nano: float
 

--- a/products/tracing/backend/aggregation_query_runner.py
+++ b/products/tracing/backend/aggregation_query_runner.py
@@ -268,6 +268,7 @@ class TraceSpansAggregationQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunn
                 avg(duration_nano) AS avg_duration_nano,
                 quantile(0.5)(duration_nano) AS p50_duration_nano,
                 quantile(0.95)(duration_nano) AS p95_duration_nano,
+                quantile(0.99)(duration_nano) AS p99_duration_nano,
                 countIf(status_code = 2) AS error_count
             FROM posthog.trace_spans
             WHERE {where}
@@ -298,7 +299,8 @@ class TraceSpansAggregationQueryRunner(_SpanAggregationMixin, AnalyticsQueryRunn
             avg_duration_nano=float(row[4] or 0),
             p50_duration_nano=float(row[5] or 0),
             p95_duration_nano=float(row[6] or 0),
-            error_count=row[7] or 0,
+            p99_duration_nano=float(row[7] or 0),
+            error_count=row[8] or 0,
         )
 
     def run(self, *args, **kwargs) -> TraceSpansAggregationQueryResponse | CachedTraceSpansAggregationQueryResponse:

--- a/products/tracing/backend/tests/test_aggregation_query_runner.py
+++ b/products/tracing/backend/tests/test_aggregation_query_runner.py
@@ -6,7 +6,7 @@ from posthog.schema import DateRange
 
 from posthog.clickhouse.client import sync_execute
 
-from products.tracing.backend.logic import run_tree_query
+from products.tracing.backend.logic import run_aggregation_query, run_tree_query
 from products.tracing.backend.tests.test_keyset_pagination import DATE_FROM, DATE_TO, _b64, _TraceSpansTestBase
 
 # Child starts 40ms after its parent. In nanoseconds that's 40_000_000 — the unit the
@@ -111,3 +111,45 @@ class TestTraceSpansTreeCallRatio(_TraceSpansTestBase):
         )
         root_edge = next(node for node in response.results if node.parent_name == "<ROOT>")
         self.assertIsNone(root_edge.calls_per_parent_invocation)
+
+
+class TestTraceSpansFlatAggregationPercentiles(_TraceSpansTestBase):
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        cls._recreate_trace_spans_tables()
+
+        # Four spans for one operation, all exactly 100ms long, so every percentile (p50/p95/p99)
+        # equals 100ms with no quantile-approximation ambiguity. One span errors (status_code = 2).
+        start = dt.datetime(2026, 6, 2, 8, 0, 0)
+        end = start + dt.timedelta(milliseconds=100)
+        start_str = start.strftime("%Y-%m-%d %H:%M:%S.%f")
+        end_str = end.strftime("%Y-%m-%d %H:%M:%S.%f")
+
+        rows: list[str] = []
+        for i in range(4):
+            trace_id = _b64((i + 1).to_bytes(16, "big"))
+            span_id = _b64((i + 1).to_bytes(8, "big"))
+            status_code = 2 if i == 0 else 1
+            rows.append(
+                f"('019e8761-0000-0000-0000-{i:012d}', {cls.team.id}, '{trace_id}', "
+                f"'{span_id}', '', 'checkout', 2, '{start_str}', '{end_str}', '{start_str}', {status_code}, 'web')"
+            )
+        sync_execute(
+            "INSERT INTO trace_spans (uuid, team_id, trace_id, span_id, parent_span_id, name, kind, "
+            "timestamp, end_time, observed_timestamp, status_code, service_name) VALUES " + ",".join(rows)
+        )
+
+    def test_flat_aggregation_reports_p99(self):
+        response = run_aggregation_query(
+            team=self.team,
+            date_range=DateRange(date_from=DATE_FROM, date_to=DATE_TO),
+        )
+        row = next(r for r in response.results if r.name == "checkout")
+        hundred_ms_nano = float(100 * 1_000_000)
+        self.assertEqual(row.count, 4)
+        self.assertEqual(row.error_count, 1)
+        self.assertEqual(row.p50_duration_nano, hundred_ms_nano)
+        self.assertEqual(row.p95_duration_nano, hundred_ms_nano)
+        self.assertEqual(row.p99_duration_nano, hundred_ms_nano)
+        self.assertEqual(row.total_duration_nano, 4 * hundred_ms_nano)

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8513,6 +8513,7 @@ export namespace Schemas {
       name: string;
       p50_duration_nano: number;
       p95_duration_nano: number;
+      p99_duration_nano: number;
       service_name: string;
       total_duration_nano: number;
     }


### PR DESCRIPTION
## Problem

The trace spans aggregation query exposes p50 and p95 latency percentiles but not p99, leaving users without visibility into tail latency for their services.

## Changes

Adds `p99_duration_nano` to the `AggregatedSpanRow` schema and wires it through the full stack:

- **Query**: adds `quantile(0.99)(duration_nano) AS p99_duration_nano` to the ClickHouse aggregation query
- **Row mapping**: shifts the `error_count` column index to account for the new p99 column
- **Schema**: `AggregatedSpanRow` updated in the TypeScript schema, generated JSON schema, Python schema, and MCP API types

## How did you test this code?

A new integration test class `TestTraceSpansFlatAggregationPercentiles` inserts four spans of identical 100ms duration (one erroring) and asserts that `p50_duration_nano`, `p95_duration_nano`, and `p99_duration_nano` all equal 100ms, with `error_count = 1` and `count = 4`. Using uniform durations avoids quantile-approximation ambiguity.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update