### PR TITLE
fix(workflows): backtick-quote account external_id group type

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.test.ts
@@ -86,13 +86,18 @@ describe('customer analytics action registry', () => {
     describe('buildAccountExternalIdInputs', () => {
         it('builds a name-based group key expression from the account group type index', () => {
             const inputs = buildAccountExternalIdInputs(2, groupTypesMap([0, 'project'], [2, 'organization']))
-            expect(inputs).toEqual({ external_id: { value: '{groups["organization"].id}' } })
+            expect(inputs).toEqual({ external_id: { value: '{groups.`organization`.id}' } })
         })
 
-        it('quotes the group type so a name with template delimiters is escaped, not injected', () => {
+        it('backtick-quotes the group type so a name with template delimiters is escaped, not injected', () => {
             const malicious = '"].id} + inject {groups["x'
             const inputs = buildAccountExternalIdInputs(0, groupTypesMap([0, malicious]))
-            expect(inputs).toEqual({ external_id: { value: `{groups[${JSON.stringify(malicious)}].id}` } })
+            expect(inputs).toEqual({ external_id: { value: '{groups.`"].id} + inject {groups["x`.id}' } })
+        })
+
+        it('escapes backticks in the group type by doubling them', () => {
+            const inputs = buildAccountExternalIdInputs(0, groupTypesMap([0, 'we`ird']))
+            expect(inputs).toEqual({ external_id: { value: '{groups.`we``ird`.id}' } })
         })
 
         it.each([null, undefined])('returns undefined when the account group type index is %s', (index) => {

--- a/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
+++ b/products/workflows/frontend/Workflows/hogflows/registry/actions/customer_analytics.ts
@@ -15,8 +15,14 @@ export const buildAccountExternalIdInputs = (
         return undefined
     }
     const groupType = groupTypes.get(accountGroupTypeIndex as GroupTypeIndex)?.group_type
-    // Quote the group type as a property key — an ingested name with template delimiters must not break out of the Hog expression.
-    return groupType ? { external_id: { value: `{groups[${JSON.stringify(groupType)}].id}` } } : undefined
+    if (!groupType) {
+        return undefined
+    }
+    // Backtick-quote the group type as an identifier. Bracket access (`groups["x"]`) compiles the index as a
+    // separate global lookup and fails at runtime; backtick quoting escapes any name (delimiters, spaces, backticks
+    // via doubling) without breaking out of the Hog expression.
+    const quotedGroupType = groupType.replace(/`/g, '``')
+    return { external_id: { value: `{groups.\`${quotedGroupType}\`.id}` } }
 }
 
 const getAccountExternalIdDefaultInputs = (): Record<string, CyclotronInputType> | undefined =>


### PR DESCRIPTION
## Problem

The account `external_id` prefill errors out at runtime with "Could not execute bytecode for input field: external_id" — Get/Update account steps fail when run.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Follow-up fix to #64926.

## Changes

- Backtick-quote the group type in the `external_id` prefill (`` {groups.`<type>`.id} ``) instead of bracket-indexing
- Bracket access (`groups["x"]`) compiles the index as a separate global lookup → "Global variable not found" at runtime
- Backtick quoting escapes any name (delimiters, spaces, backticks via doubling) and stays injection-safe
- Add test for backtick-doubling escape
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Unit tests. Verified bytecode of both forms through the real template compiler (`generate_template_bytecode` + `execute_bytecode`): bracket fails for every group type, backtick resolves correctly and escapes a malicious name rather than injecting.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code. Diagnosed from a prod error report: the bytecode for `{groups["organization"].id}` emits a spurious `GET_GLOBAL` for the bracket index, so the global lookup fails. Reproduced and confirmed the backtick form through the actual template compiler before changing code. Existing workflows saved with the broken prefill won't self-heal — the `external_id` must be re-set on those steps.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
