### PR TITLE
fix(insights): keep previous-period series glyph opaque in tooltip

### DIFF
--- a/frontend/src/lib/utils/colors.test.ts
+++ b/frontend/src/lib/utils/colors.test.ts
@@ -1,4 +1,4 @@
-import { hexToRGBA } from 'lib/utils/colors'
+import { hexToRGBA, toOpaqueHex } from 'lib/utils/colors'
 
 describe('colors utils', () => {
     describe('hexToRGBA()', () => {
@@ -6,6 +6,20 @@ describe('colors utils', () => {
             expect(hexToRGBA('#ff0000', 0.3)).toEqual('rgba(255,0,0,0.3)')
             expect(hexToRGBA('#0000Cc', 0)).toEqual('rgba(0,0,204,0)')
             expect(hexToRGBA('#5375ff', 1)).toEqual('rgba(83,117,255,1)')
+        })
+    })
+
+    describe('toOpaqueHex()', () => {
+        it.each([
+            ['rgba(29,74,255,0.5)', '#1d4aff'],
+            ['rgba(29, 74, 255, 0.5)', '#1d4aff'],
+            ['rgb(29,74,255)', '#1d4aff'],
+            ['rgba(0,0,0,0.5)', '#000000'],
+            ['#1d4aff80', '#1d4aff'],
+            ['#1d4aff', '#1d4aff'],
+            ['var(--data-color-1)', 'var(--data-color-1)'],
+        ])('strips alpha from %s -> %s', (input, expected) => {
+            expect(toOpaqueHex(input)).toEqual(expected)
         })
     })
 })

--- a/frontend/src/lib/utils/colors.ts
+++ b/frontend/src/lib/utils/colors.ts
@@ -58,6 +58,39 @@ export function RGBToRGBA(rgb: string, a: number): string {
     return `rgba(${[r, g, b, a].join(',')})`
 }
 
+/**
+ * Strip any alpha channel and return an opaque `#rrggbb` hex string.
+ * Accepts `rgb(...)`, `rgba(...)`, and 8-digit `#rrggbbaa` hex; opaque hex,
+ * `var(--…)`, or anything unparseable is returned unchanged. Dimming a series
+ * color only changes its alpha, so this losslessly recovers the opaque color.
+ */
+export function toOpaqueHex(color: string): string {
+    const toHex = (r: number, g: number, b: number): string =>
+        `#${[r, g, b]
+            .map((c) =>
+                Math.max(0, Math.min(255, Math.round(c)))
+                    .toString(16)
+                    .padStart(2, '0')
+            )
+            .join('')}`
+
+    const rgbMatch = color.match(/^rgba?\(([^)]+)\)$/i)
+    if (rgbMatch) {
+        const channels = rgbMatch[1]
+            .split(',')
+            .slice(0, 3)
+            .map((part) => parseFloat(part.trim()))
+        if (channels.length < 3 || channels.some((c) => !Number.isFinite(c))) {
+            return color
+        }
+        return toHex(channels[0], channels[1], channels[2])
+    }
+    if (/^#[0-9a-f]{8}$/i.test(color)) {
+        return color.slice(0, 7)
+    }
+    return color
+}
+
 export function RGBToHSL(r: number, g: number, b: number): { h: number; s: number; l: number } {
     // Convert RGB values to the range 0-1
     r /= 255

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -493,6 +493,67 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
             { timeout: 5000 }
         )
     })
+
+    it('keeps the previous-period identifier glyph opaque while dimming only the row ribbon', async () => {
+        // Give the previous period the larger aggregated_value so it sorts topmost (DESC) and is the
+        // bar hovered at plotTop. Its series color arrives pre-dimmed (rgba .5); the ribbon should keep
+        // that dim to mark the period, but the SeriesLetter glyph must render at full opacity.
+        const action = { id: '$pageview', type: 'events', name: '$pageview', order: 0 }
+        const compareResults = {
+            results: [
+                {
+                    action,
+                    label: '$pageview',
+                    count: 50,
+                    aggregated_value: 50,
+                    data: [50],
+                    labels: ['Day 1'],
+                    days: ['2024-06-10'],
+                    compare: true,
+                    compare_label: 'current',
+                },
+                {
+                    action,
+                    label: '$pageview',
+                    count: 500,
+                    aggregated_value: 500,
+                    data: [500],
+                    labels: ['Day 1'],
+                    days: ['2024-06-03'],
+                    compare: true,
+                    compare_label: 'previous',
+                },
+            ],
+        }
+        renderInsight({
+            query: aggregatedBar({ compareFilter: { compare: true } }),
+            mocks: {
+                additionalMockResponses: [{ match: (q) => q.kind === NodeKind.TrendsQuery, response: compareResults }],
+            },
+        })
+        const canvas = await screen.findByRole('img', { name: /chart with/i }, { timeout: 5000 })
+        const wrapper = canvas.parentElement!
+        // Topmost band is the previous period (largest aggregated_value, sorted DESC). Aim at the
+        // band centre — the bar's hittable region sits inside the band's padding.
+        const previousBandY = dimensions.plotTop + dimensions.plotHeight / 4
+
+        // Re-fire the hover each tick until the chart commits its scales and the tooltip populates —
+        // a single mouseMove before the chart settles is silently dropped.
+        await waitFor(
+            () => {
+                fireEvent.mouseMove(wrapper, { clientX: dimensions.plotLeft + 30, clientY: previousBandY })
+                const glyph = chart.getTooltip()?.querySelector<HTMLElement>('.graph-series-glyph')
+                expect(glyph).toBeTruthy()
+                // The identifier glyph stays opaque — no alpha channel bled in from the dimmed color.
+                expect(glyph!.style.color).not.toMatch(/rgba/)
+                expect(glyph!.style.borderColor).not.toMatch(/rgba/)
+                // The left ribbon still carries the half-opacity previous-period color.
+                const ribbon = glyph!.closest('tr')!.style.getPropertyValue('--row-ribbon-color')
+                expect(ribbon).toMatch(/rgba\([^)]*0?\.5\)/)
+            },
+            { timeout: 8000 }
+        )
+    }, 12000)
 })
 
 describe('TrendsBarChart (ActionsUnstackedBar)', () => {

--- a/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
+++ b/products/product_analytics/frontend/insights/trends/shared/TrendsTooltip.tsx
@@ -3,6 +3,7 @@ import { useCallback, useMemo } from 'react'
 import type { TooltipContext } from '@posthog/quill-charts'
 
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
+import { toOpaqueHex } from 'lib/utils/colors'
 import { percentage } from 'lib/utils/numbers'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightTooltip } from 'scenes/insights/InsightTooltip/InsightTooltip'
@@ -134,7 +135,10 @@ export function TrendsTooltip({
                             className="mr-2"
                             hasBreakdown={hasBreakdown}
                             seriesIndex={datum.action?.order ?? datum.id}
-                            seriesColor={datum.color}
+                            // Previous-period series arrive pre-dimmed (rgba); the ribbon keeps the dim to
+                            // mark the period, but the identifier glyph must stay legible — give it the
+                            // opaque color.
+                            seriesColor={datum.color ? toOpaqueHex(datum.color) : undefined}
                         />
                     )}
                     {value}


### PR DESCRIPTION
## Problem

In compare-to-previous mode, hovering a Trends or Stickiness chart dimmed the **series identifier glyph** (the A/B/C letter) for the previous period — not just the left-edge ribbon that marks the period. The identifier should stay legible.

It shows up in the aggregated **"Total value"** bar chart (`ActionsBarValue`), which slices the tooltip down to the single hovered bar. That puts `InsightTooltip` into its row layout (left ribbon + `SeriesLetter`). The regular line / time-series bar compare view uses the column layout and was unaffected, which is why this was specific to the aggregated bar.

## Changes

In the row layout one color drove both the ribbon and the glyph via `datum.color`. For the previous period that color arrives pre-dimmed (`rgba(r,g,b,0.5)`), so both faded — and `SeriesLetter`'s hex-only background helper also rendered broken on the `rgba` input.

- Added `toOpaqueHex()` in `frontend/src/lib/utils/colors.ts` — strips alpha from `rgb()` / `rgba()` / 8-digit hex (lossless, since dimming only changes alpha), and passes opaque hex or `var(--…)` through unchanged.
- `TrendsTooltip` now hands `SeriesLetter` the opaque color, leaving `datum.color` (dimmed) for the ribbon.

Net effect: the left ribbon keeps its dim to mark the previous period; the identifier glyph renders at full color. Covers both Trends and Stickiness (shared tooltip).

## How did you test this code?

I'm an agent (Claude Code). Automated tests run locally, all green:

- `frontend/src/lib/utils/colors.test.ts` — 8 cases for `toOpaqueHex` (rgba/rgb/8-digit hex → opaque hex; opaque hex and CSS var pass through).
- `products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx` — new regression test renders an aggregated compare chart, hovers the previous-period bar, and asserts the glyph color is opaque while the row ribbon stays `rgba(…, .5)`. Confirmed it fails without the fix (glyph was `rgba(29, 74, 255, 0.5)`) and passes with it.

No manual/visual QA performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). The work was directed by the assignee, who reported that the previous-period series icon dims on hover and that only the left bar should dim, not the identifier.

Approach: traced the dimming through the quill-charts tooltip pipeline — the dim is baked into the series color (`applyComparisonDimming` / `dimHexColor`, alpha 0.5) and flows to both the ribbon and `SeriesLetter`. Considered un-dimming inside `SeriesLetter` globally but rejected it: the insight legend intentionally dims its previous-period glyph, so the fix is scoped to the tooltip's single glyph call site. `SeriesLetter` needs hex input (its border/text/background helpers are hex-only), so the helper returns opaque hex rather than `rgb()`.

No repo or public skills were applicable to this change.
