### PR TITLE
feat(dashboards): filter activity feed widget by a single event

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1761,17 +1761,17 @@ snapshots:
     dashboards-dashboard-widgets-overview--all-widget-types--light:
         hash: v1.k794b7964.f32b343aa7fcaabf6767b6c533d85b40f8b7a3cc1b9d80fe7d2253859a890ad5.VQg2i7X9FGt-fh-vmxr027ufi0Bnkg7BmQAhOtTXqgs
     dashboards-dashboard-widgets-widget-types-activity-recent-events--default--dark:
-        hash: v1.k794b7964.97188569bbab124430a6a0c91f746f8d119a7ecbeb0e116c50366aa6294a12e9.CIJBmnHIDHMFKDdJNupis99nTg4U_k0843VdEctiQvc
+        hash: v1.k794b7964.efdbea5790ee8e35bd2ae969acc32686edd47bf2990008fcd3d6f572f309f18b.4ZbAHTXiE7te8-Ck6clsY28Y5-JOOCpIPfSguR6E4Es
     dashboards-dashboard-widgets-widget-types-activity-recent-events--default--light:
-        hash: v1.k794b7964.8f85f53ac70298ec370e6f4ece611e864bb0c50365e97a4a219ab67c41cea775.AAoiz7L9XHR54Pi0hkLw5OAFjEh9fgkdGXBgDzxGEvw
+        hash: v1.k794b7964.6dc76b36679b404eac3e5f7ca80eca5fd4838fc5faaa330fa85ec5b2ec934e35.gCKeaBGCpXNKRS-3WhxX-T4AebW4RZEtBCwgyZ3Zv74
     dashboards-dashboard-widgets-widget-types-activity-recent-events--empty--dark:
-        hash: v1.k794b7964.d1f363fa1c5bf0ad01c6e5a33534f009cf388adff960240dda3aeb71897ad648.0EBwK9weLWVaxeEd1qE5puY4reJBckDhpgrsxvvqVes
+        hash: v1.k794b7964.b93f3c9c0778770cfef08b793cfeebf5ace1fa5b4b8be392856bf6990011c7de.XtxVLk7Uf8kNSxgrNlGoJO3yeHdEO6vFH6hqDoVGwKk
     dashboards-dashboard-widgets-widget-types-activity-recent-events--empty--light:
-        hash: v1.k794b7964.e6d5f37f60fc8e0ad5bc26ec521fff4735d0f25003a32de1421d54c3ead8c17e.cWX0oBZeQHF1MWPLTVFLdgQfmcVK6qKrkW8cuztx7kU
+        hash: v1.k794b7964.aee31464a227cb5772d54fd1c0b704f8a7a9aeaa591662f9f7c1670439ba6f94.nm9E4VctB6D1yJXtu4sZskmLgRASOdsRy7iPzIJKQ-k
     dashboards-dashboard-widgets-widget-types-activity-recent-events--loading--dark:
-        hash: v1.k794b7964.d4ae0cb889710a1021711e03956a93cf472f6cf4d2f5c175e4f7d79ce27f370c.XMGEfUN4Zw5MoXaOG5b_Hl4kGjOK0exF8vBwH9T7NOg
+        hash: v1.k794b7964.b6f20fcb366f754bf31c75272f79fd4a6fbd756043611ec5338fd4ef2116519a.XyaO4gyx8CK-d8rjqT8rMfe75JjCh8hkZGFIoKqFlXE
     dashboards-dashboard-widgets-widget-types-activity-recent-events--loading--light:
-        hash: v1.k794b7964.d35311973193d45114ebf8715f66859c383e9c1a8cf8243e59baa1f8cb529ffa.R-apHHFkt-4M3FGDukKxm0zLKRIqWk0xUBNPwF7H068
+        hash: v1.k794b7964.c5621f0d3747c80ecd29030e2e25b73499773e821e0a46d285c8a7917f08a55b.5WHyyCLinxRE5wRdG2z2MSO1h1ZM9GcOJTx2UQ6B37E
     dashboards-dashboard-widgets-widget-types-activity-recent-events--tile-filters-read-only--dark:
         hash: v1.k794b7964.5422492e0395af69a55d6fa98e7e36fe7463123849ea5daa8f0630244b53b008.18WXCXdqVKfE2dbj-L7dOCdxPv0OGf2jMDPPnTvnY4c
     dashboards-dashboard-widgets-widget-types-activity-recent-events--tile-filters-read-only--light:

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -375,6 +375,24 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(query.properties[0].key, "$current_url")
         self.assertEqual(query.properties[0].value, ["/checkout"])
 
+    @parameterized.expand(
+        [
+            ("with_event", {"limit": 5, "eventName": "$pageview"}, "$pageview"),
+            ("without_event", {"limit": 5}, None),
+        ]
+    )
+    @patch("products.dashboards.backend.widgets.activity_events_list.EventsQueryRunner")
+    def test_activity_events_widget_event_name_filter(
+        self, _label: str, config: dict[str, Any], expected_event: str | None, mock_runner_cls: MagicMock
+    ) -> None:
+        mock_runner_cls.return_value.calculate.return_value = MagicMock(
+            model_dump=lambda mode="json": {"results": [], "hasMore": False}
+        )
+
+        run_activity_events_list_widget(self.team, config, user=self.user)
+
+        self.assertEqual(mock_runner_cls.call_args.kwargs["query"].event, expected_event)
+
     @patch("products.dashboards.backend.widgets.activity_events_list.EventsQueryRunner")
     def test_activity_events_widget_returns_total_count_when_page_has_more(self, mock_runner_cls: MagicMock) -> None:
         def make_row(index: int) -> list[Any]:

--- a/products/dashboards/backend/widget_specs/configs.py
+++ b/products/dashboards/backend/widget_specs/configs.py
@@ -72,6 +72,10 @@ class ActivityEventsListWidgetConfig(WidgetListConfigBase):
     limit: ActivityWidgetLimit = Field(
         default=ACTIVITY_EVENTS_DEFAULT_LIMIT, description="Maximum number of events to return."
     )
+    eventName: str | None = Field(
+        default=None,
+        description="Limit the feed to a single event name. Omit or null for all events.",
+    )
 
 
 class ExperimentsListWidgetConfig(BaseModel):

--- a/products/dashboards/backend/widget_specs/configs.py
+++ b/products/dashboards/backend/widget_specs/configs.py
@@ -74,6 +74,7 @@ class ActivityEventsListWidgetConfig(WidgetListConfigBase):
     )
     eventName: str | None = Field(
         default=None,
+        min_length=1,
         description="Limit the feed to a single event name. Omit or null for all events.",
     )
 

--- a/products/dashboards/backend/widget_specs/registry.py
+++ b/products/dashboards/backend/widget_specs/registry.py
@@ -99,7 +99,7 @@ def _load_widget_specs() -> dict[str, WidgetSpec]:
             product_access_denied_message=None,
             availability_requirements=(),
             form_fields=("limit", "dateRange", "filterTestAccounts"),
-            filter_fields=(),
+            filter_fields=("eventName",),
         ),
         ERROR_TRACKING_LIST_WIDGET_TYPE: WidgetSpec(
             widget_type=ERROR_TRACKING_LIST_WIDGET_TYPE,

--- a/products/dashboards/backend/widgets/activity_events_list.py
+++ b/products/dashboards/backend/widgets/activity_events_list.py
@@ -47,11 +47,15 @@ def _build_activity_events_query(
 
     property_filters = build_event_property_filters_from_widget_filters(config.get("widgetFilters"))
 
+    event_name = config.get("eventName")
+    event = event_name if isinstance(event_name, str) and event_name else None
+
     return EventsQuery(
         kind="EventsQuery",
         select=ACTIVITY_EVENTS_WIDGET_SELECT,
         orderBy=["timestamp DESC"],
         after=after,
+        event=event,
         filterTestAccounts=resolve_filter_test_accounts(config, team),
         properties=property_filters or None,
         limit=limit,

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -511,6 +511,8 @@ export interface ActivityEventsListWidgetConfigApi {
      * @maximum 50
      */
     limit?: number
+    /** Limit the feed to a single event name. Omit or null for all events. */
+    eventName?: string | null
 }
 
 /**

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -394,6 +394,12 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                                 dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault
                                             )
                                             .describe('Maximum number of events to return.'),
+                                        eventName: zod
+                                            .union([zod.string(), zod.null()])
+                                            .optional()
+                                            .describe(
+                                                'Limit the feed to a single event name. Omit or null for all events.'
+                                            ),
                                     }),
                                     zod.object({
                                         dateRange: zod
@@ -1033,6 +1039,10 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .max(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .describe('Configuration for the recent events widget.'),
                     }),

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -395,7 +395,7 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                             )
                                             .describe('Maximum number of events to return.'),
                                         eventName: zod
-                                            .union([zod.string(), zod.null()])
+                                            .union([zod.string().min(1), zod.null()])
                                             .optional()
                                             .describe(
                                                 'Limit the feed to a single event name. Omit or null for all events.'
@@ -1040,7 +1040,7 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .default(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
                                 eventName: zod
-                                    .union([zod.string(), zod.null()])
+                                    .union([zod.string().min(1), zod.null()])
                                     .optional()
                                     .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })

--- a/products/dashboards/frontend/generated/widget-config-property-keys.json
+++ b/products/dashboards/frontend/generated/widget-config-property-keys.json
@@ -1,6 +1,6 @@
 {
     "configPropertyKeys": {
-        "activity_events_list": ["dateRange", "filterTestAccounts", "limit", "widgetFilters"],
+        "activity_events_list": ["dateRange", "eventName", "filterTestAccounts", "limit", "widgetFilters"],
         "error_tracking_list": [
             "assignee",
             "dateRange",
@@ -89,6 +89,9 @@
             },
             "limit": {
                 "$type": "integer"
+            },
+            "eventName": {
+                "$type": "string"
             }
         },
         "error_tracking_list": {

--- a/products/dashboards/frontend/generated/widget-config-schemas/activityEventsListWidgetConfig.zod.ts
+++ b/products/dashboards/frontend/generated/widget-config-schemas/activityEventsListWidgetConfig.zod.ts
@@ -23,7 +23,7 @@ export const ActivityEventsListWidgetConfig = /* @__PURE__ */ zod.object({
         .default(activityEventsListWidgetConfigLimitDefault)
         .describe('Maximum number of events to return.'),
     eventName: zod
-        .union([zod.string(), zod.null()])
+        .union([zod.string().min(1), zod.null()])
         .optional()
         .describe('Limit the feed to a single event name. Omit or null for all events.'),
 })

--- a/products/dashboards/frontend/generated/widget-config-schemas/activityEventsListWidgetConfig.zod.ts
+++ b/products/dashboards/frontend/generated/widget-config-schemas/activityEventsListWidgetConfig.zod.ts
@@ -22,6 +22,10 @@ export const ActivityEventsListWidgetConfig = /* @__PURE__ */ zod.object({
         .max(activityEventsListWidgetConfigLimitMax)
         .default(activityEventsListWidgetConfigLimitDefault)
         .describe('Maximum number of events to return.'),
+    eventName: zod
+        .union([zod.string(), zod.null()])
+        .optional()
+        .describe('Limit the feed to a single event name. Omit or null for all events.'),
 })
 
 export type ActivityEventsListWidgetConfig = zod.input<typeof ActivityEventsListWidgetConfig>

--- a/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.tsx
+++ b/products/dashboards/frontend/widgets/activity/ActivityEventsWidgetTileFilters.tsx
@@ -2,10 +2,16 @@ import { useRef } from 'react'
 
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 
+import { EventName } from 'products/actions/frontend/components/EventName'
+
 import { WIDGET_DATE_RANGE_SELECT_OPTIONS, type WidgetDateFromValue } from '../../widget_types/widgetConfigShared'
 import type { DashboardWidgetTileFiltersProps } from '../registry'
 import { useWidgetTileConfigPersist } from '../widgetTileFiltersHooks'
-import { WidgetDateRangeReadOnlyValue, WidgetTileFiltersBar } from '../widgetTileFiltersReadOnly'
+import {
+    WidgetDateRangeReadOnlyValue,
+    WidgetTileFilterReadOnlyLabel,
+    WidgetTileFiltersBar,
+} from '../widgetTileFiltersReadOnly'
 import {
     parseActivityEventsWidgetConfig,
     patchActivityEventsWidgetFilterFields,
@@ -20,6 +26,7 @@ export function ActivityEventsWidgetTileFilters({
 }: ActivityEventsWidgetTileFiltersProps): JSX.Element {
     const parsed = parseActivityEventsWidgetConfig(config)
     const dateFrom = (parsed.dateRange?.date_from ?? '-24h') as WidgetDateFromValue
+    const eventName = parsed.eventName ?? null
 
     const configRef = useRef(config)
     configRef.current = config
@@ -34,10 +41,17 @@ export function ActivityEventsWidgetTileFilters({
         await persistConfigNow(nextConfig)
     }
 
+    const applyEventName = async (value: string | null): Promise<void> => {
+        const nextConfig = patchActivityEventsWidgetFilterFields(configRef.current, { eventName: value })
+        configRef.current = nextConfig
+        await persistConfigNow(nextConfig)
+    }
+
     if (!onUpdateConfig) {
         return (
             <WidgetTileFiltersBar dataAttr="activity-events-widget-tile-filters-readonly">
                 <WidgetDateRangeReadOnlyValue dateFrom={dateFrom} />
+                {eventName ? <WidgetTileFilterReadOnlyLabel name="Event" value={eventName} /> : null}
             </WidgetTileFiltersBar>
         )
     }
@@ -54,6 +68,15 @@ export function ActivityEventsWidgetTileFilters({
                     if (value) {
                         void applyDateFrom(value)
                     }
+                }}
+            />
+            <EventName
+                value={eventName}
+                allEventsOption="clear"
+                disabled={!canUpdate}
+                placeholder="All events"
+                onChange={(value) => {
+                    void applyEventName(value)
                 }}
             />
         </WidgetTileFiltersBar>

--- a/products/dashboards/frontend/widgets/activity/activityEventsWidgetConfigValidation.test.ts
+++ b/products/dashboards/frontend/widgets/activity/activityEventsWidgetConfigValidation.test.ts
@@ -60,6 +60,17 @@ describe('activityEventsWidgetConfigValidation', () => {
             expect(next.dateRange).toEqual({ date_from: '-7d' })
             expect(next.limit).toBe(15)
         })
+
+        it('sets and clears the event name without touching the date range', () => {
+            const config = activityEventsWidgetConfigSchema.parse({ limit: 15, dateRange: { date_from: '-7d' } })
+
+            const withEvent = patchActivityEventsWidgetFilterFields(config, { eventName: '$pageview' })
+            expect(withEvent.eventName).toBe('$pageview')
+            expect(withEvent.dateRange).toEqual({ date_from: '-7d' })
+
+            const cleared = patchActivityEventsWidgetFilterFields(withEvent, { eventName: null })
+            expect(cleared.eventName).toBeNull()
+        })
     })
 
     describe('parseActivityEventsWidgetConfigApiError', () => {

--- a/products/dashboards/frontend/widgets/activity/activityEventsWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/activity/activityEventsWidgetConfigValidation.ts
@@ -36,6 +36,7 @@ export function patchActivityEventsWidgetFilterFields(
     config: Record<string, unknown>,
     patch: {
         dateFrom?: WidgetDateFromValue
+        eventName?: string | null
     }
 ): ActivityEventsWidgetConfig {
     const base = parseActivityEventsWidgetConfig(config)
@@ -43,6 +44,8 @@ export function patchActivityEventsWidgetFilterFields(
     return activityEventsWidgetConfigSchema.parse({
         ...base,
         dateRange: { date_from: patch.dateFrom ?? base.dateRange?.date_from ?? ACTIVITY_EVENTS_DEFAULT_DATE_FROM },
+        // `in` (not ??) so an explicit null clears the filter — ?? would fall back to base
+        eventName: 'eventName' in patch ? patch.eventName : base.eventName,
     })
 }
 

--- a/products/dashboards/frontend/widgets/widgetTileFiltersReadOnly.tsx
+++ b/products/dashboards/frontend/widgets/widgetTileFiltersReadOnly.tsx
@@ -22,6 +22,14 @@ export function WidgetTileFilterReadOnlyValue({ children }: { children: ReactNod
     return <span className="inline-flex items-center gap-1.5 text-xs text-primary">{children}</span>
 }
 
+export function WidgetTileFilterReadOnlyLabel({ name, value }: { name: string; value: string }): JSX.Element {
+    return (
+        <WidgetTileFilterReadOnlyValue>
+            <span className="text-secondary">{name}:</span> {value}
+        </WidgetTileFilterReadOnlyValue>
+    )
+}
+
 export function WidgetDateRangeReadOnlyValue({ dateFrom }: { dateFrom: WidgetDateFromValue }): JSX.Element {
     const label = WIDGET_DATE_RANGE_SELECT_OPTIONS.find((option) => option.value === dateFrom)?.label ?? dateFrom
     return <WidgetTileFilterReadOnlyValue>{label}</WidgetTileFilterReadOnlyValue>
@@ -63,9 +71,7 @@ export function WidgetPropertyFiltersReadOnlyValues({
     return (
         <>
             {labels.map((item) => (
-                <WidgetTileFilterReadOnlyValue key={item.id}>
-                    <span className="text-secondary">{item.name}:</span> {item.value}
-                </WidgetTileFilterReadOnlyValue>
+                <WidgetTileFilterReadOnlyLabel key={item.id} name={item.name} value={item.value} />
             ))}
         </>
     )

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -1809,6 +1809,8 @@ export namespace Schemas {
          * @maximum 50
          */
       limit?: number;
+      /** Limit the feed to a single event name. Omit or null for all events. */
+      eventName?: string | null;
     }
 
     export interface ActivityEventsListWidgetAddRequestOpenApi {

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -297,7 +297,7 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                             )
                                             .describe('Maximum number of events to return.'),
                                         eventName: zod
-                                            .union([zod.string(), zod.null()])
+                                            .union([zod.string().min(1), zod.null()])
                                             .optional()
                                             .describe(
                                                 'Limit the feed to a single event name. Omit or null for all events.'
@@ -1094,7 +1094,7 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .default(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
                                 eventName: zod
-                                    .union([zod.string(), zod.null()])
+                                    .union([zod.string().min(1), zod.null()])
                                     .optional()
                                     .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -296,6 +296,12 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                                 dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneOneLimitDefault
                                             )
                                             .describe('Maximum number of events to return.'),
+                                        eventName: zod
+                                            .union([zod.string(), zod.null()])
+                                            .optional()
+                                            .describe(
+                                                'Limit the feed to a single event name. Omit or null for all events.'
+                                            ),
                                     }),
                                     zod.object({
                                         dateRange: zod
@@ -1087,6 +1093,10 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .max(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsWidgetsBatchCreateBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .describe('Configuration for the recent events widget.'),
                     }),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -151,6 +151,18 @@
                                                     }
                                                 ]
                                             },
+                                            "eventName": {
+                                                "anyOf": [
+                                                    {
+                                                        "minLength": 1,
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "Limit the feed to a single event name. Omit or null for all events."
+                                            },
                                             "filterTestAccounts": {
                                                 "anyOf": [
                                                     {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-add.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-add.json
@@ -47,6 +47,18 @@
                                             }
                                         ]
                                     },
+                                    "eventName": {
+                                        "anyOf": [
+                                            {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Limit the feed to a single event name. Omit or null for all events."
+                                    },
                                     "filterTestAccounts": {
                                         "anyOf": [
                                             {


### PR DESCRIPTION
## Problem

The activity feed page can filter down to a single event, but the activity feed dashboard widget could only set a date range. People pinning a "recent events" tile usually want it scoped to one event, not everything.

## Changes

https://github.com/user-attachments/assets/67d6c797-b1f6-488b-bc45-f30e5c849a39


- Add an event picker to the activity feed widget's filter bar, reusing the same selector the activity feed page uses.
- Pick an event to scope the tile; clear it to go back to all events.
- Stores the choice on the widget config and passes it through to the events query.

```
[ Last 24 hours ▾ ]  [ All events ▾ ]
```

## How did you test this code?

I'm an agent (Claude Code). Added automated tests; couldn't run the full suite or codegen locally (no backend venv or frontend deps in this environment):

- Backend: event filter reaches the query, and is absent when no event is picked.
- Frontend: setting and clearing the event leaves the date range untouched.
- Ran `ruff check` + `ruff format --check` on the Python changes (pass).

⚠️ The two generated files were hand-edited to match codegen. Regenerate with `hogli build:widget-types` on a dev machine before merge.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (Opus 4.8); used the `Explore` subagent to map the widget config flow.
- Skills: `skills-store` → `xp-reviewer`, which drove three cleanups (a clarifying comment, parameterized tests, and a shared read-only label component).
- Put the picker on the filter bar (next to the date range) to match the activity feed page. Used a dedicated `eventName` field rather than the generic filter mechanism since it's a first-class single-event filter.
