### PR TITLE
feat(mcp): route bare tool-name calls to the exec gateway

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -116,13 +116,13 @@ export class ToolExecutor {
 
         if (!state.allTools.some((t) => t.name === toolName)) {
             toolCallsTotal.inc({ tool: toolName, status: 'error' })
-            return { content: [{ type: 'text', text: `Tool ${toolName} not found` }], isError: true }
+            return { content: [{ type: 'text', text: this.formatToolNotFound(toolName, state) }], isError: true }
         }
 
         const preBuilt = this.catalog.getToolByName(toolName)
         if (!preBuilt) {
             toolCallsTotal.inc({ tool: toolName, status: 'error' })
-            return { content: [{ type: 'text', text: `Tool ${toolName} not found` }], isError: true }
+            return { content: [{ type: 'text', text: this.formatToolNotFound(toolName, state) }], isError: true }
         }
 
         return this.callTool(
@@ -136,6 +136,23 @@ export class ToolExecutor {
             state,
             intentMeta
         )
+    }
+
+    // Message for a bare tool name that isn't callable directly. On single-exec
+    // connections only the `exec` gateway is advertised — domain tools (workflows,
+    // insights, flags, …) are reached through it, not as top-level tools. A client
+    // that calls e.g. `workflows-create` directly lands here, so route it into exec
+    // rather than dead-ending on "not found": `search` then surfaces the tool (and
+    // any scope-gating) accurately, whether the name is unavailable or just unexposed.
+    private formatToolNotFound(toolName: string, state: ResolvedState): string {
+        if (state.useSingleExec) {
+            return (
+                `Tool "${toolName}" is not a top-level tool on this connection — tools are invoked through the ` +
+                `"exec" gateway. Call "exec" with command \`search ${toolName}\` to find it (this also reports ` +
+                `whether it's unavailable or missing a required scope), then \`call ${toolName} {…}\` to run it.`
+            )
+        }
+        return `Tool ${toolName} not found`
     }
 
     // Pull the agent's stated intent off the injected `context` arg and strip it so

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -92,6 +92,17 @@ describe('ToolExecutor', () => {
             expect(result.content[0].text).toContain('not found')
         })
 
+        it('routes a bare tool name to the exec gateway on single-exec connections', async () => {
+            const result = (await executor.handleToolCall(
+                { name: 'workflows-create', arguments: {} },
+                makeState([], { useSingleExec: true })
+            )) as any
+            expect(result.isError).toBe(true)
+            expect(result.content[0].text).toContain('exec')
+            expect(result.content[0].text).toContain('search workflows-create')
+            expect(result.content[0].text).toContain('call workflows-create')
+        })
+
         it('rejects tools not in the per-request filtered set', async () => {
             const entries = catalog.getPreBuiltEntries()
             const tool = entries[0]!

--- a/services/mcp/tests/hono/tool-executor.test.ts
+++ b/services/mcp/tests/hono/tool-executor.test.ts
@@ -82,25 +82,28 @@ describe('ToolExecutor', () => {
             expect(result.content[0].text).toContain('Missing tool name')
         })
 
-        it('returns error when tool does not exist', async () => {
+        it.each([
+            {
+                name: 'plain not-found message off single-exec',
+                useSingleExec: false,
+                toolName: 'nonexistent-tool',
+                expected: ['nonexistent-tool', 'not found'],
+            },
+            {
+                name: 'routes to the exec gateway on single-exec connections',
+                useSingleExec: true,
+                toolName: 'workflows-create',
+                expected: ['exec', 'search workflows-create', 'call workflows-create'],
+            },
+        ])('returns error for an unknown tool: $name', async ({ useSingleExec, toolName, expected }) => {
             const result = (await executor.handleToolCall(
-                { name: 'nonexistent-tool', arguments: {} },
-                makeState([])
+                { name: toolName, arguments: {} },
+                makeState([], { useSingleExec })
             )) as any
             expect(result.isError).toBe(true)
-            expect(result.content[0].text).toContain('nonexistent-tool')
-            expect(result.content[0].text).toContain('not found')
-        })
-
-        it('routes a bare tool name to the exec gateway on single-exec connections', async () => {
-            const result = (await executor.handleToolCall(
-                { name: 'workflows-create', arguments: {} },
-                makeState([], { useSingleExec: true })
-            )) as any
-            expect(result.isError).toBe(true)
-            expect(result.content[0].text).toContain('exec')
-            expect(result.content[0].text).toContain('search workflows-create')
-            expect(result.content[0].text).toContain('call workflows-create')
+            for (const fragment of expected) {
+                expect(result.content[0].text).toContain(fragment)
+            }
         })
 
         it('rejects tools not in the per-request filtered set', async () => {


### PR DESCRIPTION
## Problem

On single-exec MCP connections (CLI / vibe-coding clients like Cursor), only the `exec` gateway is advertised as a top-level tool — domain tools (workflows, insights, flags, …) are reached *through* it via `search` then `call`. When an agent instead calls a domain tool by its bare name (e.g. `workflows-create`), it dead-ends on a generic `Tool ... not found`, with no signal that the tool exists and is reachable via `exec`. This surfaced as agent feedback claiming the workflow tools were "missing" / scope-gated, when they were simply being called the wrong way.

## Changes

In the native tool-call path, when a bare tool name isn't directly callable on a single-exec connection, return a routing hint instead of a bare "not found": it points the agent at `exec` `search <tool>` (which also reports whether the tool is unavailable or missing a scope) and then `call <tool> {…}`. Non-single-exec connections keep the original message. Adds a regression test.

## How did you test this code?

I'm an agent (PostHog Slack app). I ran the automated `tests/hono/tool-executor.test.ts` suite via vitest — all 14 tests pass, including the new `routes a bare tool name to the exec gateway on single-exec connections` case, which is the regression this PR guards (a previously-unexposed tool name no longer dead-ends without exec guidance). Typecheck of the package is clean for the changed files (remaining tsgo errors are pre-existing missing-module noise from a partial checkout, unrelated to this change).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude Code) at a maintainer's request, originating from MCP agent feedback that reported workflow tools as "missing" after OAuth. Investigation showed the tools were exposed via `exec` all along; the real gap was discoverability for clients that call domain tools by bare name. Chose a minimal, mode-gated error-message hint (over exposing more top-level tools or changing scopes) so the fix funnels agents into the existing `exec` discovery flow, where scope-gating is already reported accurately. No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AV33BDCJ3/p1782251971279599?thread_ts=1782251971.279599&cid=C0AV33BDCJ3)*
