### PR TITLE
feat(dashboards): add hover refresh button to dashboard tiles

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.scss
+++ b/frontend/src/lib/components/Cards/CardMeta.scss
@@ -104,6 +104,9 @@
             position: absolute;
             top: 0.5rem;
             right: 0.75rem;
+
+            // Opaque strip so the hover-revealed refresh icon sits over (not garbles) the title tail.
+            background: var(--color-bg-surface-primary);
         }
 
         .CardMeta__divider {
@@ -196,4 +199,25 @@
     display: flex;
     gap: 0.25rem;
     align-items: center;
+}
+
+// Refresh control is hidden at rest and revealed only when hovering the tile header.
+// Use `visibility` (not `opacity`) so a disabled LemonButton's own opacity override
+// — which kicks in once a refreshed tile is rate-limited — can't keep it visible.
+// Keyboard/touch users reach refresh via the always-present "⋯" menu.
+.CardMeta__refresh {
+    visibility: hidden;
+}
+
+.CardMeta:hover .CardMeta__refresh {
+    visibility: visible;
+}
+
+// On compact tiles too narrow to fit the icon without overlapping the title, keep it hidden
+// even on hover — refresh stays available in the "⋯" menu. The container is only established in
+// compact mode, so this never applies to the non-compact (saved insights) layout.
+@container (max-width: 22rem) {
+    .CardMeta:hover .CardMeta__refresh {
+        visibility: hidden;
+    }
 }

--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -39,6 +39,8 @@ export interface CardMetaProps extends Pick<React.HTMLAttributes<HTMLDivElement>
     samplingFactor?: number | null
     /** Additional controls to show in the top controls area */
     extraControls?: JSX.Element | null
+    /** Refresh control revealed on card hover, shown in the top controls area. */
+    refreshControl?: JSX.Element | null
     /** Description shown in the compact popover. */
     metaDescription?: JSX.Element | null
     /** Heading always shown in the popover (e.g. insight type + date range). Falls back to topHeading. */
@@ -68,6 +70,7 @@ export function CardMeta({
     onMouseDown,
     samplingFactor,
     extraControls,
+    refreshControl,
 }: CardMetaProps): JSX.Element {
     const { ref: primaryRef, width: primaryWidth } = useResizeObserver()
     const { ref: detailsRef, height: detailsHeight } = useResizeObserver()
@@ -125,6 +128,7 @@ export function CardMeta({
                             <div className="CardMeta__top">
                                 <div className="CardMeta__heading">{topHeading}</div>
                                 <div className="CardMeta__controls">
+                                    {refreshControl}
                                     {showEditingControls &&
                                         (moreTooltip ? (
                                             <Tooltip title={moreTooltip}>
@@ -155,6 +159,7 @@ export function CardMeta({
                                     )}
                                 </h5>
                                 <div className="CardMeta__controls">
+                                    {refreshControl}
                                     {extraControls &&
                                         React.cloneElement(extraControls, {
                                             ...extraControls.props,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -76,7 +76,6 @@ export interface InsightCardProps extends Resizeable {
     removeFromDashboard?: () => void
     deleteWithUndo?: () => Promise<void>
     refresh?: () => void
-    refreshEnabled?: boolean
     rename?: () => void
     duplicate?: () => void
     setOverride?: () => void
@@ -131,7 +130,6 @@ function InsightCardInternal(
         removeFromDashboard,
         deleteWithUndo,
         refresh,
-        refreshEnabled,
         rename,
         duplicate,
         setOverride,
@@ -265,7 +263,6 @@ function InsightCardInternal(
                         removeFromDashboard={removeFromDashboard}
                         deleteWithUndo={deleteWithUndo}
                         refresh={refresh}
-                        refreshEnabled={refreshEnabled}
                         loadingQueued={loadingQueued}
                         loading={loading}
                         rename={rename}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -2,17 +2,17 @@ import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import React, { useCallback, useEffect, useRef, useState } from 'react'
 
-import { IconInfo, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+import { IconInfo, IconRefresh, IconThumbsDown, IconThumbsUp } from '@posthog/icons'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { areAlertsSupportedForInsight, insightAlertsLogic } from 'lib/components/Alerts/insightAlertsLogic'
 import { ManageAlertsModal } from 'lib/components/Alerts/views/ManageAlertsModal'
 import { CardMeta } from 'lib/components/Cards/CardMeta'
+import { DashboardTileRefreshDataButton } from 'lib/components/Cards/InsightCard/DashboardTileRefreshDataButton'
 import { TopHeading } from 'lib/components/Cards/InsightCard/TopHeading'
 import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ExportButton } from 'lib/components/ExportButton/ExportButton'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
-import { TZLabel } from 'lib/components/TZLabel'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
@@ -68,7 +68,6 @@ interface InsightMetaProps extends Pick<
     | 'removeFromDashboard'
     | 'deleteWithUndo'
     | 'refresh'
-    | 'refreshEnabled'
     | 'loading'
     | 'loadingQueued'
     | 'rename'
@@ -105,7 +104,6 @@ export function InsightMeta({
     removeFromDashboard,
     deleteWithUndo,
     refresh,
-    refreshEnabled,
     loading,
     loadingQueued,
     rename,
@@ -281,12 +279,41 @@ export function InsightMeta({
         )
     }
 
-    const refreshDisabledReason =
+    // Suppress this tile's icon only while this tile itself is refreshing (a full-dashboard
+    // refresh marks every tile as loading, so it still hides them all). Other tiles stay
+    // refreshable — the batched refresh already caps concurrency, so there's no need to block.
+    const tileRefreshing = !!(loading || loadingQueued)
+    const nextRefreshFromNow =
         nextAllowedClientRefresh && dayjs(nextAllowedClientRefresh).isAfter(dayjs())
-            ? 'You are viewing the most recent calculated results.'
-            : loading || loadingQueued || !refreshEnabled
-              ? 'Refreshing...'
-              : undefined
+            ? dayjs(nextAllowedClientRefresh).fromNow()
+            : null
+    const refreshDisabledReason = nextRefreshFromNow
+        ? `These results are already up to date. The next refresh is available ${nextRefreshFromNow}.`
+        : undefined
+    // The always-visible "⋯" menu keeps refresh reachable on touch/keyboard. Unlike the hover
+    // icon (which hides while this tile refreshes) the menu item stays but disables.
+    const refreshMenuDisabledReason = tileRefreshing ? 'Refreshing…' : refreshDisabledReason
+
+    // Gate the hover icon on `showEditingControls` so it doesn't appear on public/export
+    // dashboards, matching the "⋯" menu (which is already gated there).
+    const refreshControl =
+        refresh && showEditingControls && !tileRefreshing ? (
+            <LemonButton
+                className="CardMeta__refresh"
+                icon={<IconRefresh />}
+                size="small"
+                onClick={() => refresh()}
+                disabledReason={refreshDisabledReason}
+                tooltip={
+                    refreshDisabledReason
+                        ? undefined
+                        : insight.last_refresh
+                          ? `Refresh data (last computed ${dayjs(insight.last_refresh).fromNow()})`
+                          : 'Refresh data'
+                }
+                data-attr="insight-card-refresh"
+            />
+        ) : null
 
     // On compact dashboard tiles the date just mirrors the dashboard's own range unless the
     // tile overrides it, so suppress the redundant label and only keep it for tile-level overrides.
@@ -572,34 +599,13 @@ export function InsightMeta({
                                 />
                             </>
                         ) : null}
-                        <>
-                            {refresh && (
-                                <LemonButton
-                                    onClick={() => {
-                                        refresh()
-                                    }}
-                                    disabledReason={refreshDisabledReason}
-                                    fullWidth
-                                >
-                                    {insight.last_refresh ? (
-                                        <div className="block my-1">
-                                            Refresh data
-                                            <p className="text-xs text-muted mt-0.5">
-                                                Last computed{' '}
-                                                <TZLabel
-                                                    time={insight.last_refresh}
-                                                    noStyles
-                                                    className="whitespace-nowrap border-dotted border-b"
-                                                />
-                                            </p>
-                                        </div>
-                                    ) : (
-                                        <>Refresh data</>
-                                    )}
-                                </LemonButton>
-                            )}
-                        </>
-
+                        {refresh && (
+                            <DashboardTileRefreshDataButton
+                                onRefresh={refresh}
+                                disabledReason={refreshMenuDisabledReason}
+                                lastRefresh={insight.last_refresh}
+                            />
+                        )}
                         {/* More */}
                         {moreButtons && (
                             <>
@@ -615,6 +621,7 @@ export function InsightMeta({
                         : 'Duplicate, export, refresh and more…'
                 }
                 extraControls={surveyOpportunityButton ?? feedbackButtons}
+                refreshControl={refreshControl}
             />
             {showDashboardAlertsMenuItem && insight.id ? (
                 <ManageAlertsModal

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -47,7 +47,6 @@ export function DashboardItems(): JSX.Element {
         isRefreshing,
         highlightedInsightId,
         refreshStatus,
-        itemsLoading,
         dashboardStreaming,
         effectiveEditBarFilters,
         effectiveDashboardVariableOverrides,
@@ -445,7 +444,6 @@ export function DashboardItems(): JSX.Element {
                                         toggleShowDescription={() => toggleTileDescription(tile.id)}
                                         ribbonColor={tile.color}
                                         refresh={() => refreshDashboardItem({ tile })}
-                                        refreshEnabled={!itemsLoading}
                                         rename={() => renameInsight(insight)}
                                         duplicate={() => duplicateTile(tile)}
                                         setOverride={() => setTileOverride(tile)}

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -2305,6 +2305,11 @@ export const dashboardLogic = kea<dashboardLogicType>([
                 return
             }
 
+            // Shared/public/export viewers must not be able to trigger server-side refreshes.
+            if (isSharedView()) {
+                return
+            }
+
             // Cache values before the long-running await — the logic may unmount
             const { currentTeamId, effectiveRefreshFilters, urlFilters, urlVariables } = values
 


### PR DESCRIPTION
> Supersedes #64688 — recreated on a clean branch off current `master` to clear an unresolvable merge conflict in the generated `frontend/snapshots.yml` baseline file. Same change, no rebase history baggage.

## Problem

- Refreshing a single dashboard tile required opening the "⋯" menu — slow when you just want to recompute one tile.
- No at-a-glance signal for *why* a tile can't be refreshed yet.

## Changes

- Adds a refresh icon to each tile, revealed **only on hover of the tile header**.
- Respects existing refresh rules; when rate-limited, the button disables and the tooltip explains why (e.g. "next refresh available in N minutes").
- When enabled, tooltip shows when data was last computed.
- A tile's icon hides only while **that tile itself** is refreshing; other tiles stay refreshable (the batched refresh already caps concurrency).
- Hidden on public/export dashboards, and `refreshDashboardItem` is guarded with `isSharedView()` so shared viewers can't trigger server-side refreshes.
- Keeps "Refresh data" in the "⋯" menu so refresh stays reachable on touch/keyboard.

## How did you test this code?

- I'm an agent. Verified formatting (oxfmt) and TypeScript locally; relied on CI for the full suite.
- Ran an automated multi-angle code review over the diff and fixed the confirmed findings (public-dashboard exposure, compact-mode title overlap).
- No existing tests assert on the changed UI; `products/dashboards/.../WidgetCard` refresh tests target a separate component and are unaffected.
- Note: visible UI change — `InsightCard` Storybook snapshots will be regenerated by CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with Claude Code at a contributor's direction.
- Added a generic `refreshControl` slot to `CardMeta` (rendered in compact + non-compact layouts); `InsightMeta` supplies the icon button.
- Reveal gated with `visibility` (not `opacity`) on `.CardMeta:hover` — a disabled `LemonButton`'s own opacity override was otherwise keeping rate-limited tiles' icons pinned visible. Compact controls strip has a surface background so the icon overlays the title cleanly.
- Security: icon gated on `showEditingControls` and the refresh action guarded with `isSharedView()`.
- Dropped the original `refreshEnabled` gate (and its prop threading) so tiles can refresh concurrently — the batched refresh already caps concurrency at 4, so blocking other tiles was needless friction.
- No skills were applicable.
