### PR TITLE
feat(query-performance): show funnel order type in slowest queries metric tag

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -185,10 +185,14 @@ export function QueryPerformance(): JSX.Element {
         {
             title: 'Metric',
             render: function Metric(_, item) {
+                const metricTypeLabel =
+                    item.experiment_metric_type === 'funnel' && item.experiment_funnel_order_type
+                        ? `funnel:${item.experiment_funnel_order_type}`
+                        : item.experiment_metric_type
                 return (
                     <div className="flex items-center gap-1">
                         <span>{item.experiment_metric_name}</span>
-                        {item.experiment_metric_type && <LemonTag type="muted">{item.experiment_metric_type}</LemonTag>}
+                        {item.experiment_metric_type && <LemonTag type="muted">{metricTypeLabel}</LemonTag>}
                     </div>
                 )
             },

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -35,6 +35,7 @@ export interface SlowestQuery {
     experiment_query_surface: string
     experiment_precompute_table: string
     experiment_metric_type: string
+    experiment_funnel_order_type: string | null
     experiment_id: number | null
 }
 

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -418,6 +418,7 @@ class DebugCHQueries(viewsets.ViewSet):
                 argMax(JSONExtractString(log_comment, 'experiment_metric_name'), type) AS experiment_metric_name,
                 argMax(JSONExtractString(log_comment, 'experiment_execution_path'), type) AS experiment_execution_path,
                 argMax(JSONExtractString(log_comment, 'experiment_metric_type'), type) AS experiment_metric_type,
+                argMax(JSONExtractString(log_comment, 'experiment_funnel_order_type'), type) AS experiment_funnel_order_type,
                 argMax(JSONExtractInt(log_comment, 'experiment_id'), type) AS experiment_id,
                 argMax(JSONExtractString(log_comment, 'experiment_exposures_path'), type) AS experiment_exposures_path,
                 argMax(JSONExtractString(log_comment, 'experiment_metric_events_path'), type) AS experiment_metric_events_path,
@@ -478,11 +479,12 @@ class DebugCHQueries(viewsets.ViewSet):
                     "experiment_metric_name": row[9],
                     "experiment_execution_path": row[10],
                     "experiment_metric_type": row[11],
-                    "experiment_id": row[12] or None,
-                    "experiment_exposures_path": row[13],
-                    "experiment_metric_events_path": row[14],
-                    "experiment_query_surface": row[15],
-                    "experiment_precompute_table": row[16],
+                    "experiment_funnel_order_type": row[12] or None,
+                    "experiment_id": row[13] or None,
+                    "experiment_exposures_path": row[14],
+                    "experiment_metric_events_path": row[15],
+                    "experiment_query_surface": row[16],
+                    "experiment_precompute_table": row[17],
                 }
                 for row in response
             ]

--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -418,6 +418,7 @@ class QueryTags(BaseModel):
     experiment_metric_uuid: Optional[str] = None
     experiment_metric_name: Optional[str] = None
     experiment_metric_type: Optional[str] = None  # "mean", "funnel", "ratio", "retention"
+    experiment_funnel_order_type: Optional[str] = None  # funnel metrics only: "ordered", "unordered", "strict"
     # DEPRECATED: alias of experiment_exposures_path, kept so external tooling keeps working.
     experiment_execution_path: Optional[str] = None  # "direct_scan" or "precomputed"
     experiment_exposures_path: Optional[str] = None  # "direct_scan" or "precomputed"

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -434,6 +434,8 @@ class ExperimentQueryRunner(QueryRunner):
             experiment_metric_name=metric_name,
             experiment_metric_type=self.metric.metric_type,
         )
+        if isinstance(self.metric, ExperimentFunnelMetric):
+            tag_queries(experiment_funnel_order_type=self.metric.funnel_order_type or "ordered")
 
         experiment_query_ast = self._get_experiment_query()
 


### PR DESCRIPTION
## Problem

The slowest queries table on the query performance scene — an internal staff-only debugging tool, not a client-facing surface — tags every funnel metric as just `funnel`, hiding whether it's ordered, unordered, or strict, which matters because order type drives very different query shapes and costs.

## Changes

Funnel queries now carry an `experiment_funnel_order_type` tag through the query log to the API, and the metric column renders it as `funnel:ordered` / `funnel:unordered` / `funnel:strict`; the existing `experiment_metric_type` Prometheus label is left untouched. This only affects the internal query performance scene — no customer-facing behavior changes.

## How did you test this code?

I'm an agent. Ran `ruff format`/`ruff check` on the changed Python files and the frontend oxlint/oxfmt formatter — all clean. mypy couldn't run locally (missing `pkg_resources` in the venv breaks the Django plugin), so CI will cover type-checking. No automated tests added.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Threaded a new `experiment_funnel_order_type` tag through the stack: added the field to `QueryTags`, tagged it in `ExperimentQueryRunner` (defaulting `None` → `ordered`, matching existing funnel code), extracted it from `log_comment` in `debug_ch_queries.py`, and rendered the combined label in the frontend.

Chose to add a separate tag rather than overload `experiment_metric_type` (still `"funnel"`) because that field is also exported as a Prometheus label — encoding order type into it would change label cardinality and break existing dashboard filters. Only newly-logged queries get the tag; older rows fall back to plain `funnel`.