### PR TITLE
chore(agents): ban cross-language source-scraping in tests

### DIFF
--- a/.agents/skills/writing-tests/SKILL.md
+++ b/.agents/skills/writing-tests/SKILL.md
@@ -28,7 +28,7 @@ Aim each test at a failure mode we actually hit, not a hypothetical.
 The bugs PostHog ships and reverts cluster into a handful of shapes — cataloged with the test that catches each, and the failure modes no unit test should, in [references/mistakes-we-make.md](references/mistakes-we-make.md).
 If your test doesn't map to one of them, be skeptical it's worth keeping.
 
-## Don't write it — the four no's
+## Don't write it — the five no's
 
 Most low-value tests fall into one of these. Recognize and skip them.
 
@@ -49,6 +49,11 @@ Most low-value tests fall into one of these. Recognize and skip them.
 4. **Coverage-chasing.**
    Don't add tests to hit a number; an uncovered line is information, not a defect.
    If the only reason to test a branch is the coverage report, the branch probably doesn't need a test — or the code is dead and should be deleted instead.
+
+5. **Cross-language source-scraping.**
+   Never read or regex-parse one language's source from another language's test — a Python test that `Path(...).read_text()`s a `.ts` file and matches `category: '...'`, a TS test that greps a `.py` file, and so on.
+   It couples two trees through a brittle string match that breaks on edits that change nothing about behavior (a rename, a reformat, a moved file, a comment), and it proves nothing about runtime — the two sides never actually run together in the test.
+   If two sides genuinely must agree on a set of values, give them **one source of truth** — a generated artifact or a checked-in data file both import — and assert against that. Otherwise let the drift surface where the two sides really meet (an API contract test, a rendered output, a round-trip), not by scraping the other language's source for strings.
 
 When the answer is "don't write it," the right move is often to **extend an existing test** (add a parameterized case) or **delete code** rather than test it.
 Both shrink the suite's surface.


### PR DESCRIPTION
## Problem

A test in one language that reads and regex-parses another language's source file — e.g. a Python test doing `Path(...).read_text()` on a `.ts` file and matching `category: '...'` — couples two trees through a brittle string match. It breaks on edits that change nothing about behaviour (a rename, a reformat, a moved file, a comment), and it proves nothing about runtime because the two sides never actually run together in the test. We just hit a concrete instance of this in an mcp_analytics test and removed it.

## Changes

Adds a fifth entry to the "don't write it" list in the `writing-tests` skill — **Cross-language source-scraping** — telling agents and engineers to recognise and skip this pattern, and to prefer one shared source of truth (a generated artifact or checked-in data file both sides import) or to let drift surface where the two sides actually meet (an API contract test, a rendered output, a round-trip).

Skill-only change; no production code.

## How did you test this code?

I'm an agent (PostHog Code). Documentation/skill change — no automated tests. The motivating brittle test was removed in a separate PR (#65399) and that file's suite still passes (20 tests).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul flagged the brittle cross-language test during review and asked to document the lesson so we avoid it in future. Authored with PostHog Code.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
