### PR TITLE
feat(data-warehouse): add account picker to bing ads source

### DIFF
--- a/frontend/src/lib/integrations/bingAdsIntegrationLogic.ts
+++ b/frontend/src/lib/integrations/bingAdsIntegrationLogic.ts
@@ -1,0 +1,56 @@
+import { actions, isBreakpoint, kea, key, listeners, path, props, reducers } from 'kea'
+
+import { ApiConfig } from 'lib/api'
+
+import { integrationsBingAdsAccountsRetrieve } from 'products/integrations/frontend/generated/api'
+import type { BingAdsAccountApi } from 'products/integrations/frontend/generated/api.schemas'
+
+import type { bingAdsIntegrationLogicType } from './bingAdsIntegrationLogicType'
+
+export const bingAdsIntegrationLogic = kea<bingAdsIntegrationLogicType>([
+    props({} as { id: number }),
+    key((props) => props.id),
+    path((key) => ['lib', 'integrations', 'bingAdsIntegrationLogic', key]),
+
+    actions({
+        loadAccounts: true,
+        loadAccountsSuccess: (accounts: BingAdsAccountApi[]) => ({ accounts }),
+        loadAccountsFailure: true,
+    }),
+
+    reducers({
+        accounts: [
+            [] as BingAdsAccountApi[],
+            {
+                loadAccounts: () => [],
+                loadAccountsSuccess: (_, { accounts }) => accounts,
+            },
+        ],
+        accountsLoading: [
+            false,
+            {
+                loadAccounts: () => true,
+                loadAccountsSuccess: () => false,
+                loadAccountsFailure: () => false,
+            },
+        ],
+    }),
+
+    listeners(({ actions, props }) => ({
+        loadAccounts: async (_, breakpoint) => {
+            try {
+                const response = await integrationsBingAdsAccountsRetrieve(
+                    String(ApiConfig.getCurrentProjectId()),
+                    props.id
+                )
+                await breakpoint()
+                actions.loadAccountsSuccess(response.accounts)
+            } catch (e: any) {
+                if (isBreakpoint(e)) {
+                    throw e
+                }
+                actions.loadAccountsFailure()
+            }
+        },
+    })),
+])

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -326,6 +326,32 @@ class GoogleSearchConsoleSitesResponseSerializer(serializers.Serializer):
     sites = GoogleSearchConsoleSiteSerializer(many=True)
 
 
+class BingAdsAccountSerializer(serializers.Serializer):
+    id = serializers.IntegerField(
+        help_text="Numeric Bing Ads account ID. This is the value stored in the source config and used for all API calls."
+    )
+    number = serializers.CharField(
+        allow_null=True,
+        help_text="Alphanumeric account number shown in the Microsoft Advertising UI (e.g. 'F11034B5'). Display only — not the value used for API calls.",
+    )
+    name = serializers.CharField(allow_null=True, help_text="Human-readable account name.")
+    status = serializers.CharField(help_text="Account lifecycle status reported by Microsoft (e.g. 'Active', 'Pause').")
+    customer_id = serializers.IntegerField(
+        help_text="Numeric ID of the customer (Microsoft Advertising manager) that owns this account."
+    )
+    customer_name = serializers.CharField(allow_null=True, help_text="Name of the owning customer.")
+    is_primary = serializers.BooleanField(
+        help_text="True when this account belongs to the connected user's own (primary) customer, rather than another customer they merely have access to."
+    )
+
+
+class BingAdsAccountsResponseSerializer(serializers.Serializer):
+    accounts = BingAdsAccountSerializer(
+        many=True,
+        help_text="All Bing Ads accounts the connected Microsoft account can access, across every customer.",
+    )
+
+
 class IntegrationAccessRequestSerializer(serializers.Serializer):
     kind = serializers.ChoiceField(
         choices=Integration.IntegrationKind.choices,
@@ -708,6 +734,9 @@ class IntegrationViewSet(
         # Enumerates every Search Console property on the connected Google account — gate behind
         # manage access so read-only members can't discover unrelated domains (info disclosure).
         "google_search_console_sites",
+        # Enumerates every Bing Ads account across the connected user's customers — same info
+        # disclosure concern, so gate it behind manage access too.
+        "bing_ads_accounts",
     ]
     permission_classes = [TeamMemberStrictManagementPermission]
     queryset = defer_repository_cache_fields(Integration.objects.all())
@@ -1029,6 +1058,37 @@ class IntegrationViewSet(
             raise
         response_data = {"sites": sites}
         cache.set(cache_key, response_data, GSC_AUTOCOMPLETE_CACHE_TTL_SECONDS)
+        return Response(response_data)
+
+    @extend_schema(responses={200: BingAdsAccountsResponseSerializer})
+    @action(methods=["GET"], detail=True, url_path="bing_ads_accounts")
+    def bing_ads_accounts(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        """List the Bing Ads accounts the connected Microsoft account can access, across all customers."""
+        from posthog.settings import integrations  # noqa: PLC0415 — keep settings lookup local to the action
+        from posthog.temporal.data_imports.sources.bing_ads.client import (  # noqa: PLC0415 — keeps the Bing Ads SDK off the api/ import path
+            BingAdsClient,
+        )
+
+        instance = self.get_object()
+        if instance.kind != "bing-ads":
+            raise ValidationError("bing_ads_accounts endpoint is only supported for Bing Ads integrations")
+        _ensure_oauth_token_valid(instance)
+
+        if not integrations.BING_ADS_DEVELOPER_TOKEN:
+            raise ValidationError("Bing Ads developer token is not configured")
+
+        cache_key = f"bing_ads/{instance.id}/accounts"
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return Response(cached)
+
+        client = BingAdsClient(
+            access_token=instance.access_token,
+            refresh_token=instance.refresh_token,
+            developer_token=integrations.BING_ADS_DEVELOPER_TOKEN,
+        )
+        response_data = {"accounts": client.list_accounts()}
+        cache.set(cache_key, response_data, 60)
         return Response(response_data)
 
     @action(methods=["GET"], detail=True, url_path="linkedin_ads_conversion_rules")

--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -72,6 +72,7 @@ from posthog.permissions import (
     AccessControlPermission,
     APIScopePermission,
     TeamMemberAccessPermission,
+    TeamMemberAdminManagementPermission,
     TeamMemberLightManagementPermission,
     TeamMemberStrictManagementPermission,
 )
@@ -739,6 +740,8 @@ class IntegrationViewSet(
         "bing_ads_accounts",
     ]
     permission_classes = [TeamMemberStrictManagementPermission]
+    # These GET actions enumerate the connected provider's accounts/sites, so require admin even for reads.
+    account_enumeration_actions = ["bing_ads_accounts", "google_search_console_sites"]
     queryset = defer_repository_cache_fields(Integration.objects.all())
     serializer_class = IntegrationSerializer
     filter_backends = [DjangoFilterBackend]
@@ -760,6 +763,14 @@ class IntegrationViewSet(
                 APIScopePermission(),
                 AccessControlPermission(),
                 TeamMemberAccessPermission(),
+            ]
+        if self.action in self.account_enumeration_actions:
+            return [
+                IsAuthenticated(),
+                APIScopePermission(),
+                AccessControlPermission(),
+                TeamMemberAccessPermission(),
+                TeamMemberAdminManagementPermission(),
             ]
         raise NotImplementedError()
 

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -3813,3 +3813,67 @@ class TestGoogleSearchConsoleSitesEndpoint:
         response = client.get(self._url(integration.id))
 
         assert response.status_code == status.HTTP_500_INTERNAL_SERVER_ERROR, response.content
+
+
+class TestAccountEnumerationActionsRequireAdmin(APIBaseTest):
+    def _bing_integration(self) -> Integration:
+        return Integration.objects.create(
+            team=self.team,
+            kind="bing-ads",
+            config={},
+            sensitive_config={"access_token": "token", "refresh_token": "refresh"},
+            integration_id="bing_test",
+            created_by=self.user,
+        )
+
+    def _gsc_integration(self) -> Integration:
+        return Integration.objects.create(
+            team=self.team,
+            kind="google-search-console",
+            config={},
+            sensitive_config={"access_token": "ya29.test"},
+            integration_id="gsc_test",
+            created_by=self.user,
+        )
+
+    def _url(self, integration_id: int, action: str) -> str:
+        return f"/api/environments/{self.team.pk}/integrations/{integration_id}/{action}/"
+
+    @parameterized.expand(
+        [
+            ("bing_ads_accounts",),
+            ("google_search_console_sites",),
+        ]
+    )
+    def test_regular_member_is_forbidden(self, action):
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+        integration = self._bing_integration() if action == "bing_ads_accounts" else self._gsc_integration()
+
+        response = self.client.get(self._url(integration.id, action))
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN, response.content
+
+    def test_admin_passes_permission_bing(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        integration = self._bing_integration()
+
+        with patch(
+            "posthog.temporal.data_imports.sources.bing_ads.client.BingAdsClient.list_accounts", return_value=[]
+        ):
+            response = self.client.get(self._url(integration.id, "bing_ads_accounts"))
+
+        # The permission passed; the body may still 400 (e.g. unconfigured token), but never 403.
+        assert response.status_code != status.HTTP_403_FORBIDDEN, response.content
+
+    def test_admin_passes_permission_gsc(self):
+        self.organization_membership.level = OrganizationMembership.Level.ADMIN
+        self.organization_membership.save()
+        integration = self._gsc_integration()
+
+        gsc = "posthog.temporal.data_imports.sources.google_search_console.google_search_console"
+        with patch(f"{gsc}.google_search_console_session"), patch(f"{gsc}.list_sites", return_value=[]):
+            response = self.client.get(self._url(integration.id, "google_search_console_sites"))
+
+        assert response.status_code != status.HTTP_403_FORBIDDEN, response.content

--- a/posthog/permissions.py
+++ b/posthog/permissions.py
@@ -303,6 +303,20 @@ class TeamMemberStrictManagementPermission(BasePermission):
         return requesting_level >= minimum_level
 
 
+class TeamMemberAdminManagementPermission(BasePermission):
+    """
+    Require at least admin effective project access level for ALL methods, including reads.
+    """
+
+    message = "You don't have sufficient permissions in the project."
+
+    def has_permission(self, request, view) -> bool:
+        requesting_level = view.user_permissions.current_team.effective_membership_level
+        if requesting_level is None:
+            return False
+        return requesting_level >= OrganizationMembership.Level.ADMIN
+
+
 class IsStaffUser(IsAdminUser):
     message = "You are not a staff user, contact your instance admin."
 

--- a/posthog/temporal/data_imports/sources/bing_ads/client.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/client.py
@@ -135,6 +135,7 @@ class BingAdsClient:
         the user's own customer (from ``GetUser``) is flagged ``is_primary``.
         """
         primary_customer_id = self.get_customer_id()
+        original_customer_id = self.authorization_data.customer_id
         try:
             service_client = ServiceClient(
                 service="CustomerManagementService",
@@ -143,7 +144,8 @@ class BingAdsClient:
                 environment=ENVIRONMENT,
             )
 
-            customers = service_client.GetCustomersInfo(CustomerNameFilter="", TopN=100)
+            # 1000 is Microsoft's documented maximum for GetCustomersInfo.
+            customers = service_client.GetCustomersInfo(CustomerNameFilter="", TopN=1000)
 
             accounts: list[dict[str, Any]] = []
             for customer in getattr(customers, "CustomerInfo", None) or []:
@@ -156,7 +158,7 @@ class BingAdsClient:
                             "id": account.Id,
                             "number": getattr(account, "Number", None),
                             "name": getattr(account, "Name", None),
-                            "status": str(getattr(account, "AccountLifeCycleStatus", None)),
+                            "status": getattr(account, "AccountLifeCycleStatus", None) or "Unknown",
                             "customer_id": customer.Id,
                             "customer_name": getattr(customer, "Name", None),
                             "is_primary": customer.Id == primary_customer_id,
@@ -164,6 +166,9 @@ class BingAdsClient:
                     )
         except Exception as e:
             raise _wrap_with_fault_detail(e, "Failed to list Bing Ads accounts") from e
+        finally:
+            # Restore the shared scope so a later sync on this client isn't left pointed at the last customer.
+            self.authorization_data.customer_id = original_customer_id
 
         return accounts
 

--- a/posthog/temporal/data_imports/sources/bing_ads/client.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/client.py
@@ -126,6 +126,47 @@ class BingAdsClient:
 
         return self._customer_id
 
+    def list_accounts(self) -> list[dict[str, Any]]:
+        """List every Bing Ads account the connected user can access, across all their customers.
+
+        A user can belong to more than one customer (e.g. an agency managing several advertisers),
+        and ``GetAccountsInfo`` is scoped to a single customer — so enumerate the customers first
+        (``GetCustomersInfo``) and collect each one's accounts. The account whose customer matches
+        the user's own customer (from ``GetUser``) is flagged ``is_primary``.
+        """
+        primary_customer_id = self.get_customer_id()
+        try:
+            service_client = ServiceClient(
+                service="CustomerManagementService",
+                version=13,
+                authorization_data=self.authorization_data,
+                environment=ENVIRONMENT,
+            )
+
+            customers = service_client.GetCustomersInfo(CustomerNameFilter="", TopN=100)
+
+            accounts: list[dict[str, Any]] = []
+            for customer in getattr(customers, "CustomerInfo", None) or []:
+                # GetAccountsInfo reads the customer from authorization_data, so scope it per customer.
+                self.authorization_data.customer_id = customer.Id
+                result = service_client.GetAccountsInfo(CustomerId=customer.Id, OnlyParentAccounts=False)
+                for account in getattr(result, "AccountInfo", None) or []:
+                    accounts.append(
+                        {
+                            "id": account.Id,
+                            "number": getattr(account, "Number", None),
+                            "name": getattr(account, "Name", None),
+                            "status": str(getattr(account, "AccountLifeCycleStatus", None)),
+                            "customer_id": customer.Id,
+                            "customer_name": getattr(customer, "Name", None),
+                            "is_primary": customer.Id == primary_customer_id,
+                        }
+                    )
+        except Exception as e:
+            raise _wrap_with_fault_detail(e, "Failed to list Bing Ads accounts") from e
+
+        return accounts
+
     def get_campaigns(self, account_id: int, customer_id: int) -> Generator[list[dict[str, Any]]]:
         self.authorization_data.account_id = account_id
         self.authorization_data.customer_id = customer_id

--- a/posthog/temporal/data_imports/sources/bing_ads/source.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/source.py
@@ -125,6 +125,13 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
             fields=cast(
                 list[FieldType],
                 [
+                    # OAuth first: the account dropdown below is populated from this integration.
+                    SourceFieldOauthConfig(
+                        name="bing_ads_integration_id",
+                        label="Bing Ads account",
+                        required=True,
+                        kind="bing-ads",
+                    ),
                     SourceFieldInputConfig(
                         name="account_id",
                         label="Account ID",
@@ -132,12 +139,6 @@ class BingAdsSource(ResumableSource[BingAdsSourceConfig, BingAdsResumeConfig], O
                         required=True,
                         placeholder="",
                         secret=False,
-                    ),
-                    SourceFieldOauthConfig(
-                        name="bing_ads_integration_id",
-                        label="Bing Ads account",
-                        required=True,
-                        kind="bing-ads",
                     ),
                 ],
             ),

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
@@ -94,6 +94,60 @@ class TestBingAdsClient:
         mock_client_instance.GetUser.assert_called_once_with(UserId=None)
 
     @mock.patch("posthog.temporal.data_imports.sources.bing_ads.client.ServiceClient")
+    def test_list_accounts_across_customers_flags_primary(self, mock_service_client):
+        instance = mock_service_client.return_value
+        instance.GetUser.return_value = mock.MagicMock(User=mock.MagicMock(CustomerId=111))
+        instance.GetCustomersInfo.return_value = mock.MagicMock(
+            CustomerInfo=[
+                mock.MagicMock(Id=111, Name="Primary Co"),
+                mock.MagicMock(Id=222, Name="Other Co"),
+            ]
+        )
+
+        def accounts_for(CustomerId, OnlyParentAccounts):
+            if CustomerId == 111:
+                account = mock.MagicMock(Id=1, Number="A1", Name="Acc 1", AccountLifeCycleStatus="Active")
+            else:
+                account = mock.MagicMock(Id=2, Number="B2", Name="Acc 2", AccountLifeCycleStatus="Pause")
+            return mock.MagicMock(AccountInfo=[account])
+
+        instance.GetAccountsInfo.side_effect = accounts_for
+
+        client = BingAdsClient(self.access_token, self.refresh_token, self.developer_token)
+        result = client.list_accounts()
+
+        assert result == [
+            {
+                "id": 1,
+                "number": "A1",
+                "name": "Acc 1",
+                "status": "Active",
+                "customer_id": 111,
+                "customer_name": "Primary Co",
+                "is_primary": True,
+            },
+            {
+                "id": 2,
+                "number": "B2",
+                "name": "Acc 2",
+                "status": "Pause",
+                "customer_id": 222,
+                "customer_name": "Other Co",
+                "is_primary": False,
+            },
+        ]
+
+    @mock.patch("posthog.temporal.data_imports.sources.bing_ads.client.ServiceClient")
+    def test_list_accounts_wraps_soap_fault(self, mock_service_client):
+        instance = mock_service_client.return_value
+        instance.GetUser.return_value = mock.MagicMock(User=mock.MagicMock(CustomerId=111))
+        instance.GetCustomersInfo.side_effect = _make_webfault("Server raised fault: 'Invalid client data.'", None)
+
+        client = BingAdsClient(self.access_token, self.refresh_token, self.developer_token)
+        with pytest.raises(ValueError, match="Failed to list Bing Ads accounts"):
+            client.list_accounts()
+
+    @mock.patch("posthog.temporal.data_imports.sources.bing_ads.client.ServiceClient")
     def test_get_customer_id_preserves_underlying_exception_details(self, mock_service_client):
         """Underlying exception's class name and message must be embedded in the raised ValueError so
         the retry framework can selectively match auth-related substrings as non-retryable while

--- a/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
+++ b/posthog/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
@@ -108,7 +108,8 @@ class TestBingAdsClient:
             if CustomerId == 111:
                 account = mock.MagicMock(Id=1, Number="A1", Name="Acc 1", AccountLifeCycleStatus="Active")
             else:
-                account = mock.MagicMock(Id=2, Number="B2", Name="Acc 2", AccountLifeCycleStatus="Pause")
+                # A missing status falls back to "Unknown" rather than the literal string "None".
+                account = mock.MagicMock(Id=2, Number="B2", Name="Acc 2", AccountLifeCycleStatus=None)
             return mock.MagicMock(AccountInfo=[account])
 
         instance.GetAccountsInfo.side_effect = accounts_for
@@ -130,12 +131,14 @@ class TestBingAdsClient:
                 "id": 2,
                 "number": "B2",
                 "name": "Acc 2",
-                "status": "Pause",
+                "status": "Unknown",
                 "customer_id": 222,
                 "customer_name": "Other Co",
                 "is_primary": False,
             },
         ]
+        # Per-customer scoping must not leak onto the shared authorization_data after the call.
+        assert client.authorization_data.customer_id is None
 
     @mock.patch("posthog.temporal.data_imports.sources.bing_ads.client.ServiceClient")
     def test_list_accounts_wraps_soap_fault(self, mock_service_client):

--- a/products/data_warehouse/frontend/shared/components/forms/BingAdsAccountSelector.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/BingAdsAccountSelector.tsx
@@ -1,0 +1,151 @@
+import { useActions, useValues } from 'kea'
+import { FormContext } from 'kea-forms'
+import { useContext, useEffect, useMemo } from 'react'
+
+import { LemonInput, LemonTag } from '@posthog/lemon-ui'
+
+import { bingAdsIntegrationLogic } from 'lib/integrations/bingAdsIntegrationLogic'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { InputSuggestion, InputWithSuggestionsDropdown } from './InputWithSuggestionsDropdown'
+
+const ACCOUNT_ID_PLACEHOLDER = 'Numeric Bing Ads Account ID'
+
+/**
+ * Renders the Bing Ads `account_id` field as a dropdown of the connected integration's
+ * accessible accounts, so the user picks the numeric Account ID instead of typing it.
+ *
+ * Falls back to a plain text input before the user picks an OAuth account (or when the
+ * form's stored integration ID points at a stale integration), so the field stays usable
+ * while the integration choice above is being fixed.
+ *
+ * Works in both contexts that render this field:
+ *   - The new-source wizard (`sourceWizardLogic`, form key `sourceConnectionDetails`)
+ *   - The existing-source Config tab (`sourceSettingsLogic`, form key `sourceConfig`)
+ *
+ * We read the OAuth integration ID via `FormContext` from kea-forms instead of binding
+ * directly to a specific logic, so this stays decoupled from which scene renders it.
+ */
+export function BingAdsAccountSelector(): JSX.Element {
+    // FormContext.logic is set whenever this field renders inside a kea <Form> (both the
+    // new-source wizard and the existing-source config tab do). Only mount the hook-using
+    // inner component when it's present, so we never pass a null logic into useValues — and
+    // calling the hook conditionally here would itself violate the rules of hooks.
+    const formContext = useContext(FormContext)
+    if (!formContext.logic) {
+        return <AccountIdTextField />
+    }
+    return <BingAdsAccountSelectorInner formLogic={formContext.logic} formKey={formContext.formKey} />
+}
+
+function BingAdsAccountSelectorInner({ formLogic, formKey }: { formLogic: any; formKey: string }): JSX.Element {
+    const integrationId = useFormIntegrationId(formLogic, formKey)
+    const { integrations, integrationsLoading } = useValues(integrationsLogic)
+
+    const integrationIsValid = useMemo(() => {
+        if (!integrationId || integrationsLoading || !integrations) {
+            return false
+        }
+        return integrations.some((integration) => integration.id === integrationId && integration.kind === 'bing-ads')
+    }, [integrationId, integrations, integrationsLoading])
+
+    if (integrationIsValid && integrationId) {
+        return <BingAdsAccountFieldWithDropdown integrationId={integrationId} />
+    }
+
+    return <AccountIdTextField />
+}
+
+function AccountIdTextField(): JSX.Element {
+    return (
+        <LemonField name="account_id" label="Account ID">
+            {({ value, onChange }) => (
+                <LemonInput
+                    className="ph-ignore-input"
+                    data-attr="account_id"
+                    placeholder={ACCOUNT_ID_PLACEHOLDER}
+                    type="text"
+                    value={value || ''}
+                    onChange={onChange}
+                />
+            )}
+        </LemonField>
+    )
+}
+
+function useFormIntegrationId(formLogic: any, formKey: string): number | undefined {
+    // formLogic is guaranteed non-null by the caller, so useValues always runs with a valid logic.
+    const values = useValues(formLogic) as Record<string, any> | null
+    if (!values) {
+        return undefined
+    }
+    // Coerce to number — when the form is hydrated from a saved source's `job_inputs`
+    // the integration ID arrives as a string from JSONB. Without the cast, downstream
+    // `integration.id === id` lookups in `integrationsLogic` silently miss the match.
+    const raw = values[formKey]?.payload?.bing_ads_integration_id
+    const id = raw === undefined || raw === null || raw === '' ? undefined : Number(raw)
+    return id && Number.isFinite(id) ? id : undefined
+}
+
+function BingAdsAccountFieldWithDropdown({ integrationId }: { integrationId: number }): JSX.Element {
+    const { accounts, accountsLoading } = useValues(bingAdsIntegrationLogic({ id: integrationId }))
+    const { loadAccounts } = useActions(bingAdsIntegrationLogic({ id: integrationId }))
+
+    useEffect(() => {
+        loadAccounts()
+    }, [loadAccounts])
+
+    const suggestions = useMemo<InputSuggestion[]>(() => {
+        const sorted = [...accounts].sort((a, b) => Number(b.is_primary) - Number(a.is_primary))
+        return sorted.map((account) => {
+            const name = account.name ?? 'Unnamed account'
+            return {
+                // Persist the numeric id, not the alphanumeric `number` — that's what the backend expects.
+                value: String(account.id),
+                label: (
+                    <div className="flex items-center gap-2">
+                        <span>
+                            {name} ({account.id})
+                        </span>
+                        {account.is_primary && <LemonTag type="primary">Primary</LemonTag>}
+                        <LemonTag type="muted">{account.status}</LemonTag>
+                    </div>
+                ),
+                searchText: `${name} ${account.id} ${account.number ?? ''}`,
+            }
+        })
+    }, [accounts])
+
+    return (
+        <LemonField name="account_id" label="Account ID">
+            {({ value, onChange }) => {
+                const accountIds = accounts.map((account) => String(account.id))
+                const savedValueMissing =
+                    !!value && !accountsLoading && accounts.length > 0 && !accountIds.includes(String(value))
+                return (
+                    <div className="flex flex-col gap-2">
+                        <InputWithSuggestionsDropdown
+                            data-attr="account_id"
+                            placeholder={ACCOUNT_ID_PLACEHOLDER}
+                            value={value || ''}
+                            onChange={onChange}
+                            suggestions={suggestions}
+                            suggestionsLoading={accountsLoading}
+                            searchPlaceholder="Filter accounts…"
+                            emptyMessage="No accounts accessible by this integration."
+                            loadingMessage="Loading from Bing…"
+                        />
+                        {savedValueMissing && (
+                            <p className="m-0 text-xs text-warning">
+                                The currently saved Account ID <code>{value}</code> isn't in the accessible list for the
+                                connected Bing Ads account. Save anyway if you know it's correct, or pick a different
+                                one from the list.
+                            </p>
+                        )}
+                    </div>
+                )
+            }}
+        </LemonField>
+    )
+}

--- a/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/InputWithSuggestionsDropdown.tsx
@@ -1,9 +1,29 @@
-import { useMemo, useState } from 'react'
+import { ReactNode, useMemo, useState } from 'react'
 
 import { IconCheck } from '@posthog/icons'
 import { LemonButton, LemonInput, Spinner } from '@posthog/lemon-ui'
 
 import { Popover } from 'lib/lemon-ui/Popover/Popover'
+
+/**
+ * A suggestion is either a plain string (shown verbatim, and copied into `value` on click) or a
+ * rich entry where the value stored differs from what's displayed — e.g. show "Account name (id)"
+ * but store just the id. `searchText` is what the filter matches against (defaults to `value`).
+ */
+export type InputSuggestion = string | { value: string; label: ReactNode; searchText?: string }
+
+interface NormalizedSuggestion {
+    value: string
+    label: ReactNode
+    searchText: string
+}
+
+function normalizeSuggestion(suggestion: InputSuggestion): NormalizedSuggestion {
+    if (typeof suggestion === 'string') {
+        return { value: suggestion, label: suggestion, searchText: suggestion }
+    }
+    return { value: suggestion.value, label: suggestion.label, searchText: suggestion.searchText ?? suggestion.value }
+}
 
 export interface InputWithSuggestionsDropdownProps {
     /** Current value of the input. Free text — user can type anything, suggestions are only hints. */
@@ -11,8 +31,9 @@ export interface InputWithSuggestionsDropdownProps {
     onChange: (next: string) => void
     placeholder?: string
     'data-attr'?: string
-    /** Suggestions to surface in the popover. Each value is shown verbatim and copied into `value` on click. */
-    suggestions: string[]
+    /** Suggestions to surface in the popover. Plain strings, or `{ value, label, searchText }` when the
+     * stored value differs from the displayed label. Clicking one copies its `value` into the input. */
+    suggestions: InputSuggestion[]
     suggestionsLoading?: boolean
     /** Search input placeholder inside the popover. */
     searchPlaceholder?: string
@@ -50,13 +71,15 @@ export function InputWithSuggestionsDropdown({
     const [open, setOpen] = useState(false)
     const [searchTerm, setSearchTerm] = useState('')
 
+    const normalized = useMemo(() => suggestions.map(normalizeSuggestion), [suggestions])
+
     const filtered = useMemo(() => {
         const needle = searchTerm.trim().toLowerCase()
         if (!needle) {
-            return suggestions
+            return normalized
         }
-        return suggestions.filter((suggestion) => suggestion.toLowerCase().includes(needle))
-    }, [suggestions, searchTerm])
+        return normalized.filter((suggestion) => suggestion.searchText.toLowerCase().includes(needle))
+    }, [normalized, searchTerm])
 
     return (
         <Popover
@@ -87,21 +110,21 @@ export function InputWithSuggestionsDropdown({
                     ) : (
                         <div className="flex flex-col max-h-64 overflow-y-auto">
                             {filtered.map((suggestion) => {
-                                const isCurrent = suggestion === value
+                                const isCurrent = suggestion.value === value
                                 return (
                                     <LemonButton
-                                        key={suggestion}
+                                        key={suggestion.value}
                                         size="small"
                                         fullWidth
                                         active={isCurrent}
                                         icon={isCurrent ? <IconCheck /> : undefined}
                                         onClick={() => {
-                                            onChange(suggestion)
+                                            onChange(suggestion.value)
                                             setSearchTerm('')
                                             setOpen(false)
                                         }}
                                     >
-                                        {suggestion}
+                                        {suggestion.label}
                                     </LemonButton>
                                 )
                             })}

--- a/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/SourceForm.tsx
@@ -32,6 +32,7 @@ import {
     sourceWizardLogic,
 } from '../../../scenes/NewSourceScene/sourceWizardLogic'
 import { CDC_SOURCE_TYPES } from '../../cdc'
+import { BingAdsAccountSelector } from './BingAdsAccountSelector'
 import { CustomSourceManifestBuilder } from './CustomSourceManifestBuilder'
 import { GitHubRepositorySelector } from './GitHubRepositorySelector'
 import { GoogleSearchConsoleSiteSelector } from './GoogleSearchConsoleSiteSelector'
@@ -311,6 +312,12 @@ export const sourceFieldToElement = (
         // text input for a dropdown populated from the Search Console API. Avoids the
         // `sc-domain:` vs trailing-slash typos that bounce off `validate_credentials`.
         return <GoogleSearchConsoleSiteSelector key={field.name} />
+    }
+
+    if (field.name === 'account_id' && sourceConfig.name === 'BingAds') {
+        // Same pattern as Search Console above: swap the text input for an account dropdown so the
+        // user picks the numeric Account ID, not the alphanumeric Account Number (a common mistake).
+        return <BingAdsAccountSelector key={field.name} />
     }
 
     return (

--- a/products/integrations/frontend/generated/api.schemas.ts
+++ b/products/integrations/frontend/generated/api.schemas.ts
@@ -251,6 +251,37 @@ export interface PaginatedIntegrationConfigListApi {
     results: IntegrationConfigApi[]
 }
 
+export interface BingAdsAccountApi {
+    /** Numeric Bing Ads account ID. This is the value stored in the source config and used for all API calls. */
+    id: number
+    /**
+     * Alphanumeric account number shown in the Microsoft Advertising UI (e.g. 'F11034B5'). Display only — not the value used for API calls.
+     * @nullable
+     */
+    number: string | null
+    /**
+     * Human-readable account name.
+     * @nullable
+     */
+    name: string | null
+    /** Account lifecycle status reported by Microsoft (e.g. 'Active', 'Pause'). */
+    status: string
+    /** Numeric ID of the customer (Microsoft Advertising manager) that owns this account. */
+    customer_id: number
+    /**
+     * Name of the owning customer.
+     * @nullable
+     */
+    customer_name: string | null
+    /** True when this account belongs to the connected user's own (primary) customer, rather than another customer they merely have access to. */
+    is_primary: boolean
+}
+
+export interface BingAdsAccountsResponseApi {
+    /** All Bing Ads accounts the connected Microsoft account can access, across every customer. */
+    accounts: BingAdsAccountApi[]
+}
+
 export interface SlackChannelApi {
     /** Slack channel ID (e.g. C0123ABC) — pass to cdp-functions inputs.channel. */
     id: string

--- a/products/integrations/frontend/generated/api.ts
+++ b/products/integrations/frontend/generated/api.ts
@@ -9,6 +9,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    BingAdsAccountsResponseApi,
     GitHubBranchesResponseApi,
     GitHubReposRefreshResponseApi,
     GitHubReposResponseApi,
@@ -281,6 +282,24 @@ export const integrationsAnthropicManagedAgentsRetrieve = async (
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getIntegrationsAnthropicManagedAgentsRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getIntegrationsBingAdsAccountsRetrieveUrl = (projectId: string, id: number) => {
+    return `/api/projects/${projectId}/integrations/${id}/bing_ads_accounts/`
+}
+
+/**
+ * List the Bing Ads accounts the connected Microsoft account can access, across all customers.
+ */
+export const integrationsBingAdsAccountsRetrieve = async (
+    projectId: string,
+    id: number,
+    options?: RequestInit
+): Promise<BingAdsAccountsResponseApi> => {
+    return apiMutator<BingAdsAccountsResponseApi>(getIntegrationsBingAdsAccountsRetrieveUrl(projectId, id), {
         ...options,
         method: 'GET',
     })

--- a/products/integrations/mcp/tools.yaml
+++ b/products/integrations/mcp/tools.yaml
@@ -55,6 +55,9 @@ tools:
     integrations-authorize-retrieve:
         operation: integrations_authorize_retrieve
         enabled: false
+    integrations-bing-ads-accounts-retrieve:
+        operation: integrations_bing_ads_accounts_retrieve
+        enabled: false
     integrations-channels-retrieve:
         operation: integrations_channels_retrieve
         enabled: true

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11430,6 +11430,37 @@ export namespace Schemas {
       BigQuery: 'BigQuery',
     } as const;
 
+    export interface BingAdsAccount {
+      /** Numeric Bing Ads account ID. This is the value stored in the source config and used for all API calls. */
+      id: number;
+      /**
+         * Alphanumeric account number shown in the Microsoft Advertising UI (e.g. 'F11034B5'). Display only — not the value used for API calls.
+         * @nullable
+         */
+      number: string | null;
+      /**
+         * Human-readable account name.
+         * @nullable
+         */
+      name: string | null;
+      /** Account lifecycle status reported by Microsoft (e.g. 'Active', 'Pause'). */
+      status: string;
+      /** Numeric ID of the customer (Microsoft Advertising manager) that owns this account. */
+      customer_id: number;
+      /**
+         * Name of the owning customer.
+         * @nullable
+         */
+      customer_name: string | null;
+      /** True when this account belongs to the connected user's own (primary) customer, rather than another customer they merely have access to. */
+      is_primary: boolean;
+    }
+
+    export interface BingAdsAccountsResponse {
+      /** All Bing Ads accounts the connected Microsoft account can access, across every customer. */
+      accounts: BingAdsAccount[];
+    }
+
     export interface BlastRadius {
       /** Number of users matching the filters */
       affected: number;


### PR DESCRIPTION
## Problem

The Bing Ads source asked for the Account ID as free text, but Microsoft shows both a numeric **Account ID** and an alphanumeric **Account Number** — entering the Number by mistake breaks the sync with an opaque error. An account can also belong to more than one customer (agencies), so the right ID isn't obvious.

## Changes

- **Backend:** `BingAdsClient.list_accounts()` enumerates the user's customers (`GetCustomersInfo`) and collects each customer's accounts (`GetAccountsInfo`), flagging the user's own customer as `is_primary`. Exposed via a read-only `bing_ads_accounts` action on `IntegrationViewSet` (cached 60s, gated like the Search Console one to avoid info disclosure).
- **Frontend:** the Bing `account_id` field becomes an account picker once the OAuth integration is connected — it lists accessible accounts and stores the numeric ID. Fields reordered so the integration comes first (the dropdown depends on it).
- **Reuse:** generalized the shared `InputWithSuggestionsDropdown` (Search Console's) to accept rich suggestions `{value, label, searchText}` alongside plain strings, keeping it backward compatible. Bing uses it to show "name (id)" with Primary/status badges while storing only the id, and still allows free-text entry.

## How did you test this code?

I'm an agent.

- Backend unit tests (`list_accounts` iterates customers + sets `is_primary`; wraps `WebFault`). Client suite green (12 passed). `ruff` + `mypy` clean.
- Validated against a real Bing Ads account in local dev: the endpoint returns accounts across customers with the right `is_primary`; the picker loads, filters and stores the numeric ID. Frontend types come from `build:openapi`; the kea `*Type` regenerates in the dev stack / CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The frontend was prototyped by the author; refined to show the numeric ID (not the Number), allow free text, and reuse the shared dropdown instead of duplicating. Confirmed the SDK methods (`GetCustomersInfo`/`GetAccountsInfo`) with direct probes before coding. Invoked `/improving-drf-endpoints` for the endpoint and adopted the generated client/type instead of hand-written typing.


<img width="1298" height="198" alt="Screenshot 2026-06-23 at 10 22 53 PM" src="https://github.com/user-attachments/assets/b5b532e2-1625-4403-9ae4-d11644da5ad6" />
<img width="802" height="534" alt="Screenshot 2026-06-23 at 10 21 49 PM" src="https://github.com/user-attachments/assets/23b693fa-8dc4-4211-8ec8-934d8cc4efaa" />

