### PR TITLE
fix(bigquery): auto-detect dataset region during schema discovery

### DIFF
--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -274,6 +274,30 @@ def bigquery_storage_read_client(
         transport.close()
 
 
+def _detect_dataset_region(config: BigQuerySourceConfig) -> str | None:
+    """Resolve the dataset's BigQuery location for schema-discovery queries.
+
+    Credentials validate with a region-agnostic table listing, but a query job created
+    without an explicit location defaults to the US multi-region — so a dataset that lives
+    in another region passes validation yet fails discovery with "... was not found in
+    location US". `get_dataset` is region-agnostic, so read the dataset's real location and
+    pin discovery to it. Returns None on any failure, leaving the original behaviour intact.
+    """
+    with bigquery_client(
+        _resolve_project_id(config),
+        None,
+        config.key_file.private_key,
+        config.key_file.private_key_id,
+        config.key_file.client_email,
+        config.key_file.token_uri,
+    ) as bq:
+        try:
+            dataset_ref = bq.dataset(_resolve_dataset_id(config), project=_resolve_query_project(config))
+            return bq.get_dataset(dataset_ref).location
+        except Exception:
+            return None
+
+
 def delete_table(
     table_id: str,
     project_id: str,
@@ -694,7 +718,10 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
 
     @contextmanager
     def connect(self, config: BigQuerySourceConfig) -> Iterator[bigquery.Client]:
-        region = _resolve_region(config)
+        # Without a custom region the client is built with `location=None`, so discovery
+        # query jobs default to the US multi-region and miss datasets in other regions.
+        # Auto-detect the dataset's location so discovery runs where the data lives.
+        region = _resolve_region(config) or _detect_dataset_region(config)
         with bigquery_client(
             _resolve_project_id(config),
             region,

--- a/posthog/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/posthog/temporal/data_imports/sources/bigquery/bigquery.py
@@ -294,7 +294,11 @@ def _detect_dataset_region(config: BigQuerySourceConfig) -> str | None:
         try:
             dataset_ref = bq.dataset(_resolve_dataset_id(config), project=_resolve_query_project(config))
             return bq.get_dataset(dataset_ref).location
-        except Exception:
+        except Exception as e:
+            # Best-effort: fall back to the default location so `get_columns` still surfaces the
+            # actionable not-found error. Log rather than capture, to keep the fallback visible
+            # without spamming error tracking.
+            structlog.get_logger().warning("Failed to auto-detect BigQuery dataset region", exc_info=e)
             return None
 
 

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -622,6 +622,8 @@ def test_connect_auto_detects_dataset_region_when_unset():
         with BigQueryImplementation().connect(_make_config()) as conn:
             assert conn is fake_bq
 
+    # The region must come from an actual dataset-location lookup, not a hardcoded default.
+    fake_bq.get_dataset.assert_called_once()
     # The last client built is the one discovery queries run on; its location is positional arg 1.
     assert mock_client.call_args_list[-1][0][1] == "europe-west1"
 

--- a/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/posthog/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -597,6 +597,63 @@ def test_bigquery_resolve_region_trims_and_treats_whitespace_as_unset():
     assert _resolve_region(config) is None
 
 
+# Regression: credentials validate with a region-agnostic `list_tables`, but a discovery query
+# job created without a location defaults to the US multi-region — so a dataset in another region
+# passed validation yet failed schema discovery with "... was not found in location US". `connect`
+# auto-resolves the dataset's real location so discovery runs where the data lives.
+
+
+def _patch_bigquery_client(fake_bq):
+    client_cm = mock.MagicMock()
+    client_cm.__enter__.return_value = fake_bq
+    return mock.patch(
+        "posthog.temporal.data_imports.sources.bigquery.bigquery.bigquery_client",
+        return_value=client_cm,
+    )
+
+
+def test_connect_auto_detects_dataset_region_when_unset():
+    """No custom region configured: connect must pin the discovery client to the dataset's real
+    location (read via the region-agnostic `get_dataset`) instead of defaulting to US."""
+    fake_bq = mock.MagicMock()
+    fake_bq.get_dataset.return_value.location = "europe-west1"
+
+    with _patch_bigquery_client(fake_bq) as mock_client:
+        with BigQueryImplementation().connect(_make_config()) as conn:
+            assert conn is fake_bq
+
+    # The last client built is the one discovery queries run on; its location is positional arg 1.
+    assert mock_client.call_args_list[-1][0][1] == "europe-west1"
+
+
+def test_connect_uses_configured_region_without_probing():
+    """A configured custom region is used as-is — no dataset-location probe is performed."""
+    config = _make_config()
+    config.use_custom_region = BigQueryUseCustomRegionConfig(region="us-east1", enabled=True)
+    fake_bq = mock.MagicMock()
+
+    with _patch_bigquery_client(fake_bq) as mock_client:
+        with BigQueryImplementation().connect(config):
+            pass
+
+    fake_bq.get_dataset.assert_not_called()
+    assert mock_client.call_count == 1
+    assert mock_client.call_args_list[-1][0][1] == "us-east1"
+
+
+def test_connect_falls_back_to_unset_location_when_detection_fails():
+    """If the dataset-location probe fails (e.g. the dataset really doesn't exist), connect leaves
+    the location unset so `get_columns` still surfaces the actionable not-found error."""
+    fake_bq = mock.MagicMock()
+    fake_bq.get_dataset.side_effect = NotFound("Not found: Dataset prj:ds")
+
+    with _patch_bigquery_client(fake_bq) as mock_client:
+        with BigQueryImplementation().connect(_make_config()):
+            pass
+
+    assert mock_client.call_args_list[-1][0][1] is None
+
+
 def test_bigquery_resolve_dataset_project_id_trims_and_treats_whitespace_as_unset():
     config = _make_config(
         dataset_project=BigQueryDatasetProjectConfig(dataset_project_id="  other-project ", enabled=True)


### PR DESCRIPTION
## Problem

A BigQuery source's "discover tables" step (`POST /external_data_sources/database_schema/`) failed for a dataset that genuinely exists, with:

```
NotFound: Not found: Dataset <redacted> was not found in location US
```

The failure originates in `posthog/temporal/data_imports/sources/bigquery/bigquery.py` (`get_columns`, called from `get_schemas`). Reported via error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019ef93c-252e-7eb2-8489-39569701d740)).

Root cause is an asymmetry between validation and discovery:

- `validate_credentials` lists tables via the BigQuery REST `tables.list` call, which is **region-agnostic** — it succeeds for a dataset in any region.
- `get_columns` then runs an `INFORMATION_SCHEMA.COLUMNS` query. With no custom region configured, the client is built with `location=None`, and a BigQuery query job created without an explicit location defaults to the **US multi-region**.

So a dataset that lives outside the US passes validation but fails discovery with a "was not found in location US" error — even though it exists and is reachable. The source form caption already promises that "BigQuery is able to automatically determine the region your dataset is located in", but the discovery query path never did.

## Changes

When no custom region is configured, `connect()` now resolves the dataset's real location via a region-agnostic `get_dataset` lookup and pins the discovery client to it, so the `INFORMATION_SCHEMA` queries run where the data actually lives.

If the location probe fails (for example, the dataset really doesn't exist), it falls back to the previous behaviour — leaving the location unset — so `get_columns` still surfaces the existing actionable "couldn't find the configured dataset or table … set the dataset region" message. No regression for genuinely-missing datasets, and the sync path's non-retryable handling for this condition is unchanged.

## How did you test this code?

I'm an agent. I added and ran automated tests (`posthog/temporal/data_imports/sources/bigquery/tests/test_source.py`), no manual testing:

- `test_connect_auto_detects_dataset_region_when_unset` — with no custom region, the discovery client is pinned to the dataset's detected location instead of defaulting to US (the regression this PR fixes).
- `test_connect_uses_configured_region_without_probing` — a configured custom region is used as-is, with no extra dataset-location probe.
- `test_connect_falls_back_to_unset_location_when_detection_fails` — if the probe fails, the location stays unset so the actionable not-found error still surfaces.

Full file: 88 passed. `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a BigQuery error-tracking issue with Claude Code. Confirmed via the stack trace that the failure is on the synchronous wizard path (not a Temporal sync), and that it had already passed `validate_credentials` — which proved the dataset exists and the failure is purely region resolution in the discovery query job. Chose a code fix over extending `NonRetryableErrors` (that mechanism only governs sync retries and already covers this condition; the wizard already returns a clean 400). Scoped the change to `connect()` so all discovery queries inherit the right region. Invoked the `/improving-drf-endpoints` skill while inspecting the endpoint path, though the final change is confined to the source driver, not the viewset.