### PR TITLE
chore(signals): add module docstring to summary workflow

### DIFF
--- a/products/signals/backend/temporal/summary.py
+++ b/products/signals/backend/temporal/summary.py
@@ -1,3 +1,5 @@
+"""Temporal workflow that generates and persists signal report summaries."""
+
 import json
 import asyncio
 from dataclasses import dataclass, field


### PR DESCRIPTION
## Problem

The video-export Temporal worker needs a fresh image build/deploy, but its `state.yaml` entry in `PostHog/charts` only advances when a change lands under one of the paths the CD workflow maps to that worker (`container-images-cd.yml`). A no-op touch in the signals backend (one of those mapped paths) is the established way to retrigger the build.

## Changes

Adds a one-line module docstring to the signals report-summary Temporal workflow (`products/signals/backend/temporal/summary.py`). No runtime behavior change; its purpose is to land a change under `products/signals/backend/` so the video-export Temporal worker image is rebuilt and its `state.yaml` sha advances.

## How did you test this code?

I'm an agent — no local test run. The change is a single docstring line with no runtime behavior. Confirmed `products/signals/backend/` is in the video-export worker's change-detection path list in `.github/workflows/container-images-cd.yml`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by Josh Snyder to unblock a stuck video-export Temporal worker deploy. Authored by the PostHog Slack app. Verified the path-to-worker mapping in `container-images-cd.yml` before choosing where to make the touch.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09ADEV3AJD/p1782239933951869?thread_ts=1782239933.951869&cid=C09ADEV3AJD)*
