### PR TITLE
feat(experiments): tag query group id to link reads and sub-queries

### DIFF
--- a/posthog/clickhouse/query_tagging.py
+++ b/posthog/clickhouse/query_tagging.py
@@ -425,6 +425,10 @@ class QueryTags(BaseModel):
     experiment_metric_events_path: Optional[str] = None  # "direct_scan", "precomputed", or "not_applicable"
     experiment_query_surface: Optional[str] = None  # "metric", "exposures_timeseries", "actors", "precompute_build"
     experiment_precompute_table: Optional[str] = None  # on precompute_build rows: "exposures" or "metric_events"
+    # Shared id linking a top-level query to its precompute-build sub-queries. Generated once per
+    # top-level evaluation; sub-queries inherit it through the tag context. Lets the query-performance
+    # UI group the (synchronous) build INSERTs under the read that triggered them.
+    experiment_query_group_id: Optional[uuid.UUID] = None
     experiment_actors_query_step: Optional[int] = None  # funnel step for actors query
     experiment_actors_query_variant: Optional[str] = None  # variant filter for actors query
     experiment_actors_query_includes_recordings: Optional[bool] = None  # whether recordings are included

--- a/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_exposures_query_runner.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Optional
 from zoneinfo import ZoneInfo
@@ -292,6 +293,9 @@ class ExperimentExposuresQueryRunner(QueryRunner):
             product=Product.EXPERIMENTS,
             experiment_query_surface="exposures_timeseries",
             experiment_metric_events_path="not_applicable",
+            # Set before _get_exposure_query() runs the exposures precompute build, so that build
+            # sub-query inherits this id via the tag context and can be grouped under this read.
+            experiment_query_group_id=uuid.uuid4(),
         )
 
         # Set limit to avoid being cut-off by the default 100 rows limit

--- a/products/experiments/backend/hogql_queries/experiment_query_runner.py
+++ b/products/experiments/backend/hogql_queries/experiment_query_runner.py
@@ -1,3 +1,4 @@
+import uuid
 from datetime import UTC, datetime, timedelta
 from functools import cached_property
 from typing import Optional
@@ -426,6 +427,9 @@ class ExperimentQueryRunner(QueryRunner):
         tag_queries(
             product=Product.EXPERIMENTS,
             experiment_query_surface="metric",
+            # Generated before _get_experiment_query() runs the precompute builds, so those build
+            # sub-queries inherit this id via the tag context and can be grouped under this read.
+            experiment_query_group_id=uuid.uuid4(),
             experiment_id=self.experiment.id,
             experiment_name=self.experiment.name,
             experiment_feature_flag_key=self.feature_flag_key,
@@ -774,6 +778,8 @@ class ExperimentQueryRunner(QueryRunner):
         tag_queries(
             product=Product.EXPERIMENTS,
             experiment_query_surface="actors",
+            # No sub-queries here, but tag for a consistent group id per top-level query.
+            experiment_query_group_id=uuid.uuid4(),
             experiment_exposures_path="direct_scan",
             experiment_metric_events_path="not_applicable",
             experiment_id=self.experiment.id,


### PR DESCRIPTION
## Problem

The query performance scene (an internal, staff-only debugging tool) shows every experiment ClickHouse query, including the precompute-build INSERTs that a top-level read kicks off. We want to group those build sub-queries under the read that triggered them, but nothing links them today — each is an independent `system.query_log` row with its own `query_id`.

## Changes

Add an `experiment_query_group_id` query tag: a UUID generated once per top-level evaluation (`metric` / `exposures_timeseries` / `actors`) and set before the precompute builds run, so the build INSERTs inherit it through the tag context. Parent read and its build sub-queries then share one id.

Purely additive — one more key in `log_comment`, no behavior change. Nothing reads the tag yet.

## How did you test this code?

Agent-authored (Claude Code). Verified with a throwaway test (not included, per request) that the build INSERTs inherit the parent's group id and that each evaluation gets a fresh id. Ran ruff; lint-staged ran `ty check`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Producer half of a two-PR change. The follow-up reworks the `slowest_queries` endpoint + UI to nest sub-queries under their parent (grouping by this id) and rank by total build-plus-read duration. This PR ships the tag alone so it can deploy and start populating first.
- Chose a synthetic group id over reusing the read's ClickHouse `query_id`: `query_id` gets a random suffix at execution time (`execute.py`), so it can't be known before the builds, which run first. The tag context already carries it to the sub-queries, the same mechanism the existing `experiment_query_surface` tag uses.
