### PR TITLE
fix(mysql): treat table-level SELECT denied (1142) as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/source.py
+++ b/posthog/temporal/data_imports/sources/mysql/source.py
@@ -232,6 +232,13 @@ class MySQLSource(SQLSource[MySQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # egress / SSH-tunnel host) — retrying connects from the same host fails identically.
             # Match the stable tail phrase, not the volatile host in the message prefix.
             "is not allowed to connect to this MySQL server": "Your MySQL/MariaDB server isn't allowing connections from PostHog's host (error 1130). Ask your database admin to grant access for the connecting host (or allow our IP / SSH-tunnel host), then retry the sync.",
+            # MySQL/MariaDB error 1142 (ER_TABLEACCESS_DENIED_ERROR): the connecting user authenticated
+            # fine but lacks the SELECT privilege on a table the sync reads — distinct from the 1045
+            # login failure already handled above. Only a DB admin can GRANT it, and the streaming query
+            # reissues the same statement every attempt, so it fails identically forever. Match the
+            # locale-independent error code (the user, host, and table are volatile and the message text
+            # is translated on non-English servers), consistent with the other code-prefixed entries.
+            "(1142,": "PostHog's database user doesn't have SELECT permission on a table this sync reads (MySQL error 1142). Ask your database admin to grant SELECT on it, or remove that table from the sync, then resync.",
         }
 
     def reconcile_schema_metadata(

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -1321,6 +1321,25 @@ class TestMySQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            # Raw pymysql str(error) form the import/sync path classifies (`_handle_import_error`
+            # matches `str(error)`, which has no class-name prefix).
+            str(
+                pymysql.err.OperationalError(
+                    1142, "SELECT command denied to user 'reader'@'10.0.1.5' for table 'orders'"
+                )
+            ),
+            # Temporal-wrapped str(e.cause) form — different user/host/table, same stable code.
+            "OperationalError: (1142, \"SELECT command denied to user 'ro'@'10.0.1.5' for table 'events'\")",
+        ],
+    )
+    def test_table_access_denied_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"Table-access-denied error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             # A genuine transient connection drop (no SSL signature) must stay retryable.
             "OperationalError: (2013, 'Lost connection to MySQL server during query')",
             "Lost connection to MySQL server during query",


### PR DESCRIPTION
## Problem

A MySQL data-warehouse import surfaced an `OperationalError` from error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ef848-91c3-7f60-9528-91127c847670)):

```
(1142, "SELECT command denied to user '<redacted>'@'<redacted>' for table '<redacted>'")
```

The error is raised inside the MySQL source's streaming path (`mysql.py` `_stream_with_optional_force_index` → `get_rows`). MySQL/MariaDB error **1142** (`ER_TABLEACCESS_DENIED_ERROR`) means the connecting user authenticated fine but has no `SELECT` privilege on a table the sync reads. Only a DB admin can grant it, and the streaming query reissues the same statement on every attempt — so it fails identically forever.

It wasn't classified as non-retryable, so the sync retried to the maximum and the failure showed up as repeated error-tracking noise. This is a user/upstream config issue, not a bug in our code.

## Changes

Add a non-retryable entry to `MySQLSource.get_non_retryable_errors` matching the locale-independent error code `(1142,`, with a friendly message pointing the user at the missing `GRANT SELECT` (or to remove the table from the sync). This is distinct from the existing 1045 `"Access denied for user"` entry, which is the login/auth failure.

Matching on the error-code prefix mirrors the existing `(1146,` / `(1356,` / `(1054, "Unknown column` entries: it catches both the raw pymysql `str(exc)` form the import/sync path classifies and the class-name-prefixed `OperationalError: (1142, ...)` form, while keeping the volatile user/host/table out of the match.

## How did you test this code?

I'm an agent. I added a parametrized regression test (`test_table_access_denied_is_non_retryable`) covering both the raw pymysql `str(error)` form and the Temporal-wrapped `OperationalError: (1142, ...)` form, and ran the suite:

```
pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py::TestMySQLSourceNonRetryableErrors
# 26 passed
```

The new test catches the regression that a 1142 table-privilege error would otherwise be treated as retryable (no existing test exercises 1142 — the closest, 1045, is a different login-auth error). Also ran `ruff check` and `ruff format --check` on both files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the MySQL import source. Confirmed via the error-tracking MCP tools that the failure originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` (frames `_stream_with_optional_force_index` and `get_rows`), not just in serialized log context.

Decision: user/upstream error → extend `NonRetryableErrors` rather than change code behavior. A missing table grant is the customer's to fix; retrying can't help. Followed the Stripe source's `get_non_retryable_errors` pattern and the existing MySQL code-prefix convention. Matched the stable `(1142,` code, not the volatile user/host/table values. Checked open PRs (including the maintainer's) for a duplicate — the existing MySQL non-retryable PRs cover error 1038 and connect timeouts, unrelated.