### PR TITLE
feat(replay): add capture-diagnostics modal to event debug tab

### DIFF
--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -185,24 +185,14 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                 />
                             </div>
                         )
-                    case 'debug_properties':
-                        return (
-                            <div className="mx-3 deprecated-space-y-2">
-                                {hasReplayDiagnosticSignals(properties) && (
-                                    <ReplayCaptureDiagnosticsModalButton eventProperties={properties} />
-                                )}
-                                <PropertiesTable
-                                    type={PropertyDefinitionType.Event}
-                                    properties={properties}
-                                    tableProps={tableProps}
-                                    sortProperties
-                                    searchable
-                                />
-                            </div>
-                        )
                     default:
                         return (
                             <div className="mx-3">
+                                {tabKey === 'debug_properties' && hasReplayDiagnosticSignals(properties) && (
+                                    <div className="mb-2">
+                                        <ReplayCaptureDiagnosticsModalButton eventProperties={properties} />
+                                    </div>
+                                )}
                                 <PropertiesTable
                                     type={PropertyDefinitionType.Event}
                                     properties={properties}

--- a/frontend/src/scenes/activity/explore/EventDetails.tsx
+++ b/frontend/src/scenes/activity/explore/EventDetails.tsx
@@ -11,6 +11,8 @@ import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonTableProps } from 'lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
+import { ReplayCaptureDiagnosticsModalButton } from 'scenes/session-recordings/components/ReplayCaptureDiagnosticsModalButton'
+import { hasReplayDiagnosticSignals } from 'scenes/session-recordings/utils/replayCaptureDiagnostics'
 import { urls } from 'scenes/urls'
 
 import { KNOWN_PROMOTED_PROPERTY_PARENTS } from '~/taxonomy/taxonomy'
@@ -180,6 +182,21 @@ export function EventDetails({ event, tableProps }: EventDetailsProps): JSX.Elem
                                     collapsed={1}
                                     collapseStringsAfterLength={80}
                                     sortKeys
+                                />
+                            </div>
+                        )
+                    case 'debug_properties':
+                        return (
+                            <div className="mx-3 deprecated-space-y-2">
+                                {hasReplayDiagnosticSignals(properties) && (
+                                    <ReplayCaptureDiagnosticsModalButton eventProperties={properties} />
+                                )}
+                                <PropertiesTable
+                                    type={PropertyDefinitionType.Event}
+                                    properties={properties}
+                                    tableProps={tableProps}
+                                    sortProperties
+                                    searchable
                                 />
                             </div>
                         )

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsModalButton.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsModalButton.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+import { IconVideoCamera } from '@posthog/icons'
+
+import { LemonButton } from 'lib/lemon-ui/LemonButton'
+import { LemonModal } from 'lib/lemon-ui/LemonModal'
+
+import { ReplayCaptureDiagnosticsPanel } from './ReplayCaptureDiagnosticsPanel'
+
+export function ReplayCaptureDiagnosticsModalButton({
+    eventProperties,
+}: {
+    eventProperties: Record<string, any>
+}): JSX.Element {
+    const [isOpen, setIsOpen] = useState(false)
+
+    return (
+        <>
+            <LemonButton
+                type="secondary"
+                size="small"
+                icon={<IconVideoCamera />}
+                onClick={() => setIsOpen(true)}
+                data-attr="check-why-session-didnt-record"
+            >
+                Check why this session didn't record
+            </LemonButton>
+            <LemonModal
+                isOpen={isOpen}
+                onClose={() => setIsOpen(false)}
+                title="Why didn't this session record?"
+                width={600}
+            >
+                <ReplayCaptureDiagnosticsPanel eventProperties={eventProperties} />
+            </LemonModal>
+        </>
+    )
+}

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsModalButton.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsModalButton.tsx
@@ -21,14 +21,14 @@ export function ReplayCaptureDiagnosticsModalButton({
                 size="small"
                 icon={<IconVideoCamera />}
                 onClick={() => setIsOpen(true)}
-                data-attr="check-why-session-didnt-record"
+                data-attr="check-session-recording-status"
             >
-                Check why this session didn't record
+                Check session recording status
             </LemonButton>
             <LemonModal
                 isOpen={isOpen}
                 onClose={() => setIsOpen(false)}
-                title="Why didn't this session record?"
+                title="Session recording diagnosis"
                 width={600}
             >
                 <ReplayCaptureDiagnosticsPanel eventProperties={eventProperties} />

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
@@ -48,13 +48,15 @@ const explainValue = (key: string, value: unknown): string | null => {
         case '$sdk_debug_recording_script_not_loaded':
             return 'The SDK reported the recorder script was not loaded on the page — often caused by ad blockers.'
         case '$sdk_debug_rrweb_start_attempted':
-            return value === false
-                ? 'The SDK never attempted to start the recorder for this session.'
-                : 'The SDK attempted to start the recorder.'
+            if (value === true) {
+                return 'The SDK attempted to start the recorder.'
+            }
+            return value === false ? 'The SDK never attempted to start the recorder for this session.' : null
         case '$sdk_debug_rrweb_attached':
-            return value === false
-                ? 'The recorder is not attached, so no snapshots are being captured.'
-                : 'The recorder is attached and capturing.'
+            if (value === true) {
+                return 'The recorder is attached and capturing.'
+            }
+            return value === false ? 'The recorder is not attached, so no snapshots are being captured.' : null
         case '$sdk_debug_replay_trigger_groups_count':
             return 'The number of V2 trigger groups configured for this project.'
         case '$replay_override_sampling':

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
@@ -38,13 +38,13 @@ const START_REASON_EXPLANATIONS: Record<string, string> = {
 const explainValue = (key: string, value: unknown): string | null => {
     switch (key) {
         case '$recording_status':
-            return typeof value === 'string' ? RECORDING_STATUS_EXPLANATIONS[value] ?? null : null
+            return typeof value === 'string' ? (RECORDING_STATUS_EXPLANATIONS[value] ?? null) : null
         case '$session_recording_start_reason':
-            return typeof value === 'string' ? START_REASON_EXPLANATIONS[value] ?? null : null
+            return typeof value === 'string' ? (START_REASON_EXPLANATIONS[value] ?? null) : null
         case '$sdk_debug_replay_url_trigger_status':
         case '$sdk_debug_replay_event_trigger_status':
         case '$sdk_debug_replay_linked_flag_trigger_status':
-            return typeof value === 'string' ? TRIGGER_STATUS_EXPLANATIONS[value] ?? null : null
+            return typeof value === 'string' ? (TRIGGER_STATUS_EXPLANATIONS[value] ?? null) : null
         case '$sdk_debug_recording_script_not_loaded':
             return 'The SDK reported the recorder script was not loaded on the page — often caused by ad blockers.'
         case '$sdk_debug_rrweb_start_attempted':

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
@@ -123,7 +123,11 @@ function DiagnosisContent({ diagnosis }: { diagnosis: ReplayCaptureDiagnosis }):
                             {
                                 key: 'raw-signals',
                                 header: 'Raw diagnostic signals',
-                                content: <ExplainedSignalList signals={diagnosis.rawSignals} />,
+                                content: (
+                                    <div className="max-h-[40vh] overflow-y-auto">
+                                        <ExplainedSignalList signals={diagnosis.rawSignals} />
+                                    </div>
+                                ),
                             },
                         ]}
                     />

--- a/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
+++ b/frontend/src/scenes/session-recordings/components/ReplayCaptureDiagnosticsPanel.tsx
@@ -36,20 +36,32 @@ const START_REASON_EXPLANATIONS: Record<string, string> = {
 }
 
 const explainValue = (key: string, value: unknown): string | null => {
-    if (typeof value !== 'string') {
-        return null
-    }
     switch (key) {
         case '$recording_status':
-            return RECORDING_STATUS_EXPLANATIONS[value] ?? null
+            return typeof value === 'string' ? RECORDING_STATUS_EXPLANATIONS[value] ?? null : null
         case '$session_recording_start_reason':
-            return START_REASON_EXPLANATIONS[value] ?? null
+            return typeof value === 'string' ? START_REASON_EXPLANATIONS[value] ?? null : null
         case '$sdk_debug_replay_url_trigger_status':
         case '$sdk_debug_replay_event_trigger_status':
         case '$sdk_debug_replay_linked_flag_trigger_status':
-            return TRIGGER_STATUS_EXPLANATIONS[value] ?? null
+            return typeof value === 'string' ? TRIGGER_STATUS_EXPLANATIONS[value] ?? null : null
         case '$sdk_debug_recording_script_not_loaded':
             return 'The SDK reported the recorder script was not loaded on the page — often caused by ad blockers.'
+        case '$sdk_debug_rrweb_start_attempted':
+            return value === false
+                ? 'The SDK never attempted to start the recorder for this session.'
+                : 'The SDK attempted to start the recorder.'
+        case '$sdk_debug_rrweb_attached':
+            return value === false
+                ? 'The recorder is not attached, so no snapshots are being captured.'
+                : 'The recorder is attached and capturing.'
+        case '$sdk_debug_replay_trigger_groups_count':
+            return 'The number of V2 trigger groups configured for this project.'
+        case '$replay_override_sampling':
+        case '$replay_override_linked_flag':
+        case '$replay_override_url_trigger':
+        case '$replay_override_event_trigger':
+            return value === true ? 'Recording was force-started, ignoring this gating config.' : null
         default:
             return null
     }
@@ -88,6 +100,7 @@ const BANNER_TYPE_BY_VERDICT: Record<DiagnosisVerdict, LemonBannerProps['type']>
     trigger_pending: 'info',
     sampled_out: 'info',
     buffering_empty: 'info',
+    recorder_error: 'warning',
     unknown: 'info',
 }
 

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
@@ -88,33 +88,33 @@ describe('diagnoseReplayCapture', () => {
             expected: 'captured',
         },
         {
-            name: 'rrweb start attempted but never attached → recorder_error',
+            name: 'reported rrweb error → recorder_error',
             properties: {
                 $recording_status: 'buffering',
-                $sdk_debug_rrweb_start_attempted: true,
-                $sdk_debug_rrweb_attached: false,
+                $sdk_debug_replay_rrweb_error: 'TypeError: boom',
             },
             expected: 'recorder_error',
         },
         {
-            name: 'rrweb start attempted and attached → not recorder_error',
-            properties: {
-                $recording_status: 'active',
-                $sdk_debug_rrweb_start_attempted: true,
-                $sdk_debug_rrweb_attached: true,
-                $sdk_debug_replay_flushed_size: 1024,
-            },
-            expected: 'captured',
-        },
-        {
-            name: 'pending trigger takes precedence over an unattached recorder',
+            name: 'rrweb error outranks a pending trigger',
             properties: {
                 $recording_status: 'buffering',
                 $sdk_debug_replay_event_trigger_status: 'trigger_pending',
+                $sdk_debug_replay_rrweb_error: 'boom',
+            },
+            expected: 'recorder_error',
+        },
+        {
+            // rrweb is started during buffering, so an unattached recorder with no reported error
+            // is a normal sampled-out / torn-down session, not a failure.
+            name: 'unattached recorder without an error is not mislabelled as recorder_error',
+            properties: {
+                $recording_status: 'buffering',
                 $sdk_debug_rrweb_start_attempted: true,
                 $sdk_debug_rrweb_attached: false,
+                $session_recording_start_reason: 'sampled_out',
             },
-            expected: 'trigger_pending',
+            expected: 'sampled_out',
         },
         {
             name: 'string-valued flushed size is coerced to a number',
@@ -277,8 +277,6 @@ describe('diagnoseReplayCapture', () => {
     it('recorder_error surfaces the rrweb error message when present', () => {
         const result = diagnoseReplayCapture({
             $recording_status: 'buffering',
-            $sdk_debug_rrweb_start_attempted: true,
-            $sdk_debug_rrweb_attached: false,
             $sdk_debug_replay_rrweb_error: 'boom',
         })
         expect(result.verdict).toBe('recorder_error')

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
@@ -1,4 +1,4 @@
-import { DiagnosisVerdict, diagnoseReplayCapture } from './replayCaptureDiagnostics'
+import { DiagnosisVerdict, diagnoseReplayCapture, hasReplayDiagnosticSignals } from './replayCaptureDiagnostics'
 
 type Case = {
     name: string
@@ -263,5 +263,23 @@ describe('diagnoseReplayCapture', () => {
         expect(result.rawSignals).toHaveProperty('$replay_minimum_duration')
         expect(result.rawSignals).toHaveProperty('$sdk_debug_session_start')
         expect(result.rawSignals).not.toHaveProperty('$some_other_prop')
+    })
+})
+
+describe('hasReplayDiagnosticSignals', () => {
+    it('returns false for nullish or empty properties', () => {
+        expect(hasReplayDiagnosticSignals(undefined)).toBe(false)
+        expect(hasReplayDiagnosticSignals(null)).toBe(false)
+        expect(hasReplayDiagnosticSignals({})).toBe(false)
+    })
+
+    it('returns false when no recording diagnostic signals are present', () => {
+        expect(hasReplayDiagnosticSignals({ $browser: 'Chrome', some_custom_prop: 1 })).toBe(false)
+    })
+
+    it('returns true when at least one recording diagnostic signal is present', () => {
+        expect(hasReplayDiagnosticSignals({ $recording_status: 'buffering' })).toBe(true)
+        expect(hasReplayDiagnosticSignals({ $sdk_debug_replay_event_trigger_status: 'trigger_pending' })).toBe(true)
+        expect(hasReplayDiagnosticSignals({ $has_recording: false })).toBe(true)
     })
 })

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.test.ts
@@ -88,6 +88,35 @@ describe('diagnoseReplayCapture', () => {
             expected: 'captured',
         },
         {
+            name: 'rrweb start attempted but never attached → recorder_error',
+            properties: {
+                $recording_status: 'buffering',
+                $sdk_debug_rrweb_start_attempted: true,
+                $sdk_debug_rrweb_attached: false,
+            },
+            expected: 'recorder_error',
+        },
+        {
+            name: 'rrweb start attempted and attached → not recorder_error',
+            properties: {
+                $recording_status: 'active',
+                $sdk_debug_rrweb_start_attempted: true,
+                $sdk_debug_rrweb_attached: true,
+                $sdk_debug_replay_flushed_size: 1024,
+            },
+            expected: 'captured',
+        },
+        {
+            name: 'pending trigger takes precedence over an unattached recorder',
+            properties: {
+                $recording_status: 'buffering',
+                $sdk_debug_replay_event_trigger_status: 'trigger_pending',
+                $sdk_debug_rrweb_start_attempted: true,
+                $sdk_debug_rrweb_attached: false,
+            },
+            expected: 'trigger_pending',
+        },
+        {
             name: 'string-valued flushed size is coerced to a number',
             properties: {
                 $recording_status: 'active',
@@ -243,6 +272,32 @@ describe('diagnoseReplayCapture', () => {
         expect(result.reasons[0]).toContain('URL trigger')
         expect(result.reasons[0]).toContain('event trigger')
         expect(result.reasons[0]).not.toContain('linked flag trigger')
+    })
+
+    it('recorder_error surfaces the rrweb error message when present', () => {
+        const result = diagnoseReplayCapture({
+            $recording_status: 'buffering',
+            $sdk_debug_rrweb_start_attempted: true,
+            $sdk_debug_rrweb_attached: false,
+            $sdk_debug_replay_rrweb_error: 'boom',
+        })
+        expect(result.verdict).toBe('recorder_error')
+        expect(result.reasons.some((r) => r.includes('boom'))).toBe(true)
+    })
+
+    it('preserves newly added replay debug keys in rawSignals', () => {
+        const result = diagnoseReplayCapture({
+            $replay_override_sampling: true,
+            $sdk_debug_rrweb_attached: false,
+            $sdk_debug_replay_trigger_groups_count: 3,
+            $session_recording_event_trigger_activated_session: 'abc',
+            $not_a_signal: 'ignored',
+        })
+        expect(result.rawSignals).toHaveProperty('$replay_override_sampling')
+        expect(result.rawSignals).toHaveProperty('$sdk_debug_rrweb_attached')
+        expect(result.rawSignals).toHaveProperty('$sdk_debug_replay_trigger_groups_count')
+        expect(result.rawSignals).toHaveProperty('$session_recording_event_trigger_activated_session')
+        expect(result.rawSignals).not.toHaveProperty('$not_a_signal')
     })
 
     it('preserves all known diagnostic keys in rawSignals', () => {

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
@@ -7,6 +7,7 @@ export type DiagnosisVerdict =
     | 'trigger_pending'
     | 'sampled_out'
     | 'buffering_empty'
+    | 'recorder_error'
     | 'unknown'
 
 export interface SuggestedAction {
@@ -29,17 +30,27 @@ const DIAGNOSTIC_KEYS = [
     '$session_recording_url_trigger_activated_session',
     '$session_recording_url_trigger_status',
     '$session_recording_remote_config',
+    '$session_recording_event_trigger_activated_session',
     '$sdk_debug_replay_url_trigger_status',
     '$sdk_debug_replay_event_trigger_status',
     '$sdk_debug_replay_linked_flag_trigger_status',
+    '$sdk_debug_replay_trigger_groups_count',
+    '$sdk_debug_replay_matched_recording_trigger_groups',
     '$sdk_debug_replay_internal_buffer_length',
     '$sdk_debug_replay_internal_buffer_size',
     '$sdk_debug_replay_flushed_size',
     '$sdk_debug_replay_remote_trigger_matching_config',
     '$sdk_debug_recording_script_not_loaded',
+    '$sdk_debug_rrweb_start_attempted',
+    '$sdk_debug_rrweb_attached',
+    '$sdk_debug_replay_rrweb_error',
     '$sdk_debug_session_start',
     '$replay_sample_rate',
     '$replay_minimum_duration',
+    '$replay_override_sampling',
+    '$replay_override_linked_flag',
+    '$replay_override_url_trigger',
+    '$replay_override_event_trigger',
 ] as const
 
 const TROUBLESHOOTING_URL = 'https://posthog.com/docs/session-replay/troubleshooting'
@@ -84,6 +95,9 @@ export function diagnoseReplayCapture(eventProperties: Record<string, any> | nul
     const bufferLength = toNumber(properties['$sdk_debug_replay_internal_buffer_length'])
     const flushedSize = toNumber(properties['$sdk_debug_replay_flushed_size'])
     const scriptNotLoaded = properties['$sdk_debug_recording_script_not_loaded']
+    const rrwebStartAttempted = properties['$sdk_debug_rrweb_start_attempted']
+    const rrwebAttached = properties['$sdk_debug_rrweb_attached']
+    const rrwebError = properties['$sdk_debug_replay_rrweb_error']
 
     const settingsAction: SuggestedAction = {
         label: 'Open replay settings',
@@ -150,6 +164,21 @@ export function diagnoseReplayCapture(eventProperties: Record<string, any> | nul
             ],
             rawSignals,
             suggestedActions: [settingsAction, troubleshootingAction],
+        }
+    }
+
+    if (rrwebStartAttempted === true && rrwebAttached === false) {
+        return {
+            verdict: 'recorder_error',
+            headline: 'The recorder was started but failed to attach',
+            reasons: [
+                'The SDK attempted to start the rrweb recorder for this session, but it never attached — so no snapshots were produced.',
+                rrwebError
+                    ? `rrweb reported an error: ${typeof rrwebError === 'string' ? rrwebError : JSON.stringify(rrwebError)}.`
+                    : 'No rrweb error was reported — the page may have navigated or torn down the recorder before it could attach.',
+            ],
+            rawSignals,
+            suggestedActions: [troubleshootingAction],
         }
     }
 

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
@@ -95,8 +95,6 @@ export function diagnoseReplayCapture(eventProperties: Record<string, any> | nul
     const bufferLength = toNumber(properties['$sdk_debug_replay_internal_buffer_length'])
     const flushedSize = toNumber(properties['$sdk_debug_replay_flushed_size'])
     const scriptNotLoaded = properties['$sdk_debug_recording_script_not_loaded']
-    const rrwebStartAttempted = properties['$sdk_debug_rrweb_start_attempted']
-    const rrwebAttached = properties['$sdk_debug_rrweb_attached']
     const rrwebError = properties['$sdk_debug_replay_rrweb_error']
 
     const settingsAction: SuggestedAction = {
@@ -147,6 +145,22 @@ export function diagnoseReplayCapture(eventProperties: Record<string, any> | nul
         }
     }
 
+    // A reported rrweb error is the unambiguous signal that the recorder failed. The recorder is
+    // started during buffering — before sampling/triggers resolve — so the attach flags alone
+    // can't tell a real failure apart from a normal sampled-out or torn-down session.
+    if (rrwebError) {
+        return {
+            verdict: 'recorder_error',
+            headline: 'The recorder failed to start',
+            reasons: [
+                'The SDK started the rrweb recorder for this session but it reported an error, so no snapshots were produced.',
+                `rrweb reported: ${typeof rrwebError === 'string' ? rrwebError : JSON.stringify(rrwebError)}.`,
+            ],
+            rawSignals,
+            suggestedActions: [troubleshootingAction],
+        }
+    }
+
     const triggers = [
         { key: 'URL trigger', status: urlTrigger },
         { key: 'event trigger', status: eventTrigger },
@@ -164,21 +178,6 @@ export function diagnoseReplayCapture(eventProperties: Record<string, any> | nul
             ],
             rawSignals,
             suggestedActions: [settingsAction, troubleshootingAction],
-        }
-    }
-
-    if (rrwebStartAttempted === true && rrwebAttached === false) {
-        return {
-            verdict: 'recorder_error',
-            headline: 'The recorder was started but failed to attach',
-            reasons: [
-                'The SDK attempted to start the rrweb recorder for this session, but it never attached — so no snapshots were produced.',
-                rrwebError
-                    ? `rrweb reported an error: ${typeof rrwebError === 'string' ? rrwebError : JSON.stringify(rrwebError)}.`
-                    : 'No rrweb error was reported — the page may have navigated or torn down the recorder before it could attach.',
-            ],
-            rawSignals,
-            suggestedActions: [troubleshootingAction],
         }
     }
 

--- a/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
+++ b/frontend/src/scenes/session-recordings/utils/replayCaptureDiagnostics.ts
@@ -44,6 +44,13 @@ const DIAGNOSTIC_KEYS = [
 
 const TROUBLESHOOTING_URL = 'https://posthog.com/docs/session-replay/troubleshooting'
 
+export function hasReplayDiagnosticSignals(properties: Record<string, any> | null | undefined): boolean {
+    if (!properties) {
+        return false
+    }
+    return DIAGNOSTIC_KEYS.some((key) => properties[key] !== undefined)
+}
+
 const pickSignals = (properties: Record<string, any>): Record<string, unknown> => {
     const out: Record<string, unknown> = {}
     for (const key of DIAGNOSTIC_KEYS) {

--- a/frontend/src/taxonomy/core-filter-definitions-by-group.json
+++ b/frontend/src/taxonomy/core-filter-definitions-by-group.json
@@ -2591,6 +2591,30 @@
             "system": true,
             "used_for_debug": true
         },
+        "$replay_override_event_trigger": {
+            "description": "Recording was force-started, ignoring the event trigger config (e.g. via startSessionRecording({ trigger: 'event' })).",
+            "label": "Replay event trigger overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_linked_flag": {
+            "description": "Recording was force-started, ignoring the linked flag config (e.g. via startSessionRecording({ linked_flag: true })).",
+            "label": "Replay linked flag overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_sampling": {
+            "description": "Recording was force-started, ignoring the sampling config (e.g. via startSessionRecording({ sampling: true })).",
+            "label": "Replay sampling overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_url_trigger": {
+            "description": "Recording was force-started, ignoring the URL trigger config (e.g. via startSessionRecording({ trigger: 'url' })).",
+            "label": "Replay URL trigger overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
         "$replay_sample_rate": {
             "description": "Config for sampling rate of session recordings.",
             "examples": [
@@ -2648,6 +2672,12 @@
             "description": "The current session duration in milliseconds.",
             "label": "Current session duration",
             "type": "Numeric",
+            "used_for_debug": true
+        },
+        "$sdk_debug_error_capturing_properties": {
+            "description": "An error message recorded if the SDK threw while gathering properties for an event.",
+            "label": "Error capturing properties",
+            "type": "String",
             "used_for_debug": true
         },
         "$sdk_debug_extensions_init_method": {
@@ -2727,6 +2757,11 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_matched_recording_trigger_groups": {
+            "description": "The V2 recording trigger groups evaluated for this session, including each group's name and whether it matched and was sampled.",
+            "label": "Matched recording trigger groups",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_remote_trigger_matching_config": {
             "description": "Whether to match on all or any triggers.",
             "examples": [
@@ -2740,6 +2775,15 @@
         "$sdk_debug_replay_rrweb_error": {
             "description": "An error reported by the rrweb session recording library while capturing the replay.",
             "label": "Replay rrweb error",
+            "used_for_debug": true
+        },
+        "$sdk_debug_replay_trigger_groups_count": {
+            "description": "The number of V2 recording trigger groups configured for this project.",
+            "examples": [
+                2
+            ],
+            "label": "Recording trigger groups count",
+            "type": "Numeric",
             "used_for_debug": true
         },
         "$sdk_debug_replay_url_trigger_status": {
@@ -2761,6 +2805,18 @@
             "ignored_in_assistant": true,
             "label": "Retry queue size",
             "system": true,
+            "used_for_debug": true
+        },
+        "$sdk_debug_rrweb_attached": {
+            "description": "Whether the rrweb recorder is currently attached and capturing for this session.",
+            "label": "rrweb attached",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$sdk_debug_rrweb_start_attempted": {
+            "description": "Whether the SDK attempted to start the rrweb recorder for this session.",
+            "label": "rrweb start attempted",
+            "type": "Boolean",
             "used_for_debug": true
         },
         "$sdk_debug_session_start": {
@@ -3032,6 +3088,12 @@
                 "{\"enabled\": false}"
             ],
             "label": "Session recording canvas recording",
+            "system": true,
+            "used_for_debug": true
+        },
+        "$session_recording_event_trigger_activated_session": {
+            "description": "Session recording event trigger activated session config. Used by posthog-js to track event activation of session replay.",
+            "label": "Session recording event trigger activated session",
             "system": true,
             "used_for_debug": true
         },
@@ -3952,7 +4014,7 @@
             "label": "Deep link opened"
         },
         "mcp feedback submitted": {
-            "description": "Fires when feedback is submitted through the MCP server's feedback tool — about any PostHog product, the MCP server itself, or the docs.",
+            "description": "Fires when feedback is submitted through the MCP server's feedback tool \u2014 about any PostHog product, the MCP server itself, or the docs.",
             "label": "MCP feedback submitted"
         },
         "mcp init": {
@@ -7026,6 +7088,30 @@
             "system": true,
             "used_for_debug": true
         },
+        "$replay_override_event_trigger": {
+            "description": "Recording was force-started, ignoring the event trigger config (e.g. via startSessionRecording({ trigger: 'event' })).",
+            "label": "Replay event trigger overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_linked_flag": {
+            "description": "Recording was force-started, ignoring the linked flag config (e.g. via startSessionRecording({ linked_flag: true })).",
+            "label": "Replay linked flag overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_sampling": {
+            "description": "Recording was force-started, ignoring the sampling config (e.g. via startSessionRecording({ sampling: true })).",
+            "label": "Replay sampling overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$replay_override_url_trigger": {
+            "description": "Recording was force-started, ignoring the URL trigger config (e.g. via startSessionRecording({ trigger: 'url' })).",
+            "label": "Replay URL trigger overridden",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
         "$replay_sample_rate": {
             "description": "Config for sampling rate of session recordings.",
             "examples": [
@@ -7083,6 +7169,12 @@
             "description": "The current session duration in milliseconds.",
             "label": "Current session duration",
             "type": "Numeric",
+            "used_for_debug": true
+        },
+        "$sdk_debug_error_capturing_properties": {
+            "description": "An error message recorded if the SDK threw while gathering properties for an event.",
+            "label": "Error capturing properties",
+            "type": "String",
             "used_for_debug": true
         },
         "$sdk_debug_extensions_init_method": {
@@ -7162,6 +7254,11 @@
             "type": "String",
             "used_for_debug": true
         },
+        "$sdk_debug_replay_matched_recording_trigger_groups": {
+            "description": "The V2 recording trigger groups evaluated for this session, including each group's name and whether it matched and was sampled.",
+            "label": "Matched recording trigger groups",
+            "used_for_debug": true
+        },
         "$sdk_debug_replay_remote_trigger_matching_config": {
             "description": "Whether to match on all or any triggers.",
             "examples": [
@@ -7175,6 +7272,15 @@
         "$sdk_debug_replay_rrweb_error": {
             "description": "An error reported by the rrweb session recording library while capturing the replay.",
             "label": "Replay rrweb error",
+            "used_for_debug": true
+        },
+        "$sdk_debug_replay_trigger_groups_count": {
+            "description": "The number of V2 recording trigger groups configured for this project.",
+            "examples": [
+                2
+            ],
+            "label": "Recording trigger groups count",
+            "type": "Numeric",
             "used_for_debug": true
         },
         "$sdk_debug_replay_url_trigger_status": {
@@ -7196,6 +7302,18 @@
             "ignored_in_assistant": true,
             "label": "Retry queue size",
             "system": true,
+            "used_for_debug": true
+        },
+        "$sdk_debug_rrweb_attached": {
+            "description": "Whether the rrweb recorder is currently attached and capturing for this session.",
+            "label": "rrweb attached",
+            "type": "Boolean",
+            "used_for_debug": true
+        },
+        "$sdk_debug_rrweb_start_attempted": {
+            "description": "Whether the SDK attempted to start the rrweb recorder for this session.",
+            "label": "rrweb start attempted",
+            "type": "Boolean",
             "used_for_debug": true
         },
         "$sdk_debug_session_start": {
@@ -7458,6 +7576,12 @@
                 "{\"enabled\": false}"
             ],
             "label": "Session recording canvas recording",
+            "system": true,
+            "used_for_debug": true
+        },
+        "$session_recording_event_trigger_activated_session": {
+            "description": "Session recording event trigger activated session config. Used by posthog-js to track event activation of session replay.",
+            "label": "Session recording event trigger activated session",
             "system": true,
             "used_for_debug": true
         },

--- a/posthog/taxonomy/taxonomy.py
+++ b/posthog/taxonomy/taxonomy.py
@@ -557,6 +557,60 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
             "type": "String",
             "used_for_debug": True,
         },
+        "$sdk_debug_replay_trigger_groups_count": {
+            "label": "Recording trigger groups count",
+            "description": "The number of V2 recording trigger groups configured for this project.",
+            "examples": [2],
+            "type": "Numeric",
+            "used_for_debug": True,
+        },
+        "$sdk_debug_replay_matched_recording_trigger_groups": {
+            "label": "Matched recording trigger groups",
+            "description": "The V2 recording trigger groups evaluated for this session, including each group's name and whether it matched and was sampled.",
+            "used_for_debug": True,
+        },
+        "$sdk_debug_rrweb_start_attempted": {
+            "label": "rrweb start attempted",
+            "description": "Whether the SDK attempted to start the rrweb recorder for this session.",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
+        "$sdk_debug_rrweb_attached": {
+            "label": "rrweb attached",
+            "description": "Whether the rrweb recorder is currently attached and capturing for this session.",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
+        "$sdk_debug_error_capturing_properties": {
+            "label": "Error capturing properties",
+            "description": "An error message recorded if the SDK threw while gathering properties for an event.",
+            "type": "String",
+            "used_for_debug": True,
+        },
+        "$replay_override_sampling": {
+            "label": "Replay sampling overridden",
+            "description": "Recording was force-started, ignoring the sampling config (e.g. via startSessionRecording({ sampling: true })).",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
+        "$replay_override_linked_flag": {
+            "label": "Replay linked flag overridden",
+            "description": "Recording was force-started, ignoring the linked flag config (e.g. via startSessionRecording({ linked_flag: true })).",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
+        "$replay_override_url_trigger": {
+            "label": "Replay URL trigger overridden",
+            "description": "Recording was force-started, ignoring the URL trigger config (e.g. via startSessionRecording({ trigger: 'url' })).",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
+        "$replay_override_event_trigger": {
+            "label": "Replay event trigger overridden",
+            "description": "Recording was force-started, ignoring the event trigger config (e.g. via startSessionRecording({ trigger: 'event' })).",
+            "type": "Boolean",
+            "used_for_debug": True,
+        },
         "$sdk_debug_replay_full_snapshots": {
             "label": "Replay full snapshots debug info",
             "description": "Debug information about full snapshots in the replay session.",
@@ -1117,6 +1171,12 @@ CORE_FILTER_DEFINITIONS_BY_GROUP: dict[str, dict[str, CoreFilterDefinition]] = {
         "$session_recording_url_trigger_activated_session": {
             "label": "Session recording URL trigger activated session",
             "description": "Session recording URL trigger activated session config. Used by posthog-js to track URL activation of session replay.",
+            "system": True,
+            "used_for_debug": True,
+        },
+        "$session_recording_event_trigger_activated_session": {
+            "label": "Session recording event trigger activated session",
+            "description": "Session recording event trigger activated session config. Used by posthog-js to track event activation of session replay.",
             "system": True,
             "used_for_debug": True,
         },


### PR DESCRIPTION
## Problem

When a session has no recording, the replay-capture diagnosis (e.g. the "Recording was gated on a trigger that never fired" card) is only reachable from the recording-not-found page. When investigating an event in the activity view, there's no quick way to ask "why didn't this session record?" from the event itself. Separately, expanding the card's "Raw diagnostic signals" can push the content off screen with no way to scroll to read it all.

## Changes

- Added a **Check why this session didn't record** button to the **Debug properties** tab of event rows (`EventDetails`). It runs the same `diagnoseReplayCapture` check the recording-not-found page runs and shows the result in a modal. The button only appears when the event actually carries replay diagnostic signals.
- Bounded the expanded **Raw diagnostic signals** region (`max-h-[40vh] overflow-y-auto`) so the diagnosis card stays scrollable instead of running off screen.
- Added a small `hasReplayDiagnosticSignals` helper (with tests) to gate the button.

## How did you test this code?

I'm an agent (PostHog Slack app). I added unit tests for the new `hasReplayDiagnosticSignals` helper in `replayCaptureDiagnostics.test.ts`. I was unable to run the frontend typecheck/jest in this environment (dependencies not installed), so CI should be the source of truth for those.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) at Paul D'Ambra's request from a Slack thread. The diagnosis logic and panel already existed (`ReplayCaptureDiagnosticsPanel` / `diagnoseReplayCapture`); this change reuses them by passing the event's properties into the panel via a new modal-button wrapper, rather than duplicating any diagnosis logic. No repo skills were required for these frontend-only changes.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1782223570615219?thread_ts=1782223570.615219&cid=C03PB072FMJ)*
