### PR TITLE
feat: Do everything

### DIFF
--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -950,6 +950,11 @@ class BatchExportSerializer(serializers.ModelSerializer):
         if filters is None:
             return filters
 
+        # WORKFLOWS exports store the linked hog function's filters as a dict (events/actions/
+        # properties/filter_test_accounts); all other exports use a flat list of property filters.
+        if isinstance(filters, dict):
+            return filters
+
         if not isinstance(filters, list):
             raise serializers.ValidationError("'filters' should be an array of filters")
 

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -151,7 +151,9 @@ class BatchExportEventPropertyFilter:
 class BatchExportModel:
     name: str
     schema: BatchExportSchema | None
-    filters: list[dict[str, str | list[str] | None]] | None = None
+    # WORKFLOWS exports store the linked hog function's full filters dict; all other models use a
+    # flat list of serialized HogQL property filters.
+    filters: list[dict[str, str | list[str] | None]] | dict | None = None
 
 
 @dataclass

--- a/products/batch_exports/backend/temporal/backfill_batch_export.py
+++ b/products/batch_exports/backend/temporal/backfill_batch_export.py
@@ -44,7 +44,7 @@ from products.batch_exports.backend.service import (
 )
 from products.batch_exports.backend.temporal.metrics import log_query_duration
 from products.batch_exports.backend.temporal.record_batch_model import SessionsRecordBatchModel
-from products.batch_exports.backend.temporal.spmc import compose_filters_clause
+from products.batch_exports.backend.temporal.spmc import compose_filters_clause, compose_hog_function_filters_clause
 
 LOGGER = get_write_only_logger(__name__)
 
@@ -507,9 +507,15 @@ async def get_backfill_info(inputs: GetBackfillInfoInputs) -> GetBackfillInfoOut
     filters_str = ""
     extra_query_parameters: dict[str, typing.Any] = {}
     if batch_export.filters:
-        filters_str, extra_query_parameters = await sync_to_async(compose_filters_clause)(
-            batch_export.filters, team_id=inputs.team_id
-        )
+        if isinstance(batch_export.filters, dict):
+            # WORKFLOWS exports store the linked hog function's full filters dict.
+            filters_str, extra_query_parameters = await sync_to_async(compose_hog_function_filters_clause)(
+                batch_export.filters, team_id=inputs.team_id
+            )
+        else:
+            filters_str, extra_query_parameters = await sync_to_async(compose_filters_clause)(
+                batch_export.filters, team_id=inputs.team_id
+            )
         if filters_str:
             filters_str = f"AND {filters_str}"
 

--- a/products/batch_exports/backend/temporal/pipeline/internal_stage.py
+++ b/products/batch_exports/backend/temporal/pipeline/internal_stage.py
@@ -51,6 +51,7 @@ from products.batch_exports.backend.temporal.record_batch_model import resolve_b
 from products.batch_exports.backend.temporal.spmc import (
     RecordBatchModel,
     compose_filters_clause,
+    compose_hog_function_filters_clause,
     generate_query_ranges,
     is_5_min_batch_export,
     use_distributed_events_recent_table,
@@ -370,7 +371,7 @@ async def _get_query(
     data_interval_end: str,
     fields: list[BatchExportField] | None = None,
     destination_default_fields: list[BatchExportField] | None = None,
-    filters: list[dict[str, str | list[str] | None]] | None = None,
+    filters: list[dict[str, str | list[str] | None]] | dict | None = None,
     num_partitions: int | None = None,
     is_workflows: bool = False,
     **parameters,
@@ -386,9 +387,16 @@ async def _get_query(
     extra_query_parameters = parameters.pop("extra_query_parameters", {}) or {}
 
     if filters is not None and len(filters) > 0:
-        filters_str, extra_query_parameters = await database_sync_to_async(compose_filters_clause)(
-            filters, team_id=team_id, values=extra_query_parameters
-        )
+        if isinstance(filters, dict):
+            # WORKFLOWS exports store the linked hog function's full filters dict and reuse the
+            # realtime filter expression so backfills match what the destination would receive live.
+            filters_str, extra_query_parameters = await database_sync_to_async(compose_hog_function_filters_clause)(
+                filters, team_id=team_id, values=extra_query_parameters
+            )
+        else:
+            filters_str, extra_query_parameters = await database_sync_to_async(compose_filters_clause)(
+                filters, team_id=team_id, values=extra_query_parameters
+            )
     else:
         filters_str, extra_query_parameters = "", extra_query_parameters
 

--- a/products/batch_exports/backend/temporal/spmc.py
+++ b/products/batch_exports/backend/temporal/spmc.py
@@ -21,6 +21,7 @@ from posthog.hogql.printer import prepare_ast_for_printing, print_prepared_ast
 from posthog.hogql.property import property_to_expr
 from posthog.hogql.visitor import TraversingVisitor
 
+from posthog.cdp.filters import CohortInlineError, compile_filters_expr
 from posthog.models import Team
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.clickhouse import get_client
@@ -328,7 +329,7 @@ class Producer:
         destination_default_fields: list[BatchExportField] | None = None,
         max_record_batch_size_bytes: int = 0,
         min_records_per_batch: int = 100,
-        filters: list[dict[str, str | list[str] | None]] | None = None,
+        filters: list[dict[str, str | list[str] | None]] | dict | None = None,
         order_columns: collections.abc.Iterable[str] | None = ("_inserted_at", "event"),
         is_workflows: bool = False,
         **parameters,
@@ -342,9 +343,16 @@ class Producer:
         extra_query_parameters = parameters.pop("extra_query_parameters", {}) or {}
 
         if filters is not None and len(filters) > 0:
-            filters_str, extra_query_parameters = await database_sync_to_async(compose_filters_clause)(
-                filters, team_id=team_id, values=extra_query_parameters
-            )
+            if isinstance(filters, dict):
+                # WORKFLOWS exports store the linked hog function's full filters dict and reuse the
+                # realtime filter expression so backfills match what the destination would receive live.
+                filters_str, extra_query_parameters = await database_sync_to_async(compose_hog_function_filters_clause)(
+                    filters, team_id=team_id, values=extra_query_parameters
+                )
+            else:
+                filters_str, extra_query_parameters = await database_sync_to_async(compose_filters_clause)(
+                    filters, team_id=team_id, values=extra_query_parameters
+                )
         else:
             filters_str, extra_query_parameters = "", extra_query_parameters
 
@@ -650,6 +658,57 @@ class InvalidFilterError(Exception):
         super().__init__(msg)
 
 
+def _print_expr_against_events_model(
+    expr: ast.Expr,
+    team: Team,
+    values: dict[str, str] | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Print a HogQL expression as a ClickHouse WHERE-clause fragment against the events model.
+
+    Used to compile batch export filters into a clause that can be spliced into the `$filters`
+    slot of the events export queries. Shared by the flat-list `compose_filters_clause` and the
+    hog-function `compose_hog_function_filters_clause`.
+    """
+    context = HogQLContext(
+        team=team,
+        team_id=team.id,
+        enable_select_queries=False,
+        limit_top_select=False,
+        within_non_hogql_query=False,
+        values=values or {},
+        modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.DISABLED),
+    )
+    # Export models are only events/persons/sessions; warehouse tables and views are denied.
+    # Pass bypass_warehouse_access_control=True or a user if that becomes an issue.
+    context.database = Database.create_for(team=team, modifiers=context.modifiers)
+
+    # This query only supports events at the moment.
+    # TODO: Extend for other models that also wish to implement property filtering.
+    select_query = ast.SelectQuery(
+        select=[
+            parse_expr("properties as properties"),
+        ],
+        select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+        where=expr,
+    )
+    prepared_select_query: ast.SelectQuery = typing.cast(
+        ast.SelectQuery, prepare_ast_for_printing(select_query, context=context, dialect="hogql", stack=[select_query])
+    )
+    prepared_expr = prepare_ast_for_printing(expr, context=context, dialect="clickhouse", stack=[prepared_select_query])
+
+    try:
+        printed = print_prepared_ast(
+            prepared_expr,  # type: ignore
+            context=context,
+            dialect="clickhouse",
+            stack=[prepared_select_query],
+        )
+    except (ExposedHogQLError, InternalHogQLError) as e:
+        raise InvalidFilterError(e) from e
+
+    return printed, context.values
+
+
 def compose_filters_clause(
     filters: list[dict[str, str | list[str] | None]],
     team_id: int,
@@ -670,18 +729,6 @@ def compose_filters_clause(
         of placeholder to values to be used as query parameters.
     """
     team = Team.objects.get(id=team_id)
-    context = HogQLContext(
-        team=team,
-        team_id=team.id,
-        enable_select_queries=False,
-        limit_top_select=False,
-        within_non_hogql_query=False,
-        values=values or {},
-        modifiers=HogQLQueryModifiers(materializationMode=MaterializationMode.DISABLED),
-    )
-    # Export models are only events/persons/sessions; warehouse tables and views are denied.
-    # Pass bypass_warehouse_access_control=True or a user if that becomes an issue.
-    context.database = Database.create_for(team=team, modifiers=context.modifiers)
     exprs = []
     for filter in filters:
         match filter["type"]:
@@ -713,33 +760,94 @@ def compose_filters_clause(
                 raise TypeError(f"Unknown filter type: '{s}'")
 
     and_expr = ast.And(exprs=exprs)
-    # This query only supports events at the moment.
-    # TODO: Extend for other models that also wish to implement property filtering.
-    select_query = ast.SelectQuery(
-        select=[
-            parse_expr("properties as properties"),
-        ],
-        select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
-        where=and_expr,
-    )
-    prepared_select_query: ast.SelectQuery = typing.cast(
-        ast.SelectQuery, prepare_ast_for_printing(select_query, context=context, dialect="hogql", stack=[select_query])
-    )
-    prepared_and_expr = prepare_ast_for_printing(
-        and_expr, context=context, dialect="clickhouse", stack=[prepared_select_query]
-    )
+    return _print_expr_against_events_model(and_expr, team, values)
+
+
+class RewriteHogGlobalsToEventsColumns(TraversingVisitor):
+    """Rewrite hog-function filter field chains onto the person-on-events columns.
+
+    Hog function filters reference the realtime-globals chains `person.properties.X` and
+    `group_N.properties.X`. To resolve these against the events table without a join, point them
+    at the `poe` / `goe_N` virtual subtables, which print to the `person_properties` /
+    `groupN_properties` columns. Event properties (`properties.X`) and metadata columns are left
+    untouched.
+    """
+
+    def visit_field(self, node: ast.Field):
+        if not node.chain:
+            return
+        head = node.chain[0]
+        if head == "person":
+            node.chain = ["events", "poe", *node.chain[1:]]
+        elif isinstance(head, str) and head.startswith("group_") and head.removeprefix("group_").isdigit():
+            node.chain = ["events", f"goe_{head.removeprefix('group_')}", *node.chain[1:]]
+
+
+class UnsupportedWorkflowsFilterError(Exception):
+    """Raised when a hog function filter can't be compiled into a batch export WHERE clause.
+
+    Cohort and session filters require a join that the spliced `$filters` clause can't perform,
+    so they are rejected rather than silently widening the set of exported events.
+    """
+
+    def __init__(self, unsupported: set[str]):
+        self.unsupported = unsupported
+        types_str = ", ".join(sorted(unsupported))
+        super().__init__(
+            f"Workflows backfills don't support these filter types yet: {types_str}. "
+            f"They require database joins that batch export queries can't perform."
+        )
+
+
+class _UnsupportedFilterFinder(TraversingVisitor):
+    """Find filter expressions that can't be printed as a standalone events WHERE clause."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.unsupported: set[str] = set()
+
+    def visit_compare_operation(self, node: ast.CompareOperation) -> None:
+        if node.op in (ast.CompareOperationOp.InCohort, ast.CompareOperationOp.NotInCohort):
+            self.unsupported.add("cohort")
+        super().visit_compare_operation(node)
+
+    def visit_field(self, node: ast.Field) -> None:
+        if node.chain and node.chain[0] in ("session", "sessions"):
+            self.unsupported.add("session")
+
+
+def compose_hog_function_filters_clause(
+    filters: dict,
+    team_id: int,
+    values: dict[str, str] | None = None,
+) -> tuple[str, dict[str, str]]:
+    """Compose a ClickHouse WHERE clause from a hog function's filters for a WORKFLOWS export.
+
+    Reuses the same HogQL expression that realtime hog function filters compile to (via
+    `compile_filters_expr`), then prints it against the events model. Person/group property
+    chains are rewritten onto the person-on-events columns so they resolve without a join.
+
+    Empty / "all events" filters return an empty clause. Filter types that need a join (cohort,
+    session) raise `UnsupportedWorkflowsFilterError`.
+    """
+    team = Team.objects.get(id=team_id)
 
     try:
-        printed = print_prepared_ast(
-            prepared_and_expr,  # type: ignore
-            context=context,
-            dialect="clickhouse",
-            stack=[prepared_select_query],
-        )
-    except (ExposedHogQLError, InternalHogQLError) as e:
-        raise InvalidFilterError(e) from e
+        expr = compile_filters_expr(filters, team)
+    except CohortInlineError as e:
+        raise UnsupportedWorkflowsFilterError({"cohort"}) from e
 
-    return printed, context.values
+    # "All events" / empty filters compile to a constant True — no clause needed.
+    if isinstance(expr, ast.Constant) and expr.value is True:
+        return "", values or {}
+
+    finder = _UnsupportedFilterFinder()
+    finder.visit(expr)
+    if finder.unsupported:
+        raise UnsupportedWorkflowsFilterError(finder.unsupported)
+
+    RewriteHogGlobalsToEventsColumns().visit(expr)
+    return _print_expr_against_events_model(expr, team, values)
 
 
 async def wait_for_delta_past_data_interval_end(

--- a/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/workflows/test_activity.py
@@ -1,3 +1,4 @@
+import json
 import uuid
 import urllib.parse
 
@@ -377,3 +378,74 @@ async def test_insert_into_workflows_activity_from_stage_tolerates_hog_function_
     assert result.error is None
     assert result.records_failed == hog_function_error_count
     assert result.records_completed == len(handler.data) - hog_function_error_count
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        # Event property filter — only events with $browser = Chrome are kept
+        {"properties": [{"key": "$browser", "operator": "exact", "type": "event", "value": ["Chrome"]}]},
+        # Person property filter — exercises the person -> person-on-events column rewrite
+        {"properties": [{"key": "$initial_os", "operator": "exact", "type": "person", "value": ["Linux"]}]},
+    ],
+    ids=["event_property", "person_property"],
+)
+async def test_insert_into_workflows_activity_from_stage_applies_filters(
+    clickhouse_client,
+    activity_environment,
+    exclude_events,
+    data_interval_start,
+    data_interval_end,
+    generate_test_data,
+    ateam,
+    server,
+    path,
+    handler,
+    hog_function_id,
+    filters,
+):
+    """Only events matching the hog function's filters should be delivered.
+
+    `generate_test_data` creates a batch of events carrying the filtered property/person-property
+    plus a handful of "test-no-prop-*" events that carry neither. The filter must exclude the
+    no-prop events while still delivering the matching ones.
+    """
+    model = BatchExportModel(name="events", schema=None, filters=filters)
+
+    batch_export_id = str(uuid.uuid4())
+    batch_export_inputs = BatchExportInsertInputs(
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        batch_export_model=model,
+        batch_export_id=batch_export_id,
+    )
+    workflows_inputs = WorkflowsInsertInputs(
+        batch_export=batch_export_inputs,
+        url=urllib.parse.urlunsplit((server.scheme, f"{server.host}:{server.port}", "/", "", "")),
+        hog_function_id=hog_function_id,
+    )
+    await activity_environment.run(
+        insert_into_internal_stage_activity,
+        BatchExportInsertIntoInternalStageInputs(
+            team_id=ateam.pk,
+            batch_export_id=batch_export_id,
+            data_interval_start=workflows_inputs.batch_export.data_interval_start,
+            data_interval_end=workflows_inputs.batch_export.data_interval_end,
+            exclude_events=None,
+            include_events=None,
+            run_id=None,
+            backfill_details=None,
+            is_workflows=True,
+            batch_export_model=model,
+            destination_default_fields=workflows_default_fields(batch_export_id),
+        ),
+    )
+    result = await activity_environment.run(insert_into_workflows_activity_from_stage, workflows_inputs)
+
+    assert result.error is None
+    # Matching events were delivered ...
+    assert len(handler.data) > 0
+    # ... and the no-prop events (which match neither filter) were excluded by the query.
+    delivered_events = [json.loads(request_data.body)["clickhouse_event"]["event"] for request_data in handler.data]
+    assert all(not event.startswith("test-no-prop") for event in delivered_events)

--- a/products/batch_exports/backend/tests/temporal/test_spmc.py
+++ b/products/batch_exports/backend/tests/temporal/test_spmc.py
@@ -7,6 +7,7 @@ from collections.abc import Collection
 import pytest
 
 import pyarrow as pa
+from asgiref.sync import sync_to_async
 
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
@@ -15,10 +16,13 @@ from products.batch_exports.backend.temporal.spmc import (
     InvalidFilterError,
     Producer,
     RecordBatchQueue,
+    UnsupportedWorkflowsFilterError,
     compose_filters_clause,
+    compose_hog_function_filters_clause,
     slice_record_batch,
     use_distributed_events_recent_table,
 )
+from products.cohorts.backend.models.cohort import Cohort
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
 
@@ -383,3 +387,161 @@ def test_compose_filters_clause_raises(
 ):
     with pytest.raises(InvalidFilterError):
         result_clause, result_values = compose_filters_clause(filters, team_id=ateam.id)
+
+
+@pytest.mark.parametrize(
+    "filters,expected_substring,expected_values_subset",
+    [
+        # Event name match
+        (
+            {"events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}]},
+            "equals(events.event,",
+            {"$pageview"},
+        ),
+        # Global event property
+        (
+            {"properties": [{"key": "$browser", "operator": "exact", "type": "event", "value": ["Chrome"]}]},
+            "JSONExtractRaw(events.properties,",
+            {"$browser", "Chrome"},
+        ),
+        # Feature flag property (subset of event)
+        (
+            {"properties": [{"key": "$feature/my-flag", "operator": "exact", "type": "event", "value": ["true"]}]},
+            "JSONExtractRaw(events.properties,",
+            {"$feature/my-flag", "true"},
+        ),
+        # Global person property is rewritten onto the person-on-events column
+        (
+            {"properties": [{"key": "email", "operator": "exact", "type": "person", "value": ["a@b.com"]}]},
+            "events.person_properties",
+            {"email", "a@b.com"},
+        ),
+        # Global group property is rewritten onto the group-on-events column
+        (
+            {
+                "properties": [
+                    {"key": "name", "operator": "exact", "type": "group", "group_type_index": 0, "value": ["Acme"]}
+                ]
+            },
+            "events.group0_properties",
+            {"name", "Acme"},
+        ),
+        # event_metadata maps to a top-level column
+        (
+            {"properties": [{"key": "distinct_id", "operator": "exact", "type": "event_metadata", "value": ["abc"]}]},
+            "events.distinct_id",
+            {"abc"},
+        ),
+        # Event filter with a per-event property
+        (
+            {
+                "events": [
+                    {
+                        "id": "$pageview",
+                        "type": "events",
+                        "order": 0,
+                        "properties": [{"key": "$browser", "operator": "exact", "type": "event", "value": ["Chrome"]}],
+                    }
+                ]
+            },
+            "events.event",
+            {"$pageview", "$browser", "Chrome"},
+        ),
+    ],
+    ids=[
+        "event_name",
+        "event_property",
+        "feature",
+        "person_property",
+        "group_property",
+        "event_metadata",
+        "event_with_property",
+    ],
+)
+def test_compose_hog_function_filters_clause(
+    filters: dict[str, typing.Any],
+    expected_substring: str,
+    expected_values_subset: set[str],
+    ateam,
+):
+    result_clause, result_values = compose_hog_function_filters_clause(filters, team_id=ateam.id)
+    assert expected_substring in result_clause
+    assert expected_values_subset.issubset(set(result_values.values()))
+
+
+def test_compose_hog_function_filters_clause_ors_multiple_events(ateam):
+    """Multiple event filters are ORed together, mirroring realtime behavior."""
+    filters = {
+        "events": [
+            {"id": "$pageview", "type": "events", "order": 0},
+            {"id": "$autocapture", "type": "events", "order": 1},
+        ]
+    }
+    result_clause, result_values = compose_hog_function_filters_clause(filters, team_id=ateam.id)
+    assert result_clause.startswith("or(")
+    assert {"$pageview", "$autocapture"}.issubset(set(result_values.values()))
+
+
+def test_compose_hog_function_filters_clause_ands_properties_with_events(ateam):
+    """Global properties are ANDed with the OR of event filters."""
+    filters = {
+        "events": [
+            {"id": "$pageview", "type": "events", "order": 0},
+            {"id": "$autocapture", "type": "events", "order": 1},
+        ],
+        "properties": [{"key": "$browser", "operator": "exact", "type": "event", "value": ["Chrome"]}],
+    }
+    result_clause, _ = compose_hog_function_filters_clause(filters, team_id=ateam.id)
+    assert result_clause.startswith("and(")
+    assert "or(" in result_clause
+
+
+@pytest.mark.parametrize(
+    "filters",
+    [
+        {},
+        {"events": [], "actions": [], "properties": []},
+        # "All events" (id=None) matches everything, so no clause is needed
+        {"events": [{"id": None, "type": "events", "order": 0}]},
+        # Bytecode and other realtime-only keys are ignored
+        {"source": "events", "bytecode": ["_H", 1], "events": []},
+    ],
+    ids=["empty_dict", "empty_lists", "all_events", "ignores_bytecode"],
+)
+def test_compose_hog_function_filters_clause_returns_empty_for_all_events(filters: dict[str, typing.Any], ateam):
+    result_clause, _ = compose_hog_function_filters_clause(filters, team_id=ateam.id)
+    assert result_clause == ""
+
+
+async def test_compose_hog_function_filters_clause_includes_test_account_filters(ateam):
+    """When filter_test_accounts is set, the team's test account filters are ANDed in."""
+    ateam.test_account_filters = [
+        {"key": "email", "operator": "not_icontains", "type": "person", "value": "@posthog.com"}
+    ]
+    await sync_to_async(ateam.save)()
+
+    filters = {
+        "events": [{"id": "$pageview", "type": "events", "order": 0}],
+        "filter_test_accounts": True,
+    }
+    result_clause, result_values = await sync_to_async(compose_hog_function_filters_clause)(filters, team_id=ateam.id)
+
+    # Test account person filter resolves onto the person-on-events column, ANDed with the event match.
+    assert "events.person_properties" in result_clause
+    assert "events.event" in result_clause
+    assert any(isinstance(v, str) and "@posthog.com" in v for v in result_values.values())
+
+
+def test_compose_hog_function_filters_clause_rejects_session_filters(ateam):
+    """Session filters need a join the spliced WHERE clause can't carry."""
+    filters = {"properties": [{"key": "$session_duration", "operator": "gt", "type": "session", "value": 60}]}
+    with pytest.raises(UnsupportedWorkflowsFilterError):
+        compose_hog_function_filters_clause(filters, team_id=ateam.id)
+
+
+async def test_compose_hog_function_filters_clause_rejects_cohort_filters(ateam):
+    """Cohort filters need a join the spliced WHERE clause can't carry."""
+    cohort = await sync_to_async(Cohort.objects.create)(team=ateam, name="test cohort")
+    filters = {"properties": [{"key": "id", "type": "cohort", "value": cohort.pk}]}
+    with pytest.raises(UnsupportedWorkflowsFilterError):
+        await sync_to_async(compose_hog_function_filters_clause)(filters, team_id=ateam.id)

--- a/products/cdp/backend/api/hog_function.py
+++ b/products/cdp/backend/api/hog_function.py
@@ -748,6 +748,11 @@ class HogFunctionViewSet(
     @action(detail=True, methods=["POST"])
     def enable_backfills(self, request: Request, *args, **kwargs):
         from products.batch_exports.backend.api.batch_export import BatchExportSerializer
+        from products.batch_exports.backend.temporal.spmc import (
+            InvalidFilterError,
+            UnsupportedWorkflowsFilterError,
+            compose_hog_function_filters_clause,
+        )
 
         hog_function = self.get_object()
 
@@ -784,13 +789,31 @@ class HogFunctionViewSet(
         ):
             raise PermissionDenied("Backfilling Workflows is not enabled for this team.")
 
+        # Freeze the hog function's filters onto the batch export so backfills only deliver events
+        # that match what the realtime destination would receive. Drop the realtime bytecode — the
+        # batch export query recompiles the filters from their definition.
+        filters = hog_function.filters or {}
+        if filters.get("bytecode_error"):
+            return Response(
+                {"error": f"This destination's filters could not be compiled: {filters['bytecode_error']}"},
+                status=400,
+            )
+        export_filters = {k: v for k, v in filters.items() if k not in ("bytecode", "bytecode_error", "transpiled")}
+
+        # Validate the filters translate into a query before creating anything, so we never create a
+        # backfill with filters we can't apply (e.g. cohort or session filters that require a join).
+        try:
+            compose_hog_function_filters_clause(export_filters, team_id=self.team_id)
+        except (UnsupportedWorkflowsFilterError, InvalidFilterError) as e:
+            return Response({"error": str(e)}, status=400)
+
         # Prepare batch export data matching the frontend's structure
         batch_export_data = {
             "name": hog_function.name,
             "paused": True,
             "interval": "hour",
             "model": "events",
-            "filters": hog_function.filters.get("events", []) if hog_function.filters else [],
+            "filters": export_filters,
             "destination": {
                 "type": "Workflows",
                 "config": {"hog_function_id": str(hog_function.id)},

--- a/products/cdp/backend/api/test/test_hog_function.py
+++ b/products/cdp/backend/api/test/test_hog_function.py
@@ -15,6 +15,7 @@ from posthog.cdp.templates.hog_function_template import sync_template_to_db
 from posthog.cdp.templates.slack.template_slack import template as template_slack
 
 from products.actions.backend.models.action import Action
+from products.batch_exports.backend.models.batch_export import BatchExport
 from products.cdp.backend.api.hog_function import MAX_HOG_CODE_SIZE_BYTES, MAX_TRANSFORMATIONS_PER_TEAM
 from products.cdp.backend.api.test.test_hog_function_templates import MOCK_NODE_TEMPLATES
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
@@ -2622,3 +2623,73 @@ class TestHogFunctionAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
 
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert response.json()["error"] == "Backfills are only supported for event-sourced destinations."
+
+    @patch("products.batch_exports.backend.api.batch_export.sync_batch_export")
+    @patch("products.cdp.backend.api.hog_function.posthoganalytics.feature_enabled", return_value=True)
+    def test_enable_backfills_stores_full_filters(self, mock_feature_enabled, mock_sync_batch_export):
+        """The full filters dict (minus realtime bytecode) is frozen onto the batch export."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={**EXAMPLE_FULL, "name": "Backfill Function"},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        function_id = response.json()["id"]
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/{function_id}/enable_backfills/",
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        batch_export = BatchExport.objects.get(id=response.json()["batch_export_id"])
+        assert isinstance(batch_export.filters, dict)
+        # The whole filter definition is preserved, not just the events array ...
+        assert batch_export.filters["events"] == EXAMPLE_FULL["filters"]["events"]
+        assert "actions" in batch_export.filters
+        assert batch_export.filters["filter_test_accounts"] is True
+        # ... but the realtime-only bytecode is dropped (the query recompiles from the definition).
+        assert "bytecode" not in batch_export.filters
+
+    @patch("products.cdp.backend.api.hog_function.posthoganalytics.feature_enabled", return_value=True)
+    def test_enable_backfills_blocked_when_filters_have_bytecode_error(self, mock_feature_enabled):
+        """A hog function whose filters failed to compile to realtime bytecode (e.g. cohorts) can't be backfilled."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={**EXAMPLE_FULL, "name": "Broken Filters Function"},
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        function_id = response.json()["id"]
+
+        # Simulate filters that couldn't compile to realtime bytecode. Update directly to bypass the
+        # save-time recompilation that would otherwise clear the error.
+        hog_function = HogFunction.objects.get(id=function_id)
+        broken_filters = {**hog_function.filters, "bytecode": None, "bytecode_error": "Can't use cohorts in real-time"}
+        HogFunction.objects.filter(id=function_id).update(filters=broken_filters)
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/{function_id}/enable_backfills/",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "could not be compiled" in response.json()["error"]
+
+    @patch("products.cdp.backend.api.hog_function.posthoganalytics.feature_enabled", return_value=True)
+    def test_enable_backfills_blocked_for_session_filters(self, mock_feature_enabled):
+        """Session filters need a join the batch export query can't perform, so backfills are rejected."""
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/",
+            data={
+                **EXAMPLE_FULL,
+                "name": "Session Filter Function",
+                "filters": {
+                    "events": [{"id": "$pageview", "name": "$pageview", "type": "events", "order": 0}],
+                    "properties": [{"key": "$session_duration", "type": "session", "operator": "gt", "value": 60}],
+                },
+            },
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        function_id = response.json()["id"]
+
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/hog_functions/{function_id}/enable_backfills/",
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "session" in response.json()["error"].lower()


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

WIP
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
