### PR TITLE
fix(ai): skip agentic repo selection on sandbox open

### DIFF
--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -795,7 +795,7 @@ class ConversationViewSet(
 
         Runs only on a first message — no backing Task yet (`task_id is None`) and real content.
         Followups and resumes reuse the existing Task's repository, and warming has no message to
-        route on, so neither triggers the explicit repository mention match. Selection never raises;
+        route on, so neither triggers the (potentially heavy) selection. Selection never raises;
         any failure degrades to None — a repo-less sandbox — so it can't block the conversation.
         """
         if conversation.task_id is not None:

--- a/ee/api/conversation.py
+++ b/ee/api/conversation.py
@@ -795,7 +795,7 @@ class ConversationViewSet(
 
         Runs only on a first message — no backing Task yet (`task_id is None`) and real content.
         Followups and resumes reuse the existing Task's repository, and warming has no message to
-        route on, so neither triggers the (potentially heavy) selection. Selection never raises;
+        route on, so neither triggers the explicit repository mention match. Selection never raises;
         any failure degrades to None — a repo-less sandbox — so it can't block the conversation.
         """
         if conversation.task_id is not None:

--- a/products/tasks/backend/logic/repo_selection/cascade.py
+++ b/products/tasks/backend/logic/repo_selection/cascade.py
@@ -3,13 +3,7 @@ import logging
 from posthog.git import extract_explicit_repo
 from posthog.sync import database_sync_to_async
 
-from products.tasks.backend.logic.repo_selection.agent import (
-    RepoSelectionRejectedError,
-    RepoSelectionUnavailableError,
-    _list_candidate_repos,
-    resolve_team_github_integration,
-    select_repository,
-)
+from products.tasks.backend.logic.repo_selection.agent import _list_candidate_repos, resolve_team_github_integration
 from products.tasks.backend.models import Task
 
 logger = logging.getLogger(__name__)
@@ -22,14 +16,11 @@ async def select_repository_for_message(
     *,
     origin_product: Task.OriginProduct,
 ) -> str | None:
-    """Pick the repository a free-form chat message is most likely about, cheapest strategy first.
+    """Pick a connected repository only when the message names it explicitly.
 
-    1. An explicit `owner/repo` token in the message that matches a connected repo.
-    2. Delegated to `select_repository`, which returns the team's single eligible repo instantly,
-       or runs the sandbox LLM agent when there are several candidates.
-
-    Returns `None` when nothing connects (no integration, no candidates, the agent finds no
-    plausible subject, or selection fails for any reason). Selection must never block the
+    The sandbox conversation open path must stay fast: it runs before the Run is created, so we
+    avoid the repo-selection LLM agent here. Messages without an explicit connected `owner/repo`
+    mention return `None`, which starts a repo-less sandbox. Selection must never block the
     conversation from starting, so this never raises — every failure degrades to "no repo".
     """
     try:
@@ -40,24 +31,7 @@ async def select_repository_for_message(
         if not candidates:
             return None
 
-        explicit = extract_explicit_repo(message, candidates)
-        if explicit:
-            return explicit
-
-        # Reuse the integration and candidate list already resolved above so the heavy
-        # multi-repo path doesn't re-run both queries inside `select_repository`.
-        result = await select_repository(
-            team_id,
-            user_id,
-            context=message,
-            origin_product=origin_product,
-            github=github,
-            candidate_repos=candidates,
-        )
-        return result.repository
-    except (RepoSelectionRejectedError, RepoSelectionUnavailableError) as e:
-        logger.info("repo_selection_for_message.no_selection team_id=%s reason=%s", team_id, e)
-        return None
+        return extract_explicit_repo(message, candidates)
     except Exception:
         logger.warning("repo_selection_for_message.failed team_id=%s", team_id, exc_info=True)
         return None

--- a/products/tasks/backend/logic/repo_selection/cascade.py
+++ b/products/tasks/backend/logic/repo_selection/cascade.py
@@ -3,7 +3,13 @@ import logging
 from posthog.git import extract_explicit_repo
 from posthog.sync import database_sync_to_async
 
-from products.tasks.backend.logic.repo_selection.agent import _list_candidate_repos, resolve_team_github_integration
+from products.tasks.backend.logic.repo_selection.agent import (
+    RepoSelectionRejectedError,
+    RepoSelectionUnavailableError,
+    _list_candidate_repos,
+    resolve_team_github_integration,
+    select_repository,
+)
 from products.tasks.backend.models import Task
 
 logger = logging.getLogger(__name__)
@@ -16,11 +22,14 @@ async def select_repository_for_message(
     *,
     origin_product: Task.OriginProduct,
 ) -> str | None:
-    """Pick a connected repository only when the message names it explicitly.
+    """Pick the repository a free-form chat message is most likely about, cheapest strategy first.
 
-    The sandbox conversation open path must stay fast: it runs before the Run is created, so we
-    avoid the repo-selection LLM agent here. Messages without an explicit connected `owner/repo`
-    mention return `None`, which starts a repo-less sandbox. Selection must never block the
+    1. An explicit `owner/repo` token in the message that matches a connected repo.
+    2. Delegated to `select_repository`, which returns the team's single eligible repo instantly,
+       or runs the sandbox LLM agent when there are several candidates.
+
+    Returns `None` when nothing connects (no integration, no candidates, the agent finds no
+    plausible subject, or selection fails for any reason). Selection must never block the
     conversation from starting, so this never raises — every failure degrades to "no repo".
     """
     try:
@@ -31,7 +40,24 @@ async def select_repository_for_message(
         if not candidates:
             return None
 
-        return extract_explicit_repo(message, candidates)
+        explicit = extract_explicit_repo(message, candidates)
+        if explicit:
+            return explicit
+
+        # Reuse the integration and candidate list already resolved above so the heavy
+        # multi-repo path doesn't re-run both queries inside `select_repository`.
+        result = await select_repository(
+            team_id,
+            user_id,
+            context=message,
+            origin_product=origin_product,
+            github=github,
+            candidate_repos=candidates,
+        )
+        return result.repository
+    except (RepoSelectionRejectedError, RepoSelectionUnavailableError) as e:
+        logger.info("repo_selection_for_message.no_selection team_id=%s reason=%s", team_id, e)
+        return None
     except Exception:
         logger.warning("repo_selection_for_message.failed team_id=%s", team_id, exc_info=True)
         return None

--- a/products/tasks/backend/tests/test_repo_selection_cascade.py
+++ b/products/tasks/backend/tests/test_repo_selection_cascade.py
@@ -1,12 +1,5 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
-from parameterized import parameterized
-
-from products.tasks.backend.logic.repo_selection.agent import (
-    RepoSelectionRejectedError,
-    RepoSelectionResult,
-    RepoSelectionUnavailableError,
-)
 from products.tasks.backend.logic.repo_selection.cascade import select_repository_for_message
 from products.tasks.backend.models import Task
 
@@ -27,55 +20,20 @@ async def _run(message: str) -> str | None:
 class TestSelectRepositoryForMessage:
     async def test_no_github_integration_returns_none(self):
         resolve, list_repos = _patch_candidates(None, [])
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
+        with resolve, list_repos:
             assert await _run("anything") is None
-            select.assert_not_called()
 
     async def test_no_candidates_returns_none(self):
         resolve, list_repos = _patch_candidates(MagicMock(), [])
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
+        with resolve, list_repos:
             assert await _run("anything") is None
-            select.assert_not_called()
 
     async def test_explicit_mention_short_circuits(self):
         resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
+        with resolve, list_repos:
             assert await _run("please fix posthog/posthog-js") == "posthog/posthog-js"
-            select.assert_not_called()
 
-    async def test_delegates_to_select_repository_without_explicit_mention(self):
+    async def test_multi_candidate_without_explicit_mention_returns_none(self):
         resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        result = RepoSelectionResult(repository="posthog/posthog", reason="agent picked it")
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)) as select:
-            assert await _run("the dashboards are slow") == "posthog/posthog"
-            select.assert_awaited_once()
-
-    async def test_forwards_resolved_integration_and_candidates(self):
-        github = MagicMock()
-        candidates = ["posthog/posthog", "posthog/posthog-js"]
-        resolve, list_repos = _patch_candidates(github, candidates)
-        result = RepoSelectionResult(repository="posthog/posthog", reason="agent picked it")
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)) as select:
-            await _run("the dashboards are slow")
-            await_args = select.await_args
-            assert await_args is not None
-            assert await_args.kwargs["github"] is github
-            assert await_args.kwargs["candidate_repos"] == candidates
-
-    async def test_select_repository_null_returns_none(self):
-        resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        result = RepoSelectionResult(repository=None, reason="no plausible candidate")
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)):
-            assert await _run("a question about billing") is None
-
-    @parameterized.expand(
-        [
-            ("rejected", RepoSelectionRejectedError("posthog/hallucinated", "made it up")),
-            ("unavailable", RepoSelectionUnavailableError("all archived")),
-            ("unexpected", RuntimeError("sandbox boot failed")),
-        ]
-    )
-    async def test_selection_failure_degrades_to_none(self, _name: str, error: Exception):
-        resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(side_effect=error)):
+        with resolve, list_repos:
             assert await _run("the dashboards are slow") is None

--- a/products/tasks/backend/tests/test_repo_selection_cascade.py
+++ b/products/tasks/backend/tests/test_repo_selection_cascade.py
@@ -1,5 +1,12 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from parameterized import parameterized
+
+from products.tasks.backend.logic.repo_selection.agent import (
+    RepoSelectionRejectedError,
+    RepoSelectionResult,
+    RepoSelectionUnavailableError,
+)
 from products.tasks.backend.logic.repo_selection.cascade import select_repository_for_message
 from products.tasks.backend.models import Task
 
@@ -20,20 +27,55 @@ async def _run(message: str) -> str | None:
 class TestSelectRepositoryForMessage:
     async def test_no_github_integration_returns_none(self):
         resolve, list_repos = _patch_candidates(None, [])
-        with resolve, list_repos:
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
             assert await _run("anything") is None
+            select.assert_not_called()
 
     async def test_no_candidates_returns_none(self):
         resolve, list_repos = _patch_candidates(MagicMock(), [])
-        with resolve, list_repos:
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
             assert await _run("anything") is None
+            select.assert_not_called()
 
     async def test_explicit_mention_short_circuits(self):
         resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        with resolve, list_repos:
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock()) as select:
             assert await _run("please fix posthog/posthog-js") == "posthog/posthog-js"
+            select.assert_not_called()
 
-    async def test_multi_candidate_without_explicit_mention_returns_none(self):
+    async def test_delegates_to_select_repository_without_explicit_mention(self):
         resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
-        with resolve, list_repos:
+        result = RepoSelectionResult(repository="posthog/posthog", reason="agent picked it")
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)) as select:
+            assert await _run("the dashboards are slow") == "posthog/posthog"
+            select.assert_awaited_once()
+
+    async def test_forwards_resolved_integration_and_candidates(self):
+        github = MagicMock()
+        candidates = ["posthog/posthog", "posthog/posthog-js"]
+        resolve, list_repos = _patch_candidates(github, candidates)
+        result = RepoSelectionResult(repository="posthog/posthog", reason="agent picked it")
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)) as select:
+            await _run("the dashboards are slow")
+            await_args = select.await_args
+            assert await_args is not None
+            assert await_args.kwargs["github"] is github
+            assert await_args.kwargs["candidate_repos"] == candidates
+
+    async def test_select_repository_null_returns_none(self):
+        resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
+        result = RepoSelectionResult(repository=None, reason="no plausible candidate")
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(return_value=result)):
+            assert await _run("a question about billing") is None
+
+    @parameterized.expand(
+        [
+            ("rejected", RepoSelectionRejectedError("posthog/hallucinated", "made it up")),
+            ("unavailable", RepoSelectionUnavailableError("all archived")),
+            ("unexpected", RuntimeError("sandbox boot failed")),
+        ]
+    )
+    async def test_selection_failure_degrades_to_none(self, _name: str, error: Exception):
+        resolve, list_repos = _patch_candidates(MagicMock(), ["posthog/posthog", "posthog/posthog-js"])
+        with resolve, list_repos, patch(f"{_CASCADE}.select_repository", new=AsyncMock(side_effect=error)):
             assert await _run("the dashboards are slow") is None


### PR DESCRIPTION
## Problem

Sandbox conversation open can ask the repo-selection cascade to infer a repository before a Run exists. For teams with multiple connected GitHub repositories, the fallback path can invoke the LLM-backed selector even when the message does not name a repository. The open endpoint only needs deterministic routing when the user explicitly names a connected `owner/repo`.

## Changes

- Make `select_repository_for_message` explicit-mention-only: resolve the GitHub integration and cached candidate repos, then return the `owner/repo` match or `None`.
- Remove the cascade branch that called the LLM-backed repo-selection agent. The shared agent remains unchanged for other callers.
- Update the sandbox route comment and cascade tests to cover the multi-candidate no-explicit-match case.

## How did you test this code?

I’m an agent. I ran:

- `hogli test products/tasks/backend/tests/test_repo_selection_cascade.py`
- `ruff check products/tasks/backend/logic/repo_selection/cascade.py`
- A direct Django-initialized selector probe with mocked multi-repo candidates. No explicit match returned `None` in under 1 ms, and an explicit `posthog/posthog-js` mention resolved in under 1 ms.

I also attempted `hogli test ee/api/tests/test_conversation.py::TestConversationSandboxRoute`; it did not finish locally after several minutes. The single repository-routing test in that class also did not finish after one minute, so I interrupted both rather than leaving pytest processes running.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update required; this changes backend sandbox routing behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex CLI authored the change from a human-provided implementation plan. Skills invoked: `/improving-drf-endpoints` for the API file touch and `/hogli` for repo test/lint tooling.

The implementation keeps the facade signature and open endpoint logic intact while removing only the cascade fallback that invoked the LLM-backed selector. Messages without an explicit connected `owner/repo` now start repo-less sandboxes.
