### PR TITLE
chore(experiments): own query performance scene in codeowners-soft

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -175,6 +175,8 @@ frontend/src/scenes/settings/ @PostHog/team-growth
 frontend/src/scenes/organization/ @PostHog/team-growth
 frontend/src/scenes/project/ @PostHog/team-growth
 frontend/src/scenes/instance/ @PostHog/team-growth
+# ...except the query performance scene, owned by @PostHog/team-experiments
+frontend/src/scenes/instance/QueryPerformance/ @PostHog/team-experiments
 
 # Weekly digest - owned by @PostHog/team-growth
 posthog/temporal/weekly_digest @PostHog/team-growth


### PR DESCRIPTION
## Problem

`frontend/src/scenes/instance/QueryPerformance/` is soft-owned by team-growth via the broader `instance/` rule, but it's an experiments-owned scene.

## Changes

Add a sub-folder override in CODEOWNERS-soft assigning `frontend/src/scenes/instance/QueryPerformance/` to team-experiments.

## How did you test this code?

Agent-authored. No automated tests; CODEOWNERS-soft is non-blocking config. Verified the override is placed after the broader `instance/` rule so last-match-wins applies.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Added one line to `.github/CODEOWNERS-soft`. Takes effect once merged to master (the auto-assign workflow reads ownership from master).
