### PR TITLE
feat(experiments): add a new global loading status indicator

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx
@@ -4,6 +4,8 @@ import { IconSparkles } from '@posthog/icons'
 import { LemonTabs } from '@posthog/lemon-ui'
 
 import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { PendingChangeRequestBanner } from 'scenes/approvals/PendingChangeRequestBanner'
 import { EXPERIMENT_MIN_EXPOSURES_FOR_RESULTS } from 'scenes/experiments/constants'
 import { WebExperimentImplementationDetails } from 'scenes/experiments/WebExperimentImplementationDetails'
@@ -25,6 +27,7 @@ import { SharedMetricDetailsModal } from '../Metrics/SharedMetricDetailsModal'
 import { SharedMetricModal } from '../Metrics/SharedMetricModal'
 import { sharedMetricModalLogic } from '../Metrics/sharedMetricModalLogic'
 import { Metrics } from '../MetricsView/new/Metrics'
+import { RecalculationStatus } from '../MetricsView/shared/RecalculationStatus'
 import { isLegacyExperiment } from '../utils'
 import { DistributionModal, DistributionTable } from './DistributionTable'
 import { ExperimentDebugPanel } from './ExperimentExecutionPathComparison'
@@ -71,8 +74,12 @@ const AiAnalysisTab = (): JSX.Element => {
 }
 
 const MetricsTab = (): JSX.Element => {
-    const { orderedPrimaryMetricsWithResults, orderedSecondaryMetricsWithResults, isExperimentLaunched } =
+    const { experiment, orderedPrimaryMetricsWithResults, orderedSecondaryMetricsWithResults, isExperimentLaunched } =
         useValues(experimentLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+
+    const hasMetrics = orderedPrimaryMetricsWithResults.length > 0 || orderedSecondaryMetricsWithResults.length > 0
+    const showRecalculationStatus = !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION] && hasMetrics
 
     return (
         <>
@@ -83,8 +90,14 @@ const MetricsTab = (): JSX.Element => {
                 <MultiVariantBiasWarning />
             </div>
 
+            {showRecalculationStatus && (
+                <div className="mb-2">
+                    <RecalculationStatus experiment={experiment} />
+                </div>
+            )}
+
             {/* Modern metrics view */}
-            {orderedPrimaryMetricsWithResults.length === 0 && orderedSecondaryMetricsWithResults.length === 0 ? (
+            {!hasMetrics ? (
                 <EmptyMetricsPanel isLaunched={isExperimentLaunched} />
             ) : (
                 <>

--- a/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx
@@ -4,28 +4,19 @@ import { useEffect } from 'react'
 import { IconClock } from '@posthog/icons'
 import { LemonBanner, LemonButton } from '@posthog/lemon-ui'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
-import { Experiment } from '~/types'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 
 import { experimentLogic } from '../experimentLogic'
-import { experimentMetricsLogic } from '../experimentMetricsLogic'
-import { experimentResultsNotificationLogic } from '../experimentResultsNotificationLogic'
-import { isSavedExperiment } from '../utils'
 
 /**
- * "Results are taking a while" banner. On the recalculation flow it reads the standalone
- * experimentResultsNotificationLogic (driven by isRecalculating); the legacy flow keeps reading the
- * equivalent state on experimentLogic.
+ * Legacy "results are taking a while" banner. On the recalculation flow the RecalculationStatus bar
+ * owns the notify affordance, so this renders nothing there.
  */
 export function ResultsNotificationBanner(): JSX.Element | null {
-    const { experiment } = useValues(experimentLogic)
-    const { featureFlags } = useValues(featureFlagLogic)
-    const recalculationFlow = !!featureFlags[FEATURE_FLAGS.EXPERIMENTS_METRICS_RECALCULATION]
+    const recalculationFlow = useFeatureFlag('EXPERIMENTS_METRICS_RECALCULATION')
 
-    if (recalculationFlow && isSavedExperiment(experiment)) {
-        return <RecalculationNotificationBanner experiment={experiment} />
+    if (recalculationFlow) {
+        return null
     }
     return <LegacyNotificationBanner />
 }
@@ -79,23 +70,6 @@ function NotificationBannerView({
                 </div>
             )}
         </LemonBanner>
-    )
-}
-
-function RecalculationNotificationBanner({ experiment }: { experiment: Experiment }): JSX.Element | null {
-    const notificationLogic = experimentResultsNotificationLogic({ experiment })
-    const { showNotificationOffer, notifyWhenResultsReady } = useValues(notificationLogic)
-    const { subscribeToResultsNotification, dismissNotificationOffer } = useActions(notificationLogic)
-    const { isRecalculating } = useValues(experimentMetricsLogic({ experiment }))
-
-    return (
-        <NotificationBannerView
-            showNotificationOffer={showNotificationOffer}
-            notifyWhenResultsReady={notifyWhenResultsReady}
-            isLoading={isRecalculating}
-            onSubscribe={subscribeToResultsNotification}
-            onDismiss={dismissNotificationOffer}
-        />
     )
 }
 

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -596,13 +596,8 @@ export function MetricRowGroup({
         useActions(experimentLogic)
     const { variants } = useValues(experimentLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const { isRecalculating, isMetricRecalculating } = useValues(experimentMetricsLogic({ experiment }))
+    const { isRecalculating } = useValues(experimentMetricsLogic({ experiment }))
     const { triggerRecalculation } = useActions(experimentMetricsLogic({ experiment }))
-
-    /**
-     * Dim the stale value in place while a non-cold recalc refreshes this metric; block clicks on it.
-     */
-    const recalculatingClassName = isMetricRecalculating(metric.uuid) ? 'opacity-40 pointer-events-none' : ''
 
     /**
      * On the recalculation flow, retrying a single metric just re-runs the whole recalculation (plus
@@ -802,10 +797,7 @@ export function MetricRowGroup({
 
         return (
             <>
-                <tr
-                    className={clsx('hover:bg-bg-hover group [&:last-child>td]:border-b-0', recalculatingClassName)}
-                    style={noResultStateStyle}
-                >
+                <tr className="hover:bg-bg-hover group [&:last-child>td]:border-b-0" style={noResultStateStyle}>
                     {/* Metric column - always visible */}
                     <td
                         className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${
@@ -911,10 +903,7 @@ export function MetricRowGroup({
                 )}
 
             {/* Baseline row */}
-            <tr
-                className={clsx('hover:bg-bg-hover group [&:last-child>td]:border-b-0', recalculatingClassName)}
-                style={FIXED_HEIGHT_STYLE}
-            >
+            <tr className="hover:bg-bg-hover group [&:last-child>td]:border-b-0" style={FIXED_HEIGHT_STYLE}>
                 {/* Metric column - with rowspan */}
                 <td
                     className={`w-1/5 border-r p-3 align-top text-left relative overflow-hidden ${!isLastMetric ? 'border-b' : ''} ${isAlternatingRow ? 'bg-bg-table' : 'bg-bg-light'}`}
@@ -1044,7 +1033,7 @@ export function MetricRowGroup({
                 return (
                     <tr
                         key={`${metric.uuid}-${variant.key}`}
-                        className={clsx('hover:bg-bg-hover group [&:last-child>td]:border-b-0', recalculatingClassName)}
+                        className="hover:bg-bg-hover group [&:last-child>td]:border-b-0"
                         style={FIXED_HEIGHT_STYLE}
                         onMouseEnter={(e) => handleTooltipMouseEnter(e, variant)}
                         onMouseLeave={handleTooltipMouseLeave}

--- a/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx
@@ -1,4 +1,4 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
 import { IconCopy, IconEllipsis, IconPencil, IconStack, IconTarget, IconTrash } from '@posthog/icons'
@@ -6,6 +6,9 @@ import { LemonButton, LemonDialog, LemonDropdown, LemonMenu, LemonTag, Tooltip }
 
 import { TaxonomicFilter } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+import { experimentMetricsLogic } from 'scenes/experiments/experimentMetricsLogic'
 import { isMetricThresholdCueVisible } from 'scenes/experiments/ExperimentMetricThreshold'
 import { METRIC_CONTEXTS, experimentMetricModalLogic } from 'scenes/experiments/Metrics/experimentMetricModalLogic'
 import { sharedMetricDetailsModalLogic } from 'scenes/experiments/Metrics/sharedMetricDetailsModalLogic'
@@ -202,6 +205,10 @@ export const MetricHeader = ({
 
     const canAddBreakdown = (metric.breakdownFilter?.breakdowns || []).length < MAX_BREAKDOWNS
 
+    const recalculationEnabled = useFeatureFlag('EXPERIMENTS_METRICS_RECALCULATION')
+    const { isMetricRecalculating } = useValues(experimentMetricsLogic({ experiment }))
+    const showRecalculatingTag = recalculationEnabled && isMetricRecalculating(metric.uuid)
+
     return (
         <div className="text-xs font-semibold flex flex-col justify-between h-full">
             <div className="deprecated-space-y-1">
@@ -281,6 +288,11 @@ export const MetricHeader = ({
                     )}
                 </div>
                 <div className="flex flex-wrap items-center gap-1">
+                    {showRecalculatingTag && (
+                        <LemonTag type="highlight" size="medium" icon={<Spinner textColored />}>
+                            Recalculating
+                        </LemonTag>
+                    )}
                     <LemonTag type="muted" size="small">
                         {getMetricTag(metric)}
                     </LemonTag>

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -1,64 +1,238 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
+import { TextMorph } from 'torph/react'
 
-import { IconCheck } from '@posthog/icons'
+import { IconBell, IconCheck, IconInfo } from '@posthog/icons'
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
+import { TZLabel } from 'lib/components/TZLabel'
+import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { Spinner } from 'lib/lemon-ui/Spinner'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
 
-import { experimentLogic } from '~/scenes/experiments/experimentLogic'
 import { experimentMetricsLogic } from '~/scenes/experiments/experimentMetricsLogic'
-import { ExperimentLastRefreshText } from '~/scenes/experiments/ExperimentView/ExperimentReloadAction'
+import { experimentResultsNotificationLogic } from '~/scenes/experiments/experimentResultsNotificationLogic'
 import { Experiment } from '~/types'
 
-function StatusSegment({ loading, children }: { loading: boolean; children: React.ReactNode }): JSX.Element {
+import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
+
+const RECALCULATION_LOADING_MESSAGES = [
+    'Snuffling through spiky piles for metrics…',
+    'Counting quills, clicks, and conversions…',
+    'Scurrying through the underbrush for results…',
+    'Hoarding shiny little significant digits…',
+    'Padding softly through fields of variants…',
+    'Untangling prickly paths to results…',
+    'Balancing nuts, berries, and confidence intervals…',
+]
+
+/**
+ * Always-on status line for the recalculation flow. Renders exactly one state from
+ * `recalculationDisplayState`; the in-flight states read live ClickHouse progress off the poll.
+ * Only rendered behind EXPERIMENTS_METRICS_RECALCULATION (see ExperimentView).
+ */
+export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element {
+    const { recalculationDisplayState, currentRecalculation, totalMetricsCount } = useValues(
+        experimentMetricsLogic({ experiment })
+    )
+    /**
+     * Mounted here rather than inside the in-flight branch so the finish-edge subscription that
+     * fires the browser notification is still alive when the bar swaps to a terminal state.
+     */
+    const notificationLogic = experimentResultsNotificationLogic({ experiment })
+    const { notifyWhenResultsReady } = useValues(notificationLogic)
+    const { subscribeToResultsNotification } = useActions(notificationLogic)
+
+    switch (recalculationDisplayState) {
+        case 'initial':
+            return (
+                <StatusBar>
+                    <span className="flex items-center gap-1.5 whitespace-nowrap">
+                        <Spinner textColored className="text-sm text-accent" />
+                        <span className="font-medium">Loading metrics…</span>
+                    </span>
+                </StatusBar>
+            )
+        case 'cold':
+        case 'refreshing':
+            return (
+                <InFlightStatus
+                    recalculation={currentRecalculation}
+                    notifyWhenResultsReady={notifyWhenResultsReady}
+                    onSubscribe={subscribeToResultsNotification}
+                />
+            )
+        case 'partial':
+        case 'resting':
+            return (
+                <StatusBar>
+                    <span className="flex items-center gap-1.5 whitespace-nowrap">
+                        <IconCheck className="text-success text-sm" />
+                        <span className="font-medium">
+                            {totalMetricsCount} {totalMetricsCount === 1 ? 'metric' : 'metrics'}
+                        </span>
+                        {recalculationDisplayState === 'partial' && (
+                            <span className="text-danger font-medium">
+                                · {currentRecalculation?.failed_metrics} failed
+                            </span>
+                        )}
+                    </span>
+                    {currentRecalculation?.completed_at && (
+                        <>
+                            <LemonDivider vertical className="h-3.5" />
+                            <span className="flex items-center gap-1 whitespace-nowrap text-muted text-xs [&_span]:align-baseline">
+                                <span>Refreshed</span>
+                                <TZLabel time={currentRecalculation.completed_at} timestampStyle="relative" />
+                            </span>
+                        </>
+                    )}
+                </StatusBar>
+            )
+    }
+}
+
+function InFlightStatus({
+    recalculation,
+    notifyWhenResultsReady,
+    onSubscribe,
+}: {
+    recalculation: ExperimentMetricsRecalculationApi | null
+    notifyWhenResultsReady: boolean
+    onSubscribe: () => void
+}): JSX.Element {
+    const rowsRead = recalculation?.rows_read ?? undefined
+    const running = recalculation?.running_metrics ?? 0
+    const succeeded = recalculation?.completed_metrics ?? 0
+    const failed = recalculation?.failed_metrics ?? 0
+    const total = recalculation?.total_metrics ?? 0
+    /**
+     * `running` is a momentary sample of system.processes, so it reads 0 between per-metric queries.
+     * Pending (not yet resolved, not currently sampled as running) keeps the segment truthful in those gaps.
+     */
+    const pending = Math.max(0, total - succeeded - failed - running)
     return (
-        <span className="flex items-center gap-1.5 whitespace-nowrap">
-            {loading ? (
+        <StatusBar>
+            <span className="flex items-center gap-1.5 whitespace-nowrap">
                 <Spinner textColored className="text-sm text-accent" />
+                <CountsSegment running={running} pending={pending} succeeded={succeeded} failed={failed} />
+                <span className="text-muted text-xs">· running in the background</span>
+                <Tooltip title="We're computing each metric against the latest data. This runs server-side so you can leave this page; results appear as each metric finishes.">
+                    <IconInfo className="text-muted text-xs" />
+                </Tooltip>
+                {rowsRead !== undefined && (
+                    <ClimbingRows
+                        rowsRead={rowsRead}
+                        estimatedRows={recalculation?.estimated_rows_total ?? undefined}
+                    />
+                )}
+                <RotatingMessage />
+            </span>
+            {notifyWhenResultsReady ? (
+                <LemonButton
+                    size="xsmall"
+                    icon={<IconCheck />}
+                    disabledReason="Keep this tab open to get notified"
+                    className="ml-auto"
+                >
+                    We'll notify you
+                </LemonButton>
             ) : (
-                <IconCheck className="text-success text-sm" />
+                <LemonButton size="xsmall" icon={<IconBell />} onClick={onSubscribe} className="ml-auto">
+                    Notify me
+                </LemonButton>
             )}
+        </StatusBar>
+    )
+}
+
+function StatusBar({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        <div className="flex min-h-8 w-full flex-wrap items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-sm">
             {children}
+        </div>
+    )
+}
+
+function CountsSegment({
+    running,
+    pending,
+    succeeded,
+    failed,
+}: {
+    running: number
+    pending: number
+    succeeded: number
+    failed: number
+}): JSX.Element {
+    // "running" is only shown when the live sample caught a query mid-flight; pending covers the rest.
+    const parts: JSX.Element[] = []
+    if (running > 0) {
+        parts.push(<span key="running">{running} running</span>)
+    }
+    if (pending > 0 || running === 0) {
+        parts.push(<span key="pending">{pending} pending</span>)
+    }
+    parts.push(
+        <span key="succeeded" className="text-success">
+            {succeeded} succeeded
+        </span>
+    )
+    if (failed > 0) {
+        parts.push(
+            <span key="failed" className="text-danger">
+                {failed} failed
+            </span>
+        )
+    }
+    return (
+        <span className="flex items-center gap-1 whitespace-nowrap font-medium">
+            {parts.map((part, i) => (
+                <span key={part.key} className="flex items-center gap-1">
+                    {i > 0 && <span>·</span>}
+                    {part}
+                </span>
+            ))}
         </span>
     )
 }
 
-export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element {
-    const { exposuresLoading } = useValues(experimentLogic)
-    const { isRecalculating, recalculationProgress, lastRefresh, currentRecalculation, totalMetricsCount } = useValues(
-        experimentMetricsLogic({ experiment })
+function ClimbingRows({ rowsRead, estimatedRows }: { rowsRead: number; estimatedRows?: number }): JSX.Element {
+    const showCeiling = estimatedRows !== undefined && estimatedRows >= rowsRead
+    return (
+        <span className="text-muted text-xs whitespace-nowrap">
+            · {humanFriendlyNumber(rowsRead, 0)}
+            {showCeiling && ` / ${humanFriendlyNumber(estimatedRows, 0)}`} rows
+        </span>
     )
+}
 
-    const { completed, total } = recalculationProgress
-    const failed = currentRecalculation?.failed_metrics ?? 0
+function RotatingMessage(): JSX.Element {
+    const [index, setIndex] = useState(0)
+    const { isVisible } = usePageVisibility()
 
-    const metricsLabel = !isRecalculating
-        ? `${totalMetricsCount} ${totalMetricsCount === 1 ? 'metric' : 'metrics'}`
-        : // No run loaded yet (latest is still being fetched), so there's no real progress to show.
-          total > 0
-          ? `Calculating metrics ${completed}/${total}`
-          : 'Loading metrics…'
+    useEffect(() => {
+        if (!isVisible) {
+            return
+        }
+        const interval = setInterval(
+            () => {
+                setIndex((current) => {
+                    let next = Math.floor(Math.random() * RECALCULATION_LOADING_MESSAGES.length)
+                    if (next === current) {
+                        next = (next + 1) % RECALCULATION_LOADING_MESSAGES.length
+                    }
+                    return next
+                })
+            },
+            3000 + Math.random() * 2000
+        )
+        return () => clearInterval(interval)
+    }, [isVisible])
 
     return (
-        <div className="inline-flex items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-xs">
-            <StatusSegment loading={isRecalculating}>
-                <span className="font-medium">{metricsLabel}</span>
-                {failed > 0 && <span className="text-danger font-medium">· {failed} failed</span>}
-            </StatusSegment>
-
-            <LemonDivider vertical className="h-3.5" />
-
-            <StatusSegment loading={exposuresLoading}>
-                <span>exposures</span>
-            </StatusSegment>
-
-            <LemonDivider vertical className="h-3.5" />
-
-            {/* TZLabel hardcodes `align-middle`, which sits a few px low in this flex row; reset its span. */}
-            <span className="flex items-center gap-1 whitespace-nowrap text-muted [&_span]:align-baseline">
-                <span>Updated</span>
-                <ExperimentLastRefreshText lastRefresh={lastRefresh} />
-            </span>
-        </div>
+        <TextMorph as="span" className="text-muted text-xs">
+            {`· ${RECALCULATION_LOADING_MESSAGES[index]}`}
+        </TextMorph>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -1,12 +1,9 @@
 import { useActions, useValues } from 'kea'
-import { useEffect, useState } from 'react'
-import { TextMorph } from 'torph/react'
 
 import { IconBell, IconCheck, IconInfo } from '@posthog/icons'
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { TZLabel } from 'lib/components/TZLabel'
-import { usePageVisibility } from 'lib/hooks/usePageVisibility'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
 import { Spinner } from 'lib/lemon-ui/Spinner'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
@@ -16,16 +13,6 @@ import { experimentResultsNotificationLogic } from '~/scenes/experiments/experim
 import { Experiment } from '~/types'
 
 import type { ExperimentMetricsRecalculationApi } from 'products/experiments/frontend/generated/api.schemas'
-
-const RECALCULATION_LOADING_MESSAGES = [
-    'Snuffling through spiky piles for metrics…',
-    'Counting quills, clicks, and conversions…',
-    'Scurrying through the underbrush for results…',
-    'Hoarding shiny little significant digits…',
-    'Padding softly through fields of variants…',
-    'Untangling prickly paths to results…',
-    'Balancing nuts, berries, and confidence intervals…',
-]
 
 /**
  * Always-on status line for the recalculation flow. Renders exactly one state from
@@ -102,20 +89,18 @@ function InFlightStatus({
     onSubscribe: () => void
 }): JSX.Element {
     const rowsRead = recalculation?.rows_read ?? undefined
-    const running = recalculation?.running_metrics ?? 0
     const succeeded = recalculation?.completed_metrics ?? 0
     const failed = recalculation?.failed_metrics ?? 0
     const total = recalculation?.total_metrics ?? 0
     /**
-     * `running` is a momentary sample of system.processes, so it reads 0 between per-metric queries.
      * Pending (not yet resolved, not currently sampled as running) keeps the segment truthful in those gaps.
      */
-    const pending = Math.max(0, total - succeeded - failed - running)
+    const pending = Math.max(0, total - succeeded - failed)
     return (
         <StatusBar>
             <span className="flex items-center gap-1.5 whitespace-nowrap">
                 <Spinner textColored className="text-sm text-accent" />
-                <CountsSegment running={running} pending={pending} succeeded={succeeded} failed={failed} />
+                <CountsSegment pending={pending} succeeded={succeeded} failed={failed} />
                 <span className="text-muted text-xs">· running in the background</span>
                 <Tooltip title="We're computing each metric against the latest data. This runs server-side so you can leave this page; results appear as each metric finishes.">
                     <IconInfo className="text-muted text-xs" />
@@ -126,7 +111,6 @@ function InFlightStatus({
                         estimatedRows={recalculation?.estimated_rows_total ?? undefined}
                     />
                 )}
-                <RotatingMessage />
             </span>
             {notifyWhenResultsReady ? (
                 <LemonButton
@@ -155,22 +139,18 @@ function StatusBar({ children }: { children: React.ReactNode }): JSX.Element {
 }
 
 function CountsSegment({
-    running,
     pending,
     succeeded,
     failed,
 }: {
-    running: number
     pending: number
     succeeded: number
     failed: number
 }): JSX.Element {
     // "running" is only shown when the live sample caught a query mid-flight; pending covers the rest.
     const parts: JSX.Element[] = []
-    if (running > 0) {
-        parts.push(<span key="running">{running} running</span>)
-    }
-    if (pending > 0 || running === 0) {
+
+    if (pending > 0) {
         parts.push(<span key="pending">{pending} pending</span>)
     }
     parts.push(
@@ -204,35 +184,5 @@ function ClimbingRows({ rowsRead, estimatedRows }: { rowsRead: number; estimated
             · {humanFriendlyNumber(rowsRead, 0)}
             {showCeiling && ` / ${humanFriendlyNumber(estimatedRows, 0)}`} rows
         </span>
-    )
-}
-
-function RotatingMessage(): JSX.Element {
-    const [index, setIndex] = useState(0)
-    const { isVisible } = usePageVisibility()
-
-    useEffect(() => {
-        if (!isVisible) {
-            return
-        }
-        const interval = setInterval(
-            () => {
-                setIndex((current) => {
-                    let next = Math.floor(Math.random() * RECALCULATION_LOADING_MESSAGES.length)
-                    if (next === current) {
-                        next = (next + 1) % RECALCULATION_LOADING_MESSAGES.length
-                    }
-                    return next
-                })
-            },
-            3000 + Math.random() * 2000
-        )
-        return () => clearInterval(interval)
-    }, [isVisible])
-
-    return (
-        <TextMorph as="span" className="text-muted text-xs">
-            {`· ${RECALCULATION_LOADING_MESSAGES[index]}`}
-        </TextMorph>
     )
 }

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -32,9 +32,12 @@ export function RecalculationStatus({ experiment }: { experiment: Experiment }):
     const { completed, total } = recalculationProgress
     const failed = currentRecalculation?.failed_metrics ?? 0
 
-    const metricsLabel = isRecalculating
-        ? `Calculating metrics ${completed}/${total}`
-        : `${totalMetricsCount} ${totalMetricsCount === 1 ? 'metric' : 'metrics'}`
+    const metricsLabel = !isRecalculating
+        ? `${totalMetricsCount} ${totalMetricsCount === 1 ? 'metric' : 'metrics'}`
+        : // No run loaded yet (latest is still being fetched), so there's no real progress to show.
+          total > 0
+          ? `Calculating metrics ${completed}/${total}`
+          : 'Loading metrics…'
 
     return (
         <div className="inline-flex items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-xs">

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -1,0 +1,62 @@
+import { useValues } from 'kea'
+
+import { IconCheck } from '@posthog/icons'
+
+import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { Spinner } from 'lib/lemon-ui/Spinner'
+
+import { experimentLogic } from '~/scenes/experiments/experimentLogic'
+import { experimentMetricsLogic } from '~/scenes/experiments/experimentMetricsLogic'
+import { ExperimentLastRefreshText } from '~/scenes/experiments/ExperimentView/ExperimentReloadAction'
+import { Experiment } from '~/types'
+
+function StatusSegment({ loading, children }: { loading: boolean; children: React.ReactNode }): JSX.Element {
+    return (
+        <span className="flex items-center gap-1.5 whitespace-nowrap">
+            {loading ? (
+                <Spinner textColored className="text-sm text-accent" />
+            ) : (
+                <IconCheck className="text-success text-sm" />
+            )}
+            {children}
+        </span>
+    )
+}
+
+export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element {
+    const { exposuresLoading } = useValues(experimentLogic)
+    const { isRecalculating, recalculationProgress, lastRefresh, currentRecalculation } = useValues(
+        experimentMetricsLogic({ experiment })
+    )
+
+    const { completed, total } = recalculationProgress
+    const failed = currentRecalculation?.failed_metrics ?? 0
+
+    const metricsLabel = isRecalculating
+        ? `Calculating metrics ${completed}/${total}`
+        : total > 0
+          ? `${total} ${total === 1 ? 'metric' : 'metrics'}`
+          : 'No metrics'
+
+    return (
+        <div className="inline-flex items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-xs">
+            <StatusSegment loading={isRecalculating}>
+                <span className="font-medium">{metricsLabel}</span>
+                {failed > 0 && <span className="text-danger font-medium">· {failed} failed</span>}
+            </StatusSegment>
+
+            <LemonDivider vertical className="h-3.5" />
+
+            <StatusSegment loading={exposuresLoading}>
+                <span>exposures</span>
+            </StatusSegment>
+
+            <LemonDivider vertical className="h-3.5" />
+
+            <span className="flex items-center gap-1 whitespace-nowrap text-muted">
+                <span>Updated</span>
+                <ExperimentLastRefreshText lastRefresh={lastRefresh} />
+            </span>
+        </div>
+    )
+}

--- a/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx
@@ -25,7 +25,7 @@ function StatusSegment({ loading, children }: { loading: boolean; children: Reac
 
 export function RecalculationStatus({ experiment }: { experiment: Experiment }): JSX.Element {
     const { exposuresLoading } = useValues(experimentLogic)
-    const { isRecalculating, recalculationProgress, lastRefresh, currentRecalculation } = useValues(
+    const { isRecalculating, recalculationProgress, lastRefresh, currentRecalculation, totalMetricsCount } = useValues(
         experimentMetricsLogic({ experiment })
     )
 
@@ -34,9 +34,7 @@ export function RecalculationStatus({ experiment }: { experiment: Experiment }):
 
     const metricsLabel = isRecalculating
         ? `Calculating metrics ${completed}/${total}`
-        : total > 0
-          ? `${total} ${total === 1 ? 'metric' : 'metrics'}`
-          : 'No metrics'
+        : `${totalMetricsCount} ${totalMetricsCount === 1 ? 'metric' : 'metrics'}`
 
     return (
         <div className="inline-flex items-center gap-2.5 rounded border border-primary bg-surface-secondary px-2.5 py-1 text-xs">
@@ -53,7 +51,8 @@ export function RecalculationStatus({ experiment }: { experiment: Experiment }):
 
             <LemonDivider vertical className="h-3.5" />
 
-            <span className="flex items-center gap-1 whitespace-nowrap text-muted">
+            {/* TZLabel hardcodes `align-middle`, which sits a few px low in this flex row; reset its span. */}
+            <span className="flex items-center gap-1 whitespace-nowrap text-muted [&_span]:align-baseline">
                 <span>Updated</span>
                 <ExperimentLastRefreshText lastRefresh={lastRefresh} />
             </span>

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -52,7 +52,7 @@ const completedRecalculation = {
     status: 'completed',
     completed_metrics: 2,
     started_at: new Date().toISOString(),
-    // Fresh by default (within the 24h window) so tests using this fixture don't auto-trigger.
+    // Fresh by default (within the 12h window) so tests using this fixture don't auto-trigger.
     completed_at: new Date().toISOString(),
     query_to: '2026-06-10T00:05:00Z',
     results: [
@@ -61,7 +61,7 @@ const completedRecalculation = {
     ],
 }
 
-// completed_at far in the past → older than the 24h staleness threshold.
+// completed_at far in the past, older than the 12h staleness threshold.
 const staleCompletedRecalculation = {
     ...completedRecalculation,
     completed_at: '2020-01-01T00:00:00Z',
@@ -383,7 +383,7 @@ describe('experimentMetricsLogic', () => {
             expect(capturedBody).toEqual({ trigger: 'cold_run' })
         })
 
-        it('auto-triggers a stale_refresh recalculation when the latest completed run is stale (>24h)', async () => {
+        it('auto-triggers a stale_refresh recalculation when the latest completed run is stale (>12h)', async () => {
             let capturedBody: any
             useMocks({
                 get: {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.test.ts
@@ -52,7 +52,6 @@ const completedRecalculation = {
     status: 'completed',
     completed_metrics: 2,
     started_at: new Date().toISOString(),
-    // Fresh by default (within the 12h window) so tests using this fixture don't auto-trigger.
     completed_at: new Date().toISOString(),
     query_to: '2026-06-10T00:05:00Z',
     results: [
@@ -61,11 +60,6 @@ const completedRecalculation = {
     ],
 }
 
-// completed_at far in the past, older than the 12h staleness threshold.
-const staleCompletedRecalculation = {
-    ...completedRecalculation,
-    completed_at: '2020-01-01T00:00:00Z',
-}
 const freshCompletedRecalculation = completedRecalculation
 
 const pendingRecalculation = { ...baseRecalculation, id: 'recalc-2', status: 'pending' }
@@ -383,36 +377,9 @@ describe('experimentMetricsLogic', () => {
             expect(capturedBody).toEqual({ trigger: 'cold_run' })
         })
 
-        it('auto-triggers a stale_refresh recalculation when the latest completed run is stale (>12h)', async () => {
-            let capturedBody: any
-            useMocks({
-                get: {
-                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [
-                        200,
-                        staleCompletedRecalculation,
-                    ],
-                },
-                post: {
-                    // Return a terminal run so triggerRecalculation finishes without arming a poll timer.
-                    '/api/projects/:team_id/experiments/:id/metrics_recalculation/': async ({ request }) => {
-                        capturedBody = await request.json()
-                        return [201, completedRecalculation2]
-                    },
-                },
-            })
-            mountLogic()
-
-            // Stale results still load, but a fresh run is kicked off in the background.
-            await expectLogic(logic)
-                .toDispatchActions(['setCurrentRecalculation', 'triggerRecalculation'])
-                .toFinishAllListeners()
-            expect(logic.values.primaryMetricsResults[0]).toEqual(primaryResult)
-            expect(capturedBody).toEqual({ trigger: 'stale_refresh' })
-        })
-
-        it('does not auto-trigger when the latest completed run is fresh', async () => {
-            // freshCompletedRecalculation has result_source 'recalculation' (a real run), so neither the
-            // staleness path nor the timeseries-fallback path fires.
+        it('does not auto-trigger when the latest completed run is healthy', async () => {
+            // freshCompletedRecalculation has result_source 'recalculation' (a real run) with all metrics
+            // resolved, so neither the config-change heal path nor the timeseries-fallback path fires.
             useMocks({
                 get: {
                     '/api/projects/:team_id/experiments/:id/metrics_recalculation/latest/': () => [

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -230,6 +230,13 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 total: recalc?.total_metrics ?? 0,
             }),
         ],
+        // Total metrics on the experiment itself, independent of whether a recalculation run exists yet.
+        // Sourced from the experiment so the count is truthful on first render, before the first run loads.
+        totalMetricsCount: [
+            () => [(_, props) => props.experiment],
+            (experiment: Experiment): number =>
+                metricsInOrder(experiment, 'primary').length + metricsInOrder(experiment, 'secondary').length,
+        ],
         lastRefresh: [(s) => [s.currentRecalculation], (recalc): string | null => recalc?.query_to ?? null],
         // Predicate the table uses to dim a metric whose stale value is still being refreshed.
         isMetricRecalculating: [

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -40,7 +40,7 @@ export interface ExperimentMetricsLogicProps {
 }
 
 const RECALCULATION_POLL_INTERVAL_MS = 2000
-const RECALCULATION_STALE_AFTER_HOURS = 24
+const RECALCULATION_STALE_AFTER_HOURS = 12
 const MAX_POLL_RETRIES = 5
 
 export const RECALCULATION_STATUSES = {

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -3,7 +3,6 @@ import { actions, afterMount, connect, kea, key, listeners, path, props, reducer
 import { lemonToast } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { projectLogic } from 'scenes/projectLogic'
@@ -40,7 +39,6 @@ export interface ExperimentMetricsLogicProps {
 }
 
 const RECALCULATION_POLL_INTERVAL_MS = 2000
-const RECALCULATION_STALE_AFTER_HOURS = 12
 const MAX_POLL_RETRIES = 5
 
 export const RECALCULATION_STATUSES = {
@@ -51,13 +49,6 @@ export const RECALCULATION_STATUSES = {
 } as const
 
 export type RecalculationStatuses = (typeof RECALCULATION_STATUSES)[keyof typeof RECALCULATION_STATUSES]
-
-const isRecalculationStale = (recalculation: ExperimentMetricsRecalculationApi): boolean => {
-    if (!recalculation.completed_at) {
-        return false
-    }
-    return dayjs().diff(dayjs(recalculation.completed_at), 'hours') >= RECALCULATION_STALE_AFTER_HOURS
-}
 
 /**
  * transform shared metrics into experiment metrics.
@@ -238,6 +229,22 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 metricsInOrder(experiment, 'primary').length + metricsInOrder(experiment, 'secondary').length,
         ],
         lastRefresh: [(s) => [s.currentRecalculation], (recalc): string | null => recalc?.query_to ?? null],
+        recalculationDisplayState: [
+            (s) => [s.recalculationLoading, s.currentRecalculation],
+            (recalculationLoading, recalculation): 'initial' | 'cold' | 'refreshing' | 'partial' | 'resting' => {
+                if (!recalculation) {
+                    return recalculationLoading ? 'initial' : 'resting'
+                }
+                const inFlight =
+                    recalculationLoading ||
+                    recalculation.status === RECALCULATION_STATUSES.pending ||
+                    recalculation.status === RECALCULATION_STATUSES.in_progress
+                if (inFlight) {
+                    return (recalculation.results?.length ?? 0) > 0 ? 'refreshing' : 'cold'
+                }
+                return recalculation.failed_metrics > 0 ? 'partial' : 'resting'
+            },
+        ],
         // Predicate the table uses to dim a metric whose stale value is still being refreshed.
         isMetricRecalculating: [
             (s) => [s.recalculatingMetricUuids],
@@ -429,14 +436,6 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                     ) {
                         actions.triggerRecalculation('config_change')
                         return
-                    }
-
-                    /**
-                     * if the recalculation resutls are stale, trigger a new recalculation
-                     * without hiding the existing resutls.
-                     */
-                    if (isRecalculationStale(recalculation)) {
-                        actions.triggerRecalculation('stale_refresh')
                     }
                 } catch (error: any) {
                     if (error?.status === 404) {

--- a/frontend/src/scenes/experiments/experimentResultsNotificationLogic.test.ts
+++ b/frontend/src/scenes/experiments/experimentResultsNotificationLogic.test.ts
@@ -13,7 +13,12 @@ import { experimentMetricsLogic } from './experimentMetricsLogic'
 import { experimentResultsNotificationLogic } from './experimentResultsNotificationLogic'
 
 const EXPERIMENT = experimentJson as unknown as Experiment
-const OFFER_DELAY_MS = 10_000
+
+const dispatchBeforeUnload = (): boolean => {
+    const event = new Event('beforeunload', { cancelable: true })
+    window.dispatchEvent(event)
+    return event.defaultPrevented
+}
 
 describe('experimentResultsNotificationLogic', () => {
     let logic: ReturnType<typeof experimentResultsNotificationLogic.build>
@@ -54,49 +59,28 @@ describe('experimentResultsNotificationLogic', () => {
     })
 
     afterEach(() => {
-        jest.useRealTimers()
         logic?.unmount()
         metricsLogic?.unmount()
     })
 
-    it('offers the notification banner once a recalculation has run for the delay', async () => {
-        jest.useFakeTimers()
-        // Recalculation starts → the offer timer begins.
+    it('fires notifyResultsReady and resets the subscription when the recalculation finishes', async () => {
         metricsLogic.actions.setCurrentRecalculation({ id: 'x', status: 'in_progress' } as any)
-        expect(logic.values.showNotificationOffer).toBe(false)
+        logic.actions.setNotifyWhenResultsReady(true)
 
-        await jest.advanceTimersByTimeAsync(OFFER_DELAY_MS)
-        expect(logic.values.showNotificationOffer).toBe(true)
-    })
-
-    it('resets the offer when the recalculation finishes', async () => {
-        jest.useFakeTimers()
-        metricsLogic.actions.setCurrentRecalculation({ id: 'x', status: 'in_progress' } as any)
-        await jest.advanceTimersByTimeAsync(OFFER_DELAY_MS)
-        expect(logic.values.showNotificationOffer).toBe(true)
-
-        // Recalculation completes → offer is cleared.
         metricsLogic.actions.setCurrentRecalculation({ id: 'x', status: 'completed' } as any)
         await expectLogic(logic).toDispatchActions(['notifyResultsReady'])
-        expect(logic.values.showNotificationOffer).toBe(false)
         expect(logic.values.notifyWhenResultsReady).toBe(false)
     })
 
-    it('dismissNotificationOffer clears both flags', () => {
-        logic.actions.setShowNotificationOffer(true)
-        logic.actions.setNotifyWhenResultsReady(true)
-        logic.actions.dismissNotificationOffer()
-        expect(logic.values.showNotificationOffer).toBe(false)
-        expect(logic.values.notifyWhenResultsReady).toBe(false)
-    })
-
-    it('dismissing the offer disposes the pending timer so it cannot re-show the banner', async () => {
-        jest.useFakeTimers()
+    it('warns before unload while subscribed and stops once results land', async () => {
         metricsLogic.actions.setCurrentRecalculation({ id: 'x', status: 'in_progress' } as any)
-        // Dismiss before the offer timer fires.
-        logic.actions.dismissNotificationOffer()
-        await jest.advanceTimersByTimeAsync(OFFER_DELAY_MS)
-        // The timer was disposed, so the offer must stay dismissed.
-        expect(logic.values.showNotificationOffer).toBe(false)
+        expect(dispatchBeforeUnload()).toBe(false)
+
+        logic.actions.setNotifyWhenResultsReady(true)
+        expect(dispatchBeforeUnload()).toBe(true)
+
+        metricsLogic.actions.setCurrentRecalculation({ id: 'x', status: 'completed' } as any)
+        await expectLogic(logic).toDispatchActions(['notifyResultsReady'])
+        expect(dispatchBeforeUnload()).toBe(false)
     })
 })

--- a/frontend/src/scenes/experiments/experimentResultsNotificationLogic.ts
+++ b/frontend/src/scenes/experiments/experimentResultsNotificationLogic.ts
@@ -12,14 +12,10 @@ export interface ExperimentResultsNotificationLogicProps {
     experiment: Experiment
 }
 
-// How long a recalculation must run before we offer the "notify me when ready" banner.
-const NOTIFICATION_OFFER_DELAY_MS = 10_000
-
 /**
- * Standalone "results are taking a while" notification for the recalculation flow: offers a banner
- * once a recalculation has been running for a bit, and (if the user opts in) fires a browser
- * notification when it finishes. Driven entirely by `experimentMetricsLogic.isRecalculating` so it's
- * decoupled from how results are loaded. The legacy equivalent still lives in experimentLogic.
+ * Browser notification for the recalculation flow: the status bar's "Notify me" button opts in, and a
+ * notification fires when the run finishes. Driven entirely by `experimentMetricsLogic.isRecalculating`
+ * so it's decoupled from how results are loaded. The legacy equivalent still lives in experimentLogic.
  */
 export const experimentResultsNotificationLogic = kea<experimentResultsNotificationLogicType>([
     props({} as ExperimentResultsNotificationLogicProps),
@@ -29,33 +25,19 @@ export const experimentResultsNotificationLogic = kea<experimentResultsNotificat
         values: [experimentMetricsLogic({ experiment: props.experiment }), ['isRecalculating']],
     })),
     actions({
-        setShowNotificationOffer: (show: boolean) => ({ show }),
         setNotifyWhenResultsReady: (notify: boolean) => ({ notify }),
-        dismissNotificationOffer: true,
         subscribeToResultsNotification: true,
         notifyResultsReady: true,
     }),
     reducers({
-        showNotificationOffer: [
-            false,
-            {
-                setShowNotificationOffer: (_, { show }) => show,
-                dismissNotificationOffer: () => false,
-            },
-        ],
         notifyWhenResultsReady: [
             false,
             {
                 setNotifyWhenResultsReady: (_, { notify }) => notify,
-                dismissNotificationOffer: () => false,
             },
         ],
     }),
     listeners(({ props, values, actions, cache }) => ({
-        dismissNotificationOffer: () => {
-            // Stop the pending offer timer so it can't re-show the banner after the user dismissed it.
-            cache.disposables.dispose('notificationOfferTimer')
-        },
         subscribeToResultsNotification: async () => {
             if (!('Notification' in window)) {
                 lemonToast.error('Your browser does not support notifications.')
@@ -73,6 +55,26 @@ export const experimentResultsNotificationLogic = kea<experimentResultsNotificat
                 )
             }
         },
+        setNotifyWhenResultsReady: ({ notify }) => {
+            /**
+             * Warn before closing the tab while subscribed: the notification can only fire from this page.
+             * Must survive tab-hide (closing a background tab still fires beforeunload), so it opts out of
+             * pause-on-page-hide.
+             */
+            if (notify) {
+                cache.disposables.add(
+                    () => {
+                        const handler = (e: BeforeUnloadEvent): void => e.preventDefault()
+                        window.addEventListener('beforeunload', handler)
+                        return () => window.removeEventListener('beforeunload', handler)
+                    },
+                    'beforeUnloadGuard',
+                    { pauseOnPageHidden: false }
+                )
+            } else {
+                cache.disposables.dispose('beforeUnloadGuard')
+            }
+        },
         // Fire the browser notification (if subscribed) once a recalculation finishes.
         notifyResultsReady: () => {
             if (values.notifyWhenResultsReady && 'Notification' in window && Notification.permission === 'granted') {
@@ -86,8 +88,6 @@ export const experimentResultsNotificationLogic = kea<experimentResultsNotificat
                     notification.close()
                 }
             }
-            cache.disposables.dispose('notificationOfferTimer')
-            actions.setShowNotificationOffer(false)
             actions.setNotifyWhenResultsReady(false)
         },
     })),
@@ -95,30 +95,11 @@ export const experimentResultsNotificationLogic = kea<experimentResultsNotificat
      * Subscriptions (not listeners) on purpose: we react to the EDGE of `isRecalculating`, a derived
      * boolean composed from two upstream actions (setCurrentRecalculation + setRecalculationLoading) on
      * experimentMetricsLogic. There's no single action whose handler cleanly expresses "the derived value
-     * just flipped", so this is the skill's sanctioned subscriptions case. The (next, prev) args give us
-     * the transition for free instead of hand-tracking a previous value across two listeners.
+     * just flipped", so this is the skill's sanctioned subscriptions case.
      */
-    subscriptions(({ actions, cache }) => ({
+    subscriptions(({ actions }) => ({
         isRecalculating: (isRecalculating: boolean, previous: boolean | undefined) => {
-            if (isRecalculating && !previous) {
-                /**
-                 * A recalculation just started: offer the banner after it has been running a while. The
-                 * timer must keep running while the tab is hidden (the point is to notify a user who has
-                 * navigated away), so it opts out of pause-on-page-hide.
-                 */
-                cache.disposables.add(
-                    () => {
-                        const timer = setTimeout(
-                            () => actions.setShowNotificationOffer(true),
-                            NOTIFICATION_OFFER_DELAY_MS
-                        )
-                        return () => clearTimeout(timer)
-                    },
-                    'notificationOfferTimer',
-                    { pauseOnPageHidden: false }
-                )
-            } else if (!isRecalculating && previous) {
-                // Fire the notification (if subscribed) and reset the offer.
+            if (!isRecalculating && previous) {
                 actions.notifyResultsReady()
             }
         },

--- a/frontend/src/scenes/experiments/experimentResultsNotificationLogic.ts
+++ b/frontend/src/scenes/experiments/experimentResultsNotificationLogic.ts
@@ -64,7 +64,11 @@ export const experimentResultsNotificationLogic = kea<experimentResultsNotificat
             if (notify) {
                 cache.disposables.add(
                     () => {
-                        const handler = (e: BeforeUnloadEvent): void => e.preventDefault()
+                        const handler = (e: BeforeUnloadEvent): void => {
+                            e.preventDefault()
+                            // Legacy fallback (Chrome/Edge < 119); preventDefault is the modern trigger.
+                            e.returnValue = true
+                        }
                         window.addEventListener('beforeunload', handler)
                         return () => window.removeEventListener('beforeunload', handler)
                     },


### PR DESCRIPTION
## Problem

The recalculation state was scattered or hidden behind the reload button: no single place showed whether metrics were being computed, how far along a run was, or how fresh the data is. Long runs (customers with dozens of metrics) looked stuck, and the old treatment dimmed the whole metric row and blocked interaction while refreshing.

Stacked on #68067, which adds the live ClickHouse progress fields this UI consumes.

## Changes

This PR rewires all the loading statuses on the recalculation flow into one status bar plus a per-row signal, everything gated on `EXPERIMENTS_METRICS_RECALCULATION`; the legacy path is untouched.

### Status bar

`RecalculationStatus` renders exactly one state from the new `recalculationDisplayState` selector (`initial | cold | refreshing | partial | resting`). In-flight states show live ClickHouse progress off the poll: running (momentary `system.processes` sample), pending (derived as `total − resolved − running`, so the bar stays truthful in the gaps between per-metric queries), succeeded, failed, plus a climbing rows-read count against ClickHouse's own estimate, rotating loading messages, and an explicit "running in the background" note. Terminal states show the metric count and a relative "Refreshed" timestamp.

- `frontend/src/scenes/experiments/MetricsView/shared/RecalculationStatus.tsx`
- `frontend/src/scenes/experiments/ExperimentView/ExperimentView.tsx`
- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

### Notify me

The bar's "Notify me" button replaces the "results are taking a while" banner on this flow: it subscribes via `experimentResultsNotificationLogic`, flips to a checked "We'll notify you" state, and a browser notification fires when the run finishes. The banner's offer machinery (10s timer, dismiss state) is deleted from the logic; the before-unload warning while subscribed moved into the logic as a disposable. The legacy banner is untouched.

- `frontend/src/scenes/experiments/experimentResultsNotificationLogic.ts`
- `frontend/src/scenes/experiments/ExperimentView/ResultsNotificationBanner.tsx`

### Per-row signal instead of dimming

Refreshing metrics keep their stale values fully visible and interactive; a "Recalculating" tag in the metric header replaces the old `opacity-40 pointer-events-none` treatment.

- `frontend/src/scenes/experiments/MetricsView/shared/MetricHeader.tsx`
- `frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx`

### Side effects

Removed the 12h stale-refresh auto-trigger from the logic (`isRecalculationStale` and the `stale_refresh` trigger) and its tests; freshness is surfaced in the bar instead of silently kicking off runs.

- `frontend/src/scenes/experiments/experimentMetricsLogic.test.ts`
- `frontend/src/scenes/experiments/experimentResultsNotificationLogic.test.ts`

#### full loading cycle
https://github.com/user-attachments/assets/8ca8f180-6ca0-49c7-b56f-40853d1ee38c

#### recalculating individual metrics
https://github.com/user-attachments/assets/511028f9-6560-42f1-b922-ebe2bc30922c

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend exec jest src/scenes/experiments/experimentMetricsLogic.test.ts src/scenes/experiments/experimentResultsNotificationLogic.test.ts
```

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/3a98c25f-13d1-439e-871a-0dee4258c78a)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8 / Fable 5
Manually refactored: **yes**

Skills used:

- /brainstorming (superpowers)
- /writing-tests (local)
- /using-kea-disposables (local)

Relevant decisions:

- One `recalculationDisplayState` selector drives a single rendered state; cold and refreshing share one in-flight rendering fed entirely by the live progress fields.
- The live "running" count is a momentary sample, so a derived "pending" count covers the idle gaps; rejected a backend-tracked running counter (drifts under Temporal retries) and faster polling (cost without benefit).
- Notify affordance moved from an offer banner into the always-visible bar; the notification logic mounts at the bar's top level so the finish-edge subscription is alive when the bar swaps to a terminal state.