### PR TITLE
chore(hogql): fix json pushdown argMax assertions

### DIFF
--- a/posthog/hogql/transforms/test/test_json_property_pushdown.py
+++ b/posthog/hogql/transforms/test/test_json_property_pushdown.py
@@ -26,12 +26,12 @@ class TestJSONPropertyPushdown(BaseTest):
 
     def test_whole_properties_access_still_aggregates_blob(self):
         printed = self._print("SELECT key, properties FROM groups")
-        self.assertIn("argMax(tuple(groups.group_properties)", printed)
+        self.assertIn("argMax(groups.group_properties,", printed)
         self.assertNotIn("properties___name", printed)
 
     def test_non_constant_key_is_not_rewritten(self):
         printed = self._print("SELECT key, JSONExtractString(properties, key) AS name FROM groups")
-        self.assertIn("argMax(tuple(groups.group_properties)", printed)
+        self.assertIn("argMax(groups.group_properties,", printed)
 
     def test_does_not_rewrite_on_hogql_dialect(self):
         context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)


### PR DESCRIPTION
## Problem

Master backend CI is red. [perf(hogql): drop tuple wrapping in argMax for non-nullable columns](https://github.com/PostHog/posthog/pull/64577) stopped emitting `tuple()` around `argMax(...)` for non-nullable columns, but two assertions in `test_json_property_pushdown.py` still expected the old `argMax(tuple(groups.group_properties)` form. They fail the Django test matrix, which blocks the Container Images CD deploy gate.

### Root cause: semantic merge conflict (two green PRs colliding)

- [#61184](https://github.com/PostHog/posthog/pull/61184) **added** these tests, hard-coding the old `argMax(tuple(...))` output. Merged 16:45 UTC.
- [#64577](https://github.com/PostHog/posthog/pull/64577) **changed** the printer to drop the tuple and updated every snapshot/test in its own branch — but that branch never contained #61184's new test file. Merged 16:49 UTC, ~4 min later.

Each PR was green against a master lacking the other's change; master only breaks with both present. PRs are tested against `PR-merged-with-master-at-run-time`, not re-run at the merge moment, so neither run saw the combination. A strict merge queue would have caught it.

## Changes

Update the two whole-blob assertions to match the new generated SQL `argMax(groups.group_properties, ...)` (no tuple wrapper):

- `test_whole_properties_access_still_aggregates_blob`
- `test_non_constant_key_is_not_rewritten`

Test-only; no production behavior change.

## How did you test this code?

I'm an agent. I could not run the test locally (dev ClickHouse not up). The new substring is verified against the **actual CI failure output**: in run [28042086301](https://github.com/PostHog/posthog/actions/runs/28042086301) the assertion error shows the real generated SQL is `argMax(groups.group_properties, toTimeZone(groups._timestamp, %(hogql_val_0)s)) AS properties` for both queries, so `argMax(groups.group_properties,` is a literal substring of the printed output. CI on this branch will exercise the tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Driven by Raúl Negrón (DRI / assignee), authored by Claude Code.
- Diagnosis started from the `hogli ci:insights` digest, but the fix was **not** taken on trust: I validated the exact replacement string against the live GitHub Actions job log (the failing assertion's actual `printed` value) and confirmed the assertions were still unfixed at master tip before editing.
- Trivial test-only assertion fix; labeled `skip-agent-review`.
