### PR TITLE
chore(signals): raise llm gateway cost limits for signals

### DIFF
--- a/services/llm-gateway/src/llm_gateway/config.py
+++ b/services/llm-gateway/src/llm_gateway/config.py
@@ -30,7 +30,7 @@ DEFAULT_PRODUCT_COST_LIMITS: dict[str, "ProductCostLimit"] = {
     "posthog_code": ProductCostLimit(limit_usd=5000.0, window_seconds=3600),
     "background_agents": ProductCostLimit(limit_usd=1000.0, window_seconds=3600),
     "django": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),
-    "signals": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),
+    "signals": ProductCostLimit(limit_usd=25000.0, window_seconds=86400),
     "posthog_ai": ProductCostLimit(limit_usd=5000.0, window_seconds=86400),
 }
 
@@ -54,9 +54,9 @@ DEFAULT_USER_COST_LIMITS: dict[str, "UserCostLimit"] = {
         sustained_window_seconds=2592000,
     ),
     "signals": UserCostLimit(
-        burst_limit_usd=500.0,
+        burst_limit_usd=2500.0,
         burst_window_seconds=604800,
-        sustained_limit_usd=1000.0,
+        sustained_limit_usd=10000.0,
         sustained_window_seconds=2592000,
     ),
 }


### PR DESCRIPTION
## Problem

The signals product was hitting its LLM gateway cost caps. We're raising both the product-wide and per-user spending limits to give it more headroom.

## Changes

In `services/llm-gateway/src/llm_gateway/config.py`:
- Product cost limit for `signals`: $5,000/24h → **$25,000/24h**
- Per-user burst limit for `signals`: $500/7d → **$2,500/7d**
- Per-user sustained limit for `signals`: $1,000/30d → **$10,000/30d**

## How did you test this code?

I'm an agent — no manual testing. These are constant value changes in the gateway config; no tests were run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack to raise the signals LLM gateway limits. Edited the three `signals` entries in `config.py` (`DEFAULT_PRODUCT_COST_LIMITS` and `DEFAULT_USER_COST_LIMITS`). All values remain overridable at runtime via `LLM_GATEWAY_*` env vars.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B98FCPT3N/p1782231726405719)*
