### PR TITLE
feat(customer-analytics): Return to accounts on back from a group

### DIFF
--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -70,6 +70,7 @@ export function Group(): JSX.Element {
         groupEventsQuery,
         groupEventsQueryIsDirty,
         backTo,
+        backNavigation,
     } = useValues(mountedGroupLogic)
     const { groupKey, groupTypeIndex } = logicProps
     const { setGroupEventsQuery, resetGroupEventsQuery, editProperty, deleteProperty } = useActions(mountedGroupLogic)
@@ -113,13 +114,12 @@ export function Group(): JSX.Element {
             <LemonTabs
                 sceneInset
                 activeKey={activeTab}
-                onChange={(tab) => {
-                    const { backUrl, backName } = router.values.searchParams
+                onChange={(tab) =>
                     router.actions.push(
                         urls.group(String(groupTypeIndex), groupKey, true, tab),
-                        backUrl ? { backUrl, backName } : undefined
+                        backNavigation ? { backUrl: backNavigation.url, backName: backNavigation.name } : undefined
                     )
-                }}
+                }
                 tabs={[
                     ...(showProfile
                         ? [

--- a/frontend/src/scenes/groups/Group.tsx
+++ b/frontend/src/scenes/groups/Group.tsx
@@ -14,7 +14,6 @@ import { LemonTabs } from 'lib/lemon-ui/LemonTabs'
 import { Link } from 'lib/lemon-ui/Link'
 import { Spinner, SpinnerOverlay } from 'lib/lemon-ui/Spinner/Spinner'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { GroupLogicProps, groupLogic } from 'scenes/groups/groupLogic'
 import { NotebookSelectButton } from 'scenes/notebooks/NotebookSelectButton/NotebookSelectButton'
 import { NotebookNodeType } from 'scenes/notebooks/types'
@@ -29,7 +28,6 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneDivider } from '~/layout/scenes/components/SceneDivider'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
-import { groupsModel } from '~/models/groupsModel'
 import { Query } from '~/queries/Query/Query'
 import type { ActionFilter } from '~/types'
 import {
@@ -71,12 +69,12 @@ export function Group(): JSX.Element {
         groupTab,
         groupEventsQuery,
         groupEventsQueryIsDirty,
+        backTo,
     } = useValues(mountedGroupLogic)
     const { groupKey, groupTypeIndex } = logicProps
     const { setGroupEventsQuery, resetGroupEventsQuery, editProperty, deleteProperty } = useActions(mountedGroupLogic)
     const { currentTeam } = useValues(teamLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { aggregationLabel } = useValues(groupsModel)
     const groupProfileVariant = useFeatureFlagVariantKey(FEATURE_FLAGS.GROUP_PROFILE_EXPERIMENT)
     const isProfileEnabled = groupProfileVariant === 'test'
     const showProfile = featureFlags[FEATURE_FLAGS.CUSTOMER_ANALYTICS] || isProfileEnabled
@@ -92,11 +90,7 @@ export function Group(): JSX.Element {
             <SceneTitleSection
                 name={groupDisplayId(groupData.group_key, groupData.group_properties)}
                 resourceType={{ type: 'group' }}
-                forceBackTo={{
-                    name: capitalizeFirstLetter(aggregationLabel(groupTypeIndex).plural),
-                    key: 'groups',
-                    path: urls.groups(groupTypeIndex),
-                }}
+                forceBackTo={backTo}
                 actions={
                     <>
                         <FeedbackButton id="customer-analytics-group-profile-feedback-button" />
@@ -119,7 +113,13 @@ export function Group(): JSX.Element {
             <LemonTabs
                 sceneInset
                 activeKey={activeTab}
-                onChange={(tab) => router.actions.push(urls.group(String(groupTypeIndex), groupKey, true, tab))}
+                onChange={(tab) => {
+                    const { backUrl, backName } = router.values.searchParams
+                    router.actions.push(
+                        urls.group(String(groupTypeIndex), groupKey, true, tab),
+                        backUrl ? { backUrl, backName } : undefined
+                    )
+                }}
                 tabs={[
                     ...(showProfile
                         ? [

--- a/frontend/src/scenes/groups/groupLogic.test.ts
+++ b/frontend/src/scenes/groups/groupLogic.test.ts
@@ -1,0 +1,32 @@
+import { resolveBackNavigation } from './groupLogic'
+
+describe('resolveBackNavigation', () => {
+    it('returns the sanitized internal path and name', () => {
+        expect(resolveBackNavigation({ backUrl: '/customer_analytics/accounts', backName: 'Accounts' })).toEqual({
+            url: '/customer_analytics/accounts',
+            name: 'Accounts',
+        })
+    })
+
+    it('preserves search and hash on the internal path', () => {
+        expect(
+            resolveBackNavigation({ backUrl: '/customer_analytics/accounts?tab=usage#view=abc', backName: 'Accounts' })
+        ).toEqual({ url: '/customer_analytics/accounts?tab=usage#view=abc', name: 'Accounts' })
+    })
+
+    it('rejects an absolute external URL (open redirect guard)', () => {
+        expect(resolveBackNavigation({ backUrl: 'https://evil.com', backName: 'Accounts' })).toBeNull()
+    })
+
+    it('rejects a protocol-relative URL', () => {
+        expect(resolveBackNavigation({ backUrl: '//evil.com' })).toBeNull()
+    })
+
+    it('returns null when backUrl is absent', () => {
+        expect(resolveBackNavigation({})).toBeNull()
+    })
+
+    it('falls back to a default name when backName is missing', () => {
+        expect(resolveBackNavigation({ backUrl: '/groups/0/acme' })).toEqual({ url: '/groups/0/acme', name: 'Back' })
+    })
+})

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -1,6 +1,6 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
-import { urlToAction } from 'kea-router'
+import { router, urlToAction } from 'kea-router'
 import posthog from 'posthog-js'
 
 import api from 'lib/api'
@@ -278,6 +278,21 @@ export const groupLogic = kea<groupLogicType>([
         hasRevenueData: [
             (s) => [s.effectiveMRR, s.effectiveLifetimeValue],
             (mrr, ltv): boolean => mrr.value !== null || ltv.value !== null,
+        ],
+        backTo: [
+            (s, p) => [s.aggregationLabel, p.groupTypeIndex, router.selectors.searchParams],
+            (aggregationLabel, groupTypeIndex, searchParams): Breadcrumb => {
+                const backUrl = searchParams.backUrl as string | undefined
+                const backName = searchParams.backName as string | undefined
+                if (backUrl) {
+                    return { key: 'group-back', name: backName || 'Back', path: backUrl }
+                }
+                return {
+                    key: 'groups',
+                    name: capitalizeFirstLetter(aggregationLabel(groupTypeIndex).plural),
+                    path: urls.groups(groupTypeIndex),
+                }
+            },
         ],
         breadcrumbs: [
             (s, p) => [s.groupTypeName, p.groupTypeIndex, p.groupKey, s.groupData],

--- a/frontend/src/scenes/groups/groupLogic.ts
+++ b/frontend/src/scenes/groups/groupLogic.ts
@@ -10,7 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { objectsEqual } from 'lib/utils/objects'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
-import { toParams } from 'lib/utils/url'
+import { getRelativeNextPath, toParams } from 'lib/utils/url'
 import { groupDisplayId } from 'scenes/persons/GroupActorDisplay'
 import { Scene } from 'scenes/sceneTypes'
 import { teamLogic } from 'scenes/teamLogic'
@@ -51,6 +51,22 @@ function getGroupEventsQuery(groupTypeIndex: number, groupKey: string): DataTabl
 export type GroupLogicProps = {
     groupTypeIndex: number
     groupKey: string
+}
+
+export interface GroupBackNavigation {
+    url: string
+    name: string
+}
+
+// `backUrl` comes from an untrusted search param; only honor it as an internal relative path so a
+// crafted link can't turn the back button into an open redirect. `getRelativeNextPath` also sanitizes.
+export function resolveBackNavigation(searchParams: Record<string, any>): GroupBackNavigation | null {
+    const url = getRelativeNextPath(searchParams.backUrl, window.location)
+    if (!url) {
+        return null
+    }
+    const name = searchParams.backName
+    return { url, name: typeof name === 'string' && name ? name : 'Back' }
 }
 
 export const groupLogic = kea<groupLogicType>([
@@ -279,13 +295,15 @@ export const groupLogic = kea<groupLogicType>([
             (s) => [s.effectiveMRR, s.effectiveLifetimeValue],
             (mrr, ltv): boolean => mrr.value !== null || ltv.value !== null,
         ],
+        backNavigation: [
+            () => [router.selectors.searchParams],
+            (searchParams): GroupBackNavigation | null => resolveBackNavigation(searchParams),
+        ],
         backTo: [
-            (s, p) => [s.aggregationLabel, p.groupTypeIndex, router.selectors.searchParams],
-            (aggregationLabel, groupTypeIndex, searchParams): Breadcrumb => {
-                const backUrl = searchParams.backUrl as string | undefined
-                const backName = searchParams.backName as string | undefined
-                if (backUrl) {
-                    return { key: 'group-back', name: backName || 'Back', path: backUrl }
+            (s, p) => [s.aggregationLabel, p.groupTypeIndex, s.backNavigation],
+            (aggregationLabel, groupTypeIndex, backNavigation): Breadcrumb => {
+                if (backNavigation) {
+                    return { key: 'group-back', name: backNavigation.name, path: backNavigation.url }
                 }
                 return {
                     key: 'groups',

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.test.ts
@@ -1,5 +1,6 @@
 import { MOCK_DEFAULT_TEAM } from '~/lib/api.mock'
 
+import { combineUrl, router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
 import { initKeaTests } from '~/test/init'
@@ -171,5 +172,25 @@ describe('accountLinksLogic', () => {
         expect(logic.values.editorOpen).toBe(true)
         expect(logic.values.savingLinks).toBe(false)
         expect(logic.values.account).toEqual(initial)
+    })
+
+    it('organization link opens the group and carries the accounts list as backUrl', async () => {
+        router.actions.push('/customer_analytics/accounts', {}, { view: { search: 'acme' } })
+        await mountWith(buildAccount({ external_id: 'ext-1' }))
+
+        const organization = logic.values.links.find((link) => link.key === 'organization')
+        const destination = combineUrl(organization!.to!)
+        expect(destination.pathname).toBe('/groups/0/ext-1')
+        expect(destination.searchParams.backName).toBe('Accounts')
+        expect(destination.searchParams.backUrl).toContain('/customer_analytics/accounts')
+        expect(destination.searchParams.backUrl).toContain('#view=')
+    })
+
+    it('organization link is disabled without an external_id', async () => {
+        await mountWith(buildAccount({ external_id: null }))
+
+        const organization = logic.values.links.find((link) => link.key === 'organization')
+        expect(organization?.to).toBeNull()
+        expect(organization?.disabledReason).toBe('No external ID set')
     })
 })

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
@@ -1,8 +1,10 @@
 import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
+import { combineUrl, router } from 'kea-router'
 import posthog from 'posthog-js'
 
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
@@ -125,17 +127,24 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
             }),
         ],
         links: [
-            (s) => [s.account],
-            (account: AccountApi | null): AccountLink[] => {
+            (s) => [s.account, router.selectors.currentLocation],
+            (account: AccountApi | null, currentLocation): AccountLink[] => {
                 const externalId = account?.external_id ?? null
                 const billingId = account?.properties?.billing_id ?? null
                 const slackChannelId = account?.properties?.slack_channel_id ?? null
                 const usageDashboardLink = account?.properties?.usage_dashboard_link ?? null
+                const backUrl =
+                    removeProjectIdIfPresent(currentLocation.pathname) + currentLocation.search + currentLocation.hash
                 return [
                     {
                         key: 'organization',
                         label: 'Organization',
-                        to: externalId ? urls.group(ORGANIZATION_GROUP_TYPE_INDEX, externalId) : null,
+                        to: externalId
+                            ? combineUrl(urls.group(ORGANIZATION_GROUP_TYPE_INDEX, externalId), {
+                                  backUrl,
+                                  backName: 'Accounts',
+                              }).url
+                            : null,
                         targetBlank: false,
                         disabledReason: externalId ? null : 'No external ID set',
                     },


### PR DESCRIPTION
## Problem

Opening a group from the Accounts list and hitting back sends you to the groups list — not the accounts list you came from.
<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add a `backTo` selector to `groupLogic` — returns the `backUrl`/`backName` search params when present, else the existing groups-list crumb.
- Drive the group page back button (`forceBackTo`) from `backTo`, and carry the params across in-page tab switches.
- Accounts "Organization" link now passes the live accounts-list URL (including the `#view=` filter hash) as `backUrl`.
- Net: back from a group opened via Accounts returns to that accounts list (filters preserved); opened from the groups list, it's unchanged.
- Add unit tests for the Organization link's `backUrl`.
<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-authored. Ran the `accountLinksLogic` jest suite (8 passing) and the frontend typecheck (`tsgo`) — changed files clean. No manual UI testing.
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes.
<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code. Skill invoked: `/pr-description`. Design note: the back target travels as generic `backUrl`/`backName` search params (the same pattern `dashboardLogic` already uses), so core `groupLogic` / `Group.tsx` stay decoupled from the `customer_analytics` product — no cross-product import.
<!-- Fill this section if an agent co-authored or authored this PR. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
