### PR TITLE
fix(data-warehouse): allow collapsing sidebar groups while searching

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/queryDatabaseLogic.tsx
@@ -1571,7 +1571,7 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
             },
         ],
     })),
-    selectors(({ actions }) => ({
+    selectors(({ actions, cache }) => ({
         hasNonPosthogSources: [
             (s) => [s.dataWarehouseTables],
             (dataWarehouseTables: DatabaseSchemaDataWarehouseTable[]): boolean => {
@@ -1944,10 +1944,13 @@ export const queryDatabaseLogic = kea<queryDatabaseLogicType>([
                     searchResults.push(createTopLevelFolderNode('drafts', draftsChildren, true))
                 }
 
+                // Auto-expand matching groups once per search term, so the user can freely collapse
+                // them afterwards without the selector immediately re-expanding them.
                 const expandedIdSet = new Set(expandedSearchFolders)
                 const missingRequiredExpansion = expandedIds.some((id) => !expandedIdSet.has(id))
 
-                if (missingRequiredExpansion) {
+                if (missingRequiredExpansion && cache.lastAutoExpandedSearchTerm !== searchTerm) {
+                    cache.lastAutoExpandedSearchTerm = searchTerm
                     // Auto-expand only parent folders, not the matching nodes themselves.
                     setTimeout(() => {
                         actions.setExpandedSearchFolders(


### PR DESCRIPTION
## Problem

In the SQL editor, once you type a search term in the sources sidebar, you can no longer collapse any of the groups — clicking to collapse a group just snaps it right back open. This makes the sidebar hard to navigate while filtering.

## Changes

The `searchTreeData` selector in `queryDatabaseLogic` force-re-expanded every group with matching results on each recompute. Since the selector reads `expandedSearchFolders`, collapsing a group (which removes it from that state) re-triggered the selector and immediately re-expanded it — an inescapable loop.

Now we auto-expand matching groups only **once per search term** (tracked in `cache`). Typing or deleting characters changes the term and re-expands fresh; within a given term, collapses stick.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not run the app manually. I traced the reactive cycle in `queryDatabaseLogic.tsx` and verified the fix breaks it by gating the auto-expand on a changed search term. No automated tests were added. Worth a quick manual check in the SQL editor: search a term, collapse a group, confirm it stays collapsed, then edit the term and confirm groups re-expand.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at Jovan's request from a Slack thread. Jovan reported that sidebar groups couldn't be collapsed while searching in the SQL editor. Root-caused to a selector that both reads and mutates `expandedSearchFolders`, creating a re-expand loop on every collapse. Chose the minimal fix — a `cache.lastAutoExpandedSearchTerm` guard so auto-expand fires once per term — over reworking the expand-state model, per the request for the simplest possible fix that still re-expands on each new search.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GNDPDNEN/p1782295721816939)*
