### PR TITLE
fix(data-warehouse): fix duckling persons export fanout

### DIFF
--- a/posthog/dags/events_backfill_to_duckling.py
+++ b/posthog/dags/events_backfill_to_duckling.py
@@ -1642,7 +1642,7 @@ def export_persons_to_duckling_s3(
         '{s3_url}',
         'Parquet'
     )
-    PARTITION BY toString(cityHash64(pd.distinct_id) % {fanout})
+    PARTITION BY toString(cityHash64(distinct_id) % {fanout})
     SELECT
         {PERSONS_COLUMNS}
     FROM person AS p FINAL
@@ -1743,7 +1743,7 @@ def export_persons_full_to_duckling_s3(
         '{s3_url}',
         'Parquet'
     )
-    PARTITION BY toString(cityHash64(pd.distinct_id) % {fanout})
+    PARTITION BY toString(cityHash64(distinct_id) % {fanout})
     SELECT
         {PERSONS_COLUMNS}
     FROM person AS p FINAL

--- a/posthog/dags/test_events_backfill_to_duckling.py
+++ b/posthog/dags/test_events_backfill_to_duckling.py
@@ -1251,7 +1251,7 @@ class TestExportFanOut:
         insert_sql, count_sql, s3_glob, _ = self._run_export(
             export_persons_to_duckling_s3, target, row_count=3_000_000, team_id=2, date=datetime(2026, 6, 17)
         )
-        assert "PARTITION BY toString(cityHash64(pd.distinct_id) % 3)" in insert_sql
+        assert "PARTITION BY toString(cityHash64(distinct_id) % 3)" in insert_sql
         # Pin the full predicate: dropping is_deleted/date would silently over-size the fan-out.
         assert "FROM person WHERE team_id = 2 AND toDate(_timestamp) = '2026-06-17' AND is_deleted = 0" in count_sql
         assert s3_glob == "s3://bkt/backfill/persons/2/year=2026/month=06/run1_*.parquet"
@@ -1260,7 +1260,7 @@ class TestExportFanOut:
         insert_sql, count_sql, s3_glob, _ = self._run_export(
             export_persons_full_to_duckling_s3, target, row_count=5_000_000, team_id=2
         )
-        assert "PARTITION BY toString(cityHash64(pd.distinct_id) % 5)" in insert_sql
+        assert "PARTITION BY toString(cityHash64(distinct_id) % 5)" in insert_sql
         assert "FROM person_distinct_id2 WHERE team_id = 2 AND is_deleted = 0" in count_sql
         assert s3_glob == "s3://bkt/backfill/persons/2/year=0/month=0/run1_*.parquet"
 


### PR DESCRIPTION
## Problem

Duckling persons backfills can fail after fanned-out Parquet exports were added. The generated ClickHouse `INSERT INTO FUNCTION s3(...)` used `PARTITION BY ... pd.distinct_id`, but ClickHouse evaluates the S3 export partition expression against the SELECT output columns, where the field is exported as `distinct_id`.

## Changes

Use the exported `distinct_id` alias for daily and full persons export fan-out partitioning. Update the export SQL tests to pin the valid expression for both paths.

## How did you test this code?

Automated tests run by agent:

- `flox activate -- bash -c './bin/hogli test "posthog/dags/test_events_backfill_to_duckling.py::TestExportFanOut"'`
- `flox activate -- bash -c './bin/hogli test "posthog/dags/test_events_backfill_to_duckling.py"'`

Pre-commit also ran `bin/hogli lint:python:fix`, `bin/hogli format:python`, and `uv run ty check` on staged Python files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this fixes generated ClickHouse SQL for an existing Dagster backfill path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

OpenCode diagnosed the failing ClickHouse expression, checked git history for the DAG, and applied the smallest code change. Tools used: git, GitHub CLI, and `hogli`/pytest. Skill invoked: `/writing-clickhouse-queries` because this changes raw ClickHouse SQL in a DAG.

Decision made: keep the existing fan-out behavior and only change the `PARTITION BY` expression to reference the SELECT alias visible to ClickHouse.
