### PR TITLE
chore(hogql): fix postgres identifier roundtrip PBT for '%'

### DIFF
--- a/posthog/hogql/printer/test/test_printer_pbt.py
+++ b/posthog/hogql/printer/test/test_printer_pbt.py
@@ -191,11 +191,11 @@ class TestPostgresIdentifier:
     unescaping that Postgres identifiers don't use).
     """
 
-    @given(s=st.text(alphabet=st.characters(blacklist_characters="%"), min_size=1, max_size=63))
+    @given(s=st.text(alphabet=st.characters(codec="utf-8", blacklist_characters="%"), min_size=1, max_size=63))
     @settings(parent=_BASE, max_examples=1000)
     def test_roundtrip(self, s: str) -> None:
-        # '%' is excluded: escape_postgres_identifier rejects it (psycopg treats it
-        # as a parameter placeholder). Its rejection is covered separately below.
+        # Exclude "%" (escape_postgres_identifier rejects it; covered by test_percent_always_rejected).
+        # codec="utf-8" matches the default st.text() alphabet so we don't generate lone surrogates.
         escaped = escape_postgres_identifier(s)
         if escaped.startswith('"'):
             # Double-quoted: strip quotes and unescape "" → "

--- a/posthog/hogql/printer/test/test_printer_pbt.py
+++ b/posthog/hogql/printer/test/test_printer_pbt.py
@@ -206,7 +206,7 @@ class TestPostgresIdentifier:
 
     @given(
         s=st.builds(
-            # Keep total length ≤ 63 so the '%' rejection fires before the length check.
+            # Keep total length ≤ 63 so inputs clear the length check (len > 63) and reach the '%' rejection.
             lambda prefix, suffix: prefix + "%" + suffix,
             prefix=st.text(max_size=31),
             suffix=st.text(max_size=31),

--- a/posthog/hogql/printer/test/test_printer_pbt.py
+++ b/posthog/hogql/printer/test/test_printer_pbt.py
@@ -191,9 +191,11 @@ class TestPostgresIdentifier:
     unescaping that Postgres identifiers don't use).
     """
 
-    @given(s=st.text(min_size=1, max_size=63))
+    @given(s=st.text(alphabet=st.characters(blacklist_characters="%"), min_size=1, max_size=63))
     @settings(parent=_BASE, max_examples=1000)
     def test_roundtrip(self, s: str) -> None:
+        # '%' is excluded: escape_postgres_identifier rejects it (psycopg treats it
+        # as a parameter placeholder). Its rejection is covered separately below.
         escaped = escape_postgres_identifier(s)
         if escaped.startswith('"'):
             # Double-quoted: strip quotes and unescape "" → "
@@ -201,6 +203,18 @@ class TestPostgresIdentifier:
             assert inner.replace('""', '"') == s
         else:
             assert escaped == s
+
+    @given(
+        s=st.builds(
+            # Keep total length ≤ 63 so the '%' rejection fires before the length check.
+            lambda prefix, suffix: prefix + "%" + suffix,
+            prefix=st.text(max_size=31),
+            suffix=st.text(max_size=31),
+        )
+    )
+    def test_percent_always_rejected(self, s: str) -> None:
+        with pytest.raises(QueryError, match='is not permitted as it contains the "%" character'):
+            escape_postgres_identifier(s)
 
     @given(s=st.from_regex(r"[a-z_][a-z0-9_$]*", fullmatch=True).filter(lambda s: len(s) <= 63))
     def test_simple_identifiers_returned_bare(self, s: str) -> None:


### PR DESCRIPTION
## Problem

`TestPostgresIdentifier.test_roundtrip` in `posthog/hogql/printer/test/test_printer_pbt.py` fails with the falsifying example `s='%'`.

The property draws `st.text(min_size=1, max_size=63)` and feeds it to `escape_postgres_identifier`, but that function raises `QueryError` for any identifier containing `%` (psycopg treats `%` as a parameter placeholder; see `_quote_postgres_wire_identifier`). The strategy never excluded `%`, so once Hypothesis draws it the test errors instead of asserting.

Pre-existing on master, and only surfaces under `RUN_PBT=1` (these PBTs are gated out of CI), so it wasn't blocking anything.

## Changes

- Exclude `%` from the `test_roundtrip` strategy alphabet (`st.characters(blacklist_characters="%")`), mirroring how `_roundtrip_safe_identifier_text` already excludes `\0%` for the HogQL/ClickHouse backtick functions.
- Add `test_percent_always_rejected` for Postgres, matching the equivalent cases already present for HogQL and ClickHouse.

Postgres-specific wrinkle: `escape_postgres_identifier` checks length (>63) **before** the `%` check, so the new rejection test can't reuse the unbounded `_text_with_percent` strategy (HogQL/ClickHouse have no length limit). I bounded the prefix/suffix to ≤31 chars each so total length stays ≤63 and the `%` rejection fires before the length error.

## How did you test this code?

I'm an agent (Claude Code). Automated only, no manual testing:

```
RUN_PBT=1 hogli test posthog/hogql/printer/test/test_printer_pbt.py::TestPostgresIdentifier
# 4 passed
```

Test-only change to a CI-gated PBT file, so the normal CI path is unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie via Claude Code (Opus 4.8). No repo skills were invoked; this was a self-contained Hypothesis strategy fix. I chose to do both fix options (exclude `%` from the roundtrip strategy *and* add a dedicated rejection test) rather than one, because the file already pairs those two for every other identifier escaper, so doing half would have been inconsistent.
