### PR TITLE
chore(devex): fix broken links in agent skills

### DIFF
--- a/.agents/skills/implementing-mcp-tools/SKILL.md
+++ b/.agents/skills/implementing-mcp-tools/SKILL.md
@@ -5,7 +5,7 @@ description: 'Guide for exposing PostHog product endpoints as MCP tools. Use whe
 
 # Implementing MCP tools
 
-Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-tools.md](docs/published/handbook/engineering/ai/implementing-mcp-tools.md).
+Read the full guide at [docs/published/handbook/engineering/ai/implementing-mcp-tools.md](../../../docs/published/handbook/engineering/ai/implementing-mcp-tools.md).
 
 ## Quick workflow
 
@@ -187,7 +187,7 @@ These descriptions are what agents read to understand tool parameters.
 ## HogQL system tables
 
 Every list/get endpoint should have a corresponding HogQL system table
-in [`posthog/hogql/database/schema/system.py`](posthog/hogql/database/schema/system.py).
+in [`posthog/hogql/database/schema/system.py`](../../../posthog/hogql/database/schema/system.py).
 This lets agents query data via SQL in v2 of the MCP.
 
 Each system table **must include a `team_id` column** for data isolation.
@@ -196,8 +196,8 @@ Use `mcp_version: 1` on read/list YAML tools when a system table covers the same
 v2 agents use SQL instead.
 
 When adding a system table, also add a model reference file
-(`models-<domain>.md`) in [`products/posthog_ai/skills/querying-posthog-data/references/`](products/posthog_ai/skills/querying-posthog-data/references/)
-and register it in [`products/posthog_ai/skills/querying-posthog-data/SKILL.md`](products/posthog_ai/skills/querying-posthog-data/SKILL.md) under **Data Schema**.
+(`models-<domain>.md`) in [`products/posthog_ai/skills/querying-posthog-data/references/`](../../../products/posthog_ai/skills/querying-posthog-data/references/)
+and register it in [`products/posthog_ai/skills/querying-posthog-data/SKILL.md`](../../../products/posthog_ai/skills/querying-posthog-data/SKILL.md) under **Data Schema**.
 
 ## Two MCP versions
 

--- a/.agents/skills/isolating-product-facade-contracts/SKILL.md
+++ b/.agents/skills/isolating-product-facade-contracts/SKILL.md
@@ -17,23 +17,23 @@ exists only as the merge base for team-sliced sweeps — per the PR strategy bel
 
 Read these before changing code:
 
-1. [products/architecture.md](products/architecture.md)
-2. [products/README.md](products/README.md)
-3. [docs/internal/monorepo-layout.md](docs/internal/monorepo-layout.md)
-4. [posthog/models/team/README.md](posthog/models/team/README.md) (team extension model rule)
-5. [docs/published/handbook/engineering/type-system.md](docs/published/handbook/engineering/type-system.md) (serializer/OpenAPI type flow)
-6. [docs/published/handbook/engineering/ai/implementing-mcp-tools.md](docs/published/handbook/engineering/ai/implementing-mcp-tools.md) (schema quality and team isolation expectations)
-7. [.agents/security.md](.agents/security.md) (SQL/HogQL security guidelines)
+1. [products/architecture.md](../../../products/architecture.md)
+2. [products/README.md](../../../products/README.md)
+3. [docs/internal/monorepo-layout.md](../../../docs/internal/monorepo-layout.md)
+4. [posthog/models/team/README.md](../../../posthog/models/team/README.md) (team extension model rule)
+5. [docs/published/handbook/engineering/type-system.md](../../../docs/published/handbook/engineering/type-system.md) (serializer/OpenAPI type flow)
+6. [docs/published/handbook/engineering/ai/implementing-mcp-tools.md](../../../docs/published/handbook/engineering/ai/implementing-mcp-tools.md) (schema quality and team isolation expectations)
+7. [.agents/security.md](../../../.agents/security.md) (SQL/HogQL security guidelines)
 
 Use Visual review as the concrete reference implementation:
 
-- [products/visual_review/backend/facade/contracts.py](products/visual_review/backend/facade/contracts.py)
-- [products/visual_review/backend/facade/api.py](products/visual_review/backend/facade/api.py)
-- [products/visual_review/backend/presentation/views.py](products/visual_review/backend/presentation/views.py)
-- [products/visual_review/backend/presentation/serializers.py](products/visual_review/backend/presentation/serializers.py)
-- [products/visual_review/backend/logic.py](products/visual_review/backend/logic.py)
-- [products/visual_review/backend/tests/test_api.py](products/visual_review/backend/tests/test_api.py)
-- [products/visual_review/backend/tests/test_presentation.py](products/visual_review/backend/tests/test_presentation.py)
+- [products/visual_review/backend/facade/contracts.py](../../../products/visual_review/backend/facade/contracts.py)
+- [products/visual_review/backend/facade/api.py](../../../products/visual_review/backend/facade/api.py)
+- [products/visual_review/backend/presentation/views.py](../../../products/visual_review/backend/presentation/views.py)
+- [products/visual_review/backend/presentation/serializers.py](../../../products/visual_review/backend/presentation/serializers.py)
+- [products/visual_review/backend/logic.py](../../../products/visual_review/backend/logic.py)
+- [products/visual_review/backend/tests/test_api.py](../../../products/visual_review/backend/tests/test_api.py)
+- [products/visual_review/backend/tests/test_presentation.py](../../../products/visual_review/backend/tests/test_presentation.py)
 
 Before changing code, get the baseline:
 

--- a/.agents/skills/optimizing-clickhouse-and-hogql-queries/SKILL.md
+++ b/.agents/skills/optimizing-clickhouse-and-hogql-queries/SKILL.md
@@ -57,7 +57,7 @@ Table schemas, skim for `ORDER BY` / `PARTITION BY` / `INDEX` / materialized col
 - Events: [`posthog/models/event/sql.py`](../../../posthog/models/event/sql.py)
 - Sessions v3: [`sessions_v3.py`](../../../posthog/models/raw_sessions/sessions_v3.py) (v2: [`sessions_v2.py`](../../../posthog/models/raw_sessions/sessions_v2.py))
 - Persons: [`posthog/models/person/sql.py`](../../../posthog/models/person/sql.py); overrides: [`person_overrides/sql.py`](../../../posthog/models/person_overrides/sql.py)
-- Cohorts (`cohortpeople` membership): [`posthog/models/cohort/sql.py`](../../../posthog/models/cohort/sql.py). The Postgres `Cohort` definition ([`cohort.py`](../../../posthog/models/cohort/cohort.py)) is a Postgres concern (Step 0).
+- Cohorts (`cohortpeople` membership): [`products/cohorts/backend/models/sql.py`](../../../products/cohorts/backend/models/sql.py). The Postgres `Cohort` definition ([`cohort.py`](../../../products/cohorts/backend/models/cohort.py)) is a Postgres concern (Step 0).
 - Other tables (`app_metrics2`, `session_replay_events`, `log_entries`, `heatmaps`, product tables): find under [`posthog/models/*/sql.py`](../../../posthog/models/) or the [migration](../../../posthog/clickhouse/migrations/) that created them.
 
 HogQL side: query entry [`query.py`](../../../posthog/hogql/query.py); printers [`clickhouse.py`](../../../posthog/hogql/printer/clickhouse.py) / [`base.py`](../../../posthog/hogql/printer/base.py); helpers [`utils.py`](../../../posthog/hogql/printer/utils.py); functions [`posthog/hogql/functions/`](../../../posthog/hogql/functions/) (aggregations in [`aggregations.py`](../../../posthog/hogql/functions/aggregations.py)); schema [`posthog/hogql/database/schema/`](../../../posthog/hogql/database/schema/).

--- a/.agents/skills/querying-local-postgres/SKILL.md
+++ b/.agents/skills/querying-local-postgres/SKILL.md
@@ -95,7 +95,7 @@ Equivalent: `postgresql://posthog:posthog@localhost:5432/posthog`
 
 **Configuration source of truth (app):** `posthog/settings/data_stores.py` (Django `DATABASES`, optional replica `POSTHOG_POSTGRES_READ_HOST`, direct `POSTHOG_POSTGRES_DIRECT_HOST`, `PERSONS_DB_WRITER_URL`, product DB routing from `products/db_routing.yaml`).
 
-**When not using the hardcoded URL:** Connecting **from the host** with the same credentials is documented in [Developing locally](docs/published/handbook/engineering/developing-locally.md) (`fe_sendauth` troubleshooting). Ensure containers are running.
+**When not using the hardcoded URL:** Connecting **from the host** with the same credentials is documented in [Developing locally](../../../docs/published/handbook/engineering/developing-locally.md) (`fe_sendauth` troubleshooting). Ensure containers are running.
 
 **Default env when `DEBUG` is on:** Django builds a default `DATABASE_URL` from `PGHOST` (default **`db`**), `PGUSER` / `PGPASSWORD`, `PGPORT`, `PGDATABASE` — matching **in-container** hostnames. From the **host**, use `localhost` and the same user/password/database name unless your shell already exports `DATABASE_URL`.
 

--- a/.agents/skills/setup-web-tests/SKILL.md
+++ b/.agents/skills/setup-web-tests/SKILL.md
@@ -80,7 +80,7 @@ echo "127.0.0.1 kafka clickhouse clickhouse-coordinator objectstorage" | sudo te
 
 ## Environment Variables
 
-Tests require environment variables defined in [`.github/workflows/ci-backend.yml`](.github/workflows/ci-backend.yml) (see the `env:` section at the top of the file). You can also copy `.env.example` to `.env` for local development defaults.
+Tests require environment variables defined in [`.github/workflows/ci-backend.yml`](../../../.github/workflows/ci-backend.yml) (see the `env:` section at the top of the file). You can also copy `.env.example` to `.env` for local development defaults.
 
 ## Additional Setup
 
@@ -116,7 +116,7 @@ Default ignores: `--ignore=posthog/user_scripts --ignore=services/llm-gateway --
 
 ## Debugging Installation Issues
 
-If you encounter issues with the test setup, refer to [`.github/workflows/ci-backend.yml`](.github/workflows/ci-backend.yml) for the authoritative CI configuration. This file shows:
+If you encounter issues with the test setup, refer to [`.github/workflows/ci-backend.yml`](../../../.github/workflows/ci-backend.yml) for the authoritative CI configuration. This file shows:
 
 - Exact Python version used in CI
 - System dependencies installed

--- a/.agents/skills/writing-skills/SKILL.md
+++ b/.agents/skills/writing-skills/SKILL.md
@@ -5,7 +5,7 @@ description: 'Guide for writing PostHog agent skills — job-to-be-done template
 
 # Writing skills for PostHog agents
 
-Read the full guide at [docs/published/handbook/engineering/ai/writing-skills.md](docs/published/handbook/engineering/ai/writing-skills.md).
+Read the full guide at [docs/published/handbook/engineering/ai/writing-skills.md](../../../docs/published/handbook/engineering/ai/writing-skills.md).
 
 ## Quick workflow
 
@@ -66,7 +66,7 @@ Only `references/` and `scripts/` subdirectories are collected. Others are ignor
 ## Template functions
 
 Files ending in `.j2` are rendered with Jinja2 at build time
-by [`products/posthog_ai/scripts/build_skills.py`](products/posthog_ai/scripts/build_skills.py).
+by [`products/posthog_ai/scripts/build_skills.py`](../../../products/posthog_ai/scripts/build_skills.py).
 Extend the build pipeline so the monorepo stays the source of truth —
 when domain knowledge lives in code (Pydantic models, query runners, function registries),
 add a template function rather than duplicating it as static markdown that drifts.
@@ -82,7 +82,7 @@ Available functions:
 - Clear entry point linking to 30+ reference files
 - Progressive disclosure — agents load only what they need
 - Mix of static `.md` and generated `.md.j2` content
-- See [`products/posthog_ai/skills/querying-posthog-data/SKILL.md`](products/posthog_ai/skills/querying-posthog-data/SKILL.md)
+- See [`products/posthog_ai/skills/querying-posthog-data/SKILL.md`](../../../products/posthog_ai/skills/querying-posthog-data/SKILL.md)
 
 ## Bad example: `llm-analytics`
 


### PR DESCRIPTION
## Problem

26 markdown links across 6 `.agents/skills/*/SKILL.md` files 404 on GitHub. Two causes:

- 24 use repo-root-relative paths (e.g. `](products/architecture.md)`) instead of skill-relative (`](../../../...)`). Same file often mixes correct and broken forms — drift, not convention.
- 2 are stale: `optimizing-clickhouse-and-hogql-queries` points at `posthog/models/cohort/{sql,cohort}.py`, which moved to `products/cohorts/backend/models/` during cohort isolation (old path is gone).

Two of the six (`implementing-mcp-tools`, `writing-skills`) are on the AGENTS.md mandatory-invocation list, so the first signposted link in an "always invoke" skill is broken.

## Changes

- Prefix the 24 root-relative links with `../../../` (5 files). Pure path fix — link text unchanged.
- Repoint the 2 cohort links to `products/cohorts/backend/models/` and update the visible label to match.

Verified with a link-resolution scan: 26 → 0 broken across the targeted files (an unrelated false-positive in `implementing-warehouse-sources`, a type signature `[...](inputs, MyResumeConfig)`, is intentionally left untouched).

## How did you test this code?

Agent-authored. Ran a script that resolves every `](path)` from each SKILL.md's own directory and reports non-existent targets, before and after; confirmed the 26 targeted links now resolve and the cohort targets exist on disk.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)