### PR TITLE
feat(experiments): separate exposures and metric-events query tags

### DIFF
--- a/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueriesImpl.tsx
+++ b/frontend/src/lib/components/AppShortcuts/utils/DebugCHQueriesImpl.tsx
@@ -411,7 +411,30 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
                                                     <span>{item.logComment.experiment_metric_name}</span>
                                                 </LemonTag>
                                             ) : null}
-                                            {typeof item.logComment.experiment_execution_path === 'string' ? (
+                                            {item.logComment.experiment_query_surface === 'precompute_build' ? (
+                                                <LemonTag type="warning" className="inline-block">
+                                                    build
+                                                    {typeof item.logComment.experiment_precompute_table === 'string'
+                                                        ? `: ${item.logComment.experiment_precompute_table}`
+                                                        : ''}
+                                                </LemonTag>
+                                            ) : null}
+                                            {/* Falls back to the deprecated experiment_execution_path for old rows. */}
+                                            {typeof item.logComment.experiment_exposures_path === 'string' ? (
+                                                <LemonTag
+                                                    type={
+                                                        item.logComment.experiment_exposures_path === 'precomputed'
+                                                            ? 'success'
+                                                            : 'default'
+                                                    }
+                                                    className="inline-block"
+                                                >
+                                                    exposures:{' '}
+                                                    {item.logComment.experiment_exposures_path === 'precomputed'
+                                                        ? 'precomputed'
+                                                        : 'direct'}
+                                                </LemonTag>
+                                            ) : typeof item.logComment.experiment_execution_path === 'string' ? (
                                                 <LemonTag
                                                     type={
                                                         item.logComment.experiment_execution_path === 'precomputed'
@@ -420,7 +443,26 @@ export function DebugCHQueries({ insightId, experimentId }: DebugCHQueriesProps)
                                                     }
                                                     className="inline-block"
                                                 >
-                                                    {item.logComment.experiment_execution_path}
+                                                    exposures:{' '}
+                                                    {item.logComment.experiment_execution_path === 'precomputed'
+                                                        ? 'precomputed'
+                                                        : 'direct'}
+                                                </LemonTag>
+                                            ) : null}
+                                            {typeof item.logComment.experiment_metric_events_path === 'string' &&
+                                            item.logComment.experiment_metric_events_path !== 'not_applicable' ? (
+                                                <LemonTag
+                                                    type={
+                                                        item.logComment.experiment_metric_events_path === 'precomputed'
+                                                            ? 'success'
+                                                            : 'default'
+                                                    }
+                                                    className="inline-block"
+                                                >
+                                                    events:{' '}
+                                                    {item.logComment.experiment_metric_events_path === 'precomputed'
+                                                        ? 'precomputed'
+                                                        : 'direct'}
                                                 </LemonTag>
                                             ) : null}
                                         </div>

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -195,15 +195,36 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Path',
-            width: 120,
+            width: 200,
             render: function Path(_, item) {
-                if (!item.experiment_execution_path) {
+                if (item.experiment_query_surface === 'precompute_build') {
+                    return (
+                        <LemonTag type="warning">
+                            build{item.experiment_precompute_table ? `: ${item.experiment_precompute_table}` : ''}
+                        </LemonTag>
+                    )
+                }
+                const pathTag = (label: string, value: string): JSX.Element | null => {
+                    if (!value || value === 'not_applicable') {
+                        return null
+                    }
+                    return (
+                        <LemonTag type={value === 'precomputed' ? 'success' : 'default'}>
+                            {label}: {value === 'precomputed' ? 'precomputed' : 'direct'}
+                        </LemonTag>
+                    )
+                }
+                // Fall back to the deprecated experiment_execution_path for rows logged before the split.
+                const exposures = pathTag('exposures', item.experiment_exposures_path || item.experiment_execution_path)
+                const events = pathTag('events', item.experiment_metric_events_path)
+                if (!exposures && !events) {
                     return null
                 }
                 return (
-                    <LemonTag type={item.experiment_execution_path === 'precomputed' ? 'success' : 'default'}>
-                        {item.experiment_execution_path}
-                    </LemonTag>
+                    <div className="flex flex-wrap gap-1">
+                        {exposures}
+                        {events}
+                    </div>
                 )
             },
         },

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -30,6 +30,10 @@ export interface SlowestQuery {
     experiment_name: string
     experiment_metric_name: string
     experiment_execution_path: string
+    experiment_exposures_path: string
+    experiment_metric_events_path: string
+    experiment_query_surface: string
+    experiment_precompute_table: string
     experiment_metric_type: string
     experiment_id: number | null
 }

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -418,7 +418,11 @@ class DebugCHQueries(viewsets.ViewSet):
                 argMax(JSONExtractString(log_comment, 'experiment_metric_name'), type) AS experiment_metric_name,
                 argMax(JSONExtractString(log_comment, 'experiment_execution_path'), type) AS experiment_execution_path,
                 argMax(JSONExtractString(log_comment, 'experiment_metric_type'), type) AS experiment_metric_type,
-                argMax(JSONExtractInt(log_comment, 'experiment_id'), type) AS experiment_id
+                argMax(JSONExtractInt(log_comment, 'experiment_id'), type) AS experiment_id,
+                argMax(JSONExtractString(log_comment, 'experiment_exposures_path'), type) AS experiment_exposures_path,
+                argMax(JSONExtractString(log_comment, 'experiment_metric_events_path'), type) AS experiment_metric_events_path,
+                argMax(JSONExtractString(log_comment, 'experiment_query_surface'), type) AS experiment_query_surface,
+                argMax(JSONExtractString(log_comment, 'experiment_precompute_table'), type) AS experiment_precompute_table
             FROM (
                 SELECT
                     query_id, query, query_start_time, query_duration_ms, exception,
@@ -475,6 +479,10 @@ class DebugCHQueries(viewsets.ViewSet):
                     "experiment_execution_path": row[10],
                     "experiment_metric_type": row[11],
                     "experiment_id": row[12] or None,
+                    "experiment_exposures_path": row[13],
+                    "experiment_metric_events_path": row[14],
+                    "experiment_query_surface": row[15],
+                    "experiment_precompute_table": row[16],
                 }
                 for row in response
             ]

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -416,7 +416,12 @@ class QueryTags(BaseModel):
     experiment_metric_uuid: Optional[str] = None
     experiment_metric_name: Optional[str] = None
     experiment_metric_type: Optional[str] = None  # "mean", "funnel", "ratio", "retention"
+    # DEPRECATED: alias of experiment_exposures_path, kept so external tooling keeps working.
     experiment_execution_path: Optional[str] = None  # "direct_scan" or "precomputed"
+    experiment_exposures_path: Optional[str] = None  # "direct_scan" or "precomputed"
+    experiment_metric_events_path: Optional[str] = None  # "direct_scan", "precomputed", or "not_applicable"
+    experiment_query_surface: Optional[str] = None  # "metric", "exposures_timeseries", "actors", "precompute_build"
+    experiment_precompute_table: Optional[str] = None  # on precompute_build rows: "exposures" or "metric_events"
     experiment_actors_query_step: Optional[int] = None  # funnel step for actors query
     experiment_actors_query_variant: Optional[str] = None  # variant filter for actors query
     experiment_actors_query_includes_recordings: Optional[bool] = None  # whether recordings are included

--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -22,7 +22,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.models.team.extensions import get_or_create_team_extension
@@ -165,15 +165,18 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             self.experiment.end_date,
         ):
             try:
-                result = self._ensure_exposures_precomputed(builder)
+                with tags_context(experiment_query_surface="precompute_build", experiment_precompute_table="exposures"):
+                    result = self._ensure_exposures_precomputed(builder)
                 if result.ready:
                     job_ids = [str(job_id) for job_id in result.job_ids]
+                    tag_queries(experiment_exposures_path="precomputed")
                     return builder.get_daily_exposures_from_precomputed(job_ids)
                 else:
                     logger.warning("exposure_lazy_computation_not_ready", experiment_id=self.experiment.id)
             except Exception:
                 logger.exception("exposure_lazy_computation_failed", experiment_id=self.experiment.id)
 
+        tag_queries(experiment_exposures_path="direct_scan")
         return builder.get_exposure_timeseries_query()
 
     def _calculate_srm(self, total_exposures: dict[str, int]) -> SampleRatioMismatch | None:
@@ -287,6 +290,8 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             experiment_name=self.query.experiment_name,
             experiment_feature_flag_key=self.feature_flag_key,
             product=Product.EXPERIMENTS,
+            experiment_query_surface="exposures_timeseries",
+            experiment_metric_events_path="not_applicable",
         )
 
         # Set limit to avoid being cut-off by the default 100 rows limit

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -28,7 +28,7 @@ from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.modifiers import create_default_modifiers_for_team
 from posthog.hogql.query import execute_hogql_query
 
-from posthog.clickhouse.query_tagging import Product, tag_queries
+from posthog.clickhouse.query_tagging import Product, tag_queries, tags_context
 from posthog.exceptions_capture import capture_exception
 from posthog.hogql_queries.query_runner import QueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
@@ -204,7 +204,8 @@ class ExperimentQueryRunner(QueryRunner):
 
         self.clickhouse_sql: str | None = None
         self.hogql: str | None = None
-        self._is_precomputed: bool = False
+        self._is_precomputed: bool = False  # exposures precompute
+        self._metric_events_precomputed: bool = False
 
     def _get_breakdowns_for_builder(self) -> list | None:
         """Extract and validate breakdowns from metric configuration."""
@@ -300,6 +301,16 @@ class ExperimentQueryRunner(QueryRunner):
             self.experiment.end_date,
         )
 
+    def _metric_events_precompute_applicable(self) -> bool:
+        """Metric-events precompute only supports ordered funnels without breakdowns, CUPED, or data warehouse."""
+        return (
+            isinstance(self.metric, ExperimentFunnelMetric)
+            and (self.metric.funnel_order_type or "ordered") == "ordered"
+            and not self._get_breakdowns_for_builder()
+            and not self.cuped_config.enabled
+            and not self.is_data_warehouse_query
+        )
+
     def _resolve_funnel_steps_data_disabled(self) -> bool:
         """Resolve funnel_steps_data_disabled: experiment parameter > team config."""
         parameters = self.experiment.parameters or {}
@@ -353,7 +364,8 @@ class ExperimentQueryRunner(QueryRunner):
         # doesn't include the join keys needed to link exposures to data warehouse tables
         if should_precompute and not self.is_data_warehouse_query:
             try:
-                result = self._ensure_exposures_precomputed(builder)
+                with tags_context(experiment_query_surface="precompute_build", experiment_precompute_table="exposures"):
+                    result = self._ensure_exposures_precomputed(builder)
                 if result.ready:
                     exposure_job_ids = [str(job_id) for job_id in result.job_ids]
                     self._is_precomputed = True
@@ -376,16 +388,15 @@ class ExperimentQueryRunner(QueryRunner):
             # funnel scan back by `lookback_days` to source the pre-exposure covariate;
             # the precomputed metric_events table only covers the experiment window, so
             # skip precomputation here and let the builder issue a fresh scan.
-            if (
-                isinstance(self.metric, ExperimentFunnelMetric)
-                and (self.metric.funnel_order_type or "ordered") == "ordered"
-                and not self._get_breakdowns_for_builder()
-                and not self.cuped_config.enabled
-            ):
+            if self._metric_events_precompute_applicable():
                 try:
-                    metric_result = self._ensure_metric_events_precomputed(builder)
+                    with tags_context(
+                        experiment_query_surface="precompute_build", experiment_precompute_table="metric_events"
+                    ):
+                        metric_result = self._ensure_metric_events_precomputed(builder)
                     if metric_result.ready:
                         metric_events_job_ids = [str(job_id) for job_id in metric_result.job_ids]
+                        self._metric_events_precomputed = True
                     else:
                         logger.warning("metric_events_lazy_computation_not_ready", experiment_id=self.experiment.id)
                 except Exception as e:
@@ -414,6 +425,7 @@ class ExperimentQueryRunner(QueryRunner):
         metric_name = self.metric.name or get_default_metric_title(self.metric.model_dump())
         tag_queries(
             product=Product.EXPERIMENTS,
+            experiment_query_surface="metric",
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag_key,
@@ -425,9 +437,16 @@ class ExperimentQueryRunner(QueryRunner):
 
         experiment_query_ast = self._get_experiment_query()
 
-        # Tag after _get_experiment_query() which sets _is_precomputed
+        # Tag after _get_experiment_query() which sets the precompute flags
+        exposures_path = "precomputed" if self._is_precomputed else "direct_scan"
+        if not self._metric_events_precompute_applicable():
+            metric_events_path = "not_applicable"
+        else:
+            metric_events_path = "precomputed" if self._metric_events_precomputed else "direct_scan"
         tag_queries(
-            experiment_execution_path="precomputed" if self._is_precomputed else "direct_scan",
+            experiment_exposures_path=exposures_path,
+            experiment_metric_events_path=metric_events_path,
+            experiment_execution_path=exposures_path,
         )
         experiment_query_debug = get_experiment_query_debug(experiment_query_ast, self.team)
         self.hogql = experiment_query_debug[0]
@@ -752,6 +771,9 @@ class ExperimentQueryRunner(QueryRunner):
         metric_name = self.metric.name or get_default_metric_title(self.metric.model_dump())
         tag_queries(
             product=Product.EXPERIMENTS,
+            experiment_query_surface="actors",
+            experiment_exposures_path="direct_scan",
+            experiment_metric_events_path="not_applicable",
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=feature_flag_key,


### PR DESCRIPTION
## Problem

The query performance "Path" column only tracked exposures precomputation, so it couldn't distinguish whether an experiment query used exposures precompute, metric-events precompute, both, or neither.

## Changes

Split the single `experiment_execution_path` query tag into separate `experiment_exposures_path` and `experiment_metric_events_path` tags, and added an `experiment_query_surface` tag so non-metric experiment queries (precompute-build inserts, exposure timeseries, actors) no longer render a blank Path. Surfaced the new tags in the query performance scene and the debug CH queries panel; `experiment_execution_path` is kept as a deprecated alias.

## How did you test this code?

Agent-authored (Claude Code). Ran the existing experiment precompute suites (funnel metric-events, exposures preaggregation, exposures runner, data-warehouse) — all pass. No new tests added.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Investigated why queries from precompute-enabled teams still showed a blank/`direct_scan` Path; root cause was that only the main metric query was tagged, and its single tag reflected exposures precompute only.
- Kept `experiment_execution_path` as a deprecated alias of `experiment_exposures_path` to avoid breaking external tooling; deliberately left the canary `is_precomputed` response field untouched (out of scope).
