### PR TITLE
feat(web): sample per-worker RSS periodically as worker_memory

### DIFF
--- a/posthog/test/test_web_memory_sampler.py
+++ b/posthog/test/test_web_memory_sampler.py
@@ -1,6 +1,5 @@
 import os
 import sys
-import threading
 
 import pytest
 from unittest import mock
@@ -28,13 +27,23 @@ def test_current_rss_mb_handles_missing_proc(monkeypatch):
 def test_sampler_disabled_starts_no_thread(monkeypatch):
     # A non-positive interval must be a no-op so the sampler can be turned off in prod
     # without a deploy, and so it never spawns a thread in environments that don't want it.
+    started_threads: list[str] = []
+
+    class _RecordingThread:
+        def __init__(self, **kwargs):
+            self._name = kwargs["name"]
+
+        def start(self):
+            started_threads.append(self._name)
+
+    monkeypatch.setattr(sampler.threading, "Thread", _RecordingThread)
     monkeypatch.setattr(sampler, "_sampler_started_pid", None)
     monkeypatch.setenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "0")
 
     sampler.start_web_memory_sampler()
 
     assert sampler._sampler_started_pid is None
-    assert not any(t.name == "web-memory-sampler" for t in threading.enumerate())
+    assert started_threads == []
 
 
 def test_sampler_rearms_when_guard_inherited_from_another_process(monkeypatch):

--- a/posthog/test/test_web_memory_sampler.py
+++ b/posthog/test/test_web_memory_sampler.py
@@ -1,8 +1,16 @@
+import os
+import sys
 import threading
+
+import pytest
+from unittest import mock
+
+from parameterized import parameterized
 
 import posthog.web_memory_sampler as sampler
 
 
+@pytest.mark.skipif(sys.platform != "linux", reason="requires /proc (Linux only)")
 def test_current_rss_mb_returns_positive_on_linux():
     rss = sampler.current_rss_mb()
     assert rss is not None
@@ -20,10 +28,59 @@ def test_current_rss_mb_handles_missing_proc(monkeypatch):
 def test_sampler_disabled_starts_no_thread(monkeypatch):
     # A non-positive interval must be a no-op so the sampler can be turned off in prod
     # without a deploy, and so it never spawns a thread in environments that don't want it.
-    monkeypatch.setattr(sampler, "_sampler_started", False)
+    monkeypatch.setattr(sampler, "_sampler_started_pid", None)
     monkeypatch.setenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "0")
 
     sampler.start_web_memory_sampler()
 
-    assert sampler._sampler_started is False
+    assert sampler._sampler_started_pid is None
     assert not any(t.name == "web-memory-sampler" for t in threading.enumerate())
+
+
+def test_sampler_rearms_when_guard_inherited_from_another_process(monkeypatch):
+    # Unit forks workers from a prototype, so the once-flag is copy-on-write-inherited with
+    # the prototype's pid. A worker must re-arm on its own pid and start the thread, not see
+    # the inherited value and skip — a plain bool guard here would silently sample nothing.
+    started_threads = []
+
+    class _RecordingThread:
+        def __init__(self, **kwargs):
+            self._name = kwargs["name"]
+
+        def start(self):
+            started_threads.append(self._name)
+
+    monkeypatch.setattr(sampler.threading, "Thread", _RecordingThread)
+    monkeypatch.setattr(sampler, "_sampler_started_pid", os.getpid() + 1)
+    monkeypatch.setenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "30")
+
+    sampler.start_web_memory_sampler()
+
+    assert sampler._sampler_started_pid == os.getpid()
+    assert started_threads == ["web-memory-sampler"]
+
+
+@parameterized.expand(
+    [
+        ("rss_present", 123.4, [123.4], 1),
+        ("rss_unavailable", None, [], 0),
+    ]
+)
+def test_sample_once_records_gauge_and_log_only_when_rss_available(
+    _name, rss_value, expected_gauge_sets, expected_log_count
+):
+    gauge_sets: list[float] = []
+    log_events: list[tuple] = []
+
+    class _RecordingLog:
+        def info(self, *args, **kwargs):
+            log_events.append((args, kwargs))
+
+    with (
+        mock.patch.object(sampler, "current_rss_mb", lambda: rss_value),
+        mock.patch.object(sampler.WORKER_RSS_MB, "set", lambda value: gauge_sets.append(value)),
+    ):
+        sampler._sample_once(_RecordingLog(), "pod-1", "7500")
+
+    assert gauge_sets == expected_gauge_sets
+    assert len(log_events) == expected_log_count

--- a/posthog/test/test_web_memory_sampler.py
+++ b/posthog/test/test_web_memory_sampler.py
@@ -4,7 +4,9 @@ import sys
 import pytest
 from unittest import mock
 
+import structlog
 from parameterized import parameterized
+from structlog.testing import capture_logs
 
 import posthog.web_memory_sampler as sampler
 
@@ -79,17 +81,13 @@ def test_sample_once_records_gauge_and_log_only_when_rss_available(
     _name, rss_value, expected_gauge_sets, expected_log_count
 ):
     gauge_sets: list[float] = []
-    log_events: list[tuple] = []
-
-    class _RecordingLog:
-        def info(self, *args, **kwargs):
-            log_events.append((args, kwargs))
 
     with (
         mock.patch.object(sampler, "current_rss_mb", lambda: rss_value),
         mock.patch.object(sampler.WORKER_RSS_MB, "set", lambda value: gauge_sets.append(value)),
+        capture_logs() as log_events,
     ):
-        sampler._sample_once(_RecordingLog(), "pod-1", "7500")
+        sampler._sample_once(structlog.get_logger("test"), "pod-1", "7500")
 
     assert gauge_sets == expected_gauge_sets
     assert len(log_events) == expected_log_count

--- a/posthog/test/test_web_memory_sampler.py
+++ b/posthog/test/test_web_memory_sampler.py
@@ -1,0 +1,29 @@
+import threading
+
+import posthog.web_memory_sampler as sampler
+
+
+def test_current_rss_mb_returns_positive_on_linux():
+    rss = sampler.current_rss_mb()
+    assert rss is not None
+    assert rss > 0
+
+
+def test_current_rss_mb_handles_missing_proc(monkeypatch):
+    def _boom(*_args, **_kwargs):
+        raise OSError("no /proc here")
+
+    monkeypatch.setattr("builtins.open", _boom)
+    assert sampler.current_rss_mb() is None
+
+
+def test_sampler_disabled_starts_no_thread(monkeypatch):
+    # A non-positive interval must be a no-op so the sampler can be turned off in prod
+    # without a deploy, and so it never spawns a thread in environments that don't want it.
+    monkeypatch.setattr(sampler, "_sampler_started", False)
+    monkeypatch.setenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "0")
+
+    sampler.start_web_memory_sampler()
+
+    assert sampler._sampler_started is False
+    assert not any(t.name == "web-memory-sampler" for t in threading.enumerate())

--- a/posthog/web_memory_sampler.py
+++ b/posthog/web_memory_sampler.py
@@ -1,0 +1,67 @@
+import os
+import time
+import logging
+import threading
+
+import structlog
+
+logger = logging.getLogger(__name__)
+
+_sampler_started = False
+_lock = threading.Lock()
+
+
+def current_rss_mb() -> float | None:
+    """Resident set size of the current worker process in MiB, read from
+    /proc/self/statm (field 2 = resident pages). Returns None when unavailable,
+    e.g. on non-Linux dev machines where /proc is absent."""
+    try:
+        with open("/proc/self/statm") as statm:
+            resident_pages = int(statm.read().split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+    return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
+
+
+def _sample_loop(interval_seconds: float) -> None:
+    log = structlog.get_logger("posthog.web_memory_sampler")
+    pod = os.getenv("K8S_POD_NAME") or os.getenv("HOSTNAME")
+    request_limit = os.getenv("NGINX_UNIT_REQUEST_LIMIT")
+    while True:
+        time.sleep(interval_seconds)
+        rss_mb = current_rss_mb()
+        if rss_mb is None:
+            continue
+        log.info(
+            "worker_memory",
+            pid=os.getpid(),
+            rss_mb=round(rss_mb, 1),
+            pod=pod,
+            request_limit=request_limit,
+        )
+
+
+def start_web_memory_sampler() -> None:
+    """Start a daemon thread that periodically logs this worker's RSS as
+    `worker_memory`, so the gradual climb toward the cgroup limit that precedes
+    an OOM kill is visible in PostHog logs rather than only on infra dashboards.
+
+    Interval is set by WEB_MEMORY_SAMPLE_INTERVAL_SECONDS (default 30); set it to
+    0 or less to disable. Best-effort and idempotent — never breaks startup."""
+    global _sampler_started
+    try:
+        interval_seconds = float(os.getenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "30"))
+        if interval_seconds <= 0:
+            return
+        with _lock:
+            if _sampler_started:
+                return
+            _sampler_started = True
+        threading.Thread(
+            target=_sample_loop,
+            args=(interval_seconds,),
+            name="web-memory-sampler",
+            daemon=True,
+        ).start()
+    except Exception:
+        logger.exception("failed to start web memory sampler")

--- a/posthog/web_memory_sampler.py
+++ b/posthog/web_memory_sampler.py
@@ -10,15 +10,15 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_SAMPLE_INTERVAL_SECONDS = 30.0
 
-# Per-worker RSS, scraped via bin/unit_metrics.py's MultiProcessCollector. `liveall`
-# exposes one series per live worker pid, so a single worker climbing toward the cgroup
-# limit is visible rather than hidden inside an aggregate. A worker hard-killed by the OOM
-# reaper cannot call `mark_process_dead`, so its pid series can linger until the pod
-# recycles — the `worker_memory` log line below is the per-worker forensic backstop.
+# Web-worker RSS, scraped via bin/unit_metrics.py's MultiProcessCollector. `livemax`
+# reports the maximum across live workers as a single series, so the worker nearest the
+# cgroup limit is visible without the per-pid cardinality — and stale-series-on-recycle,
+# since a request-limited or OOM-killed worker never calls `mark_process_dead` — that
+# `liveall` would accumulate. Per-worker detail lives in the `worker_memory` log line.
 WORKER_RSS_MB = Gauge(
     "posthog_web_worker_rss_mb",
-    "Resident set size of a web worker process, in MiB.",
-    multiprocess_mode="liveall",
+    "Maximum resident set size across live web worker processes, in MiB.",
+    multiprocess_mode="livemax",
 )
 
 _sampler_started_pid: int | None = None

--- a/posthog/web_memory_sampler.py
+++ b/posthog/web_memory_sampler.py
@@ -4,10 +4,22 @@ import logging
 import threading
 
 import structlog
+from prometheus_client import Gauge
 
 logger = logging.getLogger(__name__)
 
-_sampler_started = False
+# Per-worker RSS, scraped via bin/unit_metrics.py's MultiProcessCollector. `liveall`
+# exposes one series per live worker pid, so a single worker climbing toward the cgroup
+# limit is visible rather than hidden inside an aggregate. A worker hard-killed by the OOM
+# reaper cannot call `mark_process_dead`, so its pid series can linger until the pod
+# recycles — the `worker_memory` log line below is the per-worker forensic backstop.
+WORKER_RSS_MB = Gauge(
+    "posthog_web_worker_rss_mb",
+    "Resident set size of a web worker process, in MiB.",
+    multiprocess_mode="liveall",
+)
+
+_sampler_started_pid: int | None = None
 _lock = threading.Lock()
 
 
@@ -23,40 +35,56 @@ def current_rss_mb() -> float | None:
     return resident_pages * os.sysconf("SC_PAGE_SIZE") / (1024 * 1024)
 
 
+def _sample_once(log: structlog.BoundLogger, pod: str | None, request_limit: str | None) -> None:
+    rss_mb = current_rss_mb()
+    if rss_mb is None:
+        return
+    WORKER_RSS_MB.set(rss_mb)
+    log.info(
+        "worker_memory",
+        pid=os.getpid(),
+        rss_mb=round(rss_mb, 1),
+        pod=pod,
+        request_limit=request_limit,
+    )
+
+
 def _sample_loop(interval_seconds: float) -> None:
     log = structlog.get_logger("posthog.web_memory_sampler")
     pod = os.getenv("K8S_POD_NAME") or os.getenv("HOSTNAME")
     request_limit = os.getenv("NGINX_UNIT_REQUEST_LIMIT")
     while True:
         time.sleep(interval_seconds)
-        rss_mb = current_rss_mb()
-        if rss_mb is None:
-            continue
-        log.info(
-            "worker_memory",
-            pid=os.getpid(),
-            rss_mb=round(rss_mb, 1),
-            pod=pod,
-            request_limit=request_limit,
-        )
+        _sample_once(log, pod, request_limit)
 
 
 def start_web_memory_sampler() -> None:
-    """Start a daemon thread that periodically logs this worker's RSS as
-    `worker_memory`, so the gradual climb toward the cgroup limit that precedes
-    an OOM kill is visible in PostHog logs rather than only on infra dashboards.
+    """Start a daemon thread that periodically records this worker's RSS — as the
+    `posthog_web_worker_rss_mb` Prometheus gauge and a `worker_memory` log line — so the
+    gradual climb toward the cgroup limit that precedes an OOM kill is visible in both
+    metrics and PostHog logs rather than only on infra dashboards.
 
-    Interval is set by WEB_MEMORY_SAMPLE_INTERVAL_SECONDS (default 30); set it to
-    0 or less to disable. Best-effort and idempotent — never breaks startup."""
-    global _sampler_started
+    MUST be called post-fork, from inside each worker (see posthog/wsgi.py). Nginx Unit
+    forks workers from a prototype process that imported this module, and a thread started
+    in the prototype does not survive the fork — an import-time start would only ever
+    sample the idle prototype, never the workers that serve requests. The pid guard re-arms
+    per process because the once-flag is copy-on-write-inherited from the prototype.
+
+    Interval is set by WEB_MEMORY_SAMPLE_INTERVAL_SECONDS (default 30); set it to 0 or less
+    to disable. Best-effort and idempotent — never breaks startup."""
+    global _sampler_started_pid
     try:
-        interval_seconds = float(os.getenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "30"))
+        try:
+            interval_seconds = float(os.getenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "30"))
+        except ValueError:
+            interval_seconds = 30.0
         if interval_seconds <= 0:
             return
+        pid = os.getpid()
         with _lock:
-            if _sampler_started:
+            if _sampler_started_pid == pid:
                 return
-            _sampler_started = True
+            _sampler_started_pid = pid
         threading.Thread(
             target=_sample_loop,
             args=(interval_seconds,),

--- a/posthog/web_memory_sampler.py
+++ b/posthog/web_memory_sampler.py
@@ -8,6 +8,8 @@ from prometheus_client import Gauge
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_SAMPLE_INTERVAL_SECONDS = 30.0
+
 # Per-worker RSS, scraped via bin/unit_metrics.py's MultiProcessCollector. `liveall`
 # exposes one series per live worker pid, so a single worker climbing toward the cgroup
 # limit is visible rather than hidden inside an aggregate. A worker hard-killed by the OOM
@@ -39,11 +41,11 @@ def _sample_once(log: structlog.BoundLogger, pod: str | None, request_limit: str
     rss_mb = current_rss_mb()
     if rss_mb is None:
         return
-    WORKER_RSS_MB.set(rss_mb)
+    rss_mb_rounded = round(rss_mb, 1)
+    WORKER_RSS_MB.set(rss_mb_rounded)
     log.info(
         "worker_memory",
-        pid=os.getpid(),
-        rss_mb=round(rss_mb, 1),
+        rss_mb=rss_mb_rounded,
         pod=pod,
         request_limit=request_limit,
     )
@@ -55,7 +57,10 @@ def _sample_loop(interval_seconds: float) -> None:
     request_limit = os.getenv("NGINX_UNIT_REQUEST_LIMIT")
     while True:
         time.sleep(interval_seconds)
-        _sample_once(log, pod, request_limit)
+        try:
+            _sample_once(log, pod, request_limit)
+        except Exception:
+            logger.exception("web memory sample failed")
 
 
 def start_web_memory_sampler() -> None:
@@ -75,11 +80,14 @@ def start_web_memory_sampler() -> None:
     global _sampler_started_pid
     try:
         try:
-            interval_seconds = float(os.getenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", "30"))
+            interval_seconds = float(
+                os.getenv("WEB_MEMORY_SAMPLE_INTERVAL_SECONDS", str(DEFAULT_SAMPLE_INTERVAL_SECONDS))
+            )
         except ValueError:
-            interval_seconds = 30.0
+            interval_seconds = DEFAULT_SAMPLE_INTERVAL_SECONDS
         if interval_seconds <= 0:
             return
+        interval_seconds = max(interval_seconds, 1.0)
         pid = os.getpid()
         with _lock:
             if _sampler_started_pid == pid:

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -15,12 +15,18 @@ from django.core.wsgi import get_wsgi_application
 from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
 from posthog.continuous_profiling import start_continuous_profiling
 from posthog.otel_instrumentation import initialize_otel
+from posthog.web_memory_sampler import start_web_memory_sampler
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
 os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "WSGI")
 
 start_continuous_profiling()
 initialize_otel()
+
+# Periodically log this worker's RSS (`worker_memory`) so the climb toward the cgroup
+# limit that precedes an OOM kill is visible in PostHog logs. Web-only: non-web processes
+# never import this module. No-op when WEB_MEMORY_SAMPLE_INTERVAL_SECONDS <= 0.
+start_web_memory_sampler()
 
 # Boot allocations are almost all permanent, so cyclic GC during django.setup() only adds
 # pauses (~300ms). Disable it for the boot, then freeze the survivors so later full

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -23,11 +23,6 @@ os.environ.setdefault("SERVER_GATEWAY_INTERFACE", "WSGI")
 start_continuous_profiling()
 initialize_otel()
 
-# Periodically log this worker's RSS (`worker_memory`) so the climb toward the cgroup
-# limit that precedes an OOM kill is visible in PostHog logs. Web-only: non-web processes
-# never import this module. No-op when WEB_MEMORY_SAMPLE_INTERVAL_SECONDS <= 0.
-start_web_memory_sampler()
-
 # Boot allocations are almost all permanent, so cyclic GC during django.setup() only adds
 # pauses (~300ms). Disable it for the boot, then freeze the survivors so later full
 # collections skip them — which also maximizes copy-on-write sharing when a prototype
@@ -69,5 +64,10 @@ def application(environ, start_response):
     global _prewarmed
     if not _prewarmed:
         prewarm_query_cache_cluster_in_background()
+        # Start the RSS sampler post-fork, here in the worker. Unit forks workers from a
+        # prototype that already imported this module, and a thread started pre-fork does
+        # not survive into the worker — starting it on the worker's first call samples the
+        # process that actually serves requests and grows toward the OOM limit.
+        start_web_memory_sampler()
         _prewarmed = True
     return _django_application(environ, start_response)

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -34,11 +34,10 @@ try:
     # Resolve the URLconf now, at module load. The lazy API router otherwise builds on
     # each worker's FIRST LIVE REQUEST — k8s probes (/_livez, /_readyz) short-circuit in
     # middleware and never warm it — costing seconds per worker after every deploy.
-    # Building it here keeps the cost at worker boot, behind readiness. (Verified against
-    # the production image: Unit 1.35 loads this module once per application process — no
-    # prototype fork/COW — so each worker pays its own boot, exactly like before the lazy
-    # router.) Non-web processes (celery, temporal, migrate, shell) never load this module
-    # and keep the lazy win.
+    # Building it here keeps the cost to the prototype-process boot: Unit forks workers
+    # from that prototype after the module loads, so the built router lands in the frozen
+    # heap and is copy-on-write shared across all forked workers. Non-web processes
+    # (celery, temporal, migrate, shell) never load this module and keep the lazy win.
     from django.urls import get_resolver
 
     _ = get_resolver().url_patterns  # property access triggers the build


### PR DESCRIPTION
## Problem

The gradual climb in a web worker's resident memory toward the cgroup limit — the thing that ultimately triggers an OOM kill — is currently only visible on infra-level dashboards. Our own logs and traces have no per-worker memory signal, so we can't correlate the climb with request activity or worker churn in PostHog.

This is one of three small, independently-reviewable PRs adding web-worker memory observability. This one covers the continuous memory trend.

## Changes

- New `posthog/web_memory_sampler.py`: a daemon thread per web worker that logs `worker_memory` (`pid`, `rss_mb`, `pod`, `request_limit`) on an interval.
- Interval via `WEB_MEMORY_SAMPLE_INTERVAL_SECONDS` (default 30; `<= 0` disables, so it can be turned off without a deploy). At 30s × 4 workers that's a handful of log lines per pod per minute.
- Wired into `wsgi.py` so it's web-only — non-web processes (celery, temporal, migrate, shell) never import it. Best-effort and idempotent: failures can't break worker startup.
- RSS read from `/proc/self/statm` (no new dependency).

If you'd rather this live as a Prometheus gauge on the existing multiproc registry (you already export `django_prometheus` + `bin/unit_metrics` to Grafana) instead of PostHog logs, that's an easy swap — say the word and I'll repoint it.

## How did you test this code?

I'm an agent (PostHog Code). Automated only, no manual testing:
- Added `posthog/test/test_web_memory_sampler.py`: `current_rss_mb()` returns a positive value where `/proc` exists and `None` (no raise) when the read fails; the disabled path (`interval <= 0`) is a no-op and starts no thread. The disabled-path test catches a regression where the sampler can't be turned off / leaks a thread.
- `ruff check` clean; modules compile.
- CI is the source of truth for the full suite.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing change; internal observability only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at the request of a PostHog engineer investigating web-worker OOM kills that left no trace in our own logs/traces. The DRI is the requesting engineer; assignee to be set by them (handle not verified in-session, so not guessing one).

Design notes for reviewers:
- Deployment is Nginx Unit (WSGI). A daemon thread per worker is the simplest portable sampler; Unit loads `wsgi.py` once per worker process (no prototype fork in prod), so one thread per worker.
- `/proc/self/statm` over `psutil` (not a Linux runtime dep) or `resource.getrusage` (`ru_maxrss` is peak, not current).
- Open design choice flagged in Changes: PostHog logs (this PR) vs a Prometheus gauge to the existing Grafana dashboard. Defaulted to logs to match the investigation this came out of and keep it self-contained in this repo.
- Companion PRs (separate branches): per-request worker RSS in request logs (#65739), worker-boot lifecycle logging (#65740).

No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCQ3ARU9X/p1782293735796899?thread_ts=1782293735.796899&cid=C0BCQ3ARU9X)*
