### PR TITLE
feat(experiments): use a skeleton for the metric loading state instead of a spinner

### DIFF
--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -1,5 +1,6 @@
 import './MetricRowGroup.scss'
 
+import clsx from 'clsx'
 import { useActions, useValues } from 'kea'
 import React, { useEffect, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
@@ -9,6 +10,7 @@ import { IconTrending } from '@posthog/icons'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { IconTrendingDown } from 'lib/lemon-ui/icons'
 import { LemonCollapse } from 'lib/lemon-ui/LemonCollapse'
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 import { VariantTag } from 'scenes/experiments/ExperimentView/VariantTag'
@@ -27,9 +29,15 @@ import { experimentMetricsLogic } from '~/scenes/experiments/experimentMetricsLo
 import { isLaunched } from '~/scenes/experiments/experimentsLogic'
 import { useColumnWidthSync } from '~/scenes/experiments/MetricsView/hooks/useColumnWidthSync'
 import { ChartEmptyState } from '~/scenes/experiments/MetricsView/shared/ChartEmptyState'
+import { SkeletonResultCells } from '~/scenes/experiments/MetricsView/shared/ChartLoadingSkeleton'
 import { ChartLoadingState } from '~/scenes/experiments/MetricsView/shared/ChartLoadingState'
 import { useChartColors } from '~/scenes/experiments/MetricsView/shared/colors'
 import { MetricHeader } from '~/scenes/experiments/MetricsView/shared/MetricHeader'
+import {
+    FIXED_HEIGHT_STYLE,
+    getMinHeightStyle,
+    getScaledHeightStyle,
+} from '~/scenes/experiments/MetricsView/shared/rowHeights'
 import {
     type ExperimentVariantResult,
     formatChanceToWinForGoal,
@@ -61,22 +69,6 @@ import { GridLines } from './GridLines'
 import { renderTooltipContent } from './MetricRowGroupTooltip'
 import { TimeseriesModal } from './TimeseriesModal'
 import { useAxisScale } from './useAxisScale'
-
-const FIXED_HEIGHT_STYLE: React.CSSProperties = {
-    height: `${CELL_HEIGHT}px`,
-    maxHeight: `${CELL_HEIGHT}px`,
-}
-
-const getScaledHeightStyle = (rowCount: number): React.CSSProperties => {
-    const scaledHeight = `${CELL_HEIGHT * rowCount}px`
-
-    return {
-        height: scaledHeight,
-        maxHeight: scaledHeight,
-    }
-}
-
-const getMinHeightStyle = (height: number): React.CSSProperties => ({ minHeight: `${height}px` })
 
 interface BreakdownErrorStateProps {
     metric: ExperimentMetric
@@ -597,6 +589,7 @@ export function MetricRowGroup({
 
     const { reportExperimentTimeseriesViewed, retryPrimaryMetric, retrySecondaryMetric, refreshExperimentResults } =
         useActions(experimentLogic)
+    const { variants } = useValues(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const { isRecalculating } = useValues(experimentMetricsLogic({ experiment }))
     const { triggerRecalculation } = useActions(experimentMetricsLogic({ experiment }))
@@ -720,9 +713,76 @@ export function MetricRowGroup({
         })
     }
 
-    if (isLoading || error || !result) {
-        const hasError = !!error
-        const noResultHeight = hasError ? CELL_HEIGHT : Math.max(CELL_HEIGHT, EMPTY_STATE_ROW_MIN_HEIGHT)
+    // Skeleton-with-variants while results compute: keeps the final row layout so data fills in place
+    if (!error && (isLoading || exposuresLoading)) {
+        const skeletonVariantKeys = variants.length > 0 ? variants.map((variant) => variant.key) : ['control']
+        const bg = isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'
+
+        return (
+            <>
+                <tr className="hover:bg-bg-hover group [&:last-child>td]:border-b-0" style={FIXED_HEIGHT_STYLE}>
+                    {/* Metric column: real header spanning every variant row, stays interactive while loading */}
+                    <td
+                        className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
+                            !isLastMetric ? 'border-b' : ''
+                        } ${bg}`}
+                        rowSpan={skeletonVariantKeys.length}
+                        style={getScaledHeightStyle(skeletonVariantKeys.length)}
+                    >
+                        <MetricHeader
+                            displayOrder={displayOrder}
+                            metric={metric}
+                            metricType={metricType}
+                            isPrimaryMetric={!isSecondary}
+                            experiment={experiment}
+                            onDuplicateMetricClick={() => onDuplicateMetric?.()}
+                            onDeleteMetricClick={onDeleteMetric ? () => onDeleteMetric() : undefined}
+                            onBreakdownChange={onBreakdownChange}
+                        />
+                    </td>
+
+                    <SkeletonResultCells
+                        variantKey={skeletonVariantKeys[0]}
+                        className={clsx(bg, skeletonVariantKeys.length === 1 && 'border-b')}
+                        detailsCell={
+                            <td
+                                className={clsx(
+                                    'w-20 pt-3 align-top relative overflow-hidden',
+                                    !isLastMetric && 'border-b',
+                                    bg
+                                )}
+                                rowSpan={skeletonVariantKeys.length}
+                                style={getScaledHeightStyle(skeletonVariantKeys.length)}
+                            >
+                                {/* Reserve the Details button's footprint so the chart column doesn't shift when results land */}
+                                {showDetailsModal && (
+                                    <div className="flex justify-end">
+                                        <LemonSkeleton className="h-6 w-[74px]" />
+                                    </div>
+                                )}
+                            </td>
+                        }
+                    />
+                </tr>
+
+                {skeletonVariantKeys.slice(1).map((variantKey, index) => (
+                    <tr
+                        key={variantKey}
+                        className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
+                        style={FIXED_HEIGHT_STYLE}
+                    >
+                        <SkeletonResultCells
+                            variantKey={variantKey}
+                            className={clsx(bg, index === skeletonVariantKeys.length - 2 && 'border-b')}
+                        />
+                    </tr>
+                ))}
+            </>
+        )
+    }
+
+    if (error || !result) {
+        const noResultHeight = error ? CELL_HEIGHT : Math.max(CELL_HEIGHT, EMPTY_STATE_ROW_MIN_HEIGHT)
         const noResultStateStyle = getMinHeightStyle(noResultHeight)
 
         return (
@@ -747,7 +807,7 @@ export function MetricRowGroup({
                         />
                     </td>
 
-                    {/* Combined columns for loading/error state */}
+                    {/* Combined columns for error/empty state */}
                     <td
                         colSpan={6}
                         className={`p-3 text-center ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'} ${
@@ -755,18 +815,14 @@ export function MetricRowGroup({
                         }`}
                         style={noResultStateStyle}
                     >
-                        {!hasError && (isLoading || exposuresLoading) ? (
-                            <ChartLoadingState height={noResultHeight} />
-                        ) : (
-                            <ChartEmptyState
-                                height={noResultHeight}
-                                experimentStarted={isLaunched(experiment)}
-                                metric={metric}
-                                error={error}
-                                query={debugQuery}
-                                onRetry={handleRetry}
-                            />
-                        )}
+                        <ChartEmptyState
+                            height={noResultHeight}
+                            experimentStarted={isLaunched(experiment)}
+                            metric={metric}
+                            error={error}
+                            query={debugQuery}
+                            onRetry={handleRetry}
+                        />
                     </td>
                 </tr>
                 {metric.breakdownFilter?.breakdowns && metric.breakdownFilter.breakdowns.length > 0 && (

--- a/frontend/src/scenes/experiments/MetricsView/shared/ChartLoadingSkeleton.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ChartLoadingSkeleton.tsx
@@ -1,0 +1,65 @@
+import clsx from 'clsx'
+
+import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { VariantTag } from 'scenes/experiments/ExperimentView/VariantTag'
+
+import { FIXED_HEIGHT_STYLE } from '~/scenes/experiments/MetricsView/shared/rowHeights'
+
+export function SkeletonResultCells({
+    variantKey,
+    className,
+    detailsCell,
+}: {
+    variantKey: string
+    className: string
+    // Rendered between P-value and Chart, with rowSpan, on the baseline row only; matches the real layout
+    detailsCell?: JSX.Element
+}): JSX.Element {
+    return (
+        <>
+            {/* Variant tag is real; we know the variants before any result lands */}
+            <td
+                className={clsx('w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden', className)}
+                style={FIXED_HEIGHT_STYLE}
+            >
+                <VariantTag variantKey={variantKey} />
+            </td>
+
+            {/* Value */}
+            <td
+                className={clsx('w-24 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden', className)}
+                style={FIXED_HEIGHT_STYLE}
+            >
+                <LemonSkeleton className="h-4 w-12" />
+            </td>
+
+            {/* Delta */}
+            <td
+                className={clsx('w-20 pt-1 pl-3 pr-3 pb-1 text-left whitespace-nowrap overflow-hidden', className)}
+                style={FIXED_HEIGHT_STYLE}
+            >
+                <LemonSkeleton className="h-4 w-10" />
+            </td>
+
+            {/* P-value / Win probability */}
+            <td
+                className={clsx('w-20 pt-1 pl-3 pr-3 pb-1 text-center whitespace-nowrap overflow-hidden', className)}
+                style={FIXED_HEIGHT_STYLE}
+            >
+                <LemonSkeleton className="h-4 w-10 mx-auto" />
+            </td>
+
+            {detailsCell}
+
+            {/* Chart: mirrors ChartCell's wrapper so the bar lands where the real chart will */}
+            <td
+                className={clsx('p-0 align-middle text-center relative overflow-hidden', className)}
+                style={FIXED_HEIGHT_STYLE}
+            >
+                <div className="px-3">
+                    <LemonSkeleton className="h-3 w-full" />
+                </div>
+            </td>
+        </>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/shared/rowHeights.ts
+++ b/frontend/src/scenes/experiments/MetricsView/shared/rowHeights.ts
@@ -1,0 +1,13 @@
+import { CELL_HEIGHT } from '~/scenes/experiments/MetricsView/new/constants'
+
+export const FIXED_HEIGHT_STYLE: React.CSSProperties = {
+    height: `${CELL_HEIGHT}px`,
+    maxHeight: `${CELL_HEIGHT}px`,
+}
+
+export const getScaledHeightStyle = (rowCount: number): React.CSSProperties => {
+    const scaledHeight = `${CELL_HEIGHT * rowCount}px`
+    return { height: scaledHeight, maxHeight: scaledHeight }
+}
+
+export const getMinHeightStyle = (height: number): React.CSSProperties => ({ minHeight: `${height}px` })


### PR DESCRIPTION
## Problem

The per-metric loading spinner collapsed the row, gave no sense of its final shape, and caused a layout shift when the real result replaced it.

## Changes

This PR replaces the per-metric spinner with a skeleton that preserves the metric's final layout, so results fill in place instead of reflowing.

### Skeleton that mirrors the real result row

The skeleton renders the exact column structure of a loaded metric: the real metric header, the real variant tags, and shimmer bars for the value, delta, win probability, and chart cells. Because the row count and column widths match the real result, the row keeps its shape and stays interactive while the data animates in place.

- `frontend/src/scenes/experiments/MetricsView/shared/ChartLoadingSkeleton.tsx`
- `frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx`

### Loading branch split from error/empty

The old branch handled loading, error, and empty in a single collapsed cell; it is now split, so the loading branch renders the skeleton, and the error/empty branch keeps the existing `ChartEmptyState`. The breakdown sub-table keeps its existing `ChartLoadingState` spinner, which is out of scope here.

### Details column footprint

Under the table's auto layout, the details column sizes to the "Details" button, so loading without a placeholder collapsed it and shifted the chart left when results landed. The skeleton reserves a button-sized placeholder gated on `showDetailsModal`, leaving only a minor residual shift from the content-sized value and delta columns.

### Shared row-height helpers

`FIXED_HEIGHT_STYLE`, `getScaledHeightStyle`, and `getMinHeightStyle` moved out of `MetricRowGroup` into a small shared module so the skeleton and the row use the same definitions.

- `frontend/src/scenes/experiments/MetricsView/shared/rowHeights.ts`

| loading skeleton |
| - |
| <img alt="metric skeleton loading" src="https://github.com/user-attachments/assets/fb160e75-c92f-4e0c-b3ce-b326912d619b" /> |

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/MetricsView
```

![cat-type-small](https://github.com/user-attachments/assets/2d54ff25-1654-4aea-ba9b-35e3f790352c)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **yes**

Skills used:

- /brainstorming (superpowers)

Relevant decisions:

- `SkeletonResultCells` returns only the per-variant cells; `MetricRowGroup` keeps ownership of the metric and details columns with their `rowSpan`, rather than duplicating the whole row scaffolding inside the skeleton.