### PR TITLE
fix(logs): allow server-side CSV export through query access guard

### DIFF
--- a/products/logs/backend/logs_query_runner.py
+++ b/products/logs/backend/logs_query_runner.py
@@ -516,10 +516,14 @@ class LogsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMi
     paginator: HogQLHasMorePaginator
 
     def validate_query_runner_access(self, user: "User") -> bool:
-        # LogsQuery is registered in get_query_runner solely for server-side CSV export
-        # (via ExportedAsset + Celery, which runs without a user context and skips this check).
-        # Block all user-initiated queries via the generic /api/projects/:id/query/ endpoint
+        # LogsQuery is registered in get_query_runner solely for server-side CSV export.
+        # The export runs via ExportedAsset + Celery and attributes the read to the export
+        # owner (LimitContext.EXPORT), which must be allowed through. Block everything else —
+        # i.e. user-initiated queries via the generic /api/projects/:id/query/ endpoint —
         # until the LogsQuery schema is stable and ready to be a public API.
+        if self.limit_context == LimitContext.EXPORT:
+            return True
+
         from posthog.rbac.user_access_control import UserAccessControlError
 
         raise UserAccessControlError("logs", "viewer")

--- a/products/logs/backend/test/test_logs_query_runner_access.py
+++ b/products/logs/backend/test/test_logs_query_runner_access.py
@@ -5,6 +5,8 @@ from rest_framework import status
 
 from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter
 
+from posthog.hogql.constants import LimitContext
+
 from posthog.rbac.user_access_control import UserAccessControlError
 
 from products.logs.backend.logs_query_runner import LogsQueryRunner
@@ -19,7 +21,7 @@ def _minimal_query_data() -> dict:
     }
 
 
-def _build_runner(team) -> LogsQueryRunner:
+def _build_runner(team, limit_context: LimitContext | None = None) -> LogsQueryRunner:
     return LogsQueryRunner(
         team=team,
         query=LogsQuery(
@@ -29,15 +31,32 @@ def _build_runner(team) -> LogsQueryRunner:
             serviceNames=[],
             kind="LogsQuery",
         ),
+        limit_context=limit_context,
     )
 
 
 class TestLogsQueryRunnerAccess(APIBaseTest):
-    def test_validate_query_runner_access_always_blocks_with_user(self):
+    def test_validate_query_runner_access_blocks_user_initiated_query(self):
         runner = _build_runner(self.team)
 
         with self.assertRaises(UserAccessControlError):
             runner.validate_query_runner_access(self.user)
+
+    def test_validate_query_runner_access_allows_export_context(self):
+        """Server-side CSV export attributes the read to the export owner — must be allowed."""
+        runner = _build_runner(self.team, limit_context=LimitContext.EXPORT)
+
+        assert runner.validate_query_runner_access(self.user) is True
+
+    def test_run_with_user_in_export_context_skips_block(self):
+        runner = _build_runner(self.team, limit_context=LimitContext.EXPORT)
+
+        with patch.object(runner, "_calculate") as mock_calculate:
+            from posthog.schema import LogsQueryResponse
+
+            mock_calculate.return_value = LogsQueryResponse(results=[], hasMore=False)
+            response = runner.run(user=self.user)
+            assert response is not None
 
     def test_run_without_user_skips_access_check(self):
         """Celery export tasks call run() without a user — access check must be skipped."""


### PR DESCRIPTION
## Problem

Exporting logs to CSV failed for everyone — including org owners — with a "viewer access to logs" error. Users reported this as "export requires viewer permission on the logs resource that not all accounts have," but the real cause wasn't RBAC config.

## Changes

`LogsQueryRunner.validate_query_runner_access` existed to keep `LogsQuery` off the public `/api/projects/:id/query/` endpoint while the schema stabilizes, so it unconditionally raised `UserAccessControlError("logs", "viewer")`. Its comment assumed the only other caller — the server-side CSV export — "runs without a user context and skips this check."

That assumption was wrong. The export task runs the query attributing the read to the export owner (`user=exported_asset.created_by`, with `LimitContext.EXPORT`) so warehouse HogQL access control resolves against the owner. Because a user is present, the guard fired on every export and blocked it, irrespective of the user's actual access.

The fix lets `LimitContext.EXPORT` through and keeps blocking everything else (i.e. direct hits on the generic `/query/` endpoint, which use the default `LimitContext.QUERY`).

## How did you test this code?

I'm an agent (PostHog Code). I added unit tests in `test_logs_query_runner_access.py` covering: the export context is allowed, a `run()` with a user in export context succeeds, and direct user-initiated queries are still blocked. I could not execute the DB-backed tests in this session — the local Postgres was misconfigured and unauthenticatable — so they need a run on a working dev DB:

```
hogli test products/logs/backend/test/test_logs_query_runner_access.py
```

Static checks (`ruff check`, `ruff format`) pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Traced the failure from the logs export endpoint → `ExportedAsset` → Celery `export_asset` → `csv_exporter.get_from_query` → `process_query_dict(user=created_by, limit_context=EXPORT)` → `QueryRunner.run` calling `validate_query_runner_access` whenever a user is present. The guard's own comment was the red herring — it claimed exports run user-less, but the export path deliberately passes the owner. Chose to discriminate on `LimitContext.EXPORT` (already plumbed into the runner) rather than loosen the block or stop passing the user, preserving the intent of keeping `LogsQuery` private on the generic endpoint.

No skills were applicable; this is a single-method backend fix with no migration, serializer, or viewset surface changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
