### PR TITLE
fix(llma): repoint update-ai-costs paths after pipelines move

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -25,7 +25,7 @@ posthog/schema.py linguist-generated
 posthog/temporal/data_imports/sources/generated_configs.py linguist-generated
 posthog/temporal/proxy_service/proto/*_pb2*.py linguist-generated
 
-nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts linguist-generated
+nodejs/src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts linguist-generated
 
 posthog/hogql/grammar/HogQLLexer.py linguist-generated
 posthog/hogql/grammar/HogQLParser.py linguist-generated

--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -201,9 +201,9 @@ services/mcp/src/tools/aiObservability/ @PostHog/team-ai-observability
 services/mcp/src/ui-apps/apps/generated/llm-costs.tsx @PostHog/team-ai-observability
 
 # LLM Gateway - owned by @PostHog/team-ai-gateway
-nodejs/src/ingestion/ai/costs/ @PostHog/team-ai-observability @PostHog/team-ai-gateway
-nodejs/src/ingestion/ai/costs/scripts/ @PostHog/team-ai-gateway
-nodejs/src/ingestion/ai/costs/providers/ @PostHog/team-ai-gateway
+nodejs/src/ingestion/pipelines/ai/costs/ @PostHog/team-ai-observability @PostHog/team-ai-gateway
+nodejs/src/ingestion/pipelines/ai/costs/scripts/ @PostHog/team-ai-gateway
+nodejs/src/ingestion/pipelines/ai/costs/providers/ @PostHog/team-ai-gateway
 products/ai_observability/backend/api/proxy.py @PostHog/team-ai-gateway
 products/ai_observability/backend/api/test/test_proxy.py @PostHog/team-ai-gateway
 products/ai_observability/frontend/playground/ @PostHog/team-ai-gateway

--- a/.github/scripts/assign-reviewers.js
+++ b/.github/scripts/assign-reviewers.js
@@ -22,8 +22,8 @@ const CONFIG = {
         '**/*.snap',
         '**/*.ambr',
         // Regenerated wholesale by `pnpm update-ai-costs` from the OpenRouter API.
-        'nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts',
-        'nodejs/src/ingestion/ai/costs/providers/llm-costs.json',
+        'nodejs/src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts',
+        'nodejs/src/ingestion/pipelines/ai/costs/providers/llm-costs.json',
     ],
     // An owner is formally requested for review only if their footprint clears
     // one of these bars; otherwise they are demoted to the explanation comment

--- a/.github/scripts/assign-reviewers.test.js
+++ b/.github/scripts/assign-reviewers.test.js
@@ -30,9 +30,9 @@ describe('assign-reviewers', () => {
             ['uv.lock', true],
             ['posthog/api/test/__snapshots__/test_survey.ambr', true],
             ['frontend/src/scenes/x/Component.test.tsx.snap', true],
-            ['nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts', true],
-            ['nodejs/src/ingestion/ai/costs/providers/llm-costs.json', true],
-            ['nodejs/src/ingestion/ai/costs/providers/manual-providers.ts', false],
+            ['nodejs/src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts', true],
+            ['nodejs/src/ingestion/pipelines/ai/costs/providers/llm-costs.json', true],
+            ['nodejs/src/ingestion/pipelines/ai/costs/providers/manual-providers.ts', false],
             ['posthog/api/survey.py', false],
             ['frontend/src/scenes/surveys/Survey.tsx', false],
         ])('%s -> %s', (filename, expected) => {

--- a/.github/workflows/update-ai-costs.yml
+++ b/.github/workflows/update-ai-costs.yml
@@ -47,18 +47,18 @@ jobs:
             - name: Format generated files
               run: |
                   cd nodejs
-                  pnpm prettier --write src/ingestion/ai/costs/providers/canonical-providers.ts src/ingestion/ai/costs/providers/llm-costs.json
+                  pnpm prettier --write src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts src/ingestion/pipelines/ai/costs/providers/llm-costs.json
 
             - name: Check for changes
               id: check-changes
               run: |
-                  if git diff --quiet nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts nodejs/src/ingestion/ai/costs/providers/llm-costs.json; then
+                  if git diff --quiet nodejs/src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts nodejs/src/ingestion/pipelines/ai/costs/providers/llm-costs.json; then
                     echo "changes=false" >> $GITHUB_OUTPUT
                     echo "No changes detected in AI costs"
                   else
                     echo "changes=true" >> $GITHUB_OUTPUT
                     echo "Changes detected in AI costs"
-                    git diff --stat nodejs/src/ingestion/ai/costs/providers/canonical-providers.ts nodejs/src/ingestion/ai/costs/providers/llm-costs.json
+                    git diff --stat nodejs/src/ingestion/pipelines/ai/costs/providers/canonical-providers.ts nodejs/src/ingestion/pipelines/ai/costs/providers/llm-costs.json
                   fi
 
             - name: Clean up stale branch

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -47,7 +47,7 @@
         "build:cyclotron": "pnpm --filter=@posthog/cyclotron package",
         "build:cyclotron:dev": "pnpm --filter=@posthog/cyclotron run build:dev",
         "generate:personhog-proto": "cd ../proto && buf generate --template ../nodejs/buf.gen.yaml --path personhog/service --path personhog/types .",
-        "update-ai-costs": "ts-node src/ingestion/ai/costs/scripts/update-ai-costs.ts",
+        "update-ai-costs": "ts-node src/ingestion/pipelines/ai/costs/scripts/update-ai-costs.ts",
         "sync-segment-icons": "DATABASE_URL=something ts-node src/cdp/segment/sync-segment-icons.ts",
         "start:recording-rasterizer": "node dist/recording-rasterizer/index.js"
     },


### PR DESCRIPTION
## Problem

The scheduled **Update AI Costs** job (`.github/workflows/update-ai-costs.yml`) has failed on every run since 2026-06-22 12:00 UTC, so no automated LLM cost PRs have opened since [#64955](https://github.com/PostHog/posthog/pull/64955). The job still fires on cron; it crashes in the `pnpm update-ai-costs` step with:

```
Error: Cannot find module './update-ai-costs.ts'  (MODULE_NOT_FOUND)
```

## Cause

#64506 ("separate ingestion code from CDP") relocated `nodejs/src/ingestion/ai/costs/` to `nodejs/src/ingestion/pipelines/ai/costs/`. The TypeScript imports were updated by the refactor, but six non-typechecked string references to the old path were not. The first scheduled run after that merge failed and every run since has.

## Changes

Repoint all six stale references to the new path:

- `nodejs/package.json` — `update-ai-costs` script entrypoint (the crash)
- `.github/workflows/update-ai-costs.yml` — prettier `--write` and `git diff` paths (would still fail after the script fix)
- `.github/CODEOWNERS-soft` — ownership routing for the moved dir
- `.gitattributes` — `linguist-generated` marker
- `.github/scripts/assign-reviewers.js` + `.test.js` — excluded-file paths for reviewer assignment

## Verification

- Confirmed the entrypoint now exists at the path `package.json` references, resolving the MODULE_NOT_FOUND.
- Verified `isExcludedFile()` returns the expected results for all three new provider paths.
- YAML edits are path-string-only inside existing `run:` blocks; structure unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)