### PR TITLE
feat(query-performance): show full error in tooltip on hover

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -9,6 +9,7 @@ import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
@@ -238,7 +239,11 @@ export function QueryPerformance(): JSX.Element {
                 const preview = firstLine.length > 60 ? firstLine.slice(0, 60) + '…' : firstLine
                 return (
                     <div className="flex items-center gap-1 min-w-0">
-                        <LemonTag type="danger">Error</LemonTag>
+                        <Tooltip
+                            title={<span className="font-mono text-xs whitespace-pre-wrap">{item.exception}</span>}
+                        >
+                            <LemonTag type="danger">Error</LemonTag>
+                        </Tooltip>
                         <span className="font-mono text-xs text-danger truncate">{preview}</span>
                     </div>
                 )

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -238,14 +238,12 @@ export function QueryPerformance(): JSX.Element {
                 const firstLine = item.exception.split('\n')[0]
                 const preview = firstLine.length > 60 ? firstLine.slice(0, 60) + '…' : firstLine
                 return (
-                    <div className="flex items-center gap-1 min-w-0">
-                        <Tooltip
-                            title={<span className="font-mono text-xs whitespace-pre-wrap">{item.exception}</span>}
-                        >
+                    <Tooltip title={<span className="font-mono text-xs whitespace-pre-wrap">{item.exception}</span>}>
+                        <div className="flex items-center gap-1 min-w-0">
                             <LemonTag type="danger">Error</LemonTag>
-                        </Tooltip>
-                        <span className="font-mono text-xs text-danger truncate">{preview}</span>
-                    </div>
+                            <span className="font-mono text-xs text-danger truncate">{preview}</span>
+                        </div>
+                    </Tooltip>
                 )
             },
         },


### PR DESCRIPTION
## Problem

In the slowest queries table, the Status column truncates long error messages, so the full error isn't visible.

## Changes

Wrap the Error tag in a tooltip that shows the full exception on hover.

## How did you test this code?

Agent-authored. Verified the change renders via the existing scene; no automated tests added.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, directed to add a hover tooltip showing the full error in the query performance scene's Status column.
