### PR TITLE
feat(experiments): hide precompute sub-queries in query performance

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -39,6 +39,7 @@ export function QueryPerformance(): JSX.Element {
         visibleSlowestQueries,
         slowestQueriesLoading,
         showSubQueries,
+        allQueriesHiddenAsSubQueries,
         hoursBack,
         teamIdFilter,
         experimentIdFilter,
@@ -326,7 +327,11 @@ export function QueryPerformance(): JSX.Element {
                                     columns={slowestQueryColumns}
                                     dataSource={visibleSlowestQueries}
                                     loading={slowestQueriesLoading}
-                                    emptyState="No queries found in this time range"
+                                    emptyState={
+                                        allQueriesHiddenAsSubQueries
+                                            ? 'All queries in this range are sub-queries — enable "Show sub-queries" to view them'
+                                            : 'No queries found in this time range'
+                                    }
                                     pagination={{ pageSize: 20 }}
                                     className="overflow-visible! flex-none!"
                                     expandable={{

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -36,14 +36,22 @@ export function QueryPerformance(): JSX.Element {
         precomputationTeams,
         precomputationTeamsLoading,
         search,
-        slowestQueries,
+        visibleSlowestQueries,
         slowestQueriesLoading,
+        showSubQueries,
         hoursBack,
         teamIdFilter,
         experimentIdFilter,
     } = useValues(queryPerformanceLogic)
-    const { setSearch, setPrecomputation, setHoursBack, loadSlowestQueries, setTeamIdFilter, setExperimentIdFilter } =
-        useActions(queryPerformanceLogic)
+    const {
+        setSearch,
+        setPrecomputation,
+        setHoursBack,
+        loadSlowestQueries,
+        setTeamIdFilter,
+        setExperimentIdFilter,
+        setShowSubQueries,
+    } = useActions(queryPerformanceLogic)
 
     if (!user?.is_staff) {
         return (
@@ -306,10 +314,17 @@ export function QueryPerformance(): JSX.Element {
                                     >
                                         Refresh
                                     </LemonButton>
+                                    <LemonSwitch
+                                        label="Show sub-queries"
+                                        checked={showSubQueries}
+                                        onChange={setShowSubQueries}
+                                        size="small"
+                                        bordered
+                                    />
                                 </div>
                                 <LemonTable
                                     columns={slowestQueryColumns}
-                                    dataSource={slowestQueries}
+                                    dataSource={visibleSlowestQueries}
                                     loading={slowestQueriesLoading}
                                     emptyState="No queries found in this time range"
                                     pagination={{ pageSize: 20 }}

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -132,6 +132,13 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
                     ? slowestQueries
                     : slowestQueries.filter((query) => query.experiment_query_surface !== 'precompute_build'),
         ],
+        // True when the visible table is empty only because every returned row is a hidden sub-query,
+        // so the empty state can say so instead of claiming there are no queries in the range.
+        allQueriesHiddenAsSubQueries: [
+            (s) => [s.slowestQueries, s.visibleSlowestQueries],
+            (slowestQueries, visibleSlowestQueries): boolean =>
+                slowestQueries.length > 0 && visibleSlowestQueries.length === 0,
+        ],
     }),
     listeners(({ actions }) => ({
         setSearch: async (_, breakpoint) => {

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -1,4 +1,4 @@
-import { actions, afterMount, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
@@ -46,6 +46,7 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
         setHoursBack: (hours: number) => ({ hours }),
         setTeamIdFilter: (teamId: string) => ({ teamId }),
         setExperimentIdFilter: (experimentId: string) => ({ experimentId }),
+        setShowSubQueries: (show: boolean) => ({ show }),
     }),
     reducers({
         search: [
@@ -70,6 +71,12 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             '',
             {
                 setExperimentIdFilter: (_, { experimentId }) => experimentId,
+            },
+        ],
+        showSubQueries: [
+            false,
+            {
+                setShowSubQueries: (_, { show }) => show,
             },
         ],
     }),
@@ -115,6 +122,17 @@ export const queryPerformanceLogic = kea<queryPerformanceLogicType>([
             },
         ],
     })),
+    selectors({
+        // The precompute-build INSERTs are sub-queries of a top-level read; hide them by default so the
+        // table reflects what a user actually waited for, with a toggle to surface them for debugging.
+        visibleSlowestQueries: [
+            (s) => [s.slowestQueries, s.showSubQueries],
+            (slowestQueries, showSubQueries): SlowestQuery[] =>
+                showSubQueries
+                    ? slowestQueries
+                    : slowestQueries.filter((query) => query.experiment_query_surface !== 'precompute_build'),
+        ],
+    }),
     listeners(({ actions }) => ({
         setSearch: async (_, breakpoint) => {
             await breakpoint(300)


### PR DESCRIPTION
## Problem

The query performance scene is an internal, staff-only debugging tool. Its "Slowest queries" table lists every experiment ClickHouse query, including the precompute-build INSERTs that populate the preaggregated tables. Those are sub-queries of a top-level read, not something a user directly waited for, so they add noise to a table whose job is to answer "how long did results take to load."

## Changes

Hide rows tagged `experiment_query_surface = 'precompute_build'` by default, with a "Show sub-queries" toggle to bring them back. Filtering lives in `queryPerformanceLogic` (a `visibleSlowestQueries` selector + `showSubQueries` reducer); the table renders the filtered list.

This is phase 1 of a planned change. Phase 2 will nest each top-level query's sub-queries in a collapsible row and rank by total (build + read) duration — that needs a new per-evaluation correlation tag and a backend change, so it's a separate PR.

## How did you test this code?

Agent-authored (Claude Code). Ran oxlint, oxfmt, kea typegen, and tsgo against the two changed files — all clean. No automated tests added (UI-only filter/toggle on a staff-gated internal scene).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Builds on the `experiment_query_surface` tag added in #65437 (now merged) — that tag is what distinguishes a top-level read (`metric` / `exposures_timeseries` / `actors`) from a `precompute_build` sub-query.
- Chose client-side filtering via a selector over a backend `WHERE` clause so the toggle works without a refetch and the sub-query rows stay available for the phase-2 collapsible.
