### PR TITLE
fix(mcp_store): unblock OAuth MCP servers (mem0) — DCR refresh_token grant + trailing-slash redirects

### DIFF
--- a/products/mcp_store/backend/oauth.py
+++ b/products/mcp_store/backend/oauth.py
@@ -213,10 +213,15 @@ def register_dcr_client(metadata: dict, redirect_uri: str) -> tuple[str, str | N
     if not registration_endpoint:
         raise ValueError("Authorization server does not support Dynamic Client Registration")
 
+    # Request the grant types the server advertises, intersected with what we support.
+    # Some servers (e.g. mem0) reject registration unless refresh_token is requested.
+    supported_grants = metadata.get("grant_types_supported") or ["authorization_code"]
+    grant_types = [g for g in ("authorization_code", "refresh_token") if g in supported_grants]
+
     payload: dict[str, object] = {
         "client_name": "MCP Store (PostHog)",
         "redirect_uris": [redirect_uri],
-        "grant_types": ["authorization_code"],
+        "grant_types": grant_types or ["authorization_code"],
         "response_types": ["code"],
         "token_endpoint_auth_method": "none",
     }

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -30,6 +30,29 @@ BATCH_REJECTED_CODE = -32000
 METHOD_NOT_FOUND_CODE = -32601
 
 
+def validated_redirect_target(request_url: str, response: httpx.Response) -> tuple[str | None, str | None]:
+    """Resolve an HTTP redirect to an SSRF-validated absolute URL.
+
+    Returns ``(target, None)`` when ``response`` is a redirect to an allowed URL,
+    ``(None, None)`` when it isn't a redirect, or ``(None, reason)`` when the
+    target is rejected by the SSRF guard. We deliberately keep httpx's
+    ``follow_redirects`` off and re-validate here instead — letting httpx chase
+    the ``Location`` itself would skip the guard and could be steered into the
+    internal network. MCP servers routinely 307 ``/mcp`` to ``/mcp/``, so we
+    honor a single redirect safely rather than failing the handshake.
+    """
+    if not response.is_redirect:
+        return None, None
+    location = response.headers.get("location")
+    if not location:
+        return None, None
+    target = str(httpx.URL(request_url).join(location))
+    allowed, reason = is_url_allowed(target)
+    if not allowed:
+        return None, reason or "redirect target blocked by SSRF guard"
+    return target, None
+
+
 def build_upstream_auth_headers(installation: MCPServerInstallation) -> dict[str, str]:
     sensitive = installation.sensitive_configuration or {}
 
@@ -300,6 +323,24 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
             headers=headers,
         )
         upstream_response = client.send(upstream_request, stream=True)
+        # Follow a single trailing-slash-style redirect (e.g. /mcp -> /mcp/),
+        # re-running the SSRF guard on the target rather than letting httpx chase it.
+        redirect_target, redirect_reason = validated_redirect_target(installation.url, upstream_response)
+        if redirect_reason:
+            upstream_response.close()
+            client.close()
+            logger.warning("SSRF: blocked proxy redirect", url=installation.url, reason=redirect_reason)
+            return HttpResponse(
+                json.dumps({"error": f"Redirect target not allowed: {redirect_reason}"}),
+                content_type="application/json",
+                status=400,
+            )
+        if redirect_target:
+            upstream_response.close()
+            upstream_response = client.send(
+                client.build_request("POST", redirect_target, content=body, headers=headers),
+                stream=True,
+            )
     except httpx.ConnectError:
         client.close()
         logger.warning("Upstream MCP server unreachable", url=installation.url)

--- a/products/mcp_store/backend/test/test_oauth.py
+++ b/products/mcp_store/backend/test/test_oauth.py
@@ -885,6 +885,44 @@ class TestRegisterDCRClient(TestCase):
 
         assert result == expected
 
+    @parameterized.expand(
+        [
+            (
+                "requests_refresh_token_when_advertised",
+                ["authorization_code", "refresh_token"],
+                ["authorization_code", "refresh_token"],
+            ),
+            (
+                "omits_refresh_token_when_not_advertised",
+                ["authorization_code"],
+                ["authorization_code"],
+            ),
+            (
+                "defaults_to_authorization_code_when_metadata_silent",
+                None,
+                ["authorization_code"],
+            ),
+        ]
+    )
+    @patch("products.mcp_store.backend.oauth.is_url_allowed", return_value=(True, ""))
+    @patch("products.mcp_store.backend.oauth.requests.post")
+    def test_requests_grant_types_the_server_advertises(
+        self, _name, grant_types_supported, expected_grant_types, mock_post, _allow
+    ):
+        mock_response = MagicMock()
+        mock_response.ok = True
+        mock_response.json.return_value = {"client_id": "abc", "token_endpoint_auth_method": "none"}
+        mock_post.return_value = mock_response
+
+        metadata: dict = {"registration_endpoint": "https://auth.example.com/register"}
+        if grant_types_supported is not None:
+            metadata["grant_types_supported"] = grant_types_supported
+
+        register_dcr_client(metadata, "https://app.posthog.com/callback")
+
+        sent_payload = mock_post.call_args.kwargs["json"]
+        assert sent_payload["grant_types"] == expected_grant_types
+
 
 class TestResolveInstallationOauthContext(BaseTest):
     def test_template_backed_install_returns_template_creds(self):

--- a/products/mcp_store/backend/test/test_proxy.py
+++ b/products/mcp_store/backend/test/test_proxy.py
@@ -112,6 +112,60 @@ class TestMCPProxyEndpoint(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         assert kwargs["headers"]["Authorization"] == "Bearer oauth-token-123"
 
     @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_proxy_follows_trailing_slash_redirect(self, mock_client_cls):
+        # Servers like mem0 307 /mcp -> /mcp/; real tool calls must follow it too.
+        installation = self._create_installation(sensitive_configuration={"api_key": "sk-test-key"})
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.headers = {"location": "/mcp/"}
+        real = MagicMock()
+        real.status_code = 200
+        real.is_redirect = False
+        real.headers = {"content-type": "application/json"}
+        real.content = b'{"jsonrpc":"2.0","id":1,"result":{}}'
+        mock_client = MagicMock()
+        mock_client.build_request.return_value = MagicMock()
+        mock_client.send.side_effect = [redirect, real]
+        mock_client_cls.return_value = mock_client
+
+        response = self.client.post(
+            self._proxy_url(installation.id),
+            data={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+            format="json",
+        )
+
+        assert response.status_code == 200
+        redirect.close.assert_called_once()
+        # The retry targets the canonical /mcp/ URL.
+        assert mock_client.build_request.call_args_list[-1].args == ("POST", "https://mcp.example.com/mcp/")
+
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
+    def test_proxy_rejects_redirect_to_blocked_host(self, mock_client_cls):
+        installation = self._create_installation(sensitive_configuration={"api_key": "sk-test-key"})
+        redirect = MagicMock()
+        redirect.is_redirect = True
+        redirect.headers = {"location": "http://169.254.169.254/"}
+        mock_client = MagicMock()
+        mock_client.build_request.return_value = MagicMock()
+        mock_client.send.return_value = redirect
+        mock_client_cls.return_value = mock_client
+
+        def allow(url):
+            return (False, "Private IP") if "169.254.169.254" in url else (True, None)
+
+        with patch("products.mcp_store.backend.proxy.is_url_allowed", side_effect=allow):
+            response = self.client.post(
+                self._proxy_url(installation.id),
+                data={"jsonrpc": "2.0", "id": 1, "method": "tools/list"},
+                format="json",
+            )
+
+        assert response.status_code == 400
+        assert "Redirect target not allowed" in response.content.decode()
+        # We never re-issue to the blocked target.
+        assert mock_client.send.call_count == 1
+
+    @patch("products.mcp_store.backend.proxy.httpx.Client")
     def test_proxy_streams_sse_response_in_chunks(self, mock_client_cls):
         installation = self._create_installation(
             sensitive_configuration={"api_key": "sk-test-key"},

--- a/products/mcp_store/backend/test/test_tools.py
+++ b/products/mcp_store/backend/test/test_tools.py
@@ -19,19 +19,27 @@ from products.mcp_store.backend.tools import (
 
 
 def _build_response(
-    *, status: int = 200, body: str = "", content_type: str = "application/json", session_id: str | None = None
+    *,
+    status: int = 200,
+    body: str = "",
+    content_type: str = "application/json",
+    session_id: str | None = None,
+    location: str | None = None,
 ) -> MagicMock:
     """Build a MagicMock that looks enough like an httpx.Response for our code.
 
-    Our parser reads ``status_code``, ``text``, and ``headers`` — so we set those
-    explicitly rather than relying on MagicMock auto-spec.
+    Our parser reads ``status_code``, ``text``, ``headers``, and ``is_redirect`` —
+    so we set those explicitly rather than relying on MagicMock auto-spec.
     """
     response = MagicMock()
     response.status_code = status
     response.text = body
+    response.is_redirect = status in (301, 302, 303, 307, 308)
     headers: dict[str, str] = {"content-type": content_type}
     if session_id is not None:
         headers["mcp-session-id"] = session_id
+    if location is not None:
+        headers["location"] = location
     response.headers = headers
     return response
 
@@ -119,6 +127,53 @@ class TestFetchUpstreamTools(ClickhouseTestMixin, APIBaseTest):
         # DELETE cleans up the session afterwards.
         assert client.delete.called
         assert client.delete.call_args.kwargs["headers"]["Mcp-Session-Id"] == "sess-1"
+
+    @patch("products.mcp_store.backend.proxy.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.tools.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.tools.httpx.Client")
+    def test_fetch_upstream_tools_follows_trailing_slash_redirect(self, mock_client_cls, _allow, _allow_redirect):
+        # mem0 and other servers 307 a slash-less /mcp to /mcp/. We must follow it
+        # and run the rest of the handshake against the canonical URL.
+        installation = self._installation(url="https://mcp.example.com/mcp")
+        redirect = _build_response(status=307, location="/mcp/")
+        initialize_ok = _build_response(body=json.dumps({"jsonrpc": "2.0", "id": 1, "result": {}}), session_id="sess-1")
+        notify = _build_response(status=202)
+        tools_list = _build_response(
+            body=json.dumps({"jsonrpc": "2.0", "id": 2, "result": {"tools": [{"name": "alpha"}]}})
+        )
+        client = MagicMock()
+        client.post.side_effect = [redirect, initialize_ok, notify, tools_list]
+        client.delete.return_value = _build_response(status=200)
+        mock_client_cls.return_value.__enter__.return_value = client
+
+        tools = fetch_upstream_tools(installation)
+        assert [t["name"] for t in tools] == ["alpha"]
+
+        # First POST hits the slash-less URL; the retry and every later step use /mcp/.
+        urls = [call.args[0] for call in client.post.call_args_list]
+        assert urls == [
+            "https://mcp.example.com/mcp",
+            "https://mcp.example.com/mcp/",
+            "https://mcp.example.com/mcp/",
+            "https://mcp.example.com/mcp/",
+        ]
+        assert client.delete.call_args.args[0] == "https://mcp.example.com/mcp/"
+
+    @patch("products.mcp_store.backend.proxy.is_url_allowed", return_value=(False, "Private IP"))
+    @patch("products.mcp_store.backend.tools.is_url_allowed", return_value=(True, None))
+    @patch("products.mcp_store.backend.tools.httpx.Client")
+    def test_fetch_upstream_tools_rejects_redirect_to_blocked_host(self, mock_client_cls, _allow, _block_redirect):
+        # A malicious server could 307 to an internal host; the SSRF guard must run
+        # on the redirect target rather than letting httpx chase it.
+        installation = self._installation(url="https://mcp.example.com/mcp")
+        client = MagicMock()
+        client.post.return_value = _build_response(status=307, location="http://169.254.169.254/")
+        mock_client_cls.return_value.__enter__.return_value = client
+
+        with pytest.raises(ToolsFetchError, match="redirect target not allowed"):
+            fetch_upstream_tools(installation)
+        # We never re-POST to the blocked target.
+        assert client.post.call_count == 1
 
     @patch("products.mcp_store.backend.tools.is_url_allowed", return_value=(True, None))
     @patch("products.mcp_store.backend.tools.httpx.Client")

--- a/products/mcp_store/backend/tools.py
+++ b/products/mcp_store/backend/tools.py
@@ -17,7 +17,7 @@ from posthog.security.url_validation import is_url_allowed
 
 from .models import MCPServerInstallation, MCPServerInstallationTool
 from .oauth import TokenRefreshError, is_token_expiring, refresh_installation_token
-from .proxy import build_upstream_auth_headers
+from .proxy import build_upstream_auth_headers, validated_redirect_target
 
 logger = structlog.get_logger(__name__)
 
@@ -80,26 +80,52 @@ def fetch_upstream_tools(installation: MCPServerInstallation) -> list[dict[str, 
 
     try:
         with httpx.Client(timeout=HANDSHAKE_TIMEOUT) as client:
-            session_id = _mcp_initialize(client, installation.url, base_headers)
+            # initialize resolves any trailing-slash redirect (e.g. /mcp -> /mcp/);
+            # reuse the canonical URL for the rest of the handshake so each step
+            # doesn't redirect again.
+            session_id, resolved_url = _mcp_initialize(client, installation.url, base_headers)
             session_headers = dict(base_headers)
             if session_id:
                 session_headers["Mcp-Session-Id"] = session_id
 
-            _mcp_send_initialized(client, installation.url, session_headers)
+            _mcp_send_initialized(client, resolved_url, session_headers)
             try:
-                return _mcp_list_tools(client, installation.url, session_headers)
+                return _mcp_list_tools(client, resolved_url, session_headers)
             finally:
                 # Best-effort cleanup so we don't leak sessions upstream. Failures
                 # here are purely janitorial and must not mask real errors above.
                 if session_id:
-                    _mcp_terminate_session(client, installation.url, session_headers)
+                    _mcp_terminate_session(client, resolved_url, session_headers)
     except httpx.ConnectError as exc:
         raise ToolsFetchError("Upstream MCP server unreachable") from exc
     except httpx.TimeoutException as exc:
         raise ToolsFetchError("Upstream MCP server timed out") from exc
 
 
-def _mcp_initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> str | None:
+def _post_following_redirect(
+    client: httpx.Client, url: str, *, content: bytes, headers: dict[str, str]
+) -> tuple[httpx.Response, str]:
+    """POST to ``url``, following a single SSRF-validated redirect.
+
+    MCP servers commonly 307 a slash-less endpoint to its canonical form
+    (e.g. ``/mcp`` -> ``/mcp/``). httpx doesn't follow redirects by default and
+    we keep it that way so the SSRF guard runs on the ``Location`` target; here
+    we re-validate and retry once. Returns the final response and the URL it was
+    served from, so the caller can reuse the canonical URL for later steps.
+    """
+    response = client.post(url, content=content, headers=headers)
+    target, reason = validated_redirect_target(url, response)
+    if reason:
+        raise ToolsFetchError(f"Upstream redirect target not allowed: {reason}")
+    if not target:
+        return response, url
+    response = client.post(target, content=content, headers=headers)
+    if response.is_redirect:
+        raise ToolsFetchError(f"Upstream redirected more than once (last target {target!r})")
+    return response, target
+
+
+def _mcp_initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> tuple[str | None, str]:
     body = json.dumps(
         {
             "jsonrpc": "2.0",
@@ -113,11 +139,11 @@ def _mcp_initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> 
         }
     ).encode()
 
-    response = client.post(url, content=body, headers=headers)
+    response, resolved_url = _post_following_redirect(client, url, content=body, headers=headers)
     if response.status_code >= 400:
         logger.warning(
             "initialize request returned error",
-            url=url,
+            url=resolved_url,
             status_code=response.status_code,
             body=response.text[:500],
         )
@@ -131,7 +157,7 @@ def _mcp_initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> 
 
     # Session id is optional per the spec — servers that don't need one still
     # work with tools/list, so treat a missing header as "no session needed".
-    return response.headers.get("mcp-session-id")
+    return response.headers.get("mcp-session-id"), resolved_url
 
 
 def _mcp_send_initialized(client: httpx.Client, url: str, headers: dict[str, str]) -> None:


### PR DESCRIPTION
## Problem

Adding the mem0 MCP server to the MCP store failed at two distinct steps. Both are general bugs that affect any similarly-behaved OAuth MCP server, not just mem0.

1. **OAuth Dynamic Client Registration returned `400`.** Our DCR payload hardcoded `grant_types: ["authorization_code"]`. mem0's `/register` rejects that with `invalid_client_metadata` — "grant_types must be authorization_code and refresh_token". Requesting the `refresh_token` grant is also what yields the refresh tokens we store per-user for long-lived connections.

2. **After auth succeeded, fetching tools failed.** mem0's MCP endpoint `307`-redirects a slash-less `/mcp` to `/mcp/`. httpx doesn't follow redirects by default, so the `initialize`/`tools/list` handshake received an empty `307` body and the parse failed. The proxy path (real tool calls) POSTs to the same URL and would have failed identically.

## Changes

**DCR grant types** (`oauth.py`): derive `grant_types` from the auth server's advertised `grant_types_supported`, intersected with what we support (`authorization_code`, `refresh_token`), falling back to `["authorization_code"]` when the server is silent. No-op for any server that doesn't advertise `refresh_token`.

**Trailing-slash redirects** (`tools.py`, `proxy.py`): follow a single redirect in both the handshake and the proxy, re-running the existing SSRF guard (`is_url_allowed`) on the `Location` target. We deliberately do **not** enable httpx `follow_redirects` — that would skip the guard and could be steered into the internal network. The handshake resolves the canonical URL once at `initialize` and reuses it for the remaining steps.

### Operator note
The mem0 server template URL should be stored with the trailing slash (`https://mcp.mem0.ai/mcp/`). The redirect-follow makes the slash-less form work too, but storing the canonical URL avoids a redirect round-trip on every call.

## How did you test this code?

I'm an agent (Claude Code). Automated only:

- `oauth.py`: parameterized test asserting the posted `grant_types` for advertised-both / authorization_code-only / metadata-silent.
- `tools.py`: tests that the handshake follows a `/mcp` → `/mcp/` redirect and reuses the canonical URL, and that a redirect to a blocked host is rejected without re-POSTing.
- `proxy.py`: tests that a real tool call follows the redirect, and that a redirect to an internal host returns `400` without re-issuing.
- Ran `test_oauth.py::TestRegisterDCRClient` (8 passed), `test_tools.py` (14 passed), `test_proxy.py` (38 passed).

I also reproduced both failures against mem0's live endpoints out-of-band (the DCR `400` and the `/mcp` `307`) and confirmed the fixes resolve them. The full end-to-end install through the live callback has not been run and should be verified after deploy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at Chris Volzer's direction while debugging a real mem0 install. Diagnosis was empirical end-to-end — probed mem0's OAuth discovery, its DCR `/register`, and its `/mcp` endpoint directly to isolate each blocker (`grant_types`, then the trailing-slash `307`). No repo skills were required (plain helper functions, no DRF viewset or migration).

Key decision: for the redirect handling we rejected the one-line `follow_redirects=True` because it bypasses the SSRF guard this module intentionally enforces; instead we follow one hop and re-validate the target. A worthwhile follow-up (separate PR): surface the upstream provider's `error_description` from `presentation/views.py` instead of the flat `"OAuth registration failed."` — that would have made the DCR failure self-diagnosing.
