### PR TITLE
fix(conversations): give safety_filter_activity a unique temporal name

### DIFF
--- a/products/conversations/backend/temporal/pipeline.py
+++ b/products/conversations/backend/temporal/pipeline.py
@@ -509,7 +509,7 @@ def _build_context_sync(team_id: int, ticket_id: str) -> BuildContextOutput:
     )
 
 
-@activity.defn
+@activity.defn(name="conversations_safety_filter_activity")
 async def safety_filter_activity(input: SafetyFilterInput) -> SafetyFilterOutput:
     """Screen ticket for prompt injection / data exfiltration before the draft loop."""
     async with Heartbeater():


### PR DESCRIPTION
## Problem

The local Temporal worker crashes on startup:

```
ValueError: More than one activity named safety_filter_activity
```

## Changes

Both `products/signals` and `products/conversations` register a Temporal activity named `safety_filter_activity` (bare `@activity.defn`, so the name is derived from the function). In `DEBUG`, `posthog/settings/temporal.py` collapses every product's queue onto a single `development-task-queue` worker, so the duplicate name aborts worker startup. Production is unaffected because each product runs on its own queue.

Gave the conversations activity an explicit name, `conversations_safety_filter_activity`. Signals keeps `safety_filter_activity` to preserve its existing workflow history. The Python function name is unchanged, so conversations' imports and tests are untouched, and `execute_activity` passes the callable, so the new name resolves automatically.

## How did you test this code?

Agent-authored (Claude Code, Opus). I did not run the temporal test suite. Verified statically: the two `@activity.defn` decorators now resolve to distinct activity names, and confirmed in `posthog/settings/temporal.py` that `DEBUG=True` routes all product queues onto one `development-task-queue` worker, which is the collision source. Conversations tests reference the activity by function object, so they are unaffected. Relying on CI for the suites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes, internal dev-environment fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus 4.8). Diagnosed from a local `start_temporal_worker` crash log.
- Consulted the repo product-isolation rule; the change is intra-product (conversations only), so there is no facade or import-boundary impact.
- Decision: renamed the conversations activity rather than signals, since signals is the older definition with existing production workflow history. Kept the Python function name to avoid touching imports and tests.
