### PR TITLE
fix(settings): resume team invite after re-authentication

### DIFF
--- a/frontend/src/scenes/settings/organization/inviteLogic.ts
+++ b/frontend/src/scenes/settings/organization/inviteLogic.ts
@@ -2,6 +2,7 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { lazyLoaders, loaders } from 'kea-loaders'
 
 import api, { PaginatedResponse } from 'lib/api'
+import { timeSensitiveAuthenticationLogic } from 'lib/components/TimeSensitiveAuthentication/timeSensitiveAuthenticationLogic'
 import { OrganizationMembershipLevel } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { bindModalToUrl } from 'lib/logic/bindModalToUrl'
@@ -68,6 +69,9 @@ export const inviteLogic = kea<inviteLogicType>([
                     if (values.message) {
                         payload.forEach((payload) => (payload.message = values.message))
                     }
+                    // Inviting members is a sensitive action; if re-authentication is required,
+                    // await its completion so the invite resumes once the user re-authenticates.
+                    await timeSensitiveAuthenticationLogic.findMounted()?.asyncActions.checkReauthentication()
                     return await api.create<OrganizationInviteType[]>(
                         `api/organizations/${organizationLogic.values.currentOrganizationId}/invites/bulk/`,
                         payload


### PR DESCRIPTION
## Problem

When a user invites a team member but their session is older than the re-authentication window, the bulk-invite request is rejected by the backend with a `403 sensitive_action_required_reauth`. The frontend pops the re-auth modal, the user re-enters their credentials — and then nothing happens. The modal closes, but the invite is never retried: no success toast, no error, no confirmation. The invite is silently lost and the user has no idea it didn't send.

This was reported by a user: _"when I want to invite a user to my PostHog team, it asks for re-auth, but after re-auth it didn't tell me if the invite sent."_

The root cause: `inviteLogic.inviteTeamMembers` fired the API call directly with no resume mechanism. The 403 sets the re-auth flag to a plain boolean, so on re-auth success the resolve-tuple guard in `timeSensitiveAuthenticationLogic` is never hit and the original action is never resumed.

## Changes

`inviteTeamMembers` now awaits `checkReauthentication()` before issuing the bulk-invite request, exactly as `organizationLogic` already does for `createOrganization` / `updateOrganization`. That call stores a `[resolve, reject]` promise tuple, so when the user completes re-auth the invite request resumes and the existing `Invited N new team member(s)` success toast fires.

## How did you test this code?

I'm an agent (PostHog Slack app). I made the change to match the established sensitive-action pattern but did **not** run the app or add automated tests. Suggested manual verification: let a session age past the re-auth window, invite a team member, complete the re-auth modal, and confirm the invite sends and the success toast appears.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Slack-reported bug about missing confirmation after re-auth when inviting team members. Traced the flow across `inviteLogic`, `apiStatusLogic`, and `timeSensitiveAuthenticationLogic` and found the real issue was a missing action-resume after re-auth (not just a missing confirmation page). Fix mirrors the existing `organizationLogic` pattern rather than introducing a new mechanism. No skills were required for this one-line logic change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782248202614129?thread_ts=1782248202.614129&cid=C0ACRAMJUAG)*
