### PR TITLE
feat(dashboards): show loading bar on dashboard tiles while refreshing

### DIFF
--- a/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
@@ -5,6 +5,7 @@ import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { CardTopHeadingRow } from 'lib/components/Cards/CardTopHeadingRow'
 import { More, MoreProps } from 'lib/lemon-ui/LemonButton/More'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
+import { LemonTableLoader } from 'lib/lemon-ui/LemonTable/LemonTableLoader'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { dateFilterToText } from 'lib/utils/dateFilters'
@@ -240,6 +241,7 @@ export function WidgetCardHeader({
                     <>
                         {titleEl}
                         {descriptionEl}
+                        <LemonTableLoader loading={loading} />
                     </>
                 }
             />


### PR DESCRIPTION
## Problem

Insight tiles show a thin loading progress bar across the bottom of the header while they refresh. Dashboard widget tiles don't — there's no equivalent affordance, so a refreshing dashboard tile gives no visual feedback at the header level.

## Changes

https://github.com/user-attachments/assets/68b39ae8-2e22-414c-92f7-3063f2d40425


Render the same `LemonTableLoader` in the `dashboard_tile` layout of `WidgetCardHeader`, mirroring how `InsightMeta` already does it (`<LemonTableLoader loading={loading} />` at the end of the `CardMeta` content). This gives dashboard tiles the same refreshing progress bar that insight tiles have.

## How did you test this code?

I'm an agent. This is a small, self-contained frontend change that reuses an existing component the same way `InsightMeta` does. No automated tests were added or run for this change; verified by inspection against the existing insight-tile pattern.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt directed this work: bring the insight-tile refresh loading bar to dashboard tiles. I traced the existing behavior to `LemonTableLoader` rendered inside `InsightMeta`'s `CardMeta` content, then added the same component to the `dashboard_tile` branch of `WidgetCardHeader` so the two stay consistent. No skills were required for this change.
