### PR TITLE
fix(logs): show error state in drop-rule preview instead of infinite spinner

### DIFF
--- a/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import { useMemo } from 'react'
 
-import { LemonInput, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+import { LemonButton, LemonInput, LemonSegmentedButton, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
 
 import { dataColorVars } from 'lib/colors'
 import { Sparkline, SparklineReferenceLine, SparklineTimeSeries } from 'lib/components/Sparkline'
@@ -106,7 +106,7 @@ function formatBytes(bytes: number): string {
 
 export function LogsSamplingForm(): JSX.Element {
     const { samplingForm, samplingFormErrors, filterPreview, filterPreviewLoading } = useValues(logsSamplingFormLogic)
-    const { setSamplingFormValue } = useActions(logsSamplingFormLogic)
+    const { setSamplingFormValue, refreshFilterPreview } = useActions(logsSamplingFormLogic)
 
     const isRateLimit = samplingForm.rule_type === RuleTypeEnumApi.RateLimit
     const hasFilters = samplingForm.filter_group.values.length > 0
@@ -224,7 +224,7 @@ export function LogsSamplingForm(): JSX.Element {
                             <div className="h-full flex items-center justify-center text-muted text-xs">
                                 Add a filter above to preview matching log volume
                             </div>
-                        ) : filterPreviewLoading || !filterPreview ? (
+                        ) : filterPreviewLoading ? (
                             <Sparkline
                                 data={[]}
                                 labels={[]}
@@ -232,6 +232,13 @@ export function LogsSamplingForm(): JSX.Element {
                                 className="w-full h-full"
                                 maximumIndicator={false}
                             />
+                        ) : !filterPreview ? (
+                            <div className="h-full flex flex-col gap-1 items-center justify-center text-muted text-xs">
+                                <span>Couldn't load the volume preview.</span>
+                                <LemonButton size="xsmall" type="secondary" onClick={() => refreshFilterPreview()}>
+                                    Retry
+                                </LemonButton>
+                            </div>
                         ) : series.length === 0 ? (
                             <div className="h-full flex items-center justify-center text-muted text-xs">
                                 No logs match these filters in the last 24h

--- a/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
+++ b/products/logs/frontend/components/LogsSampling/LogsSamplingForm.tsx
@@ -235,7 +235,7 @@ export function LogsSamplingForm(): JSX.Element {
                         ) : !filterPreview ? (
                             <div className="h-full flex flex-col gap-1 items-center justify-center text-muted text-xs">
                                 <span>Couldn't load the volume preview.</span>
-                                <LemonButton size="xsmall" type="secondary" onClick={() => refreshFilterPreview()}>
+                                <LemonButton size="xsmall" type="secondary" onClick={refreshFilterPreview}>
                                     Retry
                                 </LemonButton>
                             </div>


### PR DESCRIPTION
## Problem

The drop-rule "Volume preview by service" panel sometimes spins forever. The panel rendered its loading sparkline whenever `filterPreview` was null — but that's also the state after the preview query **fails or times out** (the kea loader sets `loading=false` but leaves the value `null`). A failed preview was therefore visually indistinguishable from "still loading" and never recovered.

This is most visible for **rate-limit rules** (bytes mode), whose `sum(_bytes_uncompressed)` query isn't projection-accelerated and can hit the query timeout on very high-volume services.

## Changes

Split the render branch in `LogsSamplingForm.tsx`:
- show the loading sparkline **only while `filterPreviewLoading`**;
- when the load finished but `filterPreview` is still null (i.e. it failed), show a short error message with a **Retry** button that re-runs the preview.

`filterPreviewLoading` is `true` for the entire request (set on dispatch, before the debounce), so `!loading && !filterPreview` uniquely means "failed" — no new kea state or typegen change was needed.

## How did you test this code?

I'm an agent (PostHog Code). No automated tests were added — this is a small render-branch change in a component with no existing test file. Verified by reading the loader/render flow: the only state where `!filterPreviewLoading && !filterPreview` holds (with filters present) is after a failed load, since `afterMount` triggers the load and the loader sets `loading=true` synchronously on dispatch. Manual UI verification of the error/retry path is still worth doing in the preview build.

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to an investigation into the drop-rule volume preview. Root-caused the "infinite spinner" to a frontend render condition that conflated "loading" with "failed". This PR is the user-facing fix; a companion PR lowers the backend sparkline query timeout so failures surface faster. Kept the change to the component only (no kea reducer / generated-type churn) by relying on the loader's existing `loading` semantics.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
