### PR TITLE
fix(ingestion-consumer): bind health server before waiting for workers

### DIFF
--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -11,7 +11,7 @@ use lifecycle::{ComponentOptions, Manager};
 use metrics_exporter_prometheus::{Matcher, PrometheusBuilder};
 use tokio::net::TcpListener;
 use tokio_util::sync::CancellationToken;
-use tracing::info;
+use tracing::{error, info};
 use tracing_subscriber::fmt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
@@ -217,32 +217,11 @@ async fn async_main(config: Config) -> Result<()> {
         });
     }
 
-    // For dynamic discovery, wait for the first workers before consuming so the
-    // first batch has somewhere to route.
-    if config.worker_discovery_mode == DiscoveryMode::EndpointSlice {
-        info!("Waiting for the first workers from EndpointSlice discovery");
-        while registry.worker_count() == 0 {
-            tokio::select! {
-                _ = consumer_handle.shutdown_recv() => {
-                    info!("Shutdown received while waiting for worker discovery");
-                    break;
-                }
-                _ = tokio::time::sleep(Duration::from_millis(250)) => {}
-            }
-        }
-    }
-
-    let consumer = IngestionConsumer::new(&config, dispatcher, transport, consumer_handle)
-        .context("Failed to create Kafka consumer")?;
-
-    tokio::spawn(async move {
-        consumer.process().await;
-        // Cancel background tasks once the consumer loop exits.
-        probe_token.cancel();
-        discovery_token.cancel();
-    });
-
-    // Build and serve the health/metrics HTTP server
+    // Build and serve the health/metrics HTTP server BEFORE gating on worker
+    // discovery. Otherwise /_readiness and /_liveness stay unbound while we wait
+    // for the first workers, so kubelet sees "connection refused" instead of a
+    // proper 503 — and since /_liveness is meant to always answer 200, an unbound
+    // port lets the liveness probe kill the pod mid-startup.
     let mut app = Router::new()
         .route("/", get(|| async { "ingestion consumer" }))
         .route(
@@ -272,12 +251,42 @@ async fn async_main(config: Config) -> Result<()> {
 
     let bind = config.bind_address();
     info!(address = %bind, "Health/metrics server starting");
-
     let listener = TcpListener::bind(&bind).await?;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(metrics_handle.shutdown_signal())
-        .await?;
-    metrics_handle.work_completed();
+    tokio::spawn(async move {
+        if let Err(err) = axum::serve(listener, app)
+            .with_graceful_shutdown(metrics_handle.shutdown_signal())
+            .await
+        {
+            error!(error = %err, "Health/metrics server error");
+        }
+        metrics_handle.work_completed();
+    });
+
+    // For dynamic discovery, wait for the first workers before consuming so the
+    // first batch has somewhere to route. Readiness stays 503 until the consumer
+    // starts; the server above keeps the probes answering during the wait.
+    if config.worker_discovery_mode == DiscoveryMode::EndpointSlice {
+        info!("Waiting for the first workers from EndpointSlice discovery");
+        while registry.worker_count() == 0 {
+            tokio::select! {
+                _ = consumer_handle.shutdown_recv() => {
+                    info!("Shutdown received while waiting for worker discovery");
+                    break;
+                }
+                _ = tokio::time::sleep(Duration::from_millis(250)) => {}
+            }
+        }
+    }
+
+    let consumer = IngestionConsumer::new(&config, dispatcher, transport, consumer_handle)
+        .context("Failed to create Kafka consumer")?;
+
+    tokio::spawn(async move {
+        consumer.process().await;
+        // Cancel background tasks once the consumer loop exits.
+        probe_token.cancel();
+        discovery_token.cancel();
+    });
 
     guard.wait().await?;
 


### PR DESCRIPTION
## Problem

The consumer's readiness probe fails with connection refused on startup:

```
Readiness probe failed: Get "http://<pod>:3301/_readiness": dial tcp <pod>:3301: connect: connection refused
```

In EndpointSlice discovery mode, `main` blocks in a "wait for the first worker" loop *before* it binds the health/metrics HTTP server. Until discovery finds a worker, nothing listens on the probe port, so kubelet gets connection refused on both `/_readiness` and `/_liveness` instead of a proper response. Because `/_liveness` is designed to always return 200 (liveness-driven shutdown is handled internally, not via the K8s probe), an unbound port lets the liveness probe surprise-kill the pod mid-startup — exactly the outcome the always-200 design exists to avoid.

## Changes

Bind and spawn the health/metrics server before the worker-discovery gate, so the probes answer throughout startup.

- During the wait, `/_readiness` returns 503 (correct: the pod isn't ready to route yet) and `/_liveness` returns 200, so kubelet keeps the pod alive while workers come up.
- The server runs as a spawned task with the same graceful-shutdown signal; the bind error still fails startup fast.
- No behavior change once workers are present.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while rolling out the ingestion-analytics-parallel split in dev: consumer pods were marked NotReady (and at risk of liveness kills) while waiting for the processor pool to be discovered. Confirmed `/_liveness` is intentionally always 200 and the `report_healthy` sentinel keeps the pre-start wait from tripping the internal stall monitor, so serving the probes during the wait is safe. `cargo build`/`fmt`/`clippy` clean. Follow-up to the merged consumer robustness work (#65809). Agent-authored; requires human review.
