### PR TITLE
fix: default Meta Ads token expiry when missing

### DIFF
--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -29,6 +29,7 @@ from posthog.models.integration import (
     GitHubIntegration,
     GitHubIntegrationError,
     Integration,
+    MetaAdsIntegration,
     SlackIntegration,
     StripeIntegration,
 )
@@ -3242,6 +3243,49 @@ class TestAnthropicIntegration:
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "is not an Anthropic integration" in str(response.json())
         mock_anthropic_class.assert_not_called()
+
+
+class TestMetaAdsIntegration:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.user = User.objects.create(email="test@posthog.com")
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+
+    def _make_integration(self, config=None):
+        return Integration.objects.create(
+            team=self.team,
+            kind="meta-ads",
+            integration_id="12345",
+            config=config or {"refreshed_at": int(time.time())},
+            sensitive_config={"access_token": "meta-access-token"},
+            created_by=self.user,
+        )
+
+    @patch("posthog.models.integration.requests.post")
+    def test_refresh_access_token_uses_default_expiry_when_meta_omits_expires_in(self, mock_post):
+        integration = self._make_integration(
+            config={"expires_in": 1, "refreshed_at": int(time.time()) - MetaAdsIntegration.default_expires_in}
+        )
+        mock_post.return_value.status_code = 200
+        mock_post.return_value.json.return_value = {"access_token": "new-meta-access-token"}
+
+        MetaAdsIntegration(integration).refresh_access_token()
+
+        integration.refresh_from_db()
+        assert integration.sensitive_config["access_token"] == "new-meta-access-token"
+        assert integration.config["expires_in"] == MetaAdsIntegration.default_expires_in
+        assert integration.errors == ""
+
+    @patch("posthog.models.integration.requests.post")
+    def test_refresh_access_token_skips_recent_token_when_meta_omitted_expires_in(self, mock_post):
+        integration = self._make_integration(config={"refreshed_at": int(time.time())})
+
+        MetaAdsIntegration(integration).refresh_access_token()
+
+        mock_post.assert_not_called()
+        integration.refresh_from_db()
+        assert integration.errors == ""
 
     @patch("anthropic.Anthropic")
     def test_anthropic_managed_agent_environments_action(self, mock_anthropic_class, client: HttpClient):

--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -2964,6 +2964,7 @@ class GitLabIntegration:
 class MetaAdsIntegration:
     integration: Integration
     api_version: str = "v25.0"
+    default_expires_in: int = 60 * 24 * 60 * 60
 
     def __init__(self, integration: Integration) -> None:
         if integration.kind != "meta-ads":
@@ -2974,10 +2975,11 @@ class MetaAdsIntegration:
         oauth_config = OauthIntegration.oauth_config_for_kind(self.integration.kind)
 
         # skip refresh if more than 7 days until expiry
-        if self.integration.config.get("expires_in") and self.integration.config.get("refreshed_at"):
+        expires_in = self.integration.config.get("expires_in") or self.default_expires_in
+        if expires_in and self.integration.config.get("refreshed_at"):
             if (
                 time.time()
-                < self.integration.config.get("refreshed_at") + self.integration.config.get("expires_in") - 604800
+                < self.integration.config.get("refreshed_at") + expires_in - 604800
             ):
                 return
 
@@ -3002,7 +3004,7 @@ class MetaAdsIntegration:
             logger.info(f"Refreshed access token for {self}")
             self.integration.sensitive_config["access_token"] = config["access_token"]
             self.integration.errors = ""
-            self.integration.config["expires_in"] = config.get("expires_in")
+            self.integration.config["expires_in"] = config.get("expires_in") or self.default_expires_in
             self.integration.config["refreshed_at"] = int(time.time())
             # not used in CDP yet
             # reload_integrations_on_workers(self.integration.team_id, [self.integration.id])


### PR DESCRIPTION
## Problem
Meta Ads source syncs can fail after a successful OAuth reconnect when Meta/PostHog stores the integration config with `refreshed_at` but no `expires_in`. `MetaAdsIntegration.refresh_access_token()` only skips refresh when both fields exist, so every source run immediately attempts another `fb_exchange_token` exchange. When that exchange fails, the integration is marked `TOKEN_REFRESH_FAILED` and Meta Ads source schemas are auto-disabled.

I hit this on PostHog Cloud US in project 389330 with a MetaAds source: the UI reconnect succeeded and cleared the warning, but the next source reload failed all six schemas (`ads`, `adsets`, `adset_stats`, `ad_stats`, `campaigns`, `campaign_stats`) with `Failed to refresh token for Meta Ads integration. Please re-authorize the integration.` The integration record had `refreshed_at` but no `expires_in`.

## Change
- Treat Meta Ads tokens that omit `expires_in` as 60-day tokens when `refreshed_at` is present.
- When Meta returns a refreshed access token without `expires_in`, store the same 60-day default.
- Add regression tests for both shapes.

This matches the existing `set_token_expires_in_60_days` request parameter and Meta long-lived token behavior.

## Tests
- `python3 -m py_compile posthog/models/integration.py posthog/api/test/test_integration.py`
- `git diff --check`

Could not run targeted pytest locally because this checkout requires Python `3.13.13`; `uv` could not install that exact interpreter for macOS arm64 in this environment.