### PR TITLE
fix(max): dedupe provisional human bubble on repeated ask

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -1128,6 +1128,33 @@ describe('maxThreadLogic', () => {
         })
     })
 
+    describe('provisional human bubble dedup', () => {
+        it('does not add a second identical provisional when the ask fires twice before a response', async () => {
+            mockStream()
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation({ agent_mode: null, content: 'What are my most popular pages?' }, 0)
+                logic.actions.streamConversation({ agent_mode: null, content: 'What are my most popular pages?' }, 0)
+            })
+
+            const humanMessages = logic.values.threadRaw.filter((m) => m.type === AssistantMessageType.Human)
+            expect(humanMessages).toHaveLength(1)
+            expect(humanMessages[0].content).toBe('What are my most popular pages?')
+        })
+
+        it('still adds a provisional when the previous human message has different content', async () => {
+            mockStream()
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation({ agent_mode: null, content: 'first question' }, 0)
+                logic.actions.streamConversation({ agent_mode: null, content: 'second question' }, 0)
+            })
+
+            const humanMessages = logic.values.threadRaw.filter((m) => m.type === AssistantMessageType.Human)
+            expect(humanMessages).toHaveLength(2)
+        })
+    })
+
     describe('parallel conversation isolation', () => {
         it('only processes askMax for the active thread, not other mounted threads', async () => {
             const streamSpy = mockStream()

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -686,13 +686,24 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
             // briefly show a duplicate (until the runtime resolves to the SandboxThread) that vanishes
             // on reload, since sandbox turns live in the run log, not the legacy conversation messages.
             if (generationAttempt === 0 && streamData.content && addToThread && !isSandboxConversation) {
-                const message: ThreadMessage = {
-                    type: AssistantMessageType.Human,
-                    content: streamData.content,
-                    status: 'completed',
-                    trace_id: traceId,
+                // Guard against a duplicate provisional bubble when the ask flow fires more than
+                // once before the first response arrives (e.g. maxThreadLogic remounts as the
+                // conversation id resolves and an effect keyed on the askMax action re-issues the
+                // ask): if the most recent message is already an identical human bubble we just
+                // added, skip it so the streamed human echo replaces a single provisional instead
+                // of leaving the earlier one orphaned.
+                const lastMessage = values.threadRaw.at(-1)
+                const isDuplicateProvisional =
+                    !!lastMessage && isHumanMessage(lastMessage) && lastMessage.content === streamData.content
+                if (!isDuplicateProvisional) {
+                    const message: ThreadMessage = {
+                        type: AssistantMessageType.Human,
+                        content: streamData.content,
+                        status: 'completed',
+                        trace_id: traceId,
+                    }
+                    actions.addMessage(message)
                 }
-                actions.addMessage(message)
             }
 
             if (isSandboxConversation) {


### PR DESCRIPTION
## Problem

Max (PostHog AI) renders the user's message twice when the ask flow fires more than once before the first response arrives. On the LangGraph path, `maxThreadLogic` remounts as the conversation id resolves — the thread key flips from the frontend-generated uuid to the real conversation id — and an effect keyed on the `askMax` action reference re-issues the ask. Each ask adds a provisional human bubble; the streamed human echo then replaces only the most recent one, leaving the earlier provisional orphaned. Surfaced as a Storybook visual-review diff on the `Scenes-App/PostHog AI → Thread` story, which shows "What are my most popular pages?" twice.

## Changes

Guard the provisional human-message add in `streamConversation`: if the most recent message is already an identical human bubble we just added, skip adding another. The streamed echo then replaces a single provisional instead of orphaning one. LangGraph-only path; the sandbox echo path is unchanged. This is a bugfix to keep existing LangGraph conversations working (not new LangGraph capability).

## How did you test this code?

I'm an agent (Claude Code) — automated tests only, no manual QA claimed beyond local reproduction.

- Added two unit tests in `maxThreadLogic.test.ts` ("provisional human bubble dedup"): two back-to-back identical asks → a single human bubble; two asks with different content → two bubbles (guards against over-dedup). Both pass via `hogli test frontend/src/scenes/max/maxThreadLogic.test.ts -t "provisional human bubble dedup"`.
- Reproduced the duplicate locally in Storybook and instrumented the ask/stream/dedup flow to confirm the root cause (two provisionals added before the echo; the existing echo dedup replaces only the last).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated by Claude Code at the assignee's direction while triaging a Storybook visual-review diff. Traced the duplicate to `askMax` firing multiple times because the `maxThreadLogic` thread key flips (frontend uuid → conversation id), remounting the logic and re-running a story effect that lists the `askMax` action creator in its dependency array. Confirmed the streamed-echo dedup in `onEventImplementation` is correct — the duplicate originates upstream as two provisional bubbles. Considered stabilizing the thread key itself (rejected: structural change to Max's keying with broad blast radius into history matching and URL sync) and chose the minimal, low-risk guard in the provisional add. No repo skills were invoked.
