### PR TITLE
chore(devex): drop no-op cooldown from dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,9 @@
+# Version updates are disabled here (open-pull-requests-limit: 0 everywhere); they're owned
+# by Renovate (.github/renovate.json5). schedule is a required key, so it stays on every entry.
+# cooldown was removed: it applies to version updates only, so it's a no-op under limit 0.
 version: 2
 updates:
     - package-ecosystem: 'github-actions'
-      cooldown:
-          default-days: 7
       directory: '/'
       schedule:
           interval: weekly
@@ -12,8 +13,6 @@ updates:
     # Without this, automatic security updates may try to update from subdirectories
     # which fails with "Updating workspaces from inside a workspace subdirectory is not supported"
     - package-ecosystem: 'npm'
-      cooldown:
-          default-days: 7
       directory: '/'
       schedule:
           interval: weekly
@@ -23,16 +22,11 @@ updates:
     # uv updates both pyproject.toml and uv.lock
     - package-ecosystem: 'uv'
       directory: '/'
-      open-pull-requests-limit: 0
       schedule:
           interval: weekly
+      open-pull-requests-limit: 0
       reviewers:
           - 'PostHog/team-devex'
-
-      # Cooldown period - avoid packages released in last 7 days (applies to version updates only)
-      cooldown:
-          default-days: 7
-
       ignore:
           # Exclude Django core from updates
           - dependency-name: 'django'


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` runs version updates off — `open-pull-requests-limit: 0` on all three ecosystems (version updates are owned by Renovate). Per Dependabot's options reference, `cooldown` applies to version updates only, so the three `cooldown` blocks are no-ops here.

## Changes

- Remove the 3 no-op `cooldown` blocks.
- Keep `schedule` on every entry — it is a **required** key per Dependabot's schema, even though it only governs the (disabled) version-update cadence. (An earlier version of this PR removed it; that would have made the config invalid.)
- Keep `directory`, `open-pull-requests-limit`, `reviewers`, and the `django` `ignore`.
- Add a short header comment explaining the security-only posture.

## How did you test this code?

Agent-authored. Validated the YAML parses, `schedule` remains on all three entries (required key), `cooldown` is gone, and all other fields are intact. Confirmed against GitHub's Dependabot options reference that `schedule.interval` is required and `cooldown` is version-update-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced by an overnight DevEx repo-hygiene review, built with Claude Code at the assignee's direction, then refined after a max-effort code review caught that `schedule` is a required key (scope narrowed from "cooldown + schedule" to "cooldown only"). Note: `reviewers` may itself be deprecated Dependabot config — left in place here, worth a separate look.
