### PR TITLE
fix(data-warehouse): show schema label instead of raw id in sync failure digest

### DIFF
--- a/products/data_warehouse/backend/external_data_source/notifications.py
+++ b/products/data_warehouse/backend/external_data_source/notifications.py
@@ -92,7 +92,9 @@ def notify_external_data_sync_failures(team_id: int) -> None:
             )
             items.append(
                 {
-                    "schema_name": schema.name,
+                    # Prefer the human-readable label (e.g. a Slack channel name) over the
+                    # raw identifier in `name` (e.g. a Slack channel id); fall back to name.
+                    "schema_name": schema.label or schema.name,
                     "source_id": str(schema.source_id),
                     "source_type": schema.source.source_type,
                     "source_prefix": (schema.source.prefix or "").rstrip("_"),

--- a/products/data_warehouse/backend/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_notifications.py
@@ -1,5 +1,6 @@
 import uuid
 import datetime as dt
+from urllib.parse import quote
 
 import pytest
 from unittest.mock import patch
@@ -70,32 +71,18 @@ class TestNotifyExternalDataSyncFailures:
         assert items[0]["source_type"] == "Stripe"
         assert f"managed-{source.id}/syncs?schema=Invoice" in items[0]["url"]
 
-    def test_prefers_label_over_name_for_display(self):
+    @pytest.mark.parametrize(
+        "name,label,expected_display",
+        [
+            ("C08LGV7UHS9", "#data-alerts", "#data-alerts"),  # label preferred for display
+            ("Charge", None, "Charge"),  # falls back to name when label is missing
+        ],
+    )
+    def test_display_uses_label_but_url_uses_name(self, name, label, expected_display):
         team, source = _create_team_and_source()
         ExternalDataSchema.objects.create(
-            name="C08LGV7UHS9",
-            label="#data-alerts",
-            team=team,
-            source=source,
-            status=ExternalDataSchema.Status.FAILED,
-            should_sync=True,
-            latest_error="rate limited",
-        )
-
-        with patch(SENDER_PATH) as mock_sender:
-            notify_external_data_sync_failures(team.pk)
-
-        (_, items) = mock_sender.call_args.args
-        # The displayed name uses the human-readable label...
-        assert items[0]["schema_name"] == "#data-alerts"
-        # ...but the deep link keeps using the raw identifier.
-        assert "?schema=C08LGV7UHS9" in items[0]["url"]
-
-    def test_falls_back_to_name_when_label_missing(self):
-        team, source = _create_team_and_source()
-        ExternalDataSchema.objects.create(
-            name="Charge",
-            label=None,
+            name=name,
+            label=label,
             team=team,
             source=source,
             status=ExternalDataSchema.Status.FAILED,
@@ -106,7 +93,10 @@ class TestNotifyExternalDataSyncFailures:
             notify_external_data_sync_failures(team.pk)
 
         (_, items) = mock_sender.call_args.args
-        assert items[0]["schema_name"] == "Charge"
+        # The displayed name prefers the human-readable label...
+        assert items[0]["schema_name"] == expected_display
+        # ...but the deep link always keeps using the raw identifier.
+        assert f"?schema={quote(name)}" in items[0]["url"]
 
     @pytest.mark.parametrize(
         "status,should_sync,deleted",

--- a/products/data_warehouse/backend/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_notifications.py
@@ -70,6 +70,44 @@ class TestNotifyExternalDataSyncFailures:
         assert items[0]["source_type"] == "Stripe"
         assert f"managed-{source.id}/syncs?schema=Invoice" in items[0]["url"]
 
+    def test_prefers_label_over_name_for_display(self):
+        team, source = _create_team_and_source()
+        ExternalDataSchema.objects.create(
+            name="C08LGV7UHS9",
+            label="#data-alerts",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            should_sync=True,
+            latest_error="rate limited",
+        )
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        (_, items) = mock_sender.call_args.args
+        # The displayed name uses the human-readable label...
+        assert items[0]["schema_name"] == "#data-alerts"
+        # ...but the deep link keeps using the raw identifier.
+        assert "?schema=C08LGV7UHS9" in items[0]["url"]
+
+    def test_falls_back_to_name_when_label_missing(self):
+        team, source = _create_team_and_source()
+        ExternalDataSchema.objects.create(
+            name="Charge",
+            label=None,
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            latest_error="transient error",
+        )
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        (_, items) = mock_sender.call_args.args
+        assert items[0]["schema_name"] == "Charge"
+
     @pytest.mark.parametrize(
         "status,should_sync,deleted",
         [


### PR DESCRIPTION
## Problem

The "[Alert] Data warehouse syncs failing" digest email rendered each failing sync using the schema's raw identifier (`schema.name`). For most sources that's a readable table name (e.g. `Invoice`), but for Slack sources `name` is the raw channel id (e.g. `C08LGV7UHS9`), so recipients saw cryptic ids instead of the channel name (e.g. `#data-alerts`).

## Changes

`ExternalDataSchema` already stores the human-readable name in its `label` field (the Slack source sets `name=channel_id`, `label=channel_name`). The digest context now uses `schema.label or schema.name`, so any source with a label displays its readable name and everything else falls back to `name` as before.

The `?schema=` deep-link query param deliberately keeps using `name` — that's the identifier the sources page matches on, not the display label. No email template change was needed; the template already renders the `schema_name` value it's handed.

## How did you test this code?

I'm an agent. I added two automated tests in `test_notifications.py`: one asserting the label is shown while the deep link keeps the raw id, and one asserting the fallback to `name` when no label exists. I could not run the Django test suite in my environment (dev dependencies and Postgres weren't provisioned), so these tests still need to run in CI. `ruff check` passes and both changed files byte-compile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Marcus flagged that the sync-failure digest email was showing raw Slack channel ids and asked it to use the label instead "and generally when available". I traced the digest builder (`products/data_warehouse/backend/external_data_source/notifications.py`) and confirmed `ExternalDataSchema.label` already holds the human-readable name, populated by the Slack source and kept current via `_update_labels`. This was the only surface rendering the raw identifier, so the fix is a one-line display swap plus tests. The deep-link query param was left on `name` on purpose since it's the navigation identifier.
