### PR TITLE
fix(logs): fail fast on slow drop-rule volume preview query

### DIFF
--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -1,10 +1,12 @@
 from posthog.schema import LogsSparklineBreakdownBy
 
 from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
 from posthog.clickhouse.client.connection import Workload
+from posthog.models.filters.mixins.utils import cached_property
 
 from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunner
 
@@ -16,8 +18,22 @@ BREAKDOWN_DB_FIELD: dict[LogsSparklineBreakdownBy, str] = {
 
 DEFAULT_BREAKDOWN = LogsSparklineBreakdownBy.SEVERITY
 
+# The volume preview must return quickly or fail clearly. Its bytes breakdown sums
+# `_bytes_uncompressed`, which the minute-aggregate projection doesn't cover, so a
+# high-volume service can fall back to a full table scan. Cap execution well below the
+# 60s default so a slow preview surfaces an error promptly instead of appearing to hang.
+SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS = 30
+
 
 class SparklineQueryRunner(LogsQueryRunner):
+    @cached_property
+    def settings(self) -> HogQLGlobalSettings:
+        return HogQLGlobalSettings(
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
+            max_execution_time=SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS,
+        )
+
     def _calculate(self) -> LogsQueryResponse:
         response = execute_hogql_query(
             query_type="LogsQuery",

--- a/products/logs/backend/sparkline_query_runner.py
+++ b/products/logs/backend/sparkline_query_runner.py
@@ -28,11 +28,11 @@ SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS = 30
 class SparklineQueryRunner(LogsQueryRunner):
     @cached_property
     def settings(self) -> HogQLGlobalSettings:
-        return HogQLGlobalSettings(
-            max_bytes_to_read=None,
-            read_overflow_mode=None,
-            max_execution_time=SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS,
-        )
+        # Inherit LogsQueryRunner's distributed-logs settings — including the
+        # allow_experimental_object_type / allow_experimental_join_condition / transform_null_in
+        # bug-workaround flags it sets to False — and only tighten the execution timeout. Building
+        # a fresh HogQLGlobalSettings here would silently re-enable those buggy defaults.
+        return super().settings.model_copy(update={"max_execution_time": SPARKLINE_PREVIEW_MAX_EXECUTION_SECONDS})
 
     def _calculate(self) -> LogsQueryResponse:
         response = execute_hogql_query(


### PR DESCRIPTION
## Problem

The drop-rule volume preview can take ~60s to error on high-volume services, which (combined with the frontend bug fixed in the companion PR) presents as an infinite spinner. The sparkline runner inherits the default 60s ClickHouse `max_execution_time`. Its **bytes** breakdown (rate-limit rules) sums `_bytes_uncompressed`, which the logs minute-aggregate projection does **not** cover (`projection_aggregate_counts` only materializes `count()`), so a busy service falls back to a full scan and runs near that 60s ceiling before failing.

## Changes

Override `settings` in `SparklineQueryRunner` to cap `max_execution_time` at 30s. A preview that can't complete in 30s now errors promptly, and the companion frontend PR renders that error with a retry button instead of spinning.

This affects the sparkline endpoint (drop-rule preview and the logs-viewer sparkline) — both are meant to be quick visualizations, so a 30s ceiling is comfortably above normal and well below the previous 60s.

## How did you test this code?

I'm an agent (PostHog Code). No automated test added — this is a query-setting override with no behavior change other than the timeout ceiling; `uv run ty check` passed via lint-staged. The timeout path itself is hard to exercise deterministically in a unit test without a contrived slow query.

## Docs update

n/a

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

One of two follow-ups from investigating the drop-rule "infinite spinner". Considered adding `sum(_bytes_uncompressed)` to the logs minute projection so bytes-mode previews are projection-accelerated (the real perf fix), but that's a heavier ClickHouse migration with only partial benefit (attribute-filtered rules still scan) and the prod logs tables are manually managed — left as a separate, larger follow-up. This PR is the small, safe fail-fast guard; the companion frontend PR surfaces the resulting error.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
