### PR TITLE
fix(shopify): retry connection broken mid-stream in-process

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -6,6 +6,7 @@ from collections.abc import Iterator
 from typing import Any
 
 import requests
+from requests.exceptions import ChunkedEncodingError
 from structlog.types import FilteringBoundLogger
 from tenacity import RetryCallState, retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
 
@@ -179,7 +180,12 @@ def _make_paginated_shopify_request(
         reraise=True,
     )
     def execute(vars: dict[str, Any]):
-        response = sess.post(url, json={"query": graphql_object.query, "variables": vars})
+        # `post` reads the body eagerly (stream=False), so a connection dropped mid-stream
+        # surfaces here as ChunkedEncodingError. It's transient — retry it like a 5xx below.
+        try:
+            response = sess.post(url, json={"query": graphql_object.query, "variables": vars})
+        except ChunkedEncodingError as e:
+            raise ShopifyRetryableError(f"Shopify: connection broken while reading response: {e}") from e
         if response.status_code >= 500:
             raise ShopifyRetryableError(
                 f"Shopify: internal error from request {response.status_code} {response.reason}"

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
@@ -1,11 +1,15 @@
 import pytest
+from unittest.mock import MagicMock, patch
 
+from requests.exceptions import ChunkedEncodingError
 from tenacity import Future, RetryCallState, Retrying
 
+from posthog.temporal.data_imports.sources.shopify.constants import ABANDONED_CHECKOUTS, SHOPIFY_GRAPHQL_OBJECTS
 from posthog.temporal.data_imports.sources.shopify.shopify import (
     _SHOPIFY_MAX_THROTTLE_WAIT_SECONDS,
     ShopifyRetryableError,
     _get_retryable_error,
+    _make_paginated_shopify_request,
     _shopify_retry_wait,
     _throttle_retry_after,
 )
@@ -81,3 +85,47 @@ def test_retry_wait_honors_throttle_refill_time():
 def test_retry_wait_falls_back_to_backoff_without_retry_after():
     wait = _shopify_retry_wait(_retry_state(ShopifyRetryableError("internal error")))
     assert 1.0 <= wait <= 2.0  # initial=1, max=30, jitter up to 1s on attempt 1
+
+
+def _ok_page() -> MagicMock:
+    response = MagicMock()
+    response.status_code = 200
+    response.json.return_value = {
+        "data": {ABANDONED_CHECKOUTS: {"nodes": [{"id": "1"}], "pageInfo": {"hasNextPage": False, "endCursor": None}}}
+    }
+    return response
+
+
+@patch("tenacity.nap.time.sleep")
+def test_request_retries_connection_broken_mid_stream_then_succeeds(_mock_sleep):
+    # A connection dropped mid-response surfaces from `post` as ChunkedEncodingError; it's
+    # transient, so the request is reissued rather than failing the import.
+    sess = MagicMock()
+    sess.post.side_effect = [
+        ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)"),
+        _ok_page(),
+    ]
+
+    batches = list(
+        _make_paginated_shopify_request(
+            "https://example.invalid/graphql", sess, SHOPIFY_GRAPHQL_OBJECTS[ABANDONED_CHECKOUTS], MagicMock()
+        )
+    )
+
+    assert batches == [[{"id": "1"}]]
+    assert sess.post.call_count == 2
+
+
+@patch("tenacity.nap.time.sleep")
+def test_request_reraises_retryable_after_persistent_connection_broken(_mock_sleep):
+    sess = MagicMock()
+    sess.post.side_effect = ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)")
+
+    with pytest.raises(ShopifyRetryableError):
+        list(
+            _make_paginated_shopify_request(
+                "https://example.invalid/graphql", sess, SHOPIFY_GRAPHQL_OBJECTS[ABANDONED_CHECKOUTS], MagicMock()
+            )
+        )
+
+    assert sess.post.call_count == 5


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ValueError: invalid literal for int() with base 16: b''` originating in the Shopify data-warehouse source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef959-a409-7032-a7ef-b76343c937c8)).

The full exception chain is `ChunkedEncodingError` → `ProtocolError` → `InvalidChunkLength` → `ValueError` ("Connection broken: InvalidChunkLength"). It's raised by `requests` while reading the response body inside `sess.post` at `shopify.py`, called from `_make_paginated_shopify_request`. In other words, the Shopify server (or an intermediary) closed the connection mid-response, leaving an empty chunk-size line.

This is a transient connection error, not a user/upstream config problem — so it should stay retryable, not go into `NonRetryableErrors`. The bug is that it wasn't being retried where it should be: the request retry loop only caught `ShopifyRetryableError` (5xx, rate limits), so a mid-stream connection drop escaped in-process retry entirely and failed the whole import activity.

## Changes

Catch `ChunkedEncodingError` at the `sess.post` call in the Shopify request executor and re-raise it as `ShopifyRetryableError`, so it flows through the existing bounded exponential backoff — exactly how 5xx responses are already handled. `post` reads the body eagerly (`stream=False`), so the mid-stream drop surfaces synchronously at that call site.

This mirrors the same fix already applied to the shared REST source (#65728) and the Stripe source (#65713) for the identical root cause.

## How did you test this code?

I'm an agent. I added two automated regression tests in `test_rate_limit_retry.py` and ran them with the rest of the file (14 passed):

- `test_request_retries_connection_broken_mid_stream_then_succeeds` — a `ChunkedEncodingError` on the first `post` is retried and the second attempt succeeds (catches the regression: before the fix the error escaped immediately, after it's reissued).
- `test_request_reraises_retryable_after_persistent_connection_broken` — a persistent `ChunkedEncodingError` is retried up to the bounded 5 attempts and then re-raised as `ShopifyRetryableError` (confirms retries stay bounded and the surfaced type stays retryable).

I verified both tests fail against `master` (raw `ChunkedEncodingError` propagates) and pass with the fix.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to pull the issue, its full stack trace, and frequency, confirming the failure originates in `posthog/temporal/data_imports/sources/shopify/shopify.py` rather than only appearing in serialized log context.

Decision: classified as a transient infrastructure error (connection broken mid-stream), so deliberately **not** added to `NonRetryableErrors`. Instead fixed the in-process retry gap so the transient drop is absorbed with backoff like a 5xx, consistent with the established per-source pattern (#65728 REST, #65713 Stripe). Checked open PRs (including the maintainer's) and found no existing Shopify fix for this.
