### PR TITLE
fix(max): keep human message above streaming thinking block after stop + resend

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -2146,6 +2146,68 @@ describe('maxThreadLogic', () => {
             ])
         })
 
+        // Regression test for #65566: after a stop + resend, the server can echo the human
+        // message back with a different trace_id than the provisional bubble we added. We must
+        // still replace the provisional bubble in place (matching on content) instead of
+        // appending the echo at the end, otherwise it lands below the assistant's streaming
+        // thinking block and the transcript reads out of order until reload.
+        it('replaces provisional human message by content when trace_id differs (stop + resend)', async () => {
+            const { onEventImplementation } = await import('./maxThreadLogic')
+
+            // Provisional human bubble added on ask: no server id yet, carries the client trace_id
+            logic.actions.addMessage({
+                type: AssistantMessageType.Human,
+                content: 'My original prompt with more detail',
+                status: 'completed',
+                trace_id: 'client-trace-new',
+            })
+
+            await expectLogic(logic, async () => {
+                // Assistant starts streaming a thinking block before the human echo arrives
+                await onEventImplementation(
+                    AssistantEventType.Message,
+                    JSON.stringify({
+                        id: 'temp-0',
+                        type: AssistantMessageType.Assistant,
+                        content: '',
+                        meta: { thinking: [{ type: 'thinking', thinking: 'Let me think...' }] },
+                    }),
+                    { actions: logic.actions, values: logic.values, props: logic.props, agentMode: null, cache: {} }
+                )
+
+                // Server echoes the human message back, but with a reassigned trace_id
+                await onEventImplementation(
+                    AssistantEventType.Message,
+                    JSON.stringify({
+                        id: 'human-server-1',
+                        type: AssistantMessageType.Human,
+                        content: 'My original prompt with more detail',
+                        trace_id: 'server-trace-reassigned',
+                    }),
+                    { actions: logic.actions, values: logic.values, props: logic.props, agentMode: null, cache: {} }
+                )
+            })
+
+            // The human echo must replace the provisional bubble in place (index 0), keeping the
+            // assistant thinking block below it — not append a duplicate human message at the end.
+            expect(logic.values.threadRaw).toEqual([
+                {
+                    id: 'human-server-1',
+                    type: AssistantMessageType.Human,
+                    content: 'My original prompt with more detail',
+                    trace_id: 'server-trace-reassigned',
+                    status: 'completed',
+                },
+                {
+                    id: 'temp-0',
+                    type: AssistantMessageType.Assistant,
+                    content: '',
+                    meta: { thinking: [{ type: 'thinking', thinking: 'Let me think...' }] },
+                    status: 'loading',
+                },
+            ])
+        })
+
         it('replaces existing message when final ID matches already present ID', async () => {
             const { onEventImplementation } = await import('./maxThreadLogic')
 

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -2118,12 +2118,18 @@ export async function onEventImplementation(
                 .find(([m]) => isHumanMessage(m))?.[1]
 
             const lastHumanMessage = lastHumanIndex != null ? values.threadRaw[lastHumanIndex] : null
-            const shouldReplace =
+            // Normally the server echoes back the same trace_id we sent, so we can match the
+            // provisional bubble on it. After a stop + resend, though, the trace_id can be
+            // reassigned, so we also fall back to matching the un-persisted provisional bubble
+            // (no server id yet) by its content. Without this, the echo gets appended at the end
+            // of the thread, landing *below* the assistant's streaming thinking block instead of
+            // above it (the order self-corrects on reload). See bug #65566.
+            const provisionalHumanMatches =
                 isHumanMessage(lastHumanMessage) &&
-                parsedResponse.trace_id &&
-                lastHumanMessage.trace_id === parsedResponse.trace_id
+                ((parsedResponse.trace_id && lastHumanMessage.trace_id === parsedResponse.trace_id) ||
+                    (!lastHumanMessage.id && lastHumanMessage.content === parsedResponse.content))
 
-            if (lastHumanIndex != null && shouldReplace) {
+            if (lastHumanIndex != null && provisionalHumanMatches) {
                 actions.replaceMessage(lastHumanIndex, {
                     ...parsedResponse,
                     status: 'completed',


### PR DESCRIPTION
## Problem

In PostHog AI (Max) chat, if a user sends a prompt, clicks **stop** to halt generation, then pastes the original text back with additions and sends again, the agent''s reasoning/**thinking** block initially renders *above* the user''s second message — so the transcript reads out of order. Reloading the conversation restores the correct order, so this is a client-side streaming render-order issue.

Fixes #65566

### Reproduction
1. Start typing a prompt for Max and send it.
2. Click **stop** to halt generation.
3. Paste the text from step 1 back into the input, add more, and send again.
4. While the second response streams, the Thought/reasoning block renders above the latest user message.
5. Leave and return to the chat — the order is then correct.

## Root cause

When a prompt is sent, we add a provisional human bubble that carries a **client-generated `trace_id`**. As the next generation streams, the server echoes the human message back, and `onEventImplementation` replaces the provisional bubble in place by matching on `trace_id`.

After a **stop + resend**, the echoed human message can come back with a **reassigned `trace_id`**. The match then fails and we fall into the `else` branch, which `addMessage`s the echo at the **end** of the thread. Since the assistant''s streaming thinking block has already been appended, the human echo lands *below* it — producing the out-of-order render. On reload the server returns the canonical ordering, which is why it self-corrects.

## Fix

When the `trace_id` doesn''t match, fall back to matching the **un-persisted provisional bubble** (no server `id` yet) by its `content`, and replace it in place. A real, already-persisted human message always has an `id`, so this can''t accidentally collapse two distinct human messages.

```ts
const provisionalHumanMatches =
    isHumanMessage(lastHumanMessage) &&
    ((parsedResponse.trace_id && lastHumanMessage.trace_id === parsedResponse.trace_id) ||
        (!lastHumanMessage.id && lastHumanMessage.content === parsedResponse.content))
```

## Testing

Adds a regression test in `maxThreadLogic.test.ts` that streams the assistant thinking block first, then delivers the human echo with a different `trace_id`, and asserts the echo replaces the provisional bubble in place (human stays above the thinking block) rather than being appended below it.