### PR TITLE
feat(dashboards): widget-updated event + edge-case tests

### DIFF
--- a/products/dashboards/backend/api/dashboard.py
+++ b/products/dashboards/backend/api/dashboard.py
@@ -1170,6 +1170,36 @@ def _report_dashboard_tile_removed(
     )
 
 
+def _report_dashboard_widget_updated(
+    *,
+    user: User,
+    dashboard: Dashboard,
+    tile: DashboardTile,
+    fields_changed: builtins.list[str],
+    request: Request | None = None,
+) -> None:
+    # Fired only by the dedicated widgets/batch_update endpoint, so it doubles as the signal for
+    # whether agents reach for this path rather than the generic dashboard PATCH.
+    if tile.widget is None:
+        return
+    properties: dict[str, Any] = {
+        "widget_type": tile.widget.widget_type,
+        "dashboard_id": dashboard.id,
+        "tile_id": tile.id,
+        "fields_changed": fields_changed,
+    }
+    if tile.widget_id is not None:
+        properties["widget_id"] = str(tile.widget_id)
+
+    report_user_action(
+        user,
+        "dashboard widget updated",
+        properties,
+        team=dashboard.team,
+        request=request,
+    )
+
+
 class DashboardSerializer(DashboardMetadataSerializer):
     tiles = serializers.SerializerMethodField()
     use_template = serializers.CharField(
@@ -3038,6 +3068,16 @@ class DashboardsViewSet(
 
         for tile in tiles:
             tile.refresh_from_db()
+
+        # Report after the transaction commits so a rolled-back batch never emits events.
+        for tile, payload in zip(tiles, widget_payloads):
+            _report_dashboard_widget_updated(
+                user=user,
+                dashboard=dashboard,
+                tile=tile,
+                fields_changed=[field for field in ("config", "name", "description") if field in payload],
+                request=request,
+            )
 
         tile_context = {**self.get_serializer_context(), "dashboard": dashboard}
         return Response({"tiles": DashboardTileSerializer(tiles, context=tile_context, many=True).data})

--- a/products/dashboards/backend/api/test/test_dashboard_widgets.py
+++ b/products/dashboards/backend/api/test/test_dashboard_widgets.py
@@ -2,7 +2,7 @@ from typing import Any
 
 from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
-from unittest.mock import ANY, patch
+from unittest.mock import ANY, PropertyMock, patch
 
 from django.test import override_settings
 
@@ -1382,6 +1382,78 @@ class TestDashboardWidgetsBatchUpdate(APIBaseTest):
         for call in mock_report_user_action.call_args_list:
             assert call[0][1] != "dashboard tile added"
             assert call[0][1] != "dashboard widget added"
+
+    @override_settings(IN_UNIT_TESTING=True)
+    @patch("products.dashboards.backend.api.dashboard.report_user_action")
+    def test_update_fires_widget_updated_event(self, mock_report_user_action) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(dashboard_id, config={"limit": 5})
+        tile = dashboard_json["tiles"][0]
+        mock_report_user_action.reset_mock()
+
+        response = self._batch_update(dashboard_id, [{"tile_id": tile["id"], "name": "Renamed"}])
+        assert response.status_code == status.HTTP_200_OK
+
+        updated_events = [
+            call for call in mock_report_user_action.call_args_list if call[0][1] == "dashboard widget updated"
+        ]
+        assert len(updated_events) == 1
+        properties = updated_events[0][0][2]
+        assert properties["tile_id"] == tile["id"]
+        assert properties["fields_changed"] == ["name"]
+
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_denies_without_edit_permission(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(dashboard_id, config={"limit": 5})
+        tile = dashboard_json["tiles"][0]
+
+        with patch(
+            "posthog.user_permissions.UserDashboardPermissions.can_edit",
+            new_callable=PropertyMock,
+            return_value=False,
+        ):
+            response = self._batch_update(dashboard_id, [{"tile_id": tile["id"], "config": {"limit": 9}}])
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_rejects_update_on_deleted_dashboard(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(dashboard_id, config={"limit": 5})
+        tile = dashboard_json["tiles"][0]
+        Dashboard.objects.filter(id=dashboard_id).update(deleted=True)
+
+        response = self._batch_update(dashboard_id, [{"tile_id": tile["id"], "config": {"limit": 9}}])
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+
+    @override_settings(IN_UNIT_TESTING=True)
+    def test_denies_without_product_access(self) -> None:
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dashboard"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(dashboard_id, config={"limit": 10})
+        tile = dashboard_json["tiles"][0]
+
+        real_check = UserAccessControl.check_access_level_for_resource
+
+        def deny_error_tracking_only(
+            user_access_control: UserAccessControl,
+            resource: APIScopeObject,
+            required_level: AccessControlLevel = "viewer",
+        ) -> bool:
+            if resource == "error_tracking":
+                return False
+            return real_check(user_access_control, resource, required_level)
+
+        with patch.object(
+            UserAccessControl,
+            "check_access_level_for_resource",
+            autospec=True,
+            side_effect=deny_error_tracking_only,
+        ):
+            response = self._batch_update(dashboard_id, [{"tile_id": tile["id"], "config": {"limit": 12}}])
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == "You do not have access to error tracking."
 
 
 class TestDashboardWidgetOpenApiSchema(APIBaseTest):


### PR DESCRIPTION
Stacked on top of #65564 — addresses review feedback from @vdekrijger on that PR. Merges into `posthog-code/dashboard-widgets-batch-update`, not master.

## Changes
- Emit a `dashboard widget updated` analytics event (with `fields_changed`) from the `widgets/batch_update` endpoint, after the atomic block — mirroring the existing `dashboard widget added` / `removed` events. Only this endpoint fires it, so it doubles as the signal for whether agents use the dedicated update path vs the generic dashboard PATCH.
- Add tests for the guards that were previously uncovered: edit-permission denial (403), update on a soft-deleted dashboard (404), and product-access denial through the batch endpoint (403).

## 🤖 Agent context
Written by an agent. Backend-only change (new analytics event + tests); no serializer/schema change, so no OpenAPI regen needed. Tests could not be run in the sandbox (no Postgres) — they will run in CI.

Review notes also dispositioned without code changes:
- greptile P1 on the `widget_type` error key is a false positive — PostHog routes errors through `drf-exceptions-hog`, which flattens dict-keyed `ValidationError`s into `{detail, attr, ...}`, so `response.json()["detail"]` resolves correctly (the existing PATCH test asserts the same shape).
- graphite's `widget_type` required-vs-optional note: the OpenAPI discriminator field intentionally matches the proven add-request path (required in the schema, optional at runtime), needed for the discriminated-union codegen.
