### PR TITLE
fix(security): suppress high-volume introspection commands from exec audit

### DIFF
--- a/posthog/security/command_exec_audit.py
+++ b/posthog/security/command_exec_audit.py
@@ -73,6 +73,14 @@ _CONTROL_CHARS[0x7F] = " "
 # Characters that let one command string spawn or chain into another.
 _SHELL_OPERATORS = frozenset(";|&$`<>\n")
 
+_VOLUME_SUPPRESSION_RULES: dict[str, Callable[[list[str]], bool]] = {
+    "uname": lambda tail: all(a.startswith("-") for a in tail),
+    "lsb_release": lambda tail: all(a.startswith("-") for a in tail),
+    "ldd": lambda tail: tail == ["--version"],
+    "file": lambda tail: bool(tail) and tail[0] == "-b",
+    "ldconfig": lambda tail: tail == ["-p"],
+}
+
 # Context fields pulled from the query-tag ContextVar (set by middleware / Celery / Temporal).
 # Identifiers only — deliberately no PII (e.g. user_email) and nothing that can leak secrets
 # (http_referer / http_user_agent can carry tokens in query strings). Resolve a user/org from
@@ -120,6 +128,14 @@ def _redact_value(text: str) -> str:
     # base64 payloads.
     text = _URL_USERINFO_RE.sub(_URL_USERINFO_REPL, text)
     return _BLOB_RE.sub(_REDACTED, text)
+
+
+def _is_volume_suppressed(command: Any, shell: bool) -> bool:
+    if shell or not isinstance(command, (list, tuple)) or not command:
+        return False
+    argv = [_to_text(token) for token in command]
+    predicate = _VOLUME_SUPPRESSION_RULES.get(os.path.basename(argv[0].strip()))
+    return predicate is not None and predicate(argv[1:])
 
 
 def _scrub_args(tokens: Any) -> list[str]:
@@ -222,6 +238,8 @@ def _emit(
     extra: Optional[dict[str, Any]] = None,
 ) -> None:
     if _in_audit.get():
+        return
+    if _is_volume_suppressed(command, shell):
         return
     token = _in_audit.set(True)
     try:

--- a/posthog/security/test/test_command_exec_audit.py
+++ b/posthog/security/test/test_command_exec_audit.py
@@ -24,6 +24,7 @@ from posthog.models.utils import generate_random_token_personal
 from posthog.security import command_exec_audit
 from posthog.security.command_exec_audit import (
     _REDACTED as _R,
+    _is_volume_suppressed,
     _scrub_args,
     _scrub_command_string,
     _summarize_env,
@@ -115,6 +116,31 @@ class TestCommandExecAuditScrubbing(TestCase):
     def test_summarize_env_empty(self) -> None:
         self.assertEqual(_summarize_env(None), (None, 0))
 
+    @parameterized.expand(
+        [
+            # The high-volume introspection shapes we suppress to keep audit volume sane.
+            ("uname_flags", ["uname", "-rs"], False, True),
+            ("uname_single_flag", ["uname", "-p"], False, True),
+            ("lsb_release", ["lsb_release", "-a"], False, True),
+            ("ldd_version", ["ldd", "--version"], False, True),
+            ("file_brief", ["file", "-b", "/some/path"], False, True),
+            ("ldconfig_print", ["ldconfig", "-p"], False, True),
+            ("ldconfig_other_flag", ["ldconfig", "-v"], False, False),
+            # Absolute path still matches on basename.
+            ("absolute_path_uname", ["/usr/bin/uname", "-rs"], False, True),
+            # Anything that isn't the exact suppressed shape must fall through to a full audit entry.
+            ("uname_positional_arg", ["uname", "-a", "extra"], False, False),
+            ("ldd_on_a_binary", ["ldd", "/bin/ls"], False, False),
+            ("file_without_brief", ["file", "/some/path"], False, False),
+            ("unknown_binary", ["curl", "-s", "https://x"], False, False),
+            # shell=True can chain commands — never suppressed, even for a suppressed-looking program.
+            ("shell_string_uname", "uname -rs", True, False),
+            ("empty_command", [], False, False),
+        ]
+    )
+    def test_is_volume_suppressed(self, _name: str, command: Any, shell: bool, expected: bool) -> None:
+        self.assertEqual(_is_volume_suppressed(command, shell), expected)
+
 
 class TestCommandExecAuditPatching(TestCase):
     def setUp(self) -> None:
@@ -141,6 +167,20 @@ class TestCommandExecAuditPatching(TestCase):
         assert entry is not None
         self.assertTrue(entry["shell"])
         self.assertNotIn("hunter2", entry["command"])
+
+    def test_volume_suppressed_command_is_not_logged(self) -> None:
+        # The high-volume introspection commands are dropped to keep audit volume sane.
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["uname", "-rs"], check=False)
+        self.assertIsNone(self._find(logs, "subprocess.Popen"))
+
+    def test_non_suppressed_variant_is_still_logged(self) -> None:
+        # A positional operand on an otherwise suppressed program is not the suppressed shape — keep auditing.
+        with structlog.testing.capture_logs() as logs:
+            subprocess.run(["uname", "-a", "extra"], check=False)
+        entry = self._find(logs, "subprocess.Popen")
+        assert entry is not None
+        self.assertEqual(entry["command"], ["uname", "-a", "extra"])
 
     def test_os_system_is_logged(self) -> None:
         with structlog.testing.capture_logs() as logs:


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

The `posthog.security.command_exec_audit` logger is generating too much noise due to `distro` and `platform` introspection commands, such as `file -b /usr/local/bin/python3.13`. 

## Changes

Adding suppression rules to avoid generating too much noise.

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted)

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
