### PR TITLE
feat(admin): show duckgres warehouse password once after provisioning

### DIFF
--- a/posthog/admin/admins/duckgres_server_admin.py
+++ b/posthog/admin/admins/duckgres_server_admin.py
@@ -147,9 +147,34 @@ class DuckgresServerAdmin(admin.ModelAdmin):
         resp = managed_warehouse.provision(
             team.organization_id, database_name, team.id, table_name, require_enabled=False
         )
-        self._report(request, resp, f"Provisioned managed warehouse for org {team.organization_id}")
         if 200 <= resp.status_code < 300:
-            return redirect(reverse("admin:posthog_duckgresserver_changelist"))
+            # The control plane returns the root password exactly once, in this
+            # response; afterwards it's stored only encrypted and can't be read
+            # back. Show it once here. Deliberately NOT routed through the message
+            # framework (which persists to the session/cookie store) or the audit
+            # log — only the action + actor are logged, never the credential.
+            user = cast(User, request.user)
+            logger.info(
+                "admin_managed_warehouse_action",
+                action=f"Provisioned managed warehouse for org {team.organization_id}",
+                triggered_by=user.email,
+            )
+            body = resp.data if isinstance(resp.data, dict) else {}
+            return render(
+                request,
+                "admin/posthog/duckgres_server/provision_result.html",
+                {
+                    **self.admin_site.each_context(request),
+                    "title": "Managed warehouse provisioned",
+                    "organization_id": str(team.organization_id),
+                    "team_id": team.id,
+                    "connection": managed_warehouse._present_connection(
+                        {"database": database_name, "username": body.get("username", "root")}
+                    ),
+                    "password": body.get("password", ""),
+                },
+            )
+        self._report(request, resp, f"Provisioned managed warehouse for org {team.organization_id}")
         return redirect(reverse("admin:posthog_duckgresserver_provision"))
 
     def enable_backfill_view(self, request: HttpRequest, object_id: str) -> HttpResponse:

--- a/posthog/admin/test_duckgres_server_admin.py
+++ b/posthog/admin/test_duckgres_server_admin.py
@@ -92,13 +92,36 @@ class TestDuckgresServerAdminProvision(BaseTest):
                 "table_name": "prod_events",
             },
         )
-        with patch(f"{MW}.provision", return_value=Response({"status": "ok"}, status=202)) as mock_provision:
-            self.admin.provision_view(request)
+        body = {"username": "root", "password": "sup3r-secret-pw"}
+        with patch(f"{MW}.provision", return_value=Response(body, status=202)) as mock_provision:
+            response = self.admin.provision_view(request)
 
         mock_provision.assert_called_once_with(
             self.organization.id, "my-warehouse", self.team.id, "prod_events", require_enabled=False
         )
-        assert any("Provisioned managed warehouse" in m for m in _messages(request))
+        # Success renders the credentials once, in the page body...
+        assert response.status_code == 200
+        assert b"sup3r-secret-pw" in response.content
+        # ...and the password must NOT leak into the message framework (it persists
+        # to the session/cookie store).
+        assert all("sup3r-secret-pw" not in m for m in _messages(request))
+
+    def test_provision_failure_surfaces_error_without_rendering_password(self) -> None:
+        request = self._post(
+            "/admin/posthog/duckgresserver/provision/",
+            {
+                "organization_id": str(self.organization.id),
+                "team_id": str(self.team.id),
+                "database_name": "my-warehouse",
+                "table_name": "prod_events",
+            },
+        )
+        with patch(f"{MW}.provision", return_value=Response({"error": "nope"}, status=400)):
+            response = self.admin.provision_view(request)
+
+        # Failures still flash the error and redirect back to the form.
+        assert response.status_code == 302
+        assert any("Failed (status 400): nope" in m for m in _messages(request))
 
     def test_provision_rejects_team_org_mismatch(self) -> None:
         other_org = Organization.objects.create(name="Other")

--- a/posthog/templates/admin/posthog/duckgres_server/provision_result.html
+++ b/posthog/templates/admin/posthog/duckgres_server/provision_result.html
@@ -1,0 +1,37 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block content %}
+<div style="max-width: 640px;">
+    <p>Provisioned a managed warehouse for organization <code>{{ organization_id }}</code>
+    (first team <code>{{ team_id }}</code>).</p>
+
+    <p style="background: #fff3cd; border: 1px solid #ffe69c; border-radius: 4px; padding: 12px 16px; color: #664d03;">
+        <strong>Save the password now.</strong> The root password is returned by the control plane
+        only once and is stored encrypted afterwards &mdash; it <strong>cannot be retrieved later</strong>.
+        If you lose it, the warehouse must be re-provisioned or its credentials rotated.
+    </p>
+
+    <h2>Connection</h2>
+    <table style="border-collapse: collapse; margin-bottom: 20px;">
+        <tr><th style="text-align: left; padding: 4px 16px 4px 0;">Host</th><td><code>{{ connection.host }}</code></td></tr>
+        <tr><th style="text-align: left; padding: 4px 16px 4px 0;">Port</th><td><code>{{ connection.port }}</code></td></tr>
+        <tr><th style="text-align: left; padding: 4px 16px 4px 0;">Database</th><td><code>{{ connection.database }}</code></td></tr>
+        <tr><th style="text-align: left; padding: 4px 16px 4px 0;">Username</th><td><code>{{ connection.username }}</code></td></tr>
+    </table>
+
+    <h2>Password</h2>
+    {% if password %}
+    <p>Copy this now:</p>
+    <input type="text" readonly value="{{ password }}" onclick="this.select()"
+           style="width: 100%; padding: 8px; font-family: monospace; font-size: 14px;" />
+    {% else %}
+    <p><em>The control plane did not return a password in this response. Retrieve the credentials
+    via the duckgres control plane / 1Password onboarding flow.</em></p>
+    {% endif %}
+
+    <p style="margin-top: 24px;">
+        <a href="{% url 'admin:posthog_duckgresserver_changelist' %}" class="default" style="padding: 8px 16px;">Done</a>
+    </p>
+</div>
+{% endblock %}


### PR DESCRIPTION
## What

The `DuckgresServer` admin provision flow (#65351) discarded the control plane's response and redirected with a generic success flash — so the admin never got the **generated root password**. That password is returned **exactly once** at provision time and stored only encrypted afterwards (`DuckgresServer.password`, an `EncryptedTextField`, excluded from the change-form fieldsets), so there was no way to retrieve it.

This adds a **one-time render**: on a successful provision, instead of redirecting, render a dedicated `provision_result.html` showing the connection details + password, with a clear "save it now — it can't be retrieved later" warning.

## Security posture (deliberate)

- **Not via `messages`.** Django's message framework serializes messages into the session/cookie store; a credential there would persist beyond the single render. The password goes straight into the template context for one HTML response and nowhere else.
- **Not logged.** Only the action + actor are audited (`admin_managed_warehouse_action` / `triggered_by`), exactly as before — never `resp.data`.
- **Not re-displayable.** No "reveal stored password" action is added; the change-form still excludes `password`. It's shown once, at creation, only.
- Failures keep the existing error-flash + redirect-to-form behavior.

This matches the intent already documented in `_persist_duckgres_server` ("the provision password is shown to the user exactly once").

## Tests

- `test_provision_post_calls_managed_warehouse_bypassing_flag` — updated: success now **renders** the password in the page body (200), and the password must **not** appear in any flash message.
- `test_provision_failure_surfaces_error_without_rendering_password` — new: failure still flashes the error + 302 redirects.

ruff lint/format pass; package tests run on CI (local env can't import the Django test harness).

## Note
There's also the 1Password-based `onboard-duckling` flow for sanctioned credential storage; this admin render is for ops who provision directly via the admin button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)