### PR TITLE
feat(web): log web_worker_started at end of WSGI boot

### DIFF
--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -12,6 +12,8 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
+import structlog
+
 from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
 from posthog.continuous_profiling import start_continuous_profiling
 from posthog.otel_instrumentation import initialize_otel
@@ -44,6 +46,35 @@ try:
 finally:
     gc.freeze()
     gc.enable()
+
+
+# A web worker logs `web_worker_started` once, here at the end of boot. Nginx Unit recycles a
+# worker after NGINX_UNIT_REQUEST_LIMIT requests, and the kernel respawns one whenever a worker
+# is OOM-killed (SIGKILL is uncatchable, so the kill itself can't be logged from inside the
+# worker). Either way the replacement boots and emits this line — so a burst of these on a pod
+# is the in-app fingerprint of worker churn / OOM kills, queryable in PostHog even though the
+# kill leaves no other application-level trace. Best-effort: never break worker startup.
+def _log_web_worker_started() -> None:
+    try:
+        rss_mb: float | None
+        try:
+            with open("/proc/self/statm") as statm:
+                rss_mb = int(statm.read().split()[1]) * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+        except (OSError, ValueError, IndexError):
+            rss_mb = None
+
+        structlog.get_logger("posthog.wsgi").info(
+            "web_worker_started",
+            pid=os.getpid(),
+            rss_mb=round(rss_mb, 1) if rss_mb is not None else None,
+            request_limit=os.getenv("NGINX_UNIT_REQUEST_LIMIT"),
+            pod=os.getenv("K8S_POD_NAME") or os.getenv("HOSTNAME"),
+        )
+    except Exception:
+        pass
+
+
+_log_web_worker_started()
 
 # Nginx Unit forks workers from a prototype process that imported this module, so
 # the query_cache RedisCluster must be discovered post-fork: a client built here at


### PR DESCRIPTION
## Problem

When a web worker is OOM-killed it dies on an uncatchable `SIGKILL`, so the kill itself can't be logged from inside the worker, and Nginx Unit's own process-exit line isn't shipped to our log/trace pipeline. The result: worker churn from OOM kills (or recycling) leaves no application-level trace we can query in PostHog — only infra dashboards see it.

This is one of three small, independently-reviewable PRs adding web-worker memory observability. This one covers worker lifecycle.

## Changes

- At the end of WSGI boot, each worker emits a structured `web_worker_started` log (`pid`, `rss_mb`, `request_limit`, `pod`).
- Unit recycles a worker after `NGINX_UNIT_REQUEST_LIMIT` requests and the kernel respawns one after an OOM kill — either way the replacement boots and emits this line, so a burst of `web_worker_started` on a pod is the in-app fingerprint of churn / OOM kills.
- RSS is read from `/proc/self/statm` (no new dependency). Best-effort: any failure here is swallowed so it can never break worker startup.

## How did you test this code?

I'm an agent (PostHog Code). Automated only, no manual testing:
- `ruff check` clean on `posthog/wsgi.py`; module compiles.
- No unit test added: this is a single best-effort boot-path log, and importing `posthog.wsgi` runs full `django.setup()` plus URLconf resolution as an import side effect, so a focused unit test isn't worth the cost. CI exercises the import.
- CI is the source of truth for the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change; internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at the request of a PostHog engineer investigating web-worker OOM kills that left no trace in our own logs/traces. The DRI is the requesting engineer; assignee to be set by them (handle not verified in-session, so not guessing one).

Design notes for reviewers:
- Deployment is Nginx Unit (WSGI), not gunicorn — no worker-exit hooks, and a true OOM is `SIGKILL` (uncatchable). So this deliberately instruments *boot* of the replacement worker rather than trying to catch the kill.
- The log sits after the existing `gc.freeze()`/`gc.enable()` boot block so RSS reflects the booted footprint; `structlog` is already configured by then (after `get_wsgi_application()`).
- Placed in `wsgi.py` only — non-web processes (celery, temporal, migrate, shell) never import it, matching the existing comments in this file.
- Companion PRs (separate branches): per-request worker RSS in request logs (#65739), and a periodic per-worker RSS sampler.

No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCQ3ARU9X/p1782293735796899?thread_ts=1782293735.796899&cid=C0BCQ3ARU9X)*
