### PR TITLE
fix(redshift): skip internal materialized-view columns in schema discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/redshift/redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/redshift.py
@@ -102,6 +102,13 @@ _REDSHIFT_CONNECT_OPTS: dict[str, Any] = {
 # system catalogs plus `pg_automv` (auto-materialized views) and per-session `pg_temp_*` schemas.
 SYSTEM_REDSHIFT_SCHEMAS = ["pg_catalog", "information_schema", "pg_internal", "pg_automv"]
 
+# Redshift stamps internal bookkeeping columns onto materialized views — e.g.
+# `padb_internal_txn_id_col` and `padb_internal_txn_seq_col`. They appear in
+# `information_schema.columns` but `SELECT *` never returns them, so leaving them in the
+# discovered schema makes the Arrow schema disagree with the streamed rows and
+# `pa.Table.from_pydict` raises a `KeyError`. The `padb_internal` prefix is Redshift-reserved.
+REDSHIFT_INTERNAL_COLUMN_LIKE = "padb_internal%"
+
 
 def _display_name(schema_name: str, table_name: str, *, qualify: bool) -> str:
     """Discovery key for a table: dotted `schema.table` in multi-schema mode, bare table otherwise."""
@@ -387,8 +394,8 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
         qualify = selected_schema is None
 
         with conn.cursor() as cursor:
-            params: dict = {}
-            where: list[str] = []
+            params: dict = {"internal_column": REDSHIFT_INTERNAL_COLUMN_LIKE}
+            where: list[str] = ["column_name NOT LIKE %(internal_column)s"]
             if selected_schema is not None:
                 params["schema"] = selected_schema
                 where.append("table_schema = %(schema)s")
@@ -803,7 +810,12 @@ class RedshiftImplementation(SQLSourceImplementation[RedshiftSourceConfig, psyco
                 information_schema.columns
             WHERE
                 table_schema = {schema}
-                AND table_name = {table}""").format(schema=sql.Literal(schema), table=sql.Literal(table_name))
+                AND table_name = {table}
+                AND column_name NOT LIKE {internal_column}""").format(
+            schema=sql.Literal(schema),
+            table=sql.Literal(table_name),
+            internal_column=sql.Literal(REDSHIFT_INTERNAL_COLUMN_LIKE),
+        )
 
         if logger is not None:
             _explain_query(cursor, query, logger)

--- a/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/posthog/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -315,6 +315,19 @@ class TestGetTableMetadata:
         assert table.columns[0].numeric_precision == 10
         assert table.columns[0].numeric_scale == 2
 
+    def test_excludes_redshift_internal_columns_from_arrow_schema(self, impl, cursor):
+        # Materialized views expose `padb_internal_*` bookkeeping columns in
+        # `information_schema.columns`, but `SELECT *` never returns them. Leaving them in the
+        # Arrow schema made `pa.Table.from_pydict` raise `KeyError: 'padb_internal_txn_id_col'`.
+        cursor.execute.return_value = cursor
+        cursor.fetchone.return_value = (False,)
+        cursor.__iter__.return_value = iter([("id", "integer", "NO", None, None)])
+
+        impl.get_table_metadata(cursor, "public", "my_mat_view")
+
+        metadata_query = cursor.execute.call_args.args[0].as_string()
+        assert "column_name NOT LIKE 'padb_internal%'" in metadata_query
+
 
 class TestGetRowsToSync:
     def _inner(self):
@@ -551,6 +564,21 @@ class TestGetColumns:
         conn.cursor.return_value = cur
 
         assert impl.get_columns(conn, _make_config(), names=["foo"]) == {}
+
+    def test_excludes_redshift_internal_columns(self, impl):
+        # Discovery must drop the `padb_internal_*` columns Redshift stamps onto materialized
+        # views — they never come back from `SELECT *`, so surfacing them desyncs the schema.
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.__enter__.return_value = cur
+        cur.fetchall.return_value = []
+        conn.cursor.return_value = cur
+
+        impl.get_columns(conn, _make_config(), names=None)
+
+        executed_sql, executed_params = cur.execute.call_args.args
+        assert "column_name NOT LIKE %(internal_column)s" in executed_sql
+        assert executed_params["internal_column"] == "padb_internal%"
 
     def test_blank_schema_qualifies_and_excludes_system_schemas(self, impl):
         conn = MagicMock()


### PR DESCRIPTION
## Problem

The Redshift data-warehouse import source crashes every run for any synced **materialized view** with:

```
KeyError: 'padb_internal_txn_id_col'
"The passed mapping doesn't contain the following field(s) of the schema: padb_internal_txn_id_col, padb_internal_txn_seq_col"
```

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019d5124-98fd-7330-8546-548641db17b0 (active, thousands of occurrences, still firing).

**Root cause.** Redshift stamps internal bookkeeping columns onto materialized views — `padb_internal_txn_id_col`, `padb_internal_txn_seq_col`. These show up in `information_schema.columns`, so `get_table_metadata` pulled them into the table's Arrow schema. But `SELECT *` against the view never returns them, so the streamed rows have no such columns. `table_from_iterator` → `pa.Table.from_pydict(data, schema=arrow_schema)` then raises `KeyError` because the schema declares fields the data mapping doesn't contain.

Stack path: `get_rows` (`redshift.py`) → `table_from_iterator` → `_process_batch` → pyarrow `from_pydict`.

## Changes

Exclude columns matching the reserved `padb_internal` prefix from both queries that read `information_schema.columns`:

- `get_table_metadata` — the one that builds the Arrow schema (the crash site).
- `get_columns` — schema discovery, so these phantom columns never surface as selectable either, keeping discovery and sync consistent.

The `padb_internal` prefix is Redshift-reserved, so this is a low-false-positive filter — user tables can't define columns with that prefix, and those columns are never returned by a normal query anyway.

This is our bug to fix rather than a non-retryable user/upstream error: the customer genuinely wants their materialized view imported, and the fix makes the discovered schema match the rows the query returns.

## How did you test this code?

I'm an agent. I added and ran automated tests; I did not run a real Redshift import.

- `TestGetTableMetadata::test_excludes_redshift_internal_columns_from_arrow_schema` — asserts the metadata query (which feeds the Arrow schema) carries the `NOT LIKE 'padb_internal%'` exclusion. Catches a regression where the Arrow schema would again include MV columns absent from `SELECT *`, reintroducing the `from_pydict` KeyError. No existing test covered internal-column exclusion.
- `TestGetColumns::test_excludes_redshift_internal_columns` — asserts discovery filters the same columns, so they're never surfaced as selectable.
- Full file: `92 passed`. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `redshift` source. Confirmed the issue in PostHog error tracking (pulled the full stack trace and a representative event), traced the `KeyError` to the Arrow-schema/`SELECT *` mismatch on materialized views, and verified no open PR (including the maintainer's own) already addressed it. Considered treating it as non-retryable and rejected that — it's a fixable shape-handling bug, not a credentials/config problem. Scoped the fix to the two `information_schema.columns` discovery queries; no retry-policy or abstraction changes.