### PR TITLE
fix(custom): omit compressed and non-text bodies from probe error

### DIFF
--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -682,11 +682,14 @@ class CustomSource(SimpleSource[CustomSourceConfig]):
             # surfaces on the first sync instead.
             try:
                 if response.status_code in (401, 403):
-                    return False, (
+                    message = (
                         f"Resource {resource['name']!r}: the upstream API rejected the request with "
-                        f"HTTP {response.status_code} from {url} — check the configured auth credentials: "
-                        f"{_read_capped_text(response)}"
+                        f"HTTP {response.status_code} from {url} — check the configured auth credentials."
                     )
+                    snippet = _read_capped_text(response)
+                    if snippet:
+                        message += f" The upstream responded: {snippet}"
+                    return False, message
             finally:
                 response.close()
 
@@ -816,14 +819,22 @@ def _read_capped_text(response: Response) -> str:
 
     ``decode_content=False`` is deliberate: it reads exactly ``PROBE_ERROR_SNIPPET_BYTES``
     raw bytes and never inflates a ``Content-Encoding: gzip`` body, so a decompression
-    bomb can't expand a tiny read into megabytes. The snippet is only a human-readable
-    diagnostic — a (rare) compressed error body just shows as bytes.
+    bomb can't expand a tiny read into megabytes. The flip side is that a compressed or
+    otherwise non-text body would decode to binary garbage, so it is omitted from the
+    snippet rather than echoed into a user-facing error.
     """
+    if response.headers.get("Content-Encoding"):
+        return ""
     try:
         raw = response.raw.read(PROBE_ERROR_SNIPPET_BYTES, decode_content=False)
     except Exception:
         return ""
-    return raw.decode("utf-8", errors="replace")
+    text = raw.decode("utf-8", errors="replace")
+    # A replacement char means the bytes weren't valid UTF-8 — a binary or still-encoded
+    # body — so drop it rather than surface garbage to the user.
+    if "�" in text:
+        return ""
+    return text.strip()
 
 
 def _static_probe_params(params: Any) -> dict[str, Any]:

--- a/posthog/temporal/data_imports/sources/custom/source.py
+++ b/posthog/temporal/data_imports/sources/custom/source.py
@@ -823,7 +823,9 @@ def _read_capped_text(response: Response) -> str:
     otherwise non-text body would decode to binary garbage, so it is omitted from the
     snippet rather than echoed into a user-facing error.
     """
-    if response.headers.get("Content-Encoding"):
+    # ``identity`` means "no transformation", so its body is plain bytes worth surfacing;
+    # any other encoding (gzip, br, …) would decode to garbage, so omit the snippet.
+    if response.headers.get("Content-Encoding", "").lower() not in ("", "identity"):
         return ""
     try:
         raw = response.raw.read(PROBE_ERROR_SNIPPET_BYTES, decode_content=False)

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -15,7 +15,6 @@ from urllib3.response import HTTPResponse
 from posthog.temporal.data_imports.sources.common.rest_source.auth import APIKeyAuth, BearerTokenAuth, HttpBasicAuth
 from posthog.temporal.data_imports.sources.custom.source import (
     MAX_MANIFEST_RESOURCES,
-    PROBE_ERROR_SNIPPET_BYTES,
     PROBE_MAX_RESOURCES,
     CustomSource,
     FanoutChain,
@@ -408,6 +407,7 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
         # The probe opens responses with stream=True and reads only a bounded slice
         # of a 401/403 body for the error snippet — never buffering the full body.
         response = MagicMock(status_code=403)
+        response.headers = {}
         response.raw.read.return_value = b"forbidden: token expired"
         mock_session.return_value.request.return_value = response
 
@@ -421,22 +421,36 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
         assert mock_session.return_value.request.call_args.kwargs["stream"] is True
         response.close.assert_called_once()
 
-    def test_read_capped_text_is_decompression_bomb_proof(self):
-        # A gzip body that inflates ~1000x must not be materialized — reading the raw
-        # (undecoded) stream caps the snippet regardless of Content-Encoding.
+    def test_read_capped_text_omits_compressed_body(self):
+        # A gzip-encoded body would decode to binary garbage, so it must be omitted from
+        # the snippet rather than echoed into a user-facing error — and never materialized.
         payload = b"\x00" * (20 * 1024 * 1024)
         compressed = gzip.compress(payload)
         assert len(payload) / len(compressed) > 100  # it really is a decompression bomb
 
         response = MagicMock()
+        response.headers = {"Content-Encoding": "gzip"}
         response.raw = HTTPResponse(
             body=io.BytesIO(compressed),
             headers={"content-encoding": "gzip", "content-length": str(len(compressed))},
             status=403,
             preload_content=False,
         )
-        snippet = _read_capped_text(response)
-        assert len(snippet) <= PROBE_ERROR_SNIPPET_BYTES
+        assert _read_capped_text(response) == ""
+
+    def test_read_capped_text_omits_non_utf8_body(self):
+        # A body that isn't valid UTF-8 (binary, or still-encoded) is dropped rather than
+        # surfaced as replacement-character garbage.
+        response = MagicMock()
+        response.headers = {}
+        response.raw.read.return_value = b"\x1f\x8b\x08\x00garbage\xff\xfe"
+        assert _read_capped_text(response) == ""
+
+    def test_read_capped_text_returns_plain_text(self):
+        response = MagicMock()
+        response.headers = {}
+        response.raw.read.return_value = b"  forbidden: token expired  "
+        assert _read_capped_text(response) == "forbidden: token expired"
 
     @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")
     def test_probe_attaches_query_location_api_key(self, mock_session):

--- a/posthog/temporal/data_imports/sources/custom/test_custom_source.py
+++ b/posthog/temporal/data_imports/sources/custom/test_custom_source.py
@@ -438,18 +438,27 @@ class TestCustomSourceValidateCredentials(SimpleTestCase):
         )
         assert _read_capped_text(response) == ""
 
-    def test_read_capped_text_omits_non_utf8_body(self):
-        # A body that isn't valid UTF-8 (binary, or still-encoded) is dropped rather than
-        # surfaced as replacement-character garbage.
+    @parameterized.expand(
+        [
+            # A body that isn't valid UTF-8 (binary, or still-encoded) is dropped rather than
+            # surfaced as replacement-character garbage.
+            ("non_utf8", b"\x1f\x8b\x08\x00garbage\xff\xfe", ""),
+            # A plain-text body is returned, stripped of surrounding whitespace.
+            ("plain_text", b"  forbidden: token expired  ", "forbidden: token expired"),
+        ]
+    )
+    def test_read_capped_text_non_compressed(self, _name, raw_bytes, expected):
         response = MagicMock()
         response.headers = {}
-        response.raw.read.return_value = b"\x1f\x8b\x08\x00garbage\xff\xfe"
-        assert _read_capped_text(response) == ""
+        response.raw.read.return_value = raw_bytes
+        assert _read_capped_text(response) == expected
 
-    def test_read_capped_text_returns_plain_text(self):
+    def test_read_capped_text_returns_identity_encoded_body(self):
+        # `Content-Encoding: identity` means no transformation, so the plain-text body
+        # is still readable and must be surfaced rather than dropped.
         response = MagicMock()
-        response.headers = {}
-        response.raw.read.return_value = b"  forbidden: token expired  "
+        response.headers = {"Content-Encoding": "identity"}
+        response.raw.read.return_value = b"forbidden: token expired"
         assert _read_capped_text(response) == "forbidden: token expired"
 
     @patch("posthog.temporal.data_imports.sources.custom.source.make_tracked_session")


### PR DESCRIPTION
## Problem

When someone creates a Custom REST API source and the probe request gets a `401`/`403`, we surface a credential-validation error that appends a capped slice of the upstream response body. For an upstream that gzip-encodes its error body (common — e.g. some hosted CRM APIs always send `Content-Encoding: gzip`), that slice is the still-compressed bytes decoded with `errors="replace"`, so the user sees a run of replacement-character garbage tacked onto the message. It's unreadable and leaks raw bytes into a user-facing string.

## Changes

Only append the response-body snippet when it's a plain, decodable text body:

- Skip it when `Content-Encoding` is set (we deliberately don't inflate the body, to stay decompression-bomb safe, so we can't render it as text).
- Drop it when the decoded bytes contain a replacement character (binary or still-encoded body).

The bounded raw read that protects against decompression bombs is unchanged; this only changes whether the snippet is included. The error now reads as a clean, actionable sentence and appends the upstream's text only when it's genuinely readable.

## How did you test this code?

I'm an agent. I added/updated unit tests in `test_custom_source.py` (compressed body omitted, non-UTF-8 body omitted, plain text returned and stripped) and updated the existing auth-rejection/streaming tests for the new message shape. Ran the affected subset with `uv run pytest` — all pass. No manual testing.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged data-warehouse source-creation failures and found Custom sources surfacing garbled binary in the probe error message. Root cause was in `_read_capped_text`: `decode_content=False` (correct, for bomb safety) means a compressed body reaches `bytes.decode(..., errors="replace")` and becomes `�` garbage. Fix gates the snippet on decodability rather than touching the read. No skills were applicable to this change.
