### PR TITLE
perf(hogql): prefilter groups JOIN by event keys to avoid OOM on huge teams

### DIFF
--- a/posthog/hogql/database/schema/groups.py
+++ b/posthog/hogql/database/schema/groups.py
@@ -20,7 +20,7 @@ from posthog.hogql.database.models import (
 from posthog.hogql.database.schema.groups_revenue_analytics import GroupsRevenueAnalyticsTable
 from posthog.hogql.errors import ResolutionError
 from posthog.hogql.parser import parse_select
-from posthog.hogql.visitor import TraversingVisitor
+from posthog.hogql.visitor import TraversingVisitor, clone_expr
 
 GROUPS_TABLE_FIELDS: dict[str, FieldOrTable] = {
     "index": IntegerDatabaseField(
@@ -163,6 +163,32 @@ def join_with_group_n_table(
         right=ast.Constant(value=group_index),
     )
 
+    # If the outer query has a bounded prefilter on `events` (one that references `timestamp` —
+    # which is the strongest signal we have that the matched set is small), push an additional
+    # `group_key IN (SELECT $group_N FROM events WHERE <outer prefilter>)` predicate into the
+    # groups subquery. Without this filter, the LEFT JOIN materializes a hash table containing
+    # every group of this type for the team, decompressing the (very wide) `group_properties`
+    # blob row by row — on high-volume teams that's enough to OOM the whole query even when
+    # only a handful of events are actually being selected. With the filter, the hash table is
+    # bounded by the distinct `$group_N` values present in the matched events.
+    events_prefilter = _outer_events_prefilter(node)
+    if events_prefilter is not None:
+        key_subquery = ast.SelectQuery(
+            select=[ast.Field(chain=[f"$group_{group_index}"])],
+            select_from=ast.JoinExpr(table=ast.Field(chain=["events"])),
+            where=events_prefilter,
+        )
+        select_query.where = ast.And(
+            exprs=[
+                select_query.where,
+                ast.CompareOperation(
+                    op=ast.CompareOperationOp.In,
+                    left=ast.Field(chain=["key"]),
+                    right=key_subquery,
+                ),
+            ]
+        )
+
     join_expr = ast.JoinExpr(table=select_query)
     join_expr.join_type = "LEFT JOIN"
     join_expr.alias = join_to_add.to_table
@@ -176,6 +202,97 @@ def join_with_group_n_table(
     )
 
     return join_expr
+
+
+# Aliases on the events table that resolve to lazy joins or traversers. If the outer WHERE
+# references any of these (e.g. `WHERE group_0.properties.X = 'Y'`, `WHERE person.id = ...`),
+# cloning that WHERE into the inner `SELECT $group_N FROM events WHERE ...` subquery would
+# carry the typed `Field` for the lazy join, and the resolver would recursively try to
+# resolve the same lazy join inside our inner subquery — producing unbounded recursion or a
+# `ResolutionError: Select query must have a type`. Skip the optimization in that case;
+# we'd rather pay the original groups-hash-table cost than crash.
+EVENTS_LAZY_JOIN_ALIASES = frozenset(
+    {
+        "person",
+        "person_id",
+        "pdi",
+        "poe",
+        "group_0",
+        "group_1",
+        "group_2",
+        "group_3",
+        "group_4",
+        "goe_0",
+        "goe_1",
+        "goe_2",
+        "goe_3",
+        "goe_4",
+        "session",
+        "revenue_analytics",
+    }
+)
+
+
+def _outer_events_prefilter(node: SelectQuery):
+    """
+    Extract a clone of the outer query's WHERE that we can safely embed inside the groups
+    join subquery. We only return it when:
+
+    1. The outer's `FROM` is a plain unaliased `events` reference. Anything else (custom
+       alias like `FROM events AS e` in funnels, JOINed tables on the outer, or a subquery)
+       means the WHERE may reference symbols (`e.timestamp`, `p.id`, …) that don't exist
+       in our inner `SELECT $group_N FROM events` subquery — cloning a WHERE that names
+       them would raise `Unable to resolve field` when the resolver walks the clone.
+    2. The WHERE references the `timestamp` field — cheap heuristic for "the matched event
+       set is bounded by a date range." Without that guard, a query whose WHERE is only
+       `team_id = X` (or empty) would push a key subquery that scans every event for the
+       team, which is strictly worse than no filter at all.
+    3. The WHERE does not reference any lazy-join alias on the events table. Cloning a
+       `group_N.X` / `person.X` reference into the inner subquery would re-trigger the
+       resolver on the same lazy join during inner-subquery resolution.
+    """
+    # Deferred: lazy_tables imports the resolver, which imports database schema modules — circular.
+    from posthog.hogql.transforms.lazy_tables import find_field_chains  # noqa: PLC0415
+
+    where = node.where
+    if where is None:
+        return None
+
+    select_from = node.select_from
+    if select_from is None:
+        return None
+    table = select_from.table
+    if not isinstance(table, ast.Field) or table.chain != ["events"]:
+        return None
+    if select_from.alias is not None and select_from.alias != "events":
+        return None
+
+    if not _references_timestamp(where):
+        return None
+    if any(
+        chain and isinstance(chain[0], str) and chain[0] in EVENTS_LAZY_JOIN_ALIASES
+        for chain in find_field_chains(where)
+    ):
+        return None
+    return clone_expr(where)
+
+
+class _TimestampReferenceFinder(TraversingVisitor):
+    """Walks an expression to see whether it touches the `timestamp` field."""
+
+    def __init__(self):
+        super().__init__()
+        self.found = False
+
+    def visit_field(self, node):
+        if node.chain and node.chain[-1] == "timestamp":
+            self.found = True
+
+
+def _references_timestamp(expr) -> bool:
+    finder = _TimestampReferenceFinder()
+    finder.visit(expr)
+    return finder.found
 
 
 class RawGroupsTable(Table):

--- a/posthog/hogql/database/schema/test/test_groups_join_prefilter.py
+++ b/posthog/hogql/database/schema/test/test_groups_join_prefilter.py
@@ -1,0 +1,108 @@
+from datetime import UTC, datetime
+
+from posthog.test.base import APIBaseTest
+
+from posthog.hogql.context import HogQLContext
+from posthog.hogql.database.database import Database
+from posthog.hogql.parser import parse_select
+from posthog.hogql.printer import prepare_and_print_ast
+
+from posthog.models.group_type_mapping import invalidate_group_types_cache
+from posthog.test.persons import create_group_type_mapping
+
+
+class TestGroupsJoinPrefilter(APIBaseTest):
+    """
+    Each `LEFT JOIN groups` subquery generated for `group_N.<field>` access should also be
+    constrained by `group_key IN (SELECT $group_N FROM events WHERE <outer prefilter>)` when
+    the outer query has a `timestamp`-bounded WHERE. Without that constraint the join hash
+    table contains every group of that type for the team, decompressing the wide
+    `group_properties` blob row-by-row — enough to OOM the query on a high-volume team even
+    when only a handful of events are actually selected.
+
+    The optimization is gated on `timestamp` appearing in the outer WHERE, so unbounded
+    queries (no WHERE, or WHERE without a date range) still go through the original path.
+    """
+
+    def setUp(self):
+        super().setUp()
+        create_group_type_mapping(
+            team=self.team,
+            project=self.team.project,
+            group_type="company",
+            group_type_index=0,
+            created_at=datetime(2020, 1, 1, tzinfo=UTC),
+        )
+        invalidate_group_types_cache(self.team.project_id)
+        self.database = Database.create_for(team=self.team)
+        self.context = HogQLContext(team=self.team, database=self.database, enable_select_queries=True)
+
+    def _print(self, query: str) -> str:
+        sql, _ = prepare_and_print_ast(parse_select(query), context=self.context, dialect="clickhouse")
+        return sql
+
+    def test_pushes_group_key_filter_when_outer_where_has_timestamp(self):
+        sql = self._print("SELECT group_0.properties FROM events WHERE timestamp > toDateTime('2026-01-01') LIMIT 10")
+        # Groups subquery now constrains group_key to the keys present in the matched events.
+        # The `$group_0` field reference can be wrapped by the resolver (timestamp clamping
+        # against the GroupTypeMapping created_at, etc.), so we only assert the column ref
+        # appears in the printed SQL — not the exact SELECT prefix.
+        self.assertIn("in(key,", sql)
+        self.assertIn("events.`$group_0`", sql)
+        self.assertIn("FROM events", sql)
+
+    def test_pushes_group_key_filter_with_uuid_and_timestamp_where(self):
+        # Mirrors the prod test-event-fetch shape: uuid set plus a tight timestamp window.
+        sql = self._print(
+            "SELECT group_0.properties FROM events "
+            "WHERE uuid IN ('019ef62f-21be-7867-9939-e0723c27efc2') "
+            "AND timestamp > toDateTime('2026-06-23 02:48:28') "
+            "AND timestamp < toDateTime('2026-06-23 13:32:26')"
+        )
+        self.assertIn("in(key,", sql)
+        self.assertIn("events.`$group_0`", sql)
+
+    def test_skips_filter_when_outer_where_lacks_timestamp(self):
+        # No timestamp reference → the optimization would push a key subquery that scans every
+        # event for the team, which is strictly worse than no filter. Guard skips it.
+        sql = self._print("SELECT group_0.properties FROM events WHERE event = '$pageview'")
+        self.assertNotIn("in(key,", sql)
+
+    def test_skips_filter_when_outer_has_no_where(self):
+        sql = self._print("SELECT group_0.properties FROM events")
+        self.assertNotIn("in(key,", sql)
+
+    def test_skips_filter_when_outer_where_references_lazy_join(self):
+        # Cloning a WHERE that references a lazy-join column (e.g. `group_0.properties.X`)
+        # into the inner `SELECT $group_N FROM events ...` subquery would re-trigger the
+        # same lazy join inside that inner subquery during resolution — producing unbounded
+        # recursion or a `ResolutionError`. The guard skips the optimization in that case;
+        # the outer group join still resolves and prints normally, just without the key
+        # prefilter pushed into its WHERE.
+        sql = self._print(
+            "SELECT group_0.properties FROM events "
+            "WHERE group_0.properties.industry = 'tech' "
+            "AND timestamp > toDateTime('2026-01-01')"
+        )
+        self.assertIn("events__group_0", sql)
+        self.assertNotIn("in(key,", sql)
+
+    def test_skips_filter_when_outer_where_references_person_lazy_join(self):
+        # Same recursive-resolution risk for `person.*` references on the events table.
+        sql = self._print(
+            "SELECT group_0.properties FROM events "
+            "WHERE person.properties.plan = 'pro' "
+            "AND timestamp > toDateTime('2026-01-01')"
+        )
+        self.assertIn("events__group_0", sql)
+        self.assertNotIn("in(key,", sql)
+
+    def test_skips_filter_when_outer_from_events_is_aliased(self):
+        # Funnel queries (and others) build `FROM events AS e ... WHERE e.timestamp > X`.
+        # Cloning that WHERE into the inner `SELECT $group_N FROM events` subquery would
+        # carry references to `e.X` that have no scope in the inner subquery, raising
+        # `Unable to resolve field: e`. Guard skips the optimization for aliased FROMs.
+        sql = self._print("SELECT group_0.properties FROM events AS e WHERE e.timestamp > toDateTime('2026-01-01')")
+        # The lazy join is named after the FROM alias, so `e__group_0` rather than `events__group_0`.
+        self.assertIn("e__group_0", sql)
+        self.assertNotIn("in(key,", sql)


### PR DESCRIPTION
## Benchmark 

- [Before](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6NDIsIm5hdGl2ZSI6eyJxdWVyeSI6IlxuICBTRUxFQ1RcbiAgICAgIHR1cGxlKGV2ZW50cy51dWlkLCBldmVudHMuZXZlbnQsIGV2ZW50cy5wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGV2ZW50cy50aW1lc3RhbXAsICdVVEMnKSxcbiAgICAgICAgICAgIGV2ZW50cy50ZWFtX2lkLCBldmVudHMuZGlzdGluY3RfaWQsIGV2ZW50cy5lbGVtZW50c19jaGFpbixcbiAgICAgICAgICAgIHRvVGltZVpvbmUoZXZlbnRzLmNyZWF0ZWRfYXQsICdVVEMnKSwgZXZlbnRzLnBlcnNvbl9tb2RlKSxcbiAgICAgIHR1cGxlKGV2ZW50c19fZ3JvdXBfMC5jcmVhdGVkX2F0LCBldmVudHNfX2dyb3VwXzAuaW5kZXgsIGV2ZW50c19fZ3JvdXBfMC5rZXksIGV2ZW50c19fZ3JvdXBfMC5wcm9wZXJ0aWVzLCBldmVudHNfX2dyb3VwXzAudXBkYXRlZF9hdCksXG4gICAgICB0dXBsZShldmVudHNfX2dyb3VwXzEuY3JlYXRlZF9hdCwgZXZlbnRzX19ncm91cF8xLmluZGV4LCBldmVudHNfX2dyb3VwXzEua2V5LCBldmVudHNfX2dyb3VwXzEucHJvcGVydGllcywgZXZlbnRzX19ncm91cF8xLnVwZGF0ZWRfYXQpLFxuICAgICAgdHVwbGUoZXZlbnRzX19ncm91cF8yLmNyZWF0ZWRfYXQsIGV2ZW50c19fZ3JvdXBfMi5pbmRleCwgZXZlbnRzX19ncm91cF8yLmtleSwgZXZlbnRzX19ncm91cF8yLnByb3BlcnRpZXMsIGV2ZW50c19fZ3JvdXBfMi51cGRhdGVkX2F0KSxcbiAgICAgIHR1cGxlKGV2ZW50c19fZ3JvdXBfMy5jcmVhdGVkX2F0LCBldmVudHNfX2dyb3VwXzMuaW5kZXgsIGV2ZW50c19fZ3JvdXBfMy5rZXksIGV2ZW50c19fZ3JvdXBfMy5wcm9wZXJ0aWVzLCBldmVudHNfX2dyb3VwXzMudXBkYXRlZF9hdCksXG4gICAgICB0dXBsZShldmVudHNfX2dyb3VwXzQuY3JlYXRlZF9hdCwgZXZlbnRzX19ncm91cF80LmluZGV4LCBldmVudHNfX2dyb3VwXzQua2V5LCBldmVudHNfX2dyb3VwXzQucHJvcGVydGllcywgZXZlbnRzX19ncm91cF80LnVwZGF0ZWRfYXQpXG4gIEZST00gZXZlbnRzXG4gIExFRlQgSk9JTiAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuY3JlYXRlZF9hdCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIGNyZWF0ZWRfYXQsXG4gICAgICAgICAgYXJnTWF4KGdyb3Vwcy5ncm91cF9wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHByb3BlcnRpZXMsXG4gICAgICAgICAgYXJnTWF4KHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSwgdG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpKSBBUyB1cGRhdGVkX2F0LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4IEFTIGluZGV4LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF9rZXkgQVMga2V5XG4gICAgICBGUk9NIGdyb3Vwc1xuICAgICAgV0hFUkUgYW5kKGVxdWFscyhncm91cHMudGVhbV9pZCwgMiksIGVxdWFscyhpbmRleCwgMCkpXG4gICAgICBHUk9VUCBCWSBncm91cHMuZ3JvdXBfdHlwZV9pbmRleCwgZ3JvdXBzLmdyb3VwX2tleVxuICApIEFTIGV2ZW50c19fZ3JvdXBfMCBPTiBlcXVhbHMoZXZlbnRzLmAkZ3JvdXBfMGAsIGV2ZW50c19fZ3JvdXBfMC5rZXkpXG4gIExFRlQgSk9JTiAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuY3JlYXRlZF9hdCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIGNyZWF0ZWRfYXQsXG4gICAgICAgICAgYXJnTWF4KGdyb3Vwcy5ncm91cF9wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHByb3BlcnRpZXMsXG4gICAgICAgICAgYXJnTWF4KHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSwgdG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpKSBBUyB1cGRhdGVkX2F0LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4IEFTIGluZGV4LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF9rZXkgQVMga2V5XG4gICAgICBGUk9NIGdyb3Vwc1xuICAgICAgV0hFUkUgYW5kKGVxdWFscyhncm91cHMudGVhbV9pZCwgMiksIGVxdWFscyhpbmRleCwgMSkpXG4gICAgICBHUk9VUCBCWSBncm91cHMuZ3JvdXBfdHlwZV9pbmRleCwgZ3JvdXBzLmdyb3VwX2tleVxuICApIEFTIGV2ZW50c19fZ3JvdXBfMSBPTiBlcXVhbHMoZXZlbnRzLmAkZ3JvdXBfMWAsIGV2ZW50c19fZ3JvdXBfMS5rZXkpXG4gIExFRlQgSk9JTiAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuY3JlYXRlZF9hdCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIGNyZWF0ZWRfYXQsXG4gICAgICAgICAgYXJnTWF4KGdyb3Vwcy5ncm91cF9wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHByb3BlcnRpZXMsXG4gICAgICAgICAgYXJnTWF4KHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSwgdG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpKSBBUyB1cGRhdGVkX2F0LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4IEFTIGluZGV4LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF9rZXkgQVMga2V5XG4gICAgICBGUk9NIGdyb3Vwc1xuICAgICAgV0hFUkUgYW5kKGVxdWFscyhncm91cHMudGVhbV9pZCwgMiksIGVxdWFscyhpbmRleCwgMikpXG4gICAgICBHUk9VUCBCWSBncm91cHMuZ3JvdXBfdHlwZV9pbmRleCwgZ3JvdXBzLmdyb3VwX2tleVxuICApIEFTIGV2ZW50c19fZ3JvdXBfMiBPTiBlcXVhbHMoZXZlbnRzLmAkZ3JvdXBfMmAsIGV2ZW50c19fZ3JvdXBfMi5rZXkpXG4gIExFRlQgSk9JTiAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuY3JlYXRlZF9hdCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIGNyZWF0ZWRfYXQsXG4gICAgICAgICAgYXJnTWF4KGdyb3Vwcy5ncm91cF9wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHByb3BlcnRpZXMsXG4gICAgICAgICAgYXJnTWF4KHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSwgdG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpKSBBUyB1cGRhdGVkX2F0LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4IEFTIGluZGV4LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF9rZXkgQVMga2V5XG4gICAgICBGUk9NIGdyb3Vwc1xuICAgICAgV0hFUkUgYW5kKGVxdWFscyhncm91cHMudGVhbV9pZCwgMiksIGVxdWFscyhpbmRleCwgMykpXG4gICAgICBHUk9VUCBCWSBncm91cHMuZ3JvdXBfdHlwZV9pbmRleCwgZ3JvdXBzLmdyb3VwX2tleVxuICApIEFTIGV2ZW50c19fZ3JvdXBfMyBPTiBlcXVhbHMoZXZlbnRzLmAkZ3JvdXBfM2AsIGV2ZW50c19fZ3JvdXBfMy5rZXkpXG4gIExFRlQgSk9JTiAoXG4gICAgICBTRUxFQ1RcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuY3JlYXRlZF9hdCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIGNyZWF0ZWRfYXQsXG4gICAgICAgICAgYXJnTWF4KGdyb3Vwcy5ncm91cF9wcm9wZXJ0aWVzLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHByb3BlcnRpZXMsXG4gICAgICAgICAgYXJnTWF4KHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSwgdG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpKSBBUyB1cGRhdGVkX2F0LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4IEFTIGluZGV4LFxuICAgICAgICAgIGdyb3Vwcy5ncm91cF9rZXkgQVMga2V5XG4gICAgICBGUk9NIGdyb3Vwc1xuICAgICAgV0hFUkUgYW5kKGVxdWFscyhncm91cHMudGVhbV9pZCwgMiksIGVxdWFscyhpbmRleCwgNCkpXG4gICAgICBHUk9VUCBCWSBncm91cHMuZ3JvdXBfdHlwZV9pbmRleCwgZ3JvdXBzLmdyb3VwX2tleVxuICApIEFTIGV2ZW50c19fZ3JvdXBfNCBPTiBlcXVhbHMoZXZlbnRzLmAkZ3JvdXBfNGAsIGV2ZW50c19fZ3JvdXBfNC5rZXkpXG4gIFdIRVJFIGFuZChcbiAgICAgIGVxdWFscyhldmVudHMudGVhbV9pZCwgMiksXG4gICAgICBpbihldmVudHMudXVpZCwgKFxuICAgICAgICAgIFNFTEVDVCBldmVudHMudXVpZCBBUyB1dWlkXG4gICAgICAgICAgRlJPTSBldmVudHNcbiAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgIExJTUlUIDlcbiAgICAgICkpLFxuICAgICAgYW5kKGVxdWFscyhldmVudHMuZXZlbnQsICckcGFnZXZpZXcnKSxcbiAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgKVxuICBPUkRFUiBCWSB0b1RpbWVab25lKGV2ZW50cy50aW1lc3RhbXAsICdVVEMnKSBERVNDXG4gIExJTUlUIDlcbiAgU0VUVElOR1MgbG9nX2NvbW1lbnQgPSAnZ3JvdXBzLXByZWZpbHRlci10ZXN0OmJlZm9yZScsIHVzZV91bmNvbXByZXNzZWRfY2FjaGUgPSAwOyIsInRlbXBsYXRlLXRhZ3MiOnt9fX0sImRpc3BsYXkiOiJ0YWJsZSIsInBhcmFtZXRlcnMiOltdLCJ2aXN1YWxpemF0aW9uX3NldHRpbmdzIjp7fX0=) (Timing out)
- [After](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7Im5hdGl2ZSI6eyJxdWVyeSI6IlNFTEVDVFxuICAgICAgdHVwbGUoZXZlbnRzLnV1aWQsIGV2ZW50cy5ldmVudCwgZXZlbnRzLnByb3BlcnRpZXMsIHRvVGltZVpvbmUoZXZlbnRzLnRpbWVzdGFtcCwgJ1VUQycpLFxuICAgICAgICAgICAgZXZlbnRzLnRlYW1faWQsIGV2ZW50cy5kaXN0aW5jdF9pZCwgZXZlbnRzLmVsZW1lbnRzX2NoYWluLFxuICAgICAgICAgICAgdG9UaW1lWm9uZShldmVudHMuY3JlYXRlZF9hdCwgJ1VUQycpLCBldmVudHMucGVyc29uX21vZGUpLFxuICAgICAgdHVwbGUoZXZlbnRzX19ncm91cF8wLmNyZWF0ZWRfYXQsIGV2ZW50c19fZ3JvdXBfMC5pbmRleCwgZXZlbnRzX19ncm91cF8wLmtleSwgZXZlbnRzX19ncm91cF8wLnByb3BlcnRpZXMsIGV2ZW50c19fZ3JvdXBfMC51cGRhdGVkX2F0KSxcbiAgICAgIHR1cGxlKGV2ZW50c19fZ3JvdXBfMS5jcmVhdGVkX2F0LCBldmVudHNfX2dyb3VwXzEuaW5kZXgsIGV2ZW50c19fZ3JvdXBfMS5rZXksIGV2ZW50c19fZ3JvdXBfMS5wcm9wZXJ0aWVzLCBldmVudHNfX2dyb3VwXzEudXBkYXRlZF9hdCksXG4gICAgICB0dXBsZShldmVudHNfX2dyb3VwXzIuY3JlYXRlZF9hdCwgZXZlbnRzX19ncm91cF8yLmluZGV4LCBldmVudHNfX2dyb3VwXzIua2V5LCBldmVudHNfX2dyb3VwXzIucHJvcGVydGllcywgZXZlbnRzX19ncm91cF8yLnVwZGF0ZWRfYXQpLFxuICAgICAgdHVwbGUoZXZlbnRzX19ncm91cF8zLmNyZWF0ZWRfYXQsIGV2ZW50c19fZ3JvdXBfMy5pbmRleCwgZXZlbnRzX19ncm91cF8zLmtleSwgZXZlbnRzX19ncm91cF8zLnByb3BlcnRpZXMsIGV2ZW50c19fZ3JvdXBfMy51cGRhdGVkX2F0KSxcbiAgICAgIHR1cGxlKGV2ZW50c19fZ3JvdXBfNC5jcmVhdGVkX2F0LCBldmVudHNfX2dyb3VwXzQuaW5kZXgsIGV2ZW50c19fZ3JvdXBfNC5rZXksIGV2ZW50c19fZ3JvdXBfNC5wcm9wZXJ0aWVzLCBldmVudHNfX2dyb3VwXzQudXBkYXRlZF9hdClcbiAgRlJPTSBldmVudHNcbiAgTEVGVCBKT0lOIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFyZ01heCh0b1RpbWVab25lKGdyb3Vwcy5jcmVhdGVkX2F0LCAnVVRDJyksIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgY3JlYXRlZF9hdCxcbiAgICAgICAgICBhcmdNYXgoZ3JvdXBzLmdyb3VwX3Byb3BlcnRpZXMsIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgcHJvcGVydGllcyxcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHVwZGF0ZWRfYXQsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX3R5cGVfaW5kZXggQVMgaW5kZXgsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX2tleSBBUyBrZXlcbiAgICAgIEZST00gZ3JvdXBzXG4gICAgICBXSEVSRSBhbmQoZXF1YWxzKGdyb3Vwcy50ZWFtX2lkLCAyKSwgZXF1YWxzKGluZGV4LCAwKSxcbiAgICAgICAgICAgICAgICBpbihncm91cHMuZ3JvdXBfa2V5LCAoXG4gICAgICAgICAgICAgICAgICAgIFNFTEVDVCBldmVudHMuYCRncm91cF8wYFxuICAgICAgICAgICAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWQgRlJPTSBldmVudHNcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIExJTUlUIDlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICkpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbGVzcyhldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICAgICAgICApKSlcbiAgICAgIEdST1VQIEJZIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4LCBncm91cHMuZ3JvdXBfa2V5XG4gICkgQVMgZXZlbnRzX19ncm91cF8wIE9OIGVxdWFscyhldmVudHMuYCRncm91cF8wYCwgZXZlbnRzX19ncm91cF8wLmtleSlcbiAgTEVGVCBKT0lOIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFyZ01heCh0b1RpbWVab25lKGdyb3Vwcy5jcmVhdGVkX2F0LCAnVVRDJyksIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgY3JlYXRlZF9hdCxcbiAgICAgICAgICBhcmdNYXgoZ3JvdXBzLmdyb3VwX3Byb3BlcnRpZXMsIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgcHJvcGVydGllcyxcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHVwZGF0ZWRfYXQsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX3R5cGVfaW5kZXggQVMgaW5kZXgsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX2tleSBBUyBrZXlcbiAgICAgIEZST00gZ3JvdXBzXG4gICAgICBXSEVSRSBhbmQoZXF1YWxzKGdyb3Vwcy50ZWFtX2lkLCAyKSwgZXF1YWxzKGluZGV4LCAxKSxcbiAgICAgICAgICAgICAgICBpbihncm91cHMuZ3JvdXBfa2V5LCAoXG4gICAgICAgICAgICAgICAgICAgIFNFTEVDVCBldmVudHMuYCRncm91cF8xYFxuICAgICAgICAgICAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWQgRlJPTSBldmVudHNcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIExJTUlUIDlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICkpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbGVzcyhldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICAgICAgICApKSlcbiAgICAgIEdST1VQIEJZIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4LCBncm91cHMuZ3JvdXBfa2V5XG4gICkgQVMgZXZlbnRzX19ncm91cF8xIE9OIGVxdWFscyhldmVudHMuYCRncm91cF8xYCwgZXZlbnRzX19ncm91cF8xLmtleSlcbiAgTEVGVCBKT0lOIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFyZ01heCh0b1RpbWVab25lKGdyb3Vwcy5jcmVhdGVkX2F0LCAnVVRDJyksIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgY3JlYXRlZF9hdCxcbiAgICAgICAgICBhcmdNYXgoZ3JvdXBzLmdyb3VwX3Byb3BlcnRpZXMsIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgcHJvcGVydGllcyxcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHVwZGF0ZWRfYXQsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX3R5cGVfaW5kZXggQVMgaW5kZXgsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX2tleSBBUyBrZXlcbiAgICAgIEZST00gZ3JvdXBzXG4gICAgICBXSEVSRSBhbmQoZXF1YWxzKGdyb3Vwcy50ZWFtX2lkLCAyKSwgZXF1YWxzKGluZGV4LCAyKSxcbiAgICAgICAgICAgICAgICBpbihncm91cHMuZ3JvdXBfa2V5LCAoXG4gICAgICAgICAgICAgICAgICAgIFNFTEVDVCBldmVudHMuYCRncm91cF8yYFxuICAgICAgICAgICAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWQgRlJPTSBldmVudHNcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIExJTUlUIDlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICkpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbGVzcyhldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICAgICAgICApKSlcbiAgICAgIEdST1VQIEJZIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4LCBncm91cHMuZ3JvdXBfa2V5XG4gICkgQVMgZXZlbnRzX19ncm91cF8yIE9OIGVxdWFscyhldmVudHMuYCRncm91cF8yYCwgZXZlbnRzX19ncm91cF8yLmtleSlcbiAgTEVGVCBKT0lOIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFyZ01heCh0b1RpbWVab25lKGdyb3Vwcy5jcmVhdGVkX2F0LCAnVVRDJyksIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgY3JlYXRlZF9hdCxcbiAgICAgICAgICBhcmdNYXgoZ3JvdXBzLmdyb3VwX3Byb3BlcnRpZXMsIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgcHJvcGVydGllcyxcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHVwZGF0ZWRfYXQsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX3R5cGVfaW5kZXggQVMgaW5kZXgsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX2tleSBBUyBrZXlcbiAgICAgIEZST00gZ3JvdXBzXG4gICAgICBXSEVSRSBhbmQoZXF1YWxzKGdyb3Vwcy50ZWFtX2lkLCAyKSwgZXF1YWxzKGluZGV4LCAzKSxcbiAgICAgICAgICAgICAgICBpbihncm91cHMuZ3JvdXBfa2V5LCAoXG4gICAgICAgICAgICAgICAgICAgIFNFTEVDVCBldmVudHMuYCRncm91cF8zYFxuICAgICAgICAgICAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWQgRlJPTSBldmVudHNcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIExJTUlUIDlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICkpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbGVzcyhldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICAgICAgICApKSlcbiAgICAgIEdST1VQIEJZIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4LCBncm91cHMuZ3JvdXBfa2V5XG4gICkgQVMgZXZlbnRzX19ncm91cF8zIE9OIGVxdWFscyhldmVudHMuYCRncm91cF8zYCwgZXZlbnRzX19ncm91cF8zLmtleSlcbiAgTEVGVCBKT0lOIChcbiAgICAgIFNFTEVDVFxuICAgICAgICAgIGFyZ01heCh0b1RpbWVab25lKGdyb3Vwcy5jcmVhdGVkX2F0LCAnVVRDJyksIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgY3JlYXRlZF9hdCxcbiAgICAgICAgICBhcmdNYXgoZ3JvdXBzLmdyb3VwX3Byb3BlcnRpZXMsIHRvVGltZVpvbmUoZ3JvdXBzLl90aW1lc3RhbXAsICdVVEMnKSkgQVMgcHJvcGVydGllcyxcbiAgICAgICAgICBhcmdNYXgodG9UaW1lWm9uZShncm91cHMuX3RpbWVzdGFtcCwgJ1VUQycpLCB0b1RpbWVab25lKGdyb3Vwcy5fdGltZXN0YW1wLCAnVVRDJykpIEFTIHVwZGF0ZWRfYXQsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX3R5cGVfaW5kZXggQVMgaW5kZXgsXG4gICAgICAgICAgZ3JvdXBzLmdyb3VwX2tleSBBUyBrZXlcbiAgICAgIEZST00gZ3JvdXBzXG4gICAgICBXSEVSRSBhbmQoZXF1YWxzKGdyb3Vwcy50ZWFtX2lkLCAyKSwgZXF1YWxzKGluZGV4LCA0KSxcbiAgICAgICAgICAgICAgICBpbihncm91cHMuZ3JvdXBfa2V5LCAoXG4gICAgICAgICAgICAgICAgICAgIFNFTEVDVCBldmVudHMuYCRncm91cF80YFxuICAgICAgICAgICAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWQgRlJPTSBldmVudHNcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBXSEVSRSBhbmQoZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICBsZXNzKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSksXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIGdyZWF0ZXIoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpIC0gdG9JbnRlcnZhbERheSg3KSkpXG4gICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgT1JERVIgQlkgdG9UaW1lWm9uZShldmVudHMudGltZXN0YW1wLCAnVVRDJykgREVTQ1xuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgIExJTUlUIDlcbiAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICkpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgbGVzcyhldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykpLFxuICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICAgICAgICApKSlcbiAgICAgIEdST1VQIEJZIGdyb3Vwcy5ncm91cF90eXBlX2luZGV4LCBncm91cHMuZ3JvdXBfa2V5XG4gICkgQVMgZXZlbnRzX19ncm91cF80IE9OIGVxdWFscyhldmVudHMuYCRncm91cF80YCwgZXZlbnRzX19ncm91cF80LmtleSlcbiAgV0hFUkUgYW5kKFxuICAgICAgZXF1YWxzKGV2ZW50cy50ZWFtX2lkLCAyKSxcbiAgICAgIGluKGV2ZW50cy51dWlkLCAoXG4gICAgICAgICAgU0VMRUNUIGV2ZW50cy51dWlkIEFTIHV1aWRcbiAgICAgICAgICBGUk9NIGV2ZW50c1xuICAgICAgICAgIFdIRVJFIGFuZChlcXVhbHMoZXZlbnRzLnRlYW1faWQsIDIpLFxuICAgICAgICAgICAgICAgICAgICBlcXVhbHMoZXZlbnRzLmV2ZW50LCAnJHBhZ2V2aWV3JyksXG4gICAgICAgICAgICAgICAgICAgIGxlc3MoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpKSxcbiAgICAgICAgICAgICAgICAgICAgZ3JlYXRlcihldmVudHMudGltZXN0YW1wLCBub3c2NCg2LCAnVVRDJykgLSB0b0ludGVydmFsRGF5KDcpKSlcbiAgICAgICAgICBPUkRFUiBCWSB0b1RpbWVab25lKGV2ZW50cy50aW1lc3RhbXAsICdVVEMnKSBERVNDXG4gICAgICAgICAgTElNSVQgOVxuICAgICAgKSksXG4gICAgICBhbmQoZXF1YWxzKGV2ZW50cy5ldmVudCwgJyRwYWdldmlldycpLFxuICAgICAgICAgIGxlc3MoZXZlbnRzLnRpbWVzdGFtcCwgbm93NjQoNiwgJ1VUQycpKSxcbiAgICAgICAgICBncmVhdGVyKGV2ZW50cy50aW1lc3RhbXAsIG5vdzY0KDYsICdVVEMnKSAtIHRvSW50ZXJ2YWxEYXkoNykpKVxuICApXG4gIE9SREVSIEJZIHRvVGltZVpvbmUoZXZlbnRzLnRpbWVzdGFtcCwgJ1VUQycpIERFU0NcbiAgTElNSVQgOVxuICBTRVRUSU5HUyBsb2dfY29tbWVudCA9ICdncm91cHMtcHJlZmlsdGVyLXRlc3Q6YWZ0ZXInLCB1c2VfdW5jb21wcmVzc2VkX2NhY2hlID0gMDtcblxuICBTdXJmYWNlIGluIE1ldGFiYXNlIHdpdGg6XG5cbiAgU0VMRUNUIGxvZ19jb21tZW50LCBob3N0TmFtZSgpIEFTIGhvc3QsIHF1ZXJ5X2R1cmF0aW9uX21zLFxuICAgICAgICAgZm9ybWF0UmVhZGFibGVTaXplKG1lbW9yeV91c2FnZSkgQVMgcGVha19tZW0sXG4gICAgICAgICByZWFkX3Jvd3MsIGZvcm1hdFJlYWRhYmxlU2l6ZShyZWFkX2J5dGVzKSBBUyByZWFkX2RhdGFcbiAgRlJPTSBjbHVzdGVyQWxsUmVwbGljYXMoJ3Bvc3Rob2cnLCBzeXN0ZW0ucXVlcnlfbG9nKVxuICBXSEVSRSB0eXBlID0gJ1F1ZXJ5RmluaXNoJ1xuICAgIEFORCBsb2dfY29tbWVudCBMSUtFICdncm91cHMtcHJlZmlsdGVyLXRlc3Q6JSdcbiAgICBBTkQgZXZlbnRfdGltZSA-IG5vdygpIC0gSU5URVJWQUwgMzAgTUlOVVRFXG4gICAgQU5EIGlzX2luaXRpYWxfcXVlcnkgPSAxXG4gIE9SREVSIEJZIGV2ZW50X3RpbWUgREVTQyBMSU1JVCAyMDsiLCJ0ZW1wbGF0ZS10YWdzIjp7fX0sImRhdGFiYXNlIjoxNDIsInR5cGUiOiJuYXRpdmUifSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==)

- [Comparison](https://metabase.prod-us.posthog.dev/question#eyJkYXRhc2V0X3F1ZXJ5Ijp7InR5cGUiOiJuYXRpdmUiLCJkYXRhYmFzZSI6NDIsIm5hdGl2ZSI6eyJxdWVyeSI6IlNFTEVDVCBsb2dfY29tbWVudCxcbiAgICAgICBpc19pbml0aWFsX3F1ZXJ5LFxuICAgICAgIGhvc3ROYW1lKCkgQVMgaG9zdCxcbiAgICAgICBxdWVyeV9kdXJhdGlvbl9tcyxcbiAgICAgICBmb3JtYXRSZWFkYWJsZVNpemUobWVtb3J5X3VzYWdlKSBBUyBwZWFrX21lbSxcbiAgICAgICByZWFkX3Jvd3MsXG4gICAgICAgZm9ybWF0UmVhZGFibGVTaXplKHJlYWRfYnl0ZXMpIEFTIHJlYWRfZGF0YVxuRlJPTSBjbHVzdGVyQWxsUmVwbGljYXMoJ3Bvc3Rob2cnLCBzeXN0ZW0ucXVlcnlfbG9nKVxuV0hFUkUgdHlwZSA9ICdRdWVyeUZpbmlzaCdcbiAgQU5EIGxvZ19jb21tZW50IExJS0UgJ2dyb3Vwcy1wcmVmaWx0ZXItdGVzdDolJ1xuICBBTkQgZXZlbnRfdGltZSA-IG5vdygpIC0gSU5URVJWQUwgMzAgTUlOVVRFXG4gIEFORCBpc19pbml0aWFsX3F1ZXJ5ID0gMVxuT1JERVIgQlkgZXZlbnRfdGltZSBERVNDLCBpc19pbml0aWFsX3F1ZXJ5IERFU0NcbkxJTUlUIDIwO1xuIiwidGVtcGxhdGUtdGFncyI6e319fSwiZGlzcGxheSI6InRhYmxlIiwicGFyYW1ldGVycyI6W10sInZpc3VhbGl6YXRpb25fc2V0dGluZ3MiOnt9fQ==) 

## Problem

For every query that accesses a `group_N.<field>` (the events explorer, person/group event tabs, hog-functions test panel, notebook event embeds, error-tracking event context, dashboard activity widget — anything that pulls group properties alongside events), the resolver auto-generates a LEFT JOIN whose right side is:

```sql
SELECT
    argMax(group_properties, _timestamp) AS properties,
    argMax(created_at,       _timestamp) AS created_at,
    argMax(_timestamp,       _timestamp) AS updated_at,
    group_type_index AS index,
    group_key AS key
FROM groups
WHERE team_id = X AND index = N
GROUP BY group_type_index, group_key
```

That subquery is **always sized to the full per-team groups population for the chosen index**. On a high-volume team (team 2 specifically — every customer org/project/etc.) the `group_properties` JSON blob is wide and the row count is in the millions. ClickHouse materializes the join hash table by decompressing the entire `group_properties` column row by row, and with five concurrent group-type joins the cumulative `group_properties` materialization is enough to OOM the whole query (~42 GiB observed, against a 42 GiB query limit) — even when the events side is selecting just 8 rows. We see this in production via the test-event fetch from `frontend/src/scenes/hog-functions/sampleEventsQuery.ts`, but the same shape powers every consumer listed above.

A peer (Pawel) hand-tested the fix on team-2 data: adding `group_key IN (SELECT $group_N FROM <matched events>)` to the groups subquery drops the join from OOM to **~1.4 GiB / ~600ms**.

## Changes

`posthog/hogql/database/schema/groups.py` — `join_with_group_n_table` now adds an extra predicate to the generated subquery's WHERE:

```sql
AND group_key IN (
    SELECT $group_N FROM events WHERE <outer prefilter>
)
```

`<outer prefilter>` is a clone of the outer SelectQuery's WHERE. The hash table is then bounded by the distinct `$group_N` values present in the matched events — typically tens of keys per type instead of millions, and the wide `group_properties` decompression collapses by the same factor.

**Gating**: the extra predicate is only applied when the outer WHERE references the `timestamp` field somewhere. Without that signal the matched event set could be unbounded, and the pushed key subquery would have to scan every event in the team to compute distinct `$group_N` values — strictly worse than no filter. The `_TimestampReferenceFinder` visitor walks the outer WHERE for the heuristic. Queries with no WHERE, or a WHERE that doesn't reference `timestamp`, keep the original behavior unchanged.

**Cost the optimization adds**: the cloned outer WHERE re-executes the events scan once per group join inside each groups subquery. Each clone is narrow (one column out — `$group_N` — plus the filter) and sits on the events PK prefix when the outer WHERE has a tight `timestamp` range, so the extra reads are cheap relative to the eliminated wide-column reads on `groups`.

## How did you test this code?

I'm an agent (PostHog Code). Automated coverage only — I did not manually run the failing query.

Added `posthog/hogql/database/schema/test/test_groups_join_prefilter.py` covering:
- group_0.properties + WHERE with timestamp → groups subquery contains `in(key, (SELECT events.$group_0 ...))`
- group_0.properties + WHERE with uuid IN and tight timestamp window (mirrors the prod test-event-fetch shape) → same
- group_0.properties + WHERE without timestamp → no filter (guard)
- group_0.properties + no WHERE → no filter (guard)

Snapshots will churn: any `.ambr` snapshot for a query that includes both a group join and a `timestamp`-bounded WHERE will pick up the additional `AND in(key, (SELECT events.$group_N FROM events WHERE ...))` fragment in the groups subquery. Pushing this draft so CI can report the exact set; I'll regenerate them once we agree on direction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code following Pawel's root-cause work on team-2 data. We initially landed on a PREWHERE-on-uuid optimization for the events scan ([#65725](https://github.com/PostHog/posthog/pull/65725)), but the error trace `(while reading column group_properties)` and Pawel's measurements showed the dominant memory pressure was on the groups joins, not the events scan — so this PR is the actual targeted fix.

Held back from this PR:
- **Materializing the events prefilter once as a CTE** instead of cloning it into each group subquery. ClickHouse CTEs are inlined anyway and the events scan is cheap; the duplication doesn't hurt and avoids the larger AST surgery in the events query runner.
- **Pushing the same shape into other JOIN-from-events tables** (persons subqueries via PoE, future product tables). Same pattern would apply but isn't load-bearing for the immediate OOM — defer until we see the equivalent failure mode on those tables.
- **Removing the `timestamp` gate** in favor of always pushing the filter. Would help more queries but creates a real regression risk for unbounded analytics queries; opt-in via timestamp is the conservative cut.

Stacks cleanly with [#65134](https://github.com/PostHog/posthog/pull/65134) (synth-by-default in the hog-functions test panel) and [#65725](https://github.com/PostHog/posthog/pull/65725) (events PREWHERE) — different layers, different blast radii, all narrowing the same query shape from different angles.

No repo skills were invoked beyond `/optimizing-clickhouse-and-hogql-queries` for diagnosis.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*