### PR TITLE
feat(quill): decouple include-time toggle from initial time in DatePicker

### DIFF
--- a/packages/quill/packages/components/AGENTS.md
+++ b/packages/quill/packages/components/AGENTS.md
@@ -77,14 +77,17 @@ import { DatePicker } from '@posthog/quill-components'
   minDate={minDate}
   maxDate={new Date()}
   dateFormat="MDY" // or 'DMY' | 'YMD'
-  showTime // adds hour/minute inputs + an "Include time" toggle
+  showTime // include time in the value initially (hour/minute inputs shown)
+  showTimeToggle // render the "Include time" toggle; defaults to showTime. false = fixed precision
+  onIncludeTimeChange={(includeTime) => ...} // fired when the toggle flips
 />
 ```
 
 Rules:
 
 - `value`/`onApply` are a single `Date`, not `{ start, end, range }`. Use this for the single-date PostHog callers (currently `LemonCalendarSelect`); reach for `DateTimePicker` only when you need a start→end range.
-- Without `showTime` the applied value is floored to start-of-day. With `showTime`, the "Include time" toggle decides whether the applied value keeps its hour/minute or is floored.
+- `showTime` seeds whether time is included; `showTimeToggle` (defaults to `showTime`) decides whether the "Include time" toggle renders. Set `showTimeToggle={false}` with `showTime` for a fixed time precision (no opt-out); pass `showTimeToggle` alone to start date-only but let the user add time. `onIncludeTimeChange` reports toggle changes so a wrapper can mirror the state (e.g. to update a trigger label).
+- Without time included the applied value is floored to start-of-day; with it, the value keeps its hour/minute.
 - Shares the calendar grid and `minDate`/`maxDate` day-granular bounds with `DateTimePicker` (both render `Calendar` from `calendar-grid.tsx`).
 - Always a single calendar; there is no `compact`/dual-calendar mode.
 

--- a/packages/quill/packages/components/src/date-picker.stories.tsx
+++ b/packages/quill/packages/components/src/date-picker.stories.tsx
@@ -40,6 +40,14 @@ export const WithTime: Story = {
     },
 }
 
+export const FixedTime: Story = {
+    args: baseArgs,
+    render: () => {
+        const [value, setValue] = React.useState<Date>(initialValue)
+        return <DatePicker value={value} onApply={setValue} showTime showTimeToggle={false} />
+    },
+}
+
 export const InPopover: Story = {
     args: baseArgs,
     render: () => {

--- a/packages/quill/packages/components/src/date-picker.test.tsx
+++ b/packages/quill/packages/components/src/date-picker.test.tsx
@@ -49,6 +49,45 @@ describe('DatePicker', () => {
         expect([applied.getDate(), applied.getHours(), applied.getMinutes()]).toEqual([15, 0, 0])
     })
 
+    it.each([
+        ['off by default', {}, false],
+        ['on when showTime is set', { showTime: true }, true],
+        ['on when showTimeToggle is set without showTime', { showTimeToggle: true }, true],
+        ['off when showTimeToggle is false despite showTime', { showTime: true, showTimeToggle: false }, false],
+    ])('renders the include-time toggle %s', (_name, props, expected) => {
+        render(<DatePicker value={VALUE} maxDate={MAX} onApply={jest.fn()} {...props} />)
+
+        expect(!!screen.queryByRole('switch', { name: 'Include time' })).toBe(expected)
+    })
+
+    it('keeps time with no toggle when showTimeToggle is false', async () => {
+        const onApply = jest.fn()
+        render(<DatePicker value={VALUE} maxDate={MAX} showTime showTimeToggle={false} onApply={onApply} />)
+
+        await userEvent.click(screen.getByLabelText('Select Jan 20, 2023'))
+        await userEvent.click(screen.getByLabelText('Apply date'))
+
+        const applied: Date = onApply.mock.calls[0][0]
+        expect([applied.getDate(), applied.getHours(), applied.getMinutes()]).toEqual([20, 10, 30])
+    })
+
+    it('reports toggle changes through onIncludeTimeChange', async () => {
+        const onIncludeTimeChange = jest.fn()
+        render(
+            <DatePicker
+                value={VALUE}
+                maxDate={MAX}
+                showTime
+                onIncludeTimeChange={onIncludeTimeChange}
+                onApply={jest.fn()}
+            />
+        )
+
+        await userEvent.click(screen.getByRole('switch', { name: 'Include time' }))
+
+        expect(onIncludeTimeChange).toHaveBeenCalledWith(false)
+    })
+
     it('disables calendar days before minDate', () => {
         render(<DatePicker value={VALUE} minDate={new Date(2023, 0, 10)} maxDate={MAX} onApply={jest.fn()} />)
 

--- a/packages/quill/packages/components/src/date-picker.tsx
+++ b/packages/quill/packages/components/src/date-picker.tsx
@@ -29,8 +29,12 @@ export interface DatePickerProps {
     dateFormat?: DateFormatOrder
     weekStartsOn?: Day
     onDateTimeSettings?: () => void
-    /** Show hour/minute inputs and an "Include time" toggle. When off, the value is floored to the start of the day. */
+    /** Include time in the value initially. When off, the value is floored to the start of the day. */
     showTime?: boolean
+    /** Render the "Include time" toggle so the user can switch time on and off. Defaults to `showTime`. Set false for a fixed precision. */
+    showTimeToggle?: boolean
+    /** Fired when the "Include time" toggle changes. */
+    onIncludeTimeChange?: (includeTime: boolean) => void
     className?: string
 }
 
@@ -45,6 +49,8 @@ export function DatePicker({
     weekStartsOn,
     onDateTimeSettings,
     showTime = false,
+    showTimeToggle = showTime,
+    onIncludeTimeChange,
     className,
 }: DatePickerProps): React.ReactElement {
     const maxDate = maxDateProp ?? new Date()
@@ -75,6 +81,11 @@ export function DatePicker({
         }
         setSelected(clamped)
         setViewing(new Date(getYear(clamped), getMonth(clamped), 1))
+    }
+
+    const handleIncludeTimeChange = (next: boolean): void => {
+        setIncludeTime(next)
+        onIncludeTimeChange?.(next)
     }
 
     const handleApply = (): void => {
@@ -144,11 +155,11 @@ export function DatePicker({
                 />
             </div>
 
-            {showTime && (
+            {showTimeToggle && (
                 <div className="flex items-center gap-2 px-3 py-1.5 border-t border-border">
                     <Switch
                         checked={includeTime}
-                        onCheckedChange={setIncludeTime}
+                        onCheckedChange={handleIncludeTimeChange}
                         aria-label="Include time"
                         id={includeTimeId}
                         data-attr="date-picker-include-time"


### PR DESCRIPTION
## Problem

Phase 2 follow-up for the LemonUI->Quill date-picker migration. The seam needs to map LemonUI's `granularity="minute"` (a fixed time precision, no opt-out) onto Quill's `DatePicker`, but Quill couldn't express it: the `showTime` prop conflated *two* concerns into one — whether the value includes time initially, **and** whether the "Include time" toggle is rendered (`{showTime && <toggle/>}`). So you could not have "time on, no toggle".

This is the most-needed panel gap: across the remaining single-date callers, `granularity="minute"` is by far the most common advanced prop.

## Changes

Split the two concerns:
- `showTime` (unchanged) seeds the initial include-time state.
- `showTimeToggle` (new, **defaults to `showTime`**) controls whether the toggle renders. Set it `false` for a fixed precision.
- `onIncludeTimeChange` (new) reports toggle changes so a wrapper can mirror its own state.

The default keeps every existing usage identical (the toggle still appears whenever `showTime` is on), so this is purely additive.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). Automated tests I ran:

- `packages/quill/packages/components/src/date-picker.test.tsx` — 11 green, including a parameterized matrix of toggle visibility (off by default, on via `showTime`, on via `showTimeToggle` alone, off when `showTimeToggle={false}` despite `showTime`), the fixed-time apply path, and `onIncludeTimeChange`.
- `pnpm --filter=@posthog/quill-components build` — green (dts + bundle).
- Added a `FixedTime` storybook story for visual coverage.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed the migration; assigned as DRI.

Stacked on #65102 (the quill-components jest/RTL infra) because the new test needs that harness. When #65102 merges, this PR's base retargets to master.

Tooling: PostHog Code (Opus). This is the first "close a panel gap" increment; the companion seam change (mapping `granularity`/`showTimeToggle` and shrinking `quillCanRender`) follows on top of the Phase 3 flip (#65519).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*