### PR TITLE
fix(max): give bare scene a stable panelId

### DIFF
--- a/frontend/src/scenes/max/Max.tsx
+++ b/frontend/src/scenes/max/Max.tsx
@@ -36,7 +36,7 @@ import { ThreadAutoScroller } from './components/ThreadAutoScroller'
 import { ConversationHistory } from './ConversationHistory'
 import { HistoryPreview } from './HistoryPreview'
 import { Intro } from './Intro'
-import { MaxLogicProps, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
+import { MaxLogicProps, SCENE_PANEL_ID, SIDE_PANEL_PANEL_ID, maxLogic } from './maxLogic'
 import { MaxThreadLogicProps, maxThreadLogic } from './maxThreadLogic'
 import { SandboxComposerSurfaces, Thread } from './Thread'
 
@@ -71,7 +71,7 @@ export function Max({ tabId }: { tabId?: string }): JSX.Element {
         )
     }
 
-    return <AiFirstMaxInstance tabId={tabId ?? ''} />
+    return <AiFirstMaxInstance tabId={tabId ?? SCENE_PANEL_ID} />
 }
 
 export interface MaxInstanceProps {

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -130,6 +130,9 @@ const CHAT_TITLE_HISTORY = 'Chat history'
 // Fixed panelId for the floating side panel chat, which is not a scene tab.
 export const SIDE_PANEL_PANEL_ID = 'sidepanel'
 
+// Fixed panelId for the bare full-page Max scene, which no longer carries a scene tab id.
+export const SCENE_PANEL_ID = 'scene'
+
 export interface MaxLogicProps {
     panelId?: string
     initialFrontendConversationId?: string
@@ -148,7 +151,7 @@ function sceneTabId(panelId?: string, syncUrl?: boolean): string | null {
 
 export const maxLogic = kea<maxLogicType>([
     props({} as MaxLogicProps),
-    key((props) => props.panelId || 'scene'),
+    key((props) => props.panelId || SCENE_PANEL_ID),
     path((key) => ['scenes', 'max', 'maxLogic', key]),
 
     connect(() => ({


### PR DESCRIPTION
## Problem

Opening the full-page PostHog AI (Max) scene crashed with:

```
Error: Max thread logic must have a panelId prop
```

This was introduced by #62051, which collapsed `sceneLogic` tabs to single-scene state and removed the selector that injected `tabId` into scene component params (the old `activeSceneComponentParamsWithTabId`). The `Max` scene component now receives `tabId === undefined`, then passed `tabId ?? ''` down to `AiFirstMaxInstance`. That empty string became `maxThreadLogic`'s `panelId`, and its `key` throws on a falsy `panelId`.

`maxLogic` survived this only because its `key` already falls back: `props.panelId || 'scene'`. `maxThreadLogic` had no such fallback.

## Changes

Give the bare full-page scene the same stable `'scene'` panelId that `maxLogic` already keys on, instead of an empty string:

- `maxLogic.tsx`: extract the existing `'scene'` literal into an exported `SCENE_PANEL_ID` constant and use it in the `key` fallback.
- `Max.tsx`: fall back to `SCENE_PANEL_ID` instead of `''` when no `tabId` is present.

Both `maxLogic` and `maxThreadLogic` now resolve to the same `'scene'` panel for the full-page scene, keeping the side-panel-vs-scene comparison in `Max` consistent.

## How did you test this code?

I'm an agent. I traced the regression to #62051 by diffing the `sceneLogic` selector history and confirming `tabId` is no longer threaded into component params. I did not run the app manually. No automated test was added — the change is a constant/fallback swap. A reviewer can verify by opening the full-page Max scene, which previously threw on mount.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul reported the runtime crash and pointed at #62051 as the likely cause. I located the thrown error in `maxThreadLogic`'s `key`, walked the prop chain back from `AiFirstMaxInstance` -> `Max` -> `sceneLogic`, and confirmed #62051 dropped the `tabId` injection. Chose to mirror `maxLogic`'s existing `'scene'` fallback rather than make `maxThreadLogic` tolerate a falsy panelId, so both logics resolve to the same instance. No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
