### PR TITLE
feat(data-warehouse): promote linear source to ga

### DIFF
--- a/posthog/temporal/data_imports/sources/linear/source.py
+++ b/posthog/temporal/data_imports/sources/linear/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldOauthConfig,
 )
@@ -38,7 +39,7 @@ class LinearSource(ResumableSource[LinearSourceConfig, LinearResumeConfig], OAut
             name=SchemaExternalDataSourceType.LINEAR,
             category=DataWarehouseSourceCategory.PRODUCTIVITY,
             label="Linear",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="Connect your Linear workspace to sync issues, projects, teams, and more.",
             iconPath="/static/services/linear.png",
             fields=cast(


### PR DESCRIPTION
## Problem

The Linear data-warehouse source has been running in beta and now clears our GA bar on the current 7-day metrics:

- **Adoption:** 170 teams · live 4.2 months (bar: 100 teams _or_ 3 months)
- **Reliability:** 1.6% import error rate (bar: < 2.5%)

Time to drop the beta label.

## Changes

Flip `releaseStatus` on the Linear `SourceConfig` from `beta` to GA. While here, switch the bare `"beta"` string to the `ReleaseStatus.GA` enum to match the convention used across the other sources.

This is a status promotion only — no connector behavior, schema, sync, or gating changes. There's no feature flag on the source, so nothing else to unwind.

## How did you test this code?

I'm an agent. This is a one-line metadata change with no behavioral impact. No test asserted the prior `beta` value, so nothing needed updating. I did not run the app manually.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Invoked the `/implementing-warehouse-sources` skill to confirm where source release status lives and the repo convention (use the `ReleaseStatus` enum, not a string literal). Located the source at `posthog/temporal/data_imports/sources/linear/source.py`, confirmed there's no feature-flag gating to remove, and checked open PRs (including the maintainer's own) to rule out a duplicate promotion before opening this.