### PR TITLE
fix(mcp): copy assets in dev

### DIFF
--- a/services/mcp/scripts/dev-hono.ts
+++ b/services/mcp/scripts/dev-hono.ts
@@ -6,6 +6,7 @@ import { context, type Plugin } from 'esbuild'
 import { existsSync } from 'fs'
 import { resolve } from 'path'
 
+import { copyInstructions } from './copy-instructions'
 import { honoEsbuildOptions, honoOutfile } from './hono-esbuild-config'
 
 // Load the same local-dev config the Workers (wrangler) runtime uses, so
@@ -20,6 +21,8 @@ const dotEnv = resolve(process.cwd(), '.env')
 if (existsSync(dotEnv)) {
     process.loadEnvFile(dotEnv)
 }
+
+copyInstructions()
 
 // flox sets SSL_CERT_FILE; Node's TLS layer only reads NODE_EXTRA_CA_CERTS.
 if (!process.env.NODE_EXTRA_CA_CERTS && process.env.SSL_CERT_FILE) {


### PR DESCRIPTION
## Problem

The MCP Hono dev server did not run the instruction asset copy step that the build scripts already run. In dev mode, shared guidelines, playbooks, and generated playbook metadata could be stale or missing before esbuild resolved the `@shared/*` imports.

## Changes

- Import and run `copyInstructions()` in `services/mcp/scripts/dev-hono.ts` before the esbuild watcher starts.
- Keep local Hono dev startup aligned with the MCP build scripts by materializing shared prompt/playbook assets and regenerating playbook metadata before bundling.

## How did you test this code?

Not run locally while filling this PR form. Existing PR CI is green for the relevant checks I verified, including MCP tests, Node.js tests, and frontend typechecking.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This only changes local MCP dev startup behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex filled out this PR description from the existing diff and current PR metadata. No code changes were made by the agent while completing the form.

Skills invoked: none. This task only updated the PR form and did not involve writing or reviewing code.