### PR TITLE
chore(devex): drop dead renovate customManager

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,7 +11,6 @@
     'github-actions',
     'gomod',
     'cargo',
-    'custom.regex',
   ],
   dependencyDashboardTitle: 'Renovate: Dependency Status',
   dependencyDashboardLabels: [
@@ -26,36 +25,7 @@
   ignorePaths: [
     'common/hogql_parser/**',
   ],
-  customManagers: [
-    {
-      customType: 'regex',
-      description: 'Update pinned chrome-headless-shell version in recording-rasterizer Dockerfile',
-      fileMatch: ['Dockerfile\\.recording-rasterizer$'],
-      matchStrings: [
-        'chrome-headless-shell@(?<currentValue>\\d+\\.\\d+\\.\\d+\\.\\d+)',
-      ],
-      depNameTemplate: 'chrome-headless-shell',
-      datasourceTemplate: 'custom.chrome-for-testing',
-      versioningTemplate: 'loose',
-    },
-  ],
-  customDatasources: {
-    'chrome-for-testing': {
-      defaultRegistryUrlTemplate: 'https://googlechromelabs.github.io/chrome-for-testing/known-good-versions.json',
-      transformTemplates: [
-        '{"releases": $map(versions, function($v) { {"version": $v.version} })}',
-      ],
-    },
-  },
   packageRules: [
-    {
-      matchDepNames: ['chrome-headless-shell'],
-      automerge: true,
-      matchUpdateTypes: ['minor', 'patch'],
-      schedule: ['every 2 weeks on Monday'],
-      commitMessageExtra: '(chrome-headless-shell)',
-      labels: ['dependencies', 'recording-rasterizer'],
-    },
     // Split github-actions updates out of the default `renovate/pin-dependencies`
     // bundle so they can be approved on the dashboard independently
     {


### PR DESCRIPTION
## Problem

The `customManagers` / `customDatasources` / `chrome-headless-shell` `packageRules` blocks in `.github/renovate.json5` are dead. They tracked a pinned `chrome-headless-shell@<version>` in `Dockerfile.recording-rasterizer`, but that was reverted to `@stable` in #61253, so the manager's regex (`chrome-headless-shell@\d+\.\d+\.\d+\.\d+`) matches zero lines and Renovate has nothing to update. The block also carries the deprecated `fileMatch` field (renamed `managerFilePatterns` in Renovate v40).

## Changes

Remove the dead `custom.regex` manager, its `chrome-for-testing` datasource, and its `chrome-headless-shell` packageRule (~30 lines), plus `custom.regex` from `enabledManagers` since nothing else uses it. Keeps the `github-actions` grouping rule and all other config. Pure subtraction, zero behavior change — the recording-rasterizer image floats `@stable` and is refreshed by its weekly rebuild workflow.

## How did you test this code?

Agent-authored. Confirmed the manager's regex matches nothing in `Dockerfile.recording-rasterizer` (now `@stable`); validated the remaining JSON5 parses and retains every non-chrome rule.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced by an overnight DevEx repo-hygiene review and built with Claude Code at the assignee's direction. Sibling cleanup to the dependabot no-op-config strip. No repo skills were applicable (Renovate config cleanup only).
