### PR TITLE
fix(experiments): set output_field when ordering experiments by created_by

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -10,7 +10,7 @@ from uuid import uuid4
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
-from django.db.models import Case, Count, F, Prefetch, Q, QuerySet, Value, When
+from django.db.models import Case, CharField, Count, F, Prefetch, Q, QuerySet, Value, When
 from django.db.models.functions import Coalesce, Now, NullIf
 from django.utils import timezone
 
@@ -2798,6 +2798,9 @@ class ExperimentService:
                     created_by_display=Coalesce(
                         NullIf(F("created_by__first_name"), Value("")),
                         F("created_by__email"),
+                        # first_name is a CharField and email an EmailField; Django refuses to
+                        # infer a type across the two, so set it explicitly.
+                        output_field=CharField(),
                     )
                 ).order_by(f"{prefix}created_by_display")
             else:


### PR DESCRIPTION
## Problem

Sorting the experiments list by the "Created by" column (`?order=created_by`) crashes the list endpoint with:

```
FieldError: Expression contains mixed types: CharField, EmailField. You must set output_field.
```

The `created_by` ordering annotates `Coalesce(NullIf(first_name, ''), email)` to mirror the frontend's `first_name || email` sorter. `first_name` is a `CharField` and `email` is an `EmailField`, and Django refuses to infer a single output type across the two — so every list request with this ordering 500s.

## Changes

Set `output_field=CharField()` on the `Coalesce` expression in `ExperimentService.filter_experiments_queryset`.

## How did you test this code?

I'm an agent. I traced the failure from the error tracking stack trace (`EnterpriseExperimentsViewSet.list` → `safely_get_queryset` → ordering annotation) to the unannotated `Coalesce`. No automated tests were added per the request. The fix is the standard Django remedy for mixed-type expressions; the surrounding ordering behavior is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at a maintainer's request to fix a recurring experiments error. Diagnosed via the PostHog error-tracking MCP — the `FieldError` fingerprint pointed at the `created_by` ordering branch of `filter_experiments_queryset`. Chose `output_field=CharField()` (both operands are string-like) over restructuring the expression.
