### PR TITLE
fix(experiments): cap recalc query_to at experiment end_date

### DIFF
--- a/products/experiments/backend/temporal/recalculation_logic.py
+++ b/products/experiments/backend/temporal/recalculation_logic.py
@@ -174,7 +174,10 @@ def _update_recalculation_progress_sync(update: RecalculationProgressUpdate) -> 
         # Temporal retry of this activity can't move query_to forward (which would orphan any rows persisted by
         # calc activities still in flight from the prior attempt).
         if update.mark_started:
+            end_date = Experiment.objects.filter(id=state.experiment_id).values_list("end_date", flat=True).first()
             proposed_query_to = timezone.now()
+            if end_date is not None:
+                proposed_query_to = min(proposed_query_to, end_date)
             won = (
                 ExperimentMetricsRecalculation.objects.filter(id=update.recalculation_id, query_to__isnull=True).update(
                     query_to=proposed_query_to,

--- a/products/experiments/backend/temporal/test_recalculation_activities.py
+++ b/products/experiments/backend/temporal/test_recalculation_activities.py
@@ -1,7 +1,8 @@
 from contextlib import contextmanager
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import pytest
+from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
@@ -211,6 +212,42 @@ class TestRecalculationActivities(BaseTest):
         assert recalc.started_at == first_started_at
         # Both attempts return the same canonical query_to so the workflow threads the same value either way.
         assert first == second == first_query_to.isoformat()
+
+    @parameterized.expand(
+        [
+            # name, end_date_offset_days (None = running experiment), expect query_to clamped to end_date
+            ("running_experiment_uses_now", None, False),
+            ("stopped_experiment_caps_at_end_date", -5, True),
+            ("future_end_date_uses_now", 5, False),
+        ]
+    )
+    @freeze_time("2026-06-23T05:00:00Z")
+    def test_mark_started_caps_query_to_at_end_date(self, name: str, end_date_offset_days, expect_capped: bool):
+        # A stopped experiment's linked flag often keeps firing, so query_to must freeze at end_date — otherwise
+        # each recalc advances it to now and pulls post-end exposures (and their conversions) into the results.
+        now = timezone.now()
+        exp = self._experiment(flag_key=f"cap-{name}")
+        if end_date_offset_days is not None:
+            exp.end_date = now + timedelta(days=end_date_offset_days)
+            exp.save(update_fields=["end_date"])
+        recalc = self._recalc(exp)
+
+        _update(
+            RecalculationProgressUpdate(
+                recalculation_id=str(recalc.id),
+                status="in_progress",
+                total_metrics=1,
+                metric_uuids=["m1"],
+                mark_started=True,
+            )
+        )
+
+        recalc.refresh_from_db()
+        assert recalc.query_to is not None
+        if expect_capped:
+            assert recalc.query_to == now + timedelta(days=end_date_offset_days)
+        else:
+            assert recalc.query_to == now
 
     def test_mark_completed_is_first_write_wins_on_retry(self):
         # Symmetric to mark_started: a retried finish activity must not re-stamp completed_at.


### PR DESCRIPTION
## Problem

The new recalculation workflow (which is behind a feature flag) does not correctly set the `end_date` so exposures after end date gets included in the results.

## Changes

Cap the run-wide `query_to` at `min(now, end_date)` when the experiment has ended:

- **Stopped** (`end_date` in the past) → window freezes at `end_date`; results stop absorbing post-stop flag traffic.
- **Running** (`end_date is None`) → stays at `now`, unchanged.
- **Scheduled to end in the future** → stays at `now` and only clamps once the experiment has actually ended.

Side benefit: a stopped experiment's `query_to` is now stable across recalcs, so the fingerprint-keyed result cache reuses prior results instead of recomputing a growing number every run.

This is a point fix. I'm working on a refactor here to simplify `end_date` handling across all call-sites.

## How did you test this code?

- Tested locally
- CI passes
