### PR TITLE
feat(cdp): add cdp-cyclotron-worker-email-legacy-pg server mode

### DIFF
--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -135,6 +135,10 @@ export function getPluginServerCapabilities(
             return {
                 cdpCyclotronWorkerEmail: true,
             }
+        case PluginServerMode.cdp_cyclotron_worker_email_legacy_pg:
+            return {
+                cdpCyclotronWorkerEmailLegacyPg: true,
+            }
         case PluginServerMode.cdp_precalculated_filters:
             return {
                 cdpPrecalculatedFilters: true,

--- a/nodejs/src/common/config.ts
+++ b/nodejs/src/common/config.ts
@@ -32,6 +32,7 @@ export enum PluginServerMode {
     cdp_cyclotron_worker_hogflow = 'cdp-cyclotron-worker-hogflow',
     cdp_cyclotron_worker_hogflow_legacy_pg = 'cdp-cyclotron-worker-hogflow-legacy-pg',
     cdp_cyclotron_worker_email = 'cdp-cyclotron-worker-email',
+    cdp_cyclotron_worker_email_legacy_pg = 'cdp-cyclotron-worker-email-legacy-pg',
     cdp_api = 'cdp-api',
     cdp_legacy_on_event = 'cdp-legacy-on-event',
     evaluation_scheduler = 'evaluation-scheduler',

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -96,6 +96,7 @@ export class PluginServer implements NodeServer {
             capabilities.cdpCyclotronWorkerHogFlow ||
             capabilities.cdpCyclotronWorkerHogFlowLegacyPg ||
             capabilities.cdpCyclotronWorkerEmail ||
+            capabilities.cdpCyclotronWorkerEmailLegacyPg ||
             capabilities.cdpPrecalculatedFilters ||
             capabilities.cdpCohortMembership ||
             capabilities.cdpBatchHogFlow ||
@@ -273,6 +274,17 @@ export class PluginServer implements NodeServer {
             serviceLoaders.push(async () => {
                 const legacyQueue = new CyclotronJobQueuePostgres(this.config.CONSUMER_BATCH_SIZE, this.config)
                 const worker = new CdpCyclotronWorkerHogFlow(this.config, cdpDeps!, legacyQueue)
+                await worker.start()
+                return worker.service
+            })
+        }
+
+        // Transitional drain for email jobs stranded on the legacy V1 queue — the email worker
+        // run against V1, sending inline. Delete once V1 'email' throughput is ~0.
+        if (capabilities.cdpCyclotronWorkerEmailLegacyPg) {
+            serviceLoaders.push(async () => {
+                const legacyQueue = new CyclotronJobQueuePostgres(this.config.CONSUMER_BATCH_SIZE, this.config)
+                const worker = new CdpCyclotronWorkerEmail(this.config, cdpDeps!, legacyQueue)
                 await worker.start()
                 return worker.service
             })

--- a/nodejs/src/types.ts
+++ b/nodejs/src/types.ts
@@ -165,6 +165,7 @@ export interface PluginServerCapabilities {
     cdpCyclotronWorkerHogFlow?: boolean
     cdpCyclotronWorkerHogFlowLegacyPg?: boolean
     cdpCyclotronWorkerEmail?: boolean
+    cdpCyclotronWorkerEmailLegacyPg?: boolean
     cdpPrecalculatedFilters?: boolean
     cdpCohortMembership?: boolean
     cdpApi?: boolean


### PR DESCRIPTION
## Problem

Workflows scheduled or delayed before the SES/V2 cutover still surface email steps on the **legacy V1 cyclotron queue**. V1 has no email consumer (the email worker is postgres-v2 only), so those jobs strand and the V1 `email` backlog grows unbounded (~2k and climbing). These are real undelivered emails, and more keep appearing as old delayed workflows come due.

<img width="1387" height="651" alt="image" src="https://github.com/user-attachments/assets/e06f0f25-b1ca-4241-ba7f-bb12ce63b2f7" />


## Changes

Add a transitional `cdp-cyclotron-worker-email-legacy-pg` server mode — the direct email counterpart of the existing `cdp-cyclotron-worker-hogflow-legacy-pg` drain (#59190). It runs the email worker against the V1 backend, so it consumes the stranded V1 `email` jobs and sends them inline.

Inline send (rather than the V2 valkey SES gate) is deliberate: this drain's volume (~100/day plus the one-time ~2k backlog) is orders of magnitude below the SES rate limit (420/sec), so the V2-only rate limiter isn't needed. Run it as a small single-pod deployment so even the initial backlog dribbles out.

Leave it deployed [until V1 email throughput is ~0](https://grafana.prod-us.posthog.dev/explore?left=%7B%22datasource%22%3A%22victoriametrics%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22sum%28cyclotron_available_jobs%7Bqueue_name%3D%5C%22email%5C%22%7D%29%22%2C%22refId%22%3A%22A%22%7D%2C%7B%22expr%22%3A%22sum%28rate%28cdp_cyclotron_jobs_processed%7Bqueue%3D%5C%22email%5C%22%2Csource%3D%5C%22postgres%5C%22%7D%5B1h%5D%29%29%22%2C%22refId%22%3A%22B%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-7d%22%2C%22to%22%3A%22now%22%7D%7D) (line B has no data until the drain worker is deployed), then delete this mode and its deployment — same lifecycle as the hogflow legacy drain.

Deploy prerequisite: the new app's DB users are provisioned in **PostHog/posthog-cloud-infra#8965** (must merge + apply first). Charts deployment (a `cdp-cyclotron-worker-email-legacy-pg` app mirroring `cdp-cyclotron-worker-hogflows-pg-legacy`) is in **PostHog/charts#12465** — merge + deploy this server-mode first so the mode exists in the image, then that.

## How did you test this code?

Agent-authored, not run against prod. `tsc` and `eslint` pass. This reuses the existing `CdpCyclotronWorkerEmail` send path unchanged — the only new surface is the server-mode wiring (capability + `server.ts` block), mirroring #59190. No new tests: the wiring has no branching logic to regress that the existing email-worker tests don't already cover.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Root-caused via prod metrics + Metabase (V1 cyclotron DB 100: ~2k stranded `email` jobs, concentrated in two teams) and git archaeology. Iterated on the approach with the DRI: started from a forwarding-to-V2 design to preserve the SES rate limiter, then confirmed the limiter is unnecessary at this volume (SES 420/sec vs drain ~0.001/sec) and collapsed it to this minimal #59190 mirror. The pre-existing root cause (the hogflow drain re-queuing follow-ups into V1 after the #58997 queue refactor) is intentionally left untouched here — this drain handles the email tail until V1 empties.


