### PR TITLE
fix(shopify): retry transient connection errors during graphql reads

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -174,7 +174,13 @@ def _make_paginated_shopify_request(
     endpoint_config = ENDPOINT_CONFIGS.get(graphql_object.name)
 
     @retry(
-        retry=retry_if_exception_type(ShopifyRetryableError),
+        # Transient network failures (proxy/egress hiccups, connect/read timeouts) surface from
+        # `sess.post` as requests ConnectionError/Timeout — e.g. a 504 from the egress proxy tunnel.
+        # They're retryable like a 5xx, so reissue the request with backoff instead of failing the
+        # whole import. ConnectionError covers ProxyError; Timeout covers connect/read timeouts.
+        retry=retry_if_exception_type(
+            (ShopifyRetryableError, requests.exceptions.ConnectionError, requests.exceptions.Timeout)
+        ),
         stop=stop_after_attempt(5),
         wait=_shopify_retry_wait,
         reraise=True,

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_rate_limit_retry.py
@@ -1,6 +1,7 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
+import requests
 from requests.exceptions import ChunkedEncodingError
 from tenacity import Future, RetryCallState, Retrying
 
@@ -116,12 +117,53 @@ def test_request_retries_connection_broken_mid_stream_then_succeeds(_mock_sleep)
     assert sess.post.call_count == 2
 
 
+@pytest.mark.parametrize(
+    "transient_error",
+    [
+        # The observed failure: a 504 from the egress proxy tunnel surfaces as ProxyError.
+        requests.exceptions.ProxyError("Tunnel connection failed: 504 Gateway timeout"),
+        requests.exceptions.ConnectionError("Connection reset by peer"),
+        requests.exceptions.ReadTimeout("Read timed out"),
+    ],
+)
+@patch("tenacity.nap.time.sleep")
+def test_request_retries_transient_connection_error_then_succeeds(_mock_sleep, transient_error):
+    # Transient network errors escaping `post` (proxy hiccup, reset, timeout) are reissued
+    # rather than failing the import.
+    sess = MagicMock()
+    sess.post.side_effect = [transient_error, _ok_page()]
+
+    batches = list(
+        _make_paginated_shopify_request(
+            "https://example.invalid/graphql", sess, SHOPIFY_GRAPHQL_OBJECTS[ABANDONED_CHECKOUTS], MagicMock()
+        )
+    )
+
+    assert batches == [[{"id": "1"}]]
+    assert sess.post.call_count == 2
+
+
 @patch("tenacity.nap.time.sleep")
 def test_request_reraises_retryable_after_persistent_connection_broken(_mock_sleep):
     sess = MagicMock()
     sess.post.side_effect = ChunkedEncodingError("Connection broken: InvalidChunkLength(got length b'', 0 bytes read)")
 
     with pytest.raises(ShopifyRetryableError):
+        list(
+            _make_paginated_shopify_request(
+                "https://example.invalid/graphql", sess, SHOPIFY_GRAPHQL_OBJECTS[ABANDONED_CHECKOUTS], MagicMock()
+            )
+        )
+
+    assert sess.post.call_count == 5
+
+
+@patch("tenacity.nap.time.sleep")
+def test_request_reraises_after_persistent_connection_error(_mock_sleep):
+    sess = MagicMock()
+    sess.post.side_effect = requests.exceptions.ProxyError("Tunnel connection failed: 504 Gateway timeout")
+
+    with pytest.raises(requests.exceptions.ProxyError):
         list(
             _make_paginated_shopify_request(
                 "https://example.invalid/graphql", sess, SHOPIFY_GRAPHQL_OBJECTS[ABANDONED_CHECKOUTS], MagicMock()


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `OSError: Tunnel connection failed: 504 Gateway timeout` originating in the Shopify data-warehouse source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef95f-f77c-7c42-8054-464b7daf612e)).

The full exception chain is `ProxyError` → `MaxRetryError` → `OSError` ("Tunnel connection failed: 504 Gateway timeout"). The top in-app frame is `execute` inside `_make_paginated_shopify_request` in `shopify.py` — the egress proxy returned a 504 while establishing the tunnel out to the store, so the connection to Shopify never opened.

This is a transient infrastructure error, not a user/upstream config problem — so it should stay retryable, **not** go into `NonRetryableErrors`. The bug is that it wasn't being retried where it should be: the GraphQL request retry loop only caught `ShopifyRetryableError` (5xx, rate limits). A connection-establishment failure surfaces from `sess.post` as a requests `ConnectionError` (`ProxyError` is a subclass), which escaped in-process retry entirely and failed the whole import activity. Notably, a 504 returned as an HTTP *response* is already retried, but the connection-level equivalent was not — this closes that gap.

## Changes

Extend the `execute` retry predicate in `_make_paginated_shopify_request` to also reissue on `requests.exceptions.ConnectionError` and `requests.exceptions.Timeout`, flowing through the existing bounded exponential backoff. `ConnectionError` covers `ProxyError`/`SSLError`/`ConnectTimeout`; `Timeout` covers connect/read timeouts. GraphQL reads are idempotent, so reissuing is safe.

This is complementary to (not a duplicate of) #65772 and #65775, which handle a different transient class — `ChunkedEncodingError` (connection dropped mid-response-body). `ChunkedEncodingError` is a sibling of `ConnectionError`, not a subclass, so those PRs don't cover this proxy/connect failure. The change touches the retry decorator line, not the body, to avoid conflicting with #65772.

## How did you test this code?

I'm an agent. I added regression tests in `test_rate_limit_retry.py` and ran the full Shopify suite (75 passed):

- `test_request_retries_transient_connection_error_then_succeeds` — parametrized over `ProxyError` (the observed 504-tunnel case), `ConnectionError`, and `ReadTimeout`: the first `post` raises, the second succeeds, and the request is reissued rather than failing the import.
- `test_request_reraises_after_persistent_connection_error` — a persistent `ProxyError` is retried up to the bounded 5 attempts and then re-raised (confirms retries stay bounded and the error stays retryable, not swallowed).

I verified both groups fail against `master` (the raw error propagates after a single attempt) and pass with the fix. Lint/format clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to pull the issue, its full stack trace, and frequency, confirming the failure originates in `_make_paginated_shopify_request` and that the exception is a transient proxy/connection failure. Checked the requests exception hierarchy to confirm `ProxyError` is a `ConnectionError` (and distinct from the `ChunkedEncodingError` handled by #65772/#65775). Decided against `NonRetryableErrors` because the error is transient and should keep retrying; scoped the fix to the retry predicate to stay minimal and conflict-free.