### PR TITLE
fix(workflows): carry groups into hogflow invocation for test mode

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1474,6 +1474,48 @@ describe('Hogflow Executor', () => {
         })
     })
 
+    describe('group propagation', () => {
+        it('carries groups from globals onto the invocation', () => {
+            const hogFlow: HogFlow = new FixtureHogFlowBuilder()
+                .withWorkflow({
+                    actions: {
+                        trigger: { type: 'trigger', config: { type: 'event', filters: {} } },
+                        exit: { type: 'exit', config: {} },
+                    },
+                    edges: [{ from: 'trigger', to: 'exit', type: 'continue' }],
+                })
+                .build()
+
+            const groups = {
+                organization: {
+                    id: 'acme-123',
+                    type: 'organization',
+                    index: 0,
+                    url: '',
+                    properties: {},
+                },
+            }
+            const globals = {
+                event: {
+                    event: 'test',
+                    properties: {},
+                    url: '',
+                    distinct_id: '',
+                    timestamp: '',
+                    uuid: '',
+                    elements_chain: '',
+                },
+                project: { id: 1, name: 'Test Project', url: '' },
+                person: { id: 'person_id', name: 'John Doe', properties: {}, url: '' },
+                groups,
+            }
+
+            const invocation = createHogFlowInvocation(globals, hogFlow, {} as any)
+
+            expect(invocation.groups).toEqual(groups)
+        })
+    })
+
     describe('output variable mapping', () => {
         let hogFlowBuilder: (outputVariable: any) => Promise<HogFlow>
 

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.ts
@@ -71,6 +71,7 @@ export function createHogFlowInvocation(
         functionId: hogFlow.id, // TODO: Include version?
         hogFlow,
         person: globals.person, // This is outside of state as we don't persist it
+        groups: globals.groups, // Same as person: in-memory only (test path); real execution re-resolves on dequeue
         filterGlobals,
         queue: 'hogflow',
         queuePriority: 1,


### PR DESCRIPTION
## Problem

Workflow `Update account` / `Get account` actions fail in **test mode** with "Account external ID is required" when the external-ID input uses a group template like `{groups.organization.id}` — even though the same workflow runs fine in real execution.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- `createHogFlowInvocation` now carries `groups` from the globals onto the invocation, mirroring the existing `person` line
- Without it, `invocation.groups` was `undefined`, so function-action inputs templated with `{groups.*}` resolved to empty in the editor's Test path
- Real execution was unaffected: the hogflow consumer re-resolves `groups` on dequeue, and `serializeInvocation` strips this field from the queued job — so the change is in-memory only and never persisted
- Add a regression unit test asserting `groups` propagates through `createHogFlowInvocation`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-authored. Ran the new Jest unit test (`group propagation › carries groups from globals onto the invocation`) — passes. Root cause confirmed by tracing the test-mode (`cdp-api.ts › postHogflowInvocation`) vs real-execution (`cdp-cyclotron-worker-hogflow.consumer.ts`) paths. No manual UI testing.

Regression caught: the test fails if `createHogFlowInvocation` stops propagating `groups` onto the invocation — the exact gap that produced "Account external ID is required". No existing test asserted group propagation.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude Code). Started from a debugging session: the user reported the test-mode-only failure. Diagnosed the asymmetry between the test invocation endpoint and the real hogflow consumer, both of which feed `createHogFlowInvocation` — which copied `person` but not `groups`. Skills invoked: `/writing-tests`, `/ship-it`, `/pr-description`.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
