### PR TITLE
docs(developing-locally): document frontend-only development against PostHog Cloud

### DIFF
--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -150,6 +150,20 @@ You can now change PostHog in any way you want. See [Project structure](./projec
 
 By default, `hogli start` runs a minimal set of services (enough for product analytics). To customize which services start, run `hogli dev:setup` which lets you select intents based on the products you're working on. Your choices are saved and used automatically by `hogli start`.
 
+### Frontend-only against PostHog Cloud
+
+If you only need to work on the frontend, you can skip the local backend entirely and develop against PostHog Cloud:
+
+```bash
+hogli start:frontend   # or the shorthand: hogli frontend
+```
+
+This runs only the Vite dev server (port 8234) — no Django, Postgres, Kafka, or other services.
+It runs independently of the intent system, so it doesn't touch the config saved by `hogli dev:setup`; your full-stack setup is unchanged the next time you run `hogli start`.
+
+Open <a href="http://localhost:8234" target="_blank">http://localhost:8234</a> and use the **Cloud login** buttons on the dev login panel to authenticate against US or EU Cloud.
+All API requests are then routed to the chosen Cloud region, so you're developing the frontend against real data without a local backend.
+
 ### Setting environment variables
 
 Three env files come into play when `hogli start` runs:

--- a/docs/published/handbook/engineering/developing-locally.md
+++ b/docs/published/handbook/engineering/developing-locally.md
@@ -155,7 +155,7 @@ By default, `hogli start` runs a minimal set of services (enough for product ana
 If you only need to work on the frontend, you can skip the local backend entirely and develop against PostHog Cloud:
 
 ```bash
-hogli start:frontend   # or the shorthand: hogli frontend
+hogli start:frontend
 ```
 
 This runs only the Vite dev server (port 8234) — no Django, Postgres, Kafka, or other services.

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -382,11 +382,12 @@ start:
         hidden: true
     start:frontend:
         bin_script: start-frontend
-        description: Install dependencies and start frontend with Vite dev server
+        description: Start only the frontend (Vite dev server, port 8234) — pair with Cloud login to develop against PostHog Cloud with no local backend
         services:
             - frontend
-            - docker
-        hidden: true
+    frontend:
+        extends: start:frontend
+        description: Alias for `hogli start:frontend`
     start:frontend-vite:
         bin_script: start-frontend-vite
         description: Start Vite dev server for frontend (runs pnpm start-vite)

--- a/hogli.yaml
+++ b/hogli.yaml
@@ -385,9 +385,6 @@ start:
         description: Start only the frontend (Vite dev server, port 8234) — pair with Cloud login to develop against PostHog Cloud with no local backend
         services:
             - frontend
-    frontend:
-        extends: start:frontend
-        description: Alias for `hogli start:frontend`
     start:frontend-vite:
         bin_script: start-frontend-vite
         description: Start Vite dev server for frontend (runs pnpm start-vite)


### PR DESCRIPTION
## Problem

Developers working only on the frontend currently need to run the full local backend stack (Django, Postgres, Kafka, etc.) even when they just want to iterate on UI code. This is a friction point for frontend-focused work.

## Changes

Added documentation and updated the `hogli.yaml` configuration to surface the `hogli start:frontend` command as a first-class development workflow:

- **docs/published/handbook/engineering/developing-locally.md**: Added a new "Frontend-only against PostHog Cloud" section explaining how to run only the Vite dev server and authenticate against PostHog Cloud, eliminating the need for a local backend
- **hogli.yaml**: 
  - Updated the `start:frontend` command description to clearly explain its purpose and port
  - Removed the `hidden: true` flag so the command appears in help/TUI
  - Removed unnecessary `docker` service dependency
  - Clarified that this workflow is independent of the intent system and doesn't interfere with full-stack setup

## How did you test this code?

Documentation and configuration changes only — no automated tests needed. The `hogli start:frontend` command already exists and functions as documented; this PR simply makes it discoverable and explains its use case to developers.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This change surfaces an existing but undiscovered developer workflow. The `start:frontend` command was already implemented but hidden and poorly documented, creating a gap between what's possible and what developers know about. The updates make the feature discoverable in the hogli TUI and provide clear guidance on when and how to use it for frontend-only work against Cloud.

https://claude.ai/code/session_0149sHNdshUALLjG45c3uo2L