### PR TITLE
refactor(error-tracking): remove dead exception-props code paths

### DIFF
--- a/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
+++ b/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
@@ -1,30 +1,8 @@
-use std::sync::Arc;
-
-use crate::modes::processing::rules::grouping::{try_grouping_rules, GroupingRule};
-use crate::{
-    app_context::AppContext,
-    error::UnhandledError,
-    modes::processing::rules::assignment::NewAssignment,
-    types::{ExceptionList, RawErrProps},
-};
-use common_types::TeamId;
+use crate::modes::processing::rules::grouping::GroupingRule;
+use crate::{modes::processing::rules::assignment::NewAssignment, types::ExceptionList};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 use uuid::Uuid;
-
-pub async fn resolve_fingerprint(
-    ctx: &Arc<AppContext>,
-    team_id: TeamId,
-    props: &RawErrProps,
-) -> Result<Fingerprint, UnhandledError> {
-    let mut conn = ctx.posthog_pool.acquire().await?;
-    let team_manager = &ctx.team_manager;
-    if let Some(rule) = try_grouping_rules(&mut conn, team_id, team_manager, props).await? {
-        Ok(Fingerprint::from_rule(rule))
-    } else {
-        Ok(Fingerprint::from_exception_list(&props.exception_list))
-    }
-}
 
 // We put a vec of these on the event as a record of what actually went into a fingerprint.
 // This data is user-facing/used in the frontend, so make changes with caution

--- a/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
+++ b/rust/cymbal/src/modes/processing/fingerprinting/mod.rs
@@ -1,5 +1,5 @@
 use crate::modes::processing::rules::grouping::GroupingRule;
-use crate::{modes::processing::rules::assignment::NewAssignment, types::ExceptionList};
+use crate::types::ExceptionList;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha512};
 use uuid::Uuid;
@@ -32,9 +32,6 @@ pub trait FingerprintComponent {
 pub struct Fingerprint {
     pub value: String,
     pub record: Vec<FingerprintRecordPart>,
-    // DEPRECATED: assignment is never used
-    #[serde(skip)]
-    pub assignment: Option<NewAssignment>, // If this fingerprint came from a custom rule, it might carry an assignment with it
 }
 
 #[derive(Debug, Clone, Default)]
@@ -58,7 +55,6 @@ impl FingerprintBuilder {
         Fingerprint {
             value: content,
             record: self.record,
-            assignment: None,
         }
     }
 }
@@ -69,7 +65,6 @@ impl Fingerprint {
         Fingerprint {
             value: content,
             record: vec![FingerprintRecordPart::Custom { rule_id: rule.id }],
-            assignment: rule.assignment(),
         }
     }
 

--- a/rust/cymbal/src/modes/processing/issue_resolution.rs
+++ b/rust/cymbal/src/modes/processing/issue_resolution.rs
@@ -6,12 +6,10 @@ use common_kafka::kafka_producer::{send_iter_to_kafka, KafkaProduceError};
 
 use rdkafka::types::RDKafkaErrorCode;
 use serde::{Deserialize, Serialize};
-use sqlx::PgConnection;
 use uuid::Uuid;
 
-use crate::modes::processing::rules::assignment::{try_assignment_rules, Assignee, Assignment};
-use crate::teams::TeamManager;
-use crate::types::{FingerprintedErrProps, OutputErrProps};
+use crate::modes::processing::rules::assignment::{Assignee, Assignment};
+use crate::types::OutputErrProps;
 use crate::{
     analytics::capture_issue_reopened, app_context::AppContext, error::UnhandledError,
     metric_consts::ISSUE_REOPENED,
@@ -352,33 +350,6 @@ impl IssueFingerprintOverride {
 
         Ok(res)
     }
-}
-
-pub async fn process_assignment(
-    conn: &mut PgConnection,
-    team_manager: &TeamManager,
-    issue: &Issue,
-    props: FingerprintedErrProps,
-) -> Result<Option<Assignment>, UnhandledError> {
-    let new_assignment = if let Some(new) = props.fingerprint.assignment.clone() {
-        Some(new)
-    } else {
-        try_assignment_rules(
-            conn,
-            team_manager,
-            issue.clone(),
-            &props.to_output(issue.id),
-        )
-        .await?
-    };
-
-    let assignment = if let Some(new_assignment) = new_assignment {
-        Some(new_assignment.apply(&mut *conn, issue.id).await?)
-    } else {
-        issue.get_assignments(&mut *conn).await?.first().cloned()
-    };
-
-    Ok(assignment)
 }
 
 pub async fn send_issue_created_alert(

--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -16,7 +16,6 @@ use crate::{
     },
     modes::processing::rules::assignment::NewAssignment,
     teams::TeamManager,
-    types::RawErrProps,
 };
 
 #[derive(Debug, Clone)]
@@ -133,45 +132,6 @@ impl GroupingRule {
     }
 }
 
-pub async fn try_grouping_rules(
-    con: &mut PgConnection,
-    team_id: TeamId,
-    team_manager: &TeamManager,
-    exception_properties: &RawErrProps,
-) -> Result<Option<GroupingRule>, UnhandledError> {
-    let mut props_json = serde_json::to_value(exception_properties)?;
-
-    if let Value::Object(ref mut props) = props_json {
-        let exception_list = &exception_properties.exception_list;
-        props.insert(
-            "$exception_types".to_string(),
-            serde_json::to_value(exception_list.get_unique_types())?,
-        );
-        props.insert(
-            "$exception_values".to_string(),
-            serde_json::to_value(exception_list.get_unique_messages())?,
-        );
-        props.insert(
-            "$exception_releases".to_string(),
-            serde_json::to_value(exception_list.get_release_map())?,
-        );
-        props.insert(
-            "$exception_sources".to_string(),
-            serde_json::to_value(exception_list.get_unique_sources())?,
-        );
-        props.insert(
-            "$exception_functions".to_string(),
-            serde_json::to_value(exception_list.get_unique_functions())?,
-        );
-        props.insert(
-            "$exception_handled".to_string(),
-            serde_json::to_value(exception_list.get_is_handled())?,
-        );
-    }
-
-    evaluate_grouping_rules(con, team_id, team_manager, props_json).await
-}
-
 pub async fn evaluate_grouping_rules(
     con: &mut PgConnection,
     team_id: TeamId,
@@ -222,20 +182,14 @@ pub async fn evaluate_grouping_rules(
 
 #[cfg(test)]
 mod test {
-    use std::collections::HashMap;
-
     use chrono::Utc;
     use serde_json::{json, Value as JsonValue};
     use sqlx::PgPool;
     use uuid::Uuid;
 
-    use crate::{
-        fingerprinting::resolve_fingerprint,
-        test_utils::create_test_context,
-        types::{ExceptionList, RawErrProps},
-    };
+    use crate::{fingerprinting::Fingerprint, test_utils::create_test_context};
 
-    use super::GroupingRule;
+    use super::{evaluate_grouping_rules, GroupingRule};
 
     fn rule_bytecode() -> JsonValue {
         // return properties.test_value = 'test_value'
@@ -268,27 +222,20 @@ mod test {
         }
     }
 
-    fn test_props() -> RawErrProps {
-        RawErrProps {
-            exception_list: ExceptionList(vec![]),
-            fingerprint: None,
-            issue_name: None,
-            issue_description: None,
-            handled: None,
-            other: HashMap::new(),
-            debug_images: vec![],
-        }
+    fn test_props(test_value: JsonValue) -> JsonValue {
+        json!({
+            "$exception_list": [],
+            "test_value": test_value,
+        })
     }
 
     #[sqlx::test(migrations = "./tests/test_migrations")]
     async fn test_grouping_rules(db: PgPool) {
         let ctx = create_test_context(db).await;
+        let mut conn = ctx.posthog_pool.acquire().await.unwrap();
 
         let test_team_id = 1;
-        let mut test_props = test_props();
-        test_props
-            .other
-            .insert("test_value".to_string(), JsonValue::from("test_value"));
+        let props = test_props(JsonValue::from("test_value"));
 
         let rule = get_test_rule();
         let expected_fingerprint = format!("custom-rule:{}", rule.id);
@@ -297,12 +244,14 @@ mod test {
             .grouping_rules
             .insert(test_team_id, vec![rule]);
 
-        let res = resolve_fingerprint(&ctx, test_team_id, &test_props)
-            .await
-            .unwrap();
+        let matched =
+            evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props.clone())
+                .await
+                .unwrap();
+        let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
 
-        assert_eq!(res.value, expected_fingerprint);
-        assert!(res.assignment.is_none()); // The rule has no assignment associated with it
+        assert_eq!(fingerprint.value, expected_fingerprint);
+        assert!(fingerprint.assignment.is_none()); // The rule has no assignment associated with it
 
         // Make sure if a rule has an assignment associated with it, it's returned in the fingerprint
         let mut rule = get_test_rule();
@@ -312,24 +261,22 @@ mod test {
             .grouping_rules
             .insert(test_team_id, vec![rule]);
 
-        let res = resolve_fingerprint(&ctx, test_team_id, &test_props)
+        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props)
             .await
             .unwrap();
+        let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
 
-        assert_eq!(res.value, expected_fingerprint);
-        assert!(res.assignment.is_some());
+        assert_eq!(fingerprint.value, expected_fingerprint);
+        assert!(fingerprint.assignment.is_some());
 
-        // Insert a different value - simply removed the value would cause the rule to be disabled, since it
+        // Insert a different value - simply removing the value would cause the rule to be disabled, since it
         // tries to access an undefined global
-        test_props
-            .other
-            .insert("test_value".to_string(), JsonValue::from("no_match"));
+        let props = test_props(JsonValue::from("no_match"));
 
-        let res = resolve_fingerprint(&ctx, test_team_id, &test_props)
+        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props)
             .await
             .unwrap();
 
-        assert_ne!(res.value, expected_fingerprint);
-        assert!(res.assignment.is_none());
+        assert!(matched.is_none());
     }
 }

--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -14,7 +14,6 @@ use crate::{
         CUSTOM_GROUPED_EVENTS, GROUPING_RULES_DISABLED, GROUPING_RULES_FOUND,
         GROUPING_RULES_PROCESSING_TIME, GROUPING_RULES_TRIED,
     },
-    modes::processing::rules::assignment::NewAssignment,
     teams::TeamManager,
 };
 
@@ -126,10 +125,6 @@ impl GroupingRule {
 
         Err(VmError::OutOfResource("steps".to_string()))
     }
-
-    pub fn assignment(&self) -> Option<NewAssignment> {
-        NewAssignment::try_new(self.user_id, self.role_id)
-    }
 }
 
 pub async fn evaluate_grouping_rules(
@@ -175,8 +170,6 @@ pub async fn evaluate_grouping_rules(
 
     timing.label("outcome", "no_match").fin();
 
-    // If none of the rules matched, grab the existing assignment, in case one exists,
-    // and return that (or None)
     Ok(None)
 }
 
@@ -251,23 +244,6 @@ mod test {
         let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
 
         assert_eq!(fingerprint.value, expected_fingerprint);
-        assert!(fingerprint.assignment.is_none()); // The rule has no assignment associated with it
-
-        // Make sure if a rule has an assignment associated with it, it's returned in the fingerprint
-        let mut rule = get_test_rule();
-        let expected_fingerprint = format!("custom-rule:{}", rule.id);
-        rule.user_id = Some(1);
-        ctx.team_manager
-            .grouping_rules
-            .insert(test_team_id, vec![rule]);
-
-        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props)
-            .await
-            .unwrap();
-        let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
-
-        assert_eq!(fingerprint.value, expected_fingerprint);
-        assert!(fingerprint.assignment.is_some());
 
         // Insert a different value - simply removing the value would cause the rule to be disabled, since it
         // tries to access an undefined global

--- a/rust/cymbal/src/modes/processing/types/mod.rs
+++ b/rust/cymbal/src/modes/processing/types/mod.rs
@@ -2,15 +2,12 @@ use common_types::embedding::{EmbeddingModel, EmbeddingRequest};
 use common_types::error_tracking::RawFrameId;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
-use sha2::{Digest, Sha512};
 use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::ops::{Deref, DerefMut};
 use uuid::Uuid;
 
-use crate::fingerprinting::{
-    Fingerprint, FingerprintBuilder, FingerprintComponent, FingerprintRecordPart,
-};
+use crate::fingerprinting::{FingerprintBuilder, FingerprintComponent, FingerprintRecordPart};
 use crate::frames::releases::{ReleaseInfo, ReleaseRecord};
 use crate::frames::{Frame, RawFrame};
 use crate::issue_resolution::Issue;
@@ -134,15 +131,20 @@ pub struct RawErrProps {
     pub other: HashMap<String, Value>,
 }
 
-#[derive(Debug, Clone)]
-pub struct FingerprintedErrProps {
-    pub exception_list: ExceptionList,
-    pub fingerprint: Fingerprint,
-    pub proposed_issue_name: Option<String>,
-    pub proposed_issue_description: Option<String>,
-    pub proposed_fingerprint: String, // We suggest a fingerprint, based on hashes, but let users override client-side
-    pub handled: Option<bool>,
-    pub other: HashMap<String, Value>,
+impl RawErrProps {
+    pub fn add_error_message(&mut self, msg: impl ToString) {
+        let mut errors = match self.other.remove("$cymbal_errors") {
+            Some(serde_json::Value::Array(errors)) => errors,
+            _ => Vec::new(),
+        };
+
+        errors.push(serde_json::Value::String(msg.to_string()));
+
+        self.other.insert(
+            "$cymbal_errors".to_string(),
+            serde_json::Value::Array(errors),
+        );
+    }
 }
 
 // We emit this
@@ -180,20 +182,6 @@ pub struct OutputErrProps {
     #[serde(rename = "$exception_functions")]
     pub functions: Vec<String>,
 }
-
-const RESERVED_PROPERTIES: [&str; 11] = [
-    "$exception_list",
-    "$exception_fingerprint",
-    "$exception_issue_id",
-    "$exception_fingerprint_record",
-    "$exception_proposed_fingerprint",
-    "$exception_handled",
-    "$exception_releases",
-    "$exception_types",
-    "$exception_values",
-    "$exception_sources",
-    "$exception_functions",
-];
 
 impl FingerprintComponent for Exception {
     fn update(&self, fp: &mut FingerprintBuilder) {
@@ -235,86 +223,6 @@ impl Exception {
             if (has_no_resolved || frame.resolved) && frame.in_app {
                 frame.update(fp)
             }
-        }
-    }
-}
-
-impl RawErrProps {
-    pub fn add_error_message(&mut self, msg: impl ToString) {
-        let mut errors = match self.other.remove("$cymbal_errors") {
-            Some(serde_json::Value::Array(errors)) => errors,
-            _ => Vec::new(),
-        };
-
-        errors.push(serde_json::Value::String(msg.to_string()));
-
-        self.other.insert(
-            "$cymbal_errors".to_string(),
-            serde_json::Value::Array(errors),
-        );
-    }
-
-    pub fn to_fingerprinted(self, mut fingerprint: Fingerprint) -> FingerprintedErrProps {
-        // We always track the fingerprint we'd have proposed if none was set
-        let proposed_fingerprint = fingerprint.value.clone();
-
-        // But if one was set, we use that and modify our fingerprint to reflect that
-        if let Some(existing) = self.fingerprint {
-            fingerprint.record.clear();
-            fingerprint.record.push(FingerprintRecordPart::Manual);
-            fingerprint.value = existing;
-            if fingerprint.value.len() > 64 {
-                let mut hasher = Sha512::default();
-                hasher.update(fingerprint.value);
-                fingerprint.value = format!("{:x}", hasher.finalize());
-            }
-            fingerprint.assignment = None;
-        }
-
-        FingerprintedErrProps {
-            exception_list: self.exception_list,
-            fingerprint,
-            proposed_issue_name: self.issue_name,
-            proposed_issue_description: self.issue_description,
-            proposed_fingerprint,
-            handled: self.handled,
-            other: self.other,
-        }
-    }
-}
-
-impl FingerprintedErrProps {
-    pub fn to_output(self, issue_id: Uuid) -> OutputErrProps {
-        let sources = self.exception_list.get_unique_sources();
-        let functions = self.exception_list.get_unique_functions();
-        let releases = self.exception_list.get_release_map();
-        let types = self.exception_list.get_unique_types();
-        let values = self.exception_list.get_unique_messages();
-        let handled: bool = self
-            .handled
-            .unwrap_or_else(|| self.exception_list.get_is_handled());
-
-        // If users send properties that are reserved, it will results in property keys being duplicated
-        let sanitized_others = self
-            .other
-            .into_iter()
-            .filter(|(k, _)| !RESERVED_PROPERTIES.contains(&k.as_str()))
-            .collect();
-
-        OutputErrProps {
-            exception_list: self.exception_list,
-            fingerprint: self.fingerprint.value,
-            issue_id,
-            proposed_fingerprint: self.proposed_fingerprint,
-            fingerprint_record: self.fingerprint.record,
-            other: sanitized_others,
-
-            types,
-            values,
-            sources,
-            functions,
-            handled,
-            releases,
         }
     }
 }

--- a/rust/cymbal/tests/assignment_rules.rs
+++ b/rust/cymbal/tests/assignment_rules.rs
@@ -1,13 +1,11 @@
-use std::collections::HashMap;
-
 use chrono::Utc;
 use cymbal::{
-    fingerprinting::Fingerprint,
-    issue_resolution::{process_assignment, Issue, IssueStatus},
-    modes::processing::rules::assignment::{AssignmentRule, NewAssignment},
+    issue_resolution::{Issue, IssueStatus},
+    modes::processing::rules::assignment::AssignmentRule,
     modes::processing::ProcessingConfig,
+    stages::linking::issue::process_assignment,
     teams::TeamManager,
-    types::{ExceptionList, FingerprintedErrProps},
+    types::exception_properties::ExceptionProperties,
 };
 use serde_json::{json, Value as JsonValue};
 use sqlx::PgPool;
@@ -44,24 +42,21 @@ fn get_test_rule() -> AssignmentRule {
     }
 }
 
-fn test_fingerprint() -> Fingerprint {
-    Fingerprint {
-        value: String::from("test value"),
-        record: vec![],
-        assignment: None,
-    }
-}
-
-fn test_props(fingerprint: Fingerprint) -> FingerprintedErrProps {
-    FingerprintedErrProps {
-        exception_list: ExceptionList(vec![]),
-        fingerprint,
-        proposed_issue_name: None,
-        proposed_issue_description: None,
-        proposed_fingerprint: String::new(),
-        handled: None,
-        other: HashMap::new(),
-    }
+fn test_props() -> ExceptionProperties {
+    // process_assignment calls to_output(), which requires the materialized
+    // search fields to be present, so seed them (empty, since exception_list is empty).
+    serde_json::from_value(json!({
+        "$exception_list": [],
+        "$exception_types": [],
+        "$exception_values": [],
+        "$exception_sources": [],
+        "$exception_functions": [],
+        "$exception_handled": false,
+        "$exception_fingerprint": "test value",
+        "$exception_proposed_fingerprint": "test value",
+        "test_value": "test_value",
+    }))
+    .unwrap()
 }
 
 fn test_issue() -> Issue {
@@ -79,12 +74,8 @@ fn test_issue() -> Issue {
 async fn test_assignment_processing(db: PgPool) {
     let config = ProcessingConfig::init_with_defaults().unwrap();
 
-    let fingerprint = test_fingerprint();
     let test_team_id = 1;
-    let mut test_props = test_props(fingerprint);
-    test_props
-        .other
-        .insert("test_value".to_string(), JsonValue::from("test_value"));
+    let test_props = test_props();
 
     let issue = test_issue();
 
@@ -97,17 +88,14 @@ async fn test_assignment_processing(db: PgPool) {
 
     let mut conn = db.acquire().await.unwrap();
 
-    let res = process_assignment(&mut conn, &team_manager, &issue, test_props.clone())
+    let res = process_assignment(&mut conn, &team_manager, &issue, &test_props)
         .await
         .unwrap();
 
+    // The assignment returned is the one from the rule
     assert!(res.is_some());
     let res = res.unwrap();
-
-    // Assert that the assignment returned is the one from the rule, because the fingerprint has no assignment
-    assert!(test_props.fingerprint.assignment.is_none());
-    assert!(res.user_id.is_some());
-    assert_eq!(res.user_id.unwrap(), 1);
+    assert_eq!(res.user_id, Some(1));
 
     let existing = res;
 
@@ -121,7 +109,7 @@ async fn test_assignment_processing(db: PgPool) {
         .assignment_rules
         .insert(test_team_id, vec![rule]);
 
-    let res = process_assignment(&mut conn, &team_manager, &issue, test_props.clone())
+    let res = process_assignment(&mut conn, &team_manager, &issue, &test_props)
         .await
         .unwrap();
 
@@ -129,28 +117,4 @@ async fn test_assignment_processing(db: PgPool) {
     let res = res.unwrap();
     assert_eq!(res.user_id, existing.user_id);
     assert_eq!(res.role_id, existing.role_id);
-
-    // Next, change the issue, and put an assignment on the fingerprint. The returned assignment should be the one from
-    // the fingerprint, rather than the rule, because fingerprint assignments take priority over assignment rules
-
-    let mut props_with_fingerprint_assignment = test_props.clone();
-    let fingerprint_assignment = NewAssignment::try_new(Some(3), None).unwrap();
-    props_with_fingerprint_assignment.fingerprint.assignment = Some(fingerprint_assignment);
-
-    let mut new_issue = issue.clone();
-    new_issue.id = Uuid::now_v7(); // So we don't hit the "respect existing assignments" path
-
-    let res = process_assignment(
-        &mut conn,
-        &team_manager,
-        &new_issue,
-        props_with_fingerprint_assignment.clone(),
-    )
-    .await
-    .unwrap();
-
-    assert!(res.is_some());
-    let res = res.unwrap();
-    assert_eq!(res.user_id, Some(3));
-    assert_eq!(res.role_id, None);
 }


### PR DESCRIPTION
## Problem

The cymbal error-tracking pipeline accumulated several exception-props types and helpers that are no longer on the live path — leftovers from an earlier fingerprinting design. They add noise and make the type story harder to follow before any larger refactor.

## Changes

Removes code that isn't exercised by the production pipeline:

- `FingerprintedErrProps` and `RawErrProps::to_fingerprinted` — never constructed.
- `resolve_fingerprint` / `try_grouping_rules` — test-only wrappers around the live `evaluate_grouping_rules`.
- the unused `issue_resolution::process_assignment` overload (the live one lives in `stages/linking/issue.rs`).
- the now-unused `RESERVED_PROPERTIES` constant.

The affected tests are retargeted onto the live code paths (`evaluate_grouping_rules`, the live `process_assignment`). `RawErrProps` is intentionally kept — it's the lossless raw-input view guarded by the serde-passthrough test, and it folds into the typestate `ExceptionEvent<Raw>` in the stacked follow-up PR.

No behavior change.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Ran the full cymbal test suite against a local Postgres (`cargo test -p cymbal`) — green; `cargo clippy -p cymbal --all-targets` clean; `cargo fmt` applied.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the user's direction. This is the first of two stacked PRs; it isolates the safe dead-code removal so the larger typestate migration (PR 2) reviews cleanly on top. The user steered scope and approach throughout.

Confirmed dead/test-only status by tracing every caller before deleting (the production fingerprint path runs `FingerprintGenerator` → `evaluate_grouping_rules` on the carrier, not the removed `RawErrProps → to_fingerprinted` chain). No repo skills were invoked.
