### PR TITLE
feat(web): log per-request worker RSS to surface memory growth

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -70,7 +70,12 @@ logger = structlog.get_logger(__name__)
 # A finished request that grew the worker's RSS by at least this many MiB is logged as
 # `request_memory_growth`. Tunable via env so the threshold can be tightened/relaxed in
 # prod without a deploy. Set to 0 to log every request's growth (noisy — debugging only).
-REQUEST_RSS_GROWTH_LOG_MB = float(os.getenv("WEB_REQUEST_RSS_GROWTH_LOG_MB", "100"))
+# Parsed defensively: a malformed value must never crash the module at import (which would
+# take the worker down before it serves a request) — fall back to the default instead.
+try:
+    REQUEST_RSS_GROWTH_LOG_MB = float(os.getenv("WEB_REQUEST_RSS_GROWTH_LOG_MB", "100"))
+except ValueError:
+    REQUEST_RSS_GROWTH_LOG_MB = 100.0
 
 
 def current_rss_mb() -> float | None:
@@ -80,9 +85,10 @@ def current_rss_mb() -> float | None:
     try:
         with open("/proc/self/statm") as statm:
             resident_pages = int(statm.read().split()[1])
+        page_size = os.sysconf("SC_PAGE_SIZE")
     except (OSError, ValueError, IndexError):
         return None
-    return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+    return resident_pages * page_size / (1024 * 1024)
 
 
 ALWAYS_ALLOWED_ENDPOINTS = [

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -1,3 +1,4 @@
+import os
 import re
 import json
 import time
@@ -63,6 +64,26 @@ from products.notebooks.backend.models import Notebook
 from products.product_analytics.backend.models.insight import Insight
 
 from .auth import PersonalAPIKeyAuthentication
+
+logger = structlog.get_logger(__name__)
+
+# A finished request that grew the worker's RSS by at least this many MiB is logged as
+# `request_memory_growth`. Tunable via env so the threshold can be tightened/relaxed in
+# prod without a deploy. Set to 0 to log every request's growth (noisy — debugging only).
+REQUEST_RSS_GROWTH_LOG_MB = float(os.getenv("WEB_REQUEST_RSS_GROWTH_LOG_MB", "100"))
+
+
+def current_rss_mb() -> float | None:
+    """Resident set size of the current worker process in MiB, read from
+    /proc/self/statm (field 2 = resident pages). Returns None when unavailable,
+    e.g. on non-Linux dev machines where /proc is absent."""
+    try:
+        with open("/proc/self/statm") as statm:
+            resident_pages = int(statm.read().split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+    return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+
 
 ALWAYS_ALLOWED_ENDPOINTS = [
     "static",
@@ -668,10 +689,19 @@ def per_request_logging_context_middleware(
         # roll out CloudFront in front of app.posthog.com. We can get the host
         # header from NGINX, but we really want to have a way to get to the
         # team_id given a host header, and we can't do that with NGINX.
+        # Capture the worker's RSS at the start of the request and bind it to the
+        # logging context, so it rides along on `request_started`/`request_finished`.
+        # A worker OOM-killed mid-request (SIGKILL, uncatchable) never logs
+        # `request_finished` — but its `request_started` line carries `rss_mb` and the
+        # `worker_pid`, so the request in flight when a worker died is identifiable
+        # after the fact. See `request_memory_growth` below for the finished-request view.
+        rss_mb_start = current_rss_mb()
         structlog.contextvars.bind_contextvars(
             host=request.headers.get("host", ""),
             container_hostname=settings.CONTAINER_HOSTNAME,
             x_forwarded_for=request.headers.get("x-forwarded-for", ""),
+            worker_pid=os.getpid(),
+            rss_mb=round(rss_mb_start, 1) if rss_mb_start is not None else None,
         )
 
         # Forwarded by the PostHog MCP server (services/mcp) on every API call.
@@ -706,7 +736,27 @@ def per_request_logging_context_middleware(
             if mcp_conversation_id:
                 span.set_attribute("mcp.conversation_id", mcp_conversation_id)
 
-        return get_response(request)
+        response = get_response(request)
+
+        # Flag requests that materially grew this worker's footprint. Steady accumulation
+        # of these on a pod is the in-app fingerprint of the request mix that walks RSS up
+        # to the cgroup limit and triggers the OOM kill.
+        rss_mb_end = current_rss_mb()
+        if (
+            rss_mb_start is not None
+            and rss_mb_end is not None
+            and rss_mb_end - rss_mb_start >= REQUEST_RSS_GROWTH_LOG_MB
+        ):
+            logger.warning(
+                "request_memory_growth",
+                rss_mb_start=round(rss_mb_start, 1),
+                rss_mb_end=round(rss_mb_end, 1),
+                rss_mb_delta=round(rss_mb_end - rss_mb_start, 1),
+                request_path=request.path,
+                method=request.method,
+            )
+
+        return response
 
     return middleware
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -69,13 +69,22 @@ logger = structlog.get_logger(__name__)
 
 # A finished request that grew the worker's RSS by at least this many MiB is logged as
 # `request_memory_growth`. Tunable via env so the threshold can be tightened/relaxed in
-# prod without a deploy. Set to 0 to log every request's growth (noisy — debugging only).
-# Parsed defensively: a malformed value must never crash the module at import (which would
-# take the worker down before it serves a request) — fall back to the default instead.
+# prod without a worker restart / code change. Set to 0 to log every request's growth
+# (noisy — debugging only). Parsed defensively: a malformed value must never crash the
+# module at import (which would take the worker down before it serves a request) — fall
+# back to the default instead.
 try:
     REQUEST_RSS_GROWTH_LOG_MB = float(os.getenv("WEB_REQUEST_RSS_GROWTH_LOG_MB", "100"))
 except ValueError:
     REQUEST_RSS_GROWTH_LOG_MB = 100.0
+
+# Page size is invariant for the lifetime of the process — hoist it so current_rss_mb()
+# doesn't pay the sysconf syscall on every call. Fall back to 4096 (the common default)
+# if sysconf is unavailable on the host (e.g. an exotic OS).
+try:
+    _PAGE_SIZE_BYTES: int = os.sysconf("SC_PAGE_SIZE")
+except (OSError, ValueError):
+    _PAGE_SIZE_BYTES = 4096
 
 
 def current_rss_mb() -> float | None:
@@ -85,10 +94,9 @@ def current_rss_mb() -> float | None:
     try:
         with open("/proc/self/statm") as statm:
             resident_pages = int(statm.read().split()[1])
-        page_size = os.sysconf("SC_PAGE_SIZE")
     except (OSError, ValueError, IndexError):
         return None
-    return resident_pages * page_size / (1024 * 1024)
+    return resident_pages * _PAGE_SIZE_BYTES / (1024 * 1024)
 
 
 ALWAYS_ALLOWED_ENDPOINTS = [
@@ -742,25 +750,31 @@ def per_request_logging_context_middleware(
             if mcp_conversation_id:
                 span.set_attribute("mcp.conversation_id", mcp_conversation_id)
 
-        response = get_response(request)
-
-        # Flag requests that materially grew this worker's footprint. Steady accumulation
-        # of these on a pod is the in-app fingerprint of the request mix that walks RSS up
-        # to the cgroup limit and triggers the OOM kill.
-        rss_mb_end = current_rss_mb()
-        if (
-            rss_mb_start is not None
-            and rss_mb_end is not None
-            and rss_mb_end - rss_mb_start >= REQUEST_RSS_GROWTH_LOG_MB
-        ):
-            logger.warning(
-                "request_memory_growth",
-                rss_mb_start=round(rss_mb_start, 1),
-                rss_mb_end=round(rss_mb_end, 1),
-                rss_mb_delta=round(rss_mb_end - rss_mb_start, 1),
-                request_path=request.path,
-                method=request.method,
-            )
+        try:
+            response = get_response(request)
+        finally:
+            # Flag requests that materially grew this worker's footprint. Steady
+            # accumulation of these on a pod is the in-app fingerprint of the request
+            # mix that walks RSS up to the cgroup limit and triggers the OOM kill.
+            # This runs even when get_response raises — exception paths (large error
+            # payloads, failed serialisation) are exactly the requests most likely to
+            # spike RSS. worker_pid is added explicitly because django_structlog's
+            # RequestMiddleware clears contextvars before this finally block fires.
+            rss_mb_end = current_rss_mb()
+            if (
+                rss_mb_start is not None
+                and rss_mb_end is not None
+                and rss_mb_end - rss_mb_start >= REQUEST_RSS_GROWTH_LOG_MB
+            ):
+                logger.warning(
+                    "request_memory_growth",
+                    rss_mb_start=round(rss_mb_start, 1),
+                    rss_mb_end=round(rss_mb_end, 1),
+                    rss_mb_delta=round(rss_mb_end - rss_mb_start, 1),
+                    request_path=request.path,
+                    method=request.method,
+                    worker_pid=os.getpid(),
+                )
 
         return response
 

--- a/posthog/test/test_request_memory.py
+++ b/posthog/test/test_request_memory.py
@@ -1,6 +1,11 @@
+import sys
+
+import pytest
+
 from posthog.middleware import current_rss_mb
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="requires /proc (Linux only)")
 def test_current_rss_mb_returns_positive_on_linux():
     # On the Linux CI runners /proc/self/statm exists, so this returns the live RSS.
     rss = current_rss_mb()

--- a/posthog/test/test_request_memory.py
+++ b/posthog/test/test_request_memory.py
@@ -1,0 +1,19 @@
+from posthog.middleware import current_rss_mb
+
+
+def test_current_rss_mb_returns_positive_on_linux():
+    # On the Linux CI runners /proc/self/statm exists, so this returns the live RSS.
+    rss = current_rss_mb()
+    # A running Python process always has a non-trivial resident set.
+    assert rss is not None
+    assert rss > 0
+
+
+def test_current_rss_mb_handles_missing_proc(monkeypatch):
+    # On platforms without /proc (e.g. macOS dev machines) the read fails and we
+    # degrade to None rather than raising into the request path.
+    def _boom(*_args, **_kwargs):
+        raise OSError("no /proc here")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    assert current_rss_mb() is None


### PR DESCRIPTION
## Problem

When a web worker is OOM-killed, it dies on an uncatchable `SIGKILL`, so nothing in the application logs or traces records the kill — the in-flight request simply never logs `request_finished`, and there is no per-request signal for which request was driving memory up. Today the only place worker memory is observable is infra-level dashboards; our own logs/traces are blind to it.

This is one of three small, independently-reviewable PRs adding web-worker memory observability. This one covers the per-request view.

## Changes

- Read the worker's resident set size from `/proc/self/statm` (no new dependency; `psutil` isn't a Linux runtime dep) and bind `rss_mb` + `worker_pid` into the request logging context, so `request_started` / `request_finished` carry it.
- Emit a `request_memory_growth` warning when a finished request grows the worker's RSS past a threshold (`WEB_REQUEST_RSS_GROWTH_LOG_MB`, default 100 MiB), so the request mix that walks RSS toward the cgroup limit is queryable.
- Helper degrades to `None` on platforms without `/proc` (dev machines) rather than raising into the request path.

Net effect: a request in flight when a worker dies is identifiable after the fact via the `request_started` line, and memory-heavy finished requests surface on their own.

## How did you test this code?

I'm an agent (PostHog Code). Automated only, no manual testing:
- Added `posthog/test/test_request_memory.py`: `current_rss_mb()` returns a positive value where `/proc` exists, and returns `None` (no raise) when the read fails — covers the dev-machine fallback branch.
- `ruff check` clean on the changed files.
- CI is the source of truth for the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change; internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at the request of a PostHog engineer investigating web-worker OOM kills that left no trace in our own logs/traces. The DRI is the requesting engineer; assignee to be set by them (handle not verified in-session, so not guessing one).

Design notes for reviewers:
- The deployment is Nginx Unit (WSGI), not gunicorn — there are no worker-exit hooks, and a true OOM is `SIGKILL` (uncatchable), so this deliberately does *not* try to log the kill itself. It instruments the request path instead.
- RSS via `/proc/self/statm` rather than `psutil` (not a Linux runtime dep) or `resource.getrusage` (`ru_maxrss` is peak, not current).
- `per_request_logging_context_middleware` runs before `django_structlog.middlewares.RequestMiddleware`, so binding here lands `rss_mb` on `request_started`.
- Companion PRs (separate branches, so they can be assessed independently): worker-boot lifecycle logging in `wsgi.py`, and a periodic per-worker RSS sampler.

No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCQ3ARU9X/p1782293735796899?thread_ts=1782293735.796899&cid=C0BCQ3ARU9X)*
