### PR TITLE
chore(data-warehouse): remove unused DWH_FREE_SYNCS feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -281,7 +281,6 @@ export const FEATURE_FLAGS = {
     DATA_WAREHOUSE_SCENE: 'data-warehouse-scene', // owner: #team-data-modeling
     DEFAULT_EVALUATION_ENVIRONMENTS: 'default-evaluation-environments', // owner: @dmarticus #team-feature-flags
     DROP_PERSON_LIST_ORDER_BY: 'drop-person-list-order-by', // owner: @arthurdedeus #team-customer-analytics
-    DWH_FREE_SYNCS: 'dwh-free-syncs', // owner: @Gilbert09  #team-warehouse-sources
     DWH_JOIN_TABLE_PREVIEW: 'dwh-join-table-preview', // owner: @arthurdedeus #team-customer-analytics
     DWH_POSTGRES_CDC: 'dwh-postgres-cdc', // owner: #team-warehouse-sources
     DWH_POSTGRES_XMIN: 'dwh-postgres-xmin', // owner: #team-warehouse-sources


### PR DESCRIPTION
## Problem

The `DWH_FREE_SYNCS` feature flag (`dwh-free-syncs`) is dead config — its `FEATURE_FLAGS` entry in `frontend/src/lib/constants.tsx` is the only reference left anywhere in the repo. Nothing reads it, so it's just noise in the flag list.

## Changes

Remove the `DWH_FREE_SYNCS` entry from `FEATURE_FLAGS`.

Verified there are no other usages before removing: a repo-wide grep for both `DWH_FREE_SYNCS` and the `'dwh-free-syncs'` string across `frontend/`, `products/`, `posthog/`, and `ee/` returns only the constant definition itself. This is a frontend-constant-only deletion — it does not delete or change the underlying flag in the PostHog instance, just removes the unused reference.

## How did you test this code?

I'm an agent (Claude Code). No manual testing — this is a one-line removal of an unreferenced constant with no runtime behavior. I confirmed zero remaining references via grep across the repo (constant name and flag string). TypeScript would fail to compile if anything still referenced `FEATURE_FLAGS.DWH_FREE_SYNCS`; nothing does.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Removed at the request of the repo owner. Before deleting, I grepped the full repo (TS/TSX/PY) for the constant and the raw flag string to confirm it was unused, so this is a safe constant-only removal with no consumers to update.
