### PR TITLE
fix(auth): guard INTERNAL_API_SECRET at request time, not startup

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -73,8 +73,8 @@ env:
     AZURE_INFERENCE_CREDENTIAL: ${{ secrets.AZURE_INFERENCE_CREDENTIAL }}
     AZURE_INFERENCE_ENDPOINT: ${{ secrets.AZURE_INFERENCE_ENDPOINT }}
     PERSONHOG_ADDR: 'localhost:50052'
-    # check_internal_api_secret requires a non-empty INTERNAL_API_SECRET outside DEBUG/TEST. The dev
-    # value matches the Node plugins container's non-prod default, so Django<->Node internal calls authenticate.
+    # Internal API auth needs a non-empty INTERNAL_API_SECRET when DEBUG/TEST are off. The dev value
+    # matches the Node plugins container's non-prod default, so Django<->Node internal calls authenticate.
     INTERNAL_API_SECRET: posthog123
 
 concurrency:

--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -268,8 +268,8 @@ jobs:
             # historical-flag override requests to the Rust flags service. Any non-empty
             # value is fine for CI — the Rust service in the test stack accepts it.
             INTERNAL_REQUEST_TOKEN: 'mcp-ci-internal-request-token'
-            # check_internal_api_secret requires a non-empty INTERNAL_API_SECRET outside DEBUG/TEST,
-            # and this job boots the app prod-like. The dev value is fine for CI.
+            # Internal API auth needs a non-empty INTERNAL_API_SECRET when DEBUG/TEST are off, and
+            # this job boots the app prod-like. The dev value is fine for CI.
             INTERNAL_API_SECRET: 'posthog123'
 
         steps:

--- a/posthog/apps.py
+++ b/posthog/apps.py
@@ -41,7 +41,6 @@ class PostHogConfig(AppConfig):
         # shell) would lose them. They live in dedicated import-light modules — never wire
         # ready() through an API module, even one that looks light today.
         import posthog.storage.checks  # noqa: F401, PLC0415
-        import posthog.internal_api_secret  # noqa: F401, PLC0415
         import posthog.caching.organization_serializer_cache  # noqa: F401, PLC0415
         import posthog.models.activity_logging.signal_handlers  # noqa: F401, PLC0415
 

--- a/posthog/auth.py
+++ b/posthog/auth.py
@@ -1006,9 +1006,10 @@ class InternalAPIAuthentication(authentication.BaseAuthentication):
         if provided_secret:
             provided_secret = provided_secret.strip()
 
-        # Primary + still-trusted fallbacks, with the dev default dropped outside dev/test. A
-        # misconfigured production deploy (no usable secret) is caught at startup by
-        # check_internal_api_secret; the empty-set guard below is a defensive backstop.
+        # Primary secret plus any still-trusted fallbacks (zero-downtime rotation), dropping empties.
+        # This is the runtime guard: a deploy with no usable secret is rejected here (fail closed)
+        # rather than at startup — most Django/Temporal processes never get the secret injected and
+        # never serve these endpoints, so a startup check would wrongly crash them.
         accepted_secrets = usable_internal_api_secrets()
 
         if not accepted_secrets:

--- a/posthog/internal_api_secret.py
+++ b/posthog/internal_api_secret.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.core.checks import Error, register
 
 
 def usable_internal_api_secrets() -> list[str]:
@@ -9,22 +8,3 @@ def usable_internal_api_secrets() -> list[str]:
     re-normalize per call.
     """
     return [secret for secret in [settings.INTERNAL_API_SECRET, *settings.INTERNAL_API_SECRET_FALLBACKS] if secret]
-
-
-@register()
-def check_internal_api_secret(app_configs: object, **kwargs: object) -> list[Error]:
-    """Fail at startup if a non-dev/test deploy has no INTERNAL_API_SECRET configured, rather than
-    rejecting every internal request at runtime. The value itself is not policed — production must
-    set a real secret (the default is empty outside DEBUG/TEST), CI may set the dev value.
-    """
-    if settings.DEBUG or settings.TEST:
-        return []
-    if usable_internal_api_secrets():
-        return []
-    return [
-        Error(
-            "INTERNAL_API_SECRET is not configured.",
-            hint="Set INTERNAL_API_SECRET to a non-empty value (it is required outside DEBUG/TEST).",
-            id="posthog.E005",
-        )
-    ]

--- a/posthog/settings/data_stores.py
+++ b/posthog/settings/data_stores.py
@@ -559,10 +559,11 @@ if not CDP_API_URL:
     )  # localhost is correct — plugin server runs on host in dev
 
 # Shared secret for internal API authentication between Django and Node.js services.
-# Defaults to the public dev secret only in DEBUG/TEST; elsewhere it must be set explicitly, so a
-# forgotten production config is empty and fails check_internal_api_secret at startup rather than
-# silently running on a known-public value. Normalized (stripped) at load so a trailing newline from
-# a mounted secret can't cause a spurious mismatch; get_list already strips the fallbacks.
+# Only the services that make/serve internal calls get this injected, so a missing value must not
+# block startup. Defaults to the public dev secret in DEBUG/TEST; elsewhere it defaults to empty and
+# internal API requests fail closed at request time (InternalAPIAuthentication) rather than silently
+# running on a known-public value. Stripped at load so a mounted secret's trailing newline can't
+# cause a spurious mismatch; get_list already strips the fallbacks.
 LOCAL_DEV_INTERNAL_API_SECRET = "posthog123"
 INTERNAL_API_SECRET = get_from_env(
     "INTERNAL_API_SECRET", LOCAL_DEV_INTERNAL_API_SECRET if DEBUG or TEST else ""

--- a/posthog/test/test_internal_api_auth.py
+++ b/posthog/test/test_internal_api_auth.py
@@ -10,7 +10,6 @@ from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.request import Request
 
 from posthog.auth import InternalAPIAuthentication
-from posthog.internal_api_secret import check_internal_api_secret
 from posthog.settings import LOCAL_DEV_INTERNAL_API_SECRET
 
 
@@ -135,31 +134,3 @@ class TestInternalAPIAuth(APIBaseTest):
 
         self.assertEqual(response.status_code, 400)
         self.assertEqual(response.json(), {"error": "Missing filters for which to get blast radius"})
-
-
-class TestInternalAPISecretCheck(APIBaseTest):
-    @override_settings(
-        INTERNAL_API_SECRET="real-prod-secret", INTERNAL_API_SECRET_FALLBACKS=[], DEBUG=False, TEST=False
-    )
-    def test_check_passes_with_usable_secret_in_prod(self):
-        self.assertEqual(check_internal_api_secret(None), [])
-
-    @override_settings(
-        INTERNAL_API_SECRET="", INTERNAL_API_SECRET_FALLBACKS=["real-prod-secret"], DEBUG=False, TEST=False
-    )
-    def test_check_passes_with_usable_fallback_in_prod(self):
-        self.assertEqual(check_internal_api_secret(None), [])
-
-    @override_settings(INTERNAL_API_SECRET="", INTERNAL_API_SECRET_FALLBACKS=[], DEBUG=False, TEST=False)
-    def test_check_errors_when_unset_in_prod(self):
-        errors = check_internal_api_secret(None)
-        self.assertEqual(len(errors), 1)
-        self.assertEqual(errors[0].id, "posthog.E005")
-
-    @override_settings(INTERNAL_API_SECRET=LOCAL_DEV_INTERNAL_API_SECRET, INTERNAL_API_SECRET_FALLBACKS=[], DEBUG=True)
-    def test_check_passes_in_dev(self):
-        self.assertEqual(check_internal_api_secret(None), [])
-
-    @override_settings(INTERNAL_API_SECRET="", INTERNAL_API_SECRET_FALLBACKS=[], TEST=True)
-    def test_check_passes_in_test(self):
-        self.assertEqual(check_internal_api_secret(None), [])


### PR DESCRIPTION
## Problem

The `check_internal_api_secret` system check (from #65346) fails app startup with `posthog.E005` whenever `INTERNAL_API_SECRET` is unset outside DEBUG/TEST. But the secret is only injected into the specific services that make/serve internal calls — most Django/Temporal processes never get it, so the startup check wrongly crashes them.

## Changes

- Drop the startup system check and rely on the existing **runtime guard** in `InternalAPIAuthentication`, which already fails closed per-request when no usable secret is configured. A misconfigured deploy now rejects the actual internal API requests (401) instead of refusing to boot. This restores the original altitude — it was a runtime guard in #65346 before review moved it to startup.
- Zero-downtime rotation fallback support is unchanged.

## How did you test this code?

Agent-authored. `posthog/test/test_internal_api_auth.py` (15 pass) covers the runtime guard, including no-secret → 401. Removed the startup-check tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

`INTERNAL_API_SECRET` is provisioned only to the receiver services (Django web, CDP, recording-api, cymbal-resolution) — not to every Django/Temporal process. A Django system check runs in *every* process at startup, so it crashed unrelated workers that never serve internal endpoints. The per-request guard only affects actual internal API calls.
