### PR TITLE
fix(data-warehouse): make duckgres table_suffix read-only in admin

### DIFF
--- a/posthog/admin/admins/ducklake_backfill_admin.py
+++ b/posthog/admin/admins/ducklake_backfill_admin.py
@@ -18,7 +18,10 @@ class DuckLakeBackfillAdmin(admin.ModelAdmin):
     )
     list_filter = ("enabled",)
     search_fields = ("=team__id", "table_suffix")
-    readonly_fields = ("id", "created_at", "updated_at")
+    # `table_suffix` is write-once: it names a team's warehouse tables/schema, so changing it after
+    # data is written moves the target and orphans the old tables. It's set only through the
+    # validated enable flow (`enable_team_backfill`), never edited here.
+    readonly_fields = ("id", "table_suffix", "created_at", "updated_at")
     raw_id_fields = ("team", "created_by")
     actions = ("make_enabled", "make_disabled")
 

--- a/posthog/admin/test_ducklake_backfill_admin.py
+++ b/posthog/admin/test_ducklake_backfill_admin.py
@@ -1,0 +1,21 @@
+from posthog.test.base import BaseTest
+
+from django.contrib.admin.sites import AdminSite
+from django.test import RequestFactory
+
+from posthog.admin.admins.ducklake_backfill_admin import DuckLakeBackfillAdmin
+from posthog.models import DuckLakeBackfill
+
+
+class TestDuckLakeBackfillAdmin(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        self.admin = DuckLakeBackfillAdmin(DuckLakeBackfill, AdminSite())
+        self.request = RequestFactory().get("/")
+        self.request.user = self.user
+
+    def test_table_suffix_is_readonly(self) -> None:
+        # `table_suffix` is write-once — editing it in admin would move a team's warehouse
+        # schema/tables and orphan the old ones. It must never be editable here.
+        backfill = DuckLakeBackfill.objects.create(team=self.team, enabled=True, table_suffix="acme")
+        assert "table_suffix" in self.admin.get_readonly_fields(self.request, backfill)


### PR DESCRIPTION
## Problem

`DuckLakeBackfill.table_suffix` names a team's warehouse tables (`events_<suffix>` / `persons_<suffix>`) and — since #65323 — the v3 data-import sink schema (`posthog_data_imports_<suffix>`). It's a write-once value: changing it after data is written moves the target and silently orphans the already-written tables/schema, splitting a team's warehouse data.

The product enable flow (`enable_team_backfill`) already enforces this — it raises if you try to change an existing suffix. But the Django admin left `table_suffix` editable, so a staff user could change it directly on the change form and bypass the guard. That was the one remaining unguarded mutation path.

This is the interim safety stopgap called out by #65331 (the full fix — drift detection + automatic re-prime — depends on the backfill state machine in #63144, which isn't merged yet).

## Changes

- Add `table_suffix` to `readonly_fields` on `DuckLakeBackfillAdmin`. The field still displays on the change form; it just can't be edited. The suffix is only ever set through the validated enable flow.
- Add a regression test asserting the field is read-only in admin.

## How did you test this code?

I'm an agent (Claude Code). Automated test only — no manual testing:

- Added `posthog/admin/test_ducklake_backfill_admin.py::TestDuckLakeBackfillAdmin::test_table_suffix_is_readonly`, which catches the regression of someone reopening the admin edit hole. Ran it locally: passes. ruff + ty clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Eric asked me to assess the relevance of #65331 (whether `table_suffix` is even mutable and the effects), then to ship the one-line stopgap. A verification pass against `origin/master` established: the suffix-based resolver (#65323) is merged and live, so the orphan-on-change hazard is real today; the full re-prime fix depends on #63144 (backfill state machine), which lives on an unmerged branch. The only realistic accidental-change vector on master is the Django admin, where the field was editable — this PR closes that without depending on #63144.

Tools: Claude Code (Opus 4.8). Skills consulted: writing-tests (gated the regression test as worth adding). No migration involved (admin-config change only).
