### PR TITLE
feature(ai-observability): add DeepSeek as a provider in the Playground

### DIFF
--- a/products/ai_observability/backend/api/provider_keys.py
+++ b/products/ai_observability/backend/api/provider_keys.py
@@ -147,8 +147,8 @@ class LLMProviderKeySerializer(serializers.ModelSerializer):
         elif provider == LLMProvider.ANTHROPIC:
             if not value.startswith("sk-ant-"):
                 raise serializers.ValidationError("Invalid Anthropic API key format. Key should start with 'sk-ant-'.")
-        # Azure, Gemini, Together AI, OpenRouter, and Fireworks keys have no standard
-        # prefix, so no format validation is enforced here.
+        # Azure, Gemini, Together AI, OpenRouter, Fireworks, and DeepSeek keys have no
+        # standard prefix we enforce, so no format validation is applied here.
 
         return value
 

--- a/products/ai_observability/backend/api/proxy.py
+++ b/products/ai_observability/backend/api/proxy.py
@@ -67,6 +67,8 @@ PROVIDER_DISPLAY_NAMES: dict[str, str] = {
     "openrouter": "OpenRouter",
     "fireworks": "Fireworks",
     "azure_openai": "Azure OpenAI",
+    "together_ai": "Together AI",
+    "deepseek": "DeepSeek",
 }
 
 

--- a/products/ai_observability/backend/llm/client.py
+++ b/products/ai_observability/backend/llm/client.py
@@ -98,6 +98,7 @@ def _get_provider(name: str, provider_key: "LLMProviderKey | None" = None) -> "P
 
     from products.ai_observability.backend.llm.providers.anthropic import AnthropicAdapter
     from products.ai_observability.backend.llm.providers.azure_openai import DEFAULT_API_VERSION, AzureOpenAIAdapter
+    from products.ai_observability.backend.llm.providers.deepseek import DeepSeekAdapter
     from products.ai_observability.backend.llm.providers.fireworks import FireworksAdapter
     from products.ai_observability.backend.llm.providers.gemini import GeminiAdapter
     from products.ai_observability.backend.llm.providers.openai import OpenAIAdapter
@@ -117,6 +118,8 @@ def _get_provider(name: str, provider_key: "LLMProviderKey | None" = None) -> "P
             return cast("Provider", OpenRouterAdapter())
         case "fireworks":
             return cast("Provider", FireworksAdapter())
+        case "deepseek":
+            return cast("Provider", DeepSeekAdapter())
         case "azure_openai":
             config = provider_key.encrypted_config if provider_key else {}
             return cast(

--- a/products/ai_observability/backend/llm/providers/deepseek.py
+++ b/products/ai_observability/backend/llm/providers/deepseek.py
@@ -1,0 +1,98 @@
+"""DeepSeek provider for the unified LLM client.
+
+DeepSeek exposes an OpenAI-compatible API and is BYOKEY-only.
+"""
+
+import logging
+from collections.abc import Generator
+from typing import Any
+
+import openai
+
+from products.ai_observability.backend.llm.providers.openai import OpenAIAdapter, OpenAIConfig
+from products.ai_observability.backend.llm.types import (
+    AnalyticsContext,
+    CompletionRequest,
+    CompletionResponse,
+    StreamChunk,
+)
+
+logger = logging.getLogger(__name__)
+
+DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+
+
+class DeepSeekAdapter(OpenAIAdapter):
+    """DeepSeek provider that reuses OpenAI's completion/streaming logic."""
+
+    name = "deepseek"
+
+    def complete(
+        self,
+        request: CompletionRequest,
+        api_key: str | None,
+        analytics: AnalyticsContext,
+        base_url: str | None = None,
+    ) -> CompletionResponse:
+        return super().complete(request, api_key, analytics, base_url=DEEPSEEK_BASE_URL)
+
+    def stream(
+        self,
+        request: CompletionRequest,
+        api_key: str | None,
+        analytics: AnalyticsContext,
+        base_url: str | None = None,
+    ) -> Generator[StreamChunk]:
+        yield from super().stream(request, api_key, analytics, base_url=DEEPSEEK_BASE_URL)
+
+    @staticmethod
+    def validate_key(api_key: str, **kwargs: Any) -> tuple[str, str | None]:
+        """Validate a DeepSeek API key using a models list request."""
+        from products.ai_observability.backend.models.provider_keys import LLMProviderKey
+
+        try:
+            client = openai.OpenAI(
+                api_key=api_key,
+                base_url=DEEPSEEK_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
+            )
+            client.models.list()
+            return (LLMProviderKey.State.OK, None)
+        except openai.AuthenticationError:
+            return (LLMProviderKey.State.INVALID, "Invalid API key")
+        except openai.RateLimitError:
+            return (LLMProviderKey.State.ERROR, "Rate limited, please try again later")
+        except openai.APIConnectionError:
+            return (LLMProviderKey.State.ERROR, "Could not connect to DeepSeek")
+        except Exception:
+            logger.exception("DeepSeek key validation error")
+            return (LLMProviderKey.State.ERROR, "Validation failed, please try again")
+
+    @staticmethod
+    def recommended_models() -> set[str]:
+        return set()
+
+    @staticmethod
+    def list_models(api_key: str | None = None, **kwargs: Any) -> list[str]:
+        """List available DeepSeek models. Returns empty list without a key (BYOKEY-only)."""
+        if not api_key:
+            return []
+
+        try:
+            client = openai.OpenAI(
+                api_key=api_key,
+                base_url=DEEPSEEK_BASE_URL,
+                timeout=OpenAIConfig.TIMEOUT,
+            )
+            # DeepSeek's models endpoint omits a `created` timestamp, so sort by id for stable output.
+            return [m.id for m in sorted(client.models.list(), key=lambda m: m.id)]
+        except Exception:
+            logger.exception("Error listing DeepSeek models")
+            return []
+
+    @staticmethod
+    def get_api_key() -> str:
+        raise ValueError("DeepSeek is BYOKEY-only. No default API key is available.")
+
+    def _get_default_api_key(self) -> str:
+        raise ValueError("DeepSeek is BYOKEY-only. No default API key is available.")

--- a/products/ai_observability/backend/llm/providers/test/test_deepseek.py
+++ b/products/ai_observability/backend/llm/providers/test/test_deepseek.py
@@ -1,0 +1,126 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+import openai
+
+from products.ai_observability.backend.llm.providers.deepseek import DEEPSEEK_BASE_URL, DeepSeekAdapter
+
+
+class TestDeepSeekValidateKey:
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_validate_key_valid_returns_ok(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = []
+        mock_openai.return_value = mock_client
+
+        state, message = DeepSeekAdapter.validate_key("sk-test-key")
+
+        assert state == "ok"
+        assert message is None
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_validate_key_auth_error_returns_invalid(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.AuthenticationError(
+            message="Invalid key",
+            response=MagicMock(),
+            body={},
+        )
+        mock_openai.return_value = mock_client
+
+        state, message = DeepSeekAdapter.validate_key("sk-test-key")
+
+        assert state == "invalid"
+        assert message == "Invalid API key"
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_validate_key_connection_error_returns_error(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.APIConnectionError(request=MagicMock())
+        mock_openai.return_value = mock_client
+
+        state, message = DeepSeekAdapter.validate_key("sk-test-key")
+
+        assert state == "error"
+        assert message == "Could not connect to DeepSeek"
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_validate_key_rate_limit_returns_error(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.RateLimitError(
+            message="Rate limited",
+            response=MagicMock(),
+            body={},
+        )
+        mock_openai.return_value = mock_client
+
+        state, message = DeepSeekAdapter.validate_key("sk-test-key")
+
+        assert state == "error"
+        assert message == "Rate limited, please try again later"
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_validate_key_uses_deepseek_base_url(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = []
+        mock_openai.return_value = mock_client
+
+        DeepSeekAdapter.validate_key("sk-test-key")
+
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["base_url"] == DEEPSEEK_BASE_URL
+
+
+class TestDeepSeekListModels:
+    def test_list_models_without_key_returns_empty(self):
+        assert DeepSeekAdapter.list_models(None) == []
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_list_models_with_key_returns_sorted_by_id(self, mock_openai):
+        model_reasoner = MagicMock()
+        model_reasoner.id = "deepseek-reasoner"
+
+        model_chat = MagicMock()
+        model_chat.id = "deepseek-chat"
+
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = [model_reasoner, model_chat]
+        mock_openai.return_value = mock_client
+
+        models = DeepSeekAdapter.list_models("sk-test-key")
+
+        assert models == ["deepseek-chat", "deepseek-reasoner"]
+
+    @patch(
+        "products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI", side_effect=Exception("API error")
+    )
+    def test_list_models_error_returns_empty(self, _mock_openai):
+        assert DeepSeekAdapter.list_models("sk-test-key") == []
+
+    @patch("products.ai_observability.backend.llm.providers.deepseek.openai.OpenAI")
+    def test_list_models_uses_deepseek_base_url(self, mock_openai):
+        mock_client = MagicMock()
+        mock_client.models.list.return_value = []
+        mock_openai.return_value = mock_client
+
+        DeepSeekAdapter.list_models("sk-test-key")
+
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["base_url"] == DEEPSEEK_BASE_URL
+
+
+class TestDeepSeekRecommendedModels:
+    def test_recommended_models_returns_empty(self):
+        assert DeepSeekAdapter.recommended_models() == set()
+
+
+class TestDeepSeekDefaultKey:
+    def test_get_api_key_raises(self):
+        with pytest.raises(ValueError, match="BYOKEY-only"):
+            DeepSeekAdapter.get_api_key()
+
+    def test_get_default_api_key_raises(self):
+        adapter = DeepSeekAdapter()
+
+        with pytest.raises(ValueError, match="BYOKEY-only"):
+            adapter._get_default_api_key()

--- a/products/ai_observability/backend/llm/test/test_client.py
+++ b/products/ai_observability/backend/llm/test/test_client.py
@@ -44,6 +44,7 @@ class TestProviderRouting(SimpleTestCase):
             ("together_ai",),
             ("openrouter",),
             ("fireworks",),
+            ("deepseek",),
         ]
     )
     def test_get_provider_returns_correct_adapter(self, provider_name):

--- a/products/ai_observability/backend/migrations/0009_alter_llmproviderkey_provider.py
+++ b/products/ai_observability/backend/migrations/0009_alter_llmproviderkey_provider.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai_observability", "0008_alter_evaluation_status_reason"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="llmproviderkey",
+            name="provider",
+            field=models.CharField(
+                choices=[
+                    ("openai", "Openai"),
+                    ("anthropic", "Anthropic"),
+                    ("gemini", "Gemini"),
+                    ("openrouter", "Openrouter"),
+                    ("fireworks", "Fireworks"),
+                    ("azure_openai", "Azure OpenAI"),
+                    ("together_ai", "Together AI"),
+                    ("deepseek", "DeepSeek"),
+                ],
+                max_length=50,
+            ),
+        ),
+    ]

--- a/products/ai_observability/backend/migrations/max_migration.txt
+++ b/products/ai_observability/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0008_alter_evaluation_status_reason
+0009_alter_llmproviderkey_provider

--- a/products/ai_observability/backend/models/provider_keys.py
+++ b/products/ai_observability/backend/models/provider_keys.py
@@ -19,6 +19,7 @@ class LLMProvider(models.TextChoices):
     FIREWORKS = "fireworks"
     AZURE_OPENAI = "azure_openai", "Azure OpenAI"
     TOGETHER_AI = "together_ai", "Together AI"
+    DEEPSEEK = "deepseek", "DeepSeek"
 
 
 class LLMProviderKey(UUIDTModel):

--- a/products/ai_observability/frontend/settings/LLMProviderKeysSettings.tsx
+++ b/products/ai_observability/frontend/settings/LLMProviderKeysSettings.tsx
@@ -101,6 +101,8 @@ function getKeyPlaceholder(provider: LLMProvider): string {
             return 'Enter your Fireworks API key'
         case 'azure_openai':
             return 'Enter your Azure OpenAI API key'
+        case 'deepseek':
+            return 'Enter your DeepSeek API key'
     }
 }
 

--- a/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
@@ -16,6 +16,7 @@ export type LLMProvider =
     | 'fireworks'
     | 'azure_openai'
     | 'together_ai'
+    | 'deepseek'
 
 /** Default Azure OpenAI API version — keep in sync with backend DEFAULT_API_VERSION. */
 export const DEFAULT_AZURE_API_VERSION = '2024-10-21'
@@ -28,6 +29,7 @@ export const LLM_PROVIDER_LABELS: Record<LLMProvider, string> = {
     fireworks: 'Fireworks',
     azure_openai: 'Azure OpenAI',
     together_ai: 'Together AI',
+    deepseek: 'DeepSeek',
 }
 
 const LLM_PROVIDERS = new Set<string>(Object.keys(LLM_PROVIDER_LABELS))
@@ -69,6 +71,9 @@ export function normalizeLLMProvider(provider: string | undefined): LLMProvider 
     }
     if (normalized === 'together' || normalized === 'together ai' || normalized === 'together-ai') {
         return 'together_ai'
+    }
+    if (normalized === 'deepseek' || normalized === 'deep-seek' || normalized === 'deepseek-ai') {
+        return 'deepseek'
     }
 
     return normalized in LLM_PROVIDER_LABELS ? (normalized as LLMProvider) : null


### PR DESCRIPTION
## Problem

DeepSeek is not selectable as a provider in the LLM analytics Playground today. To reach DeepSeek, users have to route through an aggregator (OpenRouter, Together AI, Fireworks) and pick a DeepSeek model from that key's model list, rather than selecting DeepSeek directly.

Closes #65530

## Solution

Add DeepSeek as a first-class **BYOK** provider, following the existing OpenAI-compatible adapter pattern (DeepSeek's API is OpenAI-compatible). Like Fireworks and Together AI, it is bring-your-own-key only — built-in PostHog-funded trial access is explicitly out of scope per the issue ("secondary to having DeepSeek available at all").

### Backend
- **Adapter** `products/ai_observability/backend/llm/providers/deepseek.py` — subclasses `OpenAIAdapter`, points completion / streaming / key validation / model listing at `https://api.deepseek.com`. BYOK-only (no default/trial key), mirroring `FireworksAdapter`.
- **Provider enum** — added `DEEPSEEK = "deepseek", "DeepSeek"` to the shared `LLMProvider` enum in `models/provider_keys.py`, plus migration `0007_alter_llmproviderkey_provider`.
- **Client router** — registered `deepseek` in `_get_provider`.
- **Proxy display names** — added DeepSeek to `PROVIDER_DISPLAY_NAMES` in `api/proxy.py`, and backfilled the missing `together_ai` entry (it was falling back to the title-cased `Together_Ai`).

### Frontend
- Added `deepseek` to the `LLMProvider` type, `LLM_PROVIDER_LABELS`, the alias normalizer (`deepseek` / `deep-seek` / `deepseek-ai`), and the Add Key modal placeholder in `llmProviderKeysLogic.ts` / `LLMProviderKeysSettings.tsx`. The provider select options and icons derive from the labels map, so DeepSeek appears in the dropdown automatically.

### Tests
- `test_deepseek.py` mirrors the Fireworks adapter tests: validation (ok / invalid / rate-limit / connection-error), BYOK-only model listing, base-URL usage, recommended-models, and default-key guards.
- Added `deepseek` to the provider-routing parametrization in `test_client.py`.

## Follow-up needed

- **Regenerate API types.** The generated frontend types (`products/ai_observability/frontend/generated/api.schemas.ts`, `api.zod.ts`) enumerate the provider enum and are produced from the serializer via `hogli build:openapi`. They are auto-generated (must not be hand-edited), and I was unable to run the generator in my environment. They should be regenerated so `LLMProviderEnumApi` picks up `deepseek`.
- **DeepSeek icon (optional).** No DeepSeek logo asset exists yet, so the provider renders without a custom icon (the icon component degrades gracefully). A hosted logo can be added to `PROVIDER_IMAGES` in `LLMProviderIcon.tsx` as a polish follow-up.

## Testing notes

I was unable to run the JS/Python suites locally (no Python env available, and the JS install fails on a native `node-rdkafka` build on Windows). The changes were verified by static review against the existing Fireworks/Together AI adapters, which share this exact pattern; the migration was hand-authored to match Django's `makemigrations` output exactly (verified against the original choices block in migration `0001`). CI should exercise the new adapter tests and the migration check.
