### PR TITLE
feat(auth): show session start time in web sessions list

### DIFF
--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3667,6 +3667,11 @@ export interface UserGitHubLinkStartResponseApi {
 export interface UserAuthSessionApi {
     /** Identifier used to revoke this login session. */
     readonly id: string
+    /**
+     * When this login session was first created — the original sign-in time.
+     * @nullable
+     */
+    readonly created_at: string | null
     /** When this login session last made a request (refreshed periodically). */
     readonly last_activity: string
     /** Approximate city and country derived from the IP address, if known. */

--- a/frontend/src/scenes/settings/user/LoginSessions.tsx
+++ b/frontend/src/scenes/settings/user/LoginSessions.tsx
@@ -85,9 +85,21 @@ export function LoginSessions(): JSX.Element {
                         render: (_, session) => session.login_method || <span className="text-muted">—</span>,
                     },
                     {
+                        title: 'Started',
+                        dataIndex: 'created_at',
+                        render: (_, session) =>
+                            session.created_at ? (
+                                humanFriendlyDetailedTime(session.created_at, 'MMMM DD, YYYY', 'h:mm A')
+                            ) : (
+                                <span className="text-muted">Unknown</span>
+                            ),
+                    },
+                    {
                         title: 'Last active',
                         dataIndex: 'last_activity',
-                        render: (_, session) => humanFriendlyDetailedTime(session.last_activity),
+                        // Minute precision: last_activity is throttled to ~5-min updates, so seconds would be false precision.
+                        render: (_, session) =>
+                            humanFriendlyDetailedTime(session.last_activity, 'MMMM DD, YYYY', 'h:mm A'),
                     },
                     {
                         title: '',

--- a/frontend/src/scenes/settings/user/LoginSessions.tsx
+++ b/frontend/src/scenes/settings/user/LoginSessions.tsx
@@ -85,7 +85,7 @@ export function LoginSessions(): JSX.Element {
                         render: (_, session) => session.login_method || <span className="text-muted">—</span>,
                     },
                     {
-                        title: 'Started',
+                        title: 'Started at',
                         dataIndex: 'created_at',
                         render: (_, session) =>
                             session.created_at ? (

--- a/posthog/api/test/test_user_auth_session.py
+++ b/posthog/api/test/test_user_auth_session.py
@@ -67,6 +67,26 @@ class TestUserAuthSessionAPI(APIBaseTest):
         self.assertEqual(sum(1 for s in data if s["is_current"]), 1)
         self.assertTrue(data[0]["is_current"])  # current session listed first
 
+    def test_list_includes_created_at_from_session_payload(self):
+        session = self._other_session()
+        store = self.engine.SessionStore(session_key=session.session_key)
+        store[settings.SESSION_COOKIE_CREATED_AT_KEY] = 1_700_000_000  # 2023-11-14T22:13:20+00:00
+        store.save()
+
+        data = self.client.get("/api/users/@me/login_sessions/").json()
+        entry = next(s for s in data if s["id"] == str(session_public_id(session.session_key)))
+
+        self.assertEqual(entry["created_at"], "2023-11-14T22:13:20+00:00")
+
+    def test_list_created_at_is_null_when_session_has_no_created_timestamp(self):
+        # _other_session() never runs through SessionAgeMiddleware, so it carries no created-at stamp.
+        session = self._other_session()
+
+        data = self.client.get("/api/users/@me/login_sessions/").json()
+        entry = next(s for s in data if s["id"] == str(session_public_id(session.session_key)))
+
+        self.assertIsNone(entry["created_at"])
+
     def test_list_excludes_sensitive_fields(self):
         self._other_session()
 

--- a/posthog/api/user.py
+++ b/posthog/api/user.py
@@ -797,6 +797,9 @@ class UserAuthSessionSerializer(serializers.ModelSerializer):
     """A cookie-auth login session shown on the user's 'Web sessions' screen."""
 
     id = serializers.SerializerMethodField(help_text="Identifier used to revoke this login session.")
+    created_at = serializers.SerializerMethodField(
+        help_text="When this login session was first created — the original sign-in time."
+    )
     last_activity = serializers.DateTimeField(
         read_only=True, help_text="When this login session last made a request (refreshed periodically)."
     )
@@ -817,12 +820,20 @@ class UserAuthSessionSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = Session
-        fields = ["id", "last_activity", "location", "device", "login_method", "is_current"]
+        fields = ["id", "created_at", "last_activity", "location", "device", "login_method", "is_current"]
 
     @extend_schema_field({"type": "string", "format": "uuid"})
     def get_id(self, obj: Session) -> str:
         # Expose a stable, opaque id derived from the session key — never the key itself.
         return str(session_public_id(obj.session_key))
+
+    @extend_schema_field({"type": "string", "format": "date-time", "nullable": True})
+    def get_created_at(self, obj: Session) -> str | None:
+        # The creation time lives in the encoded session payload, not a column.
+        created = obj.get_decoded().get(settings.SESSION_COOKIE_CREATED_AT_KEY)
+        if not created:
+            return None
+        return datetime.fromtimestamp(float(created), tz=UTC).isoformat()
 
     @extend_schema_field({"type": "boolean"})
     def get_is_current(self, obj: Session) -> bool:

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -50139,6 +50139,11 @@ export namespace Schemas {
     export interface UserAuthSession {
       /** Identifier used to revoke this login session. */
       readonly id: string;
+      /**
+         * When this login session was first created — the original sign-in time.
+         * @nullable
+         */
+      readonly created_at: string | null;
       /** When this login session last made a request (refreshed periodically). */
       readonly last_activity: string;
       /** Approximate city and country derived from the IP address, if known. */


### PR DESCRIPTION
Add a 'Started' column showing the session's original creation time, decoded from the session payload (session_created_at) since it isn't a column. Also show start/last-active to the minute, not the second — last_activity is throttled to ~5-minute updates, so seconds were false precision.


<img width="982" height="266" alt="Screenshot 2026-06-23 at 23 02 05" src="https://github.com/user-attachments/assets/3e506b6f-d351-4370-82c1-ecc0990b73e5" />
