### PR TITLE
fix: repair broken posthog-js entry in pnpm lockfile

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3797,8 +3797,8 @@ importers:
         specifier: '*'
         version: 17.0.4
       posthog-js:
-        specifier: '*'
-        version: 1.392.0
+        specifier: 'catalog:'
+        version: 1.393.0
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -9708,9 +9708,6 @@ packages:
 
   '@posthog/siphash@1.1.1':
     resolution: {integrity: sha512-JUFk57H89fOnHpF62FDyFGw4uXeHAX20OPfkLL8/iqg/xrVp5Q21LvJUDijmS5wt0avgUwXF2bxYgaZ5iWRmAg==}
-
-  '@posthog/types@1.390.1':
-    resolution: {integrity: sha512-GPyZY8eOa/c/EKFLW0Aa1ECVysa1TFLenGPgYbRz/PX/nrzd1IiQPlHAYLkeifE6oBVxHiv5AwkTyzX/fdOYSA==}
 
   '@posthog/types@1.391.0':
     resolution: {integrity: sha512-oJ6jkqVMq+T4ax9F0rUllJc0KHpSgpaMwTNYWkE70iBiyXDVyhcNBmYnNKzSODgpzsaQNI6VfK8JrRYbkSJZZw==}
@@ -29964,7 +29961,7 @@ snapshots:
 
   '@posthog/core@1.35.1':
     dependencies:
-      '@posthog/types': 1.390.1
+      '@posthog/types': 1.391.0
 
   '@posthog/core@1.36.0':
     dependencies:
@@ -30026,8 +30023,6 @@ snapshots:
       '@types/react': 18.3.27
 
   '@posthog/siphash@1.1.1': {}
-
-  '@posthog/types@1.390.1': {}
 
   '@posthog/types@1.391.0': {}
 

--- a/products/posthog_ai/package.json
+++ b/products/posthog_ai/package.json
@@ -7,7 +7,7 @@
         "eventsource-parser": "*",
         "kea-subscriptions": "catalog:",
         "marked": "*",
-        "posthog-js": "*",
+        "posthog-js": "catalog:",
         "tailwind-merge": "*"
     },
     "devDependencies": {


### PR DESCRIPTION
## Problem

The PostHog docker image failed to build with `ERR_PNPM_LOCKFILE_MISSING_DEPENDENCY: Broken lockfile: no entry for 'posthog-js@1.392.0' in pnpm-lock.yaml` across the `frontend-build` and `node-scripts-build` stages, blocking deploys.

Root cause: `products/posthog_ai/package.json` declared `posthog-js` with a hardcoded `"*"` specifier instead of `"catalog:"` like every other workspace package. When the catalog was bumped to `^1.393.0`, all the `catalog:` consumers moved to `1.393.0`, but the `posthog_ai` importer stayed resolved at a stale `1.392.0` — a version with no snapshot in the lockfile. A `--frozen-lockfile` install then can't find that entry. This is the classic badly-resolved-merge-conflict shape pnpm warns about.

## Changes

- `products/posthog_ai/package.json`: `posthog-js` now uses `"catalog:"` to match every other package.
- `pnpm-lock.yaml`: regenerated so the `posthog_ai` importer resolves `posthog-js` to `1.393.0`; drops the now-orphaned `@posthog/types@1.390.1` snapshot.

## How did you test this code?

I'm an agent. I ran `pnpm install --frozen-lockfile --lockfile-only` and confirmed it exits 0 (it previously failed). Verified no `1.392.0` references remain in the lockfile and the diff is limited to the lockfile and the one package.json.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from a Slack thread reporting the failed docker build. Pinpointed the single importer (`products/posthog_ai`) using a hardcoded `"*"` rather than `catalog:`, switched it to the catalog, and regenerated the lockfile with `pnpm install --lockfile-only`. No skills were required. Authored by the PostHog Slack app (Claude Code).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0185UNBSJZ/p1782242329240139?thread_ts=1782242329.240139&cid=C0185UNBSJZ)*
