### PR TITLE
fix(insights): humanize event name in stickiness actors modal

### DIFF
--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -113,7 +113,8 @@ describe('StickinessBarChart', () => {
             { timeout: 5000 }
         )
         expect(personsModal.title()).toMatch(/Stickiness on day 3/)
-        expect(personsModal.title()).toMatch(/Pageview/i)
+        // Case-sensitive: the core event must be humanized ("Pageview"), not the raw "$pageview".
+        expect(personsModal.title()).toMatch(/Pageview/)
     })
 
     it('click → context.onDataPointClick fires with the integer day instead of opening the modal', async () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.test.tsx
@@ -101,7 +101,7 @@ describe('StickinessBarChart', () => {
         expect(screen.queryByRole('img', { name: /chart with/i })).not.toBeInTheDocument()
     })
 
-    it('click → persons modal: opens with a "Stickiness on {interval} {day}" title', async () => {
+    it('click → persons modal: opens with a "stickiness on {interval} {day}" title', async () => {
         renderInsight({ query: stickinessBar() })
 
         await chart.clickAtIndex(2)
@@ -112,7 +112,7 @@ describe('StickinessBarChart', () => {
             },
             { timeout: 5000 }
         )
-        expect(personsModal.title()).toMatch(/Stickiness on day 3/)
+        expect(personsModal.title()).toMatch(/stickiness on day 3/)
         // Case-sensitive: the core event must be humanized ("Pageview"), not the raw "$pageview".
         expect(personsModal.title()).toMatch(/Pageview/)
     })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -97,7 +97,8 @@ describe('StickinessLineChart', () => {
             })
             // The clicked bucket is index 2, days are 1-indexed in the mock, so day == 3.
             expect(personsModal.title()).toMatch(/Stickiness on day 3/)
-            expect(personsModal.title()).toMatch(/Pageview/i)
+            // Case-sensitive: the core event must be humanized ("Pageview"), not the raw "$pageview".
+            expect(personsModal.title()).toMatch(/Pageview/)
         })
 
         it('fires context.onDataPointClick with the integer day instead of opening the modal', async () => {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.test.tsx
@@ -87,7 +87,7 @@ describe('StickinessLineChart', () => {
     })
 
     describe('click → persons modal', () => {
-        it('opens the modal with a "Stickiness on {interval} {day}" title', async () => {
+        it('opens the modal with a "stickiness on {interval} {day}" title', async () => {
             renderInsight({ query: buildStickinessQuery() })
 
             await chart.clickAtIndex(2)
@@ -96,7 +96,7 @@ describe('StickinessLineChart', () => {
                 expect(personsModal.get()).toBeInTheDocument()
             })
             // The clicked bucket is index 2, days are 1-indexed in the mock, so day == 3.
-            expect(personsModal.title()).toMatch(/Stickiness on day 3/)
+            expect(personsModal.title()).toMatch(/stickiness on day 3/)
             // Case-sensitive: the core event must be humanized ("Pageview"), not the raw "$pageview".
             expect(personsModal.title()).toMatch(/Pageview/)
         })

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
@@ -82,8 +82,9 @@ describe('handleStickinessChartClick', () => {
         handleStickinessChartClick(keyFor(trendResult), 2, deps)
 
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
-        // PropertyKeyInfo wraps the raw label; the label text itself surfaces in textContent.
-        expect(container.textContent).toContain('$pageview')
+        // PropertyKeyInfo humanizes the core event name, so "$pageview" surfaces as "Pageview".
+        expect(container.textContent).toContain('Pageview')
+        expect(container.textContent).not.toContain('$pageview')
         expect(container.textContent).toContain('Stickiness on day 3')
     })
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.test.tsx
@@ -74,7 +74,7 @@ describe('handleStickinessChartClick', () => {
         expect(call.orderBy).toBeUndefined()
     })
 
-    it('renders a "Stickiness on {interval} {day}" title with the series label', () => {
+    it('renders a "stickiness on {interval} {day}" title with the series label', () => {
         const openPersonsModal = jest.fn()
         const trendResult = makeTrendResult({ label: '$pageview' })
         const deps = makeDeps({ openPersonsModal, interval: 'day', indexedResults: [trendResult] })
@@ -85,7 +85,7 @@ describe('handleStickinessChartClick', () => {
         // PropertyKeyInfo humanizes the core event name, so "$pageview" surfaces as "Pageview".
         expect(container.textContent).toContain('Pageview')
         expect(container.textContent).not.toContain('$pageview')
-        expect(container.textContent).toContain('Stickiness on day 3')
+        expect(container.textContent).toContain('stickiness on day 3')
     })
 
     it('uses "day" as the default interval when interval is null', () => {
@@ -96,7 +96,7 @@ describe('handleStickinessChartClick', () => {
         handleStickinessChartClick(keyFor(trendResult), 0, deps)
 
         const { container } = render(<>{openPersonsModal.mock.calls[0][0].title}</>)
-        expect(container.textContent).toContain('Stickiness on day 1')
+        expect(container.textContent).toContain('stickiness on day 1')
     })
 
     it.each([

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
@@ -1,4 +1,5 @@
 import { PropertyKeyInfo } from 'lib/components/PropertyKeyInfo'
+import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import type { OpenPersonsModalProps } from 'scenes/trends/persons-modal/PersonsModal'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
@@ -56,7 +57,8 @@ export function handleStickinessChartClick(seriesKey: string, dataIndex: number,
     const label = dataset.label ?? ''
     const title = (
         <>
-            <PropertyKeyInfo value={label} disablePopover /> Stickiness on {deps.interval || 'day'} {day}
+            <PropertyKeyInfo value={label} disablePopover type={TaxonomicFilterGroupType.Events} /> Stickiness on{' '}
+            {deps.interval || 'day'} {day}
         </>
     )
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/handleStickinessChartClick.tsx
@@ -57,7 +57,7 @@ export function handleStickinessChartClick(seriesKey: string, dataIndex: number,
     const label = dataset.label ?? ''
     const title = (
         <>
-            <PropertyKeyInfo value={label} disablePopover type={TaxonomicFilterGroupType.Events} /> Stickiness on{' '}
+            <PropertyKeyInfo value={label} disablePopover type={TaxonomicFilterGroupType.Events} /> stickiness on{' '}
             {deps.interval || 'day'} {day}
         </>
     )


### PR DESCRIPTION
## Problem

In a stickiness insight, clicking a data point opens the actors modal titled **"$pageview Stickiness on day 3"** — the raw event key, not the friendly **"Pageview"** shown everywhere else, including this same chart's hover tooltip. Small, but jarring.

## Changes

- `handleStickinessChartClick` (shared by the stickiness line and bar charts) now renders the series label via `<PropertyKeyInfo … type={TaxonomicFilterGroupType.Events} />`. `PropertyKeyInfo` defaults `type` to `EventProperties`, where `$pageview` doesn't exist, so it fell back to the raw key; the `events` group resolves it to "Pageview". This is the same pattern the funnel persons-modal title already uses (`persons-modal-utils.tsx`). One handler change fixes both chart types.
- Tightened the two `click → persons modal` integration assertions from `/Pageview/i` to case-sensitive `/Pageview/`, so they verify the humanized label instead of passing on the raw `$pageview`.

Follow-up to #65477 (the stickiness tooltip/modal capitalization fix), which merged into master while this was in flight — so this targets master directly.

## How did you test this code?

I'm an agent (Claude Code). The frontend `node_modules` weren't installed in my environment, so I did **not** run the Jest suites locally — CI will. What I did verify:

- `oxfmt --check` passes on all four changed files.
- The taxonomy data: `events["$pageview"].label === "Pageview"`, and `$pageview` is absent from `event_properties` — the exact reason the default `type` failed to humanize.
- Updated the unit test (`handleStickinessChartClick.test.tsx`) to assert the humanized "Pageview" and `.not.toContain('$pageview')`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed — this is a display-string humanization fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked for the stickiness actors-modal title to translate `$pageview` to "Pageview" like the rest of the UI, as a follow-up stacked on #65477. #65477 squash-merged into master mid-task, so the work was rebased onto master and targets it directly.

- Traced the modal title to `handleStickinessChartClick`, which passed the raw series label into `PropertyKeyInfo` with no `type`. `PropertyKeyInfo` defaults to `TaxonomicFilterGroupType.EventProperties`, and `$pageview` only lives in the `events` group — so `getCoreFilterDefinition` returned `null` and it rendered the raw key.
- Chose `type={TaxonomicFilterGroupType.Events}` to match the funnel persons-modal title rather than reshaping the data flow. The fix is idempotent: a non-core label has no `events` definition and falls back unchanged. The bar chart reuses the same handler, so both chart types are fixed by one change.
- Confirmed the chart's own tooltip already humanizes via `InsightLabel` → `formatEventName` → the same taxonomy source, so this just brings the modal in line with it.
- No repo skills were required for this change.
