### PR TITLE
chore(stripe-app): bump version to 1.2.11

### DIFF
--- a/services/stripe-app/stripe-app.json
+++ b/services/stripe-app/stripe-app.json
@@ -2,7 +2,7 @@
     "$schema": "https://stripe.com/stripe-app.schema.json",
     "id": "com.posthog.stripe",
     "name": "PostHog",
-    "version": "1.2.10",
+    "version": "1.2.11",
     "icon": "./assets/logomark.png",
     "provisioning": {
         "base_url": "https://us.posthog.com/api/agentic/",


### PR DESCRIPTION
## Problem

The Stripe App sandbox-install removal merged in [chore(integrations): remove remaining Stripe sandbox install code](https://github.com/PostHog/posthog/pull/64150), but the manifest `version` stayed at `1.2.10`. Stripe rejects an `apps upload` that reuses a published version, so the app can't be republished without a bump.

## Changes

- Bump `services/stripe-app/stripe-app.json` `version` `1.2.10` → `1.2.11` so the removal can be published via `stripe apps upload`.

The upload itself is a separate manual step (run by someone with app-developer access to the app).

## How did you test this code?

Agent (Claude Code); one-line manifest version bump, no behavior change. `stripe-app.json` is valid JSON.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Matt directed this. Trailing version bump so the already-merged sandbox-removal can be published to the Stripe App marketplace.
