### PR TITLE
fix(insights): collapse events-only retention variant to one events scan

### DIFF
--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -226,34 +226,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
 
         select_fields.extend(
             [
-                ast.Alias(
-                    alias="start_interval_index",
-                    expr=parse_expr(
-                        """
-                        arrayJoin(
-                            arrayFilter(
-                                x -> x > -1,
-                                arrayMap(
-                                (interval_index, interval_date, _start_event_timestamps) ->
-                                    if(
-                                        {is_valid_start_interval},
-                                        interval_index - 1,
-                                        -1
-                                    ),
-                                    arrayEnumerate(date_range),
-                                    date_range,
-                                    arrayResize(
-                                        [start_event_timestamps],
-                                        length(date_range),
-                                        start_event_timestamps
-                                    )
-                                )
-                            )
-                        )
-                    """,
-                        {"is_valid_start_interval": is_valid_start_interval},
-                    ),
-                ),
+                self._start_interval_index_alias_expr(is_valid_start_interval),
                 ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
             ]
         )
@@ -365,34 +338,7 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         select_fields.extend(
             [
                 ast.Alias(alias="return_event_timestamps", expr=return_event_timestamps_expr),
-                ast.Alias(
-                    alias="start_interval_index",
-                    expr=parse_expr(
-                        """
-                        arrayJoin(
-                            arrayFilter(
-                                x -> x > -1,
-                                arrayMap(
-                                (interval_index, interval_date, _start_event_timestamps) ->
-                                    if(
-                                        {is_valid_start_interval},
-                                        interval_index - 1,
-                                        -1
-                                    ),
-                                    arrayEnumerate(date_range),
-                                    date_range,
-                                    arrayResize(
-                                        [start_event_timestamps],
-                                        length(date_range),
-                                        start_event_timestamps
-                                    )
-                                )
-                            )
-                        )
-                    """,
-                        {"is_valid_start_interval": is_valid_start_interval},
-                    ),
-                ),
+                self._start_interval_index_alias_expr(is_valid_start_interval),
                 ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
             ]
         )
@@ -450,6 +396,38 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
             },
         )
 
+    def _start_interval_index_alias_expr(self, is_valid_start_interval: ast.Expr) -> ast.Alias:
+        # Explodes the (0-based) indices of intervals whose start event matched, shared by the single-scan
+        # and UNION-outer shapes. Reads the date_range and start_event_timestamps aliases from the same SELECT.
+        return ast.Alias(
+            alias="start_interval_index",
+            expr=parse_expr(
+                """
+                arrayJoin(
+                    arrayFilter(
+                        x -> x > -1,
+                        arrayMap(
+                        (interval_index, interval_date, _start_event_timestamps) ->
+                            if(
+                                {is_valid_start_interval},
+                                interval_index - 1,
+                                -1
+                            ),
+                            arrayEnumerate(date_range),
+                            date_range,
+                            arrayResize(
+                                [start_event_timestamps],
+                                length(date_range),
+                                start_event_timestamps
+                            )
+                        )
+                    )
+                )
+            """,
+                {"is_valid_start_interval": is_valid_start_interval},
+            ),
+        )
+
     def _build_dwh_retention_event_query(
         self,
         entity: RetentionEntity,
@@ -497,23 +475,9 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
                 return_event_data_expr = event_data_expr
         else:
             if query_kind == "start":
-                timestamps_expr = parse_expr(
-                    """
-                    arraySort(
-                        groupUniqArrayIf(
-                            {start_of_interval_sql},
-                            {entity_expr} and
-                            {filter_timestamp}
-                        )
-                    )
-                    """,
-                    {
-                        "start_of_interval_sql": start_of_interval_sql,
-                        "entity_expr": entity_expr,
-                        "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
-                    },
+                start_event_timestamps_expr = self._single_scan_start_event_timestamps_expr(
+                    timestamp_field, entity_expr
                 )
-                start_event_timestamps_expr = timestamps_expr
                 return_event_timestamps_expr = ast.Array(exprs=[])
             else:
                 timestamps_expr = self._get_dwh_return_timestamps_expr(

--- a/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
+++ b/posthog/hogql_queries/insights/retention/retention_base_query_fixed.py
@@ -152,6 +152,12 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         start_interval_index_filter: int | None = None,
         selected_breakdown_value: str | list[str] | int | None = None,
     ) -> ast.SelectQuery:
+        if self._can_single_scan():
+            # Both arms read the same `events` source, so the two-pass UNION scans events twice for no
+            # benefit. Collapse to one FROM events scan computing both timestamp arrays inline. Property
+            # aggregation and any data-warehouse entity stay on the UNION below.
+            return self._build_single_scan_query(start_interval_index_filter, selected_breakdown_value)
+
         is_valid_start_interval = self._is_valid_start_interval_expr("_start_event_timestamps")
         intervals_from_base_expr, retention_value_expr = self._get_intervals_from_base_exprs()
 
@@ -297,6 +303,152 @@ class RetentionFixedIntervalBaseQueryBuilder(RetentionBaseQueryBuilder):
         )
 
         return base_query
+
+    def _can_single_scan(self) -> bool:
+        # Events-only, non-property-aggregating series read the same `events` source on both arms, so the
+        # start and return timestamp arrays can be computed in one pass. Property aggregation has a known
+        # legacy/variant discrepancy and stays on the UNION; a data-warehouse entity is a genuinely
+        # different source and cannot collapse here.
+        return (
+            not self.has_property_aggregation
+            and self.start_event.type != EntityType.DATA_WAREHOUSE
+            and self.return_event.type != EntityType.DATA_WAREHOUSE
+        )
+
+    def _build_single_scan_query(
+        self,
+        start_interval_index_filter: int | None = None,
+        selected_breakdown_value: str | list[str] | int | None = None,
+    ) -> ast.SelectQuery:
+        # Source-parameterized so the deferred same-data-warehouse-table collapse is a small follow-up.
+        # For the events-only case the source is the events table.
+        timestamp_field = ast.Field(chain=["timestamp"])
+        actor_field = ast.Field(chain=[self.aggregation_target_events_column])
+        start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=timestamp_field)
+
+        start_event_timestamps_expr = self._single_scan_start_event_timestamps_expr(
+            timestamp_field, self.start_entity_expr
+        )
+        if self.is_first_occurrence_matching_filters or self.is_first_ever_occurrence:
+            start_event_timestamps_expr = self._first_time_start_event_timestamps_expr(self.start_event)
+
+        select_fields: list[ast.Expr] = [
+            ast.Alias(alias="actor_id", expr=actor_field),
+            ast.Alias(alias="start_event_timestamps", expr=start_event_timestamps_expr),
+            self._date_range_alias(),
+        ]
+
+        if self.minimum_occurrences > 1:
+            select_fields.extend(
+                self._get_minimum_occurrences_aliases(
+                    minimum_occurrences=self.minimum_occurrences,
+                    with_dupes_expr=self._get_dwh_return_timestamps_expr(
+                        minimum_occurrences=self.minimum_occurrences,
+                        start_of_interval_sql=start_of_interval_sql,
+                        return_entity_expr=self.return_entity_expr,
+                        timestamp_field=timestamp_field,
+                    ),
+                )
+            )
+            return_event_timestamps_expr = self._minimum_occurrences_return_timestamps_expr(self.minimum_occurrences)
+        else:
+            return_event_timestamps_expr = self._get_dwh_return_timestamps_expr(
+                minimum_occurrences=1,
+                start_of_interval_sql=start_of_interval_sql,
+                return_entity_expr=self.return_entity_expr,
+                timestamp_field=timestamp_field,
+            )
+
+        is_valid_start_interval = self._is_valid_start_interval_expr("_start_event_timestamps")
+        intervals_from_base_expr, retention_value_expr = self._get_intervals_from_base_exprs()
+
+        select_fields.extend(
+            [
+                ast.Alias(alias="return_event_timestamps", expr=return_event_timestamps_expr),
+                ast.Alias(
+                    alias="start_interval_index",
+                    expr=parse_expr(
+                        """
+                        arrayJoin(
+                            arrayFilter(
+                                x -> x > -1,
+                                arrayMap(
+                                (interval_index, interval_date, _start_event_timestamps) ->
+                                    if(
+                                        {is_valid_start_interval},
+                                        interval_index - 1,
+                                        -1
+                                    ),
+                                    arrayEnumerate(date_range),
+                                    date_range,
+                                    arrayResize(
+                                        [start_event_timestamps],
+                                        length(date_range),
+                                        start_event_timestamps
+                                    )
+                                )
+                            )
+                        )
+                    """,
+                        {"is_valid_start_interval": is_valid_start_interval},
+                    ),
+                ),
+                ast.Alias(alias="intervals_from_base", expr=intervals_from_base_expr),
+            ]
+        )
+
+        if retention_value_expr:
+            select_fields.append(ast.Alias(alias="retention_value", expr=retention_value_expr))
+
+        return ast.SelectQuery(
+            select=select_fields,
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=ast.And(exprs=self._event_filters()),
+            group_by=[ast.Field(chain=["actor_id"])],
+            having=ast.And(
+                exprs=[
+                    (
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["start_interval_index"]),
+                            right=ast.Constant(value=start_interval_index_filter),
+                        )
+                        if start_interval_index_filter is not None
+                        else ast.Constant(value=1)
+                    ),
+                    (
+                        ast.CompareOperation(
+                            op=ast.CompareOperationOp.Eq,
+                            left=ast.Field(chain=["breakdown_value"]),
+                            right=ast.Constant(value=selected_breakdown_value),
+                        )
+                        if selected_breakdown_value is not None
+                        else ast.Constant(value=1)
+                    ),
+                ]
+            ),
+        )
+
+    def _single_scan_start_event_timestamps_expr(self, timestamp_field: ast.Expr, entity_expr: ast.Expr) -> ast.Expr:
+        # The recurring within-window set of start-interval timestamps, one pass over the source. Mirrors the
+        # inline aggregate the legacy path and the DWH start arm both build.
+        start_of_interval_sql = self.query_date_range.get_start_of_interval_hogql(source=timestamp_field)
+        return parse_expr(
+            """
+            arraySort(
+                groupUniqArrayIf(
+                    {start_of_interval_sql},
+                    {entity_expr} and
+                    {filter_timestamp}
+                )
+            )
+            """,
+            {
+                "start_of_interval_sql": start_of_interval_sql,
+                "entity_expr": entity_expr,
+                "filter_timestamp": self.events_timestamp_filter(field=timestamp_field),
+            },
+        )
 
     def _build_dwh_retention_event_query(
         self,

--- a/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
+++ b/posthog/hogql_queries/insights/retention/test/__snapshots__/test_retention_query_runner.ambr
@@ -460,39 +460,21 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT retention_events.actor_id AS actor_id,
-            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
-            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 11)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(has(_start_event_timestamps, interval_date), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(has(start_event_timestamps, date_range[plus(start_interval_index, 1)]), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 11), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM
-       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-               arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS start_event_timestamps,
-               [] AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
-        GROUP BY actor_id
-        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-                         [] AS start_event_timestamps,
-                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, '$pageview'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
-        GROUP BY actor_id) AS retention_events
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), and(greaterOrEquals(events.timestamp, toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(events.timestamp, toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), in(events.event, tuple('$pageview')), or(equals(events.event, '$pageview'), equals(events.event, '$pageview')))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -743,41 +725,23 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT retention_events.actor_id AS actor_id,
-            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
-            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM
-       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-               if(and(greaterOrEquals(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0))), toIntervalDay(1))], []) AS start_event_timestamps,
-               [] AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
-        GROUP BY actor_id
-        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-                         [] AS start_event_timestamps,
-                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
-        GROUP BY actor_id) AS retention_events
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')), or(and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)), equals(events.event, 'returning_event')))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,
@@ -847,41 +811,23 @@
          actor_activity.intervals_from_base AS intervals_from_base,
          count(DISTINCT actor_activity.actor_id) AS count
   FROM
-    (SELECT retention_events.actor_id AS actor_id,
-            arrayFlatten(groupArray(retention_events.start_event_timestamps)) AS start_event_timestamps,
-            arrayFlatten(groupArray(retention_events.return_event_timestamps)) AS return_event_timestamps,
+    (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
+            if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
             arrayMap(x -> plus(toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1)), toIntervalDay(x)), range(0, 6)) AS date_range,
+            arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps,
             arrayJoin(arrayFilter(x -> ifNull(greater(x, -1), 0), arrayMap((interval_index, interval_date, _start_event_timestamps) -> if(ifNull(equals(_start_event_timestamps[1], interval_date), isNull(_start_event_timestamps[1])
                                                                                                                                                  and isNull(interval_date)), minus(interval_index, 1), -1), arrayEnumerate(date_range), date_range, arrayResize([start_event_timestamps], length(date_range), start_event_timestamps)))) AS start_interval_index,
             arrayJoin(arrayConcat(if(ifNull(equals(start_event_timestamps[1], date_range[plus(start_interval_index, 1)]), isNull(start_event_timestamps[1])
                                             and isNull(date_range[plus(start_interval_index, 1)])), [0], []), arrayFilter(x -> ifNull(greater(x, 0), 0), arrayMap(_timestamp -> minus(indexOf(arraySlice(date_range, plus(start_interval_index, 1), 5), _timestamp), 1), return_event_timestamps)))) AS intervals_from_base
-     FROM
-       (SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-               if(and(greaterOrEquals(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toDateTime64('explicit_redacted_timestamp', 6, 'UTC'))), [toStartOfInterval(if(equals(minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), minIf(toTimeZone(events.timestamp, 'UTC'), and(equals(events.event, 'target_event'), ifNull(equals(replaceRegexpAll(nullIf(nullIf(JSONExtractRaw(events.properties, 'prop'), ''), 'null'), '^"|"$', ''), 'correct'), 0)))), minIf(toTimeZone(events.timestamp, 'UTC'), equals(events.event, 'target_event')), NULL), toIntervalDay(1))], []) AS start_event_timestamps,
-               [] AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
-        GROUP BY actor_id
-        UNION ALL SELECT if(not(empty(events__override.distinct_id)), events__override.person_id, events.person_id) AS actor_id,
-                         [] AS start_event_timestamps,
-                         arraySort(groupUniqArrayIf(toStartOfDay(toTimeZone(events.timestamp, 'UTC')), and(equals(events.event, 'returning_event'), and(greaterOrEquals(toTimeZone(events.timestamp, 'UTC'), toStartOfInterval(assumeNotNull(toDateTime('2020-06-10 00:00:00', 'UTC')), toIntervalDay(1))), less(toTimeZone(events.timestamp, 'UTC'), toDateTime64('explicit_redacted_timestamp', 6, 'UTC')))))) AS return_event_timestamps
-        FROM events
-        LEFT OUTER JOIN
-          (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
-                  person_distinct_id_overrides.distinct_id AS distinct_id
-           FROM person_distinct_id_overrides
-           WHERE equals(person_distinct_id_overrides.team_id, 99999)
-           GROUP BY person_distinct_id_overrides.distinct_id
-           HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
-        WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
-        GROUP BY actor_id) AS retention_events
+     FROM events
+     LEFT OUTER JOIN
+       (SELECT argMax(person_distinct_id_overrides.person_id, person_distinct_id_overrides.version) AS person_id,
+               person_distinct_id_overrides.distinct_id AS distinct_id
+        FROM person_distinct_id_overrides
+        WHERE equals(person_distinct_id_overrides.team_id, 99999)
+        GROUP BY person_distinct_id_overrides.distinct_id
+        HAVING equals(argMax(person_distinct_id_overrides.is_deleted, person_distinct_id_overrides.version), 0) SETTINGS optimize_aggregation_in_order=1) AS events__override ON equals(events.distinct_id, events__override.distinct_id)
+     WHERE and(equals(events.team_id, 99999), in(events.event, tuple('returning_event', 'target_event')))
      GROUP BY actor_id
      HAVING 1) AS actor_activity
   GROUP BY start_event_matching_interval,

--- a/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
+++ b/posthog/hogql_queries/insights/retention/test/test_retention_query_runner.py
@@ -3665,13 +3665,91 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             ),
         )
 
-    def test_dwh_variant_pushes_sampling_into_event_subqueries(self):
-        # The variant wraps a UNION ALL in a JoinExpr; SAMPLE on that wrapper never reaches the inner
-        # events scans, so it must be pushed into each FROM events arm where ClickHouse can apply it.
+    def test_dwh_variant_events_only_is_single_events_scan(self):
+        # Events-only series read the same `events` source on both arms, so the variant must
+        # collapse to one FROM events scan rather than a two-arm UNION ALL.
+        query = RetentionQuery(
+            dateRange={"date_to": _date(10, hour=6)},
+            retentionFilter={"totalIntervals": 11},
+        )
+        runner = RetentionQueryRunner(team=self.team, query=query)
+
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=True):
+            base_query = RetentionFixedIntervalBaseQueryBuilder(runner).build()
+
+        assert base_query.select_from is not None
+        self.assertNotIsInstance(base_query.select_from.table, ast.SelectSetQuery)
+        assert isinstance(base_query.select_from.table, ast.Field)
+        self.assertEqual(base_query.select_from.table.chain, ["events"])
+
+    def test_dwh_variant_events_only_sampling_lands_on_single_scan(self):
+        # No UNION wrapper to push into: sampling must land directly on the single FROM events scan,
+        # exactly as the legacy path samples it.
         query = RetentionQuery(
             dateRange={"date_to": _date(10, hour=6)},
             samplingFactor=0.5,
             retentionFilter={"totalIntervals": 11},
+        )
+        runner = RetentionQueryRunner(team=self.team, query=query)
+
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=True):
+            base_query = RetentionFixedIntervalBaseQueryBuilder(runner).build()
+
+        assert base_query.select_from is not None
+        assert isinstance(base_query.select_from.table, ast.Field)
+        self.assertEqual(base_query.select_from.table.chain, ["events"])
+        sample = base_query.select_from.sample
+        assert isinstance(sample, ast.SampleExpr)
+        self.assertEqual(sample.sample_value.left.value, 0.5)
+
+    def test_dwh_variant_multi_source_stays_union(self):
+        # Two different data-warehouse tables are genuinely separate sources and cannot collapse to a
+        # single scan, so the variant must keep the two-pass UNION ALL.
+        def dwh_entity(table: str, ts: str) -> dict:
+            return {
+                "id": table,
+                "name": table,
+                "type": "data_warehouse",
+                "table_name": table,
+                "aggregation_target_field": "person_id",
+                "timestamp_field": ts,
+            }
+
+        query = RetentionQuery(
+            dateRange={"date_to": _date(10, hour=6)},
+            retentionFilter={
+                "totalIntervals": 11,
+                "targetEntity": dwh_entity("warehouse_signups", "signed_up_at"),
+                "returningEntity": dwh_entity("warehouse_renewals", "renewed_at"),
+            },
+        )
+        runner = RetentionQueryRunner(team=self.team, query=query)
+
+        with patch(RETENTION_BASE_QUERY_VARIANT_PATCH_PATH, return_value=True):
+            base_query = RetentionFixedIntervalBaseQueryBuilder(runner).build()
+
+        assert base_query.select_from is not None
+        self.assertIsInstance(base_query.select_from.table, ast.SelectSetQuery)
+
+    def test_dwh_variant_pushes_sampling_into_event_subqueries(self):
+        # Multi-source (events start, data-warehouse return) keeps the two-pass UNION ALL. SAMPLE on the
+        # wrapper never reaches the inner scans, so it must be pushed into the events arm — and only that
+        # arm, since the data-warehouse table is skipped by apply_sampling.
+        query = RetentionQuery(
+            dateRange={"date_to": _date(10, hour=6)},
+            samplingFactor=0.5,
+            retentionFilter={
+                "totalIntervals": 11,
+                "targetEntity": {"id": "$pageview", "name": "$pageview", "type": "events"},
+                "returningEntity": {
+                    "id": "warehouse_renewals",
+                    "name": "warehouse_renewals",
+                    "type": "data_warehouse",
+                    "table_name": "warehouse_renewals",
+                    "aggregation_target_field": "person_id",
+                    "timestamp_field": "renewed_at",
+                },
+            },
         )
         runner = RetentionQueryRunner(team=self.team, query=query)
 
@@ -3691,12 +3769,24 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
             and isinstance(arm.select_from.table, ast.Field)
             and arm.select_from.table.chain == ["events"]
         ]
-        self.assertEqual(len(event_arms), 2)
-        for arm in event_arms:
-            assert arm.select_from is not None
-            sample = arm.select_from.sample
-            assert isinstance(sample, ast.SampleExpr)
-            self.assertEqual(sample.sample_value.left.value, 0.5)
+        self.assertEqual(len(event_arms), 1)
+        arm = event_arms[0]
+        assert arm.select_from is not None
+        sample = arm.select_from.sample
+        assert isinstance(sample, ast.SampleExpr)
+        self.assertEqual(sample.sample_value.left.value, 0.5)
+
+        dwh_arms = [
+            arm
+            for arm in union.select_queries()
+            if isinstance(arm, ast.SelectQuery)
+            and arm.select_from is not None
+            and isinstance(arm.select_from.table, ast.Field)
+            and arm.select_from.table.chain == ["warehouse_renewals"]
+        ]
+        self.assertEqual(len(dwh_arms), 1)
+        assert dwh_arms[0].select_from is not None
+        self.assertIsNone(dwh_arms[0].select_from.sample)
 
     def _create_sampling_parity_fixtures(self):
         for i in range(20):
@@ -3906,8 +3996,9 @@ class TestRetention(RetentionBaseQueryVariantComparisonMixin, ClickhouseTestMixi
         self.assertNotIn("control", {c.get("breakdown_value") for c in result})
 
     def test_dwh_variant_breakdown_cohort_union_of_unions_parity(self):
-        # Cohort breakdown composes as a UNION ALL of per-cohort base queries, each
-        # itself a UNION ALL inside the variant. Both paths must agree on that shape.
+        # Cohort breakdown composes as a UNION ALL of per-cohort base queries. Each per-cohort base
+        # query is events-only, so under the variant it collapses to a single events scan (not a
+        # nested UNION). Both paths must agree on the result.
         _create_person(team_id=self.team.pk, distinct_ids=["p1"], properties={"name": "p1"})
         _create_person(team_id=self.team.pk, distinct_ids=["p2"], properties={"name": "p2"})
         cohort1 = Cohort.objects.create(


### PR DESCRIPTION
## Problem

The retention fixed-interval DWH variant (`build_base_query_dwh`) reads `events` twice for events-only series. It builds a start arm and a return arm, both `FROM events`, combines them via `UNION ALL`, then re-aggregates the outer query with `arrayFlatten(groupArray(...))`. For events-only series — neither entity is a data-warehouse table, which is ~all production retention traffic — the second scan is pure overhead. An at-scale comparison measured a constant 2.0x `read_bytes` and ~+28% warm-cache median wall time versus the legacy single-pass query. The variant cannot replace the legacy path until events-only collapses to one scan.

## Changes

`build_base_query_dwh` now branches on a `_can_single_scan()` predicate: events-only, non-property-aggregating series emit a single `SELECT … FROM events … GROUP BY actor_id` that computes both the start and return interval-timestamp arrays inline — no `UNION ALL`, no outer flatten. The new builder is assembled from the variant's own expression helpers (`_single_scan_start_event_timestamps_expr`, `_get_dwh_return_timestamps_expr`, `_first_time_start_event_timestamps_expr`, the min-occurrences and interval helpers), so for events-only it is legacy-equivalent by construction. It returns a plain `ast.SelectQuery`, so the existing `apply_sampling` / `apply_breakdown` overrides fall through to the parent and handle sampling and breakdown exactly as the legacy path.

Out of scope (deferred): same-data-warehouse-table collapse (needs source-aware sampling/breakdown), property-aggregation collapse (has a known legacy/variant discrepancy), and the multi-source routing flag. Any data-warehouse entity or property aggregation keeps the two-pass UNION. The router and `build_base_query_legacy` are untouched.

This is an internal query-shape change only — zero user-visible difference.

## How did you test this code?

I'm an agent (PostHog Code). Automated tests only — no manual testing.

- New AST-shape tests: events-only variant builds a single `FROM events` scan (not a `SelectSetQuery`); sampling lands on that scan; a multi-source series (two different data-warehouse tables) still builds a `SelectSetQuery`. These catch a regression where the collapse either fails to fire for events-only or wrongly fires for a genuine multi-source series.
- Repointed `test_dwh_variant_pushes_sampling_into_event_subqueries` to a multi-source (events + data-warehouse) query, since events-only no longer produces a UNION; it now asserts the single events arm is sampled and the data-warehouse arm is skipped.
- Regression gate: the existing `TestRetention` comparison mixin runs every case through both the legacy and the variant path and asserts identical results — it now meaningfully exercises single-scan vs legacy across plain / first-time / first-ever / min-occurrences / breakdown / sampling. Full `hogli test posthog/hogql_queries/insights/retention`: 166 passed, snapshots updated to the collapsed shape. The 13 remaining failures are pre-existing in this local environment (actor/person queries need the personhog gRPC service, which isn't running locally) and fail identically on the base commit — zero new failures.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code following a detailed plan supplied by the human driver. Invoked the `/tdd` skill and worked test-first in vertical slices (shape tracer → sampling → multi-source boundary → repoint existing test → full parity gate). The plan deliberately rejected an earlier approach that refactored the load-bearing legacy path into a shared builder; this PR instead reuses the variant's own arm expression builders, so parity is verified by the existing comparison suite with no new gating logic. Snapshot `.ambr` updates are purely structural (90 deletions of the UNION/flatten machinery, 36 insertions of the single scan).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
