### PR TITLE
chore(inbox): stop showing legacy weight on signal cards

### DIFF
--- a/frontend/src/scenes/inbox/components/signalCards/SignalCardShell.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SignalCardShell.tsx
@@ -1,5 +1,3 @@
-import { LemonTag } from '@posthog/lemon-ui'
-
 import { signalCardSourceLine } from 'lib/signals/signalCardSourceLine'
 import type { SignalNode } from 'scenes/debug/signals/types'
 
@@ -7,21 +5,18 @@ import { getSourceProductMeta } from '../badges/sourceProductIcons'
 
 /**
  * Header shared by every signal card: the source product's brand icon, the human
- * "Product · Signal type" line, an optional label/right slot, and the weight tag.
+ * "Product · Signal type" line, and an optional label/right slot.
  */
 export function SignalCardHeader({
     signal,
     label,
     rightSlot,
-    hideWeight,
 }: {
     signal: SignalNode
     /** Optional bold title shown after the source line (e.g. an entity name). */
     label?: React.ReactNode
-    /** Optional content rendered before the weight tag (e.g. a severity badge). */
+    /** Optional content rendered at the end of the header (e.g. a severity badge). */
     rightSlot?: React.ReactNode
-    /** Hide the weight tag — weight is an internal pipeline knob, not user-facing for every source. */
-    hideWeight?: boolean
 }): JSX.Element {
     const meta = getSourceProductMeta(signal.source_product)
     const Icon = meta?.Icon
@@ -44,11 +39,6 @@ export function SignalCardHeader({
             {label && <span className="text-xs font-medium text-primary flex-1 truncate">{label}</span>}
             <span className="flex-1" />
             {rightSlot}
-            {!hideWeight && (
-                <LemonTag size="small" className="shrink-0">
-                    Weight: {signal.weight.toFixed(1)}
-                </LemonTag>
-            )}
         </div>
     )
 }
@@ -58,18 +48,16 @@ export function SignalCardShell({
     signal,
     label,
     rightSlot,
-    hideWeight,
     children,
 }: {
     signal: SignalNode
     label?: React.ReactNode
     rightSlot?: React.ReactNode
-    hideWeight?: boolean
     children: React.ReactNode
 }): JSX.Element {
     return (
         <div className="border rounded p-3 bg-surface-primary">
-            <SignalCardHeader signal={signal} label={label} rightSlot={rightSlot} hideWeight={hideWeight} />
+            <SignalCardHeader signal={signal} label={label} rightSlot={rightSlot} />
             {children}
         </div>
     )

--- a/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
@@ -141,7 +141,6 @@ export function SignalsScoutSignalCard({ signal }: SignalCardProps): JSX.Element
                 </span>
             }
             rightSlot={<SignalReportPriorityBadge priority={extra.severity} />}
-            hideWeight
         >
             {/* Confidence meter. */}
             <div className="mb-2">


### PR DESCRIPTION
## Problem

The signal cards in the inbox (report detail → Evidence) show a `Weight: X.X` tag. Weight is a legacy internal pipeline knob that's slated for removal, and it shouldn't be surfaced to users.

## Changes

- Remove the `Weight: X.X` `LemonTag` from the shared `SignalCardHeader`.
- Drop the now-dead `hideWeight` prop from `SignalCardHeader` / `SignalCardShell` and the one caller (`SignalsScoutSignalCard`) that passed it.

The `weight` field stays on the `SignalNode` data and types — this only stops it from rendering. `total_weight` on reports was never rendered, so nothing changed there.

## How did you test this code?

I'm an agent. I ran the frontend typecheck (`tsgo --noEmit`) — no new errors in the touched files (remaining errors are pre-existing in unrelated products). No manual UI testing performed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed the change: weight is legacy and should not appear on signal cards. The only user-facing render was the weight tag in `SignalCardHeader`; grep confirmed `hideWeight` had a single caller and `total_weight` is never rendered, so the cleanup removes the tag plus the now-unused prop. Tool used: Claude Code.
