### PR TITLE
fix(eng-analytics): drop tab-aware scene logic that 404'd the scene

### DIFF
--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
@@ -3,7 +3,6 @@ import { combineUrl, router } from 'kea-router'
 
 import { LemonBanner, LemonButton, LemonSelect, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
-import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -28,8 +27,6 @@ export function EngineeringAnalyticsScene(): JSX.Element {
     const { searchParams } = useValues(router)
     const { activeTab } = useValues(engineeringAnalyticsSceneLogic)
     const logic = engineeringAnalyticsLogic()
-    // Keep the data logic alive for the scene's lifetime, independent of which inner tab renders.
-    useAttachedLogic(logic, engineeringAnalyticsSceneLogic)
     const { anyLoading, hasMultipleSources, sourceOptions, sourceId } = useValues(logic)
     const { refresh, setSourceId } = useActions(logic)
 

--- a/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
+++ b/products/engineering_analytics/frontend/scenes/EngineeringAnalyticsScene.tsx
@@ -24,12 +24,12 @@ export const scene: SceneExport = {
     logic: engineeringAnalyticsSceneLogic,
 }
 
-export function EngineeringAnalyticsScene({ tabId }: { tabId?: string }): JSX.Element {
+export function EngineeringAnalyticsScene(): JSX.Element {
     const { searchParams } = useValues(router)
     const { activeTab } = useValues(engineeringAnalyticsSceneLogic)
-    const logic = engineeringAnalyticsLogic({ tabId })
-    // Keep this tab's filters and data alive across tab switches (React unmounts inactive tabs).
-    useAttachedLogic(logic, tabId ? engineeringAnalyticsSceneLogic({ tabId }) : undefined)
+    const logic = engineeringAnalyticsLogic()
+    // Keep the data logic alive for the scene's lifetime, independent of which inner tab renders.
+    useAttachedLogic(logic, engineeringAnalyticsSceneLogic)
     const { anyLoading, hasMultipleSources, sourceOptions, sourceId } = useValues(logic)
     const { refresh, setSourceId } = useActions(logic)
 
@@ -51,7 +51,7 @@ export function EngineeringAnalyticsScene({ tabId }: { tabId?: string }): JSX.El
     ]
 
     return (
-        <BindLogic logic={engineeringAnalyticsLogic} props={{ tabId }}>
+        <BindLogic logic={engineeringAnalyticsLogic} props={{}}>
             <SceneContent>
                 <SceneTitleSection
                     name="CI analytics"

--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
@@ -26,6 +26,7 @@ import {
     filterPullRequests,
     workflowTrendSeries,
 } from './engineeringAnalyticsLogic'
+import { engineeringAnalyticsSceneLogic } from './engineeringAnalyticsSceneLogic'
 import { sortRunsForTriage } from './pullRequestDetailLogic'
 
 jest.mock('../generated/api', () => ({
@@ -224,6 +225,13 @@ describe('engineeringAnalyticsLogic', () => {
 
         expect(tabA.values.stateFilter).toBe('merged')
         expect(tabB.values.stateFilter).toBe(DEFAULT_FILTERS.state)
+    })
+
+    it('scene logic mounts without a tabId so /engineering-analytics resolves instead of 404ing', () => {
+        // #62051 collapsed sceneLogic to single-scene state and stopped threading a tabId into
+        // scene logics. A tab-aware scene logic then throws "must have a tabId prop" on mount,
+        // sceneLogic's catch falls back to Error404, and every visit to the scene 404s.
+        expect(() => engineeringAnalyticsSceneLogic().mount()).not.toThrow()
     })
 
     it('maps the three endpoints into typed rows and defaults to the open filter', async () => {

--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsSceneLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsSceneLogic.ts
@@ -1,7 +1,5 @@
 import { connect, kea, path, selectors } from 'kea'
 
-import { tabAwareScene } from 'lib/logic/scenes/tabAwareScene'
-
 import { sceneLogic } from '~/scenes/sceneLogic'
 
 import type { engineeringAnalyticsSceneLogicType } from './engineeringAnalyticsSceneLogicType'
@@ -20,7 +18,6 @@ const SCENE_KEY_TO_TAB: Record<string, EngineeringAnalyticsTab> = {
 
 export const engineeringAnalyticsSceneLogic = kea<engineeringAnalyticsSceneLogicType>([
     path(['products', 'engineering_analytics', 'frontend', 'scenes', 'engineeringAnalyticsSceneLogic']),
-    tabAwareScene(),
     connect(() => ({
         values: [sceneLogic, ['sceneKey']],
     })),


### PR DESCRIPTION
## Problem

`/engineering-analytics` 404s for everyone with the CI analytics flag on. [#62051](https://github.com/PostHog/posthog/pull/62051) stopped threading a `tabId` into scene logics; `engineeringAnalyticsSceneLogic` was the last one still using `tabAwareScene()` (which throws without a `tabId`), so it threw on mount and `sceneLogic` fell back to `Error404`.

## Changes

- Drop `tabAwareScene()` — the scene logic is now a plain singleton.
- Remove the now-dead `tabId` plumbing in the component (including a redundant `useAttachedLogic`).
- Add a regression test: the scene logic mounts without a `tabId`.

## How did you test this code?

Agent (Claude Code), automated only — no manual browser pass (local stack down):

- Regression test fails on master with the exact prod error (`must have a tabId prop`), passes with the fix.
- `engineeringAnalyticsLogic.test.ts`: 26/26.
- Root cause confirmed live on prod via Chrome DevTools.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Claude Code (Opus 4.8), driven by @rnegron. No repo skills invoked.
- De-keyed the straggler rather than re-adding `tabId` injection (#62051 removed it repo-wide). @pauldambra — a framework-level guard in `sceneLogic` would stop the next `tabAwareScene()` scene silently 404ing the same way.
