### PR TITLE
fix(active-campaign): explain redirects as a likely wrong account name

### DIFF
--- a/posthog/temporal/data_imports/sources/active_campaign/active_campaign.py
+++ b/posthog/temporal/data_imports/sources/active_campaign/active_campaign.py
@@ -180,4 +180,13 @@ def validate_credentials(api_url: str, api_key: str) -> tuple[bool, str | None]:
         return True, None
     if response.status_code in (401, 403):
         return False, "Invalid ActiveCampaign API URL or key"
+    # A redirect from a valid account+key is never expected (the API answers directly).
+    # It almost always means the account name in the URL is wrong, so the host doesn't
+    # resolve to an API tenant and ActiveCampaign bounces the request to a login page.
+    if response.is_redirect:
+        return (
+            False,
+            "ActiveCampaign redirected the request, which usually means the account name in the API URL is "
+            "incorrect. Check that your API URL looks like https://<youraccountname>.api-us1.com",
+        )
     return False, f"ActiveCampaign returned an unexpected status code: {response.status_code}"

--- a/posthog/temporal/data_imports/sources/active_campaign/tests/test_active_campaign.py
+++ b/posthog/temporal/data_imports/sources/active_campaign/tests/test_active_campaign.py
@@ -268,6 +268,7 @@ class TestValidateCredentials:
             mock_session = MockSession.return_value
             response = MagicMock()
             response.status_code = status_code
+            response.is_redirect = False
             mock_session.get.return_value = response
 
             valid, error = validate_credentials("https://acme.api-us1.com", "test-key")
@@ -312,6 +313,7 @@ class TestValidateCredentials:
             mock_session = MockSession.return_value
             response = MagicMock()
             response.status_code = 302
+            response.is_redirect = True
             mock_session.get.return_value = response
 
             valid, error = validate_credentials("https://acme.api-us1.com", "test-key")
@@ -319,6 +321,30 @@ class TestValidateCredentials:
             assert valid is False
             assert error is not None
             assert mock_session.get.call_args.kwargs["allow_redirects"] is False
+
+    def test_redirect_returns_actionable_account_name_message(self) -> None:
+        # A redirect means the account name in the URL is likely wrong — surface that
+        # instead of a bare status code.
+        with (
+            patch(
+                "posthog.temporal.data_imports.sources.active_campaign.active_campaign.make_tracked_session"
+            ) as MockSession,
+            patch(
+                "posthog.temporal.data_imports.sources.active_campaign.active_campaign.is_url_allowed",
+                return_value=(True, None),
+            ),
+        ):
+            mock_session = MockSession.return_value
+            response = MagicMock()
+            response.status_code = 302
+            response.is_redirect = True
+            mock_session.get.return_value = response
+
+            valid, error = validate_credentials("https://acme.api-us1.com", "test-key")
+
+            assert valid is False
+            assert error is not None and "account name" in error
+            assert "status code" not in error
 
 
 class TestSsrfProtection:


### PR DESCRIPTION
## Problem

When someone connects an ActiveCampaign source and the validation request comes back as a redirect (we issue it with `allow_redirects=False`), they got a generic `ActiveCampaign returned an unexpected status code: <code>` message. That tells the user nothing actionable. A redirect from a valid account + key is never expected — the API answers directly. It almost always means the account name in the API URL is wrong, so the host doesn't resolve to an API tenant and ActiveCampaign bounces the request to a login page.

## Changes

Add a branch for the redirect case in `validate_credentials` (before the generic status-code fallback) that points the user at the likely cause: a wrong account name, with the expected `https://<youraccountname>.api-us1.com` URL shape. The `allow_redirects=False` SSRF posture is unchanged — this only improves the error message.

## How did you test this code?

I'm an agent. Added a unit test asserting the redirect path returns the account-name guidance and not the bare status-code message, and set `is_redirect` explicitly on the existing status-code mocks. Ran the `validate_credentials` test subset with `uv run pytest` — all pass. No manual testing.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while triaging data-warehouse source-creation failures: ActiveCampaign redirects were surfacing as a raw, unactionable status code. Fix keys off `response.is_redirect` so any 3xx with a Location header gets the friendlier message. No skills were applicable.
