### PR TITLE
feat(conversations): surface ai_triage status and outcome in support UI

### DIFF
--- a/products/conversations/backend/api/tickets.py
+++ b/products/conversations/backend/api/tickets.py
@@ -238,6 +238,7 @@ class TicketSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
             "anonymous_traits",
             "ai_resolved",
             "escalation_reason",
+            "ai_triage",
             "created_at",
             "updated_at",
             "message_count",
@@ -286,12 +287,16 @@ class TicketSerializer(TaggedItemSerializerMixin, serializers.ModelSerializer):
             "github_repo",
             "github_issue_number",
             "person",
+            "ai_triage",
         ]
         extra_kwargs = {
             "status": {"help_text": "Ticket status: new, open, pending, on_hold, or resolved"},
             "priority": {"help_text": "Ticket priority: low, medium, or high. Null if unset."},
             "sla_due_at": {"help_text": "SLA deadline set via workflows. Null means no SLA."},
             "anonymous_traits": {"help_text": "Customer-provided traits such as name and email"},
+            "ai_triage": {
+                "help_text": "AI support pipeline triage and outcome (status, result, ticket_type, confidence, attempts, etc.)."
+            },
         }
 
     def get_email_to(self, obj: Ticket) -> str | None:

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -688,6 +688,8 @@ export interface TicketApi {
     ai_resolved?: boolean
     /** @nullable */
     escalation_reason?: string | null
+    /** AI support pipeline triage and outcome (status, result, ticket_type, confidence, attempts, etc.). */
+    readonly ai_triage: unknown
     readonly created_at: string
     readonly updated_at: string
     readonly message_count: number
@@ -766,6 +768,8 @@ export interface PatchedTicketApi {
     ai_resolved?: boolean
     /** @nullable */
     escalation_reason?: string | null
+    /** AI support pipeline triage and outcome (status, result, ticket_type, confidence, attempts, etc.). */
+    readonly ai_triage?: unknown
     readonly created_at?: string
     readonly updated_at?: string
     readonly message_count?: number

--- a/products/conversations/frontend/scenes/ticket/AIPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/AIPanel.tsx
@@ -1,0 +1,121 @@
+import { LemonCollapse, LemonTag, Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+
+import {
+    type AITriage,
+    aiTriageResultLabel,
+    aiTriageResultTagType,
+    aiTriageTicketTypeDescription,
+    aiTriageTicketTypeLabel,
+} from '../../types'
+
+interface AIPanelProps {
+    aiTriage?: AITriage
+}
+
+function AITriageHeaderTag({ aiTriage }: { aiTriage?: AITriage }): JSX.Element | null {
+    if (!aiTriage?.status) {
+        return null
+    }
+    if (aiTriage.status === 'in_progress') {
+        return <Spinner className="text-sm ml-1" />
+    }
+    if (aiTriage.result) {
+        return (
+            <LemonTag type={aiTriageResultTagType(aiTriage.result)} size="small" className="ml-1">
+                {aiTriageResultLabel[aiTriage.result]}
+            </LemonTag>
+        )
+    }
+    return null
+}
+
+export function AIPanel({ aiTriage }: AIPanelProps): JSX.Element {
+    const hasData = aiTriage && aiTriage.status
+
+    return (
+        <LemonCollapse
+            className="bg-surface-primary"
+            panels={[
+                {
+                    key: 'ai_triage',
+                    header: (
+                        <span className="flex items-center">
+                            AI triage
+                            <AITriageHeaderTag aiTriage={aiTriage} />
+                        </span>
+                    ),
+                    content: hasData ? (
+                        <div className="space-y-2 text-xs">
+                            {aiTriage.status && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Status</span>
+                                    <span className="capitalize">
+                                        {aiTriage.status === 'in_progress' ? 'In progress' : aiTriage.status}
+                                    </span>
+                                </div>
+                            )}
+                            {aiTriage.result && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Result</span>
+                                    <LemonTag type={aiTriageResultTagType(aiTriage.result)} size="small">
+                                        {aiTriageResultLabel[aiTriage.result]}
+                                    </LemonTag>
+                                </div>
+                            )}
+                            {aiTriage.ticket_type && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Ticket type</span>
+                                    <Tooltip title={aiTriageTicketTypeDescription[aiTriage.ticket_type]}>
+                                        <LemonTag size="small">
+                                            {aiTriageTicketTypeLabel[aiTriage.ticket_type] ?? aiTriage.ticket_type}
+                                        </LemonTag>
+                                    </Tooltip>
+                                </div>
+                            )}
+                            {aiTriage.confidence != null && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Confidence</span>
+                                    <span>{(aiTriage.confidence * 100).toFixed(0)}%</span>
+                                </div>
+                            )}
+                            {aiTriage.attempts != null && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Attempts</span>
+                                    <span>{aiTriage.attempts}</span>
+                                </div>
+                            )}
+                            {aiTriage.needs_diagnostics != null && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Needs diagnostics</span>
+                                    <span>{aiTriage.needs_diagnostics ? 'Yes' : 'No'}</span>
+                                </div>
+                            )}
+                            {aiTriage.diagnostics_allowed != null && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Diagnostics allowed</span>
+                                    <span>{aiTriage.diagnostics_allowed ? 'Yes' : 'No'}</span>
+                                </div>
+                            )}
+                            {aiTriage.started_at && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Started</span>
+                                    <TZLabel time={aiTriage.started_at} />
+                                </div>
+                            )}
+                            {aiTriage.finished_at && (
+                                <div className="flex justify-between">
+                                    <span className="text-muted-alt">Finished</span>
+                                    <TZLabel time={aiTriage.finished_at} />
+                                </div>
+                            )}
+                        </div>
+                    ) : (
+                        <div className="text-muted-alt text-xs">AI has not processed this ticket yet.</div>
+                    ),
+                },
+            ]}
+        />
+    )
+}

--- a/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
+++ b/products/conversations/frontend/scenes/ticket/SupportTicketScene.tsx
@@ -12,6 +12,7 @@ import { LemonCalendarSelectInput } from 'lib/lemon-ui/LemonCalendar/LemonCalend
 import { newInternalTab } from 'lib/utils/newInternalTab'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { SceneExport } from 'scenes/sceneTypes'
+import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
@@ -25,6 +26,7 @@ import { ChatView } from '../../components/Chat/ChatView'
 import { SlaDisplay } from '../../components/SlaDisplay'
 import { TicketTags } from '../../components/TicketTags'
 import { type TicketPriority, type TicketStatus, priorityOptions, statusOptionsWithoutAll } from '../../types'
+import { AIPanel } from './AIPanel'
 import { ExceptionsPanel } from './ExceptionsPanel'
 import { PreviousTicketsPanel } from './PreviousTicketsPanel'
 import { RecentEventsPanel } from './RecentEventsPanel'
@@ -78,6 +80,8 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
     } = useActions(logic)
 
     const { user } = useValues(userLogic)
+    const { currentTeam } = useValues(teamLogic)
+    const aiSuggestionsEnabled = !!currentTeam?.conversations_settings?.ai_suggestions_enabled
 
     const chatPanelRef = useRef<HTMLDivElement>(null)
 
@@ -389,8 +393,8 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                     {/* Staff Actions Panel */}
                     {user?.is_staff && ticket && <StaffActionsPanel />}
 
-                    {/* Activity History Panel */}
-                    {ticket?.id && <TicketActivityPanel ticketId={ticket.id} />}
+                    {/* AI Triage Panel */}
+                    {aiSuggestionsEnabled && ticket && <AIPanel aiTriage={ticket.ai_triage} />}
 
                     {ticket?.channel_source === 'widget' && (
                         <>
@@ -421,6 +425,9 @@ export function SupportTicketScene({ ticketId }: { ticketId: string }): JSX.Elem
                             />
                         </>
                     )}
+
+                    {/* Activity History Panel */}
+                    {ticket?.id && <TicketActivityPanel ticketId={ticket.id} />}
                 </div>
             </div>
         </SceneContent>

--- a/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
+++ b/products/conversations/frontend/scenes/tickets/SupportTicketsScene.tsx
@@ -16,6 +16,8 @@ import {
     LemonTable,
     LemonTableColumns,
     LemonTag,
+    Spinner,
+    Tooltip,
 } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -52,6 +54,9 @@ import {
     type TicketSlaState,
     type TicketStatus,
     type TicketTagsMatch,
+    aiTriageResultLabel,
+    aiTriageResultTagType,
+    aiTriageTicketTypeLabel,
     channelOptions,
     priorityMultiselectOptions,
     slaOptions,
@@ -259,6 +264,8 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
     const { tickets, ticketsLoading, currentPage, totalCount, sorting, selectedTicketIds } = useValues(logic)
     const { setCurrentPage, setSorting, setSelectedTicketIds } = useActions(logic)
     const { push } = useActions(router)
+    const { currentTeam } = useValues(teamLogic)
+    const aiEnabled = !!currentTeam?.conversations_settings?.ai_suggestions_enabled
 
     const getKey = useMemo(() => (t: Ticket) => t.id, [])
     const bulk = useBulkSelection<Ticket, string>({ pageRecords: tickets, getKey })
@@ -314,11 +321,51 @@ export function SupportTicketsTable({ embedded = false }: SupportTicketsTablePro
                 />
             ),
         }
-        const base = embedded
+        const aiCol: LemonTableColumns<Ticket>[number] = {
+            title: 'AI status',
+            key: 'ai_triage',
+            render: (_, ticket: Ticket) => {
+                const triage = ticket.ai_triage
+                if (!triage || !triage.status) {
+                    return <span className="text-muted-alt text-xs">—</span>
+                }
+                if (triage.status === 'in_progress') {
+                    return (
+                        <span className="flex items-center gap-1 text-xs">
+                            <Spinner className="text-sm" />
+                            Processing
+                        </span>
+                    )
+                }
+                if (triage.result) {
+                    const tooltipContent = [
+                        triage.ticket_type &&
+                            `Type: ${aiTriageTicketTypeLabel[triage.ticket_type] ?? triage.ticket_type}`,
+                        triage.confidence != null && `Confidence: ${(triage.confidence * 100).toFixed(0)}%`,
+                        triage.attempts != null && `Attempts: ${triage.attempts}`,
+                    ]
+                        .filter(Boolean)
+                        .join(' · ')
+                    return (
+                        <Tooltip title={tooltipContent || undefined}>
+                            <LemonTag type={aiTriageResultTagType(triage.result)}>
+                                {aiTriageResultLabel[triage.result]}
+                            </LemonTag>
+                        </Tooltip>
+                    )
+                }
+                return <span className="text-muted-alt text-xs">—</span>
+            },
+        }
+        let base = embedded
             ? SUPPORT_TICKETS_TABLE_COLUMNS.filter((col) => 'key' in col && col.key !== 'customer')
             : SUPPORT_TICKETS_TABLE_COLUMNS
+        if (aiEnabled) {
+            const createdIdx = base.findIndex((col) => 'key' in col && col.key === 'priority')
+            base = [...base.slice(0, createdIdx), aiCol, ...base.slice(createdIdx)]
+        }
         return [checkboxCol, ...base]
-    }, [embedded, isSomeOnPageSelected, isAllOnPageSelected, toggleAllOnPage, selectedKeysSet, toggleRow])
+    }, [embedded, aiEnabled, isSomeOnPageSelected, isAllOnPageSelected, toggleAllOnPage, selectedKeysSet, toggleRow])
 
     return (
         <LemonTable<Ticket>

--- a/products/conversations/frontend/types.ts
+++ b/products/conversations/frontend/types.ts
@@ -25,6 +25,30 @@ export type AssigneeFilterValue = 'all' | 'unassigned' | TicketAssignee
 
 export type TicketTagsMatch = 'any' | 'all'
 
+export type AITriageStatus = 'in_progress' | 'done'
+export type AITriageResult =
+    | 'persisted'
+    | 'escalated_with_best'
+    | 'escalated_no_reply'
+    | 'skipped_unactionable'
+    | 'blocked_unsafe'
+    | 'blocked_unsafe_reply'
+
+export interface AITriage {
+    schema_version?: number
+    status?: AITriageStatus
+    result?: AITriageResult
+    ticket_type?: 'how_to' | 'diagnostic' | 'account_billing' | 'unactionable'
+    needs_diagnostics?: boolean
+    diagnostics_allowed?: boolean
+    confidence?: number
+    attempts?: number
+    started_at?: string
+    finished_at?: string
+    workflow_id?: string
+    run_id?: string
+}
+
 export interface TicketViewFilters {
     status?: TicketStatus[]
     priority?: TicketPriority[]
@@ -106,6 +130,7 @@ export interface Ticket {
     github_issue_number?: number | null
     person?: TicketPerson | null
     tags?: string[]
+    ai_triage?: AITriage
 }
 
 export interface ConversationTicket {
@@ -210,3 +235,43 @@ export const slaOptions: { value: TicketSlaState | 'all'; label: string }[] = [
     { value: 'at-risk', label: 'At risk' },
     { value: 'breached', label: 'Breached' },
 ]
+
+export const aiTriageResultLabel: Record<AITriageResult, string> = {
+    persisted: 'Resolved',
+    escalated_with_best: 'Escalated (best)',
+    escalated_no_reply: 'Escalated',
+    skipped_unactionable: 'Skipped',
+    blocked_unsafe: 'Blocked',
+    blocked_unsafe_reply: 'Blocked (reply)',
+}
+
+export type AITriageTagType = 'success' | 'warning' | 'danger' | 'default'
+
+export function aiTriageResultTagType(result: AITriageResult): AITriageTagType {
+    switch (result) {
+        case 'persisted':
+            return 'success'
+        case 'escalated_with_best':
+        case 'escalated_no_reply':
+            return 'warning'
+        case 'blocked_unsafe':
+        case 'blocked_unsafe_reply':
+            return 'danger'
+        case 'skipped_unactionable':
+            return 'default'
+    }
+}
+
+export const aiTriageTicketTypeLabel: Record<string, string> = {
+    how_to: 'How-to',
+    diagnostic: 'Diagnostic',
+    account_billing: 'Account/Billing',
+    unactionable: 'Unactionable',
+}
+
+export const aiTriageTicketTypeDescription: Record<string, string> = {
+    how_to: 'Customer needs guidance on how to use a feature or accomplish a task',
+    diagnostic: 'Customer is experiencing a bug or issue that requires investigation',
+    account_billing: 'Related to account settings, billing, or subscription management',
+    unactionable: 'Ticket cannot be resolved by AI (e.g. feedback, spam, or out of scope)',
+}

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -33226,6 +33226,8 @@ export namespace Schemas {
       ai_resolved?: boolean;
       /** @nullable */
       escalation_reason?: string | null;
+      /** AI support pipeline triage and outcome (status, result, ticket_type, confidence, attempts, etc.). */
+      readonly ai_triage: unknown;
       readonly created_at: string;
       readonly updated_at: string;
       readonly message_count: number;
@@ -40553,6 +40555,8 @@ export namespace Schemas {
       ai_resolved?: boolean;
       /** @nullable */
       escalation_reason?: string | null;
+      /** AI support pipeline triage and outcome (status, result, ticket_type, confidence, attempts, etc.). */
+      readonly ai_triage?: unknown;
       readonly created_at?: string;
       readonly updated_at?: string;
       readonly message_count?: number;


### PR DESCRIPTION
## Problem

Support team members had no visibility into whether the AI pipeline had processed a ticket, what outcome it reached, or how confident the reply was. The data was being written to `ai_triage` on the ticket model but never surfaced in the UI.

## Changes

<img width="800" height="530" alt="ezgif-5c996b632ba6b987" src="https://github.com/user-attachments/assets/2fe35d6a-57cc-4b64-922a-a7fe680934ec" />


- **Backend:** Added `ai_triage` as a read-only field on `TicketSerializer` (with `help_text`). OpenAPI and generated types (`api.schemas.ts`, `services/mcp/src/api/generated.ts`) regenerated automatically.
- **Frontend types:** Added `AITriage` interface, `AITriageStatus`/`AITriageResult` union types, and shared display helpers (`aiTriageResultLabel`, `aiTriageResultTagType`, `aiTriageTicketTypeLabel`) to `types.ts`.
- **Tickets table:** Added a gated "AI" column (shown only when AI suggestions are enabled for the team) showing `—` / spinner + "Processing" / result tag with a confidence/attempts/type tooltip.
- **Ticket detail:** New `AIPanel` component (collapsible sidebar card, mirrors `ExceptionsPanel`) showing the full triage breakdown — status, result, ticket type, confidence, attempts, diagnostics flags, start/finish times. Rendered for all channel types when AI is enabled.

## How did you test this code?

The changes are purely additive (new read-only serializer field + new display-only UI). Reviewers should verify the panel and column render correctly against a ticket with a populated `ai_triage` field.
