### PR TITLE
feat(experiments): attach shared metrics via experiment-update MCP tool

### DIFF
--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -862,12 +862,7 @@ tools:
                     the legacy parameters.* keys during the deprecation window, so prefer this field over writing the
                     calculator keys inside parameters.
             saved_metrics_ids:
-                description: >
-                    Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved
-                    metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or
-                    'secondary', defaulting to 'primary'). This is a full replacement — always include all of the
-                    experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one.
-                    Pass an empty list to detach all shared metrics.
+                input_schema: SavedMetricsAttachSchema
         ui_app: experiment
         response:
             include:

--- a/products/experiments/mcp/tools.yaml
+++ b/products/experiments/mcp/tools.yaml
@@ -841,6 +841,7 @@ tools:
             - running_time_calculation
             - metrics
             - metrics_secondary
+            - saved_metrics_ids
             - stats_config
             - exposure_criteria
             - holdout_id
@@ -860,6 +861,13 @@ tools:
                     recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with
                     the legacy parameters.* keys during the deprecation window, so prefer this field over writing the
                     calculator keys inside parameters.
+            saved_metrics_ids:
+                description: >
+                    Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved
+                    metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or
+                    'secondary', defaulting to 'primary'). This is a full replacement — always include all of the
+                    experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one.
+                    Pass an empty list to detach all shared metrics.
         ui_app: experiment
         response:
             include:
@@ -877,6 +885,7 @@ tools:
                 - running_time_calculation
                 - metrics
                 - metrics_secondary
+                - saved_metrics
                 - conclusion
                 - conclusion_comment
     experiments-create-exposure-cohort:

--- a/services/mcp/schema/tool-inputs.json
+++ b/services/mcp/schema/tool-inputs.json
@@ -688,6 +688,34 @@
             "properties": {},
             "description": "No input required. Returns core data warehouse schemas."
         },
+        "SavedMetricsAttachSchema": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "id": {
+                        "type": "integer",
+                        "minimum": -9007199254740991,
+                        "maximum": 9007199254740991,
+                        "description": "ID of an existing shared/saved metric. Discover IDs with experiment-saved-metrics-list."
+                    },
+                    "metadata": {
+                        "description": "Optional per-link metadata. Omit to default this metric to primary.",
+                        "type": "object",
+                        "properties": {
+                            "type": {
+                                "type": "string",
+                                "enum": ["primary", "secondary"],
+                                "description": "Whether this metric is a primary or secondary metric on the experiment."
+                            }
+                        },
+                        "required": ["type"]
+                    }
+                },
+                "required": ["id"]
+            },
+            "description": "The complete desired set of shared (saved) metrics for the experiment — this REPLACES all existing saved-metric links, it does not append. To add or remove one, first read the experiment's current saved_metrics via experiment-get and resend the full set. Pass an empty array to detach all shared metrics."
+        },
         "ScoreDefinitionConfigSchema": {
             "anyOf": [
                 {

--- a/services/mcp/src/schema/tool-inputs.ts
+++ b/services/mcp/src/schema/tool-inputs.ts
@@ -251,10 +251,29 @@ export const FeedbackSubmitSchema = z.object({
     details: z
         .string()
         .optional()
-        .describe(
-            "Any additional context that doesn't fit the other fields. Keep it to clear, concise bullet points."
-        ),
+        .describe("Any additional context that doesn't fit the other fields. Keep it to clear, concise bullet points."),
 })
+
+const SavedMetricAttachItemSchema = z.object({
+    id: z
+        .number()
+        .int()
+        .describe('ID of an existing shared/saved metric. Discover IDs with experiment-saved-metrics-list.'),
+    metadata: z
+        .object({
+            type: z
+                .enum(['primary', 'secondary'])
+                .describe('Whether this metric is a primary or secondary metric on the experiment.'),
+        })
+        .optional()
+        .describe('Optional per-link metadata. Omit to default this metric to primary.'),
+})
+
+export const SavedMetricsAttachSchema = z
+    .array(SavedMetricAttachItemSchema)
+    .describe(
+        "The complete desired set of shared (saved) metrics for the experiment — this REPLACES all existing saved-metric links, it does not append. To add or remove one, first read the experiment's current saved_metrics via experiment-get and resend the full set. Pass an empty array to detach all shared metrics."
+    )
 
 export const ExperimentResultsGetSchema = z.object({
     id: z.number().describe('The ID of the experiment to get comprehensive results for'),

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -778,7 +778,6 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
             end_date: true,
             feature_flag_key: true,
             secondary_metrics: true,
-            saved_metrics_ids: true,
             filters: true,
             deleted: true,
             type: true,
@@ -793,6 +792,9 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
         id: z.preprocess(castStringToInt, ExperimentsPartialUpdateParams.shape['id']),
         running_time_calculation: ExperimentsPartialUpdateBody.shape['running_time_calculation'].describe(
             "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
+        ),
+        saved_metrics_ids: ExperimentsPartialUpdateBody.shape['saved_metrics_ids'].describe(
+            "Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or 'secondary', defaulting to 'primary'). This is a full replacement — always include all of the experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one. Pass an empty list to detach all shared metrics."
         ),
     })
 
@@ -817,6 +819,9 @@ const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHog
             }
             if (params.running_time_calculation !== undefined) {
                 body['running_time_calculation'] = params.running_time_calculation
+            }
+            if (params.saved_metrics_ids !== undefined) {
+                body['saved_metrics_ids'] = params.saved_metrics_ids
             }
             if (params.archived !== undefined) {
                 body['archived'] = params.archived
@@ -865,6 +870,7 @@ const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHog
                 'running_time_calculation',
                 'metrics',
                 'metrics_secondary',
+                'saved_metrics',
                 'conclusion',
                 'conclusion_comment',
             ]) as typeof result

--- a/services/mcp/src/tools/generated/experiments.ts
+++ b/services/mcp/src/tools/generated/experiments.ts
@@ -35,6 +35,7 @@ import {
     ExperimentsUnarchiveCreateParams,
 } from '@/generated/experiments/api'
 import { withUiApp } from '@/resources/ui-apps'
+import { SavedMetricsAttachSchema } from '@/schema/tool-inputs'
 import { castStringToInt } from '@/tools/cast-helpers'
 import { withPostHogUrl, pickResponseFields, type WithPostHogUrl } from '@/tools/tool-utils'
 import type { Context, ToolBase, ZodObjectAny } from '@/tools/types'
@@ -793,9 +794,7 @@ const ExperimentUpdateSchema = ExperimentsPartialUpdateParams.omit({ project_id:
         running_time_calculation: ExperimentsPartialUpdateBody.shape['running_time_calculation'].describe(
             "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
         ),
-        saved_metrics_ids: ExperimentsPartialUpdateBody.shape['saved_metrics_ids'].describe(
-            "Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or 'secondary', defaulting to 'primary'). This is a full replacement — always include all of the experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one. Pass an empty list to detach all shared metrics."
-        ),
+        saved_metrics_ids: SavedMetricsAttachSchema.optional(),
     })
 
 const experimentUpdate = (): ToolBase<typeof ExperimentUpdateSchema, WithPostHogUrl<Schemas.Experiment>> =>

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -3761,16 +3761,32 @@
             "description": "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
         },
         "saved_metrics_ids": {
-            "anyOf": [
-                {
-                    "items": {},
-                    "type": "array"
+            "description": "The complete desired set of shared (saved) metrics for the experiment — this REPLACES all existing saved-metric links, it does not append. To add or remove one, first read the experiment's current saved_metrics via experiment-get and resend the full set. Pass an empty array to detach all shared metrics.",
+            "items": {
+                "properties": {
+                    "id": {
+                        "description": "ID of an existing shared/saved metric. Discover IDs with experiment-saved-metrics-list.",
+                        "maximum": 9007199254740991,
+                        "minimum": -9007199254740991,
+                        "type": "integer"
+                    },
+                    "metadata": {
+                        "description": "Optional per-link metadata. Omit to default this metric to primary.",
+                        "properties": {
+                            "type": {
+                                "description": "Whether this metric is a primary or secondary metric on the experiment.",
+                                "enum": ["primary", "secondary"],
+                                "type": "string"
+                            }
+                        },
+                        "required": ["type"],
+                        "type": "object"
+                    }
                 },
-                {
-                    "type": "null"
-                }
-            ],
-            "description": "Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or 'secondary', defaulting to 'primary'). This is a full replacement — always include all of the experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one. Pass an empty list to detach all shared metrics."
+                "required": ["id"],
+                "type": "object"
+            },
+            "type": "array"
         },
         "stats_config": {},
         "update_feature_flag_params": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -3760,6 +3760,18 @@
             ],
             "description": "Persist a running-time / sample-size plan onto the experiment (the planning target shown in the experiment's running-time panel). Object with optional keys: minimum_detectable_effect (percentage, e.g. 20 for a 20% lift), recommended_sample_size (total across all variants), recommended_running_time (days), and exposure_estimate_config. These values are kept in sync with the legacy parameters.* keys during the deprecation window, so prefer this field over writing the calculator keys inside parameters."
         },
+        "saved_metrics_ids": {
+            "anyOf": [
+                {
+                    "items": {},
+                    "type": "array"
+                },
+                {
+                    "type": "null"
+                }
+            ],
+            "description": "Shared (saved) metrics to attach to this experiment — a list of objects, each with `id` (a saved metric ID from experiment-saved-metrics-list) and optional `metadata.type` ('primary' or 'secondary', defaulting to 'primary'). This is a full replacement — always include all of the experiment's existing saved metrics (read them from its saved_metrics first) when adding a new one. Pass an empty list to detach all shared metrics."
+        },
         "stats_config": {},
         "update_feature_flag_params": {
             "description": "When true, sync feature flag configuration from parameters to the linked feature flag. Draft experiments always sync regardless of update_feature_flag_params, so only required for non-drafts.",


### PR DESCRIPTION
## Problem

The `experiment-update` MCP tool didn't expose `saved_metrics_ids`, so attaching an existing shared/saved metric to an experiment silently no-op'd — the field was dropped before the request ever hit the API, and nothing attached.

## Changes

Add `saved_metrics_ids` to the tool's `include_params` with a full-replacement description, mirroring how `insight-update` exposes `dashboards`; everything else is regenerated from the YAML.

## How did you test this code?

Regenerated from the YAML and ran the affected MCP checks locally — schema snapshot, experiments unit tests, tool-name lint, and typecheck all pass. The backend PATCH path this drives is already covered by existing tests (`test_update_experiment_replaces_saved_metrics`, `test_presentation_api.py`). Will verify end-to-end in prod after deploy.
