### PR TITLE
fix(mysql): retry transient SSL unexpected-EOF on connect

### DIFF
--- a/posthog/temporal/data_imports/sources/mysql/mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/mysql.py
@@ -288,24 +288,47 @@ def _is_bad_plan_error(e: pymysql.err.OperationalError) -> bool:
 # ~3s and surfacing the drop as error-tracking noise.
 _MAX_CONNECT_ATTEMPTS = 5
 
+# pymysql error code 2003 (CR_CONN_HOST_ERROR): the catch-all "Can't connect to MySQL server
+# on '<host>'" raised for any failure to establish the connection. Almost always a deterministic
+# config problem (wrong host/port, closed firewall) and so non-retryable — the one transient
+# exception is an SSL handshake the peer aborted with an unexpected EOF (see
+# `_is_transient_connect_drop`).
+_CANT_CONNECT_TO_SERVER_CODE = 2003
+
+# OpenSSL's signature for "the peer closed the connection before the TLS handshake finished".
+# pymysql wraps it as the 2003 connect failure above. Unlike WRONG_VERSION_NUMBER (a server that
+# doesn't speak TLS at all — a deterministic config error, already non-retryable), an unexpected
+# EOF mid-handshake is a transient drop: an overloaded server, a proxy/load-balancer idle cull, a
+# failover, or a momentary network blip, all of which a fresh attempt recovers from. Mirrors the
+# Postgres source, which retries its own "SSL connection has been closed unexpectedly" on connect.
+_SSL_UNEXPECTED_EOF_TOKEN = "[SSL: UNEXPECTED_EOF_WHILE_READING]"
+
 
 def _is_transient_connect_drop(e: BaseException) -> bool:
     """Return True if the connection was dropped mid-handshake — a transient blip.
 
-    pymysql reports a socket close while reading the server greeting as the same
-    2013 code we see mid-query, but at connect time it means the server hung up
-    before the handshake finished (an overloaded server, a proxy idle cull, a
-    failover, a momentary network blip) — a fresh attempt recovers. The one 2013
-    that is *not* transient is the SSL-version mismatch (a deterministic config
-    error, already non-retryable): it arrives with an `[SSL: ...` suffix, so
-    exclude that and let it surface.
+    Two shapes share this transient class, both surfaced by pymysql as an
+    `OperationalError` at connect time:
+
+    - `2013` (lost connection): a socket close while reading the server greeting —
+      an overloaded server, a proxy idle cull, a failover, a momentary network blip.
+      A fresh attempt recovers. The one 2013 that is *not* transient is the SSL-version
+      mismatch (a deterministic config error, already non-retryable): it arrives with an
+      `[SSL: ...` suffix, so exclude that and let it surface.
+    - `2003` (can't connect) carrying an `[SSL: UNEXPECTED_EOF_WHILE_READING]` cause:
+      the peer aborted the TLS handshake with an unexpected EOF — the SSL-flavoured
+      sibling of the 2013 drop, equally transient. The generic 2003 (wrong host/port,
+      firewall) stays non-retryable, so match only the unexpected-EOF token.
     """
     if not isinstance(e, pymysql.err.OperationalError):
         return False
     code = e.args[0] if e.args else None
-    if code != _LOST_CONNECTION_DURING_QUERY_CODE:
-        return False
-    return "[SSL:" not in " ".join(str(arg) for arg in e.args)
+    args_text = " ".join(str(arg) for arg in e.args)
+    if code == _LOST_CONNECTION_DURING_QUERY_CODE:
+        return "[SSL:" not in args_text
+    if code == _CANT_CONNECT_TO_SERVER_CODE:
+        return _SSL_UNEXPECTED_EOF_TOKEN in args_text
+    return False
 
 
 def _connect_with_transient_retry(kwargs: dict[str, Any]) -> pymysql.Connection:

--- a/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
+++ b/posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py
@@ -862,9 +862,23 @@ class TestIsTransientConnectDrop:
             )
         )
 
+    def test_matches_ssl_unexpected_eof_on_connect(self):
+        # The peer aborted the TLS handshake with an unexpected EOF, wrapped by pymysql as the
+        # 2003 connect failure. A transient drop (overloaded server, proxy idle cull, failover) —
+        # the in-process retry must catch it instead of letting the first blip surface as noise.
+        assert _is_transient_connect_drop(
+            pymysql.err.OperationalError(
+                2003,
+                "Can't connect to MySQL server on 'db.example.com' "
+                "([SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032))",
+            )
+        )
+
     @pytest.mark.parametrize(
         "code,message",
         [
+            # The generic 2003 (wrong host/port, firewall) is a deterministic config error and
+            # stays non-retryable — only the SSL unexpected-EOF flavour above is transient.
             (2003, "Can't connect to MySQL server on 'db.example.com'"),
             (1045, "Access denied for user"),
         ],
@@ -902,6 +916,26 @@ class TestConnectTransientRetry:
 
         assert mock_connect.call_count == fail_count + 1
         assert [c.args[0] for c in sleep.call_args_list] == expected_sleeps
+
+    def test_retries_ssl_unexpected_eof_then_succeeds(self, mocker):
+        sleep = mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.time.sleep")
+        conn = MagicMock()
+        conn.__enter__.return_value = conn
+        drop = pymysql.err.OperationalError(
+            2003,
+            "Can't connect to MySQL server on 'db.example.com' "
+            "([SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1032))",
+        )
+        mock_connect = mocker.patch(
+            "posthog.temporal.data_imports.sources.mysql.mysql.pymysql.connect",
+            side_effect=[drop, conn],
+        )
+
+        with MySQLImplementation().connect(_make_config()) as yielded:
+            assert yielded is conn
+
+        assert mock_connect.call_count == 2
+        sleep.assert_called_once_with(2)
 
     def test_gives_up_after_max_attempts(self, mocker):
         mocker.patch("posthog.temporal.data_imports.sources.mysql.mysql.time.sleep")


### PR DESCRIPTION
## Problem

MySQL data-warehouse imports occasionally fail at connect time with `SSLEOFError: [SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol`, wrapped by pymysql as `OperationalError(2003, "Can't connect to MySQL server on '<host>' (...)")`.

Surfaced by error tracking: [issue 019ef852-d937-72c3-9883-5cf37534d7d3](https://us.posthog.com/project/2/error_tracking/019ef852-d937-72c3-9883-5cf37534d7d3). The stack originates in `posthog/temporal/data_imports/sources/mysql/mysql.py` (`_connect_with_transient_retry` → `pymysql.connect` → TLS `do_handshake`).

This is a transient infrastructure blip: the peer (or a proxy/load balancer in front of it) accepted the TCP connection then closed it before the TLS handshake finished — an overloaded server, an idle cull, a failover, or a momentary network glitch. A single occurrence in the observed window is consistent with a one-off drop, not a persistent config problem. `_connect_with_transient_retry` already exists to absorb exactly this class of connect-time drop in-process so the first blip doesn't surface as error-tracking noise — but `_is_transient_connect_drop` only recognised the 2013 (`Lost connection`) form, so the 2003-wrapped SSL EOF slipped through.

## Changes

- `_is_transient_connect_drop` now also treats `OperationalError(2003)` as transient **when** it carries the `[SSL: UNEXPECTED_EOF_WHILE_READING]` token, so the bounded in-process retry recovers from it.
- Carefully scoped: the generic 2003 (wrong host/port, firewall) and the deterministic `[SSL: WRONG_VERSION_NUMBER]` mismatch (server doesn't speak TLS at all) stay non-retryable.
- Mirrors the Postgres source, which already retries its own "SSL connection has been closed unexpectedly" on connect and keeps it out of `NonRetryableErrors`.

No change to `NonRetryableErrors`: a persistent SSL failure still exhausts the in-process attempts and then hits the existing `"Can't connect to MySQL server on"` non-retryable classification, so it gives up rather than retrying forever.

## How did you test this code?

I'm an agent. I added and ran unit tests (no manual testing):

- `_is_transient_connect_drop` matches the 2003 + unexpected-EOF shape, and still rejects the bare generic 2003 and the `WRONG_VERSION_NUMBER` mismatch — catches the regression where the SSL EOF was misclassified as non-transient and bypassed the in-process retry.
- `_connect_with_transient_retry` retries the SSL-EOF drop once then succeeds — catches the integration-level regression that the new predicate is actually wired into the retry loop.

`python -m pytest posthog/temporal/data_imports/sources/mysql/tests/test_mysql.py -k "TestIsTransientConnectDrop or TestConnectTransientRetry"` → 12 passed. Ruff check + format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the MySQL import source. Confirmed the stack genuinely originates in the `mysql` source code (not just in serialized log context), read the connect/retry path end to end, and decided this is a fixable robustness bug rather than a user/upstream error: an unexpected EOF mid-TLS-handshake is a transient connection drop, and the prompt's guidance is that transient infra errors stay retryable.

Checked for duplicates before opening. Two adjacent open PRs touch the same function for *different* root causes and are not duplicates: #65706 (transient packet-sequence `InternalError`) and #64605 (the Postgres SSL-drop analog, which this mirrors). If #65706 merges first there may be a trivial conflict in `_connect_with_transient_retry` / the surrounding constants — both extend the same area but classify distinct errors.

Tools: Claude Code with the PostHog error-tracking MCP (`query-error-tracking-issue`, `query-error-tracking-issue-events`). No repo skills were applicable to this change.
