### PR TITLE
fix(hogql): normalize literal JSONExtract before lazy table resolution

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -32,6 +32,7 @@ from posthog.hogql.transforms.geoip_dict_fallback import (
     geoip_dict_fallback_enabled_for_team,
 )
 from posthog.hogql.transforms.in_cohort import resolve_in_cohorts, resolve_in_cohorts_conjoined
+from posthog.hogql.transforms.json_extract_to_property import normalize_json_extract_to_property
 from posthog.hogql.transforms.lazy_tables import resolve_lazy_tables
 from posthog.hogql.transforms.logical_property_lowering import lower_property_access
 from posthog.hogql.transforms.projection_pushdown import pushdown_projections
@@ -195,6 +196,13 @@ def prepare_ast_for_printing(
             build_property_swapper(node, context)
             if context.property_swapper is None:
                 return None
+
+            # Normalize literal JSONExtractString/JSONExtract(properties, 'x') calls into property-access reads BEFORE
+            # lazy-table resolution, so they flow through the same machinery as `properties.x` chain access (including
+            # the lazy persons/groups subquery) and reach their materialized column. Only rewrites when a static mat
+            # column exists, so no-mat calls keep their raw-JSONExtract semantics.
+            with context.timings.measure("normalize_json_extract_to_property"):
+                node = normalize_json_extract_to_property(node, context)
 
             # It would be nice to be able to run property swapping after we resolve lazy tables, so that logic added onto the lazy tables
             # could pass through the swapper. However, in the PropertySwapper, the group_properties and the S3 Table join

--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -197,10 +197,7 @@ def prepare_ast_for_printing(
             if context.property_swapper is None:
                 return None
 
-            # Normalize literal JSONExtractString/JSONExtract(properties, 'x') calls into property-access reads BEFORE
-            # lazy-table resolution, so they flow through the same machinery as `properties.x` chain access (including
-            # the lazy persons/groups subquery) and reach their materialized column. Only rewrites when a static mat
-            # column exists, so no-mat calls keep their raw-JSONExtract semantics.
+            # Before resolve_lazy_tables, so rewritten reads flow through the lazy persons/groups subquery like chain access.
             with context.timings.measure("normalize_json_extract_to_property"):
                 node = normalize_json_extract_to_property(node, context)
 

--- a/posthog/hogql/transforms/json_extract_to_property.py
+++ b/posthog/hogql/transforms/json_extract_to_property.py
@@ -1,19 +1,11 @@
-"""Early ClickHouse pass: normalize a literal `JSONExtractString(properties, 'x')` into a property-access read.
+"""Normalize a literal `JSONExtractString(properties, 'x')` into a `properties.x` property-access read.
 
-Users sometimes write `JSONExtractString(properties, '$browser')` (or a typed `JSONExtract(properties, 'x', 'T')`)
-directly instead of `properties.$browser`. When the property is backed by a materialized column, decompressing the
-whole JSON blob is wasted I/O. This pass rewrites such a call into the same property-access `Field` that
-`properties.$browser` produces, so the rest of the pipeline (lazy-table resolution, lowering, ClickHouse property
-resolution) treats the two forms identically and routes both to the materialized column.
+Runs before `resolve_lazy_tables` so the rewritten read flows through the same pipeline as chain access and reaches its
+materialized column, including inside the lazy persons/groups subquery — which the old in-place rewrite, running after
+lazy resolution, could not.
 
-It runs *before* `resolve_lazy_tables`, so the produced read flows through the lazy-table machinery the same way a chain
-access does — that is what lets a read off the lazy `persons`/`groups` tables reach its materialized column inside the
-generated subquery, rather than being stranded as a raw JSON extract.
-
-Behavior-preserving: it only rewrites when a static materialized column already exists and its physical type matches the
-requested JSON type. A call with no materialized column is left untouched and prints as the raw JSON extract, so its
-ClickHouse semantics (e.g. `''` for a missing key) are unchanged. The choice of which physical column to read, and the
-access-control NULLing of restricted properties, are left entirely to the downstream resolution pass.
+Only rewrites when a static materialized column exists and its type matches; an unbacked call stays a raw JSON extract.
+Column choice and restricted-property NULLing are left to the downstream resolution pass.
 """
 
 from typing import cast
@@ -55,7 +47,6 @@ class JSONExtractToPropertyNormalizer(CloningVisitor):
         if property_name is None:
             return None
 
-        # Unwrap Alias if present (the resolver wraps fields in Alias nodes).
         field_arg = node.args[0]
         if isinstance(field_arg, ast.Alias):
             field_arg = field_arg.expr
@@ -72,13 +63,10 @@ class JSONExtractToPropertyNormalizer(CloningVisitor):
         if not isinstance(database_field, StringJSONDatabaseField):
             return None
 
-        # resolve_database_table is polymorphic across concrete, lazy, alias, and virtual table types, so one call
-        # resolves the ClickHouse table name for a read off `events`, `raw_persons`, the lazy `persons`/`groups` tables,
-        # or the person-on-events virtual table alike. The materialized-column registry is keyed by that ClickHouse name
-        # (RawPersonsTable is "raw_persons" in HogQL but "person" in ClickHouse), which is why we don't use the HogQL name.
         table_type = field_type.table_type
         if not isinstance(table_type, ast.BaseTableType):
             return None
+        # Registry is keyed by the ClickHouse name, not the HogQL name (raw_persons -> person); resolve_database_table covers lazy and virtual tables too.
         table_name = table_type.resolve_database_table(self.context).to_printed_clickhouse(self.context)
         if table_name not in MATERIALIZATION_VALID_TABLES:
             return None
@@ -118,9 +106,7 @@ def _simple_json_extract_property_name(node: ast.Call) -> str | None:
 
 def _json_extract_matches_materialized_column_type(node: ast.Call, mat_col: MaterializedColumn) -> bool:
     if node.name == "JSONExtractString":
-        # JSONExtractString has string semantics, so it only matches a string-backed column.
-        # A non-string materialized column (e.g. Nullable(Float64)) would otherwise be rewritten
-        # to the bare typed column, dropping the string type the surrounding query expects.
+        # JSONExtractString is string-typed, so only a string-backed column is an equivalent rewrite.
         return parse_sql_runtime_type(mat_col.type).family == "string"
 
     if node.name != "JSONExtract" or len(node.args) != 3:
@@ -130,10 +116,7 @@ def _json_extract_matches_materialized_column_type(node: ast.Call, mat_col: Mate
     if not isinstance(type_arg, ast.Constant) or not isinstance(type_arg.value, str):
         return False
 
-    # Normalize before comparing so formatting differences in the type spelling
-    # (whitespace, quoting) don't block the rewrite; semantic differences
-    # (nullability, width, timezone) still do, because JSON helper semantics for
-    # missing keys and out-of-range values differ from bare column semantics.
+    # Normalize spellings so formatting differences don't block the rewrite, while real type differences (nullability, width, tz) still do.
     requested_type = normalized_runtime_type(parse_sql_runtime_type(type_arg.value))
     materialized_type = normalized_runtime_type(parse_sql_runtime_type(mat_col.type))
     return requested_type.family != "unknown" and requested_type == materialized_type

--- a/posthog/hogql/transforms/json_extract_to_property.py
+++ b/posthog/hogql/transforms/json_extract_to_property.py
@@ -1,0 +1,139 @@
+"""Early ClickHouse pass: normalize a literal `JSONExtractString(properties, 'x')` into a property-access read.
+
+Users sometimes write `JSONExtractString(properties, '$browser')` (or a typed `JSONExtract(properties, 'x', 'T')`)
+directly instead of `properties.$browser`. When the property is backed by a materialized column, decompressing the
+whole JSON blob is wasted I/O. This pass rewrites such a call into the same property-access `Field` that
+`properties.$browser` produces, so the rest of the pipeline (lazy-table resolution, lowering, ClickHouse property
+resolution) treats the two forms identically and routes both to the materialized column.
+
+It runs *before* `resolve_lazy_tables`, so the produced read flows through the lazy-table machinery the same way a chain
+access does — that is what lets a read off the lazy `persons`/`groups` tables reach its materialized column inside the
+generated subquery, rather than being stranded as a raw JSON extract.
+
+Behavior-preserving: it only rewrites when a static materialized column already exists and its physical type matches the
+requested JSON type. A call with no materialized column is left untouched and prints as the raw JSON extract, so its
+ClickHouse semantics (e.g. `''` for a missing key) are unchanged. The choice of which physical column to read, and the
+access-control NULLing of restricted properties, are left entirely to the downstream resolution pass.
+"""
+
+from typing import cast
+
+from posthog.hogql import ast
+from posthog.hogql.base import _T_AST
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.models import StringJSONDatabaseField
+from posthog.hogql.type_system import normalized_runtime_type, parse_sql_runtime_type
+from posthog.hogql.visitor import CloningVisitor
+
+from posthog.clickhouse.materialized_columns import (
+    MATERIALIZATION_VALID_TABLES,
+    MaterializedColumn,
+    TablesWithMaterializedColumns,
+    get_materialized_column_for_property,
+)
+from posthog.models.property import TableColumn
+
+
+def normalize_json_extract_to_property(node: _T_AST, context: HogQLContext) -> _T_AST:
+    return cast(_T_AST, JSONExtractToPropertyNormalizer(context).visit(node))
+
+
+class JSONExtractToPropertyNormalizer(CloningVisitor):
+    def __init__(self, context: HogQLContext) -> None:
+        # The AST is still type-resolved at this point and downstream passes rely on those types.
+        super().__init__(clear_types=False)
+        self.context = context
+
+    def visit_call(self, node: ast.Call) -> ast.Expr:
+        rewritten = self._try_normalize(node)
+        if rewritten is not None:
+            return rewritten
+        return super().visit_call(node)
+
+    def _try_normalize(self, node: ast.Call) -> ast.Field | None:
+        property_name = _simple_json_extract_property_name(node)
+        if property_name is None:
+            return None
+
+        # Unwrap Alias if present (the resolver wraps fields in Alias nodes).
+        field_arg = node.args[0]
+        if isinstance(field_arg, ast.Alias):
+            field_arg = field_arg.expr
+        if not isinstance(field_arg, ast.Field):
+            return None
+
+        field_type = field_arg.type
+        if isinstance(field_type, ast.FieldAliasType):
+            field_type = field_type.type
+        if not isinstance(field_type, ast.FieldType):
+            return None
+
+        database_field = field_type.resolve_database_field(self.context)
+        if not isinstance(database_field, StringJSONDatabaseField):
+            return None
+
+        # resolve_database_table is polymorphic across concrete, lazy, alias, and virtual table types, so one call
+        # resolves the ClickHouse table name for a read off `events`, `raw_persons`, the lazy `persons`/`groups` tables,
+        # or the person-on-events virtual table alike. The materialized-column registry is keyed by that ClickHouse name
+        # (RawPersonsTable is "raw_persons" in HogQL but "person" in ClickHouse), which is why we don't use the HogQL name.
+        table_type = field_type.table_type
+        if not isinstance(table_type, ast.BaseTableType):
+            return None
+        table_name = table_type.resolve_database_table(self.context).to_printed_clickhouse(self.context)
+        if table_name not in MATERIALIZATION_VALID_TABLES:
+            return None
+
+        field_name = cast(TableColumn, database_field.name)
+        mat_col = get_materialized_column_for_property(
+            cast(TablesWithMaterializedColumns, table_name),
+            field_name,
+            property_name,
+        )
+        if mat_col is None:
+            return None
+
+        if not _json_extract_matches_materialized_column_type(node, mat_col):
+            return None
+
+        return ast.Field(
+            start=node.start,
+            end=node.end,
+            chain=[*field_arg.chain, property_name],
+            type=ast.PropertyType(chain=[property_name], field_type=field_type),
+        )
+
+
+def _simple_json_extract_property_name(node: ast.Call) -> str | None:
+    if node.name == "JSONExtractString" and len(node.args) == 2:
+        prop_name_arg = node.args[1]
+    elif node.name == "JSONExtract" and len(node.args) == 3:
+        prop_name_arg = node.args[1]
+    else:
+        return None
+
+    if isinstance(prop_name_arg, ast.Constant) and isinstance(prop_name_arg.value, str):
+        return prop_name_arg.value
+    return None
+
+
+def _json_extract_matches_materialized_column_type(node: ast.Call, mat_col: MaterializedColumn) -> bool:
+    if node.name == "JSONExtractString":
+        # JSONExtractString has string semantics, so it only matches a string-backed column.
+        # A non-string materialized column (e.g. Nullable(Float64)) would otherwise be rewritten
+        # to the bare typed column, dropping the string type the surrounding query expects.
+        return parse_sql_runtime_type(mat_col.type).family == "string"
+
+    if node.name != "JSONExtract" or len(node.args) != 3:
+        return False
+
+    type_arg = node.args[2]
+    if not isinstance(type_arg, ast.Constant) or not isinstance(type_arg.value, str):
+        return False
+
+    # Normalize before comparing so formatting differences in the type spelling
+    # (whitespace, quoting) don't block the rewrite; semantic differences
+    # (nullability, width, timezone) still do, because JSON helper semantics for
+    # missing keys and out-of-range values differ from bare column semantics.
+    requested_type = normalized_runtime_type(parse_sql_runtime_type(type_arg.value))
+    materialized_type = normalized_runtime_type(parse_sql_runtime_type(mat_col.type))
+    return requested_type.family != "unknown" and requested_type == materialized_type

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -6,7 +6,7 @@ from django.db.models.functions.comparison import Coalesce
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
-from posthog.hogql.database.models import BooleanDatabaseField, DateTimeDatabaseField, StringJSONDatabaseField
+from posthog.hogql.database.models import BooleanDatabaseField, DateTimeDatabaseField
 from posthog.hogql.database.s3_table import S3Table
 from posthog.hogql.database.schema.events import (
     EVENTS_TABLE_TYPES,
@@ -18,12 +18,10 @@ from posthog.hogql.database.schema.groups import GroupsTable
 from posthog.hogql.database.schema.persons import PersonsTable, RawPersonsTable
 from posthog.hogql.escape_sql import escape_hogql_identifier
 from posthog.hogql.property_planner import PropertySourceKind, plan_property_access
-from posthog.hogql.type_system import normalized_runtime_type, parse_sql_runtime_type
 from posthog.hogql.visitor import CloningVisitor, TraversingVisitor
 
 from posthog.clickhouse.materialized_columns import (
     DMAT_STRING_COLUMN_NAME_PREFIX,
-    MATERIALIZATION_VALID_TABLES,
     MaterializedColumn,
     TablesWithMaterializedColumns,
     get_materialized_column_for_property,
@@ -289,117 +287,11 @@ class PropertySwapper(CloningVisitor):
         )
 
     def visit_call(self, node: ast.Call):
-        rewritten = self._try_rewrite_json_extract_to_mat_column(node)
-        if rewritten is not None:
-            return rewritten
-
         self._inside_call_depth += 1
         try:
             return super().visit_call(node)
         finally:
             self._inside_call_depth -= 1
-
-    def _try_rewrite_json_extract_to_mat_column(self, node: ast.Call) -> ast.Field | None:
-        """Rewrite safe direct JSON property extraction to use a materialized column.
-
-        When users write raw JSONExtractString(properties, '$foo') in HogQL,
-        ClickHouse decompresses the full properties JSON blob. If '$foo' has a
-        materialized column (mat_$foo), this is unnecessary I/O. We rewrite the
-        call to a property access node that the printer resolves to the mat_ column.
-
-        Typed JSONExtract(...) calls are only rewritten when the physical column type
-        exactly matches the requested ClickHouse type, because JSON helper semantics
-        for missing keys and type mismatches differ by function family.
-        """
-        property_name = self._simple_json_extract_property_name(node)
-        if property_name is None:
-            return None
-
-        # Unwrap Alias if present (resolver wraps fields in Alias nodes)
-        field_arg = node.args[0]
-        if isinstance(field_arg, ast.Alias):
-            field_arg = field_arg.expr
-        if not isinstance(field_arg, ast.Field):
-            return None
-
-        # Unwrap FieldAliasType to get the underlying FieldType
-        field_type = field_arg.type
-        if isinstance(field_type, ast.FieldAliasType):
-            field_type = field_type.type
-        if not isinstance(field_type, ast.FieldType):
-            return None
-
-        database_field = field_type.resolve_database_field(self.context)
-        if not isinstance(database_field, StringJSONDatabaseField):
-            return None
-
-        table_type = field_type.table_type
-        while isinstance(table_type, (ast.TableAliasType, ast.ColumnAliasedTableType, ast.VirtualTableType)):
-            table_type = table_type.table_type
-        if not isinstance(table_type, ast.TableType):
-            return None
-
-        # The materialized-column registry is keyed by the ClickHouse table name, not the HogQL name
-        # (RawPersonsTable is "raw_persons" in HogQL but "person" in ClickHouse). Match clickhouse_property_resolution,
-        # or person/group properties read off `raw_persons`/`raw_groups` would miss their materialized column here.
-        table_name = table_type.resolve_database_table(self.context).to_printed_clickhouse(self.context)
-        if table_name not in MATERIALIZATION_VALID_TABLES:
-            return None
-
-        field_name = cast(TableColumn, database_field.name)
-        mat_col = get_materialized_column_for_property(
-            cast(TablesWithMaterializedColumns, table_name),
-            field_name,
-            property_name,
-        )
-        if mat_col is None:
-            return None
-
-        if not self._json_extract_matches_materialized_column_type(node, mat_col):
-            return None
-
-        return ast.Field(
-            start=node.start,
-            end=node.end,
-            chain=[*field_arg.chain, property_name],
-            type=ast.PropertyType(chain=[property_name], field_type=field_type),
-        )
-
-    @staticmethod
-    def _simple_json_extract_property_name(node: ast.Call) -> str | None:
-        if node.name == "JSONExtractString" and len(node.args) == 2:
-            prop_name_arg = node.args[1]
-        elif node.name == "JSONExtract" and len(node.args) == 3:
-            prop_name_arg = node.args[1]
-        else:
-            return None
-
-        if isinstance(prop_name_arg, ast.Constant) and isinstance(prop_name_arg.value, str):
-            return prop_name_arg.value
-        return None
-
-    @staticmethod
-    def _json_extract_matches_materialized_column_type(node: ast.Call, mat_col: MaterializedColumn) -> bool:
-        if node.name == "JSONExtractString":
-            # JSONExtractString has string semantics, so it only matches a string-backed column.
-            # A non-string materialized column (e.g. Nullable(Float64)) would otherwise be rewritten
-            # to the bare typed column, dropping the string type the surrounding query expects.
-            return parse_sql_runtime_type(mat_col.type).family == "string"
-
-        if node.name != "JSONExtract" or len(node.args) != 3:
-            return False
-
-        type_arg = node.args[2]
-        if not isinstance(type_arg, ast.Constant) or not isinstance(type_arg.value, str):
-            return False
-
-        # Normalize before comparing so formatting differences in the type spelling
-        # (whitespace, quoting) don't block the rewrite; semantic differences
-        # (nullability, width, timezone) still do, because JSON helper semantics for
-        # missing keys and out-of-range values differ from bare column semantics.
-        requested_type = normalized_runtime_type(parse_sql_runtime_type(type_arg.value))
-        materialized_type = normalized_runtime_type(parse_sql_runtime_type(mat_col.type))
-        return requested_type.family != "unknown" and requested_type == materialized_type
 
     def visit_compare_operation(self, node: ast.CompareOperation):
         result = super().visit_compare_operation(node)

--- a/posthog/hogql/transforms/property_types.py
+++ b/posthog/hogql/transforms/property_types.py
@@ -339,7 +339,10 @@ class PropertySwapper(CloningVisitor):
         if not isinstance(table_type, ast.TableType):
             return None
 
-        table_name = table_type.resolve_database_table(self.context).to_printed_hogql()
+        # The materialized-column registry is keyed by the ClickHouse table name, not the HogQL name
+        # (RawPersonsTable is "raw_persons" in HogQL but "person" in ClickHouse). Match clickhouse_property_resolution,
+        # or person/group properties read off `raw_persons`/`raw_groups` would miss their materialized column here.
+        table_name = table_type.resolve_database_table(self.context).to_printed_clickhouse(self.context)
         if table_name not in MATERIALIZATION_VALID_TABLES:
             return None
 

--- a/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
@@ -1,4 +1,134 @@
 # serializer version: 1
+# name: TestJSONExtractToMaterializedColumn.test_lazy_persons_table_property_rewritten_to_mat_column
+  '''
+  SELECT persons.`properties___$browser`
+  FROM
+    (SELECT person.id AS id,
+            nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))
+                                                    LIMIT 101
+                                                    OFFSET 0))) SETTINGS optimize_aggregation_in_order=1) AS persons
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_person_on_events_property_rewritten_to_mat_column
+  '''
+  SELECT nullIf(nullIf(events.`mat_pp_$browser`, ''), 'null') AS `nullIf(nullIf(mat_pp_$browser, ''), 'null')`
+  FROM events
+  WHERE equals(events.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_persons_table_property_rewritten_to_mat_column
+  '''
+  SELECT nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `nullIf(nullIf(pmat_$browser, ''), 'null')`
+  FROM person
+  WHERE equals(person.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_rewrite_value_semantics_no_mat_column
+  '''
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') AS tag,
+         JSONExtractString(events.properties, '$browser') AS `JSONExtractString(properties, '$browser')`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'pageview'))
+  ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_rewrite_value_semantics_non_nullable_mat_column
+  '''
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') AS tag,
+         nullIf(nullIf(events.`mat_$browser`, ''), 'null') AS `nullIf(nullIf(mat_$browser, ''), 'null')`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'pageview'))
+  ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_rewrite_value_semantics_nullable_mat_column
+  '''
+  SELECT replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') AS tag,
+         events.`mat_$browser`
+  FROM events
+  WHERE and(equals(events.team_id, 99999), equals(events.event, 'pageview'))
+  ORDER BY replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'tag'), ''), 'null'), '^"|"$', '') ASC
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestPropertyTypes.test_data_warehouse_person_property_types
   '''
   

--- a/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_property_types.ambr
@@ -1,4 +1,23 @@
 # serializer version: 1
+# name: TestJSONExtractToMaterializedColumn.test_event_property_chain_access_uses_mat_column
+  '''
+  SELECT nullIf(nullIf(events.`mat_$browser`, ''), 'null') AS `$browser`
+  FROM events
+  WHERE equals(events.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestJSONExtractToMaterializedColumn.test_lazy_persons_table_property_rewritten_to_mat_column
   '''
   SELECT persons.`properties___$browser`
@@ -28,11 +47,95 @@
                      use_hive_partitioning=0
   '''
 # ---
+# name: TestJSONExtractToMaterializedColumn.test_person_chain_access_joined_uses_mat_column
+  '''
+  SELECT events__person.`properties___$browser` AS `$browser`
+  FROM events
+  LEFT OUTER JOIN
+    (SELECT tupleElement(argMax(tuple(person_distinct_id_overrides.person_id), person_distinct_id_overrides.version), 1) AS person_id,
+            person_distinct_id_overrides.distinct_id AS distinct_id
+     FROM person_distinct_id_overrides
+     WHERE equals(person_distinct_id_overrides.team_id, 99999)
+     GROUP BY person_distinct_id_overrides.distinct_id
+     HAVING equals(tupleElement(argMax(tuple(person_distinct_id_overrides.is_deleted), person_distinct_id_overrides.version), 1), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+  LEFT JOIN
+    (SELECT person.id AS id,
+            nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))))) SETTINGS optimize_aggregation_in_order=1) AS events__person ON equals(if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id), events__person.id)
+  WHERE equals(events.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_person_on_events_chain_access_uses_mat_column
+  '''
+  SELECT nullIf(nullIf(events.`mat_pp_$browser`, ''), 'null') AS `$browser`
+  FROM events
+  WHERE equals(events.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
 # name: TestJSONExtractToMaterializedColumn.test_person_on_events_property_rewritten_to_mat_column
   '''
   SELECT nullIf(nullIf(events.`mat_pp_$browser`, ''), 'null') AS `nullIf(nullIf(mat_pp_$browser, ''), 'null')`
   FROM events
   WHERE equals(events.team_id, 99999)
+  LIMIT 100 SETTINGS readonly=2,
+                     max_execution_time=60,
+                     allow_experimental_object_type=1,
+                     max_ast_elements=4000000,
+                     max_expanded_ast_elements=4000000,
+                     max_bytes_before_external_group_by=0,
+                     transform_null_in=1,
+                     optimize_min_equality_disjunction_chain_length=4294967295,
+                     optimize_rewrite_aggregate_function_with_if=0,
+                     optimize_min_inequality_conjunction_chain_length=4294967295,
+                     allow_experimental_join_condition=1,
+                     use_hive_partitioning=0
+  '''
+# ---
+# name: TestJSONExtractToMaterializedColumn.test_persons_table_chain_access_uses_mat_column
+  '''
+  SELECT persons.`properties___$browser` AS `$browser`
+  FROM
+    (SELECT person.id AS id,
+            nullIf(nullIf(person.`pmat_$browser`, ''), 'null') AS `properties___$browser`
+     FROM person
+     WHERE and(equals(person.team_id, 99999), in(tuple(person.id, person.version),
+                                                   (SELECT person.id AS id, max(person.version) AS version
+                                                    FROM person
+                                                    WHERE equals(person.team_id, 99999)
+                                                    GROUP BY person.id
+                                                    HAVING and(equals(argMax(person.is_deleted, person.version), 0), less(argMax(toTimeZone(person.created_at, 'UTC'), person.version), plus(now64(6, 'UTC'), toIntervalDay(1))))
+                                                    LIMIT 101
+                                                    OFFSET 0))) SETTINGS optimize_aggregation_in_order=1) AS persons
   LIMIT 100 SETTINGS readonly=2,
                      max_execution_time=60,
                      allow_experimental_object_type=1,

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -485,8 +485,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_person_on_events_property_rewritten_to_mat_column(self):
-        # In person-on-events mode person.properties physically lives on the events table's person_properties
-        # column, so the rewrite should read that materialized column (mat_pp_) and return the same value.
+        # Under PoE, person.properties lives on the events person_properties column, hence mat_pp_.
         _create_event(team=self.team, distinct_id="u1", event="pageview", person_properties={"$browser": "Chrome"})
         flush_persons_and_events()
         with materialized("events", "$browser", table_column="person_properties"):
@@ -500,8 +499,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_persons_table_property_rewritten_to_mat_column(self):
-        # The persons table is "raw_persons" in HogQL but "person" in ClickHouse, and its materialized column is
-        # pmat_. The rewrite must key off the ClickHouse name to find it (regression guard for the table-name fix).
+        # raw_persons is "person" in ClickHouse; guards that the rewrite keys off the ClickHouse name, not the HogQL one.
         _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
         with materialized("person", "$browser"):
             results, sql = self._execute("select JSONExtractString(properties, '$browser') from raw_persons")
@@ -511,9 +509,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_lazy_persons_table_property_rewritten_to_mat_column(self):
-        # Normalizing the call into a property-access read before lazy-table resolution lets it flow through the
-        # argMax subquery the same way `properties.$browser` chain access does, so the materialized column is read
-        # inside the subquery rather than the raw JSON blob.
+        # The lazy persons table reads the mat column inside its argMax subquery, like chain access.
         _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
         with materialized("person", "$browser"):
             results, sql = self._execute("select JSONExtractString(properties, '$browser') from persons")
@@ -521,11 +517,11 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         assert results == [("Chrome",)], results
         assert "pmat_$browser" in sql, sql
         assert "JSONExtractString" not in sql, sql
-        # The literal form and chain access produce the same subquery (only the outer column alias differs).
+        # Same subquery as chain access; only the outer column alias differs.
         literal_shape = self._print_select("select JSONExtractString(properties, '$browser') from persons")
         assert literal_shape.split(" FROM ", 1)[1] == chain.split(" FROM ", 1)[1]
 
-    # --- property-chain access (`properties.foo`), the canonical form the literal JSONExtract normalizes into ---
+    # --- property-chain access (`properties.foo`): the canonical form the literal call normalizes into ---
 
     @snapshot_clickhouse_queries
     def test_event_property_chain_access_uses_mat_column(self):
@@ -539,7 +535,6 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_person_on_events_chain_access_uses_mat_column(self):
-        # person.properties.foo in person-on-events mode reads the events table's person_properties column.
         _create_event(team=self.team, distinct_id="u1", event="pageview", person_properties={"$browser": "Chrome"})
         flush_persons_and_events()
         with materialized("events", "$browser", table_column="person_properties"):
@@ -553,8 +548,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
 
     @snapshot_clickhouse_queries
     def test_person_chain_access_joined_uses_mat_column(self):
-        # Non-PoE (joined) mode: person.properties.foo joins from the persons table, reading its materialized column
-        # inside the argMax subquery.
+        # Joined mode reads person.properties from the persons table's mat column via the argMax subquery.
         _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
         _create_event(team=self.team, distinct_id="u1", event="pageview")
         flush_persons_and_events()

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -18,7 +18,7 @@ from django.test import override_settings
 
 from parameterized import parameterized
 
-from posthog.schema import HogQLQueryModifiers
+from posthog.schema import HogQLQueryModifiers, PersonsOnEventsMode
 
 from posthog.hogql import ast
 from posthog.hogql.context import HogQLContext
@@ -451,11 +451,15 @@ class TestPropertyTypes(BaseTest):
 
 
 class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
-    def _print_select(self, select: str):
+    def _print_select(self, select: str, modifiers: HogQLQueryModifiers | None = None):
         expr = parse_select(select)
         query, _ = prepare_and_print_ast(
             expr,
-            HogQLContext(team_id=self.team.pk, enable_select_queries=True),
+            HogQLContext(
+                team_id=self.team.pk,
+                enable_select_queries=True,
+                modifiers=modifiers or HogQLQueryModifiers(),
+            ),
             "clickhouse",
         )
         return pretty_print_in_tests(query, self.team.pk)
@@ -470,6 +474,25 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         with materialized("events", "$browser"):
             printed = self._print_select(query)
             assert "mat_$browser" in printed, f"Expected mat_$browser in output, got: {printed}"
+            assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
+
+    def test_jsonextractstring_rewritten_to_person_on_events_mat_column(self):
+        # In person-on-events mode person.properties physically lives on the events table's person_properties
+        # column, so the rewrite should target that materialized column (mat_pp_) instead of the raw JSON blob.
+        with materialized("events", "$browser", table_column="person_properties"):
+            printed = self._print_select(
+                "select JSONExtractString(person.properties, '$browser') from events",
+                HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS),
+            )
+            assert "mat_pp_$browser" in printed, f"Expected mat_pp_$browser in output, got: {printed}"
+            assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
+
+    def test_jsonextractstring_rewritten_to_mat_column_on_persons_table(self):
+        # The persons table is "raw_persons" in HogQL but "person" in ClickHouse, and its materialized column is
+        # pmat_. The rewrite must key off the ClickHouse name to find it (regression guard for the table-name fix).
+        with materialized("person", "$browser"):
+            printed = self._print_select("select JSONExtractString(properties, '$browser') from raw_persons")
+            assert "pmat_$browser" in printed, f"Expected pmat_$browser in output, got: {printed}"
             assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
 
     def test_jsonextractstring_rewrites_all_calls_in_same_query(self):

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -495,6 +495,17 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
             assert "pmat_$browser" in printed, f"Expected pmat_$browser in output, got: {printed}"
             assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
 
+    def test_jsonextractstring_not_rewritten_on_lazy_persons_table(self):
+        # The lazy `persons` table expands into an argMax subquery, so its field_type is a LazyTableType, not a
+        # TableType, and the rewrite declines (a pmat_ reference here would be stranded outside the subquery). The
+        # materialized column is pulled in by the lazy-table machinery instead. Pins that boundary.
+        with materialized("person", "$browser"):
+            printed = self._print_select("select JSONExtractString(properties, '$browser') from persons")
+            assert "JSONExtractString" in printed, (
+                f"Expected the lazy persons read to stay a JSON extract, got: {printed}"
+            )
+            assert "pmat_$browser" not in printed, f"Did not expect a bare pmat_ column, got: {printed}"
+
     def test_jsonextractstring_rewrites_all_calls_in_same_query(self):
         with materialized("events", "$browser"), materialized("events", "$os"):
             printed = self._print_select(

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -8,9 +8,11 @@ from posthog.test.base import (
     BaseTest,
     ClickhouseTestMixin,
     _create_event,
+    _create_person,
     flush_persons_and_events,
     get_indexes_from_explain,
     materialized,
+    snapshot_clickhouse_queries,
 )
 from unittest.mock import patch
 
@@ -464,6 +466,11 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         )
         return pretty_print_in_tests(query, self.team.pk)
 
+    def _execute(self, select: str, modifiers: HogQLQueryModifiers | None = None) -> tuple[list, str]:
+        response = execute_hogql_query(select, team=self.team, modifiers=modifiers)
+        assert response.results is not None
+        return response.results, response.clickhouse or ""
+
     @parameterized.expand(
         [
             ("bare_properties", "select JSONExtractString(properties, '$browser') from events"),
@@ -476,37 +483,47 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
             assert "mat_$browser" in printed, f"Expected mat_$browser in output, got: {printed}"
             assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
 
-    def test_jsonextractstring_rewritten_to_person_on_events_mat_column(self):
+    @snapshot_clickhouse_queries
+    def test_person_on_events_property_rewritten_to_mat_column(self):
         # In person-on-events mode person.properties physically lives on the events table's person_properties
-        # column, so the rewrite should target that materialized column (mat_pp_) instead of the raw JSON blob.
+        # column, so the rewrite should read that materialized column (mat_pp_) and return the same value.
+        _create_event(team=self.team, distinct_id="u1", event="pageview", person_properties={"$browser": "Chrome"})
+        flush_persons_and_events()
         with materialized("events", "$browser", table_column="person_properties"):
-            printed = self._print_select(
+            results, sql = self._execute(
                 "select JSONExtractString(person.properties, '$browser') from events",
                 HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS),
             )
-            assert "mat_pp_$browser" in printed, f"Expected mat_pp_$browser in output, got: {printed}"
-            assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
+        assert results == [("Chrome",)], results
+        assert "mat_pp_$browser" in sql, sql
+        assert "JSONExtractString" not in sql, sql
 
-    def test_jsonextractstring_rewritten_to_mat_column_on_persons_table(self):
+    @snapshot_clickhouse_queries
+    def test_persons_table_property_rewritten_to_mat_column(self):
         # The persons table is "raw_persons" in HogQL but "person" in ClickHouse, and its materialized column is
         # pmat_. The rewrite must key off the ClickHouse name to find it (regression guard for the table-name fix).
+        _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
         with materialized("person", "$browser"):
-            printed = self._print_select("select JSONExtractString(properties, '$browser') from raw_persons")
-            assert "pmat_$browser" in printed, f"Expected pmat_$browser in output, got: {printed}"
-            assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
+            results, sql = self._execute("select JSONExtractString(properties, '$browser') from raw_persons")
+        assert results == [("Chrome",)], results
+        assert "pmat_$browser" in sql, sql
+        assert "JSONExtractString" not in sql, sql
 
-    def test_jsonextractstring_rewritten_on_lazy_persons_table(self):
+    @snapshot_clickhouse_queries
+    def test_lazy_persons_table_property_rewritten_to_mat_column(self):
         # Normalizing the call into a property-access read before lazy-table resolution lets it flow through the
         # argMax subquery the same way `properties.$browser` chain access does, so the materialized column is read
-        # inside the subquery rather than the raw JSON blob. The two forms produce the same subquery (only the outer
-        # column alias differs), so the literal call now optimizes identically to chain access.
+        # inside the subquery rather than the raw JSON blob.
+        _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
         with materialized("person", "$browser"):
-            literal = self._print_select("select JSONExtractString(properties, '$browser') from persons")
+            results, sql = self._execute("select JSONExtractString(properties, '$browser') from persons")
             chain = self._print_select("select properties.$browser from persons")
-            assert "pmat_$browser" in literal, f"Expected pmat_$browser in output, got: {literal}"
-            assert "JSONExtractString" not in literal, f"Expected no JSONExtractString, got: {literal}"
-            # Strip the outer SELECT column alias, which is all that differs (auto-derived vs `$browser`).
-            assert literal.split(" FROM ", 1)[1] == chain.split(" FROM ", 1)[1]
+        assert results == [("Chrome",)], results
+        assert "pmat_$browser" in sql, sql
+        assert "JSONExtractString" not in sql, sql
+        # The literal form and chain access produce the same subquery (only the outer column alias differs).
+        literal_shape = self._print_select("select JSONExtractString(properties, '$browser') from persons")
+        assert literal_shape.split(" FROM ", 1)[1] == chain.split(" FROM ", 1)[1]
 
     def test_jsonextractstring_rewrites_all_calls_in_same_query(self):
         with materialized("events", "$browser"), materialized("events", "$os"):
@@ -610,6 +627,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         values = {row[0]: row[1] for row in response.results}
         return values, response.clickhouse or ""
 
+    @snapshot_clickhouse_queries
     def test_rewrite_value_semantics_no_mat_column(self):
         self._seed_edge_case_events()
         values, sql = self._run_and_collect()
@@ -619,6 +637,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         # Only JSONExtractRaw returns the literal string 'null' for JSON null.
         assert values == {"set": "Chrome", "empty": "", "null_str": "null", "json_null": "", "unset": ""}
 
+    @snapshot_clickhouse_queries
     def test_rewrite_value_semantics_non_nullable_mat_column(self):
         self._seed_edge_case_events()
         with materialized("events", "$browser", is_nullable=False):
@@ -630,6 +649,7 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         assert "nullIf(nullIf(events.`mat_$browser`" in sql, sql
         assert values == {"set": "Chrome", "empty": None, "null_str": None, "json_null": None, "unset": None}
 
+    @snapshot_clickhouse_queries
     def test_rewrite_value_semantics_nullable_mat_column(self):
         self._seed_edge_case_events()
         with materialized("events", "$browser", is_nullable=True):

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -525,6 +525,57 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
         literal_shape = self._print_select("select JSONExtractString(properties, '$browser') from persons")
         assert literal_shape.split(" FROM ", 1)[1] == chain.split(" FROM ", 1)[1]
 
+    # --- property-chain access (`properties.foo`), the canonical form the literal JSONExtract normalizes into ---
+
+    @snapshot_clickhouse_queries
+    def test_event_property_chain_access_uses_mat_column(self):
+        _create_event(team=self.team, distinct_id="u1", event="pageview", properties={"$browser": "Chrome"})
+        flush_persons_and_events()
+        with materialized("events", "$browser"):
+            results, sql = self._execute("select properties.$browser from events")
+        assert results == [("Chrome",)], results
+        assert "mat_$browser" in sql, sql
+        assert "JSONExtract" not in sql, sql
+
+    @snapshot_clickhouse_queries
+    def test_person_on_events_chain_access_uses_mat_column(self):
+        # person.properties.foo in person-on-events mode reads the events table's person_properties column.
+        _create_event(team=self.team, distinct_id="u1", event="pageview", person_properties={"$browser": "Chrome"})
+        flush_persons_and_events()
+        with materialized("events", "$browser", table_column="person_properties"):
+            results, sql = self._execute(
+                "select person.properties.$browser from events",
+                HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_ON_EVENTS),
+            )
+        assert results == [("Chrome",)], results
+        assert "mat_pp_$browser" in sql, sql
+        assert "JSONExtract" not in sql, sql
+
+    @snapshot_clickhouse_queries
+    def test_person_chain_access_joined_uses_mat_column(self):
+        # Non-PoE (joined) mode: person.properties.foo joins from the persons table, reading its materialized column
+        # inside the argMax subquery.
+        _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
+        _create_event(team=self.team, distinct_id="u1", event="pageview")
+        flush_persons_and_events()
+        with materialized("person", "$browser"):
+            results, sql = self._execute(
+                "select person.properties.$browser from events",
+                HogQLQueryModifiers(personsOnEventsMode=PersonsOnEventsMode.PERSON_ID_OVERRIDE_PROPERTIES_JOINED),
+            )
+        assert results == [("Chrome",)], results
+        assert "pmat_$browser" in sql, sql
+        assert "JSONExtract" not in sql, sql
+
+    @snapshot_clickhouse_queries
+    def test_persons_table_chain_access_uses_mat_column(self):
+        _create_person(team=self.team, distinct_ids=["u1"], properties={"$browser": "Chrome"}, immediate=True)
+        with materialized("person", "$browser"):
+            results, sql = self._execute("select properties.$browser from persons")
+        assert results == [("Chrome",)], results
+        assert "pmat_$browser" in sql, sql
+        assert "JSONExtract" not in sql, sql
+
     def test_jsonextractstring_rewrites_all_calls_in_same_query(self):
         with materialized("events", "$browser"), materialized("events", "$os"):
             printed = self._print_select(

--- a/posthog/hogql/transforms/test/test_property_types.py
+++ b/posthog/hogql/transforms/test/test_property_types.py
@@ -495,16 +495,18 @@ class TestJSONExtractToMaterializedColumn(ClickhouseTestMixin, BaseTest):
             assert "pmat_$browser" in printed, f"Expected pmat_$browser in output, got: {printed}"
             assert "JSONExtractString" not in printed, f"Expected no JSONExtractString, got: {printed}"
 
-    def test_jsonextractstring_not_rewritten_on_lazy_persons_table(self):
-        # The lazy `persons` table expands into an argMax subquery, so its field_type is a LazyTableType, not a
-        # TableType, and the rewrite declines (a pmat_ reference here would be stranded outside the subquery). The
-        # materialized column is pulled in by the lazy-table machinery instead. Pins that boundary.
+    def test_jsonextractstring_rewritten_on_lazy_persons_table(self):
+        # Normalizing the call into a property-access read before lazy-table resolution lets it flow through the
+        # argMax subquery the same way `properties.$browser` chain access does, so the materialized column is read
+        # inside the subquery rather than the raw JSON blob. The two forms produce the same subquery (only the outer
+        # column alias differs), so the literal call now optimizes identically to chain access.
         with materialized("person", "$browser"):
-            printed = self._print_select("select JSONExtractString(properties, '$browser') from persons")
-            assert "JSONExtractString" in printed, (
-                f"Expected the lazy persons read to stay a JSON extract, got: {printed}"
-            )
-            assert "pmat_$browser" not in printed, f"Did not expect a bare pmat_ column, got: {printed}"
+            literal = self._print_select("select JSONExtractString(properties, '$browser') from persons")
+            chain = self._print_select("select properties.$browser from persons")
+            assert "pmat_$browser" in literal, f"Expected pmat_$browser in output, got: {literal}"
+            assert "JSONExtractString" not in literal, f"Expected no JSONExtractString, got: {literal}"
+            # Strip the outer SELECT column alias, which is all that differs (auto-derived vs `$browser`).
+            assert literal.split(" FROM ", 1)[1] == chain.split(" FROM ", 1)[1]
 
     def test_jsonextractstring_rewrites_all_calls_in_same_query(self):
         with materialized("events", "$browser"), materialized("events", "$os"):

--- a/posthog/test/base.py
+++ b/posthog/test/base.py
@@ -68,7 +68,7 @@ from posthog.clickhouse.custom_metrics import (
     CUSTOM_METRICS_VIEW,
     TRUNCATE_CUSTOM_METRICS_COUNTER_EVENTS_TABLE,
 )
-from posthog.clickhouse.materialized_columns import MaterializedColumn
+from posthog.clickhouse.materialized_columns import MaterializedColumn, TableColumn
 from posthog.clickhouse.plugin_log_entries import TRUNCATE_PLUGIN_LOG_ENTRIES_TABLE_SQL
 from posthog.clickhouse.preaggregation.sql import (
     DISTRIBUTED_PREAGGREGATION_RESULTS_TABLE_SQL,
@@ -1228,6 +1228,7 @@ def materialized(
     create_bloom_filter_index: bool = False,
     create_ngram_lower_index: bool = False,
     create_bloom_filter_lower_index: bool = False,
+    table_column: TableColumn = "properties",
 ) -> Iterator[MaterializedColumn]:
     """Materialize a property within the managed block, removing it on exit."""
     try:
@@ -1246,6 +1247,7 @@ def materialized(
         column = materialize(
             table,
             property,
+            table_column=table_column,
             create_minmax_index=create_minmax_index,
             is_nullable=is_nullable,
             column_type=column_type,


### PR DESCRIPTION
## Problem

When a user writes a literal `JSONExtractString(properties, 'foo')` in HogQL (instead of `properties.foo`), we want it to read a precomputed materialized column rather than decompressing the whole raw JSON blob.

The previous mechanism was a bespoke rewrite inside `PropertySwapper` that ran *after* `resolve_lazy_tables` and re-derived the physical column itself. That had two problems:

- It re-implemented the table-name lookup, which drifted from the canonical resolver (`to_printed_hogql` vs `to_printed_clickhouse`) and silently missed `raw_persons`/`raw_groups`.
- Running after lazy resolution, it could never optimize reads off the lazy `persons`/`groups` tables or JOINED-mode `person.properties` — by then those are subqueries, so the rewrite declined and the query fell back to a raw JSON read.

## Changes

Replace the bespoke rewrite with a dedicated early pass, `normalize_json_extract_to_property` (`posthog/hogql/transforms/json_extract_to_property.py`), wired into the pipeline **after `resolve_types` but before `resolve_lazy_tables`**.

It converts a literal `JSONExtractString/JSONExtract(properties, 'x')` into the same property-access `Field` that `properties.x` produces, then lets the single existing resolution pipeline (lazy tables → lowering → `clickhouse_property_resolution`) choose the physical source. One polymorphic `resolve_database_table` call resolves the ClickHouse table name for concrete, lazy, alias, and virtual (person-on-events) tables alike, so there's no second table-name lookup to drift.

Net effect:

| Case | Before | After |
|---|---|---|
| events, person-on-events, `raw_persons` | optimized | optimized (unchanged) |
| value-semantics (empty / `null` / missing key) | — | preserved |
| lazy `persons` (`FROM persons`) | raw JSON read | reads the materialized column inside the argMax subquery, identical to chain access |
| JOINED-mode `person.properties` | raw JSON read | optimized through the person join |
| properties with no materialized column | raw `JSONExtract` | raw `JSONExtract` (unchanged) |

This is behavior-preserving: the pass only rewrites when a **static materialized column exists**, so a call with no materialized column keeps its raw-`JSONExtract` semantics. `PropertySwapper` loses ~110 lines of bespoke rewrite logic.

## How did you test this code?

I'm an agent (Claude Code); automated tests only, no manual testing.

- `test_property_types.py` (incl. the `TestJSONExtractToMaterializedColumn` class) + `test_property_skip_indexes.py`: 143 passed.
- Full printer + transforms suites (`test_printer.py`, `posthog/hogql/transforms/test/`): 1194 passed, 2 xfailed (EE-unavailable).
- New tests cover person-on-events (`mat_pp_`), `raw_persons` (`pmat_`), and the lazy `persons` table (asserts the literal form now produces the same subquery as chain access). The existing value-semantics tests confirm no-mat behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). No repo skills (migrations / DRF / etc.) were applicable.
- This PR started as a one-line fix (`to_printed_hogql` → `to_printed_clickhouse` in the bespoke rewrite) plus tests. During review it became clear the bespoke rewrite was the wrong layer: the duplicated table-name lookup was the root cause of the original bug, and running after lazy resolution structurally excluded the lazy/JOINED person cases. We pivoted to normalizing the literal call into a property-access read early and reusing the one resolution pipeline, which removes the duplication and extends coverage to the lazy tables.
- Kept it behavior-preserving (gated on a static materialized column) on purpose. An unconditional normalization would also be valid but would change no-mat `JSONExtractString` results (`''` → `NULL`), which is a separate product decision and out of scope here.
