### PR TITLE
fix(hogql): double embedded backticks when escaping Hog identifiers

### DIFF
--- a/common/hogvm/python/stl/print.py
+++ b/common/hogvm/python/stl/print.py
@@ -15,7 +15,8 @@ escape_chars_map = {
     "\\": "\\\\",
 }
 singlequote_escape_chars_map = {**escape_chars_map, "'": "\\'"}
-backquote_escape_chars_map = {**escape_chars_map, "`": "\\`"}
+# The HogQL/Hog parsers only accept a doubled backtick inside a quoted identifier, not a backslash-escaped one.
+backquote_escape_chars_map = {**escape_chars_map, "`": "``"}
 
 
 # Copied from clickhouse_driver.util.escape_param

--- a/common/hogvm/python/test/test_print.py
+++ b/common/hogvm/python/test/test_print.py
@@ -1,0 +1,29 @@
+from parameterized import parameterized
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr
+
+from common.hogvm.python.stl.print import escape_identifier
+
+
+class TestEscapeIdentifier:
+    def test_doubles_embedded_backtick(self):
+        # The HogQL/Hog parsers only accept a doubled backtick inside a quoted identifier,
+        # never a backslash-escaped one, so the escaper must emit the doubled form.
+        assert escape_identifier("a`b") == "`a``b`"
+
+    @parameterized.expand(
+        [
+            ("plain", "normal_id"),
+            ("space", "a b"),
+            ("single_backtick", "`"),
+            ("embedded_backtick", "a`b"),
+            ("backslash", "a\\b"),
+            ("tab", "a\tb"),
+            ("backtick_and_backslash", "a`\\b"),
+        ]
+    )
+    def test_round_trips_through_parser(self, _name: str, identifier: str) -> None:
+        node = parse_expr(escape_identifier(identifier))
+        assert isinstance(node, ast.Field)
+        assert node.chain == [identifier]

--- a/common/hogvm/typescript/src/__tests__/print.test.ts
+++ b/common/hogvm/typescript/src/__tests__/print.test.ts
@@ -1,0 +1,14 @@
+import { escapeIdentifier } from '../stl/print'
+
+describe('hogvm print', () => {
+    test('escapeIdentifier doubles embedded backticks', () => {
+        // The HogQL/Hog parsers only accept a doubled backtick inside a quoted identifier, never a backslash-escaped one.
+        expect(escapeIdentifier('a`b')).toBe('`a``b`')
+        expect(escapeIdentifier('`')).toBe('````')
+    })
+
+    test('escapeIdentifier leaves simple identifiers unquoted', () => {
+        expect(escapeIdentifier('normal_id')).toBe('normal_id')
+        expect(escapeIdentifier('a b')).toBe('`a b`')
+    })
+})

--- a/common/hogvm/typescript/src/stl/print.ts
+++ b/common/hogvm/typescript/src/stl/print.ts
@@ -17,9 +17,10 @@ const singlequoteEscapeCharsMap: Record<string, string> = {
     "'": "\\'",
 }
 
+// The HogQL/Hog parsers only accept a doubled backtick inside a quoted identifier, not a backslash-escaped one.
 const backquoteEscapeCharsMap: Record<string, string> = {
     ...escapeCharsMap,
-    '`': '\\`',
+    '`': '``',
 }
 
 export function escapeString(value: string): string {

--- a/posthog/cdp/test/__snapshots__/test_site_functions.ambr
+++ b/posthog/cdp/test/__snapshots__/test_site_functions.ambr
@@ -213,7 +213,7 @@
       return `'${value.split('').map((c) => singlequoteEscapeCharsMap[c] || c).join('')}'`;
   }
   function __escapeIdentifier(identifier) {
-      const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '\\`' }
+      const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '``' }
       if (typeof identifier === 'number') return identifier.toString();
       if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier)) return identifier;
       return `\`${identifier.split('').map((c) => backquoteEscapeCharsMap[c] || c).join('')}\``;
@@ -415,7 +415,7 @@
       return `'${value.split('').map((c) => singlequoteEscapeCharsMap[c] || c).join('')}'`;
   }
   function __escapeIdentifier(identifier) {
-      const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '\\`' }
+      const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '``' }
       if (typeof identifier === 'number') return identifier.toString();
       if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier)) return identifier;
       return `\`${identifier.split('').map((c) => backquoteEscapeCharsMap[c] || c).join('')}\``;

--- a/posthog/hogql/compiler/javascript_stl.py
+++ b/posthog/hogql/compiler/javascript_stl.py
@@ -871,7 +871,7 @@ function __escapeString(value) {
     "__escapeIdentifier": [
         """
 function __escapeIdentifier(identifier) {
-    const backquoteEscapeCharsMap = { '\\b': '\\\\b', '\\f': '\\\\f', '\\r': '\\\\r', '\\n': '\\\\n', '\\t': '\\\\t', '\\0': '\\\\0', '\\v': '\\\\v', '\\\\': '\\\\\\\\', '`': '\\\\`' }
+    const backquoteEscapeCharsMap = { '\\b': '\\\\b', '\\f': '\\\\f', '\\r': '\\\\r', '\\n': '\\\\n', '\\t': '\\\\t', '\\0': '\\\\0', '\\v': '\\\\v', '\\\\': '\\\\\\\\', '`': '``' }
     if (typeof identifier === 'number') return identifier.toString();
     if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier)) return identifier;
     return `\\`${identifier.split('').map((c) => backquoteEscapeCharsMap[c] || c).join('')}\\``;

--- a/posthog/models/test/__snapshots__/test_remote_config.ambr
+++ b/posthog/models/test/__snapshots__/test_remote_config.ambr
@@ -330,7 +330,7 @@
               return `'${value.split('').map((c) => singlequoteEscapeCharsMap[c] || c).join('')}'`;
           }
           function __escapeIdentifier(identifier) {
-              const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '\\`' }
+              const backquoteEscapeCharsMap = { '\b': '\\b', '\f': '\\f', '\r': '\\r', '\n': '\\n', '\t': '\\t', '\0': '\\0', '\v': '\\v', '\\': '\\\\', '`': '``' }
               if (typeof identifier === 'number') return identifier.toString();
               if (/^[A-Za-z_$][A-Za-z0-9_$]*$/.test(identifier)) return identifier;
               return `\`${identifier.split('').map((c) => backquoteEscapeCharsMap[c] || c).join('')}\``;


### PR DESCRIPTION
## Problem

The Hog VM's identifier escaper backslash-escaped an embedded backtick (`` \` ``) inside a backtick-quoted identifier, but the HogQL/Hog lexer doesn't accept that form. The `QUOTED_IDENTIFIER` grammar rule only allows a doubled backtick (`` `` ``) to embed one, so `escape_identifier("a`b")` produced `` `a\`b` ``, which the parser rejects with `unrecognised escape '\`' in quoted identifier`. The escaped output couldn't round-trip back through the parser.

This is the Hog-language `print()` / identifier path. It's the same class of bug being fixed for the SQL escapers (`escape_hogql_identifier` / `escape_clickhouse_identifier`) in a separate, not-yet-merged PR; these are independent code paths and can land in either order.

## Changes

Double the embedded backtick instead of backslash-escaping it, across all three parallel copies of the escaper:

| Implementation | File |
|---|---|
| Python STL | `common/hogvm/python/stl/print.py` |
| Canonical TypeScript STL (the Node hogvm runtime) | `common/hogvm/typescript/src/stl/print.ts` |
| JS-compiled twin | `posthog/hogql/compiler/javascript_stl.py` |

Regenerated the two snapshots that embed the compiled JS (`test_site_functions.ambr`, `test_remote_config.ambr`) — the diff is the single map entry on three lines.

The TypeScript copy wasn't in the original bug report, but it's the actual Node runtime and carried the identical bug, so fixing it keeps the three in sync (they're hand-maintained mirrors per the `javascript_stl.py` header TODO).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8); listing only automated tests I actually ran.

- Added a Python round-trip test (`common/hogvm/python/test/test_print.py`) that escapes an identifier and parses it back through the production parser, asserting `chain == [original]`. Confirmed red against the unfixed code (backtick cases failed, incl. the parser `SyntaxError`), green after.
- Added a TypeScript test (`common/hogvm/typescript/src/__tests__/print.test.ts`) asserting the doubled form. Also verified red-green by temporarily reintroducing the bug.
- `test_execute.py` (43 tests) still green; `ruff` and `oxfmt` clean.
- Could not run the two `.ambr`-backed Django suites locally (no DB in this environment). The snapshot change is a deterministic single-token swap that I verified matches the regenerated JS by rendering it in `node`, so CI should find them already correct.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Robbie, implemented with Claude Code (Opus 4.8). No special repo skills were invoked — the work was a targeted escaper fix plus tests and snapshot regeneration.

Key decisions:
- Confirmed the bug against the real grammar (`HogQLLexer.common.g4` `QUOTED_IDENTIFIER`) and the C++ parser (`string.cpp`), which only unescape `` `` `` at the lexer level — `` \` `` can't even be tokenized inside backticks.
- Expanded scope from the two reported files to all three copies of the escaper for consistency; deliberately left `posthog/hogql/escape_sql.py` alone since its fix lives in a separate in-flight PR and touching it here would collide.
- Hand-applied the snapshot edit rather than block on a local DB, after verifying byte-equivalence with the regenerated JS.
