### PR TITLE
fix(max): don't crash the bare /ai scene when panelId is missing

### DIFF
--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -136,6 +136,9 @@ function updateInactiveTab(tabId: string, props: Partial<SceneTab>): void {
 // Fixed panelId for the floating side panel chat, which is not a scene tab.
 export const SIDE_PANEL_PANEL_ID = 'sidepanel'
 
+// Fallback panelId for the bare /ai scene, which has no tab id and no side panel chrome.
+export const SCENE_PANEL_ID = 'scene'
+
 export interface MaxLogicProps {
     panelId?: string
     initialFrontendConversationId?: string
@@ -154,7 +157,7 @@ function sceneTabId(panelId?: string, syncUrl?: boolean): string | null {
 
 export const maxLogic = kea<maxLogicType>([
     props({} as MaxLogicProps),
-    key((props) => props.panelId || 'scene'),
+    key((props) => props.panelId || SCENE_PANEL_ID),
     path((key) => ['scenes', 'max', 'maxLogic', key]),
 
     connect(() => ({

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -105,6 +105,13 @@ describe('maxThreadLogic', () => {
         jest.restoreAllMocks()
     })
 
+    it('builds for the bare scene without a panelId, falling back to the scene key', () => {
+        const sceneLogic = maxThreadLogic({ conversationId: MOCK_CONVERSATION_ID })
+        expect(() => sceneLogic.mount()).not.toThrow()
+        expect(sceneLogic.key).toBe(`${MOCK_CONVERSATION_ID}-scene`)
+        sceneLogic.unmount()
+    })
+
     it('selects threadGroup without a human message', async () => {
         await expectLogic(logic, () => {
             logic.actions.setThread([

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -71,7 +71,7 @@ import { summariseAssistantThread } from './handsFreeUtils'
 import { EnhancedToolCall, MODE_DEFINITIONS, TOOL_DEFINITIONS, ToolRegistration } from './max-constants'
 import { MaxBillingContext, MaxBillingContextSubscriptionLevel, maxBillingContextLogic } from './maxBillingContextLogic'
 import { maxGlobalLogic } from './maxGlobalLogic'
-import { SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
+import { SCENE_PANEL_ID, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import type { maxThreadLogicType } from './maxThreadLogicType'
 import { MaxUIContext } from './maxTypes'
 import { MAX_SLASH_COMMANDS, SlashCommand } from './slash-commands'
@@ -110,12 +110,9 @@ export interface MaxThreadLogicProps {
 }
 
 export const maxThreadLogic = kea<maxThreadLogicType>([
-    key((props) => {
-        if (!props.panelId) {
-            throw new Error('Max thread logic must have a panelId prop')
-        }
-        return `${props.conversationId}-${props.panelId}`
-    }),
+    // Mirror maxLogic's key fallback: the bare /ai scene has no panelId, and both logics must
+    // resolve to the same `scene` instance (maxThreadLogic connects to maxLogic({ panelId })).
+    key((props) => `${props.conversationId}-${props.panelId || SCENE_PANEL_ID}`),
 
     path((key) => ['scenes', 'max', 'maxThreadLogic', key]),
 


### PR DESCRIPTION
## Problem

The standalone `/ai` scene crashes on render with `Error: Max thread logic must have a panelId prop`. It's one of the top frontend errors right now, hitting users across many projects on both US and EU clouds.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019ef470-afe7-76c2-8a7e-ddc87564ed23

Root cause: the `/ai` scene isn't tab-aware, so its `tabId` prop is `undefined`. `Max.tsx` falls back to `''`, which flows down as `maxThreadLogic`'s `panelId`. The `key` function threw on any falsy `panelId`. `maxLogic` already tolerated a missing `panelId` (falling back to the `'scene'` key), but `maxThreadLogic` did not — so the two diverged for the bare scene and the render crashed. This was introduced when #62086 collapsed `tabId`/`sidePanel` into a single `panelId` and added the defensive throw.

## Changes

- `maxThreadLogic` now mirrors `maxLogic`'s existing key fallback: `${conversationId}-${panelId || 'scene'}` instead of throwing. Both logics resolve to the same `scene` instance for the bare scene (consistent with `maxThreadLogic` connecting to `maxLogic({ panelId })`).
- Extracted the `'scene'` literal into an exported `SCENE_PANEL_ID` constant in `maxLogic`.

Deliberately did **not** hand the scene an explicit `'scene'` panelId — `sceneTabId` keys per-tab drafts/badges off a truthy `panelId`, and its own comment says the bare scene shouldn't carry those. Keeping `panelId` falsy at the `maxLogic` level preserves that behavior.

## How did you test this code?

I'm an agent (Claude Code). Automated tests I actually ran:

- Added a regression test in `maxThreadLogic.test.ts` asserting the logic builds without a `panelId` and keys to `${conversationId}-scene` (previously threw).
- `maxThreadLogic.test.ts` (108 tests), `maxLogic.test.ts` + `max.test.ts` (40 tests) — all green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated via the PostHog MCP error-tracking tools to confirm the crashing surface (all samples on `/ai`), then traced the `tabId ?? ''` → empty `panelId` → throw path. Considered passing an explicit `'scene'` panelId from the scene, but rejected it because it would flip `sceneTabId` truthy and turn on per-tab drafts/badges the bare scene is documented not to have. Chose to align `maxThreadLogic`'s key with `maxLogic`'s existing `|| 'scene'` fallback as the minimal, behavior-preserving fix. No repo skills were applicable to this change.
