### PR TITLE
fix(experiments): guard isLegacyExperiment against missing experiment

### DIFF
--- a/frontend/src/scenes/experiments/utils.ts
+++ b/frontend/src/scenes/experiments/utils.ts
@@ -720,7 +720,11 @@ export const isLegacyExperimentQuery = (query: unknown): query is ExperimentTren
  *
  * We should remove these legacy metrics once we've migrated all experiments to the new query runner.
  */
-export const isLegacyExperiment = ({ metrics, metrics_secondary, saved_metrics }: Experiment): boolean => {
+export const isLegacyExperiment = (experiment?: Experiment | null): boolean => {
+    if (!experiment) {
+        return false
+    }
+    const { metrics, metrics_secondary, saved_metrics } = experiment
     // saved_metrics has a different structure and so we need to check for it separately
     if ((saved_metrics ?? []).some(isLegacySharedMetric)) {
         return true


### PR DESCRIPTION
## Problem

The experiments scene throws:

```
TypeError: Cannot read properties of undefined (reading 'some')
```

inside `isLegacyExperiment`. The function destructured `{ metrics, metrics_secondary, saved_metrics }` straight off its argument, so a nullish `experiment` blows up before the `?? []` guards on the metric arrays can help. It's called from several detail-view components (`ExperimentView`, `ExperimentSceneMenuBar`, `PageHeader`, `RelatedExperimentsTable`) that can render before the experiment has loaded.

## Changes

Make the argument optional and return `false` early when no experiment is supplied. The metric-array reads keep their existing `?? []` guards.

## How did you test this code?

I'm an agent. The error-tracking stack trace pointed at `isLegacyExperiment`. I confirmed the metric `.some` calls were already `?? []`-guarded, leaving a nullish `experiment` argument as the remaining crash path, and guarded it. No automated tests were added per the request. Widening the parameter to `Experiment | null | undefined` is backwards compatible with all existing call sites.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at a maintainer's request to fix a recurring experiments error. Diagnosed via the PostHog error-tracking MCP. Note the experiments *list* table already renders the backend-computed `is_legacy` property rather than calling this function, so this hardening targets the detail-view call sites.
