### PR TITLE
feat(conversations): exclude org members from channel membership alerts

### DIFF
--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -387,3 +387,25 @@ class TestSlackMemberAlerts(BaseTest):
         handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
 
         mock_get_client.return_value.chat_postMessage.assert_not_called()
+
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_member_event_skips_org_member(self, mock_get_client, _mock_bot_id, mock_resolve_user):
+        mock_resolve_user.return_value = {"name": "Teammate", "email": self.user.email, "avatar": None}
+
+        handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
+
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+
+    @patch(f"{MODULE}.resolve_slack_user")
+    @patch(f"{MODULE}.get_bot_user_id", return_value="U_OWN_BOT")
+    @patch(f"{MODULE}.get_slack_client")
+    def test_member_event_posts_for_external_user(self, mock_get_client, _mock_bot_id, mock_resolve_user):
+        mock_resolve_user.return_value = {"name": "External", "email": "external@example.com", "avatar": None}
+
+        handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
+
+        mock_get_client.return_value.chat_postMessage.assert_called_once()
+        kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
+        assert kwargs["text"] == "<@U123> joined <#C_SUPPORT>"

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -1019,7 +1019,8 @@ def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
 
     Fires for any channel the bot is in (Slack only delivers member_joined_channel /
     member_left_channel for channels the bot belongs to). Gated per-direction by the
-    team's settings.
+    team's settings. Members of the team's own organization are skipped — the alert is
+    meant to surface external participants, not internal teammates.
     """
     settings_dict = team.conversations_settings or {}
 
@@ -1051,6 +1052,12 @@ def _handle_member_event(event: dict, team: Team, *, joined: bool) -> None:
 
     # Slack also fires member_joined_channel for the bot's own join — skip it to avoid noise.
     if user == own_bot_user_id:
+        return
+
+    # Members of the team's own organization are internal teammates, not the external
+    # participants these alerts surface — skip them.
+    slack_user = resolve_slack_user(client, user)
+    if resolve_posthog_user_for_slack(slack_user.get("email"), team):
         return
 
     verb = "joined" if joined else "left"


### PR DESCRIPTION
## Problem

The Conversations (SupportHog) "Channel membership alerts" feature posts a Slack message whenever someone joins or leaves a channel the bot is in. Until now it fired for *everyone* except the bot itself, so internal teammates joining a support channel produced the same alerts as the external participants the feature is meant to surface — drowning the signal in noise.

## Changes

In `_handle_member_event` (`products/conversations/backend/slack.py`), after the existing bot self-check, resolve the joining/leaving Slack user's profile email and skip the alert when that email maps to a member of the integration's own organization. It reuses two existing helpers in the same module — `resolve_slack_user` (Slack ID → email, Redis-cached) and `resolve_posthog_user_for_slack` (email → `User` in `team.organization`).

Key behaviors:

- **Generalizes per team.** The check keys off `team.organization_id`, so every integration excludes *its own* org's members rather than a hardcoded domain. For PostHog's own usage that means PostHog staff; for any other team it means that team's own people.
- **Fails open.** If the email can't be resolved (transient Slack failure, no profile email, no matching account), the alert still fires — better to over-alert than silently drop an external join.
- **Always on.** No new setting, API field, migration, or frontend change.

One known limitation: coverage depends on the joining person's Slack email matching a PostHog account in the org, so a team whose Slack members largely lack PostHog accounts will see weaker exclusion. This fails safe (toward alerting) and can be revisited with case-insensitive matching or a configurable domain list if it ever matters.

## How did you test this code?

I'm an agent (PostHog Code), so no manual testing. Automated coverage added to `TestSlackMemberAlerts` in `products/conversations/backend/api/tests/test_slack_message_routing.py`:

- `test_member_event_skips_org_member` — a join whose resolved email belongs to the team's org posts no alert. Catches removal or inversion of the new filter.
- `test_member_event_posts_for_external_user` — a join whose email is *not* in the org still alerts. Pins the external-user path explicitly rather than relying on an unresolved email.

Ran `TestSlackMemberAlerts` (10 cases including the 2 new) — all pass. `ruff` lint/format and the pre-commit `ty` type check pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The feature is behind the `product-support-slack-notify-on-members` flag and not yet documented externally, so no docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). The human directed the work and reviewed the approach mid-flight — in particular pushing back on whether org-membership was the right exclusion signal, which led to documenting the assumptions (Slack-email ↔ account match, case sensitivity, fail-open behavior) and explicitly confirming the per-team generalization over a hardcoded `@posthog.com` domain. No repo skills were required (no migration, serializer, or viewset touched). Chose to reuse the existing `resolve_slack_user` / `resolve_posthog_user_for_slack` helpers rather than add new resolution logic, and kept the behavior always-on per the directed design.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
