### PR TITLE
fix(mysql): give specific connection errors at source validation

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -34,6 +34,40 @@ from products.data_warehouse.backend.types import ExternalDataSourceType
 
 _MYSQL_IMPLEMENTATION = MySQLImplementation()
 
+# Create-time-only refinement of the connection error shown when a source fails to
+# validate. pymysql collapses every connect-level failure into error 2003,
+# "Can't connect to MySQL server on '<host>' (<os detail>)", so the generic
+# "check all connection details" message can't tell the user whether the host is
+# wrong, the port is closed, or a firewall is dropping us — unlike the Postgres
+# source, which is granular. We match the OS detail (and the 1049 "Unknown database"
+# server error) to give the same actionable messages. Kept out of
+# get_non_retryable_errors — which the sync path also consults for retry
+# classification — so connection-error retry behaviour is unchanged.
+_VALIDATE_CONNECTION_HINTS: list[tuple[str, str]] = [
+    (
+        "Name or service not known",
+        "Host could not be resolved. Check the host is spelled correctly and reachable from PostHog.",
+    ),
+    (
+        "nodename nor servname provided",
+        "Host could not be resolved. Check the host is spelled correctly and reachable from PostHog.",
+    ),
+    (
+        "Connection refused",
+        "Could not connect to the host on the port given. Check the host and port are correct and the MySQL server is accepting connections.",
+    ),
+    ("timed out", "Connection timed out. Does your database have our IP addresses allowed?"),
+    (
+        "No route to host",
+        "Could not reach the host. Check the host is correct and that PostHog's IP addresses are allowed through your firewall.",
+    ),
+    (
+        "Network is unreachable",
+        "Could not reach the host. Check the host is correct and that PostHog's IP addresses are allowed through your firewall.",
+    ),
+    ("Unknown database", "Database does not exist. Check the database name is correct."),
+]
+
 
 @SourceRegistry.register
 class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabaseHostMixin):
@@ -245,6 +279,10 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # message without reporting them to error tracking — only genuinely unexpected
             # failures get captured. Mirrors the Postgres and MSSQL `validate_credentials` handling.
             error_msg = " ".join(str(arg) for arg in e.args) if e.args else str(e)
+            # Refine the generic connect failure into a specific, actionable message first.
+            for hint_pattern, hint_message in _VALIDATE_CONNECTION_HINTS:
+                if hint_pattern in error_msg:
+                    return False, hint_message
             for pattern, friendly_error in self.get_non_retryable_errors().items():
                 if pattern in error_msg:
                     return (

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1276,20 +1276,42 @@ class TestMySQLSourceValidateCredentials:
     @pytest.mark.parametrize(
         "raised,expected_error",
         [
-            # The exact error that fired this triage: an unreachable host surfaces as a
-            # pymysql OperationalError(2003) wrapping an OSError — already non-retryable.
-            # A connection failure keeps the generic "check connection details" message.
+            # pymysql collapses every connect-level failure into OperationalError(2003)
+            # wrapping an OSError; the OS detail is matched to give a specific, actionable
+            # message instead of the generic "check connection details" fallback.
             (
                 pymysql.err.OperationalError(
-                    2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 101] Network is unreachable)"
+                    2003, "Can't connect to MySQL server on 'db.example.com' ([Errno -2] Name or service not known)"
                 ),
-                "Could not connect to MySQL. Please check all connection details are valid.",
+                "Host could not be resolved. Check the host is spelled correctly and reachable from PostHog.",
             ),
             (
                 pymysql.err.OperationalError(
                     2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 111] Connection refused)"
                 ),
-                "Could not connect to MySQL. Please check all connection details are valid.",
+                "Could not connect to the host on the port given. Check the host and port are correct and the MySQL server is accepting connections.",
+            ),
+            (
+                pymysql.err.OperationalError(2003, "Can't connect to MySQL server on 'db.example.com' (timed out)"),
+                "Connection timed out. Does your database have our IP addresses allowed?",
+            ),
+            (
+                pymysql.err.OperationalError(
+                    2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 113] No route to host)"
+                ),
+                "Could not reach the host. Check the host is correct and that PostHog's IP addresses are allowed through your firewall.",
+            ),
+            (
+                pymysql.err.OperationalError(
+                    2003, "Can't connect to MySQL server on 'db.example.com' ([Errno 101] Network is unreachable)"
+                ),
+                "Could not reach the host. Check the host is correct and that PostHog's IP addresses are allowed through your firewall.",
+            ),
+            # Server error 1049: the host/port/credentials are fine but the named database
+            # doesn't exist. Previously fell through to capture as an unexpected error.
+            (
+                pymysql.err.OperationalError(1049, "Unknown database 'nope'"),
+                "Database does not exist. Check the database name is correct.",
             ),
             # An auth failure (error 1045) must name the credentials, not the generic message
             # that sends the user to inspect the host/port instead. Mirrors Postgres.


### PR DESCRIPTION
## Problem

When a MySQL source fails to connect during setup, every connect-level failure collapsed into one generic message: `Could not connect to MySQL. Please check all connection details are valid.` That gives the user nothing to act on — they can't tell whether the host is wrong, the port is closed, a firewall is dropping us, the hostname doesn't resolve, or the database name is wrong. The Postgres source already distinguishes all of these at setup time; MySQL should match.

## Changes

pymysql collapses every connect-level failure into error 2003 (`Can't connect to MySQL server on '<host>' (<os detail>)`), so we match on the OS detail embedded in that message — plus the 1049 `Unknown database` server error — and return the same granular, actionable messages Postgres gives:

- unresolvable host → "Host could not be resolved…"
- connection refused → "Could not connect to the host on the port given…"
- timeout → "Connection timed out. Does your database have our IP addresses allowed?"
- no route / network unreachable → "Could not reach the host…"
- unknown database → "Database does not exist…"

The mapping lives in a create-time-only list consulted by `validate_credentials`. It is deliberately kept out of `get_non_retryable_errors()`, which the sync path also consults for retry classification — adding broad substrings like "timed out" there would risk reclassifying transient sync errors. Sync retry behavior is unchanged (verified by the existing retry-classification tests). A missing-database error is now also recognized as an expected user error instead of being captured as an unexpected exception.

## How did you test this code?

I'm an agent. Extended the existing `TestMySQLSourceValidateCredentials` parametrized test with the new connect-failure shapes (DNS, refused, timeout, no-route, network-unreachable, unknown-database, plus the existing access-denied case) and updated the two cases whose expected message changed. Ran the validate-credentials and retry-classification subsets with `uv run pytest` — all pass. No manual testing.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Found while triaging data-warehouse source-creation failures: every MySQL connection failure surfaced the same generic string. Chose to scope the granularity to the create-time validation path rather than the shared non-retryable error dict, specifically to avoid touching sync retry behavior (which is being actively tuned elsewhere). No skills were applicable.
