### PR TITLE
fix: run query_log_archive export on any node

### DIFF
--- a/posthog/dags/common/resources.py
+++ b/posthog/dags/common/resources.py
@@ -92,8 +92,11 @@ class OpsClickhouseClusterResource(dagster.ConfigurableResource):
     max_execution_time: int
     max_memory_usage: int
 
-    host: str = settings.CLICKHOUSE_HOST
-    cluster: str | None = None
+    # OPS is discoverable only from the migrations host/cluster: satellite discovery runs
+    # clusterAllReplicas(ops, system.clusters) WHERE cluster = <migrations cluster>, which the default
+    # app host/cluster don't match. Mirrors get_migrations_cluster, the path migrations use to reach OPS.
+    host: str = settings.CLICKHOUSE_MIGRATIONS_HOST
+    cluster: str = settings.CLICKHOUSE_MIGRATIONS_CLUSTER
 
     def create_resource(self, context: dagster.InitResourceContext) -> ClickhouseCluster:
         return get_cluster(

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')


### PR DESCRIPTION
## Problem

The `query_log_archive` export job targets the OPS cluster on purpose, `any_host_by_role(NodeRole.OPS)`, so the daily run and backfills execute on the dedicated ops cluster rather than on customer-facing data nodes. The query reads `query_log_archive` (whose data lives on OPS) and writes the Parquet to S3; running that on an online data node would put a ~45-minute, multi-GiB query in contention with customer queries (and we have direct evidence that memory pressure on these clusters causes OOMs).

But it failed on the first run with:

```
ValueError: No hosts found with roles [<NodeRole.OPS: 'ops'>]
```

The resource bootstrapped from the default app host with `cluster=None` (→ `posthog`). OPS satellite discovery runs `clusterAllReplicas('ops', system.clusters) WHERE is_local AND cluster = <migrations cluster>`, and with the migrations cluster resolved to `posthog` the OPS hosts have no matching row, so zero OPS hosts were found.

## Changes

- Default `OpsClickhouseClusterResource` to `CLICKHOUSE_MIGRATIONS_HOST` + `CLICKHOUSE_MIGRATIONS_CLUSTER`, mirroring `get_migrations_cluster()`, the path ClickHouse migrations already use to run on `NodeRole.OPS`. Discovery then matches `cluster = posthog_migrations` and resolves the OPS hosts.


## How did you test this code?

I'm an agent (Claude Code). Automated: `ruff` + `ty check` clean; resource defaults resolve to `CLICKHOUSE_MIGRATIONS_CLUSTER` (`posthog_migrations`); the job loads and registers.

Verified empirically that the export's S3 write is done by the node that runs the query (the initiator): a successful backfill query's `query_log_archive` row shows the S3 multipart-upload ProfileEvents (1 CreateMultipartUpload, 78 UploadPart, ~1.2 GiB written) on the initiating query. So targeting OPS keeps both the read and the write on the ops cluster.

Deployment note: in the Dagster env `CLICKHOUSE_MIGRATIONS_HOST` is unset and falls back to `CLICKHOUSE_HOST` (the offline entry), which is the same host the migrate job uses, so discovery works without a charts change. The real proof is the next backfill run reaching OPS.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused with the assignee by reading the satellite-discovery query in `posthog/clickhouse/cluster.py` against `migration_tools.get_migrations_cluster`. We briefly considered running on any node (the distributed `query_log_archive` table reads from OPS from anywhere), but confirmed the initiator does the S3 write, so to keep the export off customer-facing data nodes it targets OPS, which only needs the migrations host/cluster for discovery.
