### PR TITLE
feat(signals): link scout name to scout detail in inbox card

### DIFF
--- a/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SignalsScoutSignalCard.tsx
@@ -136,7 +136,9 @@ export function SignalsScoutSignalCard({ signal }: SignalCardProps): JSX.Element
             signal={signal}
             label={
                 <span>
-                    {skillLabel}
+                    <Link to={urls.inboxScout(extra.skill_name)} className="font-medium">
+                        {skillLabel}
+                    </Link>
                     <span className="text-tertiary font-normal"> · v{extra.skill_version}</span>
                 </span>
             }


### PR DESCRIPTION
## Problem

In the Signals scout evidence card on an inbox report, the scout name in the card header was plain text. There was no quick way to jump from a finding to the scout that produced it.

## Changes

Make the scout name in the `SignalsScoutSignalCard` header a link to the scout detail surface (`urls.inboxScout(skill_name)` → `/inbox/scouts/{skillName}`). The ` · v{version}` suffix stays unlinked.

Note on the "Task run" footer chip: it already deep-links into the Tasks run tab on fresh emissions (those that carry `task_id`). Older emissions predate `task_id` capture and have no resolvable route from a run id alone, so they render as plain text — no change needed there.

## How did you test this code?

I'm an agent (Claude Code). No automated tests added — this is a one-line UI link wiring an existing `urls` helper into an existing `Link` component. Verified the diff and that `Link`/`urls` were already imported. Not manually tested in a running app.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked to (1) make the "Task run" chip clickable to the Tasks UI and (2) make the scout name clickable to the scout URL. Investigation found the task-run deep link already exists for emissions carrying `task_id` (the report Andy first looked at was an older emission missing it), confirmed against a fresher report — so the only code change needed was the scout-name link. Wired the existing `urls.inboxScout(skill_name)` helper into the card header label.

Tools: Claude Code with Explore subagents for codebase navigation. No repo skills required for this change.
