### PR TITLE
fix(ingestion-consumer): Handle fatal Kafka failures, make group instance id optional

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -100,6 +100,17 @@ pub struct Config {
     #[envconfig(from = "HOSTNAME")]
     pub pod_hostname: Option<String>,
 
+    /// Enable Kafka static membership (pins `group.instance.id` to the pod
+    /// hostname). Off by default: this runs as a Deployment, so pod names — and
+    /// thus instance IDs — already change on every rollout, meaning static
+    /// membership never avoids a deploy rebalance, yet it makes an in-place
+    /// container restart fail fatally with `UnreleasedInstanceId` (the broker
+    /// still holds the previous incarnation's slot until its session expires).
+    /// Dynamic membership rejoins cleanly on restart. Only enable for pods with
+    /// stable names (e.g. a StatefulSet).
+    #[envconfig(from = "KAFKA_CONSUMER_STATIC_MEMBERSHIP", default = "false")]
+    pub kafka_consumer_static_membership: bool,
+
     // ---- Batching ----
     /// Maximum number of messages to collect before dispatching a batch.
     /// Matches Node.js CONSUMER_BATCH_SIZE default.
@@ -288,7 +299,10 @@ impl Config {
         .with_fetch_wait_max_ms(self.kafka_consumer_fetch_wait_max_ms)
         .with_queued_min_messages(self.kafka_consumer_queued_min_messages)
         .with_queued_max_messages_kbytes(self.kafka_consumer_queued_max_messages_kbytes)
-        .with_sticky_partition_assignment(self.pod_hostname.as_deref())
+        .with_sticky_partition_assignment(
+            self.pod_hostname.as_deref(),
+            self.kafka_consumer_static_membership,
+        )
         .set("security.protocol", &self.kafka_security_protocol)
         .set(
             "socket.timeout.ms",

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -599,6 +599,14 @@ impl IngestionConsumer {
                 Ok(Some(Err(err))) => {
                     warn!(error = %err, "Kafka recv error");
                     counter!("ingestion_consumer_kafka_errors_total").increment(1);
+                    // A fatal client error (such as UnreleasedInstanceId from a
+                    // static-membership collision) permanently disables the
+                    // consumer. Propagate it so the process exits and Kubernetes
+                    // restarts the pod, instead of re-polling a dead client forever
+                    // while still reporting healthy.
+                    if let Some((code, reason)) = self.consumer.client().fatal_error() {
+                        anyhow::bail!("fatal Kafka client error ({code:?}): {reason}");
+                    }
                     break;
                 }
                 Ok(None) => break,

--- a/rust/ingestion-consumer/src/kafka_config.rs
+++ b/rust/ingestion-consumer/src/kafka_config.rs
@@ -185,14 +185,22 @@ impl ConsumerConfigBuilder {
 
     /// Enable sticky partition assignments based on the kafka client ID supplied.
     /// Always uses cooperative-sticky strategy for consistent behavior across all pods.
-    /// When client_id is provided, also enables static membership for truly sticky assignments.
-    pub fn with_sticky_partition_assignment(mut self, client_id: Option<&str>) -> Self {
+    /// When `static_membership` is set and a client_id is provided, also pins
+    /// `group.instance.id` to it for static membership — only safe for pods with
+    /// stable names, since a same-name restart collides with the broker-held slot.
+    pub fn with_sticky_partition_assignment(
+        mut self,
+        client_id: Option<&str>,
+        static_membership: bool,
+    ) -> Self {
         self.config
             .set("partition.assignment.strategy", "cooperative-sticky");
 
         if let Some(found_client_id) = client_id {
             self.config.set("client.id", found_client_id);
-            self.config.set("group.instance.id", found_client_id);
+            if static_membership {
+                self.config.set("group.instance.id", found_client_id);
+            }
         }
         self
     }
@@ -207,8 +215,8 @@ impl ConsumerConfigBuilder {
     /// the batch-consumer defaults don't break a consumer opted into the new
     /// protocol. Mirrors the Node.js `stripClassicProtocolConfig`.
     ///
-    /// `group.instance.id` (static membership) is intentionally kept — KIP-848
-    /// supports it.
+    /// `group.instance.id` (static membership, when enabled) is intentionally
+    /// kept — KIP-848 supports it.
     pub fn strip_classic_protocol_keys_if_consumer(mut self) -> Self {
         let is_consumer_protocol = self.config.get("group.protocol") == Some("consumer");
         if is_consumer_protocol {
@@ -237,7 +245,7 @@ mod tests {
     #[test]
     fn strips_classic_keys_under_consumer_protocol() {
         let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
-            .with_sticky_partition_assignment(Some("pod-1"))
+            .with_sticky_partition_assignment(Some("pod-1"), true)
             .set("group.protocol", "consumer")
             .strip_classic_protocol_keys_if_consumer()
             .build();
@@ -253,7 +261,7 @@ mod tests {
     #[test]
     fn keeps_classic_keys_under_classic_protocol() {
         let config = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
-            .with_sticky_partition_assignment(None)
+            .with_sticky_partition_assignment(None, false)
             .strip_classic_protocol_keys_if_consumer()
             .build();
 
@@ -262,5 +270,22 @@ mod tests {
             config.get("partition.assignment.strategy"),
             Some("cooperative-sticky")
         );
+    }
+
+    #[test]
+    fn static_membership_toggle_controls_group_instance_id() {
+        // Off (default): client.id is still set for sticky assignment, but no
+        // group.instance.id — so a restart rejoins dynamically without colliding.
+        let dynamic = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
+            .with_sticky_partition_assignment(Some("pod-1"), false)
+            .build();
+        assert_eq!(dynamic.get("client.id"), Some("pod-1"));
+        assert_eq!(dynamic.get("group.instance.id"), None);
+
+        // On: group.instance.id is pinned to the client id for static membership.
+        let static_member = ConsumerConfigBuilder::for_batch_consumer("kafka:9092", "g")
+            .with_sticky_partition_assignment(Some("pod-1"), true)
+            .build();
+        assert_eq!(static_member.get("group.instance.id"), Some("pod-1"));
     }
 }


### PR DESCRIPTION
## Problem

An in-place restart of the ingestion-consumer pod left it permanently broken and, worse, invisible — the pod reported `1/1 Running`/Ready while consuming nothing. Two independent gaps caused it:

1. A **fatal** librdkafka error (e.g. `UnreleasedInstanceId`) was handled exactly like a transient recv error: logged as a `WARN`, then the poll loop returned an empty batch, reported healthy, and re-polled the now-dead client forever. The process never exited, so Kubernetes never restarted it and readiness never flipped.

2. The consumer pinned `group.instance.id` to the pod hostname (**static membership**) unconditionally. Because this runs as a Deployment, pod names — and therefore instance IDs — already change on every rollout, so static membership never avoids a deploy rebalance. But a same-name **container restart** (crash, OOM, liveness kill) reuses the instance ID while the broker still holds the previous incarnation's slot, producing the fatal `UnreleasedInstanceId` and feeding gap 1.

## Changes

- Detect a fatal Kafka client error in the poll loop and propagate it so the process exits and Kubernetes restarts the pod, instead of silently re-polling a dead client while reporting healthy.
- Gate static membership behind a new `KAFKA_CONSUMER_STATIC_MEMBERSHIP` env var, defaulting to off, so the consumer uses dynamic membership and rejoins cleanly on restart.
- Keep setting `client.id` for cooperative-sticky assignment regardless of the toggle.
- Add unit coverage that the toggle controls whether `group.instance.id` is set, and update the existing protocol-strip tests for the new signature.

The dispatcher routes to workers by `distinct_id` (P2c/pins), not by Kafka partition, and the deduplicator absorbs any reprocessing, so dropping static membership by default costs nothing meaningful here. Enable `KAFKA_CONSUMER_STATIC_MEMBERSHIP=true` only for pods with stable names (e.g. a StatefulSet).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while rolling out the ingestion-analytics-parallel split in dev: the consumer pod sat Ready but stalled on `UnreleasedInstanceId` after a restart. `cargo build`/`fmt`/`clippy` clean; kafka_config unit tests pass. The fatal-exit path isn't unit-tested (it needs librdkafka in a real fatal state), but it reuses the existing `Err` → `fail_batch_processing` → `signal_failure` shutdown path. Agent-authored; requires human review.
