### PR TITLE
fix(llm-gateway): sanitize Bedrock CountTokens thinking blocks

### DIFF
--- a/services/llm-gateway/src/llm_gateway/api/anthropic.py
+++ b/services/llm-gateway/src/llm_gateway/api/anthropic.py
@@ -28,6 +28,7 @@ from llm_gateway.config import get_settings
 from llm_gateway.dependencies import AnthropicCircuitBreakerDep, RateLimitedUser
 from llm_gateway.metrics.prometheus import (
     ANTHROPIC_CIRCUIT_BREAKER_BYPASSED,
+    BEDROCK_COUNT_TOKENS_ERRORS,
     BEDROCK_FALLBACK_FAILURE,
     BEDROCK_FALLBACK_SUCCESS,
     BEDROCK_FALLBACK_TRIGGERED,
@@ -520,6 +521,7 @@ async def _bedrock_count_tokens_impl(
             bedrock_model,
             bedrock_region_name,
             settings.request_timeout,
+            product=product,
         )
         return {"input_tokens": input_tokens}
     except Exception as e:
@@ -532,6 +534,11 @@ async def _bedrock_count_tokens_impl(
             product=product,
             **_bedrock_runtime_exception_log_fields(e),
         )
+        BEDROCK_COUNT_TOKENS_ERRORS.labels(
+            transport="runtime",
+            error_type=type(e).__name__,
+            product=product,
+        ).inc()
         logger.info("Attempting bedrock-mantle count_tokens fallback", model=bedrock_model, product=product)
         try:
             input_tokens = await count_tokens_with_bedrock_mantle(
@@ -552,6 +559,11 @@ async def _bedrock_count_tokens_impl(
                 **_exception_log_fields(mantle_exc, prefix="mantle"),
                 **_bedrock_runtime_exception_log_fields(e),
             )
+            BEDROCK_COUNT_TOKENS_ERRORS.labels(
+                transport="mantle",
+                error_type=error_type_name,
+                product=product,
+            ).inc()
             raise HTTPException(
                 status_code=502,
                 detail={

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -178,17 +178,21 @@ def get_bedrock_session() -> Boto3Session:
 
 
 def _is_unsigned_thinking_block(block: Any) -> bool:
+    """Detect thinking blocks Bedrock CountTokens rejects because they cannot be replay-verified."""
     return isinstance(block, dict) and block.get("type") == "thinking" and not block.get("signature")
 
 
 @dataclass
 class CountTokensSanitizationReport:
+    """Bounded record of data lost while adapting an Anthropic CountTokens request."""
+
     dropped_property_counts: Counter[str] = field(default_factory=Counter)
     dropped_paths: list[str] = field(default_factory=list)
     dropped_items_total: int = 0
     dropped_paths_truncated: bool = False
 
     def record_drop(self, property_name: str, path: str) -> None:
+        """Track a dropped field without storing request contents."""
         self.dropped_property_counts[property_name] += 1
         self.dropped_items_total += 1
         if len(self.dropped_paths) < MAX_COUNT_TOKENS_LOSS_REPORT_PATHS:
@@ -198,10 +202,12 @@ class CountTokensSanitizationReport:
 
     @property
     def has_drops(self) -> bool:
+        """Return whether this adaptation lost any request data."""
         return self.dropped_items_total > 0
 
 
 def _sanitize_bedrock_count_tokens_messages(messages: Any) -> tuple[Any, CountTokensSanitizationReport]:
+    """Remove nested message content Bedrock CountTokens rejects, preserving a loss report."""
     report = CountTokensSanitizationReport()
     if not isinstance(messages, list):
         return messages, report
@@ -242,6 +248,7 @@ def _record_count_tokens_top_level_drops(
     *,
     body_properties: frozenset[str],
 ) -> None:
+    """Add omitted top-level request fields to the same loss report as nested drops."""
     for property_name in sorted(request_data):
         if property_name in body_properties or property_name in COUNT_TOKENS_ROUTING_PROPERTIES:
             continue
@@ -255,6 +262,7 @@ def _record_count_tokens_sanitization_report(
     product: str,
     transport: str,
 ) -> None:
+    """Emit one warning and metric update after all CountTokens drops are collected."""
     if not report.has_drops:
         return
 

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -168,6 +168,37 @@ def get_bedrock_session() -> Boto3Session:
     return boto3.Session()
 
 
+def _is_unsigned_thinking_block(block: Any) -> bool:
+    return isinstance(block, dict) and block.get("type") == "thinking" and not block.get("signature")
+
+
+def _sanitize_bedrock_count_tokens_messages(messages: Any) -> Any:
+    if not isinstance(messages, list):
+        return messages
+
+    sanitized_messages: list[Any] = []
+    for message in messages:
+        if not isinstance(message, dict):
+            sanitized_messages.append(message)
+            continue
+
+        content = message.get("content")
+        if not isinstance(content, list):
+            sanitized_messages.append(message)
+            continue
+
+        sanitized_content = [block for block in content if not _is_unsigned_thinking_block(block)]
+        if not sanitized_content:
+            continue
+
+        if len(sanitized_content) == len(content):
+            sanitized_messages.append(message)
+        else:
+            sanitized_messages.append({**message, "content": sanitized_content})
+
+    return sanitized_messages
+
+
 async def count_tokens_with_bedrock(
     request_data: dict[str, Any],
     model: str,
@@ -185,7 +216,7 @@ async def count_tokens_with_bedrock(
         body = {
             "anthropic_version": BEDROCK_ANTHROPIC_VERSION,
             "max_tokens": request_data.get("max_tokens", DEFAULT_BEDROCK_MAX_TOKENS),
-            "messages": request_data.get("messages"),
+            "messages": _sanitize_bedrock_count_tokens_messages(request_data.get("messages")),
         }
 
         response = bedrock_runtime_client.count_tokens(
@@ -246,6 +277,7 @@ async def count_tokens_with_bedrock_mantle(
     """
     mantle_model = _strip_regional_inference_prefix(model)
     body: dict[str, Any] = {"model": mantle_model, "messages": request_data.get("messages")}
+    body["messages"] = _sanitize_bedrock_count_tokens_messages(body["messages"])
     for key in ("system", "tools", "tool_choice"):
         if key in request_data:
             body[key] = request_data[key]

--- a/services/llm-gateway/src/llm_gateway/bedrock.py
+++ b/services/llm-gateway/src/llm_gateway/bedrock.py
@@ -5,6 +5,8 @@ import functools
 import json
 import os
 import time
+from collections import Counter
+from dataclasses import dataclass, field
 from typing import Any, Final
 
 import boto3
@@ -17,6 +19,7 @@ from botocore.config import Config
 from fastapi import HTTPException
 
 from llm_gateway.config import get_settings
+from llm_gateway.metrics.prometheus import BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES
 
 logger = structlog.get_logger(__name__)
 
@@ -26,6 +29,12 @@ BEDROCK_ANTHROPIC_VERSION: Final[str] = "bedrock-2023-05-31"
 BEDROCK_MANTLE_ANTHROPIC_VERSION: Final[str] = "2023-06-01"
 BEDROCK_MANTLE_SIGV4_SERVICE: Final[str] = "bedrock-mantle"
 DEFAULT_BEDROCK_MAX_TOKENS: Final[int] = 4096
+MAX_COUNT_TOKENS_LOSS_REPORT_PATHS: Final[int] = 20
+UNSIGNED_THINKING_PROPERTY: Final[str] = "messages.content.thinking_without_signature"
+EMPTY_MESSAGE_PROPERTY: Final[str] = "messages.empty_after_sanitization"
+COUNT_TOKENS_ROUTING_PROPERTIES: Final[frozenset[str]] = frozenset({"model"})
+RUNTIME_COUNT_TOKENS_BODY_PROPERTIES: Final[frozenset[str]] = frozenset({"messages", "max_tokens"})
+MANTLE_COUNT_TOKENS_BODY_PROPERTIES: Final[frozenset[str]] = frozenset({"messages", "system", "tool_choice", "tools"})
 
 BEDROCK_ANTHROPIC_MODEL_PREFIXES: Final[tuple[str, ...]] = (
     "anthropic.",
@@ -172,12 +181,33 @@ def _is_unsigned_thinking_block(block: Any) -> bool:
     return isinstance(block, dict) and block.get("type") == "thinking" and not block.get("signature")
 
 
-def _sanitize_bedrock_count_tokens_messages(messages: Any) -> Any:
+@dataclass
+class CountTokensSanitizationReport:
+    dropped_property_counts: Counter[str] = field(default_factory=Counter)
+    dropped_paths: list[str] = field(default_factory=list)
+    dropped_items_total: int = 0
+    dropped_paths_truncated: bool = False
+
+    def record_drop(self, property_name: str, path: str) -> None:
+        self.dropped_property_counts[property_name] += 1
+        self.dropped_items_total += 1
+        if len(self.dropped_paths) < MAX_COUNT_TOKENS_LOSS_REPORT_PATHS:
+            self.dropped_paths.append(path)
+        else:
+            self.dropped_paths_truncated = True
+
+    @property
+    def has_drops(self) -> bool:
+        return self.dropped_items_total > 0
+
+
+def _sanitize_bedrock_count_tokens_messages(messages: Any) -> tuple[Any, CountTokensSanitizationReport]:
+    report = CountTokensSanitizationReport()
     if not isinstance(messages, list):
-        return messages
+        return messages, report
 
     sanitized_messages: list[Any] = []
-    for message in messages:
+    for message_index, message in enumerate(messages):
         if not isinstance(message, dict):
             sanitized_messages.append(message)
             continue
@@ -187,8 +217,15 @@ def _sanitize_bedrock_count_tokens_messages(messages: Any) -> Any:
             sanitized_messages.append(message)
             continue
 
-        sanitized_content = [block for block in content if not _is_unsigned_thinking_block(block)]
+        sanitized_content: list[Any] = []
+        for block_index, block in enumerate(content):
+            if _is_unsigned_thinking_block(block):
+                report.record_drop(UNSIGNED_THINKING_PROPERTY, f"messages[{message_index}].content[{block_index}]")
+                continue
+            sanitized_content.append(block)
+
         if not sanitized_content:
+            report.record_drop(EMPTY_MESSAGE_PROPERTY, f"messages[{message_index}]")
             continue
 
         if len(sanitized_content) == len(content):
@@ -196,7 +233,50 @@ def _sanitize_bedrock_count_tokens_messages(messages: Any) -> Any:
         else:
             sanitized_messages.append({**message, "content": sanitized_content})
 
-    return sanitized_messages
+    return sanitized_messages, report
+
+
+def _record_count_tokens_top_level_drops(
+    report: CountTokensSanitizationReport,
+    request_data: dict[str, Any],
+    *,
+    body_properties: frozenset[str],
+) -> None:
+    for property_name in sorted(request_data):
+        if property_name in body_properties or property_name in COUNT_TOKENS_ROUTING_PROPERTIES:
+            continue
+        report.record_drop(f"top_level.{property_name}", property_name)
+
+
+def _record_count_tokens_sanitization_report(
+    report: CountTokensSanitizationReport,
+    *,
+    model: str,
+    product: str,
+    transport: str,
+) -> None:
+    if not report.has_drops:
+        return
+
+    dropped_property_counts = dict(sorted(report.dropped_property_counts.items()))
+    for property_name, count in dropped_property_counts.items():
+        BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+            transport=transport,
+            property=property_name,
+            product=product,
+        ).inc(count)
+
+    logger.warning(
+        "Bedrock CountTokens request sanitized",
+        model=model,
+        product=product,
+        transport=transport,
+        dropped_properties=sorted(dropped_property_counts),
+        dropped_property_counts=dropped_property_counts,
+        dropped_paths=report.dropped_paths,
+        dropped_items_total=report.dropped_items_total,
+        dropped_paths_truncated=report.dropped_paths_truncated,
+    )
 
 
 async def count_tokens_with_bedrock(
@@ -204,7 +284,13 @@ async def count_tokens_with_bedrock(
     model: str,
     aws_region_name: str,
     timeout_seconds: float,
+    *,
+    product: str,
 ) -> int:
+    sanitized_messages, report = _sanitize_bedrock_count_tokens_messages(request_data.get("messages"))
+    _record_count_tokens_top_level_drops(report, request_data, body_properties=RUNTIME_COUNT_TOKENS_BODY_PROPERTIES)
+    _record_count_tokens_sanitization_report(report, model=model, product=product, transport="runtime")
+
     def _sync() -> int:
         bedrock_runtime_client = get_bedrock_runtime_client(aws_region_name, timeout_seconds)
 
@@ -216,7 +302,7 @@ async def count_tokens_with_bedrock(
         body = {
             "anthropic_version": BEDROCK_ANTHROPIC_VERSION,
             "max_tokens": request_data.get("max_tokens", DEFAULT_BEDROCK_MAX_TOKENS),
-            "messages": _sanitize_bedrock_count_tokens_messages(request_data.get("messages")),
+            "messages": sanitized_messages,
         }
 
         response = bedrock_runtime_client.count_tokens(
@@ -277,7 +363,9 @@ async def count_tokens_with_bedrock_mantle(
     """
     mantle_model = _strip_regional_inference_prefix(model)
     body: dict[str, Any] = {"model": mantle_model, "messages": request_data.get("messages")}
-    body["messages"] = _sanitize_bedrock_count_tokens_messages(body["messages"])
+    body["messages"], report = _sanitize_bedrock_count_tokens_messages(body["messages"])
+    _record_count_tokens_top_level_drops(report, request_data, body_properties=MANTLE_COUNT_TOKENS_BODY_PROPERTIES)
+    _record_count_tokens_sanitization_report(report, model=model, product=product, transport="mantle")
     for key in ("system", "tools", "tool_choice"):
         if key in request_data:
             body[key] = request_data[key]

--- a/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
+++ b/services/llm-gateway/src/llm_gateway/metrics/prometheus.py
@@ -251,6 +251,18 @@ BEDROCK_PARAM_STRIPPED = Counter(
     labelnames=["param", "product"],
 )
 
+BEDROCK_COUNT_TOKENS_ERRORS = Counter(
+    "llm_gateway_bedrock_count_tokens_errors_total",
+    "Bedrock CountTokens provider-call failures before fallback handling",
+    labelnames=["transport", "error_type", "product"],
+)
+
+BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES = Counter(
+    "llm_gateway_bedrock_count_tokens_dropped_properties_total",
+    "Properties dropped while adapting an Anthropic CountTokens request for Bedrock",
+    labelnames=["transport", "property", "product"],
+)
+
 ANTHROPIC_CIRCUIT_BREAKER_BYPASSED = Counter(
     "llm_gateway_anthropic_circuit_breaker_bypassed_total",
     "Anthropic requests routed straight to Bedrock because the breaker was open",

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -1,3 +1,4 @@
+import json
 from typing import Any
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
@@ -616,6 +617,46 @@ class TestBedrockCountTokensViaProvider:
         assert mock_to_thread.called
         assert callable(mock_to_thread.call_args.args[0])
 
+    @pytest.mark.asyncio
+    @patch("llm_gateway.bedrock.get_bedrock_runtime_client")
+    async def test_count_tokens_strips_unsigned_thinking_blocks(self, mock_get_client: MagicMock) -> None:
+        from llm_gateway.bedrock import count_tokens_with_bedrock
+
+        mock_client = MagicMock()
+        mock_client.count_tokens.return_value = {"inputTokens": 42}
+        mock_get_client.return_value = mock_client
+
+        unsigned_thinking = {"type": "thinking", "thinking": "cannot be replayed", "index": 0}
+        signed_thinking = {"type": "thinking", "thinking": "can be replayed", "signature": "sig", "index": 0}
+        request_data: dict[str, Any] = {
+            "max_tokens": 2048,
+            "messages": [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": [unsigned_thinking, {"type": "text", "text": "Answer"}]},
+                {"role": "assistant", "content": [unsigned_thinking]},
+                {"role": "assistant", "content": [signed_thinking, {"type": "text", "text": "Signed answer"}]},
+            ],
+        }
+
+        result = await count_tokens_with_bedrock(
+            request_data,
+            "us.anthropic.claude-sonnet-4-6",
+            "us-east-1",
+            123.0,
+        )
+
+        assert result == 42
+        call_kwargs = mock_client.count_tokens.call_args.kwargs
+        assert call_kwargs["modelId"] == "anthropic.claude-sonnet-4-6"
+
+        body = json.loads(call_kwargs["input"]["invokeModel"]["body"])
+        assert body["messages"] == [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": [{"type": "text", "text": "Answer"}]},
+            {"role": "assistant", "content": [signed_thinking, {"type": "text", "text": "Signed answer"}]},
+        ]
+        assert request_data["messages"][1]["content"][0] == unsigned_thinking
+
 
 class TestModelMapping:
     @pytest.mark.parametrize(
@@ -728,7 +769,10 @@ class TestBedrockMantleCountTokens:
         mock_async_client_cls.return_value.__aenter__.return_value = mock_client
 
         request_data = {
-            "messages": [{"role": "user", "content": "Hello"}],
+            "messages": [
+                {"role": "assistant", "content": [{"type": "thinking", "thinking": "bad"}]},
+                {"role": "user", "content": "Hello"},
+            ],
             "system": "Be brief.",
             "tools": [{"name": "x", "description": "", "input_schema": {"type": "object"}}],
         }
@@ -756,11 +800,9 @@ class TestBedrockMantleCountTokens:
         signed_url = mock_sign.call_args.args[0]
         assert signed_url == "https://bedrock-mantle.us-east-1.api.aws/anthropic/v1/messages/count_tokens"
         # The signed payload carries the native Anthropic shape with the prefix-stripped model id.
-        import json
-
         signed_body = json.loads(mock_sign.call_args.args[1])
         assert signed_body["model"] == "anthropic.claude-opus-4-8"
-        assert signed_body["messages"] == request_data["messages"]
+        assert signed_body["messages"] == [{"role": "user", "content": "Hello"}]
         assert signed_body["system"] == request_data["system"]
         assert signed_body["tools"] == request_data["tools"]
         # The same signed payload bytes are what gets POSTed.

--- a/services/llm-gateway/tests/test_bedrock.py
+++ b/services/llm-gateway/tests/test_bedrock.py
@@ -7,6 +7,8 @@ from botocore.exceptions import ClientError
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
+from llm_gateway.metrics.prometheus import BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES, BEDROCK_COUNT_TOKENS_ERRORS
+
 BEDROCK_SETTINGS_PATCH = patch(
     "llm_gateway.api.anthropic.get_settings",
     return_value=MagicMock(bedrock_region_name="us-east-1", request_timeout=300.0),
@@ -447,6 +449,17 @@ class TestBedrockCountTokensViaProvider:
             detail={"error": {"message": "Access denied", "type": "permission_error"}},
         )
 
+        runtime_errors_before = BEDROCK_COUNT_TOKENS_ERRORS.labels(
+            transport="runtime",
+            error_type="Exception",
+            product="llm_gateway",
+        )._value.get()
+        mantle_errors_before = BEDROCK_COUNT_TOKENS_ERRORS.labels(
+            transport="mantle",
+            error_type="HTTPException",
+            product="llm_gateway",
+        )._value.get()
+
         response = authenticated_client.post(
             "/v1/messages/count_tokens",
             json=valid_request_body,
@@ -456,6 +469,22 @@ class TestBedrockCountTokensViaProvider:
         assert response.status_code == 502
         assert "Failed to count tokens via Bedrock" in response.json()["error"]["message"]
         assert mock_request_count.labels.call_args.kwargs["status_code"] == "502"
+        assert (
+            BEDROCK_COUNT_TOKENS_ERRORS.labels(
+                transport="runtime",
+                error_type="Exception",
+                product="llm_gateway",
+            )._value.get()
+            == runtime_errors_before + 1
+        )
+        assert (
+            BEDROCK_COUNT_TOKENS_ERRORS.labels(
+                transport="mantle",
+                error_type="HTTPException",
+                product="llm_gateway",
+            )._value.get()
+            == mantle_errors_before + 1
+        )
 
     @patch("llm_gateway.api.anthropic.get_settings")
     @patch("llm_gateway.api.anthropic.count_tokens_with_bedrock_mantle", new_callable=AsyncMock)
@@ -493,6 +522,12 @@ class TestBedrockCountTokensViaProvider:
         )
         mock_mantle_count_tokens.return_value = 77
 
+        runtime_errors_before = BEDROCK_COUNT_TOKENS_ERRORS.labels(
+            transport="runtime",
+            error_type="ClientError",
+            product="llm_gateway",
+        )._value.get()
+
         with patch("llm_gateway.api.anthropic.logger") as mock_logger:
             response = authenticated_client.post(
                 "/v1/messages/count_tokens",
@@ -502,6 +537,14 @@ class TestBedrockCountTokensViaProvider:
 
         assert response.status_code == 200
         assert response.json()["input_tokens"] == 77
+        assert (
+            BEDROCK_COUNT_TOKENS_ERRORS.labels(
+                transport="runtime",
+                error_type="ClientError",
+                product="llm_gateway",
+            )._value.get()
+            == runtime_errors_before + 1
+        )
         assert mock_mantle_count_tokens.await_count == 1
         mantle_count_tokens_call = mock_mantle_count_tokens.await_args
         assert mantle_count_tokens_call is not None
@@ -630,32 +673,109 @@ class TestBedrockCountTokensViaProvider:
         signed_thinking = {"type": "thinking", "thinking": "can be replayed", "signature": "sig", "index": 0}
         request_data: dict[str, Any] = {
             "max_tokens": 2048,
+            "system": "Be brief.",
             "messages": [
                 {"role": "user", "content": "Hello"},
                 {"role": "assistant", "content": [unsigned_thinking, {"type": "text", "text": "Answer"}]},
                 {"role": "assistant", "content": [unsigned_thinking]},
                 {"role": "assistant", "content": [signed_thinking, {"type": "text", "text": "Signed answer"}]},
             ],
+            "tools": [{"name": "x", "description": "", "input_schema": {"type": "object"}}],
+            "tool_choice": {"type": "tool", "name": "x"},
         }
+        unsigned_thinking_drops_before = BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+            transport="runtime",
+            property="messages.content.thinking_without_signature",
+            product="llm_gateway",
+        )._value.get()
+        empty_message_drops_before = BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+            transport="runtime",
+            property="messages.empty_after_sanitization",
+            product="llm_gateway",
+        )._value.get()
+        top_level_system_drops_before = BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+            transport="runtime",
+            property="top_level.system",
+            product="llm_gateway",
+        )._value.get()
 
-        result = await count_tokens_with_bedrock(
-            request_data,
-            "us.anthropic.claude-sonnet-4-6",
-            "us-east-1",
-            123.0,
-        )
+        with patch("llm_gateway.bedrock.logger") as mock_logger:
+            result = await count_tokens_with_bedrock(
+                request_data,
+                "us.anthropic.claude-sonnet-4-6",
+                "us-east-1",
+                123.0,
+                product="llm_gateway",
+            )
 
         assert result == 42
         call_kwargs = mock_client.count_tokens.call_args.kwargs
         assert call_kwargs["modelId"] == "anthropic.claude-sonnet-4-6"
 
         body = json.loads(call_kwargs["input"]["invokeModel"]["body"])
+        assert "system" not in body
+        assert "tools" not in body
+        assert "tool_choice" not in body
         assert body["messages"] == [
             {"role": "user", "content": "Hello"},
             {"role": "assistant", "content": [{"type": "text", "text": "Answer"}]},
             {"role": "assistant", "content": [signed_thinking, {"type": "text", "text": "Signed answer"}]},
         ]
         assert request_data["messages"][1]["content"][0] == unsigned_thinking
+        assert (
+            BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+                transport="runtime",
+                property="messages.content.thinking_without_signature",
+                product="llm_gateway",
+            )._value.get()
+            == unsigned_thinking_drops_before + 2
+        )
+        assert (
+            BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+                transport="runtime",
+                property="messages.empty_after_sanitization",
+                product="llm_gateway",
+            )._value.get()
+            == empty_message_drops_before + 1
+        )
+        assert (
+            BEDROCK_COUNT_TOKENS_DROPPED_PROPERTIES.labels(
+                transport="runtime",
+                property="top_level.system",
+                product="llm_gateway",
+            )._value.get()
+            == top_level_system_drops_before + 1
+        )
+        mock_logger.warning.assert_called_once_with(
+            "Bedrock CountTokens request sanitized",
+            model="us.anthropic.claude-sonnet-4-6",
+            product="llm_gateway",
+            transport="runtime",
+            dropped_properties=[
+                "messages.content.thinking_without_signature",
+                "messages.empty_after_sanitization",
+                "top_level.system",
+                "top_level.tool_choice",
+                "top_level.tools",
+            ],
+            dropped_property_counts={
+                "messages.content.thinking_without_signature": 2,
+                "messages.empty_after_sanitization": 1,
+                "top_level.system": 1,
+                "top_level.tool_choice": 1,
+                "top_level.tools": 1,
+            },
+            dropped_paths=[
+                "messages[1].content[0]",
+                "messages[2].content[0]",
+                "messages[2]",
+                "system",
+                "tool_choice",
+                "tools",
+            ],
+            dropped_items_total=6,
+            dropped_paths_truncated=False,
+        )
 
 
 class TestModelMapping:
@@ -807,6 +927,23 @@ class TestBedrockMantleCountTokens:
         assert signed_body["tools"] == request_data["tools"]
         # The same signed payload bytes are what gets POSTed.
         assert mock_client.post.call_args.kwargs["content"] == mock_sign.call_args.args[1]
+        mock_logger.warning.assert_called_once_with(
+            "Bedrock CountTokens request sanitized",
+            model="us.anthropic.claude-opus-4-8",
+            product="llm_gateway",
+            transport="mantle",
+            dropped_properties=[
+                "messages.content.thinking_without_signature",
+                "messages.empty_after_sanitization",
+            ],
+            dropped_property_counts={
+                "messages.content.thinking_without_signature": 1,
+                "messages.empty_after_sanitization": 1,
+            },
+            dropped_paths=["messages[0].content[0]", "messages[0]"],
+            dropped_items_total=2,
+            dropped_paths_truncated=False,
+        )
 
     @pytest.mark.asyncio
     @patch("llm_gateway.bedrock._sign_bedrock_mantle_request")


### PR DESCRIPTION
## Summary
- strip unsigned `thinking` blocks from Bedrock CountTokens message payloads
- drop messages that become empty after stripping, and apply the same sanitizer to bedrock-mantle CountTokens fallback
- add regression coverage for preserving signed thinking while removing unsigned thinking

## How to test
- `uv run pytest tests/test_bedrock.py`
- `uv run ruff check src/llm_gateway/bedrock.py tests/test_bedrock.py`
- `uv run ruff format --check src/llm_gateway/bedrock.py tests/test_bedrock.py`