### PR TITLE
fix(postgres): raise statement_timeout before schema discovery probes

### DIFF
--- a/posthog/temporal/data_imports/sources/postgres/postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/postgres.py
@@ -2149,6 +2149,23 @@ def _get_table(
     column already exists and the probed value is discarded, so the caller should gate
     probing on "is a fresh schema being created" (see the equivalent gating on
     `_get_estimated_row_count_for_partitioned_table` in `postgres_source`)."""
+    # Raise a generous statement_timeout for the whole discovery phase before issuing any query.
+    # The outer 10-minute setup timeout isn't set until `postgres_source` continues after
+    # `_get_table` returns, so without this every probe here — the `pg_matviews`/`pg_views` lookups,
+    # the metadata SELECT (whose `information_schema.columns` `numeric_*` columns invoke the slow
+    # per-column `_pg_numeric_*` functions), and even the `BEGIN` opening a scoping transaction —
+    # inherits a short role/server default that some hosted/pooled Postgres set, which cancels the
+    # statement with QueryCanceled mid-discovery. Session, not LOCAL: the connection is autocommit,
+    # so a LOCAL timeout has nothing to bind to and a scoping transaction's own `BEGIN` would itself
+    # run under the short default. Best-effort: engines without statement_timeout (e.g. DuckDB)
+    # reject the SET, so clear any aborted transaction and fall back to the default.
+    try:
+        cursor.execute(
+            sql.SQL("SET statement_timeout = {timeout}").format(timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS))
+        )
+    except psycopg.Error:
+        cursor.connection.rollback()
+
     is_mat_view_query = sql.SQL(
         "select {table} in (select matviewname from pg_matviews where schemaname = {schema}) as res"
     ).format(schema=sql.Literal(schema), table=sql.Literal(table_name))
@@ -2209,23 +2226,8 @@ def _get_table(
 
     _explain_query(cursor, query, logger)
     logger.debug(f"Running query: {query.as_string()}")
-    # Scope a generous statement_timeout to the schema-discovery query. On regular tables it reads
-    # `information_schema.columns`, whose `numeric_precision`/`numeric_scale` columns invoke the
-    # per-column `_pg_numeric_*` SQL functions — slow enough on large catalogs that a short
-    # role/server default `statement_timeout` (some hosted/pooled Postgres set one) cancels the
-    # query with QueryCanceled before discovery finishes. The outer 10-minute setup timeout isn't
-    # set until `postgres_source` continues after `_get_table` returns, so without this the query
-    # inherits that short default. Own transaction so the `SET LOCAL` scopes to this query and
-    # auto-resets (the connection is autocommit, so this is a self-contained BEGIN/COMMIT) without
-    # leaking onto the numeric probe below, which deliberately bounds itself tighter.
-    with cursor.connection.transaction():
-        cursor.execute(
-            sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
-                timeout=sql.Literal(METADATA_STATEMENT_TIMEOUT_MS)
-            )
-        )
-        cursor.execute(query)
-        metadata_rows = cursor.fetchall()
+    cursor.execute(query)
+    metadata_rows = cursor.fetchall()
 
     numeric_data_types = {"numeric", "decimal"}
 
@@ -2258,10 +2260,9 @@ def _get_table(
             # aggregation and auto-resets (a self-contained BEGIN/COMMIT under autocommit).
             with cursor.connection.transaction():
                 # Scope a short statement_timeout to the probe so a pathologically large table
-                # or slow aggregation can't hang schema discovery. The outer 10-minute
-                # statement_timeout isn't set until `postgres_source` continues after
-                # `_get_table` returns, so without this the probe inherits whatever role-level
-                # default postgres has — which might be "no limit" on some hosted instances.
+                # or slow aggregation can't hang schema discovery. Without this the probe would
+                # inherit the generous discovery-phase timeout set at the top of `_get_table`,
+                # which is deliberately too loose for a full-table aggregation.
                 cursor.execute(
                     sql.SQL("SET LOCAL statement_timeout = {timeout}").format(
                         timeout=sql.Literal(30 * 1000)  # 30 seconds

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4174,34 +4174,46 @@ class _RecordingConnection:
 
 class TestGetTable:
     @pytest.mark.django_db
-    def test_schema_discovery_query_runs_under_scoped_statement_timeout(self):
-        """The `information_schema.columns` metadata query is wrapped in its own transaction that
-        first issues a `SET LOCAL statement_timeout`, so a short role/server default can't cancel
-        it mid-discovery — the QueryCanceled on `_pg_numeric_scale` we observed against pooled
-        Postgres. Pin that the timeout is scoped immediately before the query it protects."""
+    def test_schema_discovery_raises_statement_timeout_before_any_probe(self):
+        """`_get_table` raises a generous session-level `statement_timeout` before issuing any
+        discovery query, so a short role/server default can't cancel discovery with QueryCanceled.
+        The protection must precede every probe — the `pg_matviews`/`pg_views` lookups and the
+        transaction `BEGIN` that scopes the metadata query both ran under the inherited short
+        default before, which canceled the statement against pooled Postgres. Pin that the timeout
+        is the first statement issued, ahead of the metadata SELECT it ultimately protects."""
         logger = structlog.get_logger()
 
-        with django_connection.cursor() as dj_cursor:
-            dj_cursor.execute(
-                "CREATE TABLE test_get_table_timeout_scope (id INTEGER PRIMARY KEY, amount NUMERIC(10, 2))"
-            )
-            spy = _RecordingCursor(dj_cursor)
-            table = _get_table(cast(Any, spy), "public", "test_get_table_timeout_scope", logger)
+        try:
+            with django_connection.cursor() as dj_cursor:
+                dj_cursor.execute(
+                    "CREATE TABLE test_get_table_timeout_scope (id INTEGER PRIMARY KEY, amount NUMERIC(10, 2))"
+                )
+                spy = _RecordingCursor(dj_cursor)
+                table = _get_table(cast(Any, spy), "public", "test_get_table_timeout_scope", logger)
 
-            # Real execution still succeeds and returns the expected columns.
-            assert {c.name for c in table.columns} >= {"id", "amount"}
+                # Real execution still succeeds and returns the expected columns.
+                assert {c.name for c in table.columns} >= {"id", "amount"}
 
-            set_local_idx = next(
-                i
-                for i, q in enumerate(spy.executed)
-                if "SET LOCAL" in q and "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
-            )
-            # The metadata SELECT (not the best-effort EXPLAIN that precedes it) must run directly
-            # after the SET LOCAL, inside the same transaction.
-            info_schema_idx = next(
-                i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
-            )
-            assert info_schema_idx == set_local_idx + 1
+                set_timeout_idx = next(
+                    i
+                    for i, q in enumerate(spy.executed)
+                    if "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
+                )
+                # The protective timeout must come before the first discovery probe (the
+                # `pg_matviews` lookup) and the metadata SELECT — not midway through, where a
+                # short default would already have canceled an earlier statement.
+                first_probe_idx = next(i for i, q in enumerate(spy.executed) if "pg_matviews" in q)
+                info_schema_idx = next(
+                    i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
+                )
+                assert set_timeout_idx < first_probe_idx < info_schema_idx
+        finally:
+            # `_get_table` now issues a session-level `SET statement_timeout` (production opens and
+            # closes its own connection, so the GUC is discarded with it). Here it runs against the
+            # shared `django_connection`, which Postgres does not reset on rollback — clear it so
+            # the raised timeout can't leak onto subsequent tests reusing the connection.
+            with django_connection.cursor() as dj_cursor:
+                dj_cursor.execute("RESET statement_timeout")
 
     @pytest.mark.django_db
     def test_schemas_from_conn_runs_under_scoped_statement_timeout(self):

--- a/posthog/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/posthog/temporal/data_imports/sources/postgres/test_postgres.py
@@ -4173,6 +4173,15 @@ class _RecordingConnection:
 
 
 class TestGetTable:
+    def teardown_method(self):
+        # `_get_table` and `_schemas_from_conn` raise a session-level `statement_timeout` on the
+        # connection (production opens and closes its own, so the GUC is discarded with it). Here
+        # they run against the shared `django_connection`, which Postgres does not reset on
+        # transaction rollback — reset it after every test so a raised timeout can't leak onto
+        # later tests reusing the connection.
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute("RESET statement_timeout")
+
     @pytest.mark.django_db
     def test_schema_discovery_raises_statement_timeout_before_any_probe(self):
         """`_get_table` raises a generous session-level `statement_timeout` before issuing any
@@ -4183,37 +4192,29 @@ class TestGetTable:
         is the first statement issued, ahead of the metadata SELECT it ultimately protects."""
         logger = structlog.get_logger()
 
-        try:
-            with django_connection.cursor() as dj_cursor:
-                dj_cursor.execute(
-                    "CREATE TABLE test_get_table_timeout_scope (id INTEGER PRIMARY KEY, amount NUMERIC(10, 2))"
-                )
-                spy = _RecordingCursor(dj_cursor)
-                table = _get_table(cast(Any, spy), "public", "test_get_table_timeout_scope", logger)
+        with django_connection.cursor() as dj_cursor:
+            dj_cursor.execute(
+                "CREATE TABLE test_get_table_timeout_scope (id INTEGER PRIMARY KEY, amount NUMERIC(10, 2))"
+            )
+            spy = _RecordingCursor(dj_cursor)
+            table = _get_table(cast(Any, spy), "public", "test_get_table_timeout_scope", logger)
 
-                # Real execution still succeeds and returns the expected columns.
-                assert {c.name for c in table.columns} >= {"id", "amount"}
+            # Real execution still succeeds and returns the expected columns.
+            assert {c.name for c in table.columns} >= {"id", "amount"}
 
-                set_timeout_idx = next(
-                    i
-                    for i, q in enumerate(spy.executed)
-                    if "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
-                )
-                # The protective timeout must come before the first discovery probe (the
-                # `pg_matviews` lookup) and the metadata SELECT — not midway through, where a
-                # short default would already have canceled an earlier statement.
-                first_probe_idx = next(i for i, q in enumerate(spy.executed) if "pg_matviews" in q)
-                info_schema_idx = next(
-                    i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
-                )
-                assert set_timeout_idx < first_probe_idx < info_schema_idx
-        finally:
-            # `_get_table` now issues a session-level `SET statement_timeout` (production opens and
-            # closes its own connection, so the GUC is discarded with it). Here it runs against the
-            # shared `django_connection`, which Postgres does not reset on rollback — clear it so
-            # the raised timeout can't leak onto subsequent tests reusing the connection.
-            with django_connection.cursor() as dj_cursor:
-                dj_cursor.execute("RESET statement_timeout")
+            set_timeout_idx = next(
+                i
+                for i, q in enumerate(spy.executed)
+                if "statement_timeout" in q and str(METADATA_STATEMENT_TIMEOUT_MS) in q
+            )
+            # The protective timeout must come before the first discovery probe (the
+            # `pg_matviews` lookup) and the metadata SELECT — not midway through, where a
+            # short default would already have canceled an earlier statement.
+            first_probe_idx = next(i for i, q in enumerate(spy.executed) if "pg_matviews" in q)
+            info_schema_idx = next(
+                i for i, q in enumerate(spy.executed) if "information_schema.columns" in q and "EXPLAIN" not in q
+            )
+            assert set_timeout_idx < first_probe_idx < info_schema_idx
 
     @pytest.mark.django_db
     def test_schemas_from_conn_runs_under_scoped_statement_timeout(self):
@@ -4225,15 +4226,7 @@ class TestGetTable:
             dj_cursor.execute("CREATE TABLE test_schemas_from_conn_timeout (id INTEGER PRIMARY KEY, name TEXT)")
 
         conn = _RecordingConnection(django_connection)
-        try:
-            discovered = _schemas_from_conn(cast(Any, conn), "public", ["test_schemas_from_conn_timeout"])
-        finally:
-            # `_schemas_from_conn` issues a session-level `SET statement_timeout` (production opens and
-            # closes its own connection, so the GUC is discarded with it). Here it runs against the shared
-            # `django_connection`, which Postgres does not reset on transaction rollback — clear it so the
-            # raised timeout can't leak onto subsequent tests reusing the connection.
-            with django_connection.cursor() as dj_cursor:
-                dj_cursor.execute("RESET statement_timeout")
+        discovered = _schemas_from_conn(cast(Any, conn), "public", ["test_schemas_from_conn_timeout"])
 
         assert "test_schemas_from_conn_timeout" in discovered
         assert {col[0] for col in discovered["test_schemas_from_conn_timeout"].columns} >= {"id", "name"}


### PR DESCRIPTION
## Problem

Error tracking surfaced a `QueryCanceled: canceling statement due to statement timeout` for the Postgres data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019ef65a-04b6-7eb0-a24d-a7306dd4dc2a)). The stack genuinely originates in the source: `source.py:source_for_pipeline` → `postgres.py:postgres_source` → `_get_table`, with the failing frame at the `BEGIN` opening the transaction that scopes the column-metadata query (`cursor.connection.transaction().__enter__` → psycopg `_exec_command`).

`_get_table` runs its catalog probes on the autocommit setup connection *before* `postgres_source` sets the 10-minute session `statement_timeout` (which only happens after `_get_table` returns). So the `pg_matviews`/`pg_views` view-detection probes, the metadata query, and the `BEGIN` of the transaction that wraps it all inherit whatever short role/server default the source has — common on pooled/hosted Postgres — and get cancelled with `QueryCanceled`.

The metadata query already scoped a generous timeout via a `SET LOCAL` inside its own transaction, but a `SET LOCAL` cannot protect that transaction's own `BEGIN` — the `BEGIN` runs first, under the inherited short default. That `BEGIN` is the exact frame in this issue.

This is a fixable bug, not a user/upstream condition: the customer's short default `statement_timeout` is legitimate, and metadata discovery should scope its own generous timeout (as the code already intends) rather than fail. It is deliberately **not** added to `NonRetryableErrors` — a statement timeout on metadata discovery is exactly what we make robust, and the code already chose the "scope a generous timeout" remedy.

## Changes

Raise a generous session-level `statement_timeout` once, as the very first statement in `_get_table`, so every subsequent probe and transaction `BEGIN` runs under it instead of the inherited short default. Best-effort: engines without `statement_timeout` (e.g. DuckDB) reject the `SET`, so clear any aborted transaction and fall back to the default — mirroring `_schemas_from_conn`, which already protects the discovery path this same way.

This subsumes the per-query `SET LOCAL` the metadata query used (removed, since the session-level timeout covers it and its `BEGIN`). The numeric-scale probe keeps its own tighter scoped `SET LOCAL` — it deliberately wants a shorter bound than the discovery phase.

### Relationship to #65608

#65608 addresses a sibling frame of the same root cause (the `pg_matviews` probe) by wrapping the view-detection probes in their own scoped transaction. That approach can't fix this issue: a `SET LOCAL` reverts when its transaction commits, so the next `BEGIN` — the metadata query's, the frame here — is unprotected again. Setting the timeout once at the session level covers the whole discovery phase, including every `BEGIN`, and makes the per-transaction `SET LOCAL`s in `_get_table` redundant. If #65608 lands first, the conflict resolves by keeping the single session-level `SET` and dropping the now-redundant scoped transactions.

## How did you test this code?

I'm an agent. This sandbox has no pytest core or test database, so I could not run the `django_db` suite here — CI will. What I did run:

- `ruff check` and `ruff format --check` pass on both files; both byte-compile clean.
- Reworked `TestGetTable::test_schema_discovery_raises_statement_timeout_before_any_probe` (was `..._query_runs_under_scoped_statement_timeout`) to assert the protective `SET statement_timeout = METADATA_STATEMENT_TIMEOUT_MS` is issued **before** the first discovery probe (`pg_matviews`) and the metadata `SELECT`. Regression it catches that no existing test did: previously the timeout was raised only midway through discovery (after the probes and after the metadata transaction's `BEGIN`), so a short role/server default could cancel an earlier statement with `QueryCanceled`. The ordering assertion fails against the old code and passes with the fix. The test resets the session GUC in teardown so the raised timeout can't leak onto other tests sharing the connection.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook for the `postgres` import source. Used the PostHog error-tracking MCP tools to confirm the issue and pull the exact stack frames (the metadata-query transaction `BEGIN` inside `_get_table`).
- Decision: classified as a fixable bug, not a `NonRetryableErrors` entry — the failure is our discovery code running statements under the customer's short default before applying its own generous timeout. Chose a session-level `SET` at the top of `_get_table` over more per-transaction `SET LOCAL`s because a `SET LOCAL` structurally cannot protect its own transaction's `BEGIN`, which is this issue's frame.
- Checked open PRs (including the maintainer's). #65608 is the closest — same function, sibling frame — but does not resolve this frame; see the "Relationship to #65608" section. #65151 / #65352 / #65349 / #65248 concern different paths (activity-layer matching, read-replica timeout, connect-timeout retry, OOM) and root causes.
