### PR TITLE
fix(insights): capitalize stickiness chart tooltip labels

### DIFF
--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -74,13 +74,13 @@ describe('StickinessBarChart', () => {
         })
     })
 
-    it('tooltip: percent value + "Stickiness on {Interval} {day}" title (not a calendar date)', async () => {
+    it('tooltip: percent value + "Stickiness on {interval} {day}" title (not a calendar date)', async () => {
         renderInsight({ query: stickinessBar() })
 
         const tooltip = await chart.hoverTooltip(2)
         // Days are 1-indexed in the mock, so bucket 2 == day 3.
         expect(tooltip.row('Pageview')).toMatch(/%/)
-        expect(tooltip.title()).toMatch(/Stickiness on Day 3/)
+        expect(tooltip.title()).toMatch(/Stickiness on day 3/)
         // Must NOT default to a Unix-epoch-derived calendar date.
         expect(tooltip.title()).not.toMatch(/1970/i)
     })
@@ -101,7 +101,7 @@ describe('StickinessBarChart', () => {
         expect(screen.queryByRole('img', { name: /chart with/i })).not.toBeInTheDocument()
     })
 
-    it('click → persons modal: opens with a "Stickiness on {Interval} {day}" title', async () => {
+    it('click → persons modal: opens with a "Stickiness on {interval} {day}" title', async () => {
         renderInsight({ query: stickinessBar() })
 
         await chart.clickAtIndex(2)
@@ -112,7 +112,7 @@ describe('StickinessBarChart', () => {
             },
             { timeout: 5000 }
         )
-        expect(personsModal.title()).toMatch(/Stickiness on Day 3/)
+        expect(personsModal.title()).toMatch(/Stickiness on day 3/)
         expect(personsModal.title()).toMatch(/Pageview/i)
     })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -74,7 +74,7 @@ describe('StickinessBarChart', () => {
         })
     })
 
-    it('tooltip: percent value + "stickiness on {interval} {day}" title (not a calendar date)', async () => {
+    it('tooltip: percent value + "Stickiness on {Interval} {day}" title (not a calendar date)', async () => {
         renderInsight({ query: stickinessBar() })
 
         const tooltip = await chart.hoverTooltip(2)
@@ -101,7 +101,7 @@ describe('StickinessBarChart', () => {
         expect(screen.queryByRole('img', { name: /chart with/i })).not.toBeInTheDocument()
     })
 
-    it('click → persons modal: opens with a "stickiness on {interval} {day}" title', async () => {
+    it('click → persons modal: opens with a "Stickiness on {Interval} {day}" title', async () => {
         renderInsight({ query: stickinessBar() })
 
         await chart.clickAtIndex(2)

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -80,7 +80,7 @@ describe('StickinessBarChart', () => {
         const tooltip = await chart.hoverTooltip(2)
         // Days are 1-indexed in the mock, so bucket 2 == day 3.
         expect(tooltip.row('Pageview')).toMatch(/%/)
-        expect(tooltip.title()).toMatch(/stickiness on day 3/i)
+        expect(tooltip.title()).toMatch(/Stickiness on Day 3/)
         // Must NOT default to a Unix-epoch-derived calendar date.
         expect(tooltip.title()).not.toMatch(/1970/i)
     })
@@ -112,7 +112,7 @@ describe('StickinessBarChart', () => {
             },
             { timeout: 5000 }
         )
-        expect(personsModal.title()).toMatch(/stickiness on day 3/i)
+        expect(personsModal.title()).toMatch(/Stickiness on Day 3/)
         expect(personsModal.title()).toMatch(/Pageview/i)
     })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -65,7 +65,7 @@ describe('StickinessLineChart', () => {
 
             const tooltip = await chart.hoverTooltip(2)
             // Day at index 2 is 3 in the mock's 1-indexed stickiness days.
-            expect(tooltip.title()).toMatch(/stickiness on day 3/i)
+            expect(tooltip.title()).toMatch(/Stickiness on Day 3/)
             // Critically — must NOT default to a Unix-epoch-derived calendar date.
             expect(tooltip.title()).not.toMatch(/1970/i)
         })
@@ -96,7 +96,7 @@ describe('StickinessLineChart', () => {
                 expect(personsModal.get()).toBeInTheDocument()
             })
             // The clicked bucket is index 2, days are 1-indexed in the mock, so day == 3.
-            expect(personsModal.title()).toMatch(/stickiness on day 3/i)
+            expect(personsModal.title()).toMatch(/Stickiness on Day 3/)
             expect(personsModal.title()).toMatch(/Pageview/i)
         })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -60,7 +60,7 @@ describe('StickinessLineChart', () => {
             expect(tooltip.row('Pageview')).toMatch(/%/)
         })
 
-        it('uses "stickiness on {interval} {day}" as the tooltip title (not a calendar date)', async () => {
+        it('uses "Stickiness on {Interval} {day}" as the tooltip title (not a calendar date)', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             const tooltip = await chart.hoverTooltip(2)
@@ -87,7 +87,7 @@ describe('StickinessLineChart', () => {
     })
 
     describe('click → persons modal', () => {
-        it('opens the modal with a "stickiness on {interval} {day}" title', async () => {
+        it('opens the modal with a "Stickiness on {Interval} {day}" title', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             await chart.clickAtIndex(2)

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -60,12 +60,12 @@ describe('StickinessLineChart', () => {
             expect(tooltip.row('Pageview')).toMatch(/%/)
         })
 
-        it('uses "Stickiness on {Interval} {day}" as the tooltip title (not a calendar date)', async () => {
+        it('uses "Stickiness on {interval} {day}" as the tooltip title (not a calendar date)', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             const tooltip = await chart.hoverTooltip(2)
             // Day at index 2 is 3 in the mock's 1-indexed stickiness days.
-            expect(tooltip.title()).toMatch(/Stickiness on Day 3/)
+            expect(tooltip.title()).toMatch(/Stickiness on day 3/)
             // Critically — must NOT default to a Unix-epoch-derived calendar date.
             expect(tooltip.title()).not.toMatch(/1970/i)
         })
@@ -87,7 +87,7 @@ describe('StickinessLineChart', () => {
     })
 
     describe('click → persons modal', () => {
-        it('opens the modal with a "Stickiness on {Interval} {day}" title', async () => {
+        it('opens the modal with a "Stickiness on {interval} {day}" title', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             await chart.clickAtIndex(2)
@@ -96,7 +96,7 @@ describe('StickinessLineChart', () => {
                 expect(personsModal.get()).toBeInTheDocument()
             })
             // The clicked bucket is index 2, days are 1-indexed in the mock, so day == 3.
-            expect(personsModal.title()).toMatch(/Stickiness on Day 3/)
+            expect(personsModal.title()).toMatch(/Stickiness on day 3/)
             expect(personsModal.title()).toMatch(/Pageview/i)
         })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
@@ -74,7 +74,7 @@ describe('handleStickinessChartClick', () => {
         expect(call.orderBy).toBeUndefined()
     })
 
-    it('renders a "Stickiness on {Interval} {day}" title with the series label', () => {
+    it('renders a "Stickiness on {interval} {day}" title with the series label', () => {
         const openPersonsModal = jest.fn()
         const trendResult = makeTrendResult({ label: '$pageview' })
         const deps = makeDeps({ openPersonsModal, interval: 'day', indexedResults: [trendResult] })
@@ -84,7 +84,7 @@ describe('handleStickinessChartClick', () => {
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
         // PropertyKeyInfo wraps the raw label; the label text itself surfaces in textContent.
         expect(container.textContent).toContain('$pageview')
-        expect(container.textContent).toContain('Stickiness on Day 3')
+        expect(container.textContent).toContain('Stickiness on day 3')
     })
 
     it('uses "day" as the default interval when interval is null', () => {
@@ -95,7 +95,7 @@ describe('handleStickinessChartClick', () => {
         handleStickinessChartClick(keyFor(trendResult), 0, deps)
 
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
-        expect(container.textContent).toContain('Stickiness on Day 1')
+        expect(container.textContent).toContain('Stickiness on day 1')
     })
 
     it.each([

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
@@ -74,7 +74,7 @@ describe('handleStickinessChartClick', () => {
         expect(call.orderBy).toBeUndefined()
     })
 
-    it('renders a "stickiness on {interval} {day}" title with the series label', () => {
+    it('renders a "Stickiness on {Interval} {day}" title with the series label', () => {
         const openPersonsModal = jest.fn()
         const trendResult = makeTrendResult({ label: '$pageview' })
         const deps = makeDeps({ openPersonsModal, interval: 'day', indexedResults: [trendResult] })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
@@ -84,7 +84,7 @@ describe('handleStickinessChartClick', () => {
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
         // PropertyKeyInfo wraps the raw label; the label text itself surfaces in textContent.
         expect(container.textContent).toContain('$pageview')
-        expect(container.textContent).toContain('stickiness on day 3')
+        expect(container.textContent).toContain('Stickiness on Day 3')
     })
 
     it('uses "day" as the default interval when interval is null', () => {
@@ -95,7 +95,7 @@ describe('handleStickinessChartClick', () => {
         handleStickinessChartClick(keyFor(trendResult), 0, deps)
 
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
-        expect(container.textContent).toContain('stickiness on day 1')
+        expect(container.textContent).toContain('Stickiness on Day 1')
     })
 
     it.each([

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
@@ -1,4 +1,5 @@
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { capitalizeFirstLetter } from 'lib/utils/strings'
 import type { OpenPersonsModalProps } from 'scenes/trends/persons-modal/PersonsModal'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
@@ -54,9 +55,10 @@ export function handleStickinessChartClick(seriesKey: string, dataIndex: number,
     }
 
     const label = dataset.label ?? ''
+    const intervalLabel = capitalizeFirstLetter(deps.interval || 'day')
     const title = (
         <>
-            <PropertyKeyInfo value={label} disablePopover /> stickiness on {deps.interval || 'day'} {day}
+            <PropertyKeyInfo value={label} disablePopover /> Stickiness on {intervalLabel} {day}
         </>
     )
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
@@ -1,5 +1,4 @@
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
-import { capitalizeFirstLetter } from 'lib/utils/strings'
 import type { OpenPersonsModalProps } from 'scenes/trends/persons-modal/PersonsModal'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
@@ -55,10 +54,9 @@ export function handleStickinessChartClick(seriesKey: string, dataIndex: number,
     }
 
     const label = dataset.label ?? ''
-    const intervalLabel = capitalizeFirstLetter(deps.interval || 'day')
     const title = (
         <>
-            <PropertyKeyInfo value={label} disablePopover /> Stickiness on {intervalLabel} {day}
+            <PropertyKeyInfo value={label} disablePopover /> Stickiness on {deps.interval || 'day'} {day}
         </>
     )
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -91,14 +91,14 @@ export function stickinessPercentFormatter(value: number): string {
 export const STICKINESS_TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 
 /** Stickiness `date` is an interval-count integer (1, 2, …), not a date.
- *  Render "Stickiness on {Interval} {day}" so InsightTooltip doesn't try to
+ *  Render "Stickiness on {interval} {day}" so InsightTooltip doesn't try to
  *  format it as a calendar date (which would land on 1970-01-01). */
 export function buildStickinessTooltipTitle(
     interval: string | null | undefined
 ): (seriesData: SeriesDatum[]) => string {
     return (seriesData) => {
         const day = seriesData[0]?.date_label ?? ''
-        return `Stickiness on ${capitalizeFirstLetter(interval || 'day')} ${day}`
+        return `Stickiness on ${interval || 'day'} ${day}`
     }
 }
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -1,6 +1,7 @@
 import { DEFAULT_Y_AXIS_ID } from '@posthog/quill-charts'
 import type { Series, TimeSeriesLineChartConfig, TooltipConfig, YAxisConfig } from '@posthog/quill-charts'
 
+import { capitalizeFirstLetter } from 'lib/utils/strings'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 
 import { ChartDisplayType } from '~/types'
@@ -91,14 +92,14 @@ export function stickinessPercentFormatter(value: number): string {
 export const STICKINESS_TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 
 /** Stickiness `date` is an interval-count integer (1, 2, …), not a date.
- *  Render "stickiness on {interval} {day}" so InsightTooltip doesn't try to
+ *  Render "Stickiness on {Interval} {day}" so InsightTooltip doesn't try to
  *  format it as a calendar date (which would land on 1970-01-01). */
 export function buildStickinessTooltipTitle(
     interval: string | null | undefined
 ): (seriesData: SeriesDatum[]) => string {
     return (seriesData) => {
         const day = seriesData[0]?.date_label ?? ''
-        return `stickiness on ${interval || 'day'} ${day}`
+        return `Stickiness on ${capitalizeFirstLetter(interval || 'day')} ${day}`
     }
 }
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -77,8 +77,7 @@ export function buildStickinessSeries<R extends StickinessResultLike, M = unknow
  * duplicate the interval prefix when paired with a stickiness-style axis, so we
  * synthesize them from the bucket count. Mirrors `formatIntervalLabels` in the legacy LineGraph. */
 export function buildStickinessLabels(count: number, interval: string | null | undefined): string[] {
-    const unit = interval ?? 'day'
-    const prefix = `${unit.slice(0, 1).toUpperCase()}${unit.slice(1)}`
+    const prefix = capitalizeFirstLetter(interval ?? 'day')
     return Array.from({ length: count }, (_, i) => `${prefix} ${i}`)
 }
 


### PR DESCRIPTION
## Problem

Hovering over a series on a stickiness chart showed an all-lowercase label — "stickiness on day 1". The persons-modal title opened on click had the same issue. It should read "Stickiness on Day 1" / "Stickiness on Week 1".

## Changes

- `buildStickinessTooltipTitle` (the hover tooltip shared by the line and bar charts) now returns `Stickiness on {Interval} {day}`, capitalizing both the leading word and the interval.
- The persons-modal title in `handleStickinessChartClick` is capitalized the same way.
- Both reuse the existing `capitalizeFirstLetter` helper — the same one already applied to the stickiness column header in `InsightsTable`, so the tooltip, modal, and table now agree.
- Updated the line/bar chart and click-handler test assertions to the capitalized form, and tightened the `toMatch` regexes to be case-sensitive so they actually pin the casing.

## How did you test this code?

I'm an agent (Claude Code). Dependencies weren't installed in my environment, so I did **not** run the Jest suite locally — CI will. I updated all three affected test suites (`StickinessLineChart`, `StickinessBarChart`, `handleStickinessChartClick`) to assert the capitalized output, and made the `toMatch` regexes case-sensitive so they verify the fix rather than pass regardless of casing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed — this is a display-string capitalization fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked for the stickiness chart hover text to be capitalized correctly. Worked with Claude Code.

- Located the shared tooltip builder (`stickinessChartTransforms.ts`) and the click → persons-modal title (`handleStickinessChartClick.tsx`); both emitted all-lowercase strings.
- Chose to reuse `capitalizeFirstLetter` from `lib/utils/strings` rather than hand-roll, matching the precedent in `InsightsTable` and the sibling `handleFunnelLineChartClick`.
- In the click handler, extracted the capitalized interval into a local (`intervalLabel`) so the JSX line stays under the 120-char print width without fragile inline wrapping.
- No repo skills were required for this change.
