### PR TITLE
fix(tasks): polish task run detail page layout

### DIFF
--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconArchive, IconExternal, IconGithub, IconPlay } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
+import { LemonButton, LemonDivider, Spinner } from '@posthog/lemon-ui'
 
 import { NotFound } from 'lib/components/NotFound'
 import { SceneMenuBarFileItems } from 'lib/components/Scenes/SceneMenuBarFileItems'
@@ -173,28 +173,36 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
             />
 
             {selectedRun && (
-                <div className="flex items-center gap-4 -mt-2 mb-2 px-2 text-xs text-muted">
-                    <span>
-                        Created: <TZLabel time={selectedRun.created_at} showSeconds />
-                    </span>
+                <div className="flex items-center gap-4 text-xs text-muted">
+                    <dl className="inline-flex gap-1 items-center">
+                        <dt className="m-0">Created:</dt>
+                        <dd className="m-0 inline-flex items-center">
+                            <TZLabel time={selectedRun.created_at} showSeconds />
+                        </dd>
+                    </dl>
                     {selectedRun.completed_at && (
-                        <span>
-                            Completed: <TZLabel time={selectedRun.completed_at} showSeconds />
-                        </span>
+                        <dl className="inline-flex gap-1 items-center">
+                            <dt className="m-0">Completed:</dt>
+                            <dd className="m-0 inline-flex items-center">
+                                <TZLabel time={selectedRun.completed_at} showSeconds />
+                            </dd>
+                        </dl>
                     )}
                     {selectedRun.completed_at && (
-                        <span>
-                            Duration:{' '}
-                            {humanFriendlyDuration(
-                                dayjs(selectedRun.completed_at).diff(selectedRun.created_at, 'second')
-                            )}
-                        </span>
+                        <dl className="inline-flex gap-1 items-center">
+                            <dt className="m-0">Duration:</dt>
+                            <dd className="m-0 inline-flex items-center">
+                                {humanFriendlyDuration(
+                                    dayjs(selectedRun.completed_at).diff(selectedRun.created_at, 'second')
+                                )}
+                            </dd>
+                        </dl>
                     )}
                 </div>
             )}
 
             {task.description && (
-                <div className="relative -mt-2 mb-2 px-2">
+                <div className="relative mt-2">
                     <CollapsibleContent>
                         <LemonMarkdown lowKeyHeadings className="text-sm">
                             {task.description}
@@ -202,6 +210,8 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                     </CollapsibleContent>
                 </div>
             )}
+
+            <LemonDivider />
 
             {runsLoading ? (
                 <div className="flex items-center justify-center h-32">
@@ -212,7 +222,7 @@ export function TaskDetailPage({ taskId }: TaskDetailPageProps): JSX.Element {
                     <p className="text-muted">This task hasn't been run yet</p>
                 </div>
             ) : selectedRun ? (
-                <div className="flex-1 overflow-hidden">
+                <div className="flex-1 overflow-hidden max-w-6xl mx-auto w-full mb-8">
                     <TaskRunChat taskId={task.id} runId={selectedRun.id} />
                 </div>
             ) : null}

--- a/products/tasks/frontend/components/TaskRunChat.tsx
+++ b/products/tasks/frontend/components/TaskRunChat.tsx
@@ -55,7 +55,7 @@ function TaskRunChatContent({ taskId, runId }: TaskRunChatProps): JSX.Element {
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
-            <div className="flex-1 overflow-y-auto px-4 py-2">
+            <div className="flex-1 overflow-y-auto flex flex-col gap-3">
                 <SandboxThreadView />
             </div>
 


### PR DESCRIPTION
## Problem

The task run detail surface had some rough edges: run metadata wasn't vertically aligned, the header ran straight into the run content with no separation, and the run chat stretched edge-to-edge at full width. Purely cosmetic — no behavior issues.

## Changes

Cosmetic-only tweaks to the task run detail page, on top of the sandbox renderer from #65442:

- Render run metadata (created / completed / duration) as aligned `<dl>` definition lists instead of inline spans, so labels and values line up consistently.
- Add a `LemonDivider` between the run header and the run content.
- Center the run chat in a `max-w-6xl` column with bottom spacing, instead of full-bleed.
- Lay out the sandbox thread with `flex flex-col gap-3` for consistent vertical spacing.

No logic, props, or data flow changed — only `className`s, markup wrappers, and one added divider.

## How did you test this code?

I'm an agent and packaged the human author's working-tree changes into this PR. These are CSS/layout-only changes (Tailwind class swaps, `<span>` → `<dl>` wrappers, one `LemonDivider`). Ran `oxfmt` and `oxlint --fix` on both files — clean, no changes needed. No behavioral change, so no automated tests were added. I did not run the app myself.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI is the assignee (@skoob13), who authored the layout changes; the agent (Claude Code) handled branching, formatting, and PR creation.

These edits originally sat on top of the unmerged sandbox-renderer branch. By the time the PR was cut, #65442 had squash-merged to master, so the cosmetic commit was rebased directly onto master and stands alone here. No skills were required (cosmetic frontend styling only); the only tooling run was `oxfmt` + `oxlint`, both clean.
