### PR TITLE
fix(data-warehouse): fix error reporting in warehouse semantic enrichment

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/enrich_table_semantics.py
+++ b/posthog/temporal/data_imports/workflow_activities/enrich_table_semantics.py
@@ -390,14 +390,20 @@ def enrich_table_semantics_sync(team_id: int, schema_id: uuid.UUID) -> dict[str,
             business_context=business_context,
         )
     except Exception as e:
-        log.warning("warehouse_enrichment.llm_failed", exc_info=e)
+        capture_exception(e)
+        log.error("warehouse_enrichment.llm_failed", exc_info=True)
+        capture_enrichment_event(
+            team,
+            EVENT_ERROR,
+            {**event_props, "error": str(e), "stage": "llm_call"},
+        )
         capture_enrichment_event(
             team,
             EVENT_LLM_CALL,
             {
                 **event_props,
                 "success": False,
-                "error": str(e)[:300],
+                "error": str(e),
                 "columns_requested": len(columns_needing_description),
             },
         )
@@ -503,8 +509,9 @@ async def enrich_table_semantics_activity(inputs: EnrichTableSemanticsInputs) ->
                     properties={
                         "team_id": inputs.team_id,
                         "schema_id": str(inputs.schema_id),
-                        "error": str(e)[:300],
+                        "error": str(e),
                     },
+                    groups={"project": str(inputs.team_id)},
                 )
             except Exception as capture_error:
                 capture_exception(capture_error)


### PR DESCRIPTION
## Problem

`enrich_table_semantics_sync` catches LLM call failures but reports them incorrectly in three ways, making LLM errors invisible in Sentry and hard to analyse in PostHog:

1. Missing `capture_exception(e)` — the exception is swallowed without reaching Sentry.
2. `log.warning(...)` — wrong severity for a real error; the exception is effectively silent in log-based alerting.
3. `EVENT_ERROR` is never fired — this handler returns rather than re-raising, so the activity-level handler that emits `EVENT_ERROR` is never reached.

Additionally, error strings in analytics events were truncated to 300 characters (`str(e)[:300]`), which hides the useful part of error messages when debugging.

The activity-level `EVENT_ERROR` capture also lacked group attribution, making those events unattributable by project in PostHog.

## Changes

- Added `capture_exception(e)` to the LLM failure path.
- `log.warning(..., exc_info=e)` → `log.error(..., exc_info=True)`.
- Added `capture_enrichment_event(team, EVENT_ERROR, {..., "stage": "llm_call"})` so LLM failures show up in the error event stream.
- Removed `[:300]` truncation from all `"error": str(e)` values in event properties.
- Added `groups={"project": str(inputs.team_id)}` to the activity-level `posthoganalytics.capture` call for `EVENT_ERROR`.

## How did you test this code?

Code-reviewed change — the existing test suite for this activity covers the happy and skip paths; the error path is straightforward. No behaviour changes outside error reporting.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written with Claude Code. Human identified the missing `EVENT_ERROR` and incorrect log level; the agent audited the full file and surfaced the additional missing `capture_exception`, truncated error strings, and missing group attribution in the activity handler.