### PR TITLE
fix(shopify): retry transient SSL/connection errors on token exchange

### DIFF
--- a/posthog/temporal/data_imports/sources/shopify/shopify.py
+++ b/posthog/temporal/data_imports/sources/shopify/shopify.py
@@ -268,6 +268,18 @@ def normalize_store_id(raw: str) -> str:
     return store_id
 
 
+@retry(
+    # A transient TLS/connection drop on the token endpoint (e.g. SSL EOF, proxy/egress hiccup,
+    # connect/read timeout) surfaces from `post` as requests ConnectionError/Timeout — SSLError
+    # is a ConnectionError. The adapter's own urllib3 retries back off for only ~1.5s, too short
+    # to ride out a multi-second blip. Minting a token is idempotent, so reissue with backoff
+    # rather than failing the whole import. 4xx/5xx are raised as plain Exceptions below and so
+    # are untouched here — auth failures still fail fast.
+    retry=retry_if_exception_type((requests.exceptions.ConnectionError, requests.exceptions.Timeout)),
+    stop=stop_after_attempt(5),
+    wait=_shopify_backoff,
+    reraise=True,
+)
 def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, shopify_client_secret: str) -> str:
     # Callers pass an already-normalized store id (see normalize_store_id).
     access_token_url = SHOPIFY_ACCESS_TOKEN_URL.format(shopify_store_id)

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest import mock
 
+from requests.exceptions import SSLError
+
 from posthog.temporal.data_imports.sources.shopify.shopify import (
     SHOPIFY_ACCESS_TOKEN_AUTH_ERROR,
     _get_shopify_access_token,
@@ -53,6 +55,24 @@ def test_get_access_token_transient_stays_retryable(status_code):
 def test_get_access_token_success_returns_token():
     with _patched_token_call(_mock_response(200, ok=True, json_data={"access_token": "tok"})):
         assert _get_shopify_access_token("store", "client-id", "client-secret") == "tok"
+
+
+@mock.patch("tenacity.nap.time.sleep")
+def test_get_access_token_retries_ssl_error_then_succeeds(_mock_sleep):
+    # A transient TLS drop on the token endpoint surfaces from `post` as SSLError (a
+    # ConnectionError); it's transient, so reissue the request rather than failing the import.
+    post = mock.MagicMock(
+        side_effect=[
+            SSLError("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol"),
+            _mock_response(200, ok=True, json_data={"access_token": "tok"}),
+        ]
+    )
+    with mock.patch(
+        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        return_value=mock.MagicMock(post=post),
+    ):
+        assert _get_shopify_access_token("store", "client-id", "client-secret") == "tok"
+    assert post.call_count == 2
 
 
 @pytest.mark.parametrize(

--- a/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
+++ b/posthog/temporal/data_imports/sources/shopify/tests/test_access_token.py
@@ -75,6 +75,20 @@ def test_get_access_token_retries_ssl_error_then_succeeds(_mock_sleep):
     assert post.call_count == 2
 
 
+@mock.patch("tenacity.nap.time.sleep")
+def test_get_access_token_reraises_after_persistent_ssl_error(_mock_sleep):
+    # A persistent connection failure must exhaust the retry budget and re-raise the original
+    # error rather than being swallowed, so the import still fails (and Temporal retries it).
+    post = mock.MagicMock(side_effect=SSLError("[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred"))
+    with mock.patch(
+        "posthog.temporal.data_imports.sources.shopify.shopify.make_tracked_session",
+        return_value=mock.MagicMock(post=post),
+    ):
+        with pytest.raises(SSLError):
+            _get_shopify_access_token("store", "client-id", "client-secret")
+    assert post.call_count == 5
+
+
 @pytest.mark.parametrize(
     "error_message",
     [


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced an `SSLEOFError` originating in the Shopify data-warehouse source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019ef965-fe53-7763-bea9-a9224849e49c)).

The exception chain is `SSLError` → `MaxRetryError` → `SSLEOFError` (`[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol`), raised by `requests` from `sess.post` inside `_get_shopify_access_token` in `shopify.py` — the OAuth token exchange (`POST /admin/oauth/access_token`). The in-app top frame is the source's token-exchange path, confirmed via the full stack trace (`source_for_pipeline` → `shopify_source` → `_get_shopify_access_token` → tracked-session `send`). In other words, the token endpoint (or an intermediary) closed the TLS connection during the handshake. Two different stores hit it within the same moment, which points at a transient network/egress blip rather than anything store-specific.

This is a transient connection error, not a user/upstream config problem — so it should stay retryable, **not** go into `NonRetryableErrors`. The gap: the tracked session's own urllib3 retries back off for only ~1.5s, too short to ride out a multi-second blip, so the error escaped and failed the whole import activity.

## Changes

Wrap `_get_shopify_access_token` in a bounded exponential-backoff retry on the transient connection/timeout class — `requests.exceptions.ConnectionError` (which `SSLError` subclasses) and `requests.exceptions.Timeout`. Minting an OAuth token is idempotent, so reissuing is safe. 4xx/5xx responses are raised as plain `Exception`s further down the function and are untouched here, so auth failures still fail fast (and the existing non-retryable 4xx classification is unaffected).

This is the same transient-class handling already applied in-process to the GraphQL data path (#65777) and to the shared REST source (#65728) / Stripe (#65713). It is **complementary**, not a duplicate, to the other open Shopify retry PRs:

- #65775 decorates this same function but only catches `ChunkedEncodingError` — which does **not** subclass `ConnectionError`, so it does not cover the `SSLError` in this issue.
- #65772 / #65777 fix the GraphQL **data** path, not the token-exchange path that is the frame in this issue.

## How did you test this code?

I'm an agent. I added one automated regression test in `test_access_token.py` and ran the full Shopify source suite (72 passed) plus lint/format on the changed files:

- `test_get_access_token_retries_ssl_error_then_succeeds` — an `SSLError` on the first `post` is retried with backoff and the second attempt succeeds (asserts two calls). Before the fix the error escaped immediately and failed the run. The existing 4xx-non-retryable and transient-stays-retryable token tests still pass, confirming the decorator doesn't swallow auth failures.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to pull the issue, its full stack trace, affected stores, and frequency, confirming the failure originates in `_get_shopify_access_token` (in-app top frame), not just in serialized log context.

Decision: classified as a transient infrastructure error (TLS connection dropped mid-handshake), so deliberately **not** added to `NonRetryableErrors`. Instead closed the in-process retry gap on the token POST so a transient drop is absorbed with backoff, consistent with the established per-source pattern. Scoped to the connection/timeout exception class and the single token-exchange function to stay narrow and complementary to the in-flight Shopify retry PRs (#65775 token-path `ChunkedEncodingError`, #65772/#65777 data-path) rather than duplicating them.