### PR TITLE
feat(session-replay): show React Native event trigger support on mobile replay settings

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -314,6 +314,7 @@ function MobileEventTriggers(): JSX.Element {
                     <Since
                         ios={{ version: '3.48.0' }}
                         android={{ version: '3.40.1' }}
+                        reactNative={{ version: '4.52.0' }}
                         flutter={{ version: '5.25.0' }}
                     />
                 </LemonLabel>
@@ -324,7 +325,7 @@ function MobileEventTriggers(): JSX.Element {
                 </Tooltip>
             </div>
             <p className="text-muted-alt">
-                Event triggers are shared across Web, iOS, Android, and Flutter.{' '}
+                Event triggers are shared across Web, iOS, Android, React Native, and Flutter.{' '}
                 <span className="font-semibold">Change this setting on the Web tab.</span>
             </p>
         </div>


### PR DESCRIPTION
## Changes

- Add `reactNative={{ version: '4.52.0' }}` to the event-trigger `Since` badge on the Mobile tab.
- Update the accompanying copy to include React Native in the list of platforms event triggers are shared across.

Mirrors the companion docs update: [posthog.com#17860](https://github.com/PostHog/posthog.com/pull/17860).

## How did you test this code?

Visual/copy-only change to existing read-only UI. The `reactNative` prop is already used by the `Since` badge elsewhere in this file (Mobile Sampling).

## Notes

- 4.52.0 is the next minor on top of the already-published `posthog-react-native` 4.51.0; it's being released now. If the published version shifts, this badge and the docs list should track it.