### PR TITLE
feat(signals): opt into bedrock fallbacks for llm gateway

### DIFF
--- a/posthog/llm/gateway_client.py
+++ b/posthog/llm/gateway_client.py
@@ -109,7 +109,11 @@ def get_async_llm_client(product: Product = "django", team_id: int | None = None
     )
 
 
-def get_async_anthropic_gateway_client(product: Product = "django", team_id: int | None = None) -> AsyncAnthropic:
+def get_async_anthropic_gateway_client(
+    product: Product = "django",
+    team_id: int | None = None,
+    use_bedrock_fallback: bool = False,
+) -> AsyncAnthropic:
     """
     Get an Anthropic-native async client pointed at the internal LLM gateway.
 
@@ -128,14 +132,22 @@ def get_async_anthropic_gateway_client(product: Product = "django", team_id: int
     rationale — it is sent identically as a default `x-posthog-property-team_id` header. For
     per-call tags, pass `extra_headers={"x-posthog-property-<key>": "<value>"}` on the individual
     `messages.create(...)` call, and the user identifier as `metadata={"user_id": ...}`.
+
+    Set `use_bedrock_fallback=True` to opt into the gateway's Bedrock fallback: if Anthropic
+    returns a 5xx/429 (or its circuit breaker is open) the gateway retries the request against
+    Bedrock instead of failing. Sent as the `x-posthog-use-bedrock-fallback` default header.
     """
     if not settings.LLM_GATEWAY_URL or not settings.LLM_GATEWAY_API_KEY:
         raise ValueError("LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured")
+
+    default_headers = _team_id_header(team_id) if team_id is not None else {}
+    if use_bedrock_fallback:
+        default_headers["x-posthog-use-bedrock-fallback"] = "true"
 
     base_url = f"{settings.LLM_GATEWAY_URL.rstrip('/')}/{product}"
     return AsyncAnthropic(
         base_url=base_url,
         api_key=settings.LLM_GATEWAY_API_KEY,
-        default_headers=_team_id_header(team_id) if team_id is not None else None,
+        default_headers=default_headers or None,
         http_client=httpx.AsyncClient(trust_env=False),
     )

--- a/posthog/llm/test_gateway_client.py
+++ b/posthog/llm/test_gateway_client.py
@@ -140,20 +140,20 @@ class TestGetAsyncAnthropicGatewayClient:
 
         assert client.default_headers.get("x-posthog-property-team_id") is None
 
+    @pytest.mark.parametrize(
+        "use_bedrock_fallback, expected_header_value",
+        [
+            (True, "true"),
+            (False, None),
+        ],
+    )
     @patch("posthog.llm.gateway_client.settings")
-    def test_attaches_bedrock_fallback_header_when_opted_in(self, mock_settings):
+    def test_bedrock_fallback_header(self, mock_settings, use_bedrock_fallback: bool, expected_header_value):
         mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
         mock_settings.LLM_GATEWAY_API_KEY = "test-key"
 
-        client = get_async_anthropic_gateway_client(product="signals", team_id=42, use_bedrock_fallback=True)
+        client = get_async_anthropic_gateway_client(
+            product="signals", team_id=42, use_bedrock_fallback=use_bedrock_fallback
+        )
 
-        assert client.default_headers.get("x-posthog-use-bedrock-fallback") == "true"
-
-    @patch("posthog.llm.gateway_client.settings")
-    def test_no_bedrock_fallback_header_by_default(self, mock_settings):
-        mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
-        mock_settings.LLM_GATEWAY_API_KEY = "test-key"
-
-        client = get_async_anthropic_gateway_client(product="signals", team_id=42)
-
-        assert client.default_headers.get("x-posthog-use-bedrock-fallback") is None
+        assert client.default_headers.get("x-posthog-use-bedrock-fallback") == expected_header_value

--- a/posthog/llm/test_gateway_client.py
+++ b/posthog/llm/test_gateway_client.py
@@ -139,3 +139,21 @@ class TestGetAsyncAnthropicGatewayClient:
         client = get_async_anthropic_gateway_client(product="signals")
 
         assert client.default_headers.get("x-posthog-property-team_id") is None
+
+    @patch("posthog.llm.gateway_client.settings")
+    def test_attaches_bedrock_fallback_header_when_opted_in(self, mock_settings):
+        mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
+        mock_settings.LLM_GATEWAY_API_KEY = "test-key"
+
+        client = get_async_anthropic_gateway_client(product="signals", team_id=42, use_bedrock_fallback=True)
+
+        assert client.default_headers.get("x-posthog-use-bedrock-fallback") == "true"
+
+    @patch("posthog.llm.gateway_client.settings")
+    def test_no_bedrock_fallback_header_by_default(self, mock_settings):
+        mock_settings.LLM_GATEWAY_URL = "http://gateway:8080"
+        mock_settings.LLM_GATEWAY_API_KEY = "test-key"
+
+        client = get_async_anthropic_gateway_client(product="signals", team_id=42)
+
+        assert client.default_headers.get("x-posthog-use-bedrock-fallback") is None

--- a/products/signals/backend/temporal/llm.py
+++ b/products/signals/backend/temporal/llm.py
@@ -89,7 +89,7 @@ async def call_llm(
 ) -> T:
     # Native Anthropic Messages endpoint so prefilling and extended thinking carry over unchanged.
     thinking = thinking and MATCHING_MODEL in ANTHROPIC_THINKING_MODELS
-    client = get_async_anthropic_gateway_client(product="signals", team_id=team_id)
+    client = get_async_anthropic_gateway_client(product="signals", team_id=team_id, use_bedrock_fallback=True)
 
     messages: list[MessageParam] = [
         {"role": "user", "content": user_prompt},


### PR DESCRIPTION
## Problem

The signals pipeline calls Anthropic models through the internal LLM gateway, but wasn't opting into the gateway's Bedrock fallback. When Anthropic returns a 5xx/429 or its circuit breaker is open, those calls just fail instead of routing to Bedrock — making the pipeline less resilient to upstream Anthropic outages.

## Changes

- Add a `use_bedrock_fallback` opt-in to `get_async_anthropic_gateway_client`, which sends the `x-posthog-use-bedrock-fallback: true` default header the gateway already understands.
- Enable it in the signals pipeline's `call_llm`, so every signals LLM call falls back to Bedrock on Anthropic errors.

## How did you test this code?

I'm an agent. I added unit tests asserting the header is attached when opted in and absent by default, and ran `posthog/llm/test_gateway_client.py` — all 36 tests pass. No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: opt the signals pipeline into the gateway's Bedrock fallback. Implemented as a reusable `use_bedrock_fallback` flag on the shared gateway client helper (mirroring how the hogai product opts in via the same header) rather than hardcoding a per-call `extra_headers`, so other products can adopt it cleanly. The "signals" gateway product already allows any model, so no gateway-side config change was needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BC44CLDJB/p1782225681944939?thread_ts=1782225681.944939&cid=C0BC44CLDJB)*
