### PR TITLE
chore(ci): skip backend tests for ee/frontend-only PRs

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -76,7 +76,8 @@ jobs:
         name: Determine need to run backend and migration checks
         # Set job outputs to values from filter step
         outputs:
-            backend: ${{ steps.filter.outputs.backend || 'true' }}
+            # Run unless a PR touches only ee/frontend/ (frontend code) — see backend_ee_frontend.
+            backend: ${{ github.event_name == 'push' || (steps.filter.outputs.backend == 'true' && fromJSON(steps.filter.outputs.backend_count || '0') > fromJSON(steps.filter.outputs.backend_ee_frontend_count || '0')) }}
             backend_files: ${{ steps.filter.outputs.backend_files }}
             migrations: ${{ steps.filter.outputs.migrations || 'true' }}
             migrations_files: ${{ steps.filter.outputs.migrations_files }}
@@ -122,10 +123,8 @@ jobs:
                         # NOTE: we are at risk of missing a dependency here. We could make
                         # the dependencies more clear if we separated the backend/frontend
                         # code completely
-                        # really we should ignore ee/frontend/** but dorny doesn't support that
-                        # - '!ee/frontend/**'
-                        # including the negated rule appears to work
-                        # but makes it always match because the checked file always isn't `ee/frontend/**` 🙈
+                        # Also matches ee/frontend/ (frontend code); netted out via
+                        # backend_ee_frontend below since dorny can't '!'-exclude here.
                         - 'ee/**/*'
                         - 'common/__init__.py'
                         - 'common/hogql_parser/**'
@@ -193,6 +192,10 @@ jobs:
                         - bin/ci-wait-for-docker
                         - frontend/public/email/*
                         - 'docker/clickhouse/**'
+                      # Subset of 'ee/**/*' above; backend output subtracts its count
+                      # so ee/frontend-only PRs skip backend (cf. ci-storybook.yml).
+                      backend_ee_frontend:
+                        - 'ee/frontend/**'
                       legacy:
                         # Non-product backend code — when only products/ change,
                         # turbo-discover uses Turbo query affectedness to detect changed


### PR DESCRIPTION
## Problem

The `backend` filter sweeps in `ee/frontend/**` via `ee/**/*`, so a PR touching only `ee/frontend/` (frontend code) runs the full backend suite for nothing. We couldn't exclude it: under `dorny/paths-filter`'s default `some` (OR) quantifier a `!ee/frontend/**` rule matches every file *outside* that path, so it fires on everything — the gotcha the old comment documented.

## Changes

- Add a `backend_ee_frontend` filter counting changed files under `ee/frontend/**` (a strict subset of `ee/**/*`).
- Gate the `backend` output on `backend_count > backend_ee_frontend_count` — true only when a non-frontend backend file changed. Same count-subtraction already used in `ci-storybook.yml`.
- Replace the stale "dorny doesn't support that" comment.

Backwards-compatible — output is identical to today except the one targeted case:

| Event / diff | Before | After |
| --- | --- | --- |
| push | run | run |
| no backend files | skip | skip |
| backend file outside `ee/frontend/` | run | run |
| only `ee/frontend/` files | run | **skip** (new) |

## How did you test this code?

I'm an agent (Claude Code). Validation done:

- `actionlint` on the workflow — no new findings (only pre-existing shellcheck info/style warnings in unrelated `run:` blocks, same count as master).
- Hand-traced the GitHub Actions expression across every event/diff case (table above). `github.event_name == 'push'` preserves the old "run-all-on-push" fallback; `|| '0'` guards `fromJSON` when the filter step is skipped.

No CI execution beyond linting.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). Raúl directed the work — understand `dorny/paths-filter`, then implement a backwards-compatible exclusion of `ee/frontend/` from the backend gate.
- Chose count-subtraction over a separate `predicate-quantifier: every` step: purely additive (the existing `backend` filter is untouched), matches the established `ci-storybook.yml` pattern, and avoids a second action invocation.
- Rejected `!ee/frontend/**` (breaks under `some`) and `every` on the main filter (its many OR-includes would then never co-match a single file).
- Scoped to `ci-backend.yml` only. Note: the `legacy` filter has the same `ee/**/*` over-inclusion and could get the same treatment as a follow-up.
