### PR TITLE
feat(lemon-ui): map granularity and time toggle in the Quill DatePicker seam

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -340,6 +340,10 @@ snapshots:
         hash: v1.k794b7964.44cfdb6fe956961256a9825c7d7a5cf0c596e937ecfb9994a4e133037ec8d76e.L_ZWqAvhq1iodO1C3KlnycjGH2PFxkGruf577T5Gb9Y
     components-date-picker--quill-empty--light:
         hash: v1.k794b7964.d40c13438b057467aa3719c70f62f7f0114635a397b394207833d764431b447a.xVNP5qzKlFD1WLEU_INK1YNK6oiuRQsrZvGNTHfXHKU
+    components-date-picker--quill-with-time--dark:
+        hash: v1.k794b7964.e950dcbe0b3f41c2f21f8a0afbed936e92ebf6e262a3159dcfcab4a0ef3e7f77.McDUOn-JGgnFOvkHeN3wFa4a-FNvW79b-IONIz6yCGo
+    components-date-picker--quill-with-time--light:
+        hash: v1.k794b7964.3018b71616ffacc7a31a89a648f5d9b1e0a28df2c1f44b282d5992942bd684ea.gQAcK0hFId1OhYioUv_o5z2B34UDE1IU_vdzrA2DLHE
     components-date-picker--quill-with-value--dark:
         hash: v1.k794b7964.a386afa786ebee7c4470eed750332a620a2002e551a9d1e041af9fa60e1da86c.fNRNWhtJ5aB4iz6iDr19zk9ebcKADccxnYpLFNVY6hU
     components-date-picker--quill-with-value--light:

--- a/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.stories.tsx
@@ -49,3 +49,8 @@ export const QuillWithValue: Story = {
     render: () => <Template value={dayjs('2023-01-15')} clearable />,
     parameters: quillEnabled,
 }
+
+export const QuillWithTime: Story = {
+    render: () => <Template value={dayjs('2023-01-15T09:30')} granularity="minute" showTimeToggle />,
+    parameters: quillEnabled,
+}

--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from '@testing-library/react'
+import { cleanup, render, screen, within } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import { useState } from 'react'
 
@@ -19,7 +19,7 @@ jest.mock('lib/hooks/useFeatureFlag', () => ({
 }))
 
 const QUILL_STUB_DATE = new Date(2023, 0, 20)
-const mockQuillPanelProps: { maxDate?: Date } = {}
+const mockQuillPanelProps: { maxDate?: Date; showTime?: boolean; showTimeToggle?: boolean } = {}
 jest.mock('@posthog/quill', () => {
     const react = require('react')
     return {
@@ -27,16 +27,29 @@ jest.mock('@posthog/quill', () => {
         DatePicker: ({
             onApply,
             onCancel,
+            onIncludeTimeChange,
             maxDate,
+            showTime,
+            showTimeToggle,
         }: {
             onApply: (value: Date) => void
             onCancel: () => void
+            onIncludeTimeChange?: (includeTime: boolean) => void
             maxDate?: Date
+            showTime?: boolean
+            showTimeToggle?: boolean
         }) => {
             mockQuillPanelProps.maxDate = maxDate
+            mockQuillPanelProps.showTime = showTime
+            mockQuillPanelProps.showTimeToggle = showTimeToggle
             return react.createElement('div', null, [
                 react.createElement('button', { key: 'apply', onClick: () => onApply(QUILL_STUB_DATE) }, 'stub-apply'),
                 react.createElement('button', { key: 'cancel', onClick: onCancel }, 'stub-cancel'),
+                react.createElement(
+                    'button',
+                    { key: 'time-on', onClick: () => onIncludeTimeChange?.(true) },
+                    'stub-time-on'
+                ),
             ])
         },
     }
@@ -67,6 +80,8 @@ const renderDatePicker = (
 }
 
 describe('DatePicker', () => {
+    afterEach(cleanup)
+
     beforeEach(() => {
         mockQuillDatePickerFlag = false
     })
@@ -114,13 +129,34 @@ describe('DatePicker', () => {
         })
 
         it.each<[string, Partial<DatePickerProps>]>([
-            ['granularity', { granularity: 'minute' }],
+            ['hour granularity', { granularity: 'hour' }],
+            ['12-hour time', { granularity: 'minute', use24HourFormat: false }],
             ['selectionPeriod', { selectionPeriod: 'past' }],
             ['months', { months: 2 }],
         ])('falls back to LemonUI when %s is requested', (_name, props) => {
             const { container } = renderDatePicker(dayjs('2023-01-15'), props)
 
             expect(container.querySelector('[data-quill]')).toBeNull()
+        })
+
+        it('renders minute granularity in Quill with a time-bearing label', () => {
+            const { container } = renderDatePicker(dayjs('2023-01-15T09:30'), { granularity: 'minute' })
+
+            expect(container.querySelector('[data-quill]')).toBeTruthy()
+            expect(within(container).getByText('January 15, 2023 09:30')).toBeTruthy()
+        })
+
+        it.each<[string, Partial<DatePickerProps>, boolean, boolean]>([
+            ['fixed minute (no toggle)', { granularity: 'minute' }, true, false],
+            ['day with toggle', { granularity: 'day', showTimeToggle: true }, false, true],
+            ['minute with toggle', { granularity: 'minute', showTimeToggle: true }, true, true],
+        ])('maps %s onto the Quill panel time props', async (_name, props, showTime, showTimeToggle) => {
+            const { container } = renderDatePicker(dayjs('2023-01-15'), props)
+
+            await userEvent.click(within(container).getByRole('button', { name: /January 15, 2023/ }))
+
+            expect(mockQuillPanelProps.showTime).toBe(showTime)
+            expect(mockQuillPanelProps.showTimeToggle).toBe(showTimeToggle)
         })
 
         it('applying a date in the Quill panel calls onChange with a dayjs value', async () => {
@@ -131,6 +167,23 @@ describe('DatePicker', () => {
 
             expect(onChange).toHaveBeenCalledTimes(1)
             expect(onChange.mock.calls[0][0].format('YYYY-MM-DD')).toBe('2023-01-20')
+        })
+
+        it('updates the trigger label when time is toggled on in the panel', async () => {
+            const { container } = renderDatePicker(dayjs('2023-01-15T09:30'), {
+                granularity: 'day',
+                showTimeToggle: true,
+            })
+
+            const trigger = within(container).getByRole('button', { name: /January 15, 2023/ })
+            expect(trigger.textContent).toBe('January 15, 2023')
+
+            await userEvent.click(trigger)
+            await userEvent.click(await screen.findByText('stub-time-on'))
+
+            expect(within(container).getByRole('button', { name: /January 15, 2023/ }).textContent).toBe(
+                'January 15, 2023 09:30'
+            )
         })
 
         it('forwards maxDate to the Quill panel so future dates can be selected', async () => {

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -15,8 +15,10 @@ import { LemonCalendarSelectInput, LemonCalendarSelectInputProps } from 'lib/lem
  * The swap is gated by the `QUILL_DATE_PICKER` feature flag so LemonUI and Quill run side
  * by side and roll back without a revert. The Quill panel does not yet cover the whole
  * feature surface, so `quillCanRender` falls back to LemonUI whenever a request needs a
- * capability Quill is missing (time, selection windows, multi-month, controlled
- * visibility). Each Quill panel increment removes one fallback condition.
+ * capability Quill is missing: hour-only granularity, 12-hour time entry, selection
+ * windows, multi-month, or controlled visibility. Day/minute granularity (with an optional
+ * include-time toggle) is handled; minute entry renders in 24-hour time. Each Quill panel
+ * increment removes one fallback condition.
  *
  * Trigger concerns (placeholder, clearable, format, ...) live here by design — Quill
  * separates the trigger from the picker panel, so the wrapper owns the trigger.
@@ -70,13 +72,13 @@ export interface DatePickerProps {
 }
 
 const QUILL_TRIGGER_FORMAT = 'MMMM D, YYYY'
+const QUILL_TRIGGER_DATETIME_FORMAT = 'MMMM D, YYYY HH:mm'
 
 function quillCanRender(props: DatePickerProps): boolean {
     return (
-        props.granularity === undefined &&
+        props.granularity !== 'hour' &&
+        props.use24HourFormat !== false &&
         props.selectionPeriod === undefined &&
-        props.showTimeToggle === undefined &&
-        props.use24HourFormat === undefined &&
         props.months === undefined &&
         props.visible === undefined &&
         props.onOpen === undefined &&
@@ -96,6 +98,9 @@ export function DatePicker(props: DatePickerProps): JSX.Element {
 function DatePickerQuill({
     value,
     onChange,
+    granularity,
+    showTimeToggle,
+    onToggleTime,
     placeholder,
     clearable,
     format,
@@ -105,7 +110,14 @@ function DatePickerQuill({
     'data-attr': dataAttr,
 }: DatePickerProps): JSX.Element {
     const [open, setOpen] = useState(false)
-    const label = value ? value.format(format ?? QUILL_TRIGGER_FORMAT) : (placeholder ?? 'Select date')
+    const [includeTime, setIncludeTime] = useState(granularity === 'minute')
+    const labelFormat = format ?? (includeTime ? QUILL_TRIGGER_DATETIME_FORMAT : QUILL_TRIGGER_FORMAT)
+    const label = value ? value.format(labelFormat) : (placeholder ?? 'Select date')
+
+    const handleIncludeTimeChange = (next: boolean): void => {
+        setIncludeTime(next)
+        onToggleTime?.(next)
+    }
 
     const applyDate = (next: Date): void => {
         onChange(dayjs(next))
@@ -134,6 +146,9 @@ function DatePickerQuill({
                     <QuillDatePicker
                         value={value ? value.toDate() : new Date()}
                         maxDate={maxDate?.toDate()}
+                        showTime={granularity === 'minute'}
+                        showTimeToggle={!!showTimeToggle}
+                        onIncludeTimeChange={handleIncludeTimeChange}
                         onApply={applyDate}
                         onCancel={() => setOpen(false)}
                     />


### PR DESCRIPTION
## Problem

Phase 2 follow-up for the LemonUI->Quill date-picker migration, consumer side. The Phase 3 flip (#65519) only routes the *pure date* case to Quill; anything with `granularity` falls back to LemonUI. But `granularity="minute"` is the single most common advanced prop across the remaining single-date callers — so until the seam maps it, the flag barely covers anyone.

## Changes

Shrinks the seam's `quillCanRender` fallback so day/minute granularity now renders via Quill:

- `granularity="day"` -> Quill `showTime` off; `"minute"` -> `showTime` on
- `showTimeToggle` -> Quill's new `showTimeToggle`; `onToggleTime` -> `onIncludeTimeChange`
- the trigger label gains a time component when minute granularity is selected

Still falls back to LemonUI for what Quill can't do yet: hour-only granularity, explicit 12-hour entry (`use24HourFormat={false}` — Quill renders 24h), selection windows, multi-month, and controlled visibility. Each is a later increment.

One deliberate behaviour note: a minute caller that doesn't explicitly request 12-hour gets Quill's 24-hour entry. The *value* is identical; only the entry UI differs. This is flag-gated and reversible, so it's safe to observe in rollout; 12-hour is a tracked follow-up.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). Automated tests I ran:

- `frontend/src/lib/components/DatePicker/DatePicker.test.tsx` — 16 green. New coverage: minute granularity renders Quill with a time-bearing label; fallbacks for hour / 12-hour / selectionPeriod / months; and a parameterized check that fixed-minute, day-with-toggle, and minute-with-toggle map onto the right `showTime`/`showTimeToggle` panel props. Added `afterEach(cleanup)` since the new popover-opening tests portal content into the body.
- `tsc --noEmit -p frontend/tsconfig.json` — no errors in the touched files.
- `pnpm --filter=@posthog/frontend format` — clean.
- Added `QuillWithTime` story for VR.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed the migration; assigned as DRI.

This is a cross-stack PR. It sits on the Phase 3 flip (#65519) and carries the quill-components `showTimeToggle` change from #65522 so it compiles. Both the carried quill commit and the flip become no-ops once #65519 and #65522 land on master and this rebases. Reviewers: the meaningful diff here is the `quillCanRender` change, the granularity->showTime mapping in `DatePickerQuill`, and the tests.

Tooling: PostHog Code (Opus). Granularity priority was chosen from caller-usage data (minute dominates the remaining single-date call sites).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*