### PR TITLE
chore(workflows): remove beta tag from batch trigger

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx
@@ -264,11 +264,6 @@ export function StepTriggerConfiguration({ node }: { node: Node<TriggerAction> }
                 description: 'Trigger your workflow to run for each person in an audience you define.',
                 value: 'batch',
                 icon: <IconPeople />,
-                tag: (
-                    <LemonTag type="completion" className="ml-1">
-                        Beta
-                    </LemonTag>
-                ),
             },
             ...getRegisteredTriggerTypes()
                 .filter((t) => !t.featureFlag || featureFlags[t.featureFlag])


### PR DESCRIPTION
## Problem

The batch trigger in workflows has been stable; the "Beta" tag in the trigger picker is no longer accurate.

## Changes

Remove the `Beta` `LemonTag` from the Batch option in `StepTriggerConfiguration` (`products/workflows/frontend/Workflows/hogflows/steps/StepTrigger.tsx`). No behavior change — only the trigger picker label.

## How did you test this code?

I'm an agent. No manual testing performed. The change is a pure label removal in a JSX item config; no new tests warranted.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, single-file edit. No skills invoked — the touched file is not a generated API type file and the change is cosmetic.