### PR TITLE
chore(lemon-ui): retire unused selectionPeriodLimit prop

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -3152,18 +3152,10 @@ snapshots:
         hash: v1.k794b7964.f83b02aa617c663b30e60c59cc62b0cfd9b81502aae8dff345444cdf9f8b4f46.VJPaF-me_GVlWNFPZKEu9QkCfv2PjanCWSV2Qlj0mrM
     lemon-ui-lemon-calendar-lemon-calendar-select--past--light:
         hash: v1.k794b7964.55806633f437998a19a369798c18cccb5bc66f47b3e9f90fabee1b5215a86c6c.TV-Tc9jia5Dgm4TsfiE5rtz-wgit6giQjxpXbmeCBG4
-    lemon-ui-lemon-calendar-lemon-calendar-select--past-with-limit--dark:
-        hash: v1.k794b7964.a3ce27d8d8a69447f773af1c452da834234723e733e4f8fe4b6268592d13ec6e.K0YicEKlIyfd1owho1FazbMStQLBI4GSdNCnhmU-ewQ
-    lemon-ui-lemon-calendar-lemon-calendar-select--past-with-limit--light:
-        hash: v1.k794b7964.b7fdf02e35a5d498d03560e0b4c6d6db8381d7d20e6881b8699d40e0c6a6ed05.d7P4E0-v0vzaCoMMUmF5p1IzbaxjKJ4bLX-Zj4W7cQ4
     lemon-ui-lemon-calendar-lemon-calendar-select--upcoming--dark:
         hash: v1.k794b7964.9d67b0402cd33ae5350a3be0eb206bbd66bd176e34671f19168bf285481e21e5.YPTWAvbYB8C0JJqur8TW_hWfkAWdrf7DQqb9suJc3ck
     lemon-ui-lemon-calendar-lemon-calendar-select--upcoming--light:
         hash: v1.k794b7964.d02f78ddaf0a659e311f8421f173d98f23c3ea07b280d6a1bad4ba913859cee2.DN9QG6fxcau2Np_GuKFOmcsmVgXcq-ZG-tVqtfnOtkg
-    lemon-ui-lemon-calendar-lemon-calendar-select--upcoming-with-limit--dark:
-        hash: v1.k794b7964.9d67b0402cd33ae5350a3be0eb206bbd66bd176e34671f19168bf285481e21e5.cj-CFVAA-LJdnQ_1i7uX44GirzgIWqQ349gnimBk9Us
-    lemon-ui-lemon-calendar-lemon-calendar-select--upcoming-with-limit--light:
-        hash: v1.k794b7964.d02f78ddaf0a659e311f8421f173d98f23c3ea07b280d6a1bad4ba913859cee2.ZAXworsDdmMSlO7O_d81dJZtU0rB1dh_8rxtUez7zkM
     lemon-ui-lemon-calendar-lemon-calendar-select--with-time-toggle--dark:
         hash: v1.k794b7964.7812a9f81abc100627a94b1630cd8d34f126f95f397e3a0feb08a078eb68d6cc.pIdBn5YFCXGH3hgTX18NM1k44260bHUYjug2XOol-r4
     lemon-ui-lemon-calendar-lemon-calendar-select--with-time-toggle--light:

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.stories.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.stories.tsx
@@ -55,15 +55,7 @@ export const Default: Story = { args: { granularity: 'day' } }
 
 export const Upcoming: Story = { args: { selectionPeriod: 'upcoming' } }
 
-export const UpcomingWithLimit: Story = {
-    args: { selectionPeriod: 'upcoming', selectionPeriodLimit: dayjs().add(1, 'day') },
-}
-
 export const Past: Story = { args: { selectionPeriod: 'past' } }
-
-export const PastWithLimit: Story = {
-    args: { selectionPeriod: 'past', selectionPeriodLimit: dayjs().subtract(1, 'day') },
-}
 
 export const Hour: Story = { args: { granularity: 'hour' } }
 

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.test.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.test.tsx
@@ -207,44 +207,6 @@ describe('LemonCalendarSelect', () => {
         expect(onChange).toHaveBeenLastCalledWith(dayjs('2023-01-11T05:00:00.000Z'))
     })
 
-    test('allow only upcoming selection after a limit (one day in the future)', async () => {
-        const { onChange, clickOnDate, clickOnTime } = renderLemonCalendarSelect(null, {
-            granularity: 'minute',
-            selectionPeriod: 'upcoming',
-            selectionPeriodLimit: dayjs('2023-01-11'),
-        })
-
-        // click on minute
-        await clickOnTime({ unit: 'm', value: 42 })
-        // time is disabled until a date is clicked
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on past date
-        await clickOnDate('9')
-        // cannot select a date in the past
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on future date beyond the limit
-        await clickOnDate('12')
-        // cannot select a date in the future
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on current date
-        await clickOnDate('10')
-        // chooses the current date and sets the time to the current hour and minute
-        expect(onChange).toHaveBeenCalledWith(dayjs('2023-01-10T17:22:00.000Z'))
-
-        // click on an earlier hour
-        await clickOnTime({ unit: 'a', value: 'am' })
-        // does not update the date because it is in the past
-        expect(onChange).toHaveBeenLastCalledWith(dayjs('2023-01-10T17:22:00.000Z'))
-
-        // click on a later hour
-        await clickOnTime({ unit: 'h', value: '8' })
-        // updates the hour to 8pm (later than 5pm)
-        expect(onChange).toHaveBeenLastCalledWith(dayjs('2023-01-10T20:22:00.000Z'))
-    })
-
     test('only allow past selection', async () => {
         const { onChange, clickOnDate, clickOnTime } = renderLemonCalendarSelect(null, {
             granularity: 'minute',
@@ -275,34 +237,6 @@ describe('LemonCalendarSelect', () => {
         await clickOnTime({ unit: 'h', value: '2' })
         // updates the hour to 2pm (earlier than 5pm)
         expect(onChange).toHaveBeenLastCalledWith(dayjs('2023-01-10T14:22:00.000Z'))
-    })
-
-    test('allow only past selection after a limit (one day in the past)', async () => {
-        const { onChange, clickOnDate, clickOnTime } = renderLemonCalendarSelect(null, {
-            granularity: 'minute',
-            selectionPeriod: 'past',
-            selectionPeriodLimit: dayjs('2023-01-09'),
-        })
-
-        // click on minute
-        await clickOnTime({ unit: 'm', value: 12 })
-        // time is disabled until a date is clicked
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on future date
-        await clickOnDate('11')
-        // cannot select a date in the future
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on a date in the past
-        await clickOnDate('8')
-        // chooses the date in the past and sets the time to the current hour and minute
-        expect(onChange).not.toHaveBeenCalled()
-
-        // click on past date within the limit
-        await clickOnDate('9')
-        // chooses the current date and sets the time to the current hour and minute
-        expect(onChange).toHaveBeenCalledWith(dayjs('2023-01-09T17:22:00.000Z'))
     })
 
     test('select times with use24HourFormat', async () => {

--- a/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
+++ b/frontend/src/lib/lemon-ui/LemonCalendar/LemonCalendarSelect.tsx
@@ -56,8 +56,7 @@ function cloneTimeToDate(targetDate: dayjs.Dayjs, timeSource: dayjs.Dayjs): dayj
 function getDateDisabledReason(
     selectionPeriod: 'past' | 'upcoming',
     date: dayjs.Dayjs,
-    today: dayjs.Dayjs,
-    selectionPeriodLimit?: dayjs.Dayjs | null
+    today: dayjs.Dayjs
 ): string | undefined {
     if (!selectionPeriod) {
         return undefined
@@ -68,18 +67,8 @@ function getDateDisabledReason(
         return 'Cannot select dates in the past'
     }
 
-    // select future dates after a limit
-    if (selectionPeriod === 'upcoming' && selectionPeriodLimit && date.isAfter(selectionPeriodLimit, 'day')) {
-        return 'Cannot select dates after the limit'
-    }
-
     if (selectionPeriod === 'past' && date.isAfter(today)) {
         return 'Cannot select dates in the future'
-    }
-
-    // select past dates before a limit
-    if (selectionPeriod === 'past' && selectionPeriodLimit && date.isBefore(selectionPeriodLimit, 'day')) {
-        return 'Cannot select dates before the limit'
     }
 
     return undefined
@@ -92,7 +81,6 @@ export interface LemonCalendarSelectProps {
     onClose?: () => void
     granularity?: LemonCalendarProps['granularity']
     selectionPeriod?: 'past' | 'upcoming'
-    selectionPeriodLimit?: dayjs.Dayjs | null
     /** Timezone used to determine which past/future dates are selectable (defaults to browser local). */
     selectionPeriodTimezone?: string
     showTimeToggle?: boolean
@@ -108,7 +96,6 @@ export function LemonCalendarSelect({
     onClose,
     granularity = 'day',
     selectionPeriod,
-    selectionPeriodLimit,
     selectionPeriodTimezone,
     showTimeToggle,
     onToggleTime,
@@ -176,7 +163,7 @@ export function LemonCalendarSelect({
                     let disabledReason: string | undefined
 
                     if (selectionPeriod) {
-                        disabledReason = getDateDisabledReason(selectionPeriod, date, today, selectionPeriodLimit)
+                        disabledReason = getDateDisabledReason(selectionPeriod, date, today)
 
                         if (selectValue && date.isSame(today, 'date')) {
                             const selectedTimeOnDate = cloneTimeToDate(date, selectValue)


### PR DESCRIPTION
## Problem

While wiring up the LemonUI→Quill date-picker migration we audited `LemonCalendarSelect`'s bounding API. `selectionPeriodLimit` (the upper/lower bound paired with `selectionPeriod`) has **zero callers** anywhere in the app — only its own stories and tests reference it. It's also a confusing way to express "bound the calendar" compared to a plain min/max date. Dead, confusing API surface that should go before more callers migrate onto this family.

## Changes

Retire `selectionPeriodLimit`:
- Removed the prop from `LemonCalendarSelectProps` and the `getDateDisabledReason` helper (and its two never-exercised limit branches).
- Dropped the `UpcomingWithLimit` / `PastWithLimit` stories and the two limit-specific tests (the non-limit `only allow upcoming/past selection` tests stay, so past/upcoming coverage is intact).

`selectionPeriod` itself (`'past'`/`'upcoming'`, 9 real callers) is unchanged. Behaviour is identical for every existing caller, since none passed a limit.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). Automated checks:

- `LemonCalendarSelect.test.tsx` — 8 tests pass after removing the two limit tests.
- `tsc --noEmit` — clean (no caller referenced the removed prop).
- `pnpm --filter=@posthog/frontend format` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul asked to retire unused props as the date-picker migration proceeds; assigned as DRI.

Part of the LemonUI→Quill date-picker migration housekeeping: the clear bounding API going forward is `min`/`maxDate` (what Quill uses), so the unused `selectionPeriodLimit` is retired now to keep the surface honest. Standalone off master; no dependency on the migration PRs.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*