### PR TITLE
feat(web-analytics): point weekly digest at the recap

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/buildNotificationSourcePath.test.ts
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/buildNotificationSourcePath.test.ts
@@ -1,6 +1,6 @@
 import { InAppNotification } from '~/types'
 
-import { buildNotificationSourcePath } from './sidePanelNotificationsLogic'
+import { buildNotificationSourcePath, withRecapSourceUrl } from './sidePanelNotificationsLogic'
 
 function makeNotification(overrides: Partial<InAppNotification> = {}): InAppNotification {
     return {
@@ -130,5 +130,29 @@ describe('buildNotificationSourcePath', () => {
             })
         )
         expect(result).toBeNull()
+    })
+})
+
+describe('withRecapSourceUrl', () => {
+    it('rewrites the /web segment of a digest source_url to /web/recap', () => {
+        const result = withRecapSourceUrl(
+            makeNotification({ source_url: '/project/2/web?utm_source=web_analytics_digest&utm_medium=in_app' })
+        )
+        expect(result.source_url).toBe('/project/2/web/recap?utm_source=web_analytics_digest&utm_medium=in_app')
+    })
+
+    it('rewrites a bare /web path with no query string', () => {
+        const result = withRecapSourceUrl(makeNotification({ source_url: '/project/2/web' }))
+        expect(result.source_url).toBe('/project/2/web/recap')
+    })
+
+    it('leaves an empty source_url untouched', () => {
+        const notification = makeNotification({ source_url: '' })
+        expect(withRecapSourceUrl(notification)).toBe(notification)
+    })
+
+    it('does not rewrite unrelated paths that merely contain web', () => {
+        const result = withRecapSourceUrl(makeNotification({ source_url: '/project/2/web-vitals' }))
+        expect(result.source_url).toBe('/project/2/web-vitals')
     })
 })

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -105,6 +105,15 @@ export function buildWebAnalyticsDigestMaxPrompt(metadata: WebAnalyticsDigestMet
     return `!Here's my web analytics digest for ${metadata.period_label.toLowerCase()} on ${metadata.project_name}: ${metricsLine}. What are the most important changes, and what should I dig into?`
 }
 
+// When the recap experience is enabled, send digest clicks to the recap page instead of the raw
+// dashboard. The digest's source_url is `/project/{id}/web?...`; only the `/web` segment is rewritten.
+export function withRecapSourceUrl(notification: InAppNotification): InAppNotification {
+    if (!notification.source_url) {
+        return notification
+    }
+    return { ...notification, source_url: notification.source_url.replace(/\/web(?=$|[?#])/, '/web/recap') }
+}
+
 export interface ChangelogFlagPayload {
     notificationDate: dayjs.Dayjs
     markdown: string
@@ -579,12 +588,13 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 })
             },
             viewWebAnalyticsFromDigest: ({ notification }) => {
+                const recapEnabled = !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_RECAP]
                 posthog.capture('web_analytics_digest_notification_clicked', {
-                    cta: 'view_web_analytics',
+                    cta: recapEnabled ? 'view_recap' : 'view_web_analytics',
                     notification_id: notification.id,
                     team_id: notification.team_id,
                 })
-                actions.navigateToNotification(notification)
+                actions.navigateToNotification(recapEnabled ? withRecapSourceUrl(notification) : notification)
             },
             askMaxAboutDigest: ({ notification }) => {
                 posthog.capture('web_analytics_digest_notification_clicked', {

--- a/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
@@ -1,5 +1,10 @@
+import { useValues } from 'kea'
+
 import { IconArrowRight, IconSparkles } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
+
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { WebAnalyticsDigestMetadata, WebAnalyticsDigestMetric, WebAnalyticsDigestMetricChange } from '~/types'
 
@@ -25,6 +30,8 @@ export function WebAnalyticsDigestNotification({
     onOpen: (e: React.MouseEvent) => void
     onAskMax: (e: React.MouseEvent) => void
 }): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const recapEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_RECAP]
     const byKey = (key: string): WebAnalyticsDigestMetric | undefined => metadata.metrics.find((m) => m.key === key)
     const hero = byKey('visitors')
     const pageviews = byKey('pageviews')
@@ -53,7 +60,7 @@ export function WebAnalyticsDigestNotification({
                     sideIcon={<IconArrowRight />}
                     onClick={onOpen}
                 >
-                    View web analytics
+                    {recapEnabled ? 'See your weekly recap' : 'View web analytics'}
                 </LemonButton>
                 <LemonButton type="secondary" size="small" fullWidth center icon={<IconSparkles />} onClick={onAskMax}>
                     Ask PostHog AI

--- a/posthog/templates/email/web_analytics_weekly_digest.html
+++ b/posthog/templates/email/web_analytics_weekly_digest.html
@@ -151,7 +151,11 @@
     <table cellpadding="0" cellspacing="0" border="0" width="100%" style="margin-top: 4px;">
         <tr>
             <td align="center">
+                {% if recap_enabled %}
+                <a href="{{ section.recap_url }}" target="_blank" style="display: inline-block; padding: 12px 24px; background-color: #1d4aff; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 0.95em; font-weight: 500;">View your weekly recap</a>
+                {% else %}
                 <a href="{{ section.dashboard_url }}" target="_blank" style="display: inline-block; padding: 12px 24px; background-color: #1d4aff; color: #ffffff; text-decoration: none; border-radius: 6px; font-size: 0.95em; font-weight: 500;">View Web analytics dashboard</a>
+                {% endif %}
             </td>
         </tr>
     </table>

--- a/products/web_analytics/backend/temporal/weekly_digest/activities.py
+++ b/products/web_analytics/backend/temporal/weekly_digest/activities.py
@@ -26,6 +26,7 @@ from posthog.tasks.email import NotificationSetting, should_send_notification
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.user_permissions import UserPermissions
 
+from products.web_analytics.backend.recap import recap_url_for_team
 from products.web_analytics.backend.temporal.digest_common import paginate_index, paginate_keyset
 from products.web_analytics.backend.temporal.weekly_digest.types import (
     WA_DIGEST_EMAIL_UNAVAILABLE_TYPE,
@@ -161,6 +162,14 @@ def _send_digest_for_user(
     if dry_run:
         return DigestOutcome.DRY_RUN
 
+    # When the recap experience is enabled for this user, the email CTA points at the recap page.
+    recap_enabled = _is_user_recap_enabled(user, str(org.id))
+    if recap_enabled:
+        for section in user_team_sections:
+            section["recap_url"] = recap_url_for_team(
+                section["team"], utm_source="web_analytics_weekly_digest", utm_medium="email"
+            )
+
     try:
         message = EmailMessage(
             campaign_key=campaign_key,
@@ -170,6 +179,7 @@ def _send_digest_for_user(
                 "organization": org,
                 "project_sections": user_team_sections,
                 "disabled_project_names": disabled_team_names,
+                "recap_enabled": recap_enabled,
                 "settings_url": f"{settings.SITE_URL}/settings/user-notifications?highlight=wa-weekly-digest",
             },
         )
@@ -190,11 +200,11 @@ def _send_digest_for_user(
     return DigestOutcome.SENT
 
 
-def _is_user_targeted_for_digest(user: User, org_id: str) -> bool:
+def _is_user_flag_enabled(user: User, org_id: str, flag_key: str) -> bool:
     try:
         return bool(
             posthoganalytics.feature_enabled(
-                "web-analytics-weekly-digest",
+                flag_key,
                 distinct_id=str(user.distinct_id),
                 groups={"organization": org_id},
                 only_evaluate_locally=False,
@@ -203,13 +213,22 @@ def _is_user_targeted_for_digest(user: User, org_id: str) -> bool:
         )
     except Exception as e:
         logger.warning(
-            "wa digest: flag eval failed, treating user as not targeted",
+            "wa digest: flag eval failed, treating user as not enabled",
+            flag_key=flag_key,
             user_id=str(user.uuid),
             org_id=org_id,
             error=str(e),
         )
         capture_exception(e, {"user_id": str(user.uuid), "org_id": org_id})
         return False
+
+
+def _is_user_recap_enabled(user: User, org_id: str) -> bool:
+    return _is_user_flag_enabled(user, org_id, "web-analytics-recap")
+
+
+def _is_user_targeted_for_digest(user: User, org_id: str) -> bool:
+    return _is_user_flag_enabled(user, org_id, "web-analytics-weekly-digest")
 
 
 def _build_and_send_for_org(org_id: str, dry_run: bool = False) -> OrgDigestCounts:

--- a/products/web_analytics/mcp/tools.yaml
+++ b/products/web_analytics/mcp/tools.yaml
@@ -171,6 +171,9 @@ tools:
     web-analytics-filter-presets-update:
         operation: web_analytics_filter_presets_update
         enabled: false
+    web-analytics-recap:
+        operation: web_analytics_recap
+        enabled: false
     web-analytics-weekly-digest:
         operation: web_analytics_weekly_digest
         enabled: true


### PR DESCRIPTION
## Problem

With the new weekly recap page (#65557), the existing weekly digest should send people to the richer recap instead of the raw dashboard — when the recap is enabled for them.

## Changes

Points the weekly digest's CTAs at `/web/recap` when the `web-analytics-recap` flag is on, falling back to the dashboard otherwise.

- **Temporal activity** (`weekly_digest/activities.py`) — injects a per-section `recap_url`, passes `recap_enabled` to the email context, and refactors the per-user flag check into a reusable `_is_user_flag_enabled` (adding `_is_user_recap_enabled`).
- **Email** (`web_analytics_weekly_digest.html`) — recap CTA ("View your weekly recap") behind `{% if recap_enabled %}`, dashboard CTA otherwise.
- **In-app notification** — `sidePanelNotificationsLogic` rewrites the digest's `/web` deep link to `/web/recap` and reports a `view_recap` CTA when the flag is on; `WebAnalyticsDigestNotification` switches the button copy. Adds `withRecapSourceUrl` unit tests.

Stacked on #65557 — depends on `recap_url_for_team`, the `WEB_ANALYTICS_RECAP` flag, and the `/web/recap` route introduced there.

## How did you test this code?

I'm an agent (Claude, via Claude Code); I did **not** run tests locally this session — CI runs them. Added `withRecapSourceUrl` cases in `buildNotificationSourcePath.test.ts` covering the `/web` → `/web/recap` rewrite, that a bare `/web` path is handled, and that unrelated paths like `/web-vitals` are left untouched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Second PR in the stack Jordan split with Claude Code (Claude Opus). Pure integration layer on top of #65557; no new backend queries. Flag-gated, so digest behavior is unchanged until `web-analytics-recap` is enabled.
