### PR TITLE
fix(mssql): treat SSH-handshake EOFError as non-retryable

### DIFF
--- a/posthog/temporal/data_imports/sources/mssql/mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/mssql.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import time
 import collections
 from collections.abc import Callable, Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import Any, TypeVar
 
 import pyarrow as pa
@@ -80,6 +80,14 @@ _MAX_DISCOVERY_CONNECTION_ATTEMPTS = 5
 # succeeds. Transient lock contention, not a config or data problem.
 _DEADLOCK_VICTIM_ERROR = "was deadlocked on lock resources"
 _MAX_DEADLOCK_ATTEMPTS = 5
+
+# paramiko raises a bare, message-less EOFError from `start_client` when the SSH gateway accepts
+# the TCP connection but closes it during the SSH handshake — a non-SSH service on the port, a
+# bastion refusing PostHog's IPs, or a proxy that resets the stream. sshtunnel doesn't wrap it, so
+# it escapes as an EOFError whose `str()` is empty, matching no non-retryable rule and retrying
+# forever. `connect` translates it into this stable, classifiable message (see
+# `MSSQLSource.get_non_retryable_errors`) — same gateway-config class as a wrapped tunnel failure.
+_SSH_HANDSHAKE_EOF_ERROR = "SSH gateway closed the connection during the SSH handshake"
 
 
 def _is_transient_connection_error(error: BaseException) -> bool:
@@ -344,7 +352,7 @@ class MSSQLImplementation(SQLSourceImplementation[MSSQLSourceConfig, pymssql.Con
         Opens the SSH tunnel (if configured) once, then connects with the
         MSSQL-wide conventions: 5s login timeout.
         """
-        with open_ssh_tunnel(config) as (host, port):
+        with self._ssh_tunnel_endpoint(config) as (host, port):
             with pymssql.connect(
                 server=host,
                 # pymssql requires port to be str
@@ -355,6 +363,21 @@ class MSSQLImplementation(SQLSourceImplementation[MSSQLSourceConfig, pymssql.Con
                 login_timeout=5,
             ) as conn:
                 yield conn
+
+    @contextmanager
+    def _ssh_tunnel_endpoint(self, config: MSSQLSourceConfig) -> Iterator[tuple[str, int]]:
+        """Yield the `(host, port)` to connect to, going through the SSH tunnel if configured.
+
+        Translates a bare paramiko handshake `EOFError` into `_SSH_HANDSHAKE_EOF_ERROR`. The
+        `yield` sits outside the `except` so a failure raised by the connection body can never be
+        misattributed to the tunnel handshake.
+        """
+        with ExitStack() as stack:
+            try:
+                host, port = stack.enter_context(open_ssh_tunnel(config))
+            except EOFError as e:
+                raise Exception(_SSH_HANDSHAKE_EOF_ERROR) from e
+            yield host, port
 
     # ------------------------------------------------------------------
     # Listing — batch queries run once during `get_schemas`

--- a/posthog/temporal/data_imports/sources/mssql/source.py
+++ b/posthog/temporal/data_imports/sources/mssql/source.py
@@ -18,7 +18,11 @@ from posthog.temporal.data_imports.sources.common.registry import SourceRegistry
 from posthog.temporal.data_imports.sources.common.schema import SourceSchema
 from posthog.temporal.data_imports.sources.common.sql.base import SQLSource
 from posthog.temporal.data_imports.sources.generated_configs import MSSQLSourceConfig
-from posthog.temporal.data_imports.sources.mssql.mssql import MSSQLImplementation, retry_on_transient_connection_error
+from posthog.temporal.data_imports.sources.mssql.mssql import (
+    _SSH_HANDSHAKE_EOF_ERROR,
+    MSSQLImplementation,
+    retry_on_transient_connection_error,
+)
 
 from products.data_warehouse.backend.types import ExternalDataSourceType
 
@@ -86,6 +90,13 @@ class MSSQLSource(SQLSource[MSSQLSourceConfig], SSHTunnelMixin, ValidateDatabase
             # times across runs before giving up, so a genuinely transient gateway reboot is
             # absorbed. Postgres already treats this identical error as non-retryable.
             "Could not establish session to SSH gateway": "Could not connect to your SSH tunnel. Check that the SSH host, port, and credentials are correct, the bastion host is running and reachable, and that PostHog's IP addresses are allowed through its firewall.",
+            # paramiko raises a bare, message-less EOFError when the SSH gateway accepts the TCP
+            # connection but drops it mid-handshake (a non-SSH service on the port, the bastion
+            # refusing PostHog's IPs, a proxy resetting the stream). sshtunnel doesn't wrap it, so
+            # without translation it surfaces as an empty-message crash that matches no rule and
+            # retries forever. `connect` re-raises it as `_SSH_HANDSHAKE_EOF_ERROR` — same
+            # gateway-configuration class as "Could not establish session to SSH gateway" above.
+            _SSH_HANDSHAKE_EOF_ERROR: "Could not connect to your SSH tunnel — the gateway accepted the connection but closed it during the SSH handshake. Check that the SSH host and port point to an SSH server (not the database port), that the bastion is running and reachable, and that PostHog's IP addresses are allowed through its firewall, then re-enable the sync.",
             # Raised from the shared `_decimal_array_from_values` fallback in
             # `pipelines/pipeline/utils.py` when a numeric/decimal/money value exceeds Delta
             # Lake's decimal budget (precision > 76 or scale > 32). Fixed source-data shape —

--- a/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
+++ b/posthog/temporal/data_imports/sources/mssql/tests/test_mssql.py
@@ -8,6 +8,7 @@ from posthog.temporal.data_imports.sources.common.sql import Table, TableStats
 from posthog.temporal.data_imports.sources.common.sql.predicates import ColumnTypeCategory, ValidatedRowFilter
 from posthog.temporal.data_imports.sources.generated_configs import MSSQLSourceConfig
 from posthog.temporal.data_imports.sources.mssql.mssql import (
+    _SSH_HANDSHAKE_EOF_ERROR,
     MSSQLColumn,
     MSSQLImplementation,
     _build_query,
@@ -518,6 +519,36 @@ class TestBuildPipeline:
         assert streaming_cursor.execute.called
 
 
+class _RaisingTunnel:
+    """Context manager whose `__enter__` raises, standing in for paramiko's handshake EOFError."""
+
+    def __enter__(self):
+        raise EOFError()
+
+    def __exit__(self, *args):
+        return False
+
+
+class TestConnectSSHTunnel:
+    def test_bare_handshake_eof_is_translated_and_non_retryable(self, mocker):
+        mocker.patch(
+            "posthog.temporal.data_imports.sources.mssql.mssql.open_ssh_tunnel",
+            return_value=_RaisingTunnel(),
+        )
+        mock_connect = mocker.patch("posthog.temporal.data_imports.sources.mssql.mssql.pymssql.connect")
+
+        with pytest.raises(Exception, match=_SSH_HANDSHAKE_EOF_ERROR) as exc_info:
+            with MSSQLImplementation().connect(_make_config()):
+                pass
+
+        # Cause preserved, the database connection is never attempted, and the translated
+        # message is classified non-retryable so the sync stops instead of retrying forever.
+        assert isinstance(exc_info.value.__cause__, EOFError)
+        mock_connect.assert_not_called()
+        non_retryable = MSSQLSource().get_non_retryable_errors()
+        assert any(pattern in str(exc_info.value) for pattern in non_retryable.keys())
+
+
 class TestMSSQLSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
@@ -542,6 +573,8 @@ class TestMSSQLSourceNonRetryableErrors:
             # Raised by the sshtunnel library when the customer's SSH bastion can't be reached
             # (wrong host/port, rejected key, firewall) — the import goes through `open_ssh_tunnel`.
             "BaseSSHTunnelForwarderError: Could not establish session to SSH gateway",
+            # `connect` translates paramiko's bare handshake EOFError into this message.
+            _SSH_HANDSHAKE_EOF_ERROR,
         ],
     )
     def test_connection_errors_are_non_retryable(self, error_msg):


### PR DESCRIPTION
## Problem

Error tracking surfaced an `EOFError` from the MSSQL data-warehouse import source: https://us.posthog.com/project/2/error_tracking/019ef961-0ded-7390-bb51-eeed5bbb4326

The stack runs through the source's own connection path — `mssql.connect` → the shared `open_ssh_tunnel` helper → `sshtunnel` → `paramiko` — and bottoms out in `paramiko.packet.read_all` raising a bare, **message-less** `EOFError` during the SSH handshake. That happens when the configured SSH gateway accepts the TCP connection but then drops it mid-handshake: a non-SSH service listening on the port, a bastion refusing PostHog's egress IPs, or a proxy that resets the stream. It's the customer's gateway configuration, not a momentary blip.

Two things made this worse than it should be:

- `sshtunnel` doesn't wrap the `EOFError`, so it escaped as a raw `EOFError` with an empty message. The non-retryable classifier matches substrings against `str(error)`, and `str(EOFError())` is `""`, so it matched **no** rule — the import kept retrying every scheduled sync forever.
- The empty message also makes the failure useless to triage, both in error tracking and in the user-facing error.

The source already treats the wrapped variant of this failure (`"Could not establish session to SSH gateway"`) as non-retryable, so this is the same gateway-configuration class slipping through only because it arrived unwrapped.

## Changes

- `connect()` now opens the SSH tunnel through a small `_ssh_tunnel_endpoint` context manager that catches the bare handshake `EOFError` **at tunnel-establishment time only** and re-raises it as a stable, classifiable message (`_SSH_HANDSHAKE_EOF_ERROR`), preserving the original as `__cause__`. The translation deliberately wraps only the tunnel `__enter__` (via `ExitStack`), so an error raised later by the connection body can never be misattributed to the handshake.
- `MSSQLSource.get_non_retryable_errors()` maps that message to an actionable, redaction-safe explanation, alongside the existing SSH-gateway entry. As with the others, the across-run retry budget in `handle_non_retryable_error` still absorbs a genuinely transient gateway reboot before giving up.

This stays scoped to MSSQL rather than touching the shared `open_ssh_tunnel` helper, matching the existing per-source convention where each SQL source lists its own SSH-gateway non-retryable string.

## How did you test this code?

I'm an agent. I added and ran automated tests (`uv run --group dev python -m pytest .../mssql/tests/test_mssql.py`, 88 passed):

- A regression test that patches the tunnel to raise `EOFError` on enter and asserts `connect()` re-raises the translated message, preserves the `EOFError` cause, never attempts the database connection, and that the message is recognised as non-retryable. I confirmed this test **fails before the fix** (the raw error's message is `''`).
- Extended the existing non-retryable parametrization with the translated message.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the MSSQL source. Used PostHog's error-tracking MCP tools to pull the full stack trace and confirm the failure originates in the source's own connection path (not just serialized log context). No skills were applicable to this change.

Decision: classified as a user/upstream gateway-configuration error rather than transient infra. An `EOFError` from `paramiko`'s handshake `read_all` means the gateway closed the stream mid-handshake — the same class already treated as non-retryable when `sshtunnel` wraps it. A string-only fix was rejected because the bare error's `str()` is empty and could never match; the code must translate it first. The catch is scoped to tunnel establishment so it can't swallow unrelated failures.
