### PR TITLE
chore(devex): exclude personhog proto from ty

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -477,6 +477,7 @@ exclude = [
     "bin/**",
     "manage.py",
     "posthog/hogql/grammar/**",
+    "posthog/personhog_client/proto/generated/**",
     "posthog/schema.py",
     "posthog/schema_enums.py",
     "posthog/temporal/proxy_service/proto/**",


### PR DESCRIPTION
## Problem

`[tool.ty.src].exclude` already skips the generated `posthog/temporal/proxy_service/proto` tree but not the sibling `posthog/personhog_client/proto/generated` tree, so `ty` typechecks autogenerated protobuf stubs (`_pb2.py` / `_pb2_grpc.py` / `.pyi`) on commit.

## Changes

Add `posthog/personhog_client/proto/generated/**` to `[tool.ty.src].exclude`, mirroring the existing `proxy_service` entry. One line, zero behavior change for hand-written code.

## How did you test this code?

Agent-authored. Confirmed the tree was absent from the ty exclude on master, that it contains only generated code, and that `pyproject.toml` still parses.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)
