### PR TITLE
fix(ingestion-consumer): install rustls CryptoProvider for kube discovery

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4991,6 +4991,7 @@ dependencies = [
  "rand 0.8.5",
  "rdkafka",
  "reqwest 0.12.28",
+ "rustls 0.23.37",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/rust/ingestion-consumer/Cargo.toml
+++ b/rust/ingestion-consumer/Cargo.toml
@@ -19,6 +19,10 @@ metrics-exporter-prometheus = { workspace = true }
 rand = { workspace = true }
 rdkafka = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+# Direct dep only to install a process-wide rustls CryptoProvider at startup (see
+# main.rs): kube's HTTPS client uses rustls 0.23, which can't auto-pick a provider
+# with both aws-lc-rs and ring in the tree. Matches personhog-router/cymbal.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
 serde = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -29,6 +29,14 @@ use ingestion_consumer::worker_registry::{WorkerRegistry, WorkerRegistryConfig};
 common_alloc::used!();
 
 fn main() -> Result<()> {
+    // Install a process-wide rustls CryptoProvider before any TLS use. kube's
+    // HTTPS client (EndpointSlice discovery) uses rustls 0.23, which can't
+    // auto-pick a provider with both aws-lc-rs and ring compiled in — it panics.
+    // Matches personhog-router / cymbal / kafka-assigner.
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("failed to install rustls ring CryptoProvider");
+
     let config = Config::init_from_env()
         .context("Failed to load configuration from environment variables")?;
 


### PR DESCRIPTION
## Problem

When the ingestion-consumer runs with `WORKER_DISCOVERY_MODE=endpointslice`, it panics at startup and the lifecycle manager shuts it down:

```
thread 'main' panicked at rustls-0.23.37/src/crypto/mod.rs:249:
Could not automatically determine the process-level CryptoProvider from Rustls crate features.
```

EndpointSlice discovery creates a `kube::Client` whose HTTPS transport uses rustls 0.23. Both `aws-lc-rs` and `ring` are compiled into the binary (via `kube` and `reqwest`'s `rustls-tls`), so rustls can't auto-select a process-default crypto provider and panics on the first TLS use.

This was latent: `static` discovery (the previous default, localhost sidecars) never creates a kube client, and no unit/integration/e2e test exercises the real kube path — so it only surfaced when EndpointSlice mode was deployed for the first time.

## Changes

Install the `ring` crypto provider explicitly at the top of `main`, before any TLS use — the same pattern already used by `personhog-router`, `cymbal`, and `kafka-assigner`.

Adds `rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }` as a direct dependency solely to make that call.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while rolling out the ingestion-analytics-parallel consumer/processor split in dev (the first deployment to enable EndpointSlice discovery). Verified `cargo build`/`fmt`/`clippy` clean; the fix mirrors the three existing Rust services that already install a provider. Agent-authored; requires human review.
