### PR TITLE
feat(tasks): render task runs with PostHog AI sandbox renderer

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -31,8 +31,8 @@ import {
 
 import { taskDetailSceneLogic } from '../logics/taskDetailSceneLogic'
 import { CollapsibleContent } from './CollapsibleContent'
+import { TaskRunChat } from './TaskRunChat'
 import { TaskRunItem } from './TaskRunItem'
-import { TaskSessionView } from './TaskSessionView'
 
 export interface TaskDetailPageProps {
     taskId: string
@@ -40,19 +40,7 @@ export interface TaskDetailPageProps {
 
 export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
     const sceneLogic = taskDetailSceneLogic({ taskId })
-    const {
-        task,
-        taskLoading,
-        runs,
-        selectedRunId,
-        selectedRun,
-        runsLoading,
-        logs,
-        logsLoading,
-        shouldPoll,
-        streamEntries,
-        isStreaming,
-    } = useValues(sceneLogic)
+    const { task, taskLoading, runs, selectedRunId, selectedRun, runsLoading } = useValues(sceneLogic)
     const { setSelectedRunId, runTask, deleteTask } = useActions(sceneLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const sceneMenuBarEnabled = !!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]
@@ -225,15 +213,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                 </div>
             ) : selectedRun ? (
                 <div className="flex-1 overflow-hidden">
-                    <TaskSessionView
-                        logs={logs}
-                        logsLoading={logsLoading}
-                        streamEntries={streamEntries}
-                        isPolling={shouldPoll}
-                        isStreaming={isStreaming}
-                        initialPrompt={task.description}
-                        run={selectedRun}
-                    />
+                    <TaskRunChat taskId={task.id} runId={selectedRun.id} />
                 </div>
             ) : null}
         </SceneContent>

--- a/products/tasks/frontend/components/TaskRunChat.tsx
+++ b/products/tasks/frontend/components/TaskRunChat.tsx
@@ -1,0 +1,99 @@
+import { BindLogic, useActions, useValues } from 'kea'
+import { useState } from 'react'
+
+import { LemonButton, LemonTextArea } from '@posthog/lemon-ui'
+
+import {
+    isTerminalRunStatus,
+    SandboxContextUsage,
+    SandboxPermissionInput,
+    SandboxQuestionInput,
+    SandboxResourcesBar,
+    SandboxThreadView,
+    sandboxStreamLogic,
+} from 'products/posthog_ai/frontend/sandbox'
+
+import { taskRunChatLogic } from '../logics/taskRunChatLogic'
+
+export interface TaskRunChatProps {
+    taskId: string
+    runId: string
+}
+
+export function TaskRunChat({ taskId, runId }: TaskRunChatProps): JSX.Element {
+    // The outer BindLogic binds the shared sandboxStreamLogic instance (keyed by runId) consumed by
+    // both the renderer (thread/permission/question views) and taskRunChatLogic. We bind in live mode;
+    // bootstrapRun (called from taskRunChatLogic.afterMount) reads the run status from the tasks API and
+    // never opens SSE for an already-terminal run — same pattern SandboxRunViewer uses.
+    return (
+        <BindLogic logic={sandboxStreamLogic} props={{ streamKey: runId }}>
+            <BindLogic logic={taskRunChatLogic} props={{ taskId, runId }}>
+                <TaskRunChatContent taskId={taskId} runId={runId} />
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+function TaskRunChatContent({ taskId, runId }: TaskRunChatProps): JSX.Element {
+    const { pendingPermissionRequest, currentRunStatus } = useValues(sandboxStreamLogic({ streamKey: runId }))
+    const { sendMessage } = useActions(taskRunChatLogic({ taskId, runId }))
+    const { sendingMessage } = useValues(taskRunChatLogic({ taskId, runId }))
+
+    const isTerminal = isTerminalRunStatus(currentRunStatus)
+    const [composerText, setComposerText] = useState('')
+
+    const isQuestion = !!pendingPermissionRequest?.questions && pendingPermissionRequest.questions.length > 0
+
+    const handleSend = (): void => {
+        const trimmed = composerText.trim()
+        if (!trimmed || sendingMessage || isTerminal) {
+            return
+        }
+        sendMessage(trimmed)
+        setComposerText('')
+    }
+
+    return (
+        <div className="flex flex-col h-full overflow-hidden">
+            <div className="flex-1 overflow-y-auto px-4 py-2">
+                <SandboxThreadView />
+            </div>
+
+            <SandboxResourcesBar />
+
+            {pendingPermissionRequest && !isTerminal && (
+                <div className="border-t px-4 py-3">
+                    {isQuestion ? (
+                        <SandboxQuestionInput streamKey={runId} request={pendingPermissionRequest} />
+                    ) : (
+                        <SandboxPermissionInput streamKey={runId} request={pendingPermissionRequest} />
+                    )}
+                </div>
+            )}
+
+            {!isTerminal && !pendingPermissionRequest && (
+                <div className="border-t px-4 py-3 flex gap-2 items-end">
+                    <LemonTextArea
+                        className="flex-1"
+                        value={composerText}
+                        onChange={setComposerText}
+                        placeholder="Send a follow-up message…"
+                        minRows={1}
+                        maxRows={8}
+                        onPressCmdEnter={handleSend}
+                    />
+                    <LemonButton
+                        type="primary"
+                        onClick={handleSend}
+                        loading={sendingMessage}
+                        disabledReason={!composerText.trim() ? 'Type a message first' : undefined}
+                    >
+                        Send
+                    </LemonButton>
+                </div>
+            )}
+
+            <SandboxContextUsage />
+        </div>
+    )
+}

--- a/products/tasks/frontend/logics/taskRunChatLogic.ts
+++ b/products/tasks/frontend/logics/taskRunChatLogic.ts
@@ -1,0 +1,80 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { isTerminalRunStatus, sandboxStreamLogic } from 'products/posthog_ai/frontend/sandbox'
+import { tasksRunsCommandCreate } from 'products/tasks/frontend/generated/api'
+
+import type { taskRunChatLogicType } from './taskRunChatLogicType'
+
+export interface TaskRunChatLogicProps {
+    taskId: string
+    runId: string
+}
+
+export const taskRunChatLogic = kea<taskRunChatLogicType>([
+    path(['products', 'tasks', 'logics', 'taskRunChatLogic']),
+    props({} as TaskRunChatLogicProps),
+    key((props) => props.runId),
+
+    connect((props: TaskRunChatLogicProps) => ({
+        values: [
+            projectLogic,
+            ['currentProjectId'],
+            sandboxStreamLogic({ streamKey: props.runId }),
+            ['currentRunStatus'],
+        ],
+        actions: [sandboxStreamLogic({ streamKey: props.runId }), ['bootstrapRun', 'pushHumanMessage', 'reset']],
+    })),
+
+    actions({
+        sendMessage: (content: string) => ({ content }),
+        setSendingMessage: (sending: boolean) => ({ sending }),
+    }),
+
+    reducers({
+        sendingMessage: [
+            false,
+            {
+                setSendingMessage: (_, { sending }) => sending,
+            },
+        ],
+    }),
+
+    selectors({
+        isTerminal: [(s) => [s.currentRunStatus], (status): boolean => isTerminalRunStatus(status)],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        sendMessage: async ({ content }) => {
+            if (values.sendingMessage || !content.trim() || values.isTerminal) {
+                return
+            }
+            if (values.currentProjectId == null) {
+                return
+            }
+            actions.setSendingMessage(true)
+            try {
+                await tasksRunsCommandCreate(String(values.currentProjectId), props.taskId, props.runId, {
+                    jsonrpc: '2.0',
+                    method: 'user_message',
+                    params: { content },
+                })
+                actions.pushHumanMessage(content)
+            } catch {
+                lemonToast.error('Failed to send message. Please try again.')
+            } finally {
+                actions.setSendingMessage(false)
+            }
+        },
+    })),
+
+    afterMount(({ props, actions }) => {
+        // sandboxStreamLogic is already bound (the BindLogic in TaskRunChat mounts it first), so a
+        // reset + bootstrapRun here re-bootstraps cleanly when a reused logic instance is remounted.
+        // Live vs. replay mode is resolved inside bootstrapRun from the run status the tasks API returns.
+        actions.reset()
+        actions.bootstrapRun({ taskId: props.taskId, runId: props.runId })
+    }),
+])


### PR DESCRIPTION
## Problem

The tasks frontend rendered a task run's agent activity with a bespoke, cruder duplicate of the PostHog AI sandbox renderer — `TaskSessionView` opened its own SSE, did its own resume/polling/S3 fallback, and parsed the same ACP wire less completely, with no tool cards, no permission/question handling, and no progress/usage UI. The PostHog AI sandbox renderer is a far more complete implementation of the same thing, and it is already tasks-API-only.

## Changes

Replace `TaskSessionView` with the relocated PostHog AI sandbox renderer, wired as a full interactive chat: live thread, tool cards, permission/question cards, and a follow-up composer.

- **New `taskRunChatLogic`** (keyed by run id) binds `sandboxStreamLogic` on the same `streamKey`, bootstraps the run (live for in-progress, replay once terminal), and owns the composer send path: `tasksRunsCommandCreate(..., { jsonrpc: '2.0', method: 'user_message', params: { content } })` followed by `pushHumanMessage` for the optimistic echo. A `sendingMessage` flag guards against double-submit and drives the send button's loading/disabled state.
- **New `TaskRunChat`** composes the renderer (`SandboxThreadView`, `SandboxPermissionInput`/`SandboxQuestionInput`, `SandboxResourcesBar`, `SandboxContextUsage`) plus the composer. The permission-vs-question split keys off `pendingPermissionRequest.questions`. The composer is hidden while a permission request is pending or once the run is terminal.
- **`TaskDetailPage`** swaps `<TaskSessionView .../>` for `<TaskRunChat taskId={task.id} runId={selectedRun.id} />` and drops the now-unused streaming values from its `useValues` destructuring. The run-history sidebar, run/PR buttons, and run-selection state are unchanged.

Tasks consume the renderer **only** through the `products/posthog_ai/frontend/sandbox` barrel and talk to tasks via `api.tasks.*` / the tasks generated API — no conversations API, no Max conversation orchestration.

This stacks on the PR1 relocation (which moved the conversation-agnostic sandbox renderer into `products/posthog_ai/frontend/` and added the public barrel). `TaskSessionView`, `lib/parse-logs.ts`, and the dead streaming slice of `taskDetailSceneLogic` are intentionally left in place for a follow-up PR3 cleanup — this PR only swaps the rendering path.

## How did you test this code?

I am an agent. Automated checks I ran:

- Jest: `taskDetailSceneLogic.test.ts`, `sandboxStreamLogic.test.ts`, and `SandboxQuestionInput.test.tsx` — 164 tests pass. Existing tasks logic test still green after the swap; barrel imports resolve.
- Type safety: the TS language server reports zero diagnostics on all three touched files. The `tsgo --noEmit` CLI currently crashes with a pre-existing compiler panic in declaration emit that reproduces identically on a clean checkout (verified by stashing these changes), so it is not caused by this PR.
- Verified no import of `ee/api/conversation`, `api.conversations.*`, or Max conversation orchestration (`maxThreadLogic`/`maxContextLogic`/`maxGlobalLogic`/`maxLogic`/`MaxUIContext`) on the tasks path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8) following an approved migration plan. This is Phase 2 + Phase 3 of that plan, stacked on the Phase 1 renderer relocation.

Decisions worth flagging for review:

- The composer's `replayOnly` mode is resolved inside `sandboxStreamLogic.bootstrapRun` from the run status the tasks API returns on bootstrap (never opens SSE for an already-terminal run) — the same pattern `SandboxRunViewer` uses — rather than being threaded through the component. `TaskRunChat` binds in live mode and lets bootstrap decide.
- `taskRunChatLogic` deliberately imports nothing from the conversations API or Max orchestration; it reuses permission/question/cancel handling already inside `sandboxStreamLogic` and only adds the follow-up-send path that Max otherwise gets from `maxThreadLogic`.
- The generated `taskRunChatLogicType.ts` is gitignored (kea-typegen regenerates it in CI), so it is not committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
