### PR TITLE
fix(data-warehouse): run webhook-only check before bulk update txn

### DIFF
--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -559,7 +559,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
 
         # Reject non-webhook sync types for webhook-only schemas (e.g. Stripe Discount —
         # no API list endpoint, so anything other than webhook produces an empty sync).
-        if "sync_type" in data and sync_type != ExternalDataSchema.SyncType.WEBHOOK:
+        if self._webhook_only_check_applies():
             if self._is_webhook_only_schema_cached(instance):
                 raise ValidationError(
                     f"{instance.name} can only be synced via webhooks — pick the Webhook sync method."
@@ -936,7 +936,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
             return False
         return any(s.name == schema.name and s.supports_xmin for s in source_schemas)
 
-    def warm_webhook_only_check(self, instance: ExternalDataSchema, payload: dict[str, Any]) -> None:
+    def warm_webhook_only_check(self, instance: ExternalDataSchema) -> None:
         """Pre-run the webhook-only validation that reaches the external source, caching the result.
 
         `_is_webhook_only_schema` calls the source's `get_schemas`, which is a network round-trip (e.g.
@@ -946,9 +946,15 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
         first (outside the transaction) does the network work up front; update() then reads the cached
         result and still raises per-schema, so failures stay isolated to one schema.
         """
-        sync_type = payload.get("sync_type")
-        if "sync_type" in payload and sync_type != ExternalDataSchema.SyncType.WEBHOOK:
+        if self._webhook_only_check_applies():
             self._is_webhook_only_schema_cached(instance)
+
+    def _webhook_only_check_applies(self) -> bool:
+        # Single source of truth for when the webhook-only check runs, so update() and the
+        # pre-transaction warm step can't drift apart and push the network call back into the
+        # transaction. Reads `initial_data` (the raw request payload), like update() does.
+        data = self.initial_data if isinstance(self.initial_data, dict) else {}
+        return "sync_type" in data and data.get("sync_type") != ExternalDataSchema.SyncType.WEBHOOK
 
     def _is_webhook_only_schema_cached(self, schema: ExternalDataSchema) -> bool:
         if "_webhook_only_result" not in self.__dict__:

--- a/products/data_warehouse/backend/api/external_data_schema.py
+++ b/products/data_warehouse/backend/api/external_data_schema.py
@@ -560,7 +560,7 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
         # Reject non-webhook sync types for webhook-only schemas (e.g. Stripe Discount —
         # no API list endpoint, so anything other than webhook produces an empty sync).
         if "sync_type" in data and sync_type != ExternalDataSchema.SyncType.WEBHOOK:
-            if self._is_webhook_only_schema(instance):
+            if self._is_webhook_only_schema_cached(instance):
                 raise ValidationError(
                     f"{instance.name} can only be synced via webhooks — pick the Webhook sync method."
                 )
@@ -935,6 +935,25 @@ class ExternalDataSchemaSerializer(serializers.ModelSerializer):
         except Exception:
             return False
         return any(s.name == schema.name and s.supports_xmin for s in source_schemas)
+
+    def warm_webhook_only_check(self, instance: ExternalDataSchema, payload: dict[str, Any]) -> None:
+        """Pre-run the webhook-only validation that reaches the external source, caching the result.
+
+        `_is_webhook_only_schema` calls the source's `get_schemas`, which is a network round-trip (e.g.
+        Google Ads OAuth refresh + field query). update() runs this same check, but bulk_update_schemas
+        wraps each update() in a transaction — making the call there held the DB connection idle-in-
+        transaction long enough for the server to close it ("the connection is closed"). Calling this
+        first (outside the transaction) does the network work up front; update() then reads the cached
+        result and still raises per-schema, so failures stay isolated to one schema.
+        """
+        sync_type = payload.get("sync_type")
+        if "sync_type" in payload and sync_type != ExternalDataSchema.SyncType.WEBHOOK:
+            self._is_webhook_only_schema_cached(instance)
+
+    def _is_webhook_only_schema_cached(self, schema: ExternalDataSchema) -> bool:
+        if "_webhook_only_result" not in self.__dict__:
+            self.__dict__["_webhook_only_result"] = self._is_webhook_only_schema(schema)
+        return self.__dict__["_webhook_only_result"]
 
     def _maybe_create_webhook(self, schema: ExternalDataSchema) -> None:
         source = schema.source

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -3599,7 +3599,7 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             # here, before the per-schema transaction below. Running it inside update()'s transaction
             # held the DB connection idle-in-transaction long enough for the server to close it.
             # update() reads the cached result, so it still validates and fails per-schema.
-            schema_serializer.warm_webhook_only_check(schema, schema_payload)
+            schema_serializer.warm_webhook_only_check(schema)
             prepared.append((schema, schema_serializer, schema_post_commit_actions))
 
         # Commit each schema in its own transaction. A single atomic block around the whole batch

--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -3595,6 +3595,11 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
                 context={**serializer_context, "post_commit_actions": schema_post_commit_actions},
             )
             schema_serializer.is_valid(raise_exception=True)
+            # Do the webhook-only source-discovery call (e.g. Google Ads token refresh + field query)
+            # here, before the per-schema transaction below. Running it inside update()'s transaction
+            # held the DB connection idle-in-transaction long enough for the server to close it.
+            # update() reads the cached result, so it still validates and fails per-schema.
+            schema_serializer.warm_webhook_only_check(schema, schema_payload)
             prepared.append((schema, schema_serializer, schema_post_commit_actions))
 
         # Commit each schema in its own transaction. A single atomic block around the whole batch

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -499,6 +499,50 @@ class TestExternalDataSource(APIBaseTest):
         assert mock_sync_external_data_job_workflow.call_args.kwargs == {"create": False, "should_sync": True}
         assert mock_sync_external_data_job_workflow.call_args.args[0].id == schema.id
 
+    @patch(
+        "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+        return_value=False,
+    )
+    def test_bulk_update_schemas_runs_source_discovery_outside_transaction(self, _mock_workflow_exists):
+        # `_is_webhook_only_schema` reaches the external source (e.g. Google Ads token refresh + field
+        # query). It must run before the per-schema transaction opens — running it inside update()'s
+        # transaction held the DB connection idle-in-transaction long enough for the server to close it.
+        from django.db import connection
+
+        from products.data_warehouse.backend.api.external_data_schema import ExternalDataSchemaSerializer
+
+        source = self._create_external_data_source()
+        schema = ExternalDataSchema.objects.create(
+            name="Customers",
+            team_id=self.team.pk,
+            source=source,
+            should_sync=False,
+            sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
+        )
+
+        # The bulk loop opens a per-schema transaction (a nested savepoint) around update(). Compare the
+        # savepoint depth at call time against the baseline before the request: equal ⇒ called from the
+        # pre-transaction warm step (the fix); baseline + 1 ⇒ called inside update()'s transaction.
+        baseline_savepoint_depth = len(connection.savepoint_ids)
+        savepoint_depth_at_call: list[int] = []
+
+        def record_savepoint_depth(_schema):
+            savepoint_depth_at_call.append(len(connection.savepoint_ids))
+            return False
+
+        with patch.object(ExternalDataSchemaSerializer, "_is_webhook_only_schema", side_effect=record_savepoint_depth):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_sources/{source.id}/bulk_update_schemas",
+                data={"schemas": [{"id": str(schema.id), "should_sync": True, "sync_type": "full_refresh"}]},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        # Called exactly once (memoized across warm + update), outside the per-schema transaction.
+        assert savepoint_depth_at_call == [baseline_savepoint_depth]
+        schema.refresh_from_db()
+        assert schema.should_sync is True
+
     @parameterized.expand(
         [
             (

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -9,6 +9,7 @@ from posthog.test.base import APIBaseTest, FuzzyInt
 from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from django.conf import settings
+from django.db import connection
 from django.test import override_settings
 from django.utils import timezone
 
@@ -60,6 +61,7 @@ from posthog.temporal.data_imports.sources.stripe.constants import (
 from posthog.temporal.data_imports.sources.stripe.settings import ENDPOINTS as STRIPE_ENDPOINTS
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
+from products.data_warehouse.backend.api.external_data_schema import ExternalDataSchemaSerializer
 from products.data_warehouse.backend.api.external_data_source import (
     get_nonsensitive_and_sensitive_field_names,
     strip_sensitive_from_dict,
@@ -507,9 +509,6 @@ class TestExternalDataSource(APIBaseTest):
         # `_is_webhook_only_schema` reaches the external source (e.g. Google Ads token refresh + field
         # query). It must run before the per-schema transaction opens — running it inside update()'s
         # transaction held the DB connection idle-in-transaction long enough for the server to close it.
-        from django.db import connection
-
-        from products.data_warehouse.backend.api.external_data_schema import ExternalDataSchemaSerializer
 
         source = self._create_external_data_source()
         schema = ExternalDataSchema.objects.create(


### PR DESCRIPTION
## Problem

Enabling/toggling a Google Ads schema intermittently failed with `OperationalError: the connection is closed` (error issue 019e92e7…, still active — 433 occurrences / 25 users).

`bulk_update_schemas` saves each schema in its own `transaction.atomic()`. The serializer's `update()` runs the webhook-only validation (`_is_webhook_only_schema`), which calls the source's `get_schemas` — a network round-trip (for Google Ads: an OAuth token refresh plus an Ads field query). Doing that inside the transaction held the DB connection idle-in-transaction long enough for the server to close it; the next query (`_get_before_update` in the activity-logging mixin) then failed with "the connection is closed". The frontend always sends `sync_type` in the bulk payload, so this check runs on every enable/toggle.

## Changes

- Added `warm_webhook_only_check` + a memoized `_is_webhook_only_schema_cached` to the schema serializer.
- `bulk_update_schemas` calls `warm_webhook_only_check` in the prepared phase — **before** the per-schema transaction opens — so the source network call happens in autocommit, not inside the transaction.
- `update()` reads the cached result, so validation still runs and still raises **per-schema** (failure isolation from #63957 is preserved).
- Single-schema PATCH path is unchanged (no transaction there; the cached accessor just computes on first call).

Scope note: the CDC publication call in `update()` has the same anti-pattern but isn't the Google Ads trigger, so it's intentionally left for a separate follow-up to keep this change focused.

## How did you test this code?

I'm an agent (PostHog Code), human-directed. Automated tests only — no manual UI testing:

- Added `test_bulk_update_schemas_runs_source_discovery_outside_transaction`, which asserts the source-discovery call fires outside the per-schema transaction (savepoint depth equals the pre-request baseline). Verified it's a real guard: passes on the fix, fails on the pre-fix code (`[1]` vs `[2]`).
- Ran the full `bulk_update_schemas` + CDC + source-discovery suites against real Postgres/ClickHouse/Kafka/Temporal: all green. `ruff check`/`format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude), directed by Kyle. Diagnosed from the production error issue: the fingerprint is the generic `_get_before_update` frame, so it aggregates every caller saving an activity-logged model on a dead connection. Traced the Google Ads enable path to `_is_webhook_only_schema` → `get_schemas` (OAuth + Ads API) running inside the per-schema transaction. Considered moving the validation into `validate()` (would change bulk semantics to whole-batch rejection); chose precompute-and-cache instead to preserve per-schema failure isolation. No repo skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
