### PR TITLE
fix(cohorts): read post-sync cohort count from a replica, not the persons writer

### DIFF
--- a/products/cohorts/backend/models/cohort.py
+++ b/products/cohorts/backend/models/cohort.py
@@ -658,7 +658,7 @@ class Cohort(FileSystemSyncMixin, RootTeamMixin, models.Model):
         finally:
             # Always update the count and cohort state, even if processing failed
             try:
-                count = count_cohort_members(cohort_id=self.id, team_id=self.team_id, consistency="strong")
+                count = count_cohort_members(cohort_id=self.id, team_id=self.team_id, consistency="eventual")
                 self.count = count
             except Exception as count_err:
                 # If count calculation fails, log the error but don't override the processing error.


### PR DESCRIPTION
## Summary
- The static-cohort -> Postgres sync recomputes `cohort.count` with a **strong-consistency** read, forcing a `SELECT count(*)` on the persons **primary** at the end of every sync.
  - Strong consistency routes to the primary pool, so this cold count competes with hot person queries for the writer's buffer cache.
- This PR routes that count to a **replica** (eventual consistency); it only updates the displayed cohort size and self-heals on the next recalc.

## Change
- [`products/cohorts/backend/models/cohort.py#L661`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/products/cohorts/backend/models/cohort.py#L661): `count_cohort_members(..., consistency="strong")` -> `"eventual"`.
  - Only strong-consistency cohort read on the sync path; all other cohort reads already default to eventual.

## Why
- The sync writes members to `posthog_cohortpeople` on the writer via [`insert_cohort_members`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/rust/personhog-replica/src/storage/postgres/cohort.rs#L234-L288) (bulk primary pool, concurrent chunks), then immediately counts members in the [`finally` block](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/products/cohorts/backend/models/cohort.py#L658-L682).
- The count uses `consistency="strong"`, which the storage layer maps to the primary pool in [`pool_for_consistency`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/rust/personhog-replica/src/storage/postgres/mod.rs#L69-L73).
- Production database query statistics show this `count(*)` and the bulk insert running on the writer with low buffer-cache hit ratios, coinciding with roughly doubled read-IO time on hot person queries during the same window.
  - The cold cohort reads evict the person working set from the writer's shared buffers, briefly raising person-processing latency.

## Tradeoff
- Eventual consistency can momentarily undercount rows just inserted (replication lag).
  - The count is approximate cohort-size state, recomputed every recalc, so it self-corrects within seconds.
  - Flagging because [`count_cohort_members` docstring](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/products/cohorts/backend/models/util.py#L1476-L1505) notes strong was chosen to avoid stale counts right after writes.

## Follow-ups (not in this PR)
- The bulk [`INSERT ... WHERE NOT EXISTS`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/rust/personhog-replica/src/storage/postgres/cohort.rs#L19-L44) runs on the writer in concurrent chunks; that write can't move to a replica.
  - A cohort-specific concurrency cap: the current `bulk_max_concurrent_chunks` default of 2 ([`config.rs#L54-L62`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/rust/personhog-replica/src/config.rs#L54-L62)) is shared with all person bulk ops, so lowering it globally would slow person bulk reads.
  - Jitter cohort recalculation enqueue ([`scheduled.py#L514-L524`](https://github.com/PostHog/posthog/blob/c8917c2b699244d008afd6d4e189d6efa86c7bc9/posthog/tasks/scheduled.py#L514-L524)) so syncs don't cluster at the top of the hour.

## Test plan
- [ ] Existing cohort sync tests pass; `cohort.count` is still populated after a static sync.
- [ ] Confirm the post-sync `count(*)` no longer targets the persons writer (allowing for replica lag).