### PR TITLE
fix(notebooks): Fix sql nodes in converting notebooks to markdown

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts
@@ -105,6 +105,61 @@ A **bold** paragraph.
 ![PostHog engineering](https://res.cloudinary.com/demo/image/upload/posthog.png)`)
     })
 
+    it('keeps a query attr whose object carries nested undefined optional fields', () => {
+        const content: JSONContent = {
+            type: 'doc',
+            content: [
+                {
+                    type: NotebookNodeType.Query,
+                    attrs: {
+                        query: {
+                            kind: 'InsightVizNode',
+                            source: {
+                                kind: 'TrendsQuery',
+                                series: [{ kind: 'EventsNode', event: '$pageview', math: undefined }],
+                                properties: undefined,
+                            },
+                            full: undefined,
+                        },
+                        isDefaultFilterApplied: false,
+                    },
+                },
+            ],
+        }
+
+        // Nested undefined must be stripped, not cause the whole query prop to be dropped.
+        expect(convertNotebookContentToMarkdown(content)).toEqual(
+            '<Query query={{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[{"kind":"EventsNode","event":"$pageview"}]}}} isDefaultFilterApplied={false} />'
+        )
+    })
+
+    it('serializes a json-string query attr as an expression that parses back to an object', () => {
+        // Persisted v1 nodes can carry `query` as a JSON string (NodeWrapper round-trips attrs as
+        // JSON). Serializing it verbatim emits query="..." which parses back as a string, rendering
+        // an empty Query node.
+        const queryObject = {
+            kind: 'DataVisualizationNode',
+            source: { kind: 'HogQLQuery', query: 'select event, count() from events group by event' },
+            display: 'ActionsTable',
+        }
+        const content: JSONContent = {
+            type: 'doc',
+            content: [
+                {
+                    type: NotebookNodeType.Query,
+                    attrs: { query: JSON.stringify(queryObject), nodeId: 'cc41998d' },
+                },
+            ],
+        }
+
+        const markdown = convertNotebookContentToMarkdown(content)
+        expect(markdown).toContain('query={{"kind":"DataVisualizationNode"')
+        expect(markdown).not.toContain('query="')
+
+        const parsedNode = parseMarkdownNotebook(markdown).nodes.find((node) => node.type === 'component')
+        expect(parsedNode?.type === 'component' ? parsedNode.props.query : null).toEqual(queryObject)
+    })
+
     it('converts legacy task lists to checkbox list markdown', () => {
         const content: JSONContent = {
             type: 'doc',

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
@@ -591,10 +591,6 @@ function normalizeTableRow(row: string[] | undefined, columnCount: number): stri
 
 function getSerializableAttrs(attrs: Record<string, unknown> | undefined): NotebookComponentProps {
     return Object.entries(attrs ?? {}).reduce<NotebookComponentProps>((props, [key, value]) => {
-        // Clean rather than reject: a V1 query attr is a QuerySchema with optional fields left as
-        // nested `undefined`, which the isNotebookPropValue guard rejects outright — dropping the
-        // whole `query` prop and producing an empty Query node. JSON-roundtrip the value to strip
-        // nested undefined first, matching how the AI-artifact path builds query props.
         const serializableValue = toSerializablePropValue(reviveJsonEncodedAttr(value))
         if (serializableValue !== undefined) {
             props[key] = serializableValue

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
@@ -8,7 +8,7 @@ import {
     serializeNode,
 } from 'lib/components/MarkdownNotebook/markdown'
 import { NotebookBlockNode, NotebookComponentProps, NotebookPropValue } from 'lib/components/MarkdownNotebook/types'
-import { getInlineText, isNotebookPropValue } from 'lib/components/MarkdownNotebook/utils'
+import { getInlineText, isNotebookPropValue, toSerializablePropValue } from 'lib/components/MarkdownNotebook/utils'
 import { JSONContent } from 'lib/components/RichContentEditor/types'
 
 import { DocumentBlock, VisualizationBlock } from '~/queries/schema/schema-assistant-artifacts'
@@ -591,9 +591,36 @@ function normalizeTableRow(row: string[] | undefined, columnCount: number): stri
 
 function getSerializableAttrs(attrs: Record<string, unknown> | undefined): NotebookComponentProps {
     return Object.entries(attrs ?? {}).reduce<NotebookComponentProps>((props, [key, value]) => {
-        if (isNotebookPropValue(value)) {
-            props[key] = value
+        // Clean rather than reject: a V1 query attr is a QuerySchema with optional fields left as
+        // nested `undefined`, which the isNotebookPropValue guard rejects outright — dropping the
+        // whole `query` prop and producing an empty Query node. JSON-roundtrip the value to strip
+        // nested undefined first, matching how the AI-artifact path builds query props.
+        const serializableValue = toSerializablePropValue(reviveJsonEncodedAttr(value))
+        if (serializableValue !== undefined) {
+            props[key] = serializableValue
         }
         return props
     }, {})
+}
+
+// Widget node attributes round-trip through HTML as JSON strings (NodeWrapper's jsonAttr), so a
+// persisted v1 node can carry an attr like `query` as the JSON *string* `'{"kind":...}'` rather than
+// the object. Serializing that string verbatim emits `query="..."`, which parses back as a string and
+// renders an empty Query node. Revive object/array-shaped JSON strings to their real value so they
+// serialize as `query={{...}}`. Only `{`/`[`-prefixed strings are touched, so plain text and HogQL
+// query strings (which never start that way) are left untouched.
+function reviveJsonEncodedAttr(value: unknown): unknown {
+    if (typeof value !== 'string') {
+        return value
+    }
+    const trimmed = value.trim()
+    if (!trimmed.startsWith('{') && !trimmed.startsWith('[')) {
+        return value
+    }
+    try {
+        const parsed = JSON.parse(trimmed) as unknown
+        return parsed !== null && typeof parsed === 'object' ? parsed : value
+    } catch {
+        return value
+    }
 }


### PR DESCRIPTION
## Problem

SQL nodes does not work once notebooks are converted to markdown-notebooks.

## Changes

Updates the conversion logic to parse/render <Query> correctly. Before, query was serialized as a quoted string (query="..." with escaped quotes), not as a JSX expression (query={{...}}). When parsed back, query becomes a string and the serializer chose string format for the query object.

## How did you test this code?

<img width="1366" height="843" alt="2026-06-24 16 28 16" src="https://github.com/user-attachments/assets/80857b80-0fb0-4bbe-b4c8-f2cdce3f153e" />
