### PR TITLE
fix(django): couple personhog behavioural fixes

### DIFF
--- a/ee/clickhouse/views/groups.py
+++ b/ee/clickhouse/views/groups.py
@@ -441,10 +441,18 @@ class GroupsViewSet(TeamAndOrgViewSetMixin, mixins.ListModelMixin, mixins.Create
         request_data = CreateGroupSerializer(data=request.data)
         request_data.is_valid(raise_exception=True)
 
+        group_key = request_data.validated_data["group_key"]
+        group_type_index = request_data.validated_data["group_type_index"]
+
+        # Personhog upserts on duplicate (team, group_type_index, group_key) instead
+        # of raising, so reject duplicates up front to preserve the 400 contract.
+        if get_group_by_key(self.team.pk, group_type_index, group_key) is not None:
+            raise ValidationError({"detail": "A group with this key already exists"})
+
         try:
             group = create_group(
-                group_key=request_data.validated_data["group_key"],
-                group_type_index=request_data.validated_data["group_type_index"],
+                group_key=group_key,
+                group_type_index=group_type_index,
                 properties=request_data.validated_data["group_properties"],
                 team_id=self.team.pk,
                 timestamp=timezone.now(),

--- a/ee/clickhouse/views/test/test_clickhouse_groups.py
+++ b/ee/clickhouse/views/test/test_clickhouse_groups.py
@@ -486,6 +486,42 @@ class GroupsViewSetTestCase(ClickhouseTestMixin, APIBaseTest):
         mock_capture.assert_not_called()
 
     @mock.patch("ee.clickhouse.views.groups.capture_internal")
+    def test_create_group_duplicated_group_key_via_personhog(self, mock_capture):
+        """Personhog upserts on duplicate so the pre-check must catch it."""
+        from posthog.personhog_client.fake_client import fake_personhog_client
+
+        group_type_mapping = create_group_type_mapping_without_created_at(
+            team=self.team,
+            project_id=self.team.project_id,
+            group_type_index=0,
+            group_type="organization",
+        )
+        group_key = "dup-key-ph"
+
+        with fake_personhog_client() as fake:
+            fake.add_group(
+                team_id=self.team.pk,
+                group_type_index=group_type_mapping.group_type_index,
+                group_key=group_key,
+                id=1,
+            )
+
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/groups",
+                {
+                    "group_key": group_key,
+                    "group_type_index": 0,
+                    "group_properties": {},
+                },
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["detail"], "A group with this key already exists")
+        create_calls = [c for c in fake.calls if c.method == "create_group"]
+        self.assertEqual(len(create_calls), 0, "create_group should not be called for duplicates")
+        mock_capture.assert_not_called()
+
+    @mock.patch("ee.clickhouse.views.groups.capture_internal")
     def test_create_group_missing_group_key(self, mock_capture):
         group_type_mapping = create_group_type_mapping_without_created_at(
             team=self.team,

--- a/posthog/models/group_type_mapping.py
+++ b/posthog/models/group_type_mapping.py
@@ -687,7 +687,7 @@ def clear_dashboard_from_group_type_mapping(
         resp = client.get_group_type_mapping_by_dashboard_id(
             GetGroupTypeMappingByDashboardIdRequest(team_id=team_id, dashboard_id=dashboard_id)
         )
-        if resp.mapping and resp.mapping.group_type_index is not None:
+        if resp.HasField("mapping"):
             client.update_group_type_mapping(
                 UpdateGroupTypeMappingRequest(
                     project_id=resp.mapping.project_id,

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -1012,7 +1012,7 @@ class TestClearDashboardFromGroupTypeMapping(SimpleTestCase):
     @patch(_CLIENT_PATCH)
     def test_personhog_no_matching_mapping_skips_update(self, mock_get_client, mock_routing_counter, mock_invalidate):
         mock_resp = MagicMock()
-        mock_resp.mapping = None
+        mock_resp.HasField.return_value = False
 
         mock_client = MagicMock()
         mock_client.get_group_type_mapping_by_dashboard_id.return_value = mock_resp

--- a/posthog/models/test/test_group_type_mapping.py
+++ b/posthog/models/test/test_group_type_mapping.py
@@ -1010,6 +1010,31 @@ class TestClearDashboardFromGroupTypeMapping(SimpleTestCase):
     @patch("posthog.models.group_type_mapping.invalidate_group_types_cache")
     @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
     @patch(_CLIENT_PATCH)
+    def test_personhog_group_type_index_zero_still_clears(self, mock_get_client, mock_routing_counter, mock_invalidate):
+        """group_type_index=0 is falsy but valid — HasField must not skip it."""
+        mock_mapping = MagicMock(spec=["project_id", "group_type_index"])
+        mock_mapping.project_id = 1
+        mock_mapping.group_type_index = 0
+
+        mock_resp = MagicMock()
+        mock_resp.HasField.return_value = True
+        mock_resp.mapping = mock_mapping
+
+        mock_client = MagicMock()
+        mock_client.get_group_type_mapping_by_dashboard_id.return_value = mock_resp
+        mock_client.update_group_type_mapping.return_value = MagicMock()
+        mock_get_client.return_value = mock_client
+
+        clear_dashboard_from_group_type_mapping(team_id=10, dashboard_id=42)
+
+        mock_client.update_group_type_mapping.assert_called_once()
+        update_req = mock_client.update_group_type_mapping.call_args[0][0]
+        assert update_req.group_type_index == 0
+        mock_invalidate.assert_called_once_with(1)
+
+    @patch("posthog.models.group_type_mapping.invalidate_group_types_cache")
+    @patch("posthog.models.group_type_mapping.PERSONHOG_ROUTING_TOTAL")
+    @patch(_CLIENT_PATCH)
     def test_personhog_no_matching_mapping_skips_update(self, mock_get_client, mock_routing_counter, mock_invalidate):
         mock_resp = MagicMock()
         mock_resp.HasField.return_value = False


### PR DESCRIPTION
## Problem

Couple behavioral differences between personhog client calls and ORM paths during the personhog migration.
1. The groups API `create` raises an IntegrityError and returns a 400 when a user tries to create a group that already existed. This is arguably the correct contract for creating a group through the API. The personhog RPC does an upsert, so without some extra logic, duplicate group creations will silently succeed.
2. `clear_dashboard_from_group_type_mapping` errors on no-match. When a dashboard is deleted, this function clears `detail_dashboard_id` from any `GroupTypeMapping` that references it. It does this in two steps: first it calls `GetGroupTypeMappingByDashboardId` to find a mapping, then calls `UpdateGroupTypeMapping` to clear the field. The response's `mapping` field is declared `optional` in the proto. When no mapping references the dashboard, personhog returns a response with `mapping` unset. In protobuf Python, an unset `optional` message field still returns a zero-valued message object that evaluates as truthy — so the current `if resp.mapping` check passes even when there's no match. The code then calls `UpdateGroupTypeMapping` with `project_id=0` and `group_type_index=0`, which the server rejects with `NOT_FOUND`. The ORM fallback path didn't have this problem because `GroupTypeMapping.objects.filter(detail_dashboard_id=...).update(...)` is a no-op when no rows match.

## Changes

1. Duplicate group key rejection:
Added a `get_group_by_key()` pre-check before `create_group()`. If a group with the same key already exists, raises `ValidationError` with the same 400 response as before.

2. HasField guard :
Replaced `if resp.mapping and resp.mapping.group_type_index is not None` with `if resp.HasField("mapping")`, which correctly detects whether the protobuf field was actually set in the response.


## How did you test this code?

- `ee/clickhouse/views/test/test_clickhouse_groups.py` — 113 passed, including `test_create_group_duplicated_group_key`
- `posthog/models/test/test_group_type_mapping.py` — `test_personhog_no_matching_mapping_skips_update` and `test_personhog_success_reads_then_updates` both pass. Updated the no-match test mock to use `HasField.return_value = False` instead of `mapping = None`
