### PR TITLE
feat(subscriptions): add Connected automations to the subscription editor

### DIFF
--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -14,6 +14,7 @@ import { getInsightId } from 'scenes/insights/utils'
 import { ExportedAssetType, ExporterFormat, SubscriptionResourceTypes, SubscriptionType } from '~/types'
 
 import type { subscriptionLogicType } from './subscriptionLogicType'
+import { subscriptionNotificationLogic } from './subscriptionNotificationLogic'
 import { subscriptionsLogic } from './subscriptionsLogic'
 import { AI_PROMPT_MAX_LENGTH, SubscriptionBaseProps, urlForSubscription } from './utils'
 
@@ -199,6 +200,14 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 mountedSubscriptionsLogic?.actions.loadAiSubscriptions()
                 actions.loadSubscriptionSuccess(updatedSub)
                 actions.loadSummaryQuota()
+
+                // Second sequential call: now that the subscription has an id, create any destinations
+                // queued inline in the Connected automations section, scoped to this subscription. No-ops
+                // when nothing was queued (e.g. the section is flag-off or untouched).
+                await subscriptionNotificationLogic({
+                    subscriptionId: props.id === 'new' ? undefined : props.id,
+                }).asyncActions.createPendingHogFunctions(updatedSub.id, updatedSub.title ?? undefined)
+
                 lemonToast.success(`Subscription saved.`)
 
                 return updatedSub

--- a/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionLogic.ts
@@ -201,12 +201,16 @@ export const subscriptionLogic = kea<subscriptionLogicType>([
                 actions.loadSubscriptionSuccess(updatedSub)
                 actions.loadSummaryQuota()
 
-                // Second sequential call: now that the subscription has an id, create any destinations
-                // queued inline in the Connected automations section, scoped to this subscription. No-ops
-                // when nothing was queued (e.g. the section is flag-off or untouched).
-                await subscriptionNotificationLogic({
-                    subscriptionId: props.id === 'new' ? undefined : props.id,
-                }).asyncActions.createPendingHogFunctions(updatedSub.id, updatedSub.title ?? undefined)
+                // Deferred create: the subscription must have an id before we can pin destinations to it.
+                // The subscription is already persisted, so a failure here is a client-side bug, not a save
+                // failure — isolate it so the user still sees the success toast (mirrors the alerts flow).
+                try {
+                    await subscriptionNotificationLogic({
+                        subscriptionId: props.id === 'new' ? undefined : props.id,
+                    }).asyncActions.createPendingHogFunctions(updatedSub.id, updatedSub.title ?? undefined)
+                } catch (e) {
+                    posthog.captureException(e)
+                }
 
                 lemonToast.success(`Subscription saved.`)
 

--- a/frontend/src/lib/components/Subscriptions/subscriptionNotificationLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionNotificationLogic.ts
@@ -1,0 +1,184 @@
+import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { deleteWithUndo } from 'lib/utils/deleteWithUndo'
+import { projectLogic } from 'scenes/projectLogic'
+
+import { HogFunctionType, IntegrationType } from '~/types'
+
+import type { subscriptionNotificationLogicType } from './subscriptionNotificationLogicType'
+import {
+    PendingSubscriptionNotification,
+    SUBSCRIPTION_DELIVERED_EVENT_ID,
+    SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
+    SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+    SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK,
+    SubscriptionNotificationType,
+    buildSubscriptionHogFunctionPayload,
+    firesForSubscription,
+    isPinnedToSubscription,
+} from './subscriptionNotificationUtils'
+
+export const SUBSCRIPTION_NOTIFICATION_TYPE_OPTIONS = [
+    { label: 'Slack', value: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK },
+    { label: 'Discord', value: SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD },
+    { label: 'Webhook', value: SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK },
+]
+
+export interface SubscriptionNotificationLogicProps {
+    subscriptionId?: number
+}
+
+export const subscriptionNotificationLogic = kea<subscriptionNotificationLogicType>([
+    path(['lib', 'components', 'Subscriptions', 'subscriptionNotificationLogic']),
+    props({} as SubscriptionNotificationLogicProps),
+    key(({ subscriptionId }) => subscriptionId ?? 'new'),
+
+    connect({
+        values: [projectLogic, ['currentProjectId'], integrationsLogic, ['slackIntegrations']],
+        actions: [integrationsLogic, ['loadIntegrationsSuccess']],
+    }),
+
+    actions({
+        addPendingNotification: (notification: PendingSubscriptionNotification) => ({ notification }),
+        removePendingNotification: (index: number) => ({ index }),
+        clearPendingNotifications: true,
+        setPendingNotifications: (notifications: PendingSubscriptionNotification[]) => ({ notifications }),
+        deleteExistingHogFunction: (hogFunction: HogFunctionType) => ({ hogFunction }),
+        createPendingHogFunctions: (subscriptionId: number, subscriptionName?: string) => ({
+            subscriptionId,
+            subscriptionName,
+        }),
+        setSelectedType: (selectedType: SubscriptionNotificationType) => ({ selectedType }),
+        setSlackChannelValue: (slackChannelValue: string | null) => ({ slackChannelValue }),
+        setWebhookUrl: (webhookUrl: string) => ({ webhookUrl }),
+    }),
+
+    reducers({
+        pendingNotifications: [
+            [] as PendingSubscriptionNotification[],
+            {
+                addPendingNotification: (state, { notification }) => [...state, notification],
+                removePendingNotification: (state, { index }) => state.filter((_, i) => i !== index),
+                clearPendingNotifications: () => [],
+                setPendingNotifications: (_, { notifications }) => notifications,
+            },
+        ],
+        slackChannelValue: [
+            null as string | null,
+            {
+                setSlackChannelValue: (_, { slackChannelValue }) => slackChannelValue,
+            },
+        ],
+        webhookUrl: [
+            '' as string,
+            {
+                setWebhookUrl: (_, { webhookUrl }) => webhookUrl,
+            },
+        ],
+        selectedType: [
+            SUBSCRIPTION_NOTIFICATION_TYPE_SLACK as SubscriptionNotificationType,
+            {
+                setSelectedType: (_, { selectedType }) => selectedType,
+            },
+        ],
+        existingHogFunctions: [
+            [] as HogFunctionType[],
+            {
+                // Optimistic removal so the item disappears immediately
+                deleteExistingHogFunction: (state, { hogFunction }) => state.filter((hf) => hf.id !== hogFunction.id),
+            },
+        ],
+    }),
+
+    selectors({
+        firstSlackIntegration: [
+            (s) => [s.slackIntegrations],
+            (slackIntegrations: IntegrationType[] | undefined): IntegrationType | undefined => slackIntegrations?.[0],
+        ],
+    }),
+
+    loaders(({ props }) => ({
+        existingHogFunctions: [
+            [] as HogFunctionType[],
+            {
+                loadExistingHogFunctions: async () => {
+                    if (props.subscriptionId == null) {
+                        return []
+                    }
+                    // Query the event only (no subscription_id pin), then keep destinations that
+                    // fire for this report — team-wide (unpinned) plus ones pinned to this sub.
+                    const response = await api.hogFunctions.list({
+                        types: ['internal_destination'],
+                        filter_groups: [{ events: [{ id: SUBSCRIPTION_DELIVERED_EVENT_ID, type: 'events' }] }],
+                        full: true,
+                    })
+                    return response.results.filter((hf) => firesForSubscription(hf, props.subscriptionId as number))
+                },
+            },
+        ],
+    })),
+
+    listeners(({ actions, values, props }) => ({
+        loadIntegrationsSuccess: () => {
+            if (!values.firstSlackIntegration) {
+                actions.setSelectedType(SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK)
+            }
+        },
+        deleteExistingHogFunction: async ({ hogFunction }) => {
+            // Guard: only this-sub destinations are deletable here; team-wide ones are managed in the library.
+            if (props.subscriptionId == null || !isPinnedToSubscription(hogFunction, props.subscriptionId)) {
+                return
+            }
+            await deleteWithUndo({
+                endpoint: `projects/${values.currentProjectId}/hog_functions`,
+                object: { id: hogFunction.id, name: hogFunction.name },
+                callback: (undo) => {
+                    if (undo) {
+                        actions.loadExistingHogFunctions()
+                    }
+                },
+            })
+        },
+
+        createPendingHogFunctions: async ({ subscriptionId, subscriptionName }) => {
+            const pending = values.pendingNotifications
+            if (pending.length === 0) {
+                return
+            }
+
+            const results = await Promise.allSettled(
+                pending.map((notification) =>
+                    api.hogFunctions.create(
+                        buildSubscriptionHogFunctionPayload(subscriptionId, subscriptionName, notification)
+                    )
+                )
+            )
+
+            const failedNotifications = pending.filter((_, i) => results[i].status === 'rejected')
+
+            if (failedNotifications.length > 0) {
+                lemonToast.error(
+                    `Subscription saved, but ${failedNotifications.length} automation(s) failed to create. Reopen the subscription to add them again.`
+                )
+                actions.setPendingNotifications(failedNotifications)
+            } else {
+                if (results.length > 0) {
+                    lemonToast.success(`${results.length} automation(s) connected.`)
+                }
+                actions.clearPendingNotifications()
+            }
+
+            actions.loadExistingHogFunctions()
+        },
+    })),
+
+    afterMount(({ actions, props }) => {
+        if (props.subscriptionId != null) {
+            actions.loadExistingHogFunctions()
+        }
+    }),
+])

--- a/frontend/src/lib/components/Subscriptions/subscriptionNotificationLogic.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionNotificationLogic.ts
@@ -115,6 +115,8 @@ export const subscriptionNotificationLogic = kea<subscriptionNotificationLogicTy
                         types: ['internal_destination'],
                         filter_groups: [{ events: [{ id: SUBSCRIPTION_DELIVERED_EVENT_ID, type: 'events' }] }],
                         full: true,
+                        // Bound the team-wide fetch; teams won't realistically exceed this many delivery destinations.
+                        limit: 100,
                     })
                     return response.results.filter((hf) => firesForSubscription(hf, props.subscriptionId as number))
                 },

--- a/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.test.ts
@@ -1,0 +1,88 @@
+import { HogFunctionType } from '~/types'
+
+import {
+    SUBSCRIPTION_DELIVERED_EVENT_ID,
+    SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
+    SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+    SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK,
+    buildSubscriptionFilterConfig,
+    buildSubscriptionHogFunctionPayload,
+    firesForSubscription,
+    isPinnedToSubscription,
+} from './subscriptionNotificationUtils'
+
+const hogFunctionWithSubscriptionId = (subscriptionId?: number): HogFunctionType =>
+    ({
+        filters:
+            subscriptionId == null
+                ? { events: [{ id: SUBSCRIPTION_DELIVERED_EVENT_ID, type: 'events' }] }
+                : buildSubscriptionFilterConfig(subscriptionId),
+    }) as HogFunctionType
+
+describe('subscriptionNotificationUtils', () => {
+    describe('buildSubscriptionFilterConfig', () => {
+        it('pins the $subscription_delivered event to the subscription id', () => {
+            const config = buildSubscriptionFilterConfig(42)
+            expect(config.events).toEqual([{ id: SUBSCRIPTION_DELIVERED_EVENT_ID, type: 'events' }])
+            expect(config.properties).toEqual([{ key: 'subscription_id', value: 42, operator: 'exact', type: 'event' }])
+        })
+    })
+
+    describe('firesForSubscription', () => {
+        it('matches team-wide (unpinned) destinations for any subscription', () => {
+            expect(firesForSubscription(hogFunctionWithSubscriptionId(undefined), 42)).toBe(true)
+        })
+        it('matches a destination pinned to this subscription', () => {
+            expect(firesForSubscription(hogFunctionWithSubscriptionId(42), 42)).toBe(true)
+        })
+        it('excludes a destination pinned to a different subscription', () => {
+            expect(firesForSubscription(hogFunctionWithSubscriptionId(99), 42)).toBe(false)
+        })
+    })
+
+    describe('isPinnedToSubscription', () => {
+        it('is true only for a destination pinned to this subscription', () => {
+            expect(isPinnedToSubscription(hogFunctionWithSubscriptionId(42), 42)).toBe(true)
+            expect(isPinnedToSubscription(hogFunctionWithSubscriptionId(99), 42)).toBe(false)
+            expect(isPinnedToSubscription(hogFunctionWithSubscriptionId(undefined), 42)).toBe(false)
+        })
+    })
+
+    describe('buildSubscriptionHogFunctionPayload', () => {
+        it('builds a Slack destination pinned to the subscription with channel + workspace', () => {
+            const payload = buildSubscriptionHogFunctionPayload(42, 'Weekly report', {
+                type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: 7,
+                slackChannelId: 'C123',
+                slackChannelName: 'general',
+            })
+            expect(payload.template_id).toBe('template-slack')
+            expect(payload.filters).toEqual(buildSubscriptionFilterConfig(42))
+            expect(payload.inputs?.channel).toEqual({ value: 'C123' })
+            expect(payload.inputs?.slack_workspace).toEqual({ value: 7 })
+            expect(payload.name).toContain('Weekly report')
+        })
+
+        it('builds a webhook destination carrying the event properties', () => {
+            const payload = buildSubscriptionHogFunctionPayload(42, undefined, {
+                type: SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK,
+                webhookUrl: 'https://example.com/hook',
+            })
+            expect(payload.template_id).toBe('template-webhook')
+            expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
+            expect(payload.inputs?.body?.value).toMatchObject({
+                subscription_name: '{event.properties.subscription_name}',
+                summary: '{event.properties.summary}',
+            })
+        })
+
+        it('builds a Discord destination from a webhook url', () => {
+            const payload = buildSubscriptionHogFunctionPayload(42, 'R', {
+                type: SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
+                webhookUrl: 'https://discord.com/api/webhooks/x',
+            })
+            expect(payload.template_id).toBe('template-discord')
+            expect(payload.inputs?.webhookUrl).toEqual({ value: 'https://discord.com/api/webhooks/x' })
+        })
+    })
+})

--- a/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.test.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.test.ts
@@ -1,6 +1,7 @@
 import { HogFunctionType } from '~/types'
 
 import {
+    PendingSubscriptionNotification,
     SUBSCRIPTION_DELIVERED_EVENT_ID,
     SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
     SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
@@ -49,26 +50,66 @@ describe('subscriptionNotificationUtils', () => {
     })
 
     describe('buildSubscriptionHogFunctionPayload', () => {
-        it('builds a Slack destination pinned to the subscription with channel + workspace', () => {
-            const payload = buildSubscriptionHogFunctionPayload(42, 'Weekly report', {
+        it.each([
+            [
+                'Slack',
+                {
+                    type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+                    slackWorkspaceId: 7,
+                    slackChannelId: 'C123',
+                    slackChannelName: 'general',
+                },
+                'template-slack',
+            ],
+            [
+                'Slack without a channel name',
+                { type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK, slackWorkspaceId: 7, slackChannelId: 'C123' },
+                'template-slack',
+            ],
+            [
+                'webhook',
+                { type: SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK, webhookUrl: 'https://example.com/hook' },
+                'template-webhook',
+            ],
+            [
+                'Discord',
+                { type: SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD, webhookUrl: 'https://discord.com/api/webhooks/x' },
+                'template-discord',
+            ],
+        ])('builds a %s destination pinned to the subscription', (_label, notification, templateId) => {
+            const payload = buildSubscriptionHogFunctionPayload(
+                42,
+                'Weekly report',
+                notification as PendingSubscriptionNotification
+            )
+            expect(payload.template_id).toBe(templateId)
+            expect(payload.filters).toEqual(buildSubscriptionFilterConfig(42))
+        })
+
+        it('carries channel + workspace for Slack and falls back to #channel without a channel name', () => {
+            const named = buildSubscriptionHogFunctionPayload(42, 'R', {
                 type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
                 slackWorkspaceId: 7,
                 slackChannelId: 'C123',
                 slackChannelName: 'general',
             })
-            expect(payload.template_id).toBe('template-slack')
-            expect(payload.filters).toEqual(buildSubscriptionFilterConfig(42))
-            expect(payload.inputs?.channel).toEqual({ value: 'C123' })
-            expect(payload.inputs?.slack_workspace).toEqual({ value: 7 })
-            expect(payload.name).toContain('Weekly report')
+            expect(named.inputs?.channel).toEqual({ value: 'C123' })
+            expect(named.inputs?.slack_workspace).toEqual({ value: 7 })
+            expect(named.name).toContain('#general')
+
+            const unnamed = buildSubscriptionHogFunctionPayload(42, 'R', {
+                type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: 7,
+                slackChannelId: 'C123',
+            })
+            expect(unnamed.name).toContain('#channel')
         })
 
-        it('builds a webhook destination carrying the event properties', () => {
+        it('carries the url and event-property body for a webhook', () => {
             const payload = buildSubscriptionHogFunctionPayload(42, undefined, {
                 type: SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK,
                 webhookUrl: 'https://example.com/hook',
             })
-            expect(payload.template_id).toBe('template-webhook')
             expect(payload.inputs?.url).toEqual({ value: 'https://example.com/hook' })
             expect(payload.inputs?.body?.value).toMatchObject({
                 subscription_name: '{event.properties.subscription_name}',
@@ -76,12 +117,11 @@ describe('subscriptionNotificationUtils', () => {
             })
         })
 
-        it('builds a Discord destination from a webhook url', () => {
+        it('carries the webhook url for Discord', () => {
             const payload = buildSubscriptionHogFunctionPayload(42, 'R', {
                 type: SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
                 webhookUrl: 'https://discord.com/api/webhooks/x',
             })
-            expect(payload.template_id).toBe('template-discord')
             expect(payload.inputs?.webhookUrl).toEqual({ value: 'https://discord.com/api/webhooks/x' })
         })
     })

--- a/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.ts
+++ b/frontend/src/lib/components/Subscriptions/subscriptionNotificationUtils.ts
@@ -1,0 +1,124 @@
+import {
+    HOG_FUNCTION_SUB_TEMPLATES,
+    HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES,
+} from 'scenes/hog-functions/sub-templates/sub-templates'
+
+import { CyclotronJobFiltersType, HogFunctionType, PropertyFilterType, PropertyOperator } from '~/types'
+
+export const SUBSCRIPTION_DELIVERED_EVENT_ID = '$subscription_delivered'
+export const SUBSCRIPTION_DELIVERED_SUB_TEMPLATE_ID = 'subscription-delivered'
+
+export const SUBSCRIPTION_NOTIFICATION_TYPE_SLACK = 'slack' as const
+export const SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK = 'webhook' as const
+export const SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD = 'discord' as const
+export type SubscriptionNotificationType =
+    | typeof SUBSCRIPTION_NOTIFICATION_TYPE_SLACK
+    | typeof SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK
+    | typeof SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD
+
+export type PendingSubscriptionNotification =
+    | {
+          type: typeof SUBSCRIPTION_NOTIFICATION_TYPE_SLACK
+          slackWorkspaceId: number
+          slackChannelId: string
+          slackChannelName?: string
+      }
+    | {
+          type: typeof SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK
+          webhookUrl: string
+      }
+    | {
+          type: typeof SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD
+          webhookUrl: string
+      }
+
+// Filter group pinning a destination to one subscription's deliveries (mirrors buildAlertFilterConfig).
+export const buildSubscriptionFilterConfig = (subscriptionId: number): CyclotronJobFiltersType => ({
+    properties: [
+        {
+            key: 'subscription_id',
+            value: subscriptionId,
+            operator: PropertyOperator.Exact,
+            type: PropertyFilterType.Event,
+        },
+    ],
+    events: [{ id: SUBSCRIPTION_DELIVERED_EVENT_ID, type: 'events' }],
+})
+
+// A destination "fires for this subscription" if it has no subscription_id pin (team-wide) or pins this id.
+export const firesForSubscription = (hogFunction: HogFunctionType, subscriptionId: number): boolean => {
+    const pinned = (hogFunction.filters?.properties ?? []).find((p) => 'key' in p && p.key === 'subscription_id')
+    return !pinned || String(pinned.value) === String(subscriptionId)
+}
+
+export const isPinnedToSubscription = (hogFunction: HogFunctionType, subscriptionId: number): boolean => {
+    const pinned = (hogFunction.filters?.properties ?? []).find((p) => 'key' in p && p.key === 'subscription_id')
+    return !!pinned && String(pinned.value) === String(subscriptionId)
+}
+
+const SLACK_INPUTS =
+    HOG_FUNCTION_SUB_TEMPLATES[SUBSCRIPTION_DELIVERED_SUB_TEMPLATE_ID].find((t) => t.template_id === 'template-slack')
+        ?.inputs ?? {}
+
+const DISCORD_INPUTS =
+    HOG_FUNCTION_SUB_TEMPLATES[SUBSCRIPTION_DELIVERED_SUB_TEMPLATE_ID].find((t) => t.template_id === 'template-discord')
+        ?.inputs ?? {}
+
+export function buildSubscriptionHogFunctionPayload(
+    subscriptionId: number,
+    subscriptionName: string | undefined,
+    notification: PendingSubscriptionNotification
+): Partial<HogFunctionType> {
+    const commonProps = HOG_FUNCTION_SUB_TEMPLATE_COMMON_PROPERTIES[SUBSCRIPTION_DELIVERED_SUB_TEMPLATE_ID]
+    const label = subscriptionName || 'Subscription'
+    const base = {
+        type: commonProps.type,
+        enabled: true,
+        masking: null,
+        filters: buildSubscriptionFilterConfig(subscriptionId),
+    }
+
+    if (notification.type === SUBSCRIPTION_NOTIFICATION_TYPE_SLACK) {
+        return {
+            ...base,
+            name: `${label}: Slack #${notification.slackChannelName ?? 'channel'}`,
+            template_id: 'template-slack',
+            inputs: {
+                ...SLACK_INPUTS,
+                slack_workspace: { value: notification.slackWorkspaceId },
+                channel: { value: notification.slackChannelId },
+            },
+        }
+    }
+
+    if (notification.type === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD) {
+        return {
+            ...base,
+            name: `${label}: Discord`,
+            template_id: 'template-discord',
+            inputs: {
+                ...DISCORD_INPUTS,
+                webhookUrl: { value: notification.webhookUrl },
+            },
+        }
+    }
+
+    return {
+        ...base,
+        name: `${label}: Webhook ${notification.webhookUrl}`,
+        template_id: 'template-webhook',
+        inputs: {
+            url: { value: notification.webhookUrl },
+            body: {
+                value: {
+                    subscription_name: '{event.properties.subscription_name}',
+                    target_type: '{event.properties.target_type}',
+                    resource_type: '{event.properties.resource_type}',
+                    recipient_count: '{event.properties.recipient_count}',
+                    summary: '{event.properties.summary}',
+                    subscription_url: '{event.properties.subscription_url}',
+                },
+            },
+        },
+    }
+}

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -772,8 +772,7 @@ function EditSubscriptionForm({
                             <div>
                                 <LemonLabel className="mb-2">Connected automations</LemonLabel>
                                 <p className="text-xs text-muted-alt mb-2">
-                                    Trigger other tools (Slack, Microsoft Teams, Discord, a webhook) when this report is
-                                    delivered.
+                                    Trigger other tools (Slack, Discord, a webhook) when this report is delivered.
                                 </p>
                                 <InlineSubscriptionNotifications subscriptionId={id === 'new' ? undefined : id} />
                             </div>

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -39,6 +39,7 @@ import { AvailableFeature, DashboardType, InsightShortId, SubscriptionResourceTy
 import { InsightSelector } from '../InsightSelector'
 import { subscriptionCountLogic } from '../subscriptionCountLogic'
 import { subscriptionLogic } from '../subscriptionLogic'
+import { subscriptionNotificationLogic } from '../subscriptionNotificationLogic'
 import { subscriptionsLogic } from '../subscriptionsLogic'
 import {
     bysetposOptions,
@@ -54,6 +55,7 @@ import {
     WEEKDAYS,
     AI_PROMPT_MAX_LENGTH,
 } from '../utils'
+import { InlineSubscriptionNotifications } from './InlineSubscriptionNotifications'
 
 // Shown wherever AI subscriptions are gated off (org hasn't approved AI data
 // processing). Mirrors the backend gate in `_ai_create_gate_reason`, which 403s
@@ -270,6 +272,12 @@ function EditSubscriptionForm({
     const { slackIntegrations, integrations } = useValues(integrationsLogic)
     const { dataProcessingAccepted } = useValues(maxGlobalLogic)
     const aiSubscriptionsEnabled = useFeatureFlag('SUBSCRIPTION_AI_PROMPT')
+    const connectedAutomationsEnabled = useFeatureFlag('SUBSCRIPTIONS_CONNECTED_AUTOMATIONS')
+    const { pendingNotifications } = useValues(
+        subscriptionNotificationLogic({ subscriptionId: id === 'new' ? undefined : id })
+    )
+    // Pending automations make the form "savable" even when no subscription field changed.
+    const hasPendingNotifications = connectedAutomationsEnabled && pendingNotifications.length > 0
 
     const emailDisabled = !preflight?.email_service_available
     const isAiPrompt = subscription?.resource_type === SubscriptionResourceTypes.AiPrompt
@@ -759,6 +767,17 @@ function EditSubscriptionForm({
                                 </div>
                             </div>
                         )}
+
+                        {connectedAutomationsEnabled && (
+                            <div>
+                                <LemonLabel className="mb-2">Connected automations</LemonLabel>
+                                <p className="text-xs text-muted-alt mb-2">
+                                    Trigger other tools (Slack, Microsoft Teams, Discord, a webhook) when this report is
+                                    delivered.
+                                </p>
+                                <InlineSubscriptionNotifications subscriptionId={id === 'new' ? undefined : id} />
+                            </div>
+                        )}
                     </>
                 )}
             </LemonModal.Content>
@@ -783,7 +802,11 @@ function EditSubscriptionForm({
                     type="primary"
                     htmlType="submit"
                     loading={isSubscriptionSubmitting}
-                    disabled={!subscriptionChanged || subscriptionLoading || aiGate.submitBlocked}
+                    disabled={
+                        (!subscriptionChanged && !hasPendingNotifications) ||
+                        subscriptionLoading ||
+                        aiGate.submitBlocked
+                    }
                 >
                     {id === 'new' ? 'Create subscription' : 'Save'}
                 </LemonButton>

--- a/frontend/src/lib/components/Subscriptions/views/InlineSubscriptionNotifications.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/InlineSubscriptionNotifications.tsx
@@ -1,0 +1,279 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconExternal, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect, LemonSkeleton, LemonTag } from '@posthog/lemon-ui'
+
+import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
+import { OrganizationMembershipLevel } from 'lib/constants'
+import { SlackChannelPicker, SlackNotConfiguredBanner } from 'lib/integrations/SlackIntegrationHelpers'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
+import { urls } from 'scenes/urls'
+
+import { HogFunctionType, SlackChannelType } from '~/types'
+
+import { SUBSCRIPTION_NOTIFICATION_TYPE_OPTIONS, subscriptionNotificationLogic } from '../subscriptionNotificationLogic'
+import {
+    PendingSubscriptionNotification,
+    SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD,
+    SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+    SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK,
+    isPinnedToSubscription,
+} from '../subscriptionNotificationUtils'
+
+function resolveSlackChannelName(channelValue: string, slackChannels: SlackChannelType[]): string | null {
+    const channelId = channelValue.split('|')[0]
+    return slackChannels.find((c) => c.id === channelId)?.name ?? null
+}
+
+function getHogFunctionDestination(
+    hf: HogFunctionType,
+    slackChannels: SlackChannelType[]
+): { type: string; detail: string | null } {
+    const channelValue = hf.inputs?.channel?.value
+    if (channelValue && typeof channelValue === 'string') {
+        const channelName = resolveSlackChannelName(channelValue, slackChannels)
+        return { type: 'Slack', detail: channelName ? `#${channelName}` : null }
+    }
+    if (channelValue) {
+        return { type: 'Slack', detail: null }
+    }
+    if (hf.template_id === 'template-discord') {
+        const webhookUrl = hf.inputs?.webhookUrl?.value
+        return { type: 'Discord', detail: typeof webhookUrl === 'string' ? webhookUrl : null }
+    }
+    const urlValue = hf.inputs?.url?.value
+    if (urlValue && typeof urlValue === 'string') {
+        return { type: 'Webhook', detail: urlValue }
+    }
+    return { type: hf.name, detail: null }
+}
+
+interface InlineSubscriptionNotificationsProps {
+    subscriptionId?: number
+}
+
+export function InlineSubscriptionNotifications({ subscriptionId }: InlineSubscriptionNotificationsProps): JSX.Element {
+    const logic = subscriptionNotificationLogic({ subscriptionId })
+    const {
+        existingHogFunctions,
+        existingHogFunctionsLoading,
+        pendingNotifications,
+        firstSlackIntegration,
+        selectedType,
+        slackChannelValue,
+        webhookUrl,
+    } = useValues(logic)
+    const {
+        addPendingNotification,
+        removePendingNotification,
+        deleteExistingHogFunction,
+        setSelectedType,
+        setSlackChannelValue,
+        setWebhookUrl,
+    } = useActions(logic)
+
+    // Non-admins can see what's wired but can't add/configure destinations (mirrors the destinations library).
+    const restrictedReason = useRestrictedArea({
+        scope: RestrictionScope.Project,
+        minimumAccessLevel: OrganizationMembershipLevel.Admin,
+    })
+
+    const slackLogic = slackIntegrationLogic({ id: firstSlackIntegration?.id ?? 0 })
+    const { slackChannels } = useValues(slackLogic)
+    const { loadAllSlackChannels } = useActions(slackLogic)
+
+    useEffect(() => {
+        if (firstSlackIntegration) {
+            loadAllSlackChannels()
+        }
+    }, [firstSlackIntegration?.id, loadAllSlackChannels, firstSlackIntegration])
+
+    const handleAdd = (): void => {
+        if (selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_SLACK) {
+            if (!slackChannelValue || !firstSlackIntegration) {
+                return
+            }
+            const parts = slackChannelValue.split('|')
+            const channelId = parts[0]
+            const channelName = parts[1]?.replace('#', '') ?? channelId
+            addPendingNotification({
+                type: SUBSCRIPTION_NOTIFICATION_TYPE_SLACK,
+                slackWorkspaceId: firstSlackIntegration.id,
+                slackChannelId: channelId,
+                slackChannelName: channelName,
+            })
+            setSlackChannelValue(null)
+            return
+        }
+
+        if (!webhookUrl) {
+            return
+        }
+        addPendingNotification(
+            selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD
+                ? { type: SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD, webhookUrl }
+                : { type: SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK, webhookUrl }
+        )
+        setWebhookUrl('')
+    }
+
+    const getNotificationLabel = (notification: PendingSubscriptionNotification): string => {
+        if (notification.type === SUBSCRIPTION_NOTIFICATION_TYPE_SLACK) {
+            return `Slack: #${notification.slackChannelName ?? 'channel'}`
+        }
+        if (notification.type === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD) {
+            return `Discord: ${notification.webhookUrl}`
+        }
+        return `Webhook: ${notification.webhookUrl}`
+    }
+
+    return (
+        <div className="space-y-4">
+            {subscriptionId != null && (
+                <div>
+                    {existingHogFunctionsLoading ? (
+                        <LemonSkeleton className="h-8" repeat={2} />
+                    ) : existingHogFunctions.length > 0 ? (
+                        <div className="space-y-2">
+                            {existingHogFunctions.map((hf) => {
+                                const { type: destType, detail } = getHogFunctionDestination(hf, slackChannels)
+                                // Team-wide destinations fire for every report and are managed in the library, so
+                                // they're read-only here; only this-subscription destinations are deletable.
+                                const thisSub = isPinnedToSubscription(hf, subscriptionId)
+                                return (
+                                    <div
+                                        key={hf.id}
+                                        className="flex items-center justify-between border rounded p-2 gap-2"
+                                    >
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2">
+                                                <span className="text-sm font-medium">{destType}</span>
+                                                <LemonTag type={hf.enabled ? 'success' : 'default'} size="small">
+                                                    {hf.enabled ? 'Active' : 'Paused'}
+                                                </LemonTag>
+                                                {!thisSub && (
+                                                    <LemonTag type="muted" size="small">
+                                                        All reports
+                                                    </LemonTag>
+                                                )}
+                                            </div>
+                                            {detail && (
+                                                <span className="text-xs text-muted-alt truncate block">{detail}</span>
+                                            )}
+                                        </div>
+                                        <div className="flex items-center gap-1 shrink-0">
+                                            <LemonButton
+                                                icon={<IconExternal />}
+                                                size="xsmall"
+                                                to={urls.hogFunction(hf.id)}
+                                                targetBlank
+                                                hideExternalLinkIcon
+                                                tooltip="Open destination"
+                                            />
+                                            {thisSub && !restrictedReason && (
+                                                <LemonButton
+                                                    icon={<IconTrash />}
+                                                    size="xsmall"
+                                                    status="danger"
+                                                    onClick={() => deleteExistingHogFunction(hf)}
+                                                    tooltip="Delete automation"
+                                                />
+                                            )}
+                                        </div>
+                                    </div>
+                                )
+                            })}
+                        </div>
+                    ) : null}
+                </div>
+            )}
+
+            {pendingNotifications.length > 0 && (
+                <div className="space-y-2">
+                    {pendingNotifications.map((notification, index) => (
+                        <div key={index} className="flex items-center justify-between border rounded p-2 gap-2">
+                            <span className="text-sm min-w-0 truncate">
+                                {getNotificationLabel(notification)}{' '}
+                                <span className="text-muted-alt">(pending - click Save to apply)</span>
+                            </span>
+                            <LemonButton
+                                icon={<IconTrash />}
+                                size="xsmall"
+                                status="danger"
+                                onClick={() => removePendingNotification(index)}
+                                tooltip="Remove automation"
+                            />
+                        </div>
+                    ))}
+                </div>
+            )}
+
+            {restrictedReason ? (
+                existingHogFunctions.length === 0 &&
+                pendingNotifications.length === 0 && (
+                    <span className="text-xs text-muted-alt">No automations connected to this subscription.</span>
+                )
+            ) : (
+                <div className="space-y-3 border rounded p-3">
+                    <div className="flex gap-2 items-end">
+                        <div className="flex-1">
+                            <LemonSelect
+                                fullWidth
+                                options={SUBSCRIPTION_NOTIFICATION_TYPE_OPTIONS}
+                                value={selectedType}
+                                onChange={(value) => setSelectedType(value)}
+                            />
+                        </div>
+                    </div>
+
+                    {selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_SLACK &&
+                        (!firstSlackIntegration ? (
+                            <SlackNotConfiguredBanner />
+                        ) : (
+                            <SlackChannelPicker
+                                value={slackChannelValue ?? undefined}
+                                onChange={(value) => setSlackChannelValue(value)}
+                                integration={firstSlackIntegration}
+                            />
+                        ))}
+
+                    {(selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_WEBHOOK ||
+                        selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD) && (
+                        <LemonInput
+                            placeholder={
+                                selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD
+                                    ? 'https://discord.com/api/webhooks/...'
+                                    : 'https://example.com/webhook'
+                            }
+                            value={webhookUrl}
+                            onChange={setWebhookUrl}
+                            fullWidth
+                        />
+                    )}
+
+                    <LemonButton
+                        type="secondary"
+                        size="small"
+                        onClick={handleAdd}
+                        disabledReason={
+                            selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_SLACK
+                                ? !firstSlackIntegration
+                                    ? 'Connect Slack first'
+                                    : !slackChannelValue
+                                      ? 'Select a Slack channel'
+                                      : undefined
+                                : !webhookUrl
+                                  ? selectedType === SUBSCRIPTION_NOTIFICATION_TYPE_DISCORD
+                                      ? 'Enter a Discord webhook URL'
+                                      : 'Enter a webhook URL'
+                                  : undefined
+                        }
+                    >
+                        Add automation
+                    </LemonButton>
+                </div>
+            )}
+        </div>
+    )
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -322,6 +322,7 @@ export const FEATURE_FLAGS = {
     FUNNEL_INSIGHT_ALERTS: 'funnel-insight-alerts', // owner: @vdekrijger, gates alerts on funnel insights (conversion rate)
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
     HACKATHONS_SUBSCRIPTIONS: 'hackathons_subscriptions', // owner: #team-analytics-platform, gates listing subscription delivery history and AI change summaries
+    SUBSCRIPTIONS_CONNECTED_AUTOMATIONS: 'subscriptions-connected-automations', // owner: #team-analytics-platform, gates the Connected automations (CDP destinations) section in the subscription editor
     HEALTH_ALERTS: 'health-alerts', // owner: #team-growth, gates the central /health/alerts scene and per-page Alerts buttons
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
     HOGQL_INSIGHT_ALERTS: 'hogql-insight-alerts', // owner: @vdekrijger, gates alerts on SQL-backed (HogQL) insights


### PR DESCRIPTION
## Problem

#65483 made subscription deliveries emit `$subscription_delivered`, so deliveries can trigger CDP destinations (Slack / Teams / Discord / webhook). But that was only discoverable in the destinations library — a user editing a subscription had no idea their report could fan out to other tools, and no view of what's already wired.

This surfaces it **in the subscription editor**: a "Connected automations" section that shows what fires when this report is delivered and lets you add a destination — without implying the subscription *owns* destinations (they stay decoupled; the event is the contract).

## Changes

Clones the alerts inline-notifications flow (`InlineAlertNotifications` / `alertNotificationLogic` — already cloned once for logs), the pattern of "configure inline + two sequential API calls on save":

- **Inline pickers** (Slack channel / Discord / webhook) queue destinations as **pending**; on Save the subscription is created/updated, then a **second sequential call** creates the pending destinations, each filter-pinned to the subscription. This solves the create-mode "no id yet" problem, and pending automations enable Save even when no subscription field changed.
- **List = "fires for this report":** team-wide `$subscription_delivered` destinations (read-only, tagged "All reports") **plus** ones pinned to this subscription (deletable). Add always pins `subscription_id` so new destinations are scoped to this report. Team-wide ones are protected from deletion here (managed in the library).
- **All resource types** (incl. AI prompt). Add/configure gated to **project admins** (`useRestrictedArea`); non-admins see the list read-only. Whole section behind the `subscriptions-connected-automations` feature flag.

```mermaid
flowchart TD
    A[Edit subscription] -->|queue Slack/Discord/webhook| P[pending notifications]
    A -->|Save| S1["call 1: create/update subscription → id"]
    S1 --> S2["call 2: createPendingHogFunctions(id)<br/>create destinations pinned to subscription_id"]
    D["$subscription_delivered delivered"] --> F{destination filter}
    F -->|subscription_id == this OR team-wide| H[hog function fires → Slack/Teams/Discord/webhook]
```

Design spec: `docs/superpowers/specs/2026-06-24-subscription-connected-automations-design.md`.

## How did you test this code?

I'm an agent (Claude Code). No manual testing. Added jest coverage for the filter scoping (`firesForSubscription` / `isPinnedToSubscription`) and the hog-function payload builder (parameterized, incl. the no-channel-name Slack fallback) — 12 cases passing. Frontend typecheck clean on the changed files (kea types generated); `oxlint`/`oxfmt` clean. Manual e2e (create a per-subscription destination, deliver, confirm only that sub's destination fires while a team-wide one fires for all) is the recommended human check.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Third PR in the subscriptions stack (toggle #65407 → CDP event #65483 → this). Direction set interactively: the user chose the "Connected automations" approach and the alerts-clone mechanism; the design was specced and the open questions resolved via Q&A before building (per-subscription-aware list scoping, all resource types, admin gate, own section). `/review-swarm` run to A- across vasco/sre/xp/intent before pushing; applied its findings (post-save error isolation mirroring the alerts flow, bounded list fetch, parameterized tests, copy fix).

### Follow-ups
- Microsoft Teams isn't offered in the inline picker (matches the cloned alerts pattern, which is Slack/Discord/webhook) — easy to add since it's webhook-URL-based; the destinations library already has the Teams template.
- The alerts/logs/subscriptions notification flows are now cloned three times; a shared abstraction could be extracted later.
