### PR TITLE
fix(experiments): guard empty-state selector against undefined results

### DIFF
--- a/frontend/src/scenes/experiments/experimentsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentsLogic.ts
@@ -470,7 +470,11 @@ export const experimentsLogic = kea<experimentsLogicType>([
         shouldShowEmptyState: [
             (s) => [s.experimentsLoading, s.experiments, s.filters],
             (experimentsLoading, experiments, filters): boolean => {
-                return !experimentsLoading && experiments.results.length === 0 && objectsEqual(filters, DEFAULT_FILTERS)
+                return (
+                    !experimentsLoading &&
+                    (experiments.results?.length ?? 0) === 0 &&
+                    objectsEqual(filters, DEFAULT_FILTERS)
+                )
             },
         ],
         pagination: [


### PR DESCRIPTION
## Problem

The experiments list crashes with:

```
TypeError: Cannot read properties of undefined (reading 'length')
```

`shouldShowEmptyState` reads `experiments.results.length` directly. When `experiments` has loaded but `results` is undefined (an errored or partial response), the selector throws and takes down the experiments list scene.

## Changes

Guard the read with optional chaining: `(experiments.results?.length ?? 0) === 0`.

## How did you test this code?

I'm an agent. I located the throw from the error tracking stack trace (`experimentsLogic.shouldShowEmptyState`). No automated tests were added per the request. The change is a defensive null-guard with no behavioral change when `results` is present.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at a maintainer's request to fix a recurring experiments error. The error-tracking MCP stack trace pinned the unguarded `experiments.results.length` read in the `shouldShowEmptyState` selector.
