### PR TITLE
feat(customer-analytics): add custom property definitions UI

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
@@ -1,0 +1,109 @@
+import { useActions, useValues } from 'kea'
+
+import { IconPencil, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
+
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { TZLabel } from 'lib/components/TZLabel'
+import { TeamMembershipLevel } from 'lib/constants'
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+
+import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
+import { CustomPropertyModal } from './CustomPropertyModal'
+import { labelForDisplayType } from './customPropertyTypes'
+
+export function CustomPropertiesConfig(): JSX.Element {
+    const { definitions, definitionsLoading } = useValues(customPropertyDefinitionsLogic)
+    const { openCreateModal, openEditModal, deleteDefinition } = useActions(customPropertyDefinitionsLogic)
+    const restrictionReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: TeamMembershipLevel.Admin,
+    })
+
+    const confirmDelete = (definition: CustomPropertyDefinitionApi): void => {
+        LemonDialog.open({
+            title: `Delete ${definition.name}?`,
+            description: `Deleting ${definition.name} removes this custom property. This can't be undone.`,
+            primaryButton: {
+                children: 'Delete',
+                status: 'danger',
+                onClick: () => deleteDefinition({ id: definition.id }),
+            },
+            secondaryButton: { children: 'Cancel' },
+        })
+    }
+
+    const columns: LemonTableColumns<CustomPropertyDefinitionApi> = [
+        {
+            title: 'Name',
+            dataIndex: 'name',
+            render: (_, definition) => <span className="font-semibold">{definition.name}</span>,
+        },
+        {
+            title: 'Type',
+            render: (_, definition) => labelForDisplayType(definition.display_type),
+        },
+        {
+            title: 'Description',
+            dataIndex: 'description',
+            render: (_, definition) =>
+                definition.description ? definition.description : <span className="text-secondary">—</span>,
+        },
+        {
+            title: 'Last updated',
+            render: (_, definition) =>
+                definition.updated_at ? (
+                    <TZLabel time={definition.updated_at} />
+                ) : (
+                    <span className="text-secondary">—</span>
+                ),
+        },
+        {
+            title: '',
+            width: 0,
+            render: (_, definition) => (
+                <div className="flex gap-1 justify-end">
+                    <LemonButton
+                        size="small"
+                        icon={<IconPencil />}
+                        tooltip="Edit"
+                        onClick={() => openEditModal(definition)}
+                        disabledReason={restrictionReason}
+                    />
+                    <LemonButton
+                        size="small"
+                        status="danger"
+                        icon={<IconTrash />}
+                        tooltip="Delete"
+                        onClick={() => confirmDelete(definition)}
+                        disabledReason={restrictionReason}
+                    />
+                </div>
+            ),
+        },
+    ]
+
+    return (
+        <div className="flex flex-col gap-2">
+            <div className="flex items-center justify-between gap-2">
+                <div>
+                    <h3 className="mb-0">Custom properties</h3>
+                    <p className="text-secondary mb-0">Define typed properties to store on your accounts.</p>
+                </div>
+                <LemonButton type="primary" onClick={openCreateModal} disabledReason={restrictionReason}>
+                    New custom property
+                </LemonButton>
+            </div>
+            <LemonTable
+                columns={columns}
+                dataSource={definitions}
+                loading={definitionsLoading}
+                rowKey="id"
+                emptyState="No custom properties yet. Create one to get started."
+            />
+            <CustomPropertyModal />
+        </div>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
@@ -1,0 +1,68 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
+import { DISPLAY_TYPE_OPTIONS } from './customPropertyTypes'
+
+export function CustomPropertyModal(): JSX.Element {
+    const { modalVisible, editingDefinition, customPropertyForm, isCustomPropertyFormSubmitting } =
+        useValues(customPropertyDefinitionsLogic)
+    const { closeModal, submitCustomPropertyForm } = useActions(customPropertyDefinitionsLogic)
+
+    const selectedOption = DISPLAY_TYPE_OPTIONS.find((option) => option.value === customPropertyForm.displayType)
+
+    return (
+        <LemonModal
+            isOpen={modalVisible}
+            onClose={closeModal}
+            title={editingDefinition ? 'Edit custom property' : 'New custom property'}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={closeModal}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        onClick={submitCustomPropertyForm}
+                        loading={isCustomPropertyFormSubmitting}
+                    >
+                        {editingDefinition ? 'Save' : 'Create'}
+                    </LemonButton>
+                </>
+            }
+        >
+            <Form
+                logic={customPropertyDefinitionsLogic}
+                formKey="customPropertyForm"
+                enableFormOnSubmit
+                className="flex flex-col gap-4"
+            >
+                <LemonField name="name" label="Name">
+                    <LemonInput placeholder="e.g. ARR" autoFocus />
+                </LemonField>
+                <LemonField name="description" label="Description">
+                    <LemonTextArea placeholder="Optional description" minRows={2} />
+                </LemonField>
+                <LemonField name="displayType" label="Type">
+                    <LemonSelect options={DISPLAY_TYPE_OPTIONS} fullWidth />
+                </LemonField>
+                {selectedOption?.isNumeric && (
+                    <LemonField name="isBigNumber">
+                        {({ value, onChange }) => (
+                            <LemonSwitch
+                                checked={value}
+                                onChange={onChange}
+                                label="Abbreviate large numbers (e.g. 10,000 → 10K)"
+                                bordered
+                            />
+                        )}
+                    </LemonField>
+                )}
+            </Form>
+        </LemonModal>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertyModal.tsx
@@ -6,14 +6,14 @@ import { LemonButton, LemonInput, LemonModal, LemonSelect, LemonSwitch, LemonTex
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
-import { DISPLAY_TYPE_OPTIONS } from './customPropertyTypes'
+import { DISPLAY_TYPE_OPTIONS, isNumericDisplayType } from './customPropertyTypes'
 
 export function CustomPropertyModal(): JSX.Element {
     const { modalVisible, editingDefinition, customPropertyForm, isCustomPropertyFormSubmitting } =
         useValues(customPropertyDefinitionsLogic)
     const { closeModal, submitCustomPropertyForm } = useActions(customPropertyDefinitionsLogic)
 
-    const selectedOption = DISPLAY_TYPE_OPTIONS.find((option) => option.value === customPropertyForm.displayType)
+    const showBigNumberSwitch = isNumericDisplayType(customPropertyForm.displayType)
 
     return (
         <LemonModal
@@ -50,7 +50,7 @@ export function CustomPropertyModal(): JSX.Element {
                 <LemonField name="displayType" label="Type">
                     <LemonSelect options={DISPLAY_TYPE_OPTIONS} fullWidth />
                 </LemonField>
-                {selectedOption?.isNumeric && (
+                {showBigNumberSwitch && (
                     <LemonField name="isBigNumber">
                         {({ value, onChange }) => (
                             <LemonSwitch

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomerAnalyticsAccountConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomerAnalyticsAccountConfig.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { LemonSelect } from '@posthog/lemon-ui'
+import { LemonDivider, LemonSelect } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TeamMembershipLevel } from 'lib/constants'
@@ -11,6 +11,8 @@ import { teamLogic } from 'scenes/teamLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 import { CustomerAnalyticsConfig } from '~/queries/schema/schema-general'
+
+import { CustomPropertiesConfig } from './CustomPropertiesConfig'
 
 const NO_ACCOUNT_GROUP = -1
 
@@ -39,20 +41,24 @@ export function CustomerAnalyticsAccountConfig(): JSX.Element {
     const value = customerAnalyticsConfig.account_group_type_index ?? NO_ACCOUNT_GROUP
 
     return (
-        <LemonSelect
-            data-attr="customer-analytics-account-group-type"
-            value={value}
-            onChange={(newValue) =>
-                updateCurrentTeam({
-                    customer_analytics_config: {
-                        account_group_type_index: newValue === NO_ACCOUNT_GROUP ? null : newValue,
-                    } as CustomerAnalyticsConfig,
-                })
-            }
-            disabledReason={currentTeamLoading ? 'Loading...' : restrictedReason}
-            fullWidth
-            className="max-w-160"
-            options={options}
-        />
+        <div className="flex flex-col gap-4">
+            <LemonSelect
+                data-attr="customer-analytics-account-group-type"
+                value={value}
+                onChange={(newValue) =>
+                    updateCurrentTeam({
+                        customer_analytics_config: {
+                            account_group_type_index: newValue === NO_ACCOUNT_GROUP ? null : newValue,
+                        } as CustomerAnalyticsConfig,
+                    })
+                }
+                disabledReason={currentTeamLoading ? 'Loading...' : restrictedReason}
+                fullWidth
+                className="max-w-160"
+                options={options}
+            />
+            <LemonDivider />
+            <CustomPropertiesConfig />
+        </div>
     )
 }

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -95,6 +95,29 @@ describe('customPropertyDefinitionsLogic', () => {
         expect(logic.values.modalVisible).toBe(false)
     })
 
+    it('drops the big-number flag when switching to a non-numeric type', async () => {
+        let patchedBody: Record<string, any> | null = null
+        useMocks({
+            ...defaultMocks(),
+            patch: {
+                [DEFINITION_URL]: async ({ request }) => {
+                    patchedBody = (await request.json()) as Record<string, any>
+                    return buildDefinition()
+                },
+            },
+        })
+        mountLogic()
+        // Edit a numeric definition that has the big-number flag on, then switch it to a
+        // non-numeric type without touching the (now hidden) switch.
+        logic.actions.openEditModal(buildDefinition({ display_type: 'currency', is_big_number: true }))
+        logic.actions.setCustomPropertyFormValue('displayType', 'text')
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertyForm()).toDispatchActions([
+            'submitCustomPropertyFormSuccess',
+        ])
+        expect(patchedBody).toMatchObject({ display_type: 'text', is_big_number: false })
+    })
+
     it('surfaces a name conflict on the name field', async () => {
         useMocks({ ...defaultMocks(), post: { [DEFINITIONS_URL]: () => [409, { detail: 'conflict' }] } })
         mountLogic()

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -1,0 +1,124 @@
+import { MOCK_DEFAULT_TEAM, MOCK_DEFAULT_USER } from '~/lib/api.mock'
+
+import { expectLogic } from 'kea-test-utils'
+
+import { userLogic } from 'scenes/userLogic'
+
+import { useMocks } from '~/mocks/jest'
+import { initKeaTests } from '~/test/init'
+
+import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
+
+const DEFINITIONS_URL = '/api/projects/:team_id/custom_property_definitions/'
+const DEFINITION_URL = '/api/projects/:team_id/custom_property_definitions/:id/'
+
+const buildDefinition = (overrides: Partial<CustomPropertyDefinitionApi> = {}): CustomPropertyDefinitionApi =>
+    ({
+        id: 'def-1',
+        name: 'ARR',
+        description: null,
+        display_type: 'currency',
+        is_big_number: true,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: 1,
+        updated_at: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }) as CustomPropertyDefinitionApi
+
+const defaultMocks = (): Parameters<typeof useMocks>[0] => ({
+    get: { [DEFINITIONS_URL]: { count: 1, results: [buildDefinition()] } },
+    post: { [DEFINITIONS_URL]: buildDefinition({ id: 'def-2' }) },
+    patch: { [DEFINITION_URL]: buildDefinition() },
+    delete: { [DEFINITION_URL]: {} },
+})
+
+describe('customPropertyDefinitionsLogic', () => {
+    let logic: ReturnType<typeof customPropertyDefinitionsLogic.build>
+
+    const mountLogic = (): void => {
+        logic = customPropertyDefinitionsLogic()
+        logic.mount()
+    }
+
+    beforeEach(() => {
+        window.POSTHOG_APP_CONTEXT = {
+            ...window.POSTHOG_APP_CONTEXT,
+            current_team: MOCK_DEFAULT_TEAM,
+            current_user: MOCK_DEFAULT_USER,
+        } as any
+        initKeaTests()
+        userLogic.mount()
+    })
+
+    it('loads definitions on mount', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic)
+            .toDispatchActions(['loadDefinitions', 'loadDefinitionsSuccess'])
+            .toMatchValues({ definitions: [expect.objectContaining({ id: 'def-1', name: 'ARR' })] })
+    })
+
+    it('hydrates the form when editing a definition', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        const definition = buildDefinition()
+        await expectLogic(logic, () => logic.actions.openEditModal(definition)).toFinishAllListeners()
+
+        expect(logic.values.modalVisible).toBe(true)
+        expect(logic.values.editingDefinition).toEqual(definition)
+        expect(logic.values.customPropertyForm).toEqual({
+            name: 'ARR',
+            description: '',
+            displayType: 'currency',
+            isBigNumber: true,
+        })
+    })
+
+    it('creates a definition, reloads, and closes the modal', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        logic.actions.openCreateModal()
+        logic.actions.setCustomPropertyFormValues({
+            name: 'Plan',
+            description: '',
+            displayType: 'text',
+            isBigNumber: false,
+        })
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertyForm()).toDispatchActions([
+            'submitCustomPropertyFormSuccess',
+            'loadDefinitions',
+            'closeModal',
+        ])
+        expect(logic.values.modalVisible).toBe(false)
+    })
+
+    it('surfaces a name conflict on the name field', async () => {
+        useMocks({ ...defaultMocks(), post: { [DEFINITIONS_URL]: () => [409, { detail: 'conflict' }] } })
+        mountLogic()
+        logic.actions.openCreateModal()
+        logic.actions.setCustomPropertyFormValues({
+            name: 'ARR',
+            description: '',
+            displayType: 'text',
+            isBigNumber: false,
+        })
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertyForm()).toDispatchActions([
+            'submitCustomPropertyFormFailure',
+            'setCustomPropertyFormManualErrors',
+        ])
+        expect(logic.values.modalVisible).toBe(true)
+    })
+
+    it('deletes a definition', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic).toDispatchActions(['loadDefinitionsSuccess'])
+        await expectLogic(logic, () => logic.actions.deleteDefinition({ id: 'def-1' }))
+            .toDispatchActions(['deleteDefinitionSuccess'])
+            .toMatchValues({ definitions: [] })
+    })
+})

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -1,0 +1,151 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { forms } from 'kea-forms'
+import { loaders } from 'kea-loaders'
+import posthog from 'posthog-js'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { projectLogic } from 'scenes/projectLogic'
+
+import {
+    customPropertyDefinitionsCreate,
+    customPropertyDefinitionsDestroy,
+    customPropertyDefinitionsList,
+    customPropertyDefinitionsPartialUpdate,
+} from 'products/customer_analytics/frontend/generated/api'
+import type {
+    CustomPropertyDefinitionApi,
+    CustomPropertyDisplayTypeEnumApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
+
+import type { customPropertyDefinitionsLogicType } from './customPropertyDefinitionsLogicType'
+
+export interface CustomPropertyFormValues {
+    name: string
+    description: string
+    displayType: CustomPropertyDisplayTypeEnumApi
+    isBigNumber: boolean
+}
+
+const DEFAULT_FORM_VALUES: CustomPropertyFormValues = {
+    name: '',
+    description: '',
+    displayType: 'text',
+    isBigNumber: false,
+}
+
+export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogicType>([
+    path([
+        'products',
+        'customer_analytics',
+        'frontend',
+        'scenes',
+        'CustomerAnalyticsConfigurationScene',
+        'account',
+        'customPropertyDefinitionsLogic',
+    ]),
+    connect(() => ({
+        values: [projectLogic, ['currentProjectId']],
+    })),
+    actions({
+        openCreateModal: true,
+        openEditModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
+        closeModal: true,
+    }),
+    reducers({
+        modalVisible: [
+            false,
+            {
+                openCreateModal: () => true,
+                openEditModal: () => true,
+                closeModal: () => false,
+            },
+        ],
+        editingDefinition: [
+            null as CustomPropertyDefinitionApi | null,
+            {
+                openCreateModal: () => null,
+                openEditModal: (_, { definition }) => definition,
+                closeModal: () => null,
+            },
+        ],
+    }),
+    loaders(({ values }) => ({
+        definitions: [
+            [] as CustomPropertyDefinitionApi[],
+            {
+                loadDefinitions: async (): Promise<CustomPropertyDefinitionApi[]> => {
+                    const response = await customPropertyDefinitionsList(String(values.currentProjectId))
+                    return response.results
+                },
+                deleteDefinition: async ({ id }: { id: string }): Promise<CustomPropertyDefinitionApi[]> => {
+                    await customPropertyDefinitionsDestroy(String(values.currentProjectId), id)
+                    return values.definitions.filter((definition) => definition.id !== id)
+                },
+            },
+        ],
+    })),
+    forms(({ values }) => ({
+        customPropertyForm: {
+            defaults: DEFAULT_FORM_VALUES,
+            errors: ({ name }: CustomPropertyFormValues) => ({
+                name: !name?.trim() ? 'Name is required' : undefined,
+            }),
+            submit: async ({ name, description, displayType, isBigNumber }: CustomPropertyFormValues) => {
+                const body = {
+                    name: name.trim(),
+                    description: description?.trim() || null,
+                    display_type: displayType,
+                    is_big_number: isBigNumber,
+                }
+                const editing = values.editingDefinition
+                if (editing) {
+                    await customPropertyDefinitionsPartialUpdate(String(values.currentProjectId), editing.id, body)
+                } else {
+                    await customPropertyDefinitionsCreate(String(values.currentProjectId), body)
+                }
+            },
+        },
+    })),
+    listeners(({ actions, values }) => ({
+        openCreateModal: () => {
+            actions.resetCustomPropertyForm()
+        },
+        openEditModal: ({ definition }) => {
+            actions.setCustomPropertyFormValues({
+                name: definition.name,
+                description: definition.description ?? '',
+                displayType: definition.display_type,
+                isBigNumber: definition.is_big_number ?? false,
+            })
+        },
+        submitCustomPropertyFormSuccess: () => {
+            lemonToast.success(values.editingDefinition ? 'Custom property updated' : 'Custom property created')
+            actions.loadDefinitions()
+            actions.closeModal()
+        },
+        submitCustomPropertyFormFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.submit' })
+            if ((error as { status?: number })?.status === 409) {
+                actions.setCustomPropertyFormManualErrors({
+                    name: 'A custom property with this name already exists.',
+                })
+                return
+            }
+            lemonToast.error('Failed to save custom property')
+        },
+        deleteDefinitionSuccess: () => {
+            lemonToast.success('Custom property deleted')
+        },
+        deleteDefinitionFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.delete' })
+            lemonToast.error('Failed to delete custom property')
+        },
+        loadDefinitionsFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.load' })
+            lemonToast.error('Failed to load custom properties')
+        },
+    })),
+    afterMount(({ actions }) => {
+        actions.loadDefinitions()
+    }),
+])

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -18,6 +18,7 @@ import type {
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import type { customPropertyDefinitionsLogicType } from './customPropertyDefinitionsLogicType'
+import { isNumericDisplayType } from './customPropertyTypes'
 
 export interface CustomPropertyFormValues {
     name: string
@@ -95,7 +96,8 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                     name: name.trim(),
                     description: description?.trim() || null,
                     display_type: displayType,
-                    is_big_number: isBigNumber,
+                    // The switch is hidden for non-numeric types, so never send a stale flag for them.
+                    is_big_number: isNumericDisplayType(displayType) ? isBigNumber : false,
                 }
                 const editing = values.editingDefinition
                 if (editing) {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
@@ -1,4 +1,4 @@
-import { DISPLAY_TYPE_OPTIONS, labelForDisplayType } from './customPropertyTypes'
+import { DISPLAY_TYPE_OPTIONS, isNumericDisplayType, labelForDisplayType } from './customPropertyTypes'
 
 describe('customPropertyTypes', () => {
     it('labels each display type with its option label', () => {
@@ -11,5 +11,12 @@ describe('customPropertyTypes', () => {
     it('marks only numeric display types as numeric (drives the big-number switch)', () => {
         const numeric = DISPLAY_TYPE_OPTIONS.filter((option) => option.isNumeric).map((option) => option.value)
         expect(numeric).toEqual(['number', 'currency', 'percent'])
+    })
+
+    it('isNumericDisplayType matches the option metadata', () => {
+        expect(isNumericDisplayType('currency')).toBe(true)
+        expect(isNumericDisplayType('number')).toBe(true)
+        expect(isNumericDisplayType('text')).toBe(false)
+        expect(isNumericDisplayType('boolean')).toBe(false)
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
@@ -1,0 +1,15 @@
+import { DISPLAY_TYPE_OPTIONS, labelForDisplayType } from './customPropertyTypes'
+
+describe('customPropertyTypes', () => {
+    it('labels each display type with its option label', () => {
+        expect(labelForDisplayType('currency')).toBe('Currency')
+        expect(labelForDisplayType('datetime')).toBe('Date & time')
+        expect(labelForDisplayType('text')).toBe('Text')
+        expect(labelForDisplayType('boolean')).toBe('True / false')
+    })
+
+    it('marks only numeric display types as numeric (drives the big-number switch)', () => {
+        const numeric = DISPLAY_TYPE_OPTIONS.filter((option) => option.isNumeric).map((option) => option.value)
+        expect(numeric).toEqual(['number', 'currency', 'percent'])
+    })
+})

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
@@ -21,3 +21,8 @@ export const DISPLAY_TYPE_OPTIONS: DisplayTypeOption[] = [
 export function labelForDisplayType(displayType: CustomPropertyDisplayTypeEnumApi): string {
     return DISPLAY_TYPE_OPTIONS.find((option) => option.value === displayType)?.label ?? displayType
 }
+
+// Drives the big-number switch: it's only shown — and only meaningful in the payload — for numeric types.
+export function isNumericDisplayType(displayType: CustomPropertyDisplayTypeEnumApi): boolean {
+    return DISPLAY_TYPE_OPTIONS.find((option) => option.value === displayType)?.isNumeric ?? false
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
@@ -1,0 +1,23 @@
+import type { CustomPropertyDisplayTypeEnumApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+
+// The backend stores the granular display type directly, so the form value maps 1:1 to the API.
+// This file holds only the UI metadata (label + whether the big-number switch applies).
+export interface DisplayTypeOption {
+    value: CustomPropertyDisplayTypeEnumApi
+    label: string
+    isNumeric: boolean
+}
+
+export const DISPLAY_TYPE_OPTIONS: DisplayTypeOption[] = [
+    { value: 'text', label: 'Text', isNumeric: false },
+    { value: 'number', label: 'Number', isNumeric: true },
+    { value: 'currency', label: 'Currency', isNumeric: true },
+    { value: 'percent', label: 'Percent', isNumeric: true },
+    { value: 'date', label: 'Date', isNumeric: false },
+    { value: 'datetime', label: 'Date & time', isNumeric: false },
+    { value: 'boolean', label: 'True / false', isNumeric: false },
+]
+
+export function labelForDisplayType(displayType: CustomPropertyDisplayTypeEnumApi): string {
+    return DISPLAY_TYPE_OPTIONS.find((option) => option.value === displayType)?.label ?? displayType
+}


### PR DESCRIPTION
## Problem

There's no UI to create, edit, or delete custom account-property definitions.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

Part of https://github.com/PostHog/posthog/issues/60300

## Changes

Frontend only — stacked on #64929 (API, generated types, DB constraint).

- Add a "Custom properties" section to the account configuration scene
- List definitions (name, display type, big-number) in a table
- Create/edit via a modal — name, display type, and a big-number toggle gated to numeric types
- Delete definitions (admin-gated, with a confirm dialog)
- `customPropertyDefinitionsLogic` (kea) drives CRUD through the generated API; `customPropertyTypes` holds the display-type metadata
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

<img width="1661" height="551" alt="image" src="https://github.com/user-attachments/assets/55f28a67-c392-480d-8648-e0c5a5a15f23" />
<img width="462" height="495" alt="image" src="https://github.com/user-attachments/assets/2464ca42-8265-4ac4-aa7e-eaf5b78abf0b" />
<img width="500" height="624" alt="image" src="https://github.com/user-attachments/assets/a50e1e59-63ae-4bfa-a88d-4e8eb06d11eb" />

## How did you test this code?

I'm an agent. Frontend unit tests (jest) — display-type labels and the logic's CRUD listeners (7 pass). Plus agent-driven browser QA on a devbox against the running app on this branch:

| Check | Result |
|---|---|
| Section renders (admin, flag-gated) | ✅ heading, "New custom property", empty state |
| Create across display types | ✅ form submits, row appears |
| Big-number switch is numeric-only | ✅ shown for Currency, hidden for Text |
| Edit display type | ✅ modal saves the change |
| Empty name | ✅ inline "Name is required" |
| Delete with confirm | ✅ confirm dialog → row removed |
| Adjacent regression | ✅ Customer analytics Accounts list still loads |
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @arthurdedeus, authored with PostHog Code. UI half of the feature; the backend (API, generated types, DB constraint) is #64929 and this is stacked on it — merge that first. Skills invoked: `/adopting-generated-api-types`, `/pr-description`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
