### PR TITLE
feat(signals): add report feedback button to inbox detail

### DIFF
--- a/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
+++ b/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
@@ -41,12 +41,13 @@ export function useReportArchive({
         openDismissReportDialog({
             reportTitle: cardTitle,
             onConfirm: async ({ reason, note }) => {
-                // Only the structured reason — the free-form note can carry proprietary text.
+                // The structured reason plus the user's note — the note is the actionable signal
+                // we want for tuning the agent, so it rides along with the dismiss event.
                 captureInboxReportAction({
                     report: report ?? null,
                     actionType: 'dismiss',
                     surface: surface ?? 'list_row',
-                    extra: { dismissal_reason: reason },
+                    extra: { dismissal_reason: reason, dismissal_note: note },
                 })
                 if (onArchive) {
                     onArchive(reason, note)

--- a/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
+++ b/frontend/src/scenes/inbox/components/cards/useReportArchive.ts
@@ -47,7 +47,7 @@ export function useReportArchive({
                     report: report ?? null,
                     actionType: 'dismiss',
                     surface: surface ?? 'list_row',
-                    extra: { dismissal_reason: reason, dismissal_note: note },
+                    extra: { dismissal_reason: reason, ...(note ? { dismissal_note: note } : {}) },
                 })
                 if (onArchive) {
                     onArchive(reason, note)

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -2,7 +2,7 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconArchive, IconFeedback, IconPullRequest, IconUndo } from '@posthog/icons'
+import { IconArchive, IconMessage, IconPullRequest, IconUndo } from '@posthog/icons'
 import { LemonButton, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
@@ -100,7 +100,7 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
         <LemonButton
             type="secondary"
             size="small"
-            icon={<IconFeedback />}
+            icon={<IconMessage />}
             tooltip="Tell us how useful this report was"
             onClick={() =>
                 openFeedbackReportDialog({

--- a/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetailActions.tsx
@@ -2,19 +2,20 @@ import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
 import { useState } from 'react'
 
-import { IconArchive, IconPullRequest, IconUndo } from '@posthog/icons'
+import { IconArchive, IconFeedback, IconPullRequest, IconUndo } from '@posthog/icons'
 import { LemonButton, lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
 import { urls } from 'scenes/urls'
 
-import { captureInboxReportAction } from '../../inboxAnalytics'
+import { captureInboxReportAction, captureInboxReportFeedback } from '../../inboxAnalytics'
 import { inboxSceneLogic } from '../../inboxSceneLogic'
 import { inboxTaskKickoffLogic } from '../../inboxTaskKickoffLogic'
 import { inboxBulkActionsLogic } from '../../logics/inboxBulkActionsLogic'
 import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from '../../logics/reportListLogic'
 import { ACTIONABLE_ACTIONABILITY_VALUES, SignalReport, SignalReportStatus } from '../../types'
 import { useReportArchive } from '../cards/useReportArchive'
+import { openFeedbackReportDialog } from '../shell/FeedbackReportDialog'
 
 /**
  * Should the Create PR action be offered? Mirrors desktop `canCreateImplementationPr` /
@@ -93,29 +94,55 @@ export function ReportDetailActions({ report }: { report: SignalReport }): JSX.E
         }
     }
 
-    // A resolved report is terminal – its PR already merged, so no detail actions apply.
+    // Feedback is always available – it never changes the report's state, just records what the
+    // user thinks of it (and its PR), so it stays even for resolved/archived reports.
+    const feedbackButton = (
+        <LemonButton
+            type="secondary"
+            size="small"
+            icon={<IconFeedback />}
+            tooltip="Tell us how useful this report was"
+            onClick={() =>
+                openFeedbackReportDialog({
+                    reportTitle: report.title ?? 'Untitled report',
+                    onConfirm: ({ sentiment, note }) => {
+                        captureInboxReportFeedback({ report, sentiment, note, surface: 'detail_pane' })
+                        lemonToast.success('Thanks for the feedback')
+                    },
+                })
+            }
+        >
+            Feedback
+        </LemonButton>
+    )
+
+    // A resolved report is terminal – its PR already merged, so only feedback applies.
     if (isResolved) {
-        return <></>
+        return feedbackButton
     }
 
     // An already-archived report offers Restore instead of Archive (and no Create PR).
     if (isArchived) {
         return (
-            <LemonButton
-                type="secondary"
-                size="small"
-                icon={<IconUndo />}
-                loading={isRestoring}
-                tooltip="Restore this report to your inbox"
-                onClick={() => void onRestoreClick()}
-            >
-                Restore
-            </LemonButton>
+            <>
+                {feedbackButton}
+                <LemonButton
+                    type="secondary"
+                    size="small"
+                    icon={<IconUndo />}
+                    loading={isRestoring}
+                    tooltip="Restore this report to your inbox"
+                    onClick={() => void onRestoreClick()}
+                >
+                    Restore
+                </LemonButton>
+            </>
         )
     }
 
     return (
         <>
+            {feedbackButton}
             <LemonButton
                 type="secondary"
                 size="small"

--- a/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
+++ b/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
@@ -67,6 +67,8 @@ export function openFeedbackReportDialog({ reportTitle, onConfirm }: OpenFeedbac
                         placeholder="Optional: what was useful or off?"
                         maxLength={FEEDBACK_NOTE_MAX_LENGTH}
                         rows={4}
+                        // Keep Enter for newlines – without this it bubbles to the dialog's submit-on-Enter handler.
+                        stopPropagation
                     />
                 </LemonField>
             </div>

--- a/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
+++ b/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
@@ -51,7 +51,8 @@ const SENTIMENT_RADIO_OPTIONS: LemonRadioOption<InboxReportFeedbackSentiment>[] 
 export function openFeedbackReportDialog({ reportTitle, onConfirm }: OpenFeedbackReportDialogParams): void {
     LemonDialog.openForm({
         title: `Feedback on "${reportTitle?.trim() ? reportTitle : 'Untitled report'}"`,
-        description: 'Tell us how useful this report was. Your feedback helps the agent improve – it does not archive the report.',
+        description:
+            'Tell us how useful this report was. Your feedback helps the agent improve – it does not archive the report.',
         maxWidth: '30rem',
         initialValues: { sentiment: null as InboxReportFeedbackSentiment | null, note: '' },
         content: (

--- a/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
+++ b/frontend/src/scenes/inbox/components/shell/FeedbackReportDialog.tsx
@@ -1,0 +1,85 @@
+import { IconThumbsDown, IconThumbsUp } from '@posthog/icons'
+
+import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonField } from 'lib/lemon-ui/LemonField'
+import { LemonRadio, LemonRadioOption } from 'lib/lemon-ui/LemonRadio'
+import { LemonTextArea } from 'lib/lemon-ui/LemonTextArea'
+
+import { InboxReportFeedbackSentiment } from '../../inboxAnalytics'
+
+/** Generous cap — feedback notes can be a paragraph or two of detail about a report or its PR. */
+const FEEDBACK_NOTE_MAX_LENGTH = 10000
+
+export interface FeedbackReportDialogResult {
+    sentiment: InboxReportFeedbackSentiment
+    note: string
+}
+
+interface OpenFeedbackReportDialogParams {
+    /** Report title for the dialog copy. */
+    reportTitle?: string | null
+    /** Called with the chosen sentiment + note once the user submits. */
+    onConfirm: (result: FeedbackReportDialogResult) => void | Promise<void>
+}
+
+const SENTIMENT_RADIO_OPTIONS: LemonRadioOption<InboxReportFeedbackSentiment>[] = [
+    {
+        value: 'positive',
+        label: (
+            <span className="inline-flex items-center gap-1.5">
+                <IconThumbsUp className="shrink-0 text-success" />
+                Helpful
+            </span>
+        ),
+    },
+    {
+        value: 'negative',
+        label: (
+            <span className="inline-flex items-center gap-1.5">
+                <IconThumbsDown className="shrink-0 text-danger" />
+                Not helpful
+            </span>
+        ),
+    },
+]
+
+/**
+ * Opens the report feedback dialog: pick a thumbs sentiment plus an optional note, then submit.
+ * Feedback-only — the report stays in the inbox (unlike {@link openDismissReportDialog}). The
+ * caller wires `onConfirm` to fire the `Inbox report feedback` analytics event.
+ */
+export function openFeedbackReportDialog({ reportTitle, onConfirm }: OpenFeedbackReportDialogParams): void {
+    LemonDialog.openForm({
+        title: `Feedback on "${reportTitle?.trim() ? reportTitle : 'Untitled report'}"`,
+        description: 'Tell us how useful this report was. Your feedback helps the agent improve – it does not archive the report.',
+        maxWidth: '30rem',
+        initialValues: { sentiment: null as InboxReportFeedbackSentiment | null, note: '' },
+        content: (
+            <div className="flex flex-col gap-3">
+                <LemonField name="sentiment" label="How useful was this?">
+                    {({ value, onChange }) => (
+                        <LemonRadio value={value} onChange={onChange} options={SENTIMENT_RADIO_OPTIONS} />
+                    )}
+                </LemonField>
+                <LemonField name="note" label="Anything to add?" info="Optional – helps the agent learn">
+                    <LemonTextArea
+                        placeholder="Optional: what was useful or off?"
+                        maxLength={FEEDBACK_NOTE_MAX_LENGTH}
+                        rows={4}
+                    />
+                </LemonField>
+            </div>
+        ),
+        errors: {
+            sentiment: (sentiment) => (!sentiment ? "You haven't picked a rating" : undefined),
+        },
+        primaryButtonProps: { children: 'Send feedback' },
+        shouldAwaitSubmit: true,
+        onSubmit: async ({ sentiment, note }) => {
+            if (!sentiment) {
+                return
+            }
+            await onConfirm({ sentiment, note: (note ?? '').trim() })
+        },
+    })
+}

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -17,6 +17,7 @@ export const INBOX_EVENTS = {
     REPORT_OPENED: 'Inbox report opened',
     REPORT_CLOSED: 'Inbox report closed',
     REPORT_ACTION: 'Inbox report action',
+    REPORT_FEEDBACK: 'Inbox report feedback',
     SOURCE_CONNECTED: 'Signal source connected',
     SOURCE_INTEREST: 'signals source interest',
 } as const
@@ -31,6 +32,9 @@ export type InboxReportOpenMethod = 'click' | 'deeplink' | 'unknown'
 
 /** How a report detail was closed. */
 export type InboxReportCloseMethod = 'next_report' | 'deselected' | 'unmount'
+
+/** Sentiment captured by the report feedback button. */
+export type InboxReportFeedbackSentiment = 'positive' | 'negative'
 
 /**
  * Report actions cloud actually emits. Names match the desktop enum one-for-one (so the
@@ -65,10 +69,10 @@ interface BaseReportProperties {
 }
 
 /**
- * Identity + classification for a report. Deliberately excludes free-form content (the report
- * title, dismissal notes): reports are generated from a customer's own data, so their titles can
- * carry proprietary detail, and these events flow to first-party app analytics. We keep events to
- * opaque ids, enums, ages, and counts.
+ * Identity + classification for a report. Kept to opaque ids, enums, ages, and counts — it never
+ * includes the agent-generated report title, which can echo proprietary detail from a customer's
+ * own data. User-authored notes (a dismissal reason note, feedback note) are a different case: they
+ * are the actionable signal we want, so the relevant capture calls attach them explicitly.
  */
 function baseReportProperties(report: SignalReport): BaseReportProperties {
     return {
@@ -183,6 +187,26 @@ export function captureInboxReportAction(params: {
         is_bulk: params.isBulk ?? false,
         bulk_size: params.bulkSize ?? 1,
         ...params.extra,
+    })
+}
+
+/**
+ * Free-form feedback on a single report, fired from the detail pane's feedback button. Unlike a
+ * dismiss, this is feedback-only: the report stays in the inbox. Carries the thumbs sentiment plus
+ * the optional note text so we can read what people actually think of a report (and its PR).
+ */
+export function captureInboxReportFeedback(params: {
+    report: SignalReport
+    sentiment: InboxReportFeedbackSentiment
+    note: string
+    surface: InboxReportActionSurface
+}): void {
+    captureInboxEvent(INBOX_EVENTS.REPORT_FEEDBACK, {
+        ...baseReportProperties(params.report),
+        sentiment: params.sentiment,
+        has_pr: !!params.report.implementation_pr_url,
+        note: params.note,
+        surface: params.surface,
     })
 }
 

--- a/frontend/src/scenes/inbox/inboxAnalytics.ts
+++ b/frontend/src/scenes/inbox/inboxAnalytics.ts
@@ -205,7 +205,7 @@ export function captureInboxReportFeedback(params: {
         ...baseReportProperties(params.report),
         sentiment: params.sentiment,
         has_pr: !!params.report.implementation_pr_url,
-        note: params.note,
+        ...(params.note ? { note: params.note } : {}),
         surface: params.surface,
     })
 }


### PR DESCRIPTION
## Problem

Reports in the signals inbox — and the PRs they auto-create — could only be given feedback by archiving them. There was no way to say "this was useful" or "this PR missed the mark" while keeping the report in the inbox.

## Changes

<img width="3022" height="598" alt="image" src="https://github.com/user-attachments/assets/d9ae2aa3-6c32-4b17-95e3-95555bf6de38" />

<img width="1186" height="1024" alt="image" src="https://github.com/user-attachments/assets/ebce53f9-2532-45f5-b8e1-9a9549b1510b" />


- New **Feedback** button on the report detail view (next to Archive / Open in GitHub). It opens a small dialog: a thumbs up/down rating plus an optional free-text note (10k char cap). Submitting fires a new `Inbox report feedback` event and leaves the report untouched.
- The event carries the sentiment, the note text, `has_pr` (so PR-specific feedback is filterable), and the standard report id/priority/actionability props.
- The button is shown for active, archived, and resolved reports — feedback never changes report state.
- Fix: the archive/dismiss flow now includes the user's note text (`dismissal_note`) on the `Inbox report action` dismiss event. It was previously dropped, so we never saw what people typed.

Both the feedback note and the dismissal note are now sent as free text; the agent-generated report title is still deliberately excluded from analytics.

## How did you test this code?

I'm an agent (PostHog Slack app). I have not run manual or automated tests — the frontend toolchain (oxlint/oxfmt, tsc) isn't installed in this environment, so formatting/typecheck were not run locally. Verified by inspection that the new event helper mirrors the existing `inboxAnalytics` patterns and that all icons (`IconFeedback`, `IconThumbsUp`, `IconThumbsDown`) are valid `@posthog/icons` exports already used elsewhere. Worth a reviewer running `pnpm --filter=@posthog/frontend typescript:check` and the formatter.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built from a Slack thread with the PostHog Slack app (Claude Code / PostHog Code). Requested change: a small feedback button on the inbox report view that fires a custom feedback event, motivated by wanting feedback on auto-created PRs without archiving the report.

Decisions:
- Feedback is event-only (no new backend field/endpoint) since the ask was a custom event — kept it consistent with the other `posthog.capture`-based inbox events in `inboxAnalytics.ts`.
- Sent the free-text note in both the new feedback event and the existing dismiss event per explicit request, updating the prior privacy note that excluded free-form text; the report title stays excluded.
- Reused the existing `LemonDialog.openForm` + `LemonRadio` pattern from `DismissReportDialog` for a consistent dialog.

No repo skills were invoked (no migrations, serializers, or generated API types touched).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782284392558659?thread_ts=1782284392.558659&cid=C09SK2PAGKF)*
