### PR TITLE
feat(lemon-ui): flip DatePicker seam to Quill behind a feature flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -336,6 +336,14 @@ snapshots:
         hash: v1.k794b7964.1edeb2b451c40f4668794b3f0b2ce26310d8de3d86251268e05e29907aefa32f.MQyuYmfzDfAt5PomF5hX-5T6Y8SbwHU1u5WNAZ-sCp8
     components-date-picker--past-only--light:
         hash: v1.k794b7964.55110c91efc330aafd9b3e13aca56ce6f318ab8705b467a4dd17ff8c0d3bcc5c.osuoC2s8h8s0ulbWzM5oSXRHH0B5jQ1uMGoOHoTqSVM
+    components-date-picker--quill-empty--dark:
+        hash: v1.k794b7964.44cfdb6fe956961256a9825c7d7a5cf0c596e937ecfb9994a4e133037ec8d76e.L_ZWqAvhq1iodO1C3KlnycjGH2PFxkGruf577T5Gb9Y
+    components-date-picker--quill-empty--light:
+        hash: v1.k794b7964.d40c13438b057467aa3719c70f62f7f0114635a397b394207833d764431b447a.xVNP5qzKlFD1WLEU_INK1YNK6oiuRQsrZvGNTHfXHKU
+    components-date-picker--quill-with-value--dark:
+        hash: v1.k794b7964.a386afa786ebee7c4470eed750332a620a2002e551a9d1e041af9fa60e1da86c.fNRNWhtJ5aB4iz6iDr19zk9ebcKADccxnYpLFNVY6hU
+    components-date-picker--quill-with-value--light:
+        hash: v1.k794b7964.0786709c470949e8a5dc67bcc19bf9d477336b1bdb122ea1a25bbd4470fa4ec5.XRrbm84hpIwAY_xUGHDELuwXK3N3GLyXPR2uWTIfXHA
     components-date-picker--with-time--dark:
         hash: v1.k794b7964.65c714e51e6bcbb96db62c5287c287106aabc63fc6e2ea9576eeb641956c4463.zD6m1LyQaP5xoQeZEWw-WpPwIojsj6JWX9c4-S3Dl_4
     components-date-picker--with-time--light:

--- a/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
@@ -1,9 +1,12 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { useState } from 'react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { dayjs } from 'lib/dayjs'
 
 import { DatePicker, DatePickerProps } from './DatePicker'
+
+const quillEnabled = { mockDate: '2023-01-26', featureFlags: [FEATURE_FLAGS.QUILL_DATE_PICKER] }
 
 type Story = StoryObj<typeof DatePicker>
 const meta: Meta<typeof DatePicker> = {
@@ -36,3 +39,13 @@ export const WithTime: Story = {
 }
 
 export const PastOnly: Story = { render: () => <Template placeholder="Select a past date" selectionPeriod="past" /> }
+
+export const QuillEmpty: Story = {
+    render: () => <Template placeholder="Select a date" />,
+    parameters: quillEnabled,
+}
+
+export const QuillWithValue: Story = {
+    render: () => <Template value={dayjs('2023-01-15')} clearable />,
+    parameters: quillEnabled,
+}

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -6,6 +6,30 @@ import { dayjs } from 'lib/dayjs'
 
 import { DatePicker, DatePickerProps } from './DatePicker'
 
+function polyfillPointerEventForBaseUI(): void {
+    if (typeof window.PointerEvent === 'undefined') {
+        window.PointerEvent = class extends MouseEvent {} as typeof window.PointerEvent
+    }
+}
+polyfillPointerEventForBaseUI()
+
+let mockQuillDatePickerFlag = false
+jest.mock('lib/hooks/useFeatureFlag', () => ({
+    useFeatureFlag: () => mockQuillDatePickerFlag,
+}))
+
+const QUILL_STUB_DATE = new Date(2023, 0, 20)
+jest.mock('@posthog/quill-components', () => {
+    const react = require('react')
+    return {
+        DatePicker: ({ onApply, onCancel }: { onApply: (value: Date) => void; onCancel: () => void }) =>
+            react.createElement('div', null, [
+                react.createElement('button', { key: 'apply', onClick: () => onApply(QUILL_STUB_DATE) }, 'stub-apply'),
+                react.createElement('button', { key: 'cancel', onClick: onCancel }, 'stub-cancel'),
+            ]),
+    }
+})
+
 const renderDatePicker = (
     initialValue: dayjs.Dayjs | null = null,
     props: Partial<DatePickerProps> = {}
@@ -31,6 +55,10 @@ const renderDatePicker = (
 }
 
 describe('DatePicker', () => {
+    beforeEach(() => {
+        mockQuillDatePickerFlag = false
+    })
+
     it.each([
         ['the placeholder when there is no value', null, { placeholder: 'Pick a day' }, 'Pick a day'],
         ['the selected value with the default format', dayjs('2023-01-15'), {}, 'January 15, 2023'],
@@ -59,5 +87,46 @@ describe('DatePicker', () => {
         await userEvent.click(within(container).getByLabelText('Clear date'))
 
         expect(onChange).toHaveBeenCalledWith(null)
+    })
+
+    describe('when the QUILL_DATE_PICKER flag is enabled', () => {
+        beforeEach(() => {
+            mockQuillDatePickerFlag = true
+        })
+
+        it('renders the Quill trigger for the simple single-date case', () => {
+            const { container } = renderDatePicker(dayjs('2023-01-15'))
+
+            expect(container.querySelector('[data-quill]')).toBeTruthy()
+            expect(within(container).getByText('January 15, 2023')).toBeTruthy()
+        })
+
+        it.each<[string, Partial<DatePickerProps>]>([
+            ['granularity', { granularity: 'minute' }],
+            ['selectionPeriod', { selectionPeriod: 'past' }],
+            ['months', { months: 2 }],
+        ])('falls back to LemonUI when %s is requested', (_name, props) => {
+            const { container } = renderDatePicker(dayjs('2023-01-15'), props)
+
+            expect(container.querySelector('[data-quill]')).toBeNull()
+        })
+
+        it('applying a date in the Quill panel calls onChange with a dayjs value', async () => {
+            const { container, onChange } = renderDatePicker(dayjs('2023-01-15'))
+
+            await userEvent.click(within(container).getByText('January 15, 2023'))
+            await userEvent.click(await screen.findByText('stub-apply'))
+
+            expect(onChange).toHaveBeenCalledTimes(1)
+            expect(onChange.mock.calls[0][0].format('YYYY-MM-DD')).toBe('2023-01-20')
+        })
+
+        it('clears to null via the trigger clear control when clearable', async () => {
+            const { container, onChange } = renderDatePicker(dayjs('2023-01-15'), { clearable: true })
+
+            await userEvent.click(within(container).getByLabelText('Clear'))
+
+            expect(onChange).toHaveBeenCalledWith(null)
+        })
     })
 })

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -19,15 +19,26 @@ jest.mock('lib/hooks/useFeatureFlag', () => ({
 }))
 
 const QUILL_STUB_DATE = new Date(2023, 0, 20)
+const mockQuillPanelProps: { maxDate?: Date } = {}
 jest.mock('@posthog/quill', () => {
     const react = require('react')
     return {
         ...jest.requireActual('@posthog/quill'),
-        DatePicker: ({ onApply, onCancel }: { onApply: (value: Date) => void; onCancel: () => void }) =>
-            react.createElement('div', null, [
+        DatePicker: ({
+            onApply,
+            onCancel,
+            maxDate,
+        }: {
+            onApply: (value: Date) => void
+            onCancel: () => void
+            maxDate?: Date
+        }) => {
+            mockQuillPanelProps.maxDate = maxDate
+            return react.createElement('div', null, [
                 react.createElement('button', { key: 'apply', onClick: () => onApply(QUILL_STUB_DATE) }, 'stub-apply'),
                 react.createElement('button', { key: 'cancel', onClick: onCancel }, 'stub-cancel'),
-            ]),
+            ])
+        },
     }
 })
 
@@ -120,6 +131,16 @@ describe('DatePicker', () => {
 
             expect(onChange).toHaveBeenCalledTimes(1)
             expect(onChange.mock.calls[0][0].format('YYYY-MM-DD')).toBe('2023-01-20')
+        })
+
+        it('forwards maxDate to the Quill panel so future dates can be selected', async () => {
+            const max = dayjs('2024-01-15')
+            const { container } = renderDatePicker(dayjs('2023-01-15'), { maxDate: max })
+
+            await userEvent.click(within(container).getByText('January 15, 2023'))
+            await screen.findByText('stub-apply')
+
+            expect(mockQuillPanelProps.maxDate?.getTime()).toBe(max.toDate().getTime())
         })
 
         it('clears to null via the trigger clear control when clearable', async () => {

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -19,9 +19,10 @@ jest.mock('lib/hooks/useFeatureFlag', () => ({
 }))
 
 const QUILL_STUB_DATE = new Date(2023, 0, 20)
-jest.mock('@posthog/quill-components', () => {
+jest.mock('@posthog/quill', () => {
     const react = require('react')
     return {
+        ...jest.requireActual('@posthog/quill'),
         DatePicker: ({ onApply, onCancel }: { onApply: (value: Date) => void; onCancel: () => void }) =>
             react.createElement('div', null, [
                 react.createElement('button', { key: 'apply', onClick: () => onApply(QUILL_STUB_DATE) }, 'stub-apply'),
@@ -124,7 +125,7 @@ describe('DatePicker', () => {
         it('clears to null via the trigger clear control when clearable', async () => {
             const { container, onChange } = renderDatePicker(dayjs('2023-01-15'), { clearable: true })
 
-            await userEvent.click(within(container).getByLabelText('Clear'))
+            await userEvent.click(within(container).getByLabelText('Clear date'))
 
             expect(onChange).toHaveBeenCalledWith(null)
         })

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -1,12 +1,23 @@
+import { useState } from 'react'
+
+import { IconCalendar, IconX } from '@posthog/icons'
+import { DatePicker as QuillDatePicker } from '@posthog/quill-components'
+import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill-primitives'
+
 import { dayjs } from 'lib/dayjs'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonCalendarSelectInput, LemonCalendarSelectInputProps } from 'lib/lemon-ui/LemonCalendar/LemonCalendarSelect'
 
 /**
  * Design-system-agnostic single-date picker — the migration seam between the LemonUI
  * calendar family and Quill's DateTimePicker. Callers depend on this dayjs-facing API;
  * the internal rendering swaps from LemonUI to Quill in one place without touching callers.
- * That swap should land behind a feature flag so LemonUI and Quill can run side by side
- * and roll back without a revert.
+ *
+ * The swap is gated by the `QUILL_DATE_PICKER` feature flag so LemonUI and Quill run side
+ * by side and roll back without a revert. The Quill panel does not yet cover the whole
+ * feature surface, so `quillCanRender` falls back to LemonUI whenever a request needs a
+ * capability Quill is missing (time, selection windows, multi-month, controlled
+ * visibility). Each Quill panel increment removes one fallback condition.
  *
  * Trigger concerns (placeholder, clearable, format, ...) live here by design — Quill
  * separates the trigger from the picker panel, so the wrapper owns the trigger.
@@ -57,7 +68,86 @@ export interface DatePickerProps {
     'data-attr'?: string
 }
 
-export function DatePicker({
+const QUILL_TRIGGER_FORMAT = 'MMMM D, YYYY'
+
+function quillCanRender(props: DatePickerProps): boolean {
+    return (
+        props.granularity === undefined &&
+        props.selectionPeriod === undefined &&
+        props.showTimeToggle === undefined &&
+        props.use24HourFormat === undefined &&
+        props.months === undefined &&
+        props.visible === undefined
+    )
+}
+
+export function DatePicker(props: DatePickerProps): JSX.Element {
+    const quillEnabled = useFeatureFlag('QUILL_DATE_PICKER')
+    if (quillEnabled && quillCanRender(props)) {
+        return <DatePickerQuill {...props} />
+    }
+    return <DatePickerLemon {...props} />
+}
+
+function DatePickerQuill({
+    value,
+    onChange,
+    placeholder,
+    clearable,
+    format,
+    fullWidth = true,
+    disabledReason,
+    'data-attr': dataAttr,
+}: DatePickerProps): JSX.Element {
+    const [open, setOpen] = useState(false)
+    const label = value ? value.format(format ?? QUILL_TRIGGER_FORMAT) : (placeholder ?? 'Select date')
+
+    const applyDate = (next: Date): void => {
+        onChange(dayjs(next))
+        setOpen(false)
+    }
+
+    return (
+        <div className={fullWidth ? 'flex w-full items-center gap-1' : 'flex items-center gap-1'}>
+            <Popover open={open} onOpenChange={setOpen}>
+                <PopoverTrigger
+                    render={
+                        <Button
+                            variant="outline"
+                            data-attr={dataAttr}
+                            data-quill
+                            disabled={!!disabledReason}
+                            title={disabledReason}
+                            className={fullWidth ? 'w-full justify-start' : 'justify-start'}
+                        >
+                            <IconCalendar />
+                            {label}
+                        </Button>
+                    }
+                />
+                <PopoverContent align="start" className="w-auto p-0">
+                    <QuillDatePicker
+                        value={value ? value.toDate() : new Date()}
+                        onApply={applyDate}
+                        onCancel={() => setOpen(false)}
+                    />
+                </PopoverContent>
+            </Popover>
+            {clearable && value && !disabledReason && (
+                <Button
+                    variant="outline"
+                    aria-label="Clear"
+                    data-attr={dataAttr ? `${dataAttr}-clear` : undefined}
+                    onClick={() => onChange(null)}
+                >
+                    <IconX />
+                </Button>
+            )}
+        </div>
+    )
+}
+
+function DatePickerLemon({
     value,
     onChange,
     granularity,

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -46,6 +46,8 @@ export interface DatePickerProps {
     use24HourFormat?: boolean
     /** Number of calendar months to render side by side. */
     months?: number
+    /** Latest selectable date. Bounds the Quill panel; when omitted Quill caps at today, so future-date callers must pass this. The LemonUI fallback has no equivalent and stays unbounded above. */
+    maxDate?: dayjs.Dayjs
     /** Placeholder shown on the trigger when no value is set. */
     placeholder?: string
     /** Show a clear affordance on the trigger to reset the value to null. */
@@ -99,6 +101,7 @@ function DatePickerQuill({
     format,
     fullWidth = true,
     disabledReason,
+    maxDate,
     'data-attr': dataAttr,
 }: DatePickerProps): JSX.Element {
     const [open, setOpen] = useState(false)
@@ -130,6 +133,7 @@ function DatePickerQuill({
                 <PopoverContent align="start" className="w-auto p-0">
                     <QuillDatePicker
                         value={value ? value.toDate() : new Date()}
+                        maxDate={maxDate?.toDate()}
                         onApply={applyDate}
                         onCancel={() => setOpen(false)}
                     />

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -1,8 +1,7 @@
 import { useState } from 'react'
 
 import { IconCalendar, IconX } from '@posthog/icons'
-import { DatePicker as QuillDatePicker } from '@posthog/quill-components'
-import { Button, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill-primitives'
+import { Button, DatePicker as QuillDatePicker, Popover, PopoverContent, PopoverTrigger } from '@posthog/quill'
 
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -77,7 +76,10 @@ function quillCanRender(props: DatePickerProps): boolean {
         props.showTimeToggle === undefined &&
         props.use24HourFormat === undefined &&
         props.months === undefined &&
-        props.visible === undefined
+        props.visible === undefined &&
+        props.onOpen === undefined &&
+        props.onClickOutside === undefined &&
+        props.onClose === undefined
     )
 }
 
@@ -136,7 +138,7 @@ function DatePickerQuill({
             {clearable && value && !disabledReason && (
                 <Button
                     variant="outline"
-                    aria-label="Clear"
+                    aria-label="Clear date"
                     data-attr={dataAttr ? `${dataAttr}-clear` : undefined}
                     onClick={() => onChange(null)}
                 >

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -280,13 +280,13 @@ export const FEATURE_FLAGS = {
     DATA_MODELING_MULTI_DAG: 'data-modeling-multi-dag', // owner: #team-data-modeling
     DATA_MODELING_TAB: 'data-modeling-tab', // owner: #team-data-modeling
     DATA_WAREHOUSE_SCENE: 'data-warehouse-scene', // owner: #team-data-modeling
+    DATA_WAREHOUSE_SEMANTIC_ENRICHMENT: 'data-warehouse-semantic-enrichment', // owner: #team-warehouse-sources
     DEFAULT_EVALUATION_ENVIRONMENTS: 'default-evaluation-environments', // owner: @dmarticus #team-feature-flags
     DROP_PERSON_LIST_ORDER_BY: 'drop-person-list-order-by', // owner: @arthurdedeus #team-customer-analytics
     DWH_JOIN_TABLE_PREVIEW: 'dwh-join-table-preview', // owner: @arthurdedeus #team-customer-analytics
     DWH_POSTGRES_CDC: 'dwh-postgres-cdc', // owner: #team-warehouse-sources
     DWH_POSTGRES_XMIN: 'dwh-postgres-xmin', // owner: #team-warehouse-sources
     DWH_SOURCE_METRICS: 'dwh-source-metrics', // owner: #team-warehouse-sources
-    DATA_WAREHOUSE_SEMANTIC_ENRICHMENT: 'data-warehouse-semantic-enrichment', // owner: #team-warehouse-sources
     EDITOR_DRAFTS: 'editor-drafts', // owner: @EDsCODE #team-data-tools
     ENDPOINTS: 'embedded-analytics', // owner: @sakce #team-clickhouse
     ENGINEERING_ANALYTICS: 'engineering-analytics', // owner: #team-devex
@@ -437,6 +437,7 @@ export const FEATURE_FLAGS = {
     PROMOTED_PRODUCT: 'promoted-product', // owner: @pauldambra #team-growth multivariate=control,control_b,intent,intent_plus, experiment for surfacing the team's primary onboarding product directly under Home
     PROPERTY_ACCESS_CONTROL: 'property-access-control', // owner: @reecejones #team-platform-features
     QUICK_START_PULSE_INDICATOR: 'quick-start-pulse-indicator', // owner: @fercgomes #team-growth multivariate=control,test
+    QUILL_DATE_PICKER: 'quill-date-picker', // owner: @pauldambra, flips the lib/components/DatePicker seam from LemonUI to Quill
     RBAC_UI_REDESIGN: 'rbac-ui-redesign', // owner: @reece #team-platform-features
     READ_ONLY_MODE: 'read-only-mode', // owner: @pauldambra, experiment: force users into read-only and steer mutations through Max/MCP
     REAL_TIME_NOTIFICATIONS: 'real-time-notifications', // owner: #team-platform-features

--- a/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/BatchExportEditForm.tsx
@@ -2,6 +2,7 @@ import { IconInfo } from '@posthog/icons'
 import { LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
 
 import { DatePicker } from 'lib/components/DatePicker/DatePicker'
+import { dayjs } from 'lib/dayjs'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 
 import { DESTINATIONS } from './destinations'
@@ -42,6 +43,7 @@ export function BatchExportGeneralEditFields({
                                 onChange={onChange}
                                 placeholder="Select end date (optional)"
                                 clearable
+                                maxDate={dayjs().add(5, 'year')}
                             />
                         )}
                     </LemonField>

--- a/products/visual_review/frontend/components/QuarantineAction.tsx
+++ b/products/visual_review/frontend/components/QuarantineAction.tsx
@@ -213,7 +213,13 @@ export function QuarantineAction({
 
                     <div>
                         <label className="text-sm font-medium mb-1 block">{copy.expiresLabel}</label>
-                        <DatePicker value={expiresAt} onChange={setExpiresAt} placeholder="No expiry" clearable />
+                        <DatePicker
+                            value={expiresAt}
+                            onChange={setExpiresAt}
+                            placeholder="No expiry"
+                            clearable
+                            maxDate={dayjs().add(1, 'year')}
+                        />
                     </div>
                 </div>
             </LemonModal>


### PR DESCRIPTION
## Problem

The LemonUI->Quill date-picker migration needs a route that moves callers without rewriting each one twice. Phases 0-2 built that route: the hook decoupling, the dayjs-facing `DatePicker` seam (LemonUI inside), the Quill single-date `DatePicker`, and its tests. This is Phase 3 — the keystone that actually flips the seam's internals from LemonUI to Quill, proving the whole route end to end.

## Changes

The seam (`lib/components/DatePicker`) now renders the Quill `DatePicker` panel — with its own trigger + popover and dayjs<->Date conversion — when the `QUILL_DATE_PICKER` feature flag is on. Callers are untouched; they still speak the same dayjs-facing API.

The flip is **capability-gated**, not all-or-nothing. `quillCanRender` falls back to LemonUI whenever a request needs a feature the Quill panel does not cover yet (time granularity, past/upcoming selection windows, multi-month, controlled visibility). So with the flag on, the simple single-date callers get Quill while richer callers stay on LemonUI — and each later Quill panel increment removes one fallback condition. Roll out is therefore incremental and reversible (flag off reverts with no code change).

Trigger/popover/Button follow the established `McpDateFilter` pattern (Base UI `render` prop, quill primitives). Two storybook stories (`QuillEmpty`, `QuillWithValue`) render the flag-on branch via the `featureFlags` story parameter so visual review covers it.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). Automated tests I actually ran:

- `frontend/src/lib/components/DatePicker/DatePicker.test.tsx` — 11 tests green, covering **both** branches: flag-off keeps the existing LemonUI behaviour; flag-on renders the Quill trigger, falls back to LemonUI for `granularity`/`selectionPeriod`/`months`, forwards the panel's apply to `onChange` as a dayjs value, and clears to null.
- `tsc --noEmit -p frontend/tsconfig.json` — no errors in the touched files.
- `pnpm --filter=@posthog/frontend format` — clean.

I did not manually drive the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed the migration; assigned as DRI.

Tooling: PostHog Code (Opus). Skill invoked: `/setting-feature-flags-in-storybook` (to add the flag-gated stories via the `featureFlags` parameter rather than setting flags imperatively).

Decisions worth flagging for review:
- **Capability fallback over a hard cutover.** Rather than block the flag until Quill reaches full parity, `quillCanRender` lets the flag light up the simple case now and fall back to LemonUI for the rest. Keeps each future panel increment small and independently shippable.
- **Sibling-component reality.** Quill's `DatePicker` is panel-only (no trigger), so the seam owns the trigger + popover — matching how Quill separates trigger from panel and how `McpDateFilter` already consumes it.
- **Unit-test boundary.** The seam test stubs the Quill panel at the module boundary so it tests the seam's wiring (apply -> onChange, Date->dayjs, close), not the calendar internals (those are covered in quill-components' own tests). The stub also sidesteps a pre-existing jest/babel quirk where the `@posthog/quill-components` barrel resolves the `DatePicker` re-export to `undefined` under the test transform — the real build and `tsc` resolve it fine via the package types/dist. Worth a follow-up for the quill team, but out of scope here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*