### PR TITLE
fix(replay): make trigger-groups SDK banner traffic-aware

### DIFF
--- a/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
+++ b/frontend/src/scenes/settings/environment/ReplayTriggers.tsx
@@ -9,6 +9,7 @@ import { FeatureFlagTrigger, Trigger, TriggerType } from 'lib/components/Ingesti
 import { PayGateMini } from 'lib/components/PayGateMini/PayGateMini'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { pluralize } from 'lib/utils/strings'
 import {
     ReplayPlatform,
@@ -504,24 +505,28 @@ function LegacyRecordingConditions(): JSX.Element {
 }
 
 function SdkCompatibilityBanner(): JSX.Element {
-    const { shouldMinimizeLegacyConditions, hasOutdatedWebSdk } = useValues(replayTriggersLogic)
+    const { shouldMinimizeLegacyConditions, hasOutdatedWebSdk, outdatedWebTraffic } = useValues(replayTriggersLogic)
 
     if (shouldMinimizeLegacyConditions) {
         return (
             <LemonBanner type="success">
-                All your recent web SDK traffic is on v{TRIGGER_GROUPS_MIN_SDK_VERSION}+, so trigger groups apply to
-                every session. The legacy recording conditions below are kept only as a fallback for older SDKs.
+                Your recent web SDK traffic is effectively all on v{TRIGGER_GROUPS_MIN_SDK_VERSION}+, so trigger groups
+                apply to essentially every session. The legacy recording conditions below are kept only as a fallback
+                for older SDKs.
             </LemonBanner>
         )
     }
 
     if (hasOutdatedWebSdk) {
+        const pct = outdatedWebTraffic.share < 0.01 ? '<1' : Math.round(outdatedWebTraffic.share * 100).toString()
         return (
-            <LemonBanner type="warning">
-                <strong>Some of your web traffic is on an older posthog-js</strong> (before v
-                {TRIGGER_GROUPS_MIN_SDK_VERSION}), which uses the legacy recording conditions below. Upgrade posthog-js
-                to v{TRIGGER_GROUPS_MIN_SDK_VERSION}+ so trigger groups apply to every session. Until then, both
-                configurations are sent for backward compatibility.
+            <LemonBanner type="info">
+                About <strong>{pct}%</strong> of recent web traffic (
+                {humanFriendlyNumber(outdatedWebTraffic.outdatedCount)}{' '}
+                {pluralize(outdatedWebTraffic.outdatedCount, 'event', 'events', false)}) is on a posthog-js before v
+                {TRIGGER_GROUPS_MIN_SDK_VERSION}. Those sessions still record using the legacy recording conditions
+                below — upgrade to v{TRIGGER_GROUPS_MIN_SDK_VERSION}+ for full trigger-group coverage. Both
+                configurations are sent meanwhile, so nothing is lost.
             </LemonBanner>
         )
     }

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.test.ts
@@ -1,29 +1,140 @@
-import { hasOutdatedWebSdk, legacyConditionsAreInactive, TRIGGER_GROUPS_MIN_SDK_VERSION } from './replayTriggersLogic'
+import {
+    hasOutdatedWebSdk,
+    legacyConditionsAreInactive,
+    outdatedWebTrafficShare,
+    TRIGGER_GROUPS_MIN_SDK_VERSION,
+    WebRelease,
+} from './replayTriggersLogic'
 
 describe('replayTriggersLogic', () => {
     describe('legacyConditionsAreInactive', () => {
-        it.each([
+        it.each<[string, WebRelease[], boolean]>([
             ['no web data', [], false],
-            ['only new versions', ['1.369.0', '1.400.1'], true],
-            ['only old versions', ['1.300.0', '1.368.9'], false],
-            ['mix of old and new', ['1.368.0', '1.400.0'], false],
-            ['exactly the minimum version', [TRIGGER_GROUPS_MIN_SDK_VERSION], true],
-            ['unparseable version stays conservative', ['not-a-version', '1.400.0'], false],
-        ])('%s -> %s', (_description, versions, expected) => {
-            expect(legacyConditionsAreInactive(versions as string[])).toBe(expected)
+            [
+                'only new versions',
+                [
+                    { version: '1.369.0', count: 100 },
+                    { version: '1.400.1', count: 100 },
+                ],
+                true,
+            ],
+            [
+                'only old versions',
+                [
+                    { version: '1.300.0', count: 100 },
+                    { version: '1.368.9', count: 100 },
+                ],
+                false,
+            ],
+            [
+                'tiny outdated tail stays inactive',
+                [
+                    { version: '1.300.0', count: 6 },
+                    { version: '1.400.0', count: 100000 },
+                ],
+                true,
+            ],
+            [
+                'outdated share above threshold is not inactive',
+                [
+                    { version: '1.300.0', count: 30 },
+                    { version: '1.400.0', count: 70 },
+                ],
+                false,
+            ],
+            ['exactly the minimum version', [{ version: TRIGGER_GROUPS_MIN_SDK_VERSION, count: 100 }], true],
+            [
+                'unparseable version counts as outdated',
+                [
+                    { version: 'not-a-version', count: 50 },
+                    { version: '1.400.0', count: 50 },
+                ],
+                false,
+            ],
+        ])('%s -> %s', (_description, releases, expected) => {
+            expect(legacyConditionsAreInactive(releases)).toBe(expected)
         })
     })
 
     describe('hasOutdatedWebSdk', () => {
-        it.each([
+        it.each<[string, WebRelease[], boolean]>([
             ['no web data', [], false],
-            ['only new versions', ['1.369.0', '1.400.1'], false],
-            ['only old versions', ['1.300.0', '1.368.9'], true],
-            ['mix of old and new', ['1.368.0', '1.400.0'], true],
-            ['exactly the minimum version', [TRIGGER_GROUPS_MIN_SDK_VERSION], false],
-            ['unparseable version stays conservative', ['not-a-version', '1.400.0'], true],
-        ])('%s -> %s', (_description, versions, expected) => {
-            expect(hasOutdatedWebSdk(versions as string[])).toBe(expected)
+            [
+                'only new versions',
+                [
+                    { version: '1.369.0', count: 100 },
+                    { version: '1.400.1', count: 100 },
+                ],
+                false,
+            ],
+            [
+                'only old versions',
+                [
+                    { version: '1.300.0', count: 100 },
+                    { version: '1.368.9', count: 100 },
+                ],
+                true,
+            ],
+            [
+                'tiny outdated tail does not warn',
+                [
+                    { version: '1.300.0', count: 6 },
+                    { version: '1.400.0', count: 100000 },
+                ],
+                false,
+            ],
+            [
+                'outdated share above threshold warns',
+                [
+                    { version: '1.300.0', count: 30 },
+                    { version: '1.400.0', count: 70 },
+                ],
+                true,
+            ],
+            ['exactly the minimum version', [{ version: TRIGGER_GROUPS_MIN_SDK_VERSION, count: 100 }], false],
+            [
+                'unparseable version counts as outdated',
+                [
+                    { version: 'not-a-version', count: 50 },
+                    { version: '1.400.0', count: 50 },
+                ],
+                true,
+            ],
+        ])('%s -> %s', (_description, releases, expected) => {
+            expect(hasOutdatedWebSdk(releases)).toBe(expected)
+        })
+    })
+
+    describe('outdatedWebTrafficShare', () => {
+        it.each<[string, WebRelease[], { outdatedCount: number; totalCount: number; share: number }]>([
+            ['no web data', [], { outdatedCount: 0, totalCount: 0, share: 0 }],
+            [
+                'just below the 5% threshold',
+                [
+                    { version: '1.300.0', count: 4 },
+                    { version: '1.400.0', count: 96 },
+                ],
+                { outdatedCount: 4, totalCount: 100, share: 0.04 },
+            ],
+            [
+                'at the 5% threshold',
+                [
+                    { version: '1.300.0', count: 5 },
+                    { version: '1.400.0', count: 95 },
+                ],
+                { outdatedCount: 5, totalCount: 100, share: 0.05 },
+            ],
+        ])('%s', (_description, releases, expected) => {
+            expect(outdatedWebTrafficShare(releases)).toEqual(expected)
+        })
+
+        it('treats the 5% threshold as inclusive for warnings', () => {
+            const atThreshold: WebRelease[] = [
+                { version: '1.300.0', count: 5 },
+                { version: '1.400.0', count: 95 },
+            ]
+            expect(hasOutdatedWebSdk(atThreshold)).toBe(true)
+            expect(legacyConditionsAreInactive(atThreshold)).toBe(false)
         })
     })
 })

--- a/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
+++ b/frontend/src/scenes/settings/environment/replayTriggersLogic.ts
@@ -17,18 +17,25 @@ export type ReplayPlatform = 'web' | 'mobile'
 /** Minimum posthog-js version that understands V2 trigger groups. Older web SDKs fall back to legacy conditions. */
 export const TRIGGER_GROUPS_MIN_SDK_VERSION = '1.369.0'
 
+/**
+ * Share of recent web traffic that must be on outdated SDKs before we warn / keep the legacy UI prominent.
+ * Below this we treat traffic as effectively all-new, so a long tail of stray old-version events doesn't
+ * raise an alarm. Lower than the backend's 20% outdated-traffic alert because trigger coverage gaps matter
+ * more in this context.
+ */
+export const OUTDATED_TRAFFIC_SHARE_THRESHOLD = 0.05
+
+export interface WebRelease {
+    version: string
+    count: number
+}
+
 const NEW_URL_TRIGGER = { url: '', matching: 'regex' }
 
 export function isStringWithLength(x: unknown): x is string {
     return typeof x === 'string' && x.trim() !== ''
 }
 
-/**
- * True when the team's recent web SDK traffic is entirely on versions that understand trigger groups, so the
- * legacy recording conditions only serve SDKs the team no longer runs. The SDK Doctor data is a rolling ~7-day
- * window, so this answers "have only new SDKs been seen recently". Returns false when there's no web data
- * (e.g. a brand-new or self-hosted team) — we never minimize the legacy UI without positive evidence.
- */
 // Unparseable versions count as "predates" so we stay conservative (prompt upgrade / keep legacy visible).
 function webSdkPredatesTriggerGroups(version: string): boolean {
     try {
@@ -38,16 +45,42 @@ function webSdkPredatesTriggerGroups(version: string): boolean {
     }
 }
 
-export function legacyConditionsAreInactive(webVersions: string[]): boolean {
-    if (webVersions.length === 0) {
-        return false
+/**
+ * Weighs recent web traffic by event volume rather than treating every distinct version equally. The SDK Doctor
+ * data is a rolling ~7-day window, so this answers "how much recent traffic is on SDKs that predate trigger
+ * groups". Returns zeros when there's no web data (e.g. a brand-new or self-hosted team).
+ */
+export function outdatedWebTrafficShare(releases: WebRelease[]): {
+    outdatedCount: number
+    totalCount: number
+    share: number
+} {
+    const totalCount = releases.reduce((sum, r) => sum + r.count, 0)
+    if (totalCount === 0) {
+        return { outdatedCount: 0, totalCount: 0, share: 0 }
     }
-    return !webVersions.some(webSdkPredatesTriggerGroups)
+    const outdatedCount = releases
+        .filter((r) => webSdkPredatesTriggerGroups(r.version))
+        .reduce((sum, r) => sum + r.count, 0)
+    return { outdatedCount, totalCount, share: outdatedCount / totalCount }
 }
 
-/** True when there's web SDK data and at least one version predates trigger-group support. */
-export function hasOutdatedWebSdk(webVersions: string[]): boolean {
-    return webVersions.some(webSdkPredatesTriggerGroups)
+/**
+ * True when the team's recent web SDK traffic is effectively all on versions that understand trigger groups, so
+ * the legacy recording conditions only serve a negligible tail of older SDKs. Returns false when there's no web
+ * data — we never minimize the legacy UI without positive evidence.
+ */
+export function legacyConditionsAreInactive(releases: WebRelease[]): boolean {
+    const { totalCount, share } = outdatedWebTrafficShare(releases)
+    if (totalCount === 0) {
+        return false
+    }
+    return share < OUTDATED_TRAFFIC_SHARE_THRESHOLD
+}
+
+/** True when a meaningful share of recent web traffic is on SDKs that predate trigger-group support. */
+export function hasOutdatedWebSdk(releases: WebRelease[]): boolean {
+    return outdatedWebTrafficShare(releases).share >= OUTDATED_TRAFFIC_SHARE_THRESHOLD
 }
 
 function ensureAnchored(url: string): string {
@@ -215,13 +248,16 @@ export const replayTriggersLogic = kea<replayTriggersLogicType>([
     selectors({
         shouldMinimizeLegacyConditions: [
             (s) => [s.augmentedData],
-            (augmentedData): boolean =>
-                legacyConditionsAreInactive((augmentedData?.web?.allReleases ?? []).map((r) => r.version)),
+            (augmentedData): boolean => legacyConditionsAreInactive(augmentedData?.web?.allReleases ?? []),
         ],
         hasOutdatedWebSdk: [
             (s) => [s.augmentedData],
-            (augmentedData): boolean =>
-                hasOutdatedWebSdk((augmentedData?.web?.allReleases ?? []).map((r) => r.version)),
+            (augmentedData): boolean => hasOutdatedWebSdk(augmentedData?.web?.allReleases ?? []),
+        ],
+        outdatedWebTraffic: [
+            (s) => [s.augmentedData],
+            (augmentedData): { outdatedCount: number; totalCount: number; share: number } =>
+                outdatedWebTrafficShare(augmentedData?.web?.allReleases ?? []),
         ],
         isAddUrlTriggerConfigFormVisible: [
             (s) => [s.editUrlTriggerIndex],


### PR DESCRIPTION
## Problem

In session replay recording conditions (under the `REPLAY_TRIGGERS_V2` flag), the SDK-compatibility banner warned whenever **any** web SDK version seen in the rolling 7-day window predated v1.369.0 — the first posthog-js that understands V2 trigger groups. The check was purely binary on version strings and ignored traffic volume entirely.

The result: an org with, say, 6 events on an old version and ~100k events on supported versions got the same alarming "some of your web traffic is on an older posthog-js" warning as an org running entirely on old SDKs, and never saw the calm success state. The per-version event count was already in the data we read (`augmentedData.web.allReleases[].count`) but wasn't being used.

## Changes

Weigh recent web traffic by event volume instead of treating every distinct version equally.

- New `OUTDATED_TRAFFIC_SHARE_THRESHOLD = 0.05` and an `outdatedWebTrafficShare()` helper that returns `{ outdatedCount, totalCount, share }`.
- `legacyConditionsAreInactive` / `hasOutdatedWebSdk` now gate on **share ≥ 5%** rather than "any old version present". A negligible long tail of old-version traffic now lands in the success state.
- The banner copy is now informative and calmer:
  - **Success**: reworded to say traffic is *effectively all* on supported versions (no longer claims a literal 100%).
  - **Warning → info**: downgraded from `type="warning"` to `type="info"`, and now quantifies impact — e.g. *"About <1% of recent web traffic (6 events) is on a posthog-js before v1.369.0. Those sessions still record using the legacy recording conditions below — upgrade to v1.369.0+ for full trigger-group coverage. Both configurations are sent meanwhile, so nothing is lost."*

5% is a single tunable constant — deliberately lower than the backend's 20% outdated-traffic alert because trigger-coverage gaps matter more in this context, but high enough to silence stray noise.

No backend change: `count` is already in the API response and cached data; this is purely a frontend interpretation change.

## How did you test this code?

I'm an agent (PostHog Code). I ran the following automated checks locally — no manual UI testing:

- `hogli test …/replayTriggersLogic.test.ts` → 18/18 pass. Updated the existing parameterized cases to pass release objects with counts and added coverage for: a tiny outdated tail staying in the success state (the 6-vs-100k regression), an above-threshold share warning, and the 5% boundary (inclusive). These lock in the volume-weighting behavior the old version-only logic couldn't express.
- `oxlint` on the three changed files → 0 warnings/errors.
- `pnpm --filter=@posthog/frontend typescript:check` → clean for the changed files (regenerated the gitignored `replayTriggersLogicType.ts` for the new selector).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus). The work started from a question about the banner being too trigger-sensitive; I traced the warning logic in `replayTriggersLogic.ts` and the `SdkCompatibilityBanner` in `ReplayTriggers.tsx`, confirmed the per-version `count` was already available from the SDK health data, and found the backend's existing 20%-share `outdated_traffic_alerts` as precedent for volume-based gating.

Decisions: chose a traffic-**share** threshold over an absolute event floor (scales with team size) and set it at 5% rather than reusing the backend's 20% (trigger coverage is more sensitive than a general staleness nudge). Copy direction — show real numbers and soften the tone — was confirmed with the human driver. No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
