### PR TITLE
feat(tracing): add operations aggregate tab

### DIFF
--- a/products/tracing/frontend/OperationsTable.tsx
+++ b/products/tracing/frontend/OperationsTable.tsx
@@ -1,0 +1,157 @@
+import { useMemo } from 'react'
+
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import { AggregatedSpanRow } from '~/queries/schema/schema-general'
+
+import { formatDuration } from './TraceWaterfallView'
+import { VirtualizedTable, VirtualizedTableColumn } from './VirtualizedTable'
+
+// Span count over the aggregation window, rendered as a request rate. Empty window → no rate.
+function formatRate(count: number, windowMs: number): string {
+    const seconds = windowMs / 1000
+    if (!seconds) {
+        return '—'
+    }
+    const perSec = count / seconds
+    if (perSec >= 1) {
+        return `${humanFriendlyNumber(perSec, perSec >= 10 ? 0 : 1)}/s`
+    }
+    const perMin = perSec * 60
+    if (perMin >= 1) {
+        return `${humanFriendlyNumber(perMin, 1)}/min`
+    }
+    return `${humanFriendlyNumber(perSec * 3600, 1)}/hr`
+}
+
+function errorRate(row: AggregatedSpanRow): number {
+    return row.count > 0 ? row.error_count / row.count : 0
+}
+
+const durationCell =
+    (pick: (row: AggregatedSpanRow) => number) =>
+    (row: AggregatedSpanRow): JSX.Element => <span className="font-mono">{formatDuration(pick(row))}</span>
+
+function buildColumns(windowMs: number): VirtualizedTableColumn<AggregatedSpanRow>[] {
+    return [
+        {
+            key: 'service_name',
+            title: 'Service',
+            width: 150,
+            sorter: (a, b) => a.service_name.localeCompare(b.service_name),
+            render: (row) => <span className="font-mono">{row.service_name}</span>,
+        },
+        {
+            key: 'name',
+            title: 'Operation',
+            sorter: (a, b) => a.name.localeCompare(b.name),
+            render: (row) => <span className="font-mono">{row.name}</span>,
+        },
+        {
+            key: 'requests',
+            title: 'Requests',
+            width: 120,
+            align: 'right',
+            sorter: (a, b) => a.count - b.count,
+            render: (row) => (
+                <div className="flex flex-col items-end">
+                    <span>{formatRate(row.count, windowMs)}</span>
+                    <span className="text-xs text-muted">{humanFriendlyNumber(row.count)}</span>
+                </div>
+            ),
+        },
+        {
+            key: 'error_rate',
+            title: 'Error rate',
+            width: 90,
+            align: 'right',
+            sorter: (a, b) => errorRate(a) - errorRate(b),
+            render: (row) => {
+                const rate = errorRate(row)
+                return (
+                    <span className={rate > 0 ? 'text-danger' : 'text-muted'}>
+                        {`${(rate * 100).toFixed(rate > 0 && rate < 0.01 ? 2 : 1)}%`}
+                    </span>
+                )
+            },
+        },
+        {
+            key: 'errors',
+            title: 'Errors',
+            width: 80,
+            align: 'right',
+            sorter: (a, b) => a.error_count - b.error_count,
+            render: (row) => (
+                <span className={row.error_count > 0 ? 'text-danger' : 'text-muted'}>
+                    {humanFriendlyNumber(row.error_count)}
+                </span>
+            ),
+        },
+        {
+            key: 'p50',
+            title: 'p50',
+            width: 80,
+            align: 'right',
+            sorter: (a, b) => a.p50_duration_nano - b.p50_duration_nano,
+            render: durationCell((row) => row.p50_duration_nano),
+        },
+        {
+            key: 'p95',
+            title: 'p95',
+            width: 80,
+            align: 'right',
+            sorter: (a, b) => a.p95_duration_nano - b.p95_duration_nano,
+            render: durationCell((row) => row.p95_duration_nano),
+        },
+        {
+            key: 'p99',
+            title: 'p99',
+            width: 80,
+            align: 'right',
+            sorter: (a, b) => a.p99_duration_nano - b.p99_duration_nano,
+            render: durationCell((row) => row.p99_duration_nano),
+        },
+        {
+            key: 'p999',
+            title: 'p99.9',
+            width: 80,
+            align: 'right',
+            sorter: (a, b) => a.p999_duration_nano - b.p999_duration_nano,
+            render: durationCell((row) => row.p999_duration_nano),
+        },
+        {
+            key: 'total_time',
+            title: 'Total time',
+            width: 100,
+            align: 'right',
+            // Per the JON-89 spike: wall-time, not self-time — nesting is double-counted; labelled as such.
+            tooltip: 'Sum of span wall-clock durations; nested spans are counted in both parent and child.',
+            sorter: (a, b) => a.total_duration_nano - b.total_duration_nano,
+            render: durationCell((row) => row.total_duration_nano),
+        },
+    ]
+}
+
+export interface OperationsTableProps {
+    rows: AggregatedSpanRow[]
+    loading: boolean
+    /** Resolved aggregation window (ms) — turns span counts into a request rate. */
+    windowMs: number
+    onRowClick?: (row: AggregatedSpanRow) => void
+}
+
+export function OperationsTable({ rows, loading, windowMs, onRowClick }: OperationsTableProps): JSX.Element {
+    const columns = useMemo(() => buildColumns(windowMs), [windowMs])
+    return (
+        <VirtualizedTable<AggregatedSpanRow>
+            columns={columns}
+            dataSource={rows}
+            loading={loading}
+            rowKey={(row) => `${row.service_name}::${row.name}`}
+            onRowClick={onRowClick}
+            defaultSort={{ columnKey: 'total_time', order: -1 }}
+            emptyLabel="No operations found for these filters"
+            data-attr="tracing-operations-table"
+        />
+    )
+}

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -1,9 +1,12 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { LemonBanner, LemonButton, LemonModal, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonModal, LemonTabs, Link } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { dayjs } from 'lib/dayjs'
 import { IconFeedback } from 'lib/lemon-ui/icons'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { SceneExport } from 'scenes/sceneTypes'
@@ -17,6 +20,7 @@ import { ProductIntentContext, ProductKey } from '~/queries/schema/schema-genera
 import { TracingSetupPrompt } from './components/SetupPrompt/SetupPrompt'
 import { TraceDrawer } from './components/TraceDrawer/TraceDrawer'
 import { VirtualizedSpanList } from './components/VirtualizedSpanList/VirtualizedSpanList'
+import { OperationsTable } from './OperationsTable'
 import { TraceCompareFlame } from './TraceCompareFlame'
 import { TraceCompareTable } from './TraceCompareTable'
 import { tracingDataLogic } from './tracingDataLogic'
@@ -74,7 +78,10 @@ function TracingSceneContents(): JSX.Element {
         visibleRowDurationRange,
         isDurationMode,
         expandedSpanIds,
+        activeTracingTab,
     } = useValues(tracingSceneLogic())
+    const { featureFlags } = useValues(featureFlagLogic)
+    const { utcDateRange } = useValues(tracingFiltersLogic())
     const {
         openTrace,
         closeTrace,
@@ -88,9 +95,20 @@ function TracingSceneContents(): JSX.Element {
         setVisibleRowRange,
         toggleExpandSpan,
         setSort,
+        setActiveTracingTab,
     } = useActions(tracingSceneLogic())
     const { addProductIntent } = useActions(teamLogic)
     const compareMode = filters.compareMode
+    const operationsViewEnabled = !!featureFlags[FEATURE_FLAGS.TRACING_OPERATIONS_VIEW]
+
+    // Resolved aggregation window (ms) — turns span counts into a request rate.
+    const operationsWindowMs = Math.max(
+        1,
+        (utcDateRange.date_to ? dayjs(utcDateRange.date_to) : dayjs()).diff(
+            dayjs(utcDateRange.date_from),
+            'millisecond'
+        )
+    )
 
     const onDocsLinkClick = (): void => {
         addProductIntent({
@@ -169,57 +187,77 @@ function TracingSceneContents(): JSX.Element {
                 />
                 <SceneDivider />
                 <TracingFilterBar />
-                {/* No loading guard: keep the last (view-mode-independent) count visible across reloads,
-                    so a Traces/Spans switch doesn't flicker the label out and back in. */}
-                {!compareMode && totalMatchingFilters > 0 && (
-                    <div className="text-xs text-muted px-1">
-                        {humanFriendlyNumber(totalMatchingFilters)} {filters.viewMode === 'spans' ? 'spans' : 'traces'}{' '}
-                        matching filters
-                    </div>
+                {operationsViewEnabled && (
+                    <LemonTabs
+                        activeKey={activeTracingTab}
+                        onChange={(key) => setActiveTracingTab(key as 'traces' | 'operations')}
+                        tabs={[
+                            { key: 'traces', label: 'Traces' },
+                            { key: 'operations', label: 'Operations' },
+                        ]}
+                    />
                 )}
-                {compareMode ? (
-                    <TraceCompareTable
-                        current={aggregation.current}
-                        previous={aggregation.previous}
+                {operationsViewEnabled && activeTracingTab === 'operations' ? (
+                    <OperationsTable
+                        rows={aggregation.current}
                         loading={aggregationLoading}
-                        onRowClick={(row) => openCompareFlame(row.name, row.service_name)}
+                        windowMs={operationsWindowMs}
                     />
                 ) : (
-                    <VirtualizedSpanList
-                        dataSource={listRows}
-                        loading={spansLoading}
-                        hasMoreToLoad={hasMoreToLoad}
-                        onLoadMore={fetchNextPage}
-                        onVisibleRowRangeChange={setVisibleRowRange}
-                        expandedSpanIds={expandedSpanIds}
-                        onToggleExpand={toggleExpandSpan}
-                        orderBy={filters.orderBy}
-                        orderDirection={filters.orderDirection}
-                        onSort={(column) =>
-                            // Click an active column to flip direction; a new column starts at DESC.
-                            setSort(
-                                column,
-                                column === filters.orderBy && filters.orderDirection === 'DESC' ? 'ASC' : 'DESC'
-                            )
-                        }
-                        emptyState={
-                            <div className="flex flex-col items-center gap-1">
-                                <span>No spans found</span>
-                                <Link to={TRACING_DOCS_URL} onClick={onDocsLinkClick} target="_blank">
-                                    Learn how to send traces
-                                </Link>
+                    <>
+                        {/* No loading guard: keep the last (view-mode-independent) count visible across reloads,
+                            so a Traces/Spans switch doesn't flicker the label out and back in. */}
+                        {!compareMode && totalMatchingFilters > 0 && (
+                            <div className="text-xs text-muted px-1">
+                                {humanFriendlyNumber(totalMatchingFilters)}{' '}
+                                {filters.viewMode === 'spans' ? 'spans' : 'traces'} matching filters
                             </div>
-                        }
-                        onRowClick={(span: Span) => {
-                            // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
-                            // element; react-modal then scrolls it back into view when restoring focus
-                            // on close. Blur so the restore target is <body>, which doesn't scroll.
-                            ;(document.activeElement as HTMLElement | null)?.blur?.()
-                            // Anchor the waterfall on the clicked span — in Spans mode this is often a
-                            // child span, so without spanId the drawer would open unfocused at the root.
-                            openTrace(span.trace_id, { spanId: span.span_id, ts: span.timestamp })
-                        }}
-                    />
+                        )}
+                        {compareMode ? (
+                            <TraceCompareTable
+                                current={aggregation.current}
+                                previous={aggregation.previous}
+                                loading={aggregationLoading}
+                                onRowClick={(row) => openCompareFlame(row.name, row.service_name)}
+                            />
+                        ) : (
+                            <VirtualizedSpanList
+                                dataSource={listRows}
+                                loading={spansLoading}
+                                hasMoreToLoad={hasMoreToLoad}
+                                onLoadMore={fetchNextPage}
+                                onVisibleRowRangeChange={setVisibleRowRange}
+                                expandedSpanIds={expandedSpanIds}
+                                onToggleExpand={toggleExpandSpan}
+                                orderBy={filters.orderBy}
+                                orderDirection={filters.orderDirection}
+                                onSort={(column) =>
+                                    // Click an active column to flip direction; a new column starts at DESC.
+                                    setSort(
+                                        column,
+                                        column === filters.orderBy && filters.orderDirection === 'DESC' ? 'ASC' : 'DESC'
+                                    )
+                                }
+                                emptyState={
+                                    <div className="flex flex-col items-center gap-1">
+                                        <span>No spans found</span>
+                                        <Link to={TRACING_DOCS_URL} onClick={onDocsLinkClick} target="_blank">
+                                            Learn how to send traces
+                                        </Link>
+                                    </div>
+                                }
+                                onRowClick={(span: Span) => {
+                                    // Clicking a row leaves the scrollable <main tabIndex="0"> as the active
+                                    // element; react-modal then scrolls it back into view when restoring focus
+                                    // on close. Blur so the restore target is <body>, which doesn't scroll.
+                                    ;(document.activeElement as HTMLElement | null)?.blur?.()
+                                    // Anchor the waterfall on the clicked span — in Spans mode this is often a
+                                    // child span, so without spanId the drawer would open unfocused at the root.
+                                    openTrace(span.trace_id, { spanId: span.span_id, ts: span.timestamp })
+                                }}
+                            />
+                        )}
+                    </>
                 )}
             </TracingSetupPrompt>
             <TraceDrawer

--- a/products/tracing/frontend/TracingScene.tsx
+++ b/products/tracing/frontend/TracingScene.tsx
@@ -4,7 +4,6 @@ import posthog from 'posthog-js'
 import { LemonBanner, LemonButton, LemonModal, LemonTabs, Link } from '@posthog/lemon-ui'
 
 import { FEATURE_FLAGS } from 'lib/constants'
-import { dayjs } from 'lib/dayjs'
 import { IconFeedback } from 'lib/lemon-ui/icons'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { useAttachedLogic } from 'lib/logic/scenes/useAttachedLogic'
@@ -81,7 +80,6 @@ function TracingSceneContents(): JSX.Element {
         activeTracingTab,
     } = useValues(tracingSceneLogic())
     const { featureFlags } = useValues(featureFlagLogic)
-    const { utcDateRange } = useValues(tracingFiltersLogic())
     const {
         openTrace,
         closeTrace,
@@ -102,13 +100,9 @@ function TracingSceneContents(): JSX.Element {
     const operationsViewEnabled = !!featureFlags[FEATURE_FLAGS.TRACING_OPERATIONS_VIEW]
 
     // Resolved aggregation window (ms) — turns span counts into a request rate.
-    const operationsWindowMs = Math.max(
-        1,
-        (utcDateRange.date_to ? dayjs(utcDateRange.date_to) : dayjs()).diff(
-            dayjs(utcDateRange.date_from),
-            'millisecond'
-        )
-    )
+    // Use sparklineWindowMs which correctly resolves relative date strings (e.g. '-1h').
+    const { sparklineWindowMs } = useValues(tracingFiltersLogic())
+    const operationsWindowMs = sparklineWindowMs.endMs - sparklineWindowMs.startMs
 
     const onDocsLinkClick = (): void => {
         addProductIntent({

--- a/products/tracing/frontend/VirtualizedTable.tsx
+++ b/products/tracing/frontend/VirtualizedTable.tsx
@@ -1,0 +1,258 @@
+import { CSSProperties, ReactNode, useMemo, useState } from 'react'
+import { List } from 'react-window'
+
+import { Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import { AutoSizer } from 'lib/components/AutoSizer'
+import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
+import { SortingIndicator } from 'lib/lemon-ui/LemonTable/sorting'
+import { cn } from 'lib/utils/css-classes'
+
+// Config-driven virtualized table: owns react-window virtualization, client-side sort, and the
+// header/row layout; callers pass column definitions + data. Extracted from TraceCompareTable so
+// the compare view and the operations view share one implementation. The column-def contract
+// mirrors logs' `VirtualizedTableColumn` (products/logs/frontend/components/VirtualizedLogsList);
+// the two are intended to converge into a single shared lib/ primitive later.
+
+const ROW_HEIGHT = 44
+const HEADER_HEIGHT = 32
+// Min width a flex (width-less) column reserves when computing the horizontal-scroll row width.
+const FLEX_MIN_WIDTH = 200
+
+export type VirtualizedSortOrder = 1 | -1
+
+export interface VirtualizedTableColumn<T> {
+    key: string
+    title: ReactNode
+    /** Fixed column width in px. Omit to flex-fill the remaining space. */
+    width?: number
+    align?: 'right'
+    /** Header tooltip. */
+    tooltip?: string
+    render: (record: T) => ReactNode
+    /** Provide to make the column sortable. */
+    sorter?: (a: T, b: T) => number
+}
+
+function Cell({ width, align, children }: { width?: number; align?: 'right'; children: ReactNode }): JSX.Element {
+    return (
+        <div
+            className={cn(
+                'shrink-0 truncate px-2 text-xs',
+                width === undefined && 'flex-1 min-w-0',
+                align === 'right' && 'text-right'
+            )}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={width !== undefined ? { width } : undefined}
+        >
+            {children}
+        </div>
+    )
+}
+
+function HeaderCell({
+    column,
+    sortKey,
+    sortOrder,
+    onSort,
+}: {
+    column: VirtualizedTableColumn<any>
+    sortKey: string | null
+    sortOrder: VirtualizedSortOrder
+    onSort: (key: string) => void
+}): JSX.Element {
+    const label = column.tooltip ? <Tooltip title={column.tooltip}>{column.title}</Tooltip> : column.title
+    if (!column.sorter) {
+        return (
+            <Cell width={column.width} align={column.align}>
+                {label}
+            </Cell>
+        )
+    }
+    const active = sortKey === column.key
+    return (
+        <Cell width={column.width} align={column.align}>
+            <button
+                type="button"
+                className={cn(
+                    'flex items-center cursor-pointer hover:text-default',
+                    column.align === 'right' && 'ml-auto',
+                    active && 'text-default'
+                )}
+                onClick={() => onSort(column.key)}
+                data-attr={`virtualized-table-sort-${column.key}`}
+            >
+                <span>{label}</span>
+                <SortingIndicator order={active ? sortOrder : null} />
+            </button>
+        </Cell>
+    )
+}
+
+// The generic T is erased to `any` at the react-window row boundary — type safety lives at the
+// column-definition site (`columns: VirtualizedTableColumn<T>[]`), not inside the row renderer.
+interface VirtualizedRowProps {
+    columns: VirtualizedTableColumn<any>[]
+    dataSource: any[]
+    rowKey: (record: any) => string
+    onRowClick?: (record: any) => void
+}
+
+function VirtualizedRow({
+    ariaAttributes,
+    index,
+    style,
+    columns,
+    dataSource,
+    rowKey,
+    onRowClick,
+}: {
+    ariaAttributes: { 'aria-posinset': number; 'aria-setsize': number; role: 'listitem' }
+    index: number
+    style: CSSProperties
+} & VirtualizedRowProps): JSX.Element {
+    const record = dataSource[index]
+    return (
+        <div
+            {...ariaAttributes}
+            // eslint-disable-next-line react/forbid-dom-props
+            style={style}
+            data-index={index}
+            data-row-key={rowKey(record)}
+        >
+            <div
+                className={cn(
+                    'flex items-center border-b border-border hover:bg-surface-primary-hover',
+                    onRowClick && 'cursor-pointer'
+                )}
+                // eslint-disable-next-line react/forbid-dom-props
+                style={{ height: ROW_HEIGHT }}
+                onClick={onRowClick ? () => onRowClick(record) : undefined}
+                onKeyDown={
+                    onRowClick
+                        ? (e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault()
+                                  onRowClick(record)
+                              }
+                          }
+                        : undefined
+                }
+                role={onRowClick ? 'button' : undefined}
+                tabIndex={onRowClick ? 0 : undefined}
+            >
+                {columns.map((column) => (
+                    <Cell key={column.key} width={column.width} align={column.align}>
+                        {column.render(record)}
+                    </Cell>
+                ))}
+            </div>
+        </div>
+    )
+}
+
+export interface VirtualizedTableProps<T> {
+    columns: VirtualizedTableColumn<T>[]
+    dataSource: T[]
+    loading: boolean
+    rowKey: (record: T) => string
+    onRowClick?: (record: T) => void
+    defaultSort?: { columnKey: string; order: VirtualizedSortOrder }
+    emptyLabel?: string
+    'data-attr'?: string
+}
+
+export function VirtualizedTable<T>({
+    columns,
+    dataSource,
+    loading,
+    rowKey,
+    onRowClick,
+    defaultSort,
+    emptyLabel = 'No rows',
+    'data-attr': dataAttr,
+}: VirtualizedTableProps<T>): JSX.Element {
+    const [sortKey, setSortKey] = useState<string | null>(defaultSort?.columnKey ?? null)
+    const [sortOrder, setSortOrder] = useState<VirtualizedSortOrder>(defaultSort?.order ?? -1)
+
+    const minRowWidth = useMemo(
+        () => columns.reduce((sum, column) => sum + (column.width ?? FLEX_MIN_WIDTH), 0),
+        [columns]
+    )
+
+    const rows = useMemo(() => {
+        const sorter = columns.find((column) => column.key === sortKey)?.sorter
+        if (!sorter) {
+            return dataSource
+        }
+        return [...dataSource].sort((a, b) => sorter(a, b) * sortOrder)
+    }, [dataSource, columns, sortKey, sortOrder])
+
+    const onSort = (key: string): void => {
+        if (key === sortKey) {
+            setSortOrder((order) => (order === 1 ? -1 : 1))
+        } else {
+            setSortKey(key)
+            setSortOrder(-1)
+        }
+    }
+
+    const rowProps = useMemo(
+        (): VirtualizedRowProps => ({ columns, dataSource: rows, rowKey, onRowClick }),
+        [columns, rows, rowKey, onRowClick]
+    )
+
+    if (rows.length === 0) {
+        return (
+            <div className="flex items-center justify-center p-8 text-muted border rounded bg-bg-light">
+                {loading ? <Spinner className="text-2xl" /> : emptyLabel}
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex flex-col flex-1 min-h-0 bg-bg-light border rounded overflow-hidden" data-attr={dataAttr}>
+            <AutoSizer
+                renderProp={({ width, height }: SizeProps) => {
+                    if (!width || !height) {
+                        return null
+                    }
+                    const rowWidth = Math.max(width, minRowWidth)
+                    return (
+                        // The viewport is fixed to the available box; inner content can be wider
+                        // (minRowWidth) so columns scroll horizontally and rows align with the header.
+                        // eslint-disable-next-line react/forbid-dom-props
+                        <div className="overflow-x-auto" style={{ width, height }}>
+                            {/* eslint-disable-next-line react/forbid-dom-props */}
+                            <div style={{ width: rowWidth }}>
+                                <div
+                                    className="flex items-center border-b border-border bg-surface-secondary font-medium text-muted"
+                                    // eslint-disable-next-line react/forbid-dom-props
+                                    style={{ height: HEADER_HEIGHT }}
+                                >
+                                    {columns.map((column) => (
+                                        <HeaderCell
+                                            key={column.key}
+                                            column={column}
+                                            sortKey={sortKey}
+                                            sortOrder={sortOrder}
+                                            onSort={onSort}
+                                        />
+                                    ))}
+                                </div>
+                                <List<VirtualizedRowProps>
+                                    style={{ height: height - HEADER_HEIGHT, width: rowWidth }}
+                                    overscanCount={10}
+                                    rowCount={rows.length}
+                                    rowHeight={ROW_HEIGHT}
+                                    rowComponent={VirtualizedRow}
+                                    rowProps={rowProps}
+                                />
+                            </div>
+                        </div>
+                    )
+                }}
+            />
+        </div>
+    )
+}

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -92,6 +92,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         closeCompareFlame: true,
         syncUrlAndRunQuery: true,
         handleFilterChange: (filterType: string, extraProps?: Record<string, unknown>) => ({ filterType, extraProps }),
+        setActiveTracingTab: (tab: 'traces' | 'operations') => ({ tab }),
     }),
 
     reducers({
@@ -147,6 +148,12 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
             {
                 openCompareFlame: (_, { serviceName }) => serviceName,
                 closeCompareFlame: () => null,
+            },
+        ],
+        activeTracingTab: [
+            'traces' as 'traces' | 'operations',
+            {
+                setActiveTracingTab: (_, { tab }) => tab,
             },
         ],
     }),
@@ -213,6 +220,10 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         handleFilterChange: ({ filterType, extraProps }) => {
             posthog.capture('tracing filter changed', { filter_type: filterType, ...extraProps })
             actions.syncUrlAndRunQuery()
+            // Keep the Operations aggregate in sync with filters/date while that tab is active.
+            if (values.activeTracingTab === 'operations') {
+                actions.fetchAggregation()
+            }
         },
         setDateRange: () => actions.handleFilterChange('date_range'),
         setServiceNames: () => actions.handleFilterChange('service_names'),
@@ -235,6 +246,11 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         },
         setFilters: () => {
             actions.syncUrlAndRunQuery()
+        },
+        setActiveTracingTab: ({ tab }) => {
+            if (tab === 'operations') {
+                actions.fetchAggregation()
+            }
         },
     })),
 


### PR DESCRIPTION
## Problem

The tracing scene only shows individual traces, making it hard to get a service-level overview of operation performance (latency percentiles, error rates, request throughput) across the selected time window.

## Changes

**`VirtualizedTable`** — a new generic, config-driven virtualized table component built on `react-window`. It handles client-side sorting, horizontal scrolling, and header/row layout via a column-definition API. Extracted as a shared primitive so both the existing compare view and the new operations view can converge on one implementation.

**`OperationsTable`** — a new table built on `VirtualizedTable` that renders aggregated span rows with columns for service, operation name, request rate, error rate, error count, p50/p95/p99/p99.9 latency, and total wall-clock time. Request counts are converted to a human-friendly rate (per second, per minute, or per hour) based on the resolved date range window.

**`TracingScene`** — when the `TRACING_OPERATIONS_VIEW` feature flag is enabled, a `LemonTabs` switcher appears above the results area with "Traces" and "Operations" tabs. Switching to Operations triggers `fetchAggregation` immediately and on subsequent filter/date-range changes while that tab is active.

**`tracingSceneLogic`** — adds `activeTracingTab` state and a `setActiveTracingTab` action. The `handleFilterChange` listener now also calls `fetchAggregation` when the operations tab is active so the aggregate stays in sync with filter changes.

## How did you test this code?

This PR was agent-assisted. No manual testing was performed by the agent. The feature is gated behind `FEATURE_FLAGS.TRACING_OPERATIONS_VIEW`, so it can be verified by enabling that flag and exercising the new "Operations" tab in the tracing scene with various date ranges and filters.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent extracted a shared `VirtualizedTable` primitive from the existing compare-table pattern, then built `OperationsTable` on top of it. The decision to gate the feature behind a feature flag and trigger `fetchAggregation` on tab switch (rather than always fetching) was made to avoid unnecessary backend load when the tab is not active. The `formatRate` helper was written to degrade gracefully across per-second, per-minute, and per-hour scales depending on the span count and window size.