### PR TITLE
fix(navigation): keep Max side panel above left nav in overlay mode

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
@@ -9,6 +9,7 @@
             position: fixed;
             top: 0;
             right: 0;
+
             // As a fixed overlay the panel escapes the content column and must sit above the
             // left nav (--z-layout-panel: 761) instead of behind it at --z-main-nav (750).
             z-index: calc(var(--z-layout-panel) + 1);

--- a/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
+++ b/frontend/src/layout/navigation-3000/sidepanel/SidePanel.scss
@@ -9,6 +9,9 @@
             position: fixed;
             top: 0;
             right: 0;
+            // As a fixed overlay the panel escapes the content column and must sit above the
+            // left nav (--z-layout-panel: 761) instead of behind it at --z-main-nav (750).
+            z-index: calc(var(--z-layout-panel) + 1);
             box-shadow: 0 0 30px rgb(0 0 0 / 20%);
 
             [theme='dark'] & {


### PR DESCRIPTION
## Problem

The Max AI chat panel renders **under / behind the left navigation menu bar** when the browser window is narrow, making the chat partly unusable.

The chat lives in the `SidePanel3000` component. Most of the time it's `position: absolute` inside the content column, so it can't collide with the left nav. But at `max-width: 1200px` it switches to `position: fixed`, which lifts it into the root stacking context. There its `z-index` was `--z-main-nav` (750) — **below** the left navigation's `--z-layout-panel` (761) and `--z-layout-navbar` (756) — so the nav paints over it.

## Changes

In `SidePanel.scss`, within the `≤1200px` fixed-overlay media query, raise the panel's `z-index` to `calc(var(--z-layout-panel) + 1)` so the overlay sits above the left nav (and its dim backdrop) as intended. No change to the wide-screen layout, where the panel remains absolutely positioned inside the content column.

## How did you test this code?

I'm the PostHog Slack app (agent-assisted). I have **not** run the app — this sandbox has no Docker/dev stack. The fix was derived by reading the layout source and the z-index scale in `frontend/src/styles/base.scss`. Manual verification still needed: open Max, narrow the window below 1200px, and confirm the panel now sits above the left nav.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — driven by @willwearing from a Slack thread.

Investigation started from an "AI styling broken" report. Error tracking surfaced a noisy `colors.ts` "Couldn't find color variable" issue, but that was a red herring — the reporter clarified the Max chat was rendering under the left menu bar, a layout/stacking problem (no JS error). Traced it to the `SidePanel3000` fixed-overlay state having a `z-index` below the nav. Chose to scope the bump to the overlay media query rather than raise the base `z-index`, since the wide-screen absolute-positioned case is unaffected.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782228030546069?thread_ts=1782228030.546069&cid=C0ACRAMJUAG)*
