### PR TITLE
feat(agent-platform): accept multimodal user messages in chat ingress

### DIFF
--- a/products/agent_platform/backend/presentation/serializers.py
+++ b/products/agent_platform/backend/presentation/serializers.py
@@ -452,6 +452,57 @@ class DecideApprovalRequestSerializer(serializers.Serializer):
     )
 
 
+# OpenAPI shape for the multimodal `message` payload. Mirrors the zod schema in
+# `products/agent_platform/services/agent-ingress/src/triggers/chat.schemas.ts`
+# (which is the authoritative parser); the schema here only exists so the
+# generated TS types + MCP tools see the right union shape downstream. Ingress
+# still runs the strict zod check on every request.
+_MESSAGE_CONTENT_SCHEMA: dict[str, Any] = {
+    "oneOf": [
+        {"type": "string", "minLength": 1},
+        {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "required": ["type", "text"],
+                        "properties": {
+                            "type": {"type": "string", "enum": ["text"]},
+                            "text": {"type": "string", "minLength": 1},
+                        },
+                    },
+                    {
+                        "type": "object",
+                        "required": ["type", "data", "mimeType"],
+                        "properties": {
+                            "type": {"type": "string", "enum": ["image"]},
+                            "data": {
+                                "type": "string",
+                                "minLength": 1,
+                                "description": "Base64-encoded image bytes.",
+                            },
+                            "mimeType": {
+                                "type": "string",
+                                "enum": ["image/png", "image/jpeg", "image/gif", "image/webp"],
+                            },
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+}
+
+
+@extend_schema_field(_MESSAGE_CONTENT_SCHEMA)
+class MessageContentField(serializers.JSONField):
+    """User chat payload — either a plain string or a list of content blocks
+    (`text` and/or `image`). Typed via `@extend_schema_field` so the generated
+    TS + MCP schemas surface the union instead of an opaque `unknown`."""
+
+
 class PreviewProxyInvokeRequestSerializer(serializers.Serializer):
     """Body forwarded verbatim to the agent ingress for a *preview* invoke of a
     non-live revision. The meaningful shape depends on the `rest` path segment:
@@ -464,11 +515,15 @@ class PreviewProxyInvokeRequestSerializer(serializers.Serializer):
     any extra keys are still forwarded as-is to ingress.
     """
 
-    message = serializers.CharField(
+    message = MessageContentField(
         required=False,
-        allow_blank=True,
-        trim_whitespace=False,
-        help_text="User message to deliver to the agent. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`.",
+        help_text=(
+            "User message to deliver to the agent. Either a plain string or a list of "
+            "content blocks: `{type: 'text', text: str}` for prose/markdown or "
+            "`{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|"
+            "'image/gif'|'image/webp'}` for inline images. Required for `run` (starts "
+            "the session) and `send` (appends to it); ignored for `cancel` / `listen`."
+        ),
     )
     session_id = serializers.CharField(
         required=False,

--- a/products/agent_platform/backend/tests/test_preview_proxy.py
+++ b/products/agent_platform/backend/tests/test_preview_proxy.py
@@ -99,3 +99,31 @@ class TestPreviewProxyInvokeBody(APIBaseTest):
         self.assertTrue(
             PreviewProxyInvokeRequestSerializer(data={"session_id": "s-1", "message": "another"}).is_valid()
         )
+
+    @parameterized.expand(
+        [
+            (
+                "text_block",
+                [{"type": "text", "text": "# markdown body"}],
+            ),
+            (
+                "image_block",
+                [{"type": "image", "data": "aGVsbG8=", "mimeType": "image/png"}],
+            ),
+            (
+                "mixed_text_and_image",
+                [
+                    {"type": "text", "text": "look at this:"},
+                    {"type": "image", "data": "aGVsbG8=", "mimeType": "image/jpeg"},
+                ],
+            ),
+        ]
+    )
+    def test_invoke_serializer_round_trips_multimodal_message(self, _name: str, message: list[dict[str, str]]) -> None:
+        # Django forwards the body verbatim to ingress (which runs the strict
+        # zod parse); the serializer just has to keep the union shape intact.
+        # A regression to CharField here would coerce the list to a string and
+        # break the runner's UserMessage.content typing downstream.
+        serializer = PreviewProxyInvokeRequestSerializer(data={"message": message})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        self.assertEqual(serializer.validated_data["message"], message)

--- a/products/agent_platform/frontend/generated/api.schemas.ts
+++ b/products/agent_platform/frontend/generated/api.schemas.ts
@@ -1365,6 +1365,28 @@ export interface AgentApprovalsDecideResponseApi {
 }
 
 /**
+ * User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose/markdown or `{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|'image/gif'|'image/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`.
+ */
+export type PreviewProxyInvokeRequestApiMessage =
+    | string
+    | (
+          | {
+                type: 'text'
+                /** @minLength 1 */
+                text: string
+            }
+          | {
+                type: 'image'
+                /**
+                 * Base64-encoded image bytes.
+                 * @minLength 1
+                 */
+                data: string
+                mimeType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp'
+            }
+      )[]
+
+/**
  * Body forwarded verbatim to the agent ingress for a *preview* invoke of a
  * non-live revision. The meaningful shape depends on the `rest` path segment:
  *
@@ -1376,8 +1398,8 @@ export interface AgentApprovalsDecideResponseApi {
  * any extra keys are still forwarded as-is to ingress.
  */
 export interface PreviewProxyInvokeRequestApi {
-    /** User message to deliver to the agent. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`. */
-    message?: string
+    /** User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose/markdown or `{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|'image/gif'|'image/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`. */
+    message?: PreviewProxyInvokeRequestApiMessage
     /** Target session id for `send` — the running session to append the message to. Omit for `run` (a fresh session is created). */
     session_id?: string
 }

--- a/products/agent_platform/frontend/generated/api.zod.ts
+++ b/products/agent_platform/frontend/generated/api.zod.ts
@@ -2368,13 +2368,31 @@ export const AgentApplicationsApprovalsDecideBody = /* @__PURE__ */ zod
  * Auth: standard PAT / session — `agents:write` scope (POST run/send/cancel
  * is a mutating invoke; the read-only `listen` GET is `agents:read`).
  */
+
 export const AgentApplicationsPreviewProxyBody = /* @__PURE__ */ zod
     .object({
         message: zod
-            .string()
+            .union([
+                zod.string().min(1),
+                zod
+                    .array(
+                        zod.union([
+                            zod.object({
+                                type: zod.enum(['text']),
+                                text: zod.string().min(1),
+                            }),
+                            zod.object({
+                                type: zod.enum(['image']),
+                                data: zod.string().min(1).describe('Base64-encoded image bytes.'),
+                                mimeType: zod.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
+                            }),
+                        ])
+                    )
+                    .min(1),
+            ])
             .optional()
             .describe(
-                'User message to deliver to the agent. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` \/ `listen`.'
+                "User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose\/markdown or `{type: 'image', data: <base64>, mimeType: 'image\/png'|'image\/jpeg'|'image\/gif'|'image\/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` \/ `listen`."
             ),
         session_id: zod
             .string()

--- a/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/server.test.ts
@@ -318,10 +318,18 @@ describe('ingress HTTP server (path mode)', () => {
                 }>
             ).map((r) => [`${r.method} ${r.path}`, r])
         )
-        expect(routesByPath['POST /run'].bodySchema!.properties!.message).toMatchObject({
-            type: 'string',
-            minLength: 1,
-        })
+        // `message` is the multimodal union (`string | (TextContent | ImageContent)[]`);
+        // z.toJSONSchema publishes the union as `anyOf` with the plain-string variant
+        // first and the content-block array second.
+        const messageSchema = routesByPath['POST /run'].bodySchema!.properties!.message as {
+            anyOf: Array<Record<string, unknown>>
+        }
+        expect(messageSchema.anyOf).toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'string', minLength: 1 })])
+        )
+        expect(messageSchema.anyOf).toEqual(
+            expect.arrayContaining([expect.objectContaining({ type: 'array', minItems: 1 })])
+        )
         expect(routesByPath['POST /run'].bodySchema!.required).toContain('message')
         // seedApp deliberately opts into public exposure (these tests
         // exercise the routing surface, not auth) → every chat route

--- a/products/agent_platform/services/agent-ingress/src/routing/server.ts
+++ b/products/agent_platform/services/agent-ingress/src/routing/server.ts
@@ -235,8 +235,13 @@ export function buildApp(opts: BuildAppOpts): Express {
         pathPrefix: opts.pathPrefix,
         internalSigningKey: opts.internalSigningKey,
     })
+    // 20 MiB headroom for multimodal chat bodies — an `image/*` block in the
+    // chat schema can carry up to ~7 MiB of base64-encoded data, and a single
+    // /run or /send may bundle several blocks alongside text. Default express
+    // body limit is 100 KiB, which silently 413s any inline-image upload.
     app.use(
         express.json({
+            limit: '20mb',
             verify: (req: Request, _res, buf) => {
                 ;(req as Request & { rawBody?: string }).rawBody = buf.toString('utf-8')
             },

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.schemas.test.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.schemas.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+
+import { ChatRunBodySchema, ChatSendBodySchema } from './chat.schemas'
+
+const VALID_SESSION_ID = '00000000-0000-4000-8000-000000000000'
+
+describe('ChatRunBodySchema', () => {
+    it('accepts a bare string message (legacy single-string callers)', () => {
+        const result = ChatRunBodySchema.safeParse({ message: 'tell me a joke' })
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts a text content block (markdown / plain text upload path)', () => {
+        const result = ChatRunBodySchema.safeParse({
+            message: [{ type: 'text', text: '# heading\n\nsome markdown' }],
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts an image content block with an allowlisted mime type', () => {
+        const result = ChatRunBodySchema.safeParse({
+            message: [{ type: 'image', data: 'aGVsbG8=', mimeType: 'image/png' }],
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('accepts a mixed text + image block', () => {
+        const result = ChatRunBodySchema.safeParse({
+            message: [
+                { type: 'text', text: 'look at this:' },
+                { type: 'image', data: 'aGVsbG8=', mimeType: 'image/jpeg' },
+            ],
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('rejects an empty content block array', () => {
+        const result = ChatRunBodySchema.safeParse({ message: [] })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects an empty string', () => {
+        const result = ChatRunBodySchema.safeParse({ message: '' })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects image/svg+xml (anthropic vision allowlist + xss risk)', () => {
+        const result = ChatRunBodySchema.safeParse({
+            message: [{ type: 'image', data: 'PHN2Zy8+', mimeType: 'image/svg+xml' }],
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects image data above the per-block size guard', () => {
+        // 8 MiB of base64 exceeds the 7 MiB ceiling — picks up an over-budget
+        // image without the express body limit having to bounce it.
+        const oversized = 'A'.repeat(8 * 1024 * 1024)
+        const result = ChatRunBodySchema.safeParse({
+            message: [{ type: 'image', data: oversized, mimeType: 'image/png' }],
+        })
+        expect(result.success).toBe(false)
+    })
+
+    it('rejects an unknown content block type', () => {
+        const result = ChatRunBodySchema.safeParse({
+            message: [{ type: 'audio', data: 'aGVsbG8=' }],
+        })
+        expect(result.success).toBe(false)
+    })
+})
+
+describe('ChatSendBodySchema', () => {
+    it('accepts a content-block message when session_id is present', () => {
+        const result = ChatSendBodySchema.safeParse({
+            session_id: VALID_SESSION_ID,
+            message: [{ type: 'text', text: 'follow-up' }],
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('still enforces message XOR client_tool_result with the wider message shape', () => {
+        const both = ChatSendBodySchema.safeParse({
+            session_id: VALID_SESSION_ID,
+            message: [{ type: 'text', text: 'hi' }],
+            client_tool_result: { call_id: 'c1', result: {} },
+        })
+        expect(both.success).toBe(false)
+
+        const neither = ChatSendBodySchema.safeParse({ session_id: VALID_SESSION_ID })
+        expect(neither.success).toBe(false)
+    })
+})

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.schemas.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.schemas.ts
@@ -11,8 +11,42 @@
 
 import { z } from 'zod'
 
+// Anthropic vision accepts these MIME types; svg+xml is explicitly rejected.
+// Match the set in `UserMessage.content` (see agent-shared spec.ts).
+const IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'] as const
+
+// Per-block size guards. Base64 inflates binary by ~33%, so a 5 MiB raw image
+// arrives as ~6.7 MiB on the wire — match against the encoded length here.
+// Anthropic's documented per-image ceiling is 5 MiB decoded.
+const MAX_IMAGE_BASE64_BYTES = 7 * 1024 * 1024
+const MAX_TEXT_BLOCK_BYTES = 1 * 1024 * 1024
+
+const TextContentSchema = z.object({
+    type: z.literal('text'),
+    text: z
+        .string()
+        .min(1, 'text must be a non-empty string')
+        .max(MAX_TEXT_BLOCK_BYTES, `text block exceeds ${MAX_TEXT_BLOCK_BYTES} bytes`),
+})
+
+const ImageContentSchema = z.object({
+    type: z.literal('image'),
+    data: z
+        .string()
+        .min(1, 'data must be a non-empty base64 string')
+        .max(MAX_IMAGE_BASE64_BYTES, `image data exceeds ${MAX_IMAGE_BASE64_BYTES} bytes (base64)`),
+    mimeType: z.enum(IMAGE_MIME_TYPES),
+})
+
+// The shape mirrors `UserMessage.content` in agent-shared/spec.ts — string for
+// plain-text legacy callers, or an array of content blocks for multimodal.
+const MessageContentSchema = z.union([
+    z.string().min(1, 'message must be a non-empty string'),
+    z.array(z.union([TextContentSchema, ImageContentSchema])).min(1, 'message must contain at least one block'),
+])
+
 export const ChatRunBodySchema = z.object({
-    message: z.string().min(1, 'message must be a non-empty string'),
+    message: MessageContentSchema,
     external_key: z.string().optional(),
 })
 
@@ -23,7 +57,7 @@ export const ChatRunBodySchema = z.object({
 export const ChatSendBodySchema = z
     .object({
         session_id: z.string().uuid('session_id must be a UUID'),
-        message: z.string().min(1, 'message must be a non-empty string').optional(),
+        message: MessageContentSchema.optional(),
         client_tool_result: z
             .object({
                 call_id: z.string().min(1, 'call_id is required'),

--- a/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
+++ b/products/agent_platform/services/agent-ingress/src/triggers/chat.ts
@@ -84,7 +84,9 @@ async function sendHandler(ctx: AuthedRouteCtx<z.infer<typeof ChatSendBodySchema
     const incomingPrincipal = ctx.principal
     const aclCheck = requireAclAccess(existing, incomingPrincipal)
     if (aclCheck.kind === 'denied') {
-        const proposed: string =
+        // Mirror the seed shape — `message` may be a plain string or a list of
+        // content blocks; either flows straight into `UserMessage.content`.
+        const proposed =
             message ??
             (client_tool_result ? `[client_tool_result for ${client_tool_result.call_id}]` : '[unknown payload]')
         const elevation = await recordElevationRequest(deps.queue, existing, {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -41156,6 +41156,23 @@ export namespace Schemas {
     }
 
     /**
+     * User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose/markdown or `{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|'image/gif'|'image/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`.
+     */
+    export type PreviewProxyInvokeRequestMessage = string | ({
+      type: 'text';
+      /** @minLength 1 */
+      text: string;
+    } | {
+      type: 'image';
+      /**
+         * Base64-encoded image bytes.
+         * @minLength 1
+         */
+      data: string;
+      mimeType: 'image/png' | 'image/jpeg' | 'image/gif' | 'image/webp';
+    })[];
+
+    /**
      * Body forwarded verbatim to the agent ingress for a *preview* invoke of a
      * non-live revision. The meaningful shape depends on the `rest` path segment:
      *
@@ -41167,8 +41184,8 @@ export namespace Schemas {
      * any extra keys are still forwarded as-is to ingress.
      */
     export interface PreviewProxyInvokeRequest {
-      /** User message to deliver to the agent. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`. */
-      message?: string;
+      /** User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose/markdown or `{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|'image/gif'|'image/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`. */
+      message?: PreviewProxyInvokeRequestMessage;
       /** Target session id for `send` — the running session to append the message to. Omit for `run` (a fresh session is created). */
       session_id?: string;
     }

--- a/services/mcp/src/generated/agent_platform/api.ts
+++ b/services/mcp/src/generated/agent_platform/api.ts
@@ -2186,10 +2186,27 @@ export const AgentApplicationsPreviewProxyQueryParams = /* @__PURE__ */ zod.obje
 export const AgentApplicationsPreviewProxyBody = /* @__PURE__ */ zod
     .object({
         message: zod
-            .string()
+            .union([
+                zod.string().min(1),
+                zod
+                    .array(
+                        zod.union([
+                            zod.object({
+                                type: zod.enum(['text']),
+                                text: zod.string().min(1),
+                            }),
+                            zod.object({
+                                type: zod.enum(['image']),
+                                data: zod.string().min(1).describe('Base64-encoded image bytes.'),
+                                mimeType: zod.enum(['image/png', 'image/jpeg', 'image/gif', 'image/webp']),
+                            }),
+                        ])
+                    )
+                    .min(1),
+            ])
             .optional()
             .describe(
-                'User message to deliver to the agent. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`.'
+                "User message to deliver to the agent. Either a plain string or a list of content blocks: `{type: 'text', text: str}` for prose/markdown or `{type: 'image', data: <base64>, mimeType: 'image/png'|'image/jpeg'|'image/gif'|'image/webp'}` for inline images. Required for `run` (starts the session) and `send` (appends to it); ignored for `cancel` / `listen`."
             ),
         session_id: zod
             .string()


### PR DESCRIPTION
## Problem

The agent builder chat trigger only accepts a plain `message: string` today, so the in-app builder UI (and every other chat client — MCP, browser dock, embeds) has no way to ship inline images or markdown / plain-text uploads alongside the typed message. The runtime is already multimodal-capable end-to-end: `UserMessage.content` in `agent-shared/spec.ts` accepts `string | (TextContent | ImageContent)[]`, the runner forwards `session.conversation` straight into `pi-agent-core` without transformation, and `AgentSession.conversation` is a JSONB column that stores whatever shape the runner appends. The single choke point was the public ingress schema. This PR opens that gate.

## Changes

| Layer | Change |
| --- | --- |
| Ingress zod (`chat.schemas.ts`) | `message` becomes `string \| (TextContent \| ImageContent)[]` in both `ChatRunBodySchema` and `ChatSendBodySchema`. Per-block guards: 1 MiB text, 7 MiB base64 image. MIME allowlist: `image/{png,jpeg,gif,webp}` (no `image/svg+xml`). |
| Ingress handler (`chat.ts`) | Drop a `: string` annotation on the elevation-path `proposed` so the widened union flows through `recordElevationRequest`. Behavior unchanged for legacy string callers. |
| Express body limit (`server.ts`) | Lift from the 100 KiB default to 20 MiB. A single inline-image upload would 413 before zod ever saw it otherwise. |
| Django proxy (`presentation/serializers.py`) | `PreviewProxyInvokeRequestSerializer.message` becomes a typed `JSONField` wrapped in `@extend_schema_field` so drf-spectacular publishes the `oneOf: [string, [TextContent \| ImageContent]]` union — frontend types, MCP tools, and OpenAPI all surface the real shape instead of `unknown`. |
| Generated surfaces | Regenerated via `hogli build:openapi`: `products/agent_platform/frontend/generated/{api.schemas,api.zod}.ts` and `services/mcp/src/{api/generated,generated/agent_platform/api}.ts`. |

Out of scope for this PR: the frontend file-picker UI, PDF / DOCX support, and the `UploadedMedia` upload-then-reference path. Inline base64 is sufficient for the chosen size budget and adds no new persistence concerns.

## How did you test this code?

I'm an agent — only the automated tests below were exercised; no manual / browser verification.

- `pnpm exec vitest run` in `services/agent-ingress` — **142 / 142 pass**.
  - New `src/triggers/chat.schemas.test.ts` (11 cases) locks in: bare string still accepted, text-block and image-block accepted (with allowlisted MIME), mixed text + image accepted, `image/svg+xml` rejected (XSS / Anthropic boundary), oversize image rejected (DoS guard), unknown block type rejected, empty block array rejected, empty string rejected, `ChatSendBodySchema`'s `message` XOR `client_tool_result` invariant still holds against an array-shaped message.
  - Updated `src/routing/server.test.ts` (one existing case) — the `GET /agents/<slug>/schemas` discovery payload now publishes an `anyOf` union for `/run`'s `message`; the test asserts both variants (string + array) appear. Without this, a schema regression to plain string would slip past discovery clients.
- `hogli test products/agent_platform/backend/tests/test_preview_proxy.py` — **9 / 9 pass**.
  - 3 new parameterized cases on `TestPreviewProxyInvokeBody` round-trip the multimodal shape (`text_block`, `image_block`, `mixed_text_and_image`) through the serializer. A regression to `CharField` would coerce the list to a string and break the runner's `UserMessage.content` typing downstream — these catch exactly that.
- `pnpm exec tsc --noEmit -p .` in `services/agent-ingress` — clean.
- `ruff check` + `ruff format` — clean.
- `oxlint` + `oxfmt --check` on the touched TS files — clean.
- `hogli build:openapi` — clean; manually inspected the regenerated `PreviewProxyInvokeRequestApiMessage` union in `products/agent_platform/frontend/generated/api.schemas.ts:1370` and confirmed it matches the zod source of truth (string variant + content-block array with narrowed MIME enum).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — multimodal upload UX still has to ship in the frontend before it's user-visible.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent: Claude Code (Opus 4.7, 1M context). Skills invoked during the work: `/plan` (Explore agents to map the chat backend + existing upload primitives, Plan-mode plan saved at `.claude/plans/can-you-look-into-wondrous-lollipop.md`), `/improving-drf-endpoints` (before touching the proxy serializer — pushed us toward the `@extend_schema_field` + custom-subclass pattern that already exists in the same file for `AgentSpecField`), and `/writing-tests` (decided each new case against a named regression rather than reflexive coverage; the routing-server existing case was updated rather than duplicated).

Design decisions made along the way:

- **Inline base64 over upload-then-reference.** Considered routing image uploads through `UploadedMedia` + `MediaViewSet` to reuse the canonical PostHog primitive (4 MiB image cap, MIME validation, SeaweedFS / S3), but inline base64 is a much smaller blast radius for v1: no new persistence, no cross-team authorization for image reads, no fetch-and-base64 step inside ingress before the LLM call. The trade-off is the ~5 MiB Anthropic-imposed per-image ceiling, which is acceptable for chat attachments. The `UploadedMedia` route stays open for a v2 if larger files or reuse-across-sessions becomes a real need.
- **MIME allowlist mirrors Anthropic vision exactly.** No `image/svg+xml` (Anthropic rejects it and it's an XSS vector), no PDF (deferred to a follow-up — bigger blast radius and Anthropic's PDF beta has its own constraints).
- **No `image/svg+xml` test was tempting to skip** as a "policy never going to change" assertion, but it's exactly the kind of regression a future contributor adding a new MIME might silently break — kept it as a guard.
- **Two-rail validation, no client trust.** Django's `JSONField` accepts the union loosely and forwards verbatim; the authoritative shape check is the zod parser in the ingress (per `products/agent_platform/CLAUDE.md` rule 3). The Django side exists only so OpenAPI / Orval / MCP see the right shape downstream.
- **Did not add a new e2e case under `services/agent-tests/`.** The plan called one out, but the existing `chat-trigger` case already exercises the seed → conversation → runner path with a string, and the new behavior is purely a schema widen on the same path — the unit-level zod + Django tests catch the actual regression risk. Happy to add an `agent-tests` case in a follow-up if reviewers want the end-to-end coverage on a content-block payload.