### PR TITLE
chore(nodejs): decouple config and types from ingestion

### DIFF
--- a/nodejs/src/api/router.ts
+++ b/nodejs/src/api/router.ts
@@ -9,7 +9,10 @@ import { logger } from '~/utils/logger'
 
 prometheus.collectDefaultMetrics()
 
-export function initializePrometheusLabels(ingestionPipeline: string | null, ingestionLane: string | null): void {
+export function initializePrometheusLabels(
+    ingestionPipeline: string | null = null,
+    ingestionLane: string | null = null
+): void {
     const labels: Record<string, string> = {}
     if (ingestionPipeline) {
         labels['ingestion_pipeline'] = ingestionPipeline

--- a/nodejs/src/config/config.ts
+++ b/nodejs/src/config/config.ts
@@ -1,9 +1,3 @@
-import { getDefaultErrorTrackingConsumerConfig } from '~/ingestion/pipelines/errortracking/config'
-import { getDefaultMetricsIngestionConsumerConfig } from '~/ingestion/pipelines/metrics/config'
-import {
-    getDefaultSessionRecordingApiConfig,
-    getDefaultSessionRecordingConfig,
-} from '~/ingestion/pipelines/sessionreplay/config'
 import { getDefaultLogsIngestionConsumerConfig, getDefaultTracesIngestionConsumerConfig } from '~/logs/config'
 
 import { getDefaultAIObservabilityConfig } from '../ai-observability/config'
@@ -15,7 +9,6 @@ import {
     getDefaultKafkaWarpstreamIngestionProducerEnvConfig,
 } from '../cdp/outputs/producers'
 import { getDefaultCommonConfig } from '../common/config'
-import { getDefaultIngestionConsumerConfig } from '../ingestion/config'
 import { PluginsServerConfig, ValueMatcher, stringToPluginServerMode } from '../types'
 import { stringToBoolean } from '../utils/env-utils'
 
@@ -29,13 +22,8 @@ export function getDefaultConfig(): PluginsServerConfig {
         ...getDefaultCommonConfig(),
         ...getDefaultCdpConfig(),
         ...getDefaultAIObservabilityConfig(),
-        ...getDefaultIngestionConsumerConfig(),
         ...getDefaultLogsIngestionConsumerConfig(),
-        ...getDefaultMetricsIngestionConsumerConfig(),
         ...getDefaultTracesIngestionConsumerConfig(),
-        ...getDefaultErrorTrackingConsumerConfig(),
-        ...getDefaultSessionRecordingConfig(),
-        ...getDefaultSessionRecordingApiConfig(),
         ...getDefaultKafkaWarpstreamIngestionProducerEnvConfig(),
         ...getDefaultKafkaWarpstreamCalculatedEventsProducerEnvConfig(),
         ...getDefaultKafkaWarpstreamCyclotronProducerEnvConfig(),

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -1,7 +1,8 @@
 // NOTE: Keep these as ~ imports as we can validate the build output this way
 import { PluginServerMode } from '~/common/config'
 import { initTracing } from '~/common/tracing/otel'
-import { defaultConfig } from '~/config/config'
+import { defaultConfig, overrideConfigWithEnv } from '~/config/config'
+import { getDefaultIngestionConsumerConfig } from '~/ingestion/config'
 import { PluginServer } from '~/server'
 import { NodeServer } from '~/servers/base-server'
 import { ErrorTrackingServer } from '~/servers/error-tracking-server'
@@ -15,6 +16,9 @@ import { RecordingApiServer } from '~/servers/recording-api-server'
 import { initSuperProperties } from '~/utils/posthog'
 
 function createServer(): NodeServer {
+    const { PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE } = overrideConfigWithEnv(getDefaultIngestionConsumerConfig())
+    initSuperProperties(PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE)
+
     switch (defaultConfig.PLUGIN_SERVER_MODE) {
         case PluginServerMode.ingestion_v2:
         case PluginServerMode.ingestion_v2_combined:
@@ -48,7 +52,6 @@ function createServer(): NodeServer {
     }
 }
 
-initSuperProperties()
 initTracing()
 const server = createServer()
 void server.start()

--- a/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
+++ b/nodejs/src/ingestion/common/persons/batch-writing-person-store.ts
@@ -29,14 +29,9 @@ import {
 import { PersonRepositoryTransaction } from '~/common/persons/repositories/person-repository-transaction'
 import { emitIngestionWarning } from '~/ingestion/common/ingestion-warnings'
 import { BatchWritingStore, BatchWritingStoreFlushStats } from '~/ingestion/common/stores/batch-writing-store'
+import { PersonBatchWritingDbWriteMode } from '~/ingestion/config'
 import { Properties } from '~/plugin-scaffold'
-import {
-    InternalPerson,
-    PersonBatchWritingDbWriteMode,
-    PropertiesLastOperation,
-    PropertiesLastUpdatedAt,
-    Team,
-} from '~/types'
+import { InternalPerson, PropertiesLastOperation, PropertiesLastUpdatedAt, Team } from '~/types'
 import { CreatePersonResult, MoveDistinctIdsResult } from '~/utils/db/db'
 import { MessageSizeTooLarge } from '~/utils/db/error'
 import { logger } from '~/utils/logger'

--- a/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
+++ b/nodejs/src/ingestion/pipelines/errortracking/error-tracking-consumer.ts
@@ -12,6 +12,7 @@ import { AppMetricsAggregator } from '~/common/services/app-metrics-aggregator'
 import { KeyedRateLimiterService } from '~/common/services/keyed-rate-limiter.service'
 import { instrumentFn } from '~/common/tracing/tracing-utils'
 import { CookielessManager } from '~/ingestion/common/cookieless/cookieless-manager'
+import { IngestionLane } from '~/ingestion/config'
 import { BatchPipelineUnwrapper } from '~/ingestion/framework/batch-pipeline-unwrapper'
 import { TopHog } from '~/ingestion/framework/tophog'
 import { MainLaneOverflowRedirect } from '~/ingestion/utils/overflow-redirect/main-lane-overflow-redirect'
@@ -20,7 +21,7 @@ import { OverflowRedirectService } from '~/ingestion/utils/overflow-redirect/ove
 import { RedisOverflowRepository } from '~/ingestion/utils/overflow-redirect/overflow-redis-repository'
 import { KafkaConsumerInterface, createKafkaConsumer } from '~/kafka/consumer'
 import { PluginEvent } from '~/plugin-scaffold'
-import { HealthCheckResult, IngestionLane, PluginServerService } from '~/types'
+import { HealthCheckResult, PluginServerService } from '~/types'
 import { ErrorTrackingSettingsManager } from '~/utils/error-tracking-settings-manager'
 import {
     EventIngestionRestrictionManager,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/consumer.ts
@@ -207,6 +207,7 @@ export class SessionRecordingIngester {
             maxBatchSizeBytes: this.config.SESSION_RECORDING_MAX_BATCH_SIZE_KB * 1024,
             maxBatchAgeMs: this.config.SESSION_RECORDING_MAX_BATCH_AGE_MS,
             maxEventsPerSessionPerBatch: this.config.SESSION_RECORDING_V2_MAX_EVENTS_PER_SESSION_PER_BATCH,
+            featuresRolloutPercentage: this.config.SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE,
             offsetManager,
             fileStorage: this.fileStorage,
             metadataStore,

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-manager.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-manager.test.ts
@@ -118,7 +118,8 @@ describe('SessionBatchManager', () => {
             mockSessionFilter,
             mockKeyStore,
             mockEncryptor,
-            Number.MAX_SAFE_INTEGER
+            Number.MAX_SAFE_INTEGER,
+            100
         )
 
         const secondBatch = manager.getCurrentBatch()
@@ -213,7 +214,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                500
+                500,
+                100
             )
         })
 
@@ -245,7 +247,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                250
+                250,
+                100
             )
         })
 
@@ -275,7 +278,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                0
+                0,
+                100
             )
         })
 
@@ -305,7 +309,8 @@ describe('SessionBatchManager', () => {
                 mockSessionFilter,
                 mockKeyStore,
                 mockEncryptor,
-                Number.MAX_SAFE_INTEGER
+                Number.MAX_SAFE_INTEGER,
+                100
             )
         })
     })

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-manager.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-manager.ts
@@ -17,6 +17,8 @@ export interface SessionBatchManagerConfig {
     maxBatchAgeMs: number
     /** Maximum number of events per session per batch before rate limiting */
     maxEventsPerSessionPerBatch: number
+    /** Rollout percentage (0-100) for the per-session ML feature recorder */
+    featuresRolloutPercentage?: number
     /** Manages Kafka offset tracking and commits */
     offsetManager: KafkaOffsetManager
     /** Handles writing session batch files to storage */
@@ -76,6 +78,7 @@ export class SessionBatchManager {
     private readonly maxBatchSizeBytes: number
     private readonly maxBatchAgeMs: number
     private readonly maxEventsPerSessionPerBatch: number
+    private readonly featuresRolloutPercentage: number
     private readonly offsetManager: KafkaOffsetManager
     private readonly fileStorage: SessionBatchFileStorage
     private readonly metadataStore: SessionMetadataStore
@@ -91,6 +94,7 @@ export class SessionBatchManager {
         this.maxBatchSizeBytes = config.maxBatchSizeBytes
         this.maxBatchAgeMs = config.maxBatchAgeMs
         this.maxEventsPerSessionPerBatch = config.maxEventsPerSessionPerBatch
+        this.featuresRolloutPercentage = config.featuresRolloutPercentage ?? 100
         this.offsetManager = config.offsetManager
         this.fileStorage = config.fileStorage
         this.metadataStore = config.metadataStore
@@ -111,7 +115,8 @@ export class SessionBatchManager {
             this.sessionFilter,
             this.keyStore,
             this.encryptor,
-            this.maxEventsPerSessionPerBatch
+            this.maxEventsPerSessionPerBatch,
+            this.featuresRolloutPercentage
         )
         this.lastFlushTime = Date.now()
     }
@@ -139,7 +144,8 @@ export class SessionBatchManager {
             this.sessionFilter,
             this.keyStore,
             this.encryptor,
-            this.maxEventsPerSessionPerBatch
+            this.maxEventsPerSessionPerBatch,
+            this.featuresRolloutPercentage
         )
         this.lastFlushTime = Date.now()
     }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-recorder.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-batch-recorder.ts
@@ -85,7 +85,8 @@ export class SessionBatchRecorder {
         private readonly sessionFilter: SessionFilter,
         private readonly keyStore: KeyStore,
         private readonly encryptor: RecordingEncryptor,
-        maxEventsPerSessionPerBatch: number = Number.MAX_SAFE_INTEGER
+        maxEventsPerSessionPerBatch: number = Number.MAX_SAFE_INTEGER,
+        private readonly featuresRolloutPercentage: number = 100
     ) {
         this.batchId = uuidv7()
         this.rateLimiter = new SessionRateLimiter(maxEventsPerSessionPerBatch)
@@ -196,7 +197,7 @@ export class SessionBatchRecorder {
             sessions.set(teamSessionKey, [
                 new SnappySessionRecorder(sessionId, teamId, this.batchId),
                 new SessionConsoleLogRecorder(sessionId, teamId, this.batchId, this.consoleLogStore),
-                new SessionFeatureRecorder(sessionId, teamId, this.batchId),
+                new SessionFeatureRecorder(sessionId, teamId, this.batchId, this.featuresRolloutPercentage),
                 sessionKey,
             ])
         }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.test.ts
@@ -1,17 +1,9 @@
 import { DateTime } from 'luxon'
 
-import { defaultConfig } from '~/config/config'
 import { ParsedMessageData, SnapshotEvent } from '~/ingestion/pipelines/sessionreplay/kafka/types'
 import { MouseInteractions, RRWebEventSource, RRWebEventType } from '~/ingestion/pipelines/sessionreplay/rrweb-types'
 
 import { MAX_UNIQUE_VALUES, SessionFeatureRecorder, md5Hex } from './session-feature-recorder'
-
-jest.mock('~/config/config', () => ({
-    defaultConfig: {
-        SESSION_RECORDING_FEATURES_ENABLED: true,
-        SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE: 100,
-    },
-}))
 
 const createMessage = (events: SnapshotEvent[], distinctId = 'user1'): ParsedMessageData => ({
     distinct_id: distinctId,
@@ -95,7 +87,7 @@ describe('SessionFeatureRecorder', () => {
     let recorder: SessionFeatureRecorder
 
     beforeEach(() => {
-        recorder = new SessionFeatureRecorder('session1', 1, 'batch1')
+        recorder = new SessionFeatureRecorder('session1', 1, 'batch1', 100)
     })
 
     describe('Basic lifecycle', () => {
@@ -1602,28 +1594,21 @@ describe('SessionFeatureRecorder', () => {
     })
 
     describe('Rollout gating', () => {
-        afterEach(() => {
-            ;(defaultConfig as any).SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE = 100
-        })
-
         it('should return null from end() when rollout is 0', () => {
-            ;(defaultConfig as any).SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE = 0
-            const gatedRecorder = new SessionFeatureRecorder('session1', 1, 'batch1')
+            const gatedRecorder = new SessionFeatureRecorder('session1', 1, 'batch1', 0)
             gatedRecorder.recordMessage(createMessage([makeClickEvent(1000)]))
             expect(gatedRecorder.end()).toBeNull()
         })
 
         it('should return features when rollout is 100', () => {
-            ;(defaultConfig as any).SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE = 100
-            const gatedRecorder = new SessionFeatureRecorder('session1', 1, 'batch1')
+            const gatedRecorder = new SessionFeatureRecorder('session1', 1, 'batch1', 100)
             gatedRecorder.recordMessage(createMessage([makeClickEvent(1000)]))
             expect(gatedRecorder.end()).not.toBeNull()
         })
 
         it('should be deterministic for the same session ID', () => {
-            ;(defaultConfig as any).SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE = 50
             const results = Array.from({ length: 10 }, () => {
-                const r = new SessionFeatureRecorder('fixed-session-id', 1, 'batch1')
+                const r = new SessionFeatureRecorder('fixed-session-id', 1, 'batch1', 50)
                 return r.end()
             })
             const allNull = results.every((r) => r === null)

--- a/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/sessions/session-feature-recorder.ts
@@ -1,7 +1,6 @@
 import crypto from 'crypto'
 import { DateTime } from 'luxon'
 
-import { defaultConfig } from '~/config/config'
 import { ParsedMessageData, SnapshotEvent } from '~/ingestion/pipelines/sessionreplay/kafka/types'
 import {
     MouseInteractions,
@@ -331,7 +330,8 @@ export class SessionFeatureRecorder {
     constructor(
         public readonly sessionId: string,
         public readonly teamId: number,
-        public readonly batchId: string
+        public readonly batchId: string,
+        public readonly rolloutPercentage: number
     ) {
         this._run = this.shouldRun(sessionId)
     }
@@ -374,7 +374,7 @@ export class SessionFeatureRecorder {
 
     /** Ad-hoc rollout md5 gate */
     private shouldRun(sessionId: string): boolean {
-        const rolloutPercentage = defaultConfig.SESSION_RECORDING_FEATURES_ROLLOUT_PERCENTAGE
+        const rolloutPercentage = this.rolloutPercentage
         if (rolloutPercentage >= 100) {
             return true
         }

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -81,7 +81,7 @@ export class PluginServer implements NodeServer {
     }
 
     private async startServices(): Promise<void> {
-        initializePrometheusLabels(this.config.INGESTION_PIPELINE, this.config.INGESTION_LANE)
+        initializePrometheusLabels()
 
         const capabilities = getPluginServerCapabilities(this.config)
 

--- a/nodejs/src/servers/error-tracking-server.ts
+++ b/nodejs/src/servers/error-tracking-server.ts
@@ -16,6 +16,7 @@ import {
 import {
     ErrorTrackingConsumerConfig,
     ErrorTrackingOutputsConfig,
+    getDefaultErrorTrackingConsumerConfig,
     getDefaultErrorTrackingOutputsConfig,
 } from '~/ingestion/pipelines/errortracking/config'
 import { ErrorTrackingConsumer } from '~/ingestion/pipelines/errortracking/error-tracking-consumer'
@@ -36,6 +37,7 @@ import {
     KafkaBrokerConfig,
     KafkaConsumerBaseConfig,
     RedisConnectionsConfig,
+    getDefaultIngestionConsumerConfig,
 } from '../ingestion/config'
 import { PluginServerService, RedisPool } from '../types'
 import { ServerCommands } from '../utils/commands'
@@ -95,6 +97,8 @@ export class ErrorTrackingServer implements NodeServer {
     constructor(config: Partial<ErrorTrackingServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultIngestionConsumerConfig()),
+            ...overrideConfigWithEnv(getDefaultErrorTrackingConsumerConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaUpstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaDownstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultErrorTrackingOutputsConfig()),

--- a/nodejs/src/servers/ingestion-api-server.ts
+++ b/nodejs/src/servers/ingestion-api-server.ts
@@ -58,6 +58,7 @@ import {
     KafkaBrokerConfig,
     KafkaConsumerBaseConfig,
     RedisConnectionsConfig,
+    getDefaultIngestionConsumerConfig,
     getDefaultIngestionOutputsConfig,
 } from '../ingestion/config'
 import { createFeatureFlagCalledDedupService } from '../ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service'
@@ -182,6 +183,7 @@ export class IngestionApiServer implements NodeServer {
     constructor(config: Partial<IngestionApiServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultIngestionConsumerConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaUpstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaDownstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultIngestionOutputsConfig()),

--- a/nodejs/src/servers/ingestion-general-server.ts
+++ b/nodejs/src/servers/ingestion-general-server.ts
@@ -45,6 +45,7 @@ import {
     KafkaBrokerConfig,
     KafkaConsumerBaseConfig,
     RedisConnectionsConfig,
+    getDefaultIngestionConsumerConfig,
     getDefaultIngestionOutputsConfig,
 } from '../ingestion/config'
 import { IngestionConsumer, IngestionConsumerDeps } from '../ingestion/ingestion-consumer'
@@ -109,6 +110,7 @@ export class IngestionGeneralServer implements NodeServer {
     constructor(config: Partial<IngestionGeneralServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultIngestionConsumerConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaUpstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaDownstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultIngestionOutputsConfig()),

--- a/nodejs/src/servers/ingestion-metrics-server.ts
+++ b/nodejs/src/servers/ingestion-metrics-server.ts
@@ -3,6 +3,7 @@ import { QuotaLimiting } from '~/common/services/quota-limiting.service'
 import {
     MetricsIngestionConsumerConfig,
     MetricsIngestionOutputsConfig,
+    getDefaultMetricsIngestionConsumerConfig,
     getDefaultMetricsIngestionOutputsConfig,
 } from '~/ingestion/pipelines/metrics/config'
 import { MetricsIngestionConsumer } from '~/ingestion/pipelines/metrics/metrics-ingestion-consumer'
@@ -59,6 +60,7 @@ export class IngestionMetricsServer implements NodeServer {
     constructor(config: Partial<IngestionMetricsServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultMetricsIngestionConsumerConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamMetricsProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaWarpstreamIngestionProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultMetricsIngestionOutputsConfig()),

--- a/nodejs/src/servers/ingestion-session-replay-server.ts
+++ b/nodejs/src/servers/ingestion-session-replay-server.ts
@@ -6,6 +6,8 @@ import {
 import {
     SessionReplayOutputsConfig,
     type SessionReplayProducerName,
+    getDefaultSessionRecordingApiConfig,
+    getDefaultSessionRecordingConfig,
     getDefaultSessionReplayOutputsConfig,
 } from '~/ingestion/pipelines/sessionreplay/config'
 import { SessionRecordingIngester, SessionRecordingIngesterConfig } from '~/ingestion/pipelines/sessionreplay/consumer'
@@ -19,7 +21,7 @@ import {
 import { initializePrometheusLabels } from '../api/router'
 import { CommonConfig } from '../common/config'
 import { defaultConfig, overrideConfigWithEnv } from '../config/config'
-import { KafkaBrokerConfig, RedisConnectionsConfig } from '../ingestion/config'
+import { KafkaBrokerConfig, RedisConnectionsConfig, getDefaultIngestionConsumerConfig } from '../ingestion/config'
 import { RedisPool } from '../types'
 import { PostgresRouter, PostgresRouterConfig } from '../utils/db/postgres'
 import { createRedisPoolFromConfig } from '../utils/db/redis'
@@ -64,6 +66,9 @@ export class IngestionSessionReplayServer implements NodeServer {
     constructor(config: Partial<IngestionSessionReplayServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultIngestionConsumerConfig()),
+            ...overrideConfigWithEnv(getDefaultSessionRecordingConfig()),
+            ...overrideConfigWithEnv(getDefaultSessionRecordingApiConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaDownstreamProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaSessionreplayProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultSessionReplayOutputsConfig()),

--- a/nodejs/src/servers/recording-api-server.ts
+++ b/nodejs/src/servers/recording-api-server.ts
@@ -1,5 +1,9 @@
 import { KafkaProducerRegistry } from '~/common/outputs/kafka-producer-registry'
 import {
+    getDefaultSessionRecordingApiConfig,
+    getDefaultSessionRecordingConfig,
+} from '~/ingestion/pipelines/sessionreplay/config'
+import {
     KafkaSessionreplayProducerEnvConfig,
     getDefaultKafkaSessionreplayProducerEnvConfig,
 } from '~/ingestion/pipelines/sessionreplay/shared/outputs/producer-config'
@@ -41,6 +45,8 @@ export class RecordingApiServer implements NodeServer {
     constructor(config: Partial<RecordingApiServerConfig> = {}) {
         this.config = {
             ...defaultConfig,
+            ...overrideConfigWithEnv(getDefaultSessionRecordingConfig()),
+            ...overrideConfigWithEnv(getDefaultSessionRecordingApiConfig()),
             ...overrideConfigWithEnv(getDefaultKafkaSessionreplayProducerEnvConfig()),
             ...overrideConfigWithEnv(getDefaultRecordingApiOutputsConfig()),
             ...config,

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -7,9 +7,6 @@ import { GroupTypeManager } from '~/common/groups/group-type-manager'
 import { GroupRepository } from '~/common/groups/repositories/group-repository.interface'
 import { PersonRepository } from '~/common/persons/repositories/person-repository'
 import { QuotaLimiting } from '~/common/services/quota-limiting.service'
-import type { ErrorTrackingConsumerConfig } from '~/ingestion/pipelines/errortracking/config'
-import type { MetricsIngestionConsumerConfig } from '~/ingestion/pipelines/metrics/config'
-import type { SessionRecordingApiConfig, SessionRecordingConfig } from '~/ingestion/pipelines/sessionreplay/config'
 import type { LogsIngestionConsumerConfig, TracesIngestionConsumerConfig } from '~/logs/config'
 import { Element, PluginEvent, Properties } from '~/plugin-scaffold'
 
@@ -24,7 +21,6 @@ import type {
 import { IntegrationManagerService } from './cdp/services/managers/integration-manager.service'
 import { EncryptedFields } from './cdp/utils/encryption-utils'
 import type { CommonConfig } from './common/config'
-import type { IngestionConsumerConfig } from './ingestion/config'
 import { PostgresRouter } from './utils/db/postgres'
 import { GeoIPService } from './utils/geoip'
 import { PubSub } from './utils/pubsub'
@@ -39,16 +35,7 @@ export type { CdpConfig } from './cdp/config'
 export type { AIObservabilityConfig } from './ai-observability/config'
 export { KafkaSaslMechanism, PluginServerMode, stringToPluginServerMode } from './common/config'
 export type { CommonConfig, LogLevel } from './common/config'
-export type {
-    IngestionConsumerConfig,
-    IngestionLane,
-    PersonBatchWritingDbWriteMode,
-    PersonBatchWritingMode,
-} from './ingestion/config'
-export type { ErrorTrackingConsumerConfig } from '~/ingestion/pipelines/errortracking/config'
 export type { LogsIngestionConsumerConfig } from '~/logs/config'
-export type { MetricsIngestionConsumerConfig } from '~/ingestion/pipelines/metrics/config'
-export type { SessionRecordingApiConfig, SessionRecordingConfig } from '~/ingestion/pipelines/sessionreplay/config'
 
 interface HealthCheckResultResponse {
     service: string
@@ -115,13 +102,8 @@ export interface PluginsServerConfig
     extends CommonConfig,
         CdpConfig,
         AIObservabilityConfig,
-        IngestionConsumerConfig,
         LogsIngestionConsumerConfig,
         TracesIngestionConsumerConfig,
-        ErrorTrackingConsumerConfig,
-        MetricsIngestionConsumerConfig,
-        SessionRecordingConfig,
-        SessionRecordingApiConfig,
         // Producer envs needed by the CDP producer registry the legacy big server builds.
         KafkaWarpstreamIngestionProducerEnvConfig,
         KafkaWarpstreamCalculatedEventsProducerEnvConfig,

--- a/nodejs/src/utils/db/hub.ts
+++ b/nodejs/src/utils/db/hub.ts
@@ -71,7 +71,8 @@ export async function createHub(config: Partial<PluginsServerConfig> = {}): Prom
     const postgresGroupRepository = new PostgresGroupRepository(postgres)
 
     const postgresPersonRepository = new PostgresPersonRepository(postgres, {
-        calculatePropertiesSize: serverConfig.PERSON_UPDATE_CALCULATE_PROPERTIES_SIZE,
+        // createHub is legacy/test-only; ingestion configures this on its own infra (see createIngestionTestInfra).
+        calculatePropertiesSize: 0,
     })
     const personRepository = buildPersonRepository(
         personhogClient,

--- a/nodejs/src/utils/posthog.ts
+++ b/nodejs/src/utils/posthog.ts
@@ -16,12 +16,12 @@ if (process.env.NODE_ENV === 'test' && posthog) {
     void posthog.disable()
 }
 
-export function initSuperProperties(): void {
+export function initSuperProperties(eventsIngestionPipeline: string | null = null): void {
     if (posthog) {
         const superProperties: Record<string, any> = {
             plugin_server_mode: defaultConfig.PLUGIN_SERVER_MODE,
             deployment: defaultConfig.CLOUD_DEPLOYMENT,
-            plugin_server_events_ingestion_pipeline: defaultConfig.PLUGIN_SERVER_EVENTS_INGESTION_PIPELINE,
+            plugin_server_events_ingestion_pipeline: eventsIngestionPipeline,
             // Super properties matching Python posthoganalytics.super_properties (posthog/apps.py)
             region: defaultConfig.CLOUD_DEPLOYMENT,
             service: defaultConfig.OTEL_SERVICE_NAME,

--- a/nodejs/src/utils/token-bucket.ts
+++ b/nodejs/src/utils/token-bucket.ts
@@ -1,5 +1,3 @@
-import { defaultConfig } from './../config/config'
-
 type Bucket = [tokens: number, lastReplenishedTimestamp: number]
 
 export class BucketKeyMissingError extends Error {
@@ -66,11 +64,6 @@ export class Limiter {
         return this.storage.consume(key, tokens)
     }
 }
-
-export const ConfiguredLimiter: Limiter = new Limiter(
-    defaultConfig.EVENT_OVERFLOW_BUCKET_CAPACITY,
-    defaultConfig.EVENT_OVERFLOW_BUCKET_REPLENISH_RATE
-)
 
 export const IngestionWarningLimiter: Limiter = new Limiter(1, 1.0 / 3600)
 

--- a/nodejs/tests/helpers/ingestion-e2e.ts
+++ b/nodejs/tests/helpers/ingestion-e2e.ts
@@ -9,6 +9,21 @@ import { buildGroupRepository, buildPersonRepository, createPersonHogClient } fr
 import { PersonRepository } from '~/common/persons/repositories/person-repository'
 import { PostgresPersonRepository } from '~/common/persons/repositories/postgres-person-repository'
 import { CookielessManager } from '~/ingestion/common/cookieless/cookieless-manager'
+import { IngestionConsumerConfig, getDefaultIngestionConsumerConfig } from '~/ingestion/config'
+import {
+    ErrorTrackingConsumerConfig,
+    getDefaultErrorTrackingConsumerConfig,
+} from '~/ingestion/pipelines/errortracking/config'
+import {
+    MetricsIngestionConsumerConfig,
+    getDefaultMetricsIngestionConsumerConfig,
+} from '~/ingestion/pipelines/metrics/config'
+import {
+    SessionRecordingApiConfig,
+    SessionRecordingConfig,
+    getDefaultSessionRecordingApiConfig,
+    getDefaultSessionRecordingConfig,
+} from '~/ingestion/pipelines/sessionreplay/config'
 
 import { IntegrationManagerService } from '../../src/cdp/services/managers/integration-manager.service'
 import { EncryptedFields } from '../../src/cdp/utils/encryption-utils'
@@ -315,12 +330,20 @@ export interface IngesterLike {
     stop(): Promise<void>
 }
 
+/** The full config an ingestion test sees — PluginsServerConfig plus every ingestion domain's config. */
+export type IngestionTestConfig = PluginsServerConfig &
+    IngestionConsumerConfig &
+    ErrorTrackingConsumerConfig &
+    MetricsIngestionConsumerConfig &
+    SessionRecordingConfig &
+    SessionRecordingApiConfig
+
 /**
  * Set of primitives the test harness exposes to an ingester builder. Built
  * directly from primitive Manager/factory calls — no hub involved.
  */
 export interface IngestionTestInfra {
-    config: PluginsServerConfig
+    config: IngestionTestConfig
     postgres: PostgresRouter
     redisPool: RedisPool
     teamManager: TeamManager
@@ -346,7 +369,7 @@ export interface TeamIngesterTestContext<T extends IngesterLike> {
 
 export interface TeamIngesterTestConfig {
     teamOverrides?: Partial<Team>
-    pluginServerConfig?: Partial<PluginsServerConfig>
+    pluginServerConfig?: Partial<IngestionTestConfig>
 }
 
 export type BuildIngester<T extends IngesterLike> = (
@@ -360,10 +383,15 @@ export type BuildIngester<T extends IngesterLike> = (
  * the infra plus a `close` that tears down every resource it owns.
  */
 export async function createIngestionTestInfra(
-    configOverrides: Partial<PluginsServerConfig> = {}
+    configOverrides: Partial<IngestionTestConfig> = {}
 ): Promise<IngestionTestInfra> {
-    const serverConfig: PluginsServerConfig = {
+    const serverConfig: IngestionTestConfig = {
         ...defaultConfig,
+        ...getDefaultIngestionConsumerConfig(),
+        ...getDefaultErrorTrackingConsumerConfig(),
+        ...getDefaultMetricsIngestionConsumerConfig(),
+        ...getDefaultSessionRecordingConfig(),
+        ...getDefaultSessionRecordingApiConfig(),
         ...configOverrides,
     }
 
@@ -442,7 +470,7 @@ export async function createIngestionTestInfra(
  * consumer under test — different pipelines have different deps.
  */
 export function createTestWithTeamIngester<T extends IngesterLike>(
-    baseConfig: Partial<PluginsServerConfig>,
+    baseConfig: Partial<IngestionTestConfig>,
     buildIngester: BuildIngester<T>
 ) {
     return (

--- a/nodejs/tests/ingestion/person-updates-e2e.test.ts
+++ b/nodejs/tests/ingestion/person-updates-e2e.test.ts
@@ -17,6 +17,7 @@ import { v4 } from 'uuid'
 
 import { createHogTransformerService } from '~/cdp/hog-transformations/hog-transformer.service'
 import { ClickhouseGroupRepository } from '~/common/groups/repositories/clickhouse-group-repository'
+import { PersonBatchWritingDbWriteMode } from '~/ingestion/config'
 import { IngestionConsumer } from '~/ingestion/ingestion-consumer'
 import { createAiEventSubpipeline } from '~/ingestion/pipelines/ai'
 import { KafkaProducerWrapper } from '~/kafka/producer'
@@ -26,7 +27,7 @@ import { IngestionTestInfra, createIngestionTestInfra } from '~/tests/helpers/in
 import { createTestIngestionOutputs, createTestMonitoringOutputs } from '~/tests/helpers/ingestion-outputs'
 import { TEST_KAFKA_TOPICS, ensureKafkaTopics } from '~/tests/helpers/kafka'
 import { createUserTeamAndOrganization, resetTestDatabase } from '~/tests/helpers/sql'
-import { PersonBatchWritingDbWriteMode, PipelineEvent, ProjectId, Team } from '~/types'
+import { PipelineEvent, ProjectId, Team } from '~/types'
 import { UUIDT } from '~/utils/utils'
 
 jest.mock('~/utils/token-bucket', () => {


### PR DESCRIPTION
## Problem

`common` (the shared nodejs layer: `types.ts`, `config/`, `utils/`, `common/`, `kafka/`) should not depend on the `ingestion` domain. The two largest remaining offenders were `config/config.ts` and `types.ts`: `PluginsServerConfig` composed the ingestion consumer-config interfaces, and `getDefaultConfig()` spread the ingestion `getDefault*ConsumerConfig` builders. This kept the shared `defaultConfig` and every server transitively coupled to ingestion.

This is the final ingestion stage of the decoupling, following #65427 (producer registry / cookieless) and #65482 (Hub), both merged.

## Changes

Remove the ingestion consumer-config interfaces from `PluginsServerConfig` and the ingestion re-exports from `types.ts`.

Drop the ingestion `getDefault*ConsumerConfig` builders from `getDefaultConfig()` in `config/config.ts`, so the shared `defaultConfig` no longer carries ingestion keys.

Each per-domain server now composes its own ingestion config by spreading the relevant domain builders into its constructor.

Inject the session-feature rollout percentage through the `SessionBatchManager` to `SessionBatchRecorder` to `SessionFeatureRecorder` chain instead of reading `defaultConfig` at the leaf.

Route the remaining ingestion config-type imports through `~/ingestion/config` rather than `~/types`, and default `initializePrometheusLabels` params to `null`.

## How did you test this code?

I'm an agent. I ran the nodejs `typescript:check` (0 errors) and the affected Jest suites: `session-feature-recorder`, `session-batch-recorder`, and `session-batch-manager` (189 passed). No manual testing.

## 🤖 Agent context

Autonomy: human-reviewed — authored by an agent, reviewed by @jose-sequeira before merge.

Part of an ingestion-only `common` to `ingestion` decoupling. Scope is deliberately ingestion only; the `logs` and `cdp` edges are left for follow-ups (note `types.ts` still imports `LogsIngestionConsumerConfig`/`TracesIngestionConsumerConfig` from `~/logs/config` by design). The rollout-percentage injection is behavior-preserving: intermediate constructors default to `100` to avoid churning unrelated test callers, while production threads the configured value from the consumer.
