### PR TITLE
feat(batch-import-worker): upgrade posthog-rs 0.4.2 to 0.13.3 + capture-v1

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1308,7 +1308,7 @@ dependencies = [
  "mockito",
  "moka",
  "natord",
- "posthog-rs 0.4.2",
+ "posthog-rs 0.13.3",
  "rayon",
  "rdkafka",
  "reqwest 0.12.28",
@@ -1606,13 +1606,34 @@ dependencies = [
 
 [[package]]
 name = "brotli"
+version = "7.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc97b8f16f944bba54f0433f07e30be199b6dc2bd25937444bbad560bcea29bd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor 4.0.3",
+]
+
+[[package]]
+name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bd8b9603c7aa97359dbd97ecf258968c95f3adddd6db2f7e7a5bef101c84560"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
- "brotli-decompressor",
+ "brotli-decompressor 5.0.0",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "4.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -1759,7 +1780,7 @@ dependencies = [
  "axum-client-ip",
  "axum-test-helper",
  "base64 0.22.1",
- "brotli",
+ "brotli 8.0.2",
  "bytes",
  "capture",
  "chrono",
@@ -2364,7 +2385,7 @@ version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb7b51a7d9c967fc26773061ba86150f19c50c0d65c887cb1fbe295fd16619b7"
 dependencies = [
- "brotli",
+ "brotli 8.0.2",
  "compression-core",
  "flate2",
  "memchr",
@@ -7580,25 +7601,6 @@ dependencies = [
 
 [[package]]
 name = "posthog-rs"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd5b47b6122821d9e26bd0ebbe76a3631b42341978e2da3a42ab26750a1ba7e"
-dependencies = [
- "chrono",
- "derive_builder",
- "regex",
- "reqwest 0.11.27",
- "semver",
- "serde",
- "serde_json",
- "sha1",
- "tokio",
- "tracing",
- "uuid",
-]
-
-[[package]]
-name = "posthog-rs"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24e1beb349e47c45a4ffdee65e8c096ff0022c0a4d6c566cacdf50f553427fb3"
@@ -7617,6 +7619,30 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "posthog-rs"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2136b5250589588b5b514cd64b286bfb8630f2223e4f56ab1fa3858f1600ab38"
+dependencies = [
+ "backtrace",
+ "brotli 7.0.0",
+ "chrono",
+ "derive_builder",
+ "flate2",
+ "os_info",
+ "regex",
+ "reqwest 0.13.4",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha1",
+ "tokio",
+ "tracing",
+ "uuid",
+ "zstd",
 ]
 
 [[package]]
@@ -8670,7 +8696,6 @@ version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
- "async-compression",
  "base64 0.21.7",
  "bytes",
  "encoding_rs",

--- a/rust/batch-import-worker/Cargo.toml
+++ b/rust/batch-import-worker/Cargo.toml
@@ -48,7 +48,7 @@ metrics = { workspace = true }
 url = { workspace = true }
 urlencoding = "2.1"
 moka = { workspace = true }
-posthog-rs = { version = "0.4.2", features = ["async-client"] }
+posthog-rs = { version = "0.13.3", features = ["async-client", "capture-v1"] }
 
 [dev-dependencies]
 httpmock = { workspace = true }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -6,20 +6,11 @@ use std::{
 use anyhow::Error;
 use async_trait::async_trait;
 use common_types::{InternallyCapturedEvent, RawEvent};
+use metrics::counter;
 use posthog_rs::{Client, Event};
-use tracing::{info, warn};
-
-use crate::job::backoff::BackoffPolicy;
+use tracing::info;
 
 use super::{Emitter, Transaction};
-
-const MAX_RETRIES: u32 = 5;
-
-/// Retry policy for transient HTTP errors from the capture service. Starts at
-/// 1 second and doubles up to 30 seconds, giving roughly a minute of total
-/// retry time before surfacing the error.
-const RETRY_POLICY: BackoffPolicy =
-    BackoffPolicy::new(Duration::from_secs(1), 2.0, Duration::from_secs(30));
 
 pub struct CaptureEmitter {
     client: Client,
@@ -31,7 +22,6 @@ pub struct CaptureTransaction<'a> {
     send_rate: u64,
     start: Instant,
     events: Mutex<Vec<Event>>,
-    retry_policy: BackoffPolicy,
 }
 
 impl CaptureEmitter {
@@ -48,7 +38,6 @@ impl Emitter for CaptureEmitter {
             send_rate: self.send_rate,
             start: Instant::now(),
             events: Mutex::new(Vec::new()),
-            retry_policy: RETRY_POLICY,
         }))
     }
 }
@@ -88,13 +77,6 @@ fn convert_event(ice: &InternallyCapturedEvent) -> Result<Event, Error> {
     Ok(event)
 }
 
-fn is_retryable(err: &posthog_rs::Error) -> bool {
-    matches!(
-        err,
-        posthog_rs::Error::RateLimit | posthog_rs::Error::ServerError { .. }
-    )
-}
-
 #[async_trait]
 impl<'a> Transaction<'a> for CaptureTransaction<'a> {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
@@ -115,15 +97,6 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
             .map_err(|e| Error::msg(format!("events lock poisoned: {e}")))?;
         let count = events.len();
 
-        // Short-circuit on empty transactions. The Capture HTTP API rejects
-        // empty batches with HTTP 400 (CaptureError::EmptyBatch), which is a
-        // non-retryable error. If we let it propagate, do_commit's two-phase
-        // commit would leave the job stuck in `paused` state: begin_part_commit
-        // pauses before commit_write is attempted, and a non-retryable failure
-        // never reaches complete_commit. This path is hit whenever a source
-        // part has zero events (e.g. an Amplitude 404 for a date range with
-        // no activity), and there's nothing meaningful to send to Capture
-        // anyway.
         if count == 0 {
             info!("skipping capture send for empty event batch");
             return Ok(Duration::ZERO);
@@ -134,30 +107,26 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         let to_sleep = min_duration.saturating_sub(txn_elapsed);
 
         info!(
-            "sending {count} events to capture in {txn_elapsed:?}, minimum send duration is {min_duration:?}, sleeping for {to_sleep:?}"
+            count,
+            ?txn_elapsed,
+            ?min_duration,
+            ?to_sleep,
+            "sending events to capture"
         );
 
-        for attempt in 0..=MAX_RETRIES {
-            match self.client.capture_batch(events.clone(), true).await {
-                Ok(()) => break,
-                Err(e) if is_retryable(&e) && attempt < MAX_RETRIES => {
-                    let delay = self.retry_policy.next_delay(attempt);
-                    warn!(
-                        "transient capture error, retrying (attempt {attempt}/{MAX_RETRIES}, delay {delay:?}): {e}"
-                    );
-                    tokio::time::sleep(delay).await;
-                }
-                Err(e) => {
-                    return Err(Error::msg(format!(
-                        "capture batch failed after {} attempts: {e}",
-                        attempt + 1
-                    )));
-                }
+        match self.client.capture_batch(events, true).await {
+            Ok(()) => {
+                counter!("capture_batch_events_total", "outcome" => "success")
+                    .increment(count as u64);
+                info!(count, "successfully sent batch to capture");
+                Ok(to_sleep)
+            }
+            Err(e) => {
+                counter!("capture_batch_events_total", "outcome" => "failure")
+                    .increment(count as u64);
+                Err(Error::msg(format!("capture batch failed: {e}")))
             }
         }
-
-        info!("successfully sent batch to capture");
-        Ok(to_sleep)
     }
 }
 
@@ -213,6 +182,10 @@ mod tests {
         }
     }
 
+    /// V1 capture returns a JSON body with per-event results. An empty results
+    /// map means all events are silently accepted (dropped from retry tracking).
+    const V1_OK_BODY: &str = r#"{"results":{}}"#;
+
     #[test]
     fn test_convert_event_basic_properties() {
         let ice = make_internally_captured_event(
@@ -227,7 +200,7 @@ mod tests {
         let json = serde_json::to_value(&event).unwrap();
 
         assert_eq!(json["event"], "test_event");
-        assert_eq!(json["$distinct_id"], "user123");
+        assert_eq!(json["distinct_id"], "user123");
         assert_eq!(json["properties"]["color"], "red");
         assert_eq!(json["properties"]["count"], 42);
         assert_eq!(json["properties"]["$geoip_disable"], true);
@@ -273,6 +246,40 @@ mod tests {
         assert_eq!(get_min_txn_duration(500, 1000), Duration::from_secs(2));
     }
 
+    async fn make_client(base_url: &str) -> Client {
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".to_string())
+            .host(base_url)
+            .max_capture_attempts(1u32)
+            .build()
+            .unwrap();
+        posthog_rs::client(options).await
+    }
+
+    async fn make_client_with_retries(base_url: &str, attempts: u32) -> Client {
+        let options = posthog_rs::ClientOptionsBuilder::default()
+            .api_key("test_api_key".to_string())
+            .host(base_url)
+            .max_capture_attempts(attempts)
+            .retry_initial_backoff_ms(1u64)
+            .retry_max_backoff_ms(1u64)
+            .build()
+            .unwrap();
+        posthog_rs::client(options).await
+    }
+
+    fn make_transaction(client: &Client) -> Box<CaptureTransaction<'_>> {
+        let mut event = Event::new("test", "user1");
+        event.insert_prop("key", "value").unwrap();
+
+        Box::new(CaptureTransaction {
+            client,
+            send_rate: 10_000,
+            start: Instant::now(),
+            events: Mutex::new(vec![event]),
+        })
+    }
+
     #[tokio::test]
     async fn test_batch_payload_preserves_uuid_and_lib_properties() {
         let expected_uuid = Uuid::parse_str("019c7d2c-5f84-7000-dd7f-9295cfe7993f").unwrap();
@@ -291,12 +298,12 @@ mod tests {
 
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .match_body(mockito::Matcher::PartialJson(serde_json::json!({
                 "batch": [{
                     "uuid": expected_uuid.to_string(),
                     "event": "test_event",
-                    "$distinct_id": "user123",
+                    "distinct_id": "user123",
                     "properties": {
                         "$lib": "posthog-python",
                         "$lib_version": "3.0.0",
@@ -306,6 +313,7 @@ mod tests {
                 }]
             })))
             .with_status(200)
+            .with_body(V1_OK_BODY)
             .expect(1)
             .create();
 
@@ -318,50 +326,12 @@ mod tests {
         mock.assert();
     }
 
-    #[test]
-    fn test_is_retryable() {
-        assert!(is_retryable(&posthog_rs::Error::RateLimit));
-        assert!(is_retryable(&posthog_rs::Error::ServerError {
-            status: 500,
-            message: "internal".to_string()
-        }));
-        assert!(!is_retryable(&posthog_rs::Error::BadRequest(
-            "bad".to_string()
-        )));
-        assert!(!is_retryable(&posthog_rs::Error::Connection(
-            "timeout".to_string()
-        )));
-    }
-
-    async fn make_client(base_url: &str) -> Client {
-        let options: posthog_rs::ClientOptions = ("test_api_key", base_url).into();
-        posthog_rs::client(options).await
-    }
-
-    fn make_transaction(client: &Client) -> Box<CaptureTransaction<'_>> {
-        let mut event = Event::new("test", "user1");
-        event.insert_prop("key", "value").unwrap();
-
-        Box::new(CaptureTransaction {
-            client,
-            send_rate: 10_000,
-            start: Instant::now(),
-            events: Mutex::new(vec![event]),
-            retry_policy: BackoffPolicy::new(Duration::ZERO, 1.0, Duration::ZERO),
-        })
-    }
-
     #[tokio::test]
     async fn test_commit_write_skips_http_on_empty_batch() {
-        // If the worker has zero events to send (e.g. an Amplitude 404 produced
-        // an empty source part), commit_write must short-circuit instead of
-        // hitting Capture's HTTP API. The API rejects empty batches with 400
-        // (CaptureError::EmptyBatch), which is non-retryable and would leave
-        // the job stuck in `paused` via do_commit's two-phase commit.
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("POST", "/batch/")
-            .expect(0) // must not be hit
+            .mock("POST", "/i/v1/analytics/events")
+            .expect(0)
             .create();
 
         let client = make_client(&server.url()).await;
@@ -370,7 +340,6 @@ mod tests {
             send_rate: 10_000,
             start: Instant::now(),
             events: Mutex::new(vec![]),
-            retry_policy: BackoffPolicy::new(Duration::ZERO, 1.0, Duration::ZERO),
         });
 
         let result = txn.commit_write().await;
@@ -390,8 +359,9 @@ mod tests {
     async fn test_commit_write_succeeds_on_first_try() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .with_status(200)
+            .with_body(V1_OK_BODY)
             .expect(1)
             .create();
 
@@ -407,18 +377,19 @@ mod tests {
     async fn test_commit_write_retries_on_500_then_succeeds() {
         let mut server = mockito::Server::new_async().await;
         let fail_mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .with_status(500)
             .with_body("internal error")
             .expect(2)
             .create();
         let success_mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .with_status(200)
+            .with_body(V1_OK_BODY)
             .expect(1)
             .create();
 
-        let client = make_client(&server.url()).await;
+        let client = make_client_with_retries(&server.url(), 3).await;
         let txn = make_transaction(&client);
 
         let result = txn.commit_write().await;
@@ -431,7 +402,7 @@ mod tests {
     async fn test_commit_write_fails_immediately_on_400() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .with_status(400)
             .with_body("bad request")
             .expect(1)
@@ -442,7 +413,33 @@ mod tests {
 
         let result = txn.commit_write().await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("after 1 attempts"));
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("capture batch failed"));
+        mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_commit_write_fails_on_402_billing_limit() {
+        let mut server = mockito::Server::new_async().await;
+        let mock = server
+            .mock("POST", "/i/v1/analytics/events")
+            .with_status(402)
+            .with_body("billing limit exceeded")
+            .expect(1)
+            .create();
+
+        let client = make_client(&server.url()).await;
+        let txn = make_transaction(&client);
+
+        let result = txn.commit_write().await;
+        assert!(result.is_err());
+        let err_msg = result.unwrap_err().to_string();
+        assert!(
+            err_msg.contains("Billing Limit Exceeded"),
+            "expected billing error, got: {err_msg}"
+        );
         mock.assert();
     }
 
@@ -450,13 +447,13 @@ mod tests {
     async fn test_commit_write_exhausts_retries_on_persistent_500() {
         let mut server = mockito::Server::new_async().await;
         let mock = server
-            .mock("POST", "/batch/")
+            .mock("POST", "/i/v1/analytics/events")
             .with_status(500)
             .with_body("internal error")
-            .expect((MAX_RETRIES + 1) as usize)
+            .expect(6)
             .create();
 
-        let client = make_client(&server.url()).await;
+        let client = make_client_with_retries(&server.url(), 6).await;
         let txn = make_transaction(&client);
 
         let result = txn.commit_write().await;

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -248,7 +248,10 @@ impl SinkConfig {
                 let options = posthog_rs::ClientOptionsBuilder::default()
                     .api_key(token)
                     .host(&context.config.capture_url)
-                    .request_timeout_seconds(30)
+                    .request_timeout_seconds(30u64)
+                    .max_capture_attempts(6u32)
+                    .retry_initial_backoff_ms(1000u64)
+                    .retry_max_backoff_ms(30000u64)
                     .build()
                     .map_err(|e| {
                         Error::msg(format!("Failed to build capture client options: {e}"))


### PR DESCRIPTION
## Summary
- Bump `posthog-rs` from `0.4.2` to `0.13.3`, enable `capture-v1` feature
- Remove outer retry loop; SDK handles retries internally with matching config (6 attempts, 1s initial backoff, 30s max, 2x multiplier)
- Add `capture_batch_events_total` metric (success/failure + event count) for observability parity
- Migrate all mockito tests to v1 contract: endpoint `/i/v1/analytics/events`, JSON `CaptureResponse` body, new error taxonomy (402 `BillingLimitExceeded`)

## Context
- `capture-v1` is a wire-protocol switch: new endpoint, request/response shape, compression support
- v1 endpoint is live in dev/prod-us/prod-eu on `capture-analytics` (no clients yet)
- SDK retry config maps 1:1 to current prod behavior (validated against Helm overlays)
- `0.4.2` row removed from `Cargo.lock`; workspace dep stays at `0.12.0` (separate PR)

## Test plan
- [x] `flox activate -- cargo build -p batch-import-worker`
- [x] `flox activate -- cargo test -p batch-import-worker` (242 + integration tests pass)
- [x] `flox activate -- cargo clippy -p batch-import-worker -- -D warnings`
- [x] Confirm `posthog-rs 0.4.2` gone from `Cargo.lock`