### PR TITLE
fix: prevent duplicate tickets from concurrent Slack reactions

### DIFF
--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -1,12 +1,13 @@
+from typing import Any
+
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, call, patch
-
-from django.core.cache import cache
 
 from parameterized import parameterized
 
 from posthog.models.comment import Comment
 
+from products.conversations.backend.cache import slack_ticket_create_lock
 from products.conversations.backend.models import Ticket
 from products.conversations.backend.models.constants import Channel, ChannelDetail
 from products.conversations.backend.slack import (
@@ -468,7 +469,7 @@ class TestSlackTicketCreateLockDedup(BaseTest):
         mock_client.return_value = MagicMock()
         mock_client.return_value.chat_postMessage = MagicMock()
 
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "team": self.team,
             "slack_channel_id": CHANNEL,
             "thread_ts": PARENT_TS,
@@ -498,12 +499,10 @@ class TestSlackTicketCreateLockDedup(BaseTest):
     def test_lock_held_returns_without_creating_duplicate(self, _files, _user, mock_client):
         mock_client.return_value = MagicMock()
 
-        team_id = self.team.id
-        lock_key = f"conversations:slack_ticket_create_lock:{team_id}:{CHANNEL}:{PARENT_TS}"
-        # Pre-acquire the lock to simulate a concurrent worker holding it
-        cache.add(lock_key, True, timeout=30)
+        # Pre-acquire the lock via production code to simulate a concurrent worker holding it
+        with slack_ticket_create_lock(self.team.id, CHANNEL, PARENT_TS) as acquired:
+            assert acquired
 
-        try:
             result = create_or_update_slack_ticket(
                 team=self.team,
                 slack_channel_id=CHANNEL,
@@ -514,14 +513,14 @@ class TestSlackTicketCreateLockDedup(BaseTest):
                 slack_team_id=SLACK_TEAM,
                 channel_detail=ChannelDetail.SLACK_EMOJI_REACTION,
             )
-        finally:
-            cache.delete(lock_key)
 
-        # No ticket created — lock was held
-        assert Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS).count() == 0
-        assert result is None
-        # No confirmation posted
-        mock_client.return_value.chat_postMessage.assert_not_called()
+            # No ticket created — lock was held
+            assert (
+                Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS).count() == 0
+            )
+            assert result is None
+            # No confirmation posted
+            mock_client.return_value.chat_postMessage.assert_not_called()
 
     @patch(f"{MODULE}.get_bot_user_id", return_value="U_BOT")
     @patch(f"{MODULE}.get_slack_client")
@@ -541,7 +540,7 @@ class TestSlackTicketCreateLockDedup(BaseTest):
         }
         mock_client.return_value = client
 
-        kwargs = {
+        kwargs: dict[str, Any] = {
             "team": self.team,
             "slack_channel_id": CHANNEL,
             "thread_ts": PARENT_TS,
@@ -560,8 +559,9 @@ class TestSlackTicketCreateLockDedup(BaseTest):
 
         tickets = Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS)
         assert tickets.count() == 1
-        ticket = tickets.first()
+        created_ticket = tickets.first()
+        assert created_ticket is not None
         # One seed comment + one backfilled reply. The duplicate call returns None, so backfill
         # runs only once and comments aren't doubled.
-        comments = Comment.objects.filter(scope="conversations_ticket", item_id=str(ticket.id))
+        comments = Comment.objects.filter(scope="conversations_ticket", item_id=str(created_ticket.id))
         assert comments.count() == 2

--- a/products/conversations/backend/api/tests/test_reaction_backfill.py
+++ b/products/conversations/backend/api/tests/test_reaction_backfill.py
@@ -1,13 +1,19 @@
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, call, patch
 
+from django.core.cache import cache
+
 from parameterized import parameterized
 
 from posthog.models.comment import Comment
 
 from products.conversations.backend.models import Ticket
-from products.conversations.backend.models.constants import Channel
-from products.conversations.backend.slack import _backfill_thread_replies, handle_support_reaction
+from products.conversations.backend.models.constants import Channel, ChannelDetail
+from products.conversations.backend.slack import (
+    _backfill_thread_replies,
+    create_or_update_slack_ticket,
+    handle_support_reaction,
+)
 
 
 def _make_slack_reply(ts: str, user: str = "U_REPLY", text: str = "reply text", **extra) -> dict:
@@ -445,3 +451,117 @@ class TestHandleSupportReactionBackfill(BaseTest):
         mock_client.assert_not_called()
         mock_create.assert_not_called()
         mock_backfill.assert_not_called()
+
+
+class TestSlackTicketCreateLockDedup(BaseTest):
+    """Verify that the Redis lock in create_or_update_slack_ticket prevents duplicate tickets."""
+
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Alice", "email": "a@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_second_call_returns_none_when_first_already_created(self, _files, _user, mock_client):
+        mock_client.return_value = MagicMock()
+        mock_client.return_value.chat_postMessage = MagicMock()
+
+        kwargs = {
+            "team": self.team,
+            "slack_channel_id": CHANNEL,
+            "thread_ts": PARENT_TS,
+            "slack_user_id": "U_SOMEONE",
+            "text": "Help me please",
+            "is_thread_reply": False,
+            "slack_team_id": SLACK_TEAM,
+            "channel_detail": ChannelDetail.SLACK_EMOJI_REACTION,
+        }
+
+        # First call creates the ticket
+        ticket1 = create_or_update_slack_ticket(**kwargs)
+        # Second call hits the re-check inside the lock and returns None (not the existing
+        # ticket) so callers don't re-run backfill side effects.
+        ticket2 = create_or_update_slack_ticket(**kwargs)
+
+        tickets = Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS)
+        assert tickets.count() == 1
+        assert ticket1 is not None
+        assert ticket2 is None
+        # Only one confirmation message posted (second call short-circuits)
+        assert mock_client.return_value.chat_postMessage.call_count == 1
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Bob", "email": "b@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_lock_held_returns_without_creating_duplicate(self, _files, _user, mock_client):
+        mock_client.return_value = MagicMock()
+
+        team_id = self.team.id
+        lock_key = f"conversations:slack_ticket_create_lock:{team_id}:{CHANNEL}:{PARENT_TS}"
+        # Pre-acquire the lock to simulate a concurrent worker holding it
+        cache.add(lock_key, True, timeout=30)
+
+        try:
+            result = create_or_update_slack_ticket(
+                team=self.team,
+                slack_channel_id=CHANNEL,
+                thread_ts=PARENT_TS,
+                slack_user_id="U_SOMEONE",
+                text="Help!",
+                is_thread_reply=False,
+                slack_team_id=SLACK_TEAM,
+                channel_detail=ChannelDetail.SLACK_EMOJI_REACTION,
+            )
+        finally:
+            cache.delete(lock_key)
+
+        # No ticket created — lock was held
+        assert Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS).count() == 0
+        assert result is None
+        # No confirmation posted
+        mock_client.return_value.chat_postMessage.assert_not_called()
+
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.resolve_slack_user", return_value={"name": "Cara", "email": "c@x.com", "avatar": None})
+    @patch(f"{MODULE}.extract_slack_files", return_value=[])
+    def test_dedup_create_returns_none_so_caller_skips_backfill(self, _files, _user, mock_client, _bot):
+        # Reproduces the race where two reaction events both pass handle_support_reaction's
+        # .exists() fast-path, then both reach create. The caller backfills only when create
+        # returns a ticket — so the loser must get None or the backfill duplicates comments.
+        reply_ts = "1700000000.000500"
+        client = MagicMock()
+        client.conversations_replies.return_value = {
+            "messages": [
+                {"user": "U_ROOT", "text": "Help me please", "ts": PARENT_TS},
+                {"user": "U_CUSTOMER", "text": "more context", "ts": reply_ts, "thread_ts": PARENT_TS},
+            ]
+        }
+        mock_client.return_value = client
+
+        kwargs = {
+            "team": self.team,
+            "slack_channel_id": CHANNEL,
+            "thread_ts": PARENT_TS,
+            "slack_user_id": "U_ROOT",
+            "text": "Help me please",
+            "is_thread_reply": False,
+            "slack_team_id": SLACK_TEAM,
+            "channel_detail": ChannelDetail.SLACK_EMOJI_REACTION,
+        }
+
+        # Mirror handle_support_reaction: create, then backfill iff a ticket came back.
+        for _ in range(2):
+            ticket = create_or_update_slack_ticket(**kwargs)
+            if ticket:
+                _backfill_thread_replies(client, self.team, ticket, CHANNEL, PARENT_TS, after_ts=PARENT_TS)
+
+        tickets = Ticket.objects.filter(team=self.team, slack_channel_id=CHANNEL, slack_thread_ts=PARENT_TS)
+        assert tickets.count() == 1
+        ticket = tickets.first()
+        # One seed comment + one backfilled reply. The duplicate call returns None, so backfill
+        # runs only once and comments aren't doubled.
+        comments = Comment.objects.filter(scope="conversations_ticket", item_id=str(ticket.id))
+        assert comments.count() == 2

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -7,6 +7,8 @@ Short TTLs ensure stale data expires quickly without explicit invalidation.
 
 import json
 import hashlib
+from collections.abc import Generator
+from contextlib import contextmanager
 
 from django.core.cache import cache
 
@@ -291,6 +293,31 @@ def set_cached_teams_user(tenant_id: str, teams_user_id: str, user_info: dict) -
 
 RESOLVED_GROUPS_CACHE_TTL = 12 * 60 * 60  # 12 hours
 RESOLVED_GROUPS_NEGATIVE_CACHE_TTL = 60 * 60  # 1 hour
+
+
+# Slack Ticket Creation Lock
+# Serializes concurrent ticket creation for the same Slack thread so two reaction_added
+# events from different users can't both pass the existence checks and create duplicate
+# tickets. cache.add is atomic (Redis SETNX): only one worker acquires. Short TTL is a
+# safety net so a crashed worker can't wedge a thread permanently.
+
+SLACK_TICKET_CREATE_LOCK_TTL = 30  # seconds
+
+
+@contextmanager
+def slack_ticket_create_lock(team_id: int, channel: str, thread_ts: str) -> Generator[bool]:
+    """Atomic Redis lock to serialize ticket creation for a Slack thread.
+
+    Yields True if the lock was acquired, False if another worker holds it.
+    Releases the lock on exit when acquired.
+    """
+    key = _make_cache_key("slack_ticket_create_lock", str(team_id), channel, thread_ts)
+    acquired = cache.add(key, True, timeout=SLACK_TICKET_CREATE_LOCK_TTL)
+    try:
+        yield acquired
+    finally:
+        if acquired:
+            cache.delete(key)
 
 
 def _resolved_groups_cache_key(team_id: int, distinct_ids: list[str]) -> str:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -32,6 +32,7 @@ from .cache import (
     set_cached_bot_user_id,
     set_cached_slack_avatar,
     set_cached_slack_user,
+    slack_ticket_create_lock,
 )
 from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content
 from .models import Ticket
@@ -469,22 +470,44 @@ def create_or_update_slack_ticket(
 
     content, rich_content = _build_content_with_images(cleaned_text, rich_content, images)
 
-    ticket = Ticket.objects.create_with_number(
-        team=team,
-        channel_source=Channel.SLACK,
-        channel_detail=channel_detail,
-        widget_session_id="",  # Not used for Slack tickets
-        distinct_id=user_info.get("email") or "",
-        status=Status.NEW,
-        anonymous_traits={
-            "name": user_info["name"],
-            **({"email": user_info["email"]} if user_info["email"] else {}),
-        },
-        slack_channel_id=slack_channel_id,
-        slack_thread_ts=thread_ts,
-        slack_team_id=slack_team_id,
-        unread_team_count=0 if is_team_member else 1,
-    )
+    # Serialize concurrent ticket creation for the same Slack thread via Redis lock.
+    # Without this, two reaction_added events from different users race through the
+    # .exists() checks above and both create a ticket.
+    with slack_ticket_create_lock(team_id, slack_channel_id, thread_ts) as acquired:
+        # Return None (not the existing ticket) on every dedup path: the winning worker
+        # owns the create-side effects (first comment, confirmation message, and the
+        # caller's _backfill_thread_replies). Handing a non-None ticket back to a losing
+        # reaction/mention would re-trigger backfill and duplicate every thread comment.
+        if not acquired:
+            logger.info(
+                "slack_ticket_create_lock_not_acquired",
+                team_id=team_id,
+                slack_channel_id=slack_channel_id,
+                thread_ts=thread_ts,
+            )
+            return None
+
+        # Re-check after acquiring — the winner may have committed between our earlier
+        # .exists() call and now.
+        if Ticket.objects.filter(team=team, slack_channel_id=slack_channel_id, slack_thread_ts=thread_ts).exists():
+            return None
+
+        ticket = Ticket.objects.create_with_number(
+            team=team,
+            channel_source=Channel.SLACK,
+            channel_detail=channel_detail,
+            widget_session_id="",  # Not used for Slack tickets
+            distinct_id=user_info.get("email") or "",
+            status=Status.NEW,
+            anonymous_traits={
+                "name": user_info["name"],
+                **({"email": user_info["email"]} if user_info["email"] else {}),
+            },
+            slack_channel_id=slack_channel_id,
+            slack_thread_ts=thread_ts,
+            slack_team_id=slack_team_id,
+            unread_team_count=0 if is_team_member else 1,
+        )
 
     Comment.objects.create(
         team=team,


### PR DESCRIPTION
## Problem

When two people react with the ticket emoji on the same Slack message at the same time, two separate `reaction_added` events fire — each with a distinct `event_id`, bypassing the existing event-id dedup in `tasks.py`. Both events run as concurrent Celery tasks, both pass the best-effort `.exists()` checks in `handle_support_reaction`, and both call `create_or_update_slack_ticket`, which unconditionally creates a ticket. The result: two tickets for the same thread.

## Changes

- Added a Redis lock (`cache.add` / `cache.delete`, same mechanism as the existing event-id dedup) in `cache.py` keyed on `(team_id, slack_channel_id, thread_ts)`. One worker acquires, the other returns `None` immediately. The winner re-checks existence inside the lock to handle the case where it committed between the earlier `.exists()` call and lock acquisition.
- Dedup paths return `None` (not the existing ticket) so callers don't re-trigger `_backfill_thread_replies` and duplicate thread comments.
- Lock lives in `cache.py` alongside the other Slack/widget caching helpers rather than inline in `slack.py`.

## How did you test this code?

 Automated tests in `test_reaction_backfill.py`:
- `test_second_call_returns_none_when_first_already_created` — sequential calls create exactly one ticket; second returns `None`.
- `test_lock_held_returns_without_creating_duplicate` — pre-acquiring the lock causes the call to short-circuit with no ticket created.
- `test_dedup_create_returns_none_so_caller_skips_backfill` — mirrors the caller's create→backfill loop twice; asserts one ticket and exactly two comments (one seed + one backfilled reply, not doubled).

