### PR TITLE
fix(data-imports): skip schema discovery on unparseable source config

### DIFF
--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -65,7 +65,7 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             # double-encoded config fails identically on every discovery run - there is nothing
             # to retry. The per-schema sync path surfaces and disables the source on the same
             # config, so skip quietly here rather than spamming retries and error tracking.
-            logger.warning("Skipping schema discovery: source config could not be parsed")
+            logger.warning("Skipping schema discovery: source config could not be parsed", exc_info=True)
             return
 
         try:

--- a/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/sync_new_schemas.py
@@ -57,7 +57,17 @@ def sync_new_schemas_activity(inputs: SyncNewSchemasActivityInputs) -> None:
             return
 
         new_source = SourceRegistry.get_source(source_type_enum)
-        config = new_source.parse_config(source.job_inputs)
+
+        try:
+            config = new_source.parse_config(source.job_inputs)
+        except Exception:
+            # Config parsing is deterministic over the stored `job_inputs`, so a corrupt or
+            # double-encoded config fails identically on every discovery run - there is nothing
+            # to retry. The per-schema sync path surfaces and disables the source on the same
+            # config, so skip quietly here rather than spamming retries and error tracking.
+            logger.warning("Skipping schema discovery: source config could not be parsed")
+            return
+
         try:
             schemas = new_source.get_schemas(config, inputs.team_id)
         except Exception as e:

--- a/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
+++ b/posthog/temporal/data_imports/workflow_activities/tests/test_sync_new_schemas.py
@@ -58,3 +58,12 @@ def test_get_schemas_error_handling(error_msg, non_retryable, expected_exc):
     else:
         with pytest.raises(Exception, match=expected_exc):
             _run_activity(source_mock)
+
+
+def test_unparseable_config_is_skipped():
+    source_mock = mock.MagicMock()
+    source_mock.parse_config.side_effect = TypeError("Cannot build 'MySQLSourceConfig' from str; expected a mapping")
+
+    _run_activity(source_mock)
+
+    source_mock.get_schemas.assert_not_called()


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `TypeError: Cannot build 'MySQLSourceConfig' from str; expected a mapping` originating from the data-warehouse import pipeline's schema-discovery activity ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef83c-b341-77f1-a4a8-03fc590eb5e5)).

The trace bottoms out in `from_dict` (`sources/common/config.py`), reached via `parse_config` from `sync_new_schemas_activity`. The stored source config (`job_inputs`, an `EncryptedJSONField`) occasionally comes back as a JSON string instead of a mapping. `from_dict` deliberately fails fast on that with an actionable message — that behavior is intentional and stays.

The problem is *where* the failure lands: `sync_new_schemas_activity` called `parse_config` **outside** the `try/except` that already skips non-retryable discovery failures quietly. So an unparseable config crashed the discovery activity and re-fired on every scheduled discovery run, producing repeated identical exceptions.

## Changes

Wrap `parse_config` in `sync_new_schemas_activity` and skip discovery quietly when the config can't be parsed.

Config parsing is deterministic over the stored `job_inputs` (no I/O), so a corrupt/double-encoded config fails identically on every run — there is nothing to retry. This mirrors the activity's existing best-effort philosophy for non-retryable source errors. The per-schema sync path still surfaces and disables the source on the same config, so the user-facing signal is unchanged; this only stops the zombie discovery runs and the error-tracking noise.

Scope is deliberately narrow:
- `from_dict`'s fail-fast raise is untouched (and its existing test still passes).
- The main sync path and `get_non_retryable_errors` are untouched — no source gets disabled differently.

## How did you test this code?

I'm an agent. I added an automated regression test and ran it; I did not perform manual testing.

- New: `test_unparseable_config_is_skipped` asserts the activity returns without raising and never calls `get_schemas` when `parse_config` raises. Without the fix, the exception propagated out of the activity — no existing test covered the `parse_config` failure path (the existing tests only stubbed `parse_config` to succeed and exercised `get_schemas` errors).
- Ran `test_sync_new_schemas.py` (3 passed) and `sources/common/test/test_config.py` (56 passed) to confirm the `from_dict` contract is unchanged.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Pulled the issue's stack trace and sampled events via the PostHog MCP error-tracking tools, traced the call path through `sync_new_schemas_activity` → `parse_config` → `from_dict`, and confirmed against the code.

Key decision: this is a fixable bug (a *missing graceful-skip*), not a `NonRetryableErrors` extension. Recovering the double-encoded string was explicitly rejected — the maintainers' recent change made `from_dict` fail fast and added a test asserting even a valid-JSON dict-string must raise, so decoding it would contradict that intent and break that test. Adding the config-parse message to a source's `get_non_retryable_errors` was also rejected because that list also drives the main sync path (disabling sources), which is broader than this discovery-only issue. Scoping the guard to the discovery activity keeps the blast radius minimal.

No skills were applicable to this change. Checked open PRs (including the maintainer's own) for duplicates by exception type, message phrase, and module path — none address this.
