### PR TITLE
fix(inbox): keep scout troop rows from breaking at narrow widths

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -50,14 +50,12 @@ export function ScoutRowCard({
             )}
         >
             <div className="flex items-center gap-4">
-                {/* overflow-hidden clips the name group so a long name + badges never spill
-                    onto the cadence/emitted column or the sparkline — the name truncates first. */}
-                <div className="flex items-center gap-2 min-w-0 flex-1 overflow-hidden">
+                <div className="flex items-center gap-2 min-w-0 flex-1">
                     {asHeader ? (
                         // min-w keeps the name from being squeezed to zero width by the
                         // trailing metadata (badges, cadence, emitted count) — truncate
                         // should clip to an ellipsis, never vanish entirely.
-                        <span className="truncate font-medium text-sm min-w-[6rem]">{displayName}</span>
+                        <span className="truncate font-medium text-sm min-w-[6rem] flex-1">{displayName}</span>
                     ) : (
                         <Tooltip title={`${config.skill_name} · view scout`}>
                             <Link
@@ -66,26 +64,30 @@ export function ScoutRowCard({
                                 // (hidden) list subtree — close it so it doesn't cover the detail page.
                                 onClick={() => closeSetupModal()}
                                 subtle
-                                className="truncate font-medium text-sm min-w-[6rem]"
+                                className="truncate font-medium text-sm min-w-[6rem] flex-1"
                             >
                                 {displayName}
                             </Link>
                         </Tooltip>
                     )}
-                    <Tooltip title={`${config.skill_name} · open skill`}>
-                        <Link
-                            to={urls.skill(config.skill_name)}
-                            target="_blank"
-                            targetBlankIcon={false}
-                            subtle
-                            className="shrink-0 text-muted"
-                            aria-label={`Open the ${config.skill_name} skill`}
-                        >
-                            <IconArrowUpRight className="size-3.5" />
-                        </Link>
-                    </Tooltip>
-                    <ScoutOriginBadge skillName={config.skill_name} />
-                    <DryRunBadge config={config} />
+                    {/* Icon + badges never shrink: the name (flex-1) absorbs width pressure and
+                        truncates, so the Custom/Canonical pill is never sliced mid-badge. */}
+                    <div className="flex items-center gap-2 shrink-0">
+                        <Tooltip title={`${config.skill_name} · open skill`}>
+                            <Link
+                                to={urls.skill(config.skill_name)}
+                                target="_blank"
+                                targetBlankIcon={false}
+                                subtle
+                                className="text-muted"
+                                aria-label={`Open the ${config.skill_name} skill`}
+                            >
+                                <IconArrowUpRight className="size-3.5" />
+                            </Link>
+                        </Tooltip>
+                        <ScoutOriginBadge skillName={config.skill_name} />
+                        <DryRunBadge config={config} />
+                    </div>
                 </div>
                 {/* Cadence + emitted count get their own non-shrinking column so they can't
                     overlap the sparkline (the name group absorbs any width pressure). */}
@@ -95,7 +97,9 @@ export function ScoutRowCard({
                         <span>· {pluralize(rollup.emittedCount, 'signal')} emitted</span>
                     ) : null}
                 </div>
-                <div className="shrink-0">
+                {/* The sparkline is the flexible region: it shrinks and clips the oldest runs
+                    off the left so it can never push the controls column off the row. */}
+                <div className="flex min-w-0 overflow-hidden">
                     <ScoutRunBoxes runs={rollup?.runs ?? []} />
                 </div>
                 <div className="flex items-center gap-2 shrink-0">

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -50,52 +50,53 @@ export function ScoutRowCard({
             )}
         >
             <div className="flex items-center gap-4">
-                <div className="flex items-center gap-2 min-w-0 flex-1">
-                    {asHeader ? (
-                        // min-w keeps the name from being squeezed to zero width by the
-                        // trailing metadata (badges, cadence, emitted count) — truncate
-                        // should clip to an ellipsis, never vanish entirely.
-                        <span className="truncate font-medium text-sm min-w-[6rem] flex-1">{displayName}</span>
-                    ) : (
-                        <Tooltip title={`${config.skill_name} · view scout`}>
-                            <Link
-                                to={urls.inboxScout(config.skill_name)}
-                                // The fleet list lives in the setup modal, which portals outside the
-                                // (hidden) list subtree — close it so it doesn't cover the detail page.
-                                onClick={() => closeSetupModal()}
-                                subtle
-                                className="truncate font-medium text-sm min-w-[6rem] flex-1"
-                            >
-                                {displayName}
-                            </Link>
-                        </Tooltip>
-                    )}
-                    {/* Icon + badges never shrink: the name (flex-1) absorbs width pressure and
-                        truncates, so the Custom/Canonical pill is never sliced mid-badge. */}
-                    <div className="flex items-center gap-2 shrink-0">
-                        <Tooltip title={`${config.skill_name} · open skill`}>
-                            <Link
-                                to={urls.skill(config.skill_name)}
-                                target="_blank"
-                                targetBlankIcon={false}
-                                subtle
-                                className="text-muted"
-                                aria-label={`Open the ${config.skill_name} skill`}
-                            >
-                                <IconArrowUpRight className="size-3.5" />
-                            </Link>
-                        </Tooltip>
-                        <ScoutOriginBadge skillName={config.skill_name} />
-                        <DryRunBadge config={config} />
+                {/* Name + badges on top, cadence/emitted as a muted subtitle below — keeps the
+                    metadata off the main row so the sparkline and controls have room to breathe. */}
+                <div className="flex flex-col gap-0.5 min-w-0 flex-1">
+                    <div className="flex items-center gap-2 min-w-0">
+                        {asHeader ? (
+                            // min-w keeps the name from being squeezed to zero width by the
+                            // trailing badges — truncate should clip to an ellipsis, never vanish.
+                            <span className="truncate font-medium text-sm min-w-[6rem] flex-1">{displayName}</span>
+                        ) : (
+                            <Tooltip title={`${config.skill_name} · view scout`}>
+                                <Link
+                                    to={urls.inboxScout(config.skill_name)}
+                                    // The fleet list lives in the setup modal, which portals outside the
+                                    // (hidden) list subtree — close it so it doesn't cover the detail page.
+                                    onClick={() => closeSetupModal()}
+                                    subtle
+                                    className="truncate font-medium text-sm min-w-[6rem] flex-1"
+                                >
+                                    {displayName}
+                                </Link>
+                            </Tooltip>
+                        )}
+                        {/* Icon + badges never shrink: the name (flex-1) absorbs width pressure and
+                            truncates, so the Custom/Canonical pill is never sliced mid-badge. */}
+                        <div className="flex items-center gap-2 shrink-0">
+                            <Tooltip title={`${config.skill_name} · open skill`}>
+                                <Link
+                                    to={urls.skill(config.skill_name)}
+                                    target="_blank"
+                                    targetBlankIcon={false}
+                                    subtle
+                                    className="text-muted"
+                                    aria-label={`Open the ${config.skill_name} skill`}
+                                >
+                                    <IconArrowUpRight className="size-3.5" />
+                                </Link>
+                            </Tooltip>
+                            <ScoutOriginBadge skillName={config.skill_name} />
+                            <DryRunBadge config={config} />
+                        </div>
                     </div>
-                </div>
-                {/* Cadence + emitted count get their own non-shrinking column so they can't
-                    overlap the sparkline (the name group absorbs any width pressure). */}
-                <div className="flex items-center gap-1 shrink-0 whitespace-nowrap text-[11px] text-muted">
-                    <span>{formatRunIntervalShort(config.run_interval_minutes)}</span>
-                    {rollup && rollup.emittedCount > 0 ? (
-                        <span>· {pluralize(rollup.emittedCount, 'signal')} emitted</span>
-                    ) : null}
+                    <div className="flex items-center gap-1 whitespace-nowrap text-[11px] text-muted">
+                        <span>{formatRunIntervalShort(config.run_interval_minutes)}</span>
+                        {rollup && rollup.emittedCount > 0 ? (
+                            <span>· {pluralize(rollup.emittedCount, 'signal')} emitted</span>
+                        ) : null}
+                    </div>
                 </div>
                 {/* The sparkline is the flexible region: it shrinks and clips the oldest runs
                     off the left so it can never push the controls column off the row. */}

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
@@ -28,7 +28,7 @@ const OUTCOME_BOX_CLASS: Record<ScoutRunOutcome, string> = {
 }
 
 const MAX_BOXES = 24
-const BOX_CLASS = 'block h-3 w-2 rounded-[2px] transition-transform duration-100 hover:scale-y-125'
+const BOX_CLASS = 'block h-3 w-2 shrink-0 rounded-[2px] transition-transform duration-100 hover:scale-y-125'
 
 function runTooltip(run: SignalScoutRunSummary, now: Date): string {
     const parts = [scoutRunOutcomeLabel(run, now)]
@@ -46,6 +46,11 @@ function runTooltip(run: SignalScoutRunSummary, now: Date): string {
  * One small box per run in the visible window, oldest on the left. Each box
  * links out to cloud's Tasks UI via the run's relative `task_url`; runs without
  * a task link are tooltip-only.
+ *
+ * Laid out with `flex-row-reverse` (newest first in the DOM) so that when the
+ * row is too narrow for every box the container clips the oldest runs off the
+ * left edge, keeping the most recent activity — and the controls column to the
+ * right — always visible.
  */
 export function ScoutRunBoxes({ runs }: { runs: SignalScoutRunSummary[] }): JSX.Element | null {
     const visible = useMemo(() => {
@@ -62,31 +67,33 @@ export function ScoutRunBoxes({ runs }: { runs: SignalScoutRunSummary[] }): JSX.
     }
     const hidden = runs.length - visible.length
 
+    // Newest first so flex-row-reverse renders them right-to-left; the oldest
+    // runs (and the +N marker) sit at the left edge and clip away first.
+    const newestFirst = visible.slice().reverse()
+
     return (
-        <div className="flex items-center gap-2 shrink-0">
-            {hidden > 0 ? <span className="text-[10px] text-muted">+{hidden}</span> : null}
-            <div className="flex items-center gap-1">
-                {visible.map(({ run, outcome, tooltip }) => {
-                    const boxClass = `${BOX_CLASS} ${OUTCOME_BOX_CLASS[outcome]}`
-                    if (run.task_url) {
-                        const linkTooltip = `${tooltip} · open task run`
-                        return (
-                            <Tooltip key={run.run_id} title={linkTooltip}>
-                                <Link to={run.task_url} className={boxClass}>
-                                    <span className="sr-only">Run {linkTooltip}</span>
-                                </Link>
-                            </Tooltip>
-                        )
-                    }
+        <div className="flex flex-row-reverse items-center gap-1 min-w-0 overflow-hidden">
+            {newestFirst.map(({ run, outcome, tooltip }) => {
+                const boxClass = `${BOX_CLASS} ${OUTCOME_BOX_CLASS[outcome]}`
+                if (run.task_url) {
+                    const linkTooltip = `${tooltip} · open task run`
                     return (
-                        <Tooltip key={run.run_id} title={tooltip}>
-                            <span className={boxClass}>
-                                <span className="sr-only">Run {tooltip}</span>
-                            </span>
+                        <Tooltip key={run.run_id} title={linkTooltip}>
+                            <Link to={run.task_url} className={boxClass}>
+                                <span className="sr-only">Run {linkTooltip}</span>
+                            </Link>
                         </Tooltip>
                     )
-                })}
-            </div>
+                }
+                return (
+                    <Tooltip key={run.run_id} title={tooltip}>
+                        <span className={boxClass}>
+                            <span className="sr-only">Run {tooltip}</span>
+                        </span>
+                    </Tooltip>
+                )
+            })}
+            {hidden > 0 ? <span className="shrink-0 text-[10px] text-muted">+{hidden}</span> : null}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

On the Scout troop modal (inbox → scout config), the per-scout rows break at the modal's real width on a smaller laptop screen (reported on a 14" MacBook). Two things go wrong:

- The run-history **sparkline** and the toggle/chat/gear **controls** were both `shrink-0`, so once their combined width exceeded the modal the whole row overflowed and the sparkline visually collided with the toggle.
- The name group used `overflow-hidden`, so once the name hit its `min-w` floor the `Custom`/`Canonical` badge got sliced mid-pill — showing up as a stray `(`.

On top of that, the `every Nh · N signals emitted` text sat inline on the main row, eating horizontal budget the sparkline and controls actually need.

## Changes

Make the sparkline the flexible region, stop clipping the badges, and free up the row:

- **Cadence + emitted count** moved to a muted subtitle line directly under the scout name, so it no longer competes for horizontal space on the main row.
- **Sparkline** (`ScoutRunBoxes`) now lays out with `flex-row-reverse` (newest run first in the DOM) inside a `min-w-0 overflow-hidden` container. When the row is too narrow for all 24 boxes it clips the **oldest** runs off the left edge, keeping the most recent activity — and the controls to its right — always visible. Boxes are `shrink-0` so they keep their size rather than squishing.
- **Name group** (`ScoutRowCard`) drops `overflow-hidden`; the icon + badges live in their own `shrink-0` group while the name (`flex-1`, `truncate`) absorbs all width pressure. The badge is never sliced again.
- The sparkline column is now a `min-w-0 overflow-hidden` flex region instead of `shrink-0`, so it can never push the controls column off the row.

CSS-only — no behavior or data changes. Applies to both the fleet-list row and the scout detail-page header (shared `ScoutRowCard`).

## How did you test this code?

I'm an agent (Claude Code). I ran `oxlint` on the changed files (0 warnings, 0 errors) and the repo format/lint-staged pass on commit. I did **not** manually verify in a running browser — the changes are pure flex/`className` layout adjustments, so a quick visual check across a couple of modal widths before merge would be worth it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy flagged a Slack report that the Scout troop modal "UI is all over the place" on a 14" MacBook, with annotated screenshots showing the sparkline overlapping the row controls and a `Custom`/`Canonical` badge clipped to a stray `(`. Traced both to the same root cause: too many `shrink-0` columns competing for width, plus `overflow-hidden` on the name group clipping the badge.

Considered letting rows wrap onto a second line, but that misaligns columns across the list. Chose to make the sparkline the single flexible/clipping region (keep newest runs, clip oldest) since "most recent activity" is the natural thing to preserve, and to move the badges into a non-shrinking group so the name truncates instead. On Andy's suggestion, also moved the cadence/emitted metadata to a subtitle line under the name to reclaim horizontal space. Tool: Claude Code (Opus). No repo skills were required for a CSS-only change.
