### PR TITLE
test(quill): run quill package jest suites in CI

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,7 +35,7 @@
         "typegen:write": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors --use-cache",
         "typegen:write:no-cache": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors",
         "schema:build:json": "ts-node ./bin/build-schema-json.mjs && oxfmt ./src/queries/schema.json && ts-node ./bin/build-validators.mjs && oxfmt ./src/queries/validators.js",
-        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/|packages/quill/packages/components/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
+        "test": "SHARD_IDX=${SHARD_INDEX:-1}; SHARD_TOTAL=${SHARD_COUNT:-1}; echo $SHARD_IDX/$SHARD_TOTAL; pnpm build:products && jest --testPathPattern='(frontend/|products/|common/|packages/quill/)' --forceExit --shard=$SHARD_IDX/$SHARD_TOTAL",
         "jest": "pnpm build:products && jest",
         "typescript:check": "tsgo --noEmit && echo \"No errors reported by tsgo.\"",
         "typescript:version": "tsgo --version",


### PR DESCRIPTION
## Problem

`@posthog/quill-charts` has 55 jest suites (1472 tests) registered in `frontend/jest.config.ts` `rootDirectories()`, so they run locally on explicit invocation — but the CI test job runs `bin/turbo run test --filter=@posthog/frontend`, whose `test` script filters with `--testPathPattern='(frontend/|products/|common/)'`. That pattern matches none of `packages/quill/...`, so **these tests have never run in the sharded CI matrix**. A regression in charts would pass CI silently.

(Surfaced while reviewing the date-picker migration's test infra — same root cause flagged there for quill-components.)

## Changes

Broaden the test path pattern to `(frontend/|products/|common/|packages/quill/)` so any quill package wired into `rootDirectories` actually gates regressions in CI. One-line change; `packages/quill/` is used rather than enumerating each sub-package so future quill packages added to `rootDirectories` are covered automatically.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). Automated checks I ran:

- Ran the full charts suite under the frontend jest config: **55 suites, 1472 tests, all passing** — so turning them on in CI is safe, no latent failures.
- `jest --listTests` with the new pattern: confirms the 55 charts suites are now included and the existing frontend selection (650 suites) is unaffected.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul asked for this follow-up; assigned as DRI.

Heads-up on a one-line overlap: PR #65102 edits the same `test` script line to add `packages/quill/packages/components/`. This PR uses the broader `packages/quill/` (which subsumes it). Whichever lands second will need a trivial one-line rebase. No other coupling — this is otherwise standalone off master.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*