### PR TITLE
fix(mcp): match pooled Anthropic clientName for cli mode

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -85,13 +85,13 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     'opencode',
 ] as const
 
-// Known `x-anthropic-client` (`vendorClient`) header values. Anthropic pools
-// MCP transports across all its products and reports the live one in this
-// header, so it's the reliable identifier for an Anthropic client (the
-// `initialize` body's `clientName` is the pool owner, e.g. `Anthropic/ClaudeAI`).
-// Every Anthropic product runs in CLI (single-exec) mode. Matched as normalized
-// substrings, so vendor-prefixed shapes like `Anthropic/ClaudeAI` resolve to
-// `claudeai`.
+// Anthropic client identifiers, matched against both the `x-anthropic-client`
+// (`vendorClient`) header and the self-reported `clientInfo.name`. Anthropic
+// pools MCP transports across its products and reports the live one in the
+// header, but the header is absent on many connector sessions, leaving the
+// pooled clientName (e.g. `Anthropic/ClaudeAI`) as the only signal. Every
+// Anthropic product runs in CLI (single-exec) mode. Matched as normalized
+// substrings, so shapes like `Anthropic/ClaudeAI` resolve to `claudeai`.
 export const ANTHROPIC_CLIENT_NAME_FRAGMENTS = ['claudecode', 'claudeai', 'cowork'] as const
 
 // Value sent in `x-posthog-mcp-consumer` by PostHog Code (the Tasks sandbox
@@ -180,16 +180,18 @@ export class MCPClientProfile {
     }
 
     isCliModeEnabled(): boolean {
-        // Every known Anthropic client runs in CLI (single-exec) mode. The
+        // Every Anthropic client runs in CLI (single-exec) mode. The
         // `x-anthropic-client` header names the live product across Anthropic's
-        // pooled MCP transports, but it is absent on many Claude.ai connector
-        // sessions, which then carry only the pooled `clientInfo.name` (e.g.
-        // `Anthropic/ClaudeAI`). Match either signal so a missing header doesn't
-        // drop the session into full tools mode; the Claude Code vs Claude.ai
-        // distinction the header adds is irrelevant here, both want CLI mode.
+        // pooled MCP transports, but it is absent on many connector sessions,
+        // which then carry only the pooled `clientInfo.name`. Match the known
+        // fragments against either signal, plus any `Anthropic/<product>`
+        // clientName, so a missing header doesn't drop a session into full tools
+        // mode and surfaces beyond Claude.ai (Toolbox, etc.) are covered too.
+        const isPooledAnthropicClientName = normalizeClientName(this.clientName ?? '').startsWith('anthropic/')
         if (
             matchesAnyFragment(this.vendorClient, ANTHROPIC_CLIENT_NAME_FRAGMENTS) ||
-            matchesAnyFragment(this.clientName, ANTHROPIC_CLIENT_NAME_FRAGMENTS)
+            matchesAnyFragment(this.clientName, ANTHROPIC_CLIENT_NAME_FRAGMENTS) ||
+            isPooledAnthropicClientName
         ) {
             return true
         }

--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -11,9 +11,10 @@
  * - `isCliModeEnabled()` matches clients that should default to single-exec
  *   ("CLI") mode and drop `structuredContent` when a `formatted_results`
  *   override is set. Every known Anthropic client qualifies — matched against
- *   the `x-anthropic-client` (`vendorClient`) header, since Anthropic pools MCP
- *   transports across all its products and reports the live one there. Other
- *   coding agents are matched by self-reported client name. Cursor is
+ *   the `x-anthropic-client` (`vendorClient`) header or the pooled
+ *   `clientInfo.name` (e.g. `Anthropic/ClaudeAI`), since the header is absent on
+ *   many Claude.ai connector sessions and the name is the only signal left.
+ *   Other coding agents are matched by self-reported client name. Cursor is
  *   deliberately excluded from the name match — it reads text for the model and
  *   renders `structuredContent` in UI, so it does not need single-exec mode or
  *   the formatted-results workaround.
@@ -179,11 +180,17 @@ export class MCPClientProfile {
     }
 
     isCliModeEnabled(): boolean {
-        // Every known Anthropic client (matched against the `x-anthropic-client`
-        // header) runs in CLI (single-exec) mode — Anthropic pools MCP transports
-        // across all its products (Claude Code, Claude.ai, Cowork, …) and reports
-        // the live product in that header.
-        if (matchesAnyFragment(this.vendorClient, ANTHROPIC_CLIENT_NAME_FRAGMENTS)) {
+        // Every known Anthropic client runs in CLI (single-exec) mode. The
+        // `x-anthropic-client` header names the live product across Anthropic's
+        // pooled MCP transports, but it is absent on many Claude.ai connector
+        // sessions, which then carry only the pooled `clientInfo.name` (e.g.
+        // `Anthropic/ClaudeAI`). Match either signal so a missing header doesn't
+        // drop the session into full tools mode; the Claude Code vs Claude.ai
+        // distinction the header adds is irrelevant here, both want CLI mode.
+        if (
+            matchesAnyFragment(this.vendorClient, ANTHROPIC_CLIENT_NAME_FRAGMENTS) ||
+            matchesAnyFragment(this.clientName, ANTHROPIC_CLIENT_NAME_FRAGMENTS)
+        ) {
             return true
         }
         // Otherwise fall back to the self-reported client name for coding agents.

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -257,6 +257,16 @@ describe('MCPClientProfile', () => {
                 }
             )
 
+            it.each([['Anthropic/ClaudeAI'], ['anthropic/claudeai'], ['ANTHROPIC/CLAUDEAI']])(
+                'enables CLI mode for pooled Anthropic clientName %s when the vendor header is absent',
+                (clientName) => {
+                    // Claude.ai connector sessions report the pooled clientInfo.name and
+                    // frequently omit x-anthropic-client; they must still get CLI mode
+                    // rather than the full tools catalog.
+                    expect(new MCPClientProfile({ clientName }).isCliModeEnabled()).toBe(true)
+                }
+            )
+
             it('does not enable CLI mode for an unknown vendorClient value', () => {
                 // Detection matches the known-header list, not mere presence.
                 expect(

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -257,15 +257,20 @@ describe('MCPClientProfile', () => {
                 }
             )
 
-            it.each([['Anthropic/ClaudeAI'], ['anthropic/claudeai'], ['ANTHROPIC/CLAUDEAI']])(
-                'enables CLI mode for pooled Anthropic clientName %s when the vendor header is absent',
-                (clientName) => {
-                    // Claude.ai connector sessions report the pooled clientInfo.name and
-                    // frequently omit x-anthropic-client; they must still get CLI mode
-                    // rather than the full tools catalog.
-                    expect(new MCPClientProfile({ clientName }).isCliModeEnabled()).toBe(true)
-                }
-            )
+            it.each([
+                ['Anthropic/ClaudeAI'],
+                ['anthropic/claudeai'],
+                ['ANTHROPIC/CLAUDEAI'],
+                ['Anthropic/Toolbox'],
+                ['Anthropic/API'],
+                ['Anthropic/ClaudeDesign'],
+            ])('enables CLI mode for pooled Anthropic clientName %s when the vendor header is absent', (clientName) => {
+                expect(new MCPClientProfile({ clientName }).isCliModeEnabled()).toBe(true)
+            })
+
+            it('does not enable CLI mode for a non-pooled name that merely contains "anthropic"', () => {
+                expect(new MCPClientProfile({ clientName: 'anthropic-sdk-wrapper' }).isCliModeEnabled()).toBe(false)
+            })
 
             it('does not enable CLI mode for an unknown vendorClient value', () => {
                 // Detection matches the known-header list, not mere presence.


### PR DESCRIPTION
## Problem

The PostHog MCP server registers tools in one of two modes: `tools` mode advertises every tool individually (currently well over 400), and `cli` mode advertises a single `exec` dispatcher that discovers and runs tools on demand. Anthropic clients are meant to auto-select `cli` mode so they don't pay the full catalog's context cost up front.

That detection relies on the `x-anthropic-client` header. Claude.ai web and desktop connector sessions report `clientInfo.name` as `Anthropic/ClaudeAI` but frequently send no `x-anthropic-client` header. `isCliModeEnabled()` only matched the Anthropic fragments against that header, so those sessions fell through to full `tools` mode and loaded the entire catalog, exhausting the client's context window. Because mode is pinned per pooled MCP session, whether a given session landed in `cli` or `tools` was effectively a coin flip on which request pinned it first, which is why it presented as intermittent.

## Changes

`isCliModeEnabled()` now treats a session as an Anthropic client when the self-reported `clientInfo.name` matches a known Anthropic fragment or carries the `Anthropic/<product>` owner prefix, in addition to the existing `x-anthropic-client` header check. So `Anthropic/ClaudeAI`, `Anthropic/Toolbox`, and the other pooled surfaces resolve to `cli` (single-exec) mode deterministically at `initialize`, whether or not the header is present. Explicit `?mode=tools` still wins, and the coding-agent fallback and Cursor exclusion are unchanged.

### Why match the client name

Matching `clientInfo.name` here is deliberate, not a fallback hack:

- `clientInfo` (`name` and `version`) is a required field of the MCP `initialize` request per the [MCP lifecycle spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/lifecycle). Per the protocol it is sent once at the handshake and not repeated on later requests such as `tools/call`, which is the only reason the name can look absent when you inspect a tool-call event. Mode is resolved at `initialize`, where the name is reliably present.
- `x-anthropic-client` is an Anthropic-specific transport header, not part of the MCP spec, and Claude.ai's web and desktop connector frequently does not send it. Relying on it alone is the fragile path; the spec-standard `clientInfo.name` is the durable one.
- Every Anthropic surface is meant to run in `cli` mode, so the one thing the header adds over the name, telling Claude Code apart from Claude.ai, does not affect this decision.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8) and have not manually exercised a live connector. Automated checks run locally, all green:

- `vitest tests/unit/client-detection.test.ts` (169 passed), including new cases asserting that the pooled `Anthropic/ClaudeAI`, `Anthropic/Toolbox`, `Anthropic/API`, and `Anthropic/ClaudeDesign` names with no vendor header resolve to `cli`, plus a guard that a non-pooled name merely containing "anthropic" does not. No existing test covered the pooled-clientName-without-header path.
- `vitest --config vitest.hono.config.mts` for the `request-state-resolver`, `session-mode-pool`, and `tool-executor` suites, confirming `resolveMode` and session pinning still behave.
- `tsgo --noEmit` typecheck and `oxlint` / `oxfmt` clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and authored with Claude Code (Opus 4.8) from a report that the connector was exhausting Claude's context. Traced the tool-registration path (`tools/index.ts`, `exec.ts`, `toolDefinitions.ts`) and mode selection (`client-detection.ts`, `request-state-resolver.ts`, `mcp-context.ts`), then confirmed against MCP session telemetry that Claude.ai connector sessions reporting `Anthropic/ClaudeAI` with no vendor header land in `tools` mode while the same user's Claude Code sessions correctly get `cli`. The introducing change was #62184, which added the Anthropic-header match but kept the clientName fallback limited to coding-agent fragments.

No repo skills were invoked. The match was broadened from the curated `ANTHROPIC_CLIENT_NAME_FRAGMENTS` to the full `Anthropic/<product>` pooled-owner prefix, so surfaces such as `Anthropic/Toolbox` and `Anthropic/ClaudeDesign` are covered rather than only `Anthropic/ClaudeAI`. `Anthropic/API` is covered by the same prefix; if that surface is a deterministic, non-model-driven integration that depends on individually registered tools, it may prefer `tools` mode and could be excluded.
