### PR TITLE
chore(dags): fix dagster local dev port from 3000 to 3030

### DIFF
--- a/posthog/dags/README.md
+++ b/posthog/dags/README.md
@@ -160,7 +160,7 @@ export DEBUG=1 # Important: Set DEBUG=1 when running locally to use local resour
 dagster dev --workspace $DAGSTER_HOME/workspace.yaml
 ```
 
-The Dagster UI will be available at http://localhost:3000 by default, where you can:
+The Dagster UI will be available at http://localhost:3030 by default, where you can:
 
 - Browse assets, jobs, and schedules
 - Manually trigger job runs


### PR DESCRIPTION
## Problem

The Dagster local dev docs referenced port 3000, but Dagster actually runs on port 3030 in local environments.

## Changes

Updated the URL in `posthog/dags/README.md` from `http://localhost:3000` to `http://localhost:3030`.

## How did you test this code?

Agent-authored doc fix — no code logic changed, verified by grepping all dagster port references in the repo.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Straightforward doc fix: user reported the port discrepancy, agent grepped the repo to confirm only one occurrence needed updating, made the change, and opened the PR.