### PR TITLE
fix(web-analytics): keep null breakdown rows in dimensional precompute reads

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/test/test_web_stats_lazy_precompute.py
@@ -20,11 +20,14 @@ from posthog.schema import (
     WebStatsTableQuery,
 )
 
+from posthog.hogql import ast
+
 from posthog.clickhouse.client import sync_execute
 from posthog.models.utils import uuid7
 
 from products.analytics_platform.backend.models.preaggregation_job import PreaggregationJob
 from products.web_analytics.backend.hogql_queries.stats_table import WebStatsTableQueryRunner
+from products.web_analytics.backend.hogql_queries.web_stats_lazy_precompute import _breakdown_having_expr
 
 # Low-cardinality breakdowns with a generic seed that have data and are cheap to
 # assert parity on. VIEWPORT is exercised separately — the raw query compares
@@ -234,6 +237,55 @@ class TestWebStatsLazyPrecompute(ClickhouseTestMixin, APIBaseTest):
             lazy = self._metrics(self._run(self._build_query(breakdown_by=breakdown_by, compare=True)))
 
         assert lazy == raw, f"lazy/raw compare mismatch for {breakdown_by}: raw={raw}, lazy={lazy}"
+
+    @parameterized.expand(
+        [
+            ("browser", WebStatsBreakdown.BROWSER, "$browser"),
+            ("os", WebStatsBreakdown.OS, "$os"),
+            ("device_type", WebStatsBreakdown.DEVICE_TYPE, "$device_type"),
+        ]
+    )
+    @freeze_time("2024-01-15T12:00:00Z")
+    def test_lazy_keeps_null_breakdown_rows(self, _name: str, breakdown_by: WebStatsBreakdown, null_prop: str):
+        self._seed()
+        # One extra session whose breakdown property is absent -> a genuine NULL that
+        # both paths must surface as a "(none)" row rather than silently drop.
+        s = str(uuid7("2024-01-05"))
+        props = self._props(
+            **{"$session_id": s, "$host": "example.com", "$current_url": "https://example.com/n", "$pathname": "/n"}
+        )
+        props.pop(null_prop)
+        _create_event(
+            team=self.team,
+            event="$pageview",
+            distinct_id="u1",
+            timestamp="2024-01-05T08:00:00Z",
+            properties=props,
+        )
+
+        raw = self._metrics(self._run(self._build_query(breakdown_by=breakdown_by)))
+        with self._enable_lazy():
+            lazy_response = self._run(self._build_query(breakdown_by=breakdown_by))
+        lazy = self._metrics(lazy_response)
+
+        # Guard against a silent fallback to raw making lazy==raw trivially true.
+        assert lazy_response.preComputeStrategy == WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE
+        assert any(row[0] is None for row in raw), f"raw should surface a null {breakdown_by} row, got {raw}"
+        assert lazy == raw, f"lazy dropped/altered the null row for {breakdown_by}: raw={raw}, lazy={lazy}"
+
+    @parameterized.expand([(b.value, b) for b in WebStatsBreakdown])
+    def test_breakdown_having_matches_live_null_handling(self, _name: str, breakdown_by: WebStatsBreakdown):
+        # The lazy read's HAVING must keep/drop NULL breakdown rows exactly as the raw
+        # runner's outer_where_breakdown does, or precompute tiles gain/lose a "(none)"
+        # row relative to raw. `outer_where_breakdown() is None` means "keep nulls"; the
+        # lazy side encodes that as a bare `True` HAVING.
+        runner = WebStatsTableQueryRunner(team=self.team, query=self._build_query(breakdown_by=breakdown_by))
+        live_keeps_null = runner.outer_where_breakdown() is None
+        having = _breakdown_having_expr(breakdown_by)
+        lazy_keeps_null = isinstance(having, ast.Constant) and having.value is True
+        assert lazy_keeps_null == live_keeps_null, (
+            f"{breakdown_by}: lazy keeps_null={lazy_keeps_null} but raw keeps_null={live_keeps_null}"
+        )
 
     @freeze_time("2024-01-15T12:00:00Z")
     def test_viewport_breakdown_lazy_runs(self):

--- a/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
+++ b/products/web_analytics/backend/hogql_queries/web_stats_lazy_precompute.py
@@ -322,9 +322,12 @@ GROUP BY breakdown_value
 #
 # `m` computes the prefix-level visitor/view metrics: `uniqMergeIf` over a GROUP BY
 # prefix dedups users across regions exactly (no double-count), matching the raw
-# query's prefix-level `uniq`. `r` derives the most-common region per prefix via
-# `argMax(region, region_views)` — the precompute-side equivalent of the raw query's
-# `topK(1)` over the region part. The `splitByChar('-', ..., 2)` limit mirrors the raw
+# query's prefix-level `uniq`. `r` derives the displayed region per prefix via
+# `argMax(region, region_views)` — a best-effort *approximation* of the raw query's
+# `topK(1)` over the region part, NOT an exact equivalent: `topK(1)` weights by session
+# count, which the precompute does not store, so the region *suffix* on a multi-region
+# language (e.g. `cs-CZ` vs `cs-`) can differ from raw. Counts are unaffected; see the
+# module-level LANGUAGE note above for why this is accepted. The `splitByChar('-', ..., 2)` limit mirrors the raw
 # query's exact split signature so the prefix/region split stays identical to the raw
 # path for multi-part BCP-47 tags (e.g. `zh-Hans-CN`) regardless of the cluster's
 # `splitby_max_substrings_includes_remaining_string` setting. Empty/null languages are
@@ -406,6 +409,26 @@ def _resolve_sort_metric(query: WebStatsTableQuery) -> tuple[str, bool]:
     return sort_metric, descending
 
 
+# Breakdowns where the raw query keeps NULL rows (surfaced as a "(none)" row) instead
+# of dropping them — must stay in lockstep with the `outer_where_breakdown() is None`
+# cases in `WebStatsTableQueryRunner`. `test_breakdown_having_matches_live_null_handling`
+# enforces the parity so the two can't drift.
+_KEEP_NULL_BREAKDOWNS = {
+    WebStatsBreakdown.COUNTRY,
+    WebStatsBreakdown.BROWSER,
+    WebStatsBreakdown.OS,
+    WebStatsBreakdown.DEVICE_TYPE,
+    WebStatsBreakdown.LANGUAGE,
+    WebStatsBreakdown.TIMEZONE,
+    WebStatsBreakdown.INITIAL_REFERRING_DOMAIN,
+    WebStatsBreakdown.INITIAL_UTM_SOURCE,
+    WebStatsBreakdown.INITIAL_UTM_CAMPAIGN,
+    WebStatsBreakdown.INITIAL_UTM_MEDIUM,
+    WebStatsBreakdown.INITIAL_UTM_TERM,
+    WebStatsBreakdown.INITIAL_UTM_CONTENT,
+}
+
+
 def _breakdown_having_expr(breakdown_by: WebStatsBreakdown) -> ast.Expr:
     """HAVING-clause equivalent of the raw query's `outer_where_breakdown()` —
     operates on the JSON-encoded `breakdown_value` column produced by the INSERT.
@@ -424,14 +447,10 @@ def _breakdown_having_expr(breakdown_by: WebStatsBreakdown) -> ast.Expr:
             "JSONExtractRaw(breakdown_value, 1) NOT IN ('null', '0') "
             "AND JSONExtractRaw(breakdown_value, 2) NOT IN ('null', '0')"
         )
-    if breakdown_by in {
-        WebStatsBreakdown.INITIAL_UTM_SOURCE,
-        WebStatsBreakdown.INITIAL_UTM_CAMPAIGN,
-        WebStatsBreakdown.INITIAL_UTM_MEDIUM,
-        WebStatsBreakdown.INITIAL_UTM_TERM,
-        WebStatsBreakdown.INITIAL_UTM_CONTENT,
-    }:
-        # The raw query intentionally keeps null UTM values.
+    if breakdown_by in _KEEP_NULL_BREAKDOWNS:
+        # Mirror the raw query's `outer_where_breakdown() is None` set: missing data is
+        # real for these dimensions and surfaces as a "(none)" row, so it must not be
+        # dropped. Source of truth is `WebStatsTableQueryRunner.outer_where_breakdown`.
         return ast.Constant(value=True)
     if breakdown_by == WebStatsBreakdown.INITIAL_CHANNEL_TYPE:
         # JSON scalars: 'null' is genuine null, '""' is empty string.


### PR DESCRIPTION
## Problem

Web analytics dimension tiles (Browser, OS, Device type, Country, Timezone, Language, Initial referring domain, UTM*) served from the lazy precompute path were silently dropping the "(none)" row for missing values, undercounting the tile versus the live query. The live runner intentionally keeps those NULL rows (surfaced as "(none)") so the breakdown totals stay consistent with the overview tile — the precompute read's `HAVING` was filtering them out.

## Changes

- The precompute read's per-breakdown `HAVING` (`_breakdown_having_expr`) now keeps NULL rows for exactly the set the live runner keeps (`outer_where_breakdown() is None`): Country, Browser, OS, Device type, Language, Timezone, Initial referring domain, and the UTM breakdowns. Previously only the UTM breakdowns were kept and the rest were dropped.
- Read-only change: the INSERT already stores the NULL rows, so existing precompute jobs surface "(none)" immediately — no re-warm needed.
- Fixed a misleading comment in the Language read that claimed `argMax(region, pageviews)` is the exact equivalent of the live `topK(1)(region)`. It's a best-effort approximation (the precompute stores no per-session region frequency), so the region suffix on a multi-region language label can differ from raw while counts stay exact. Documented as a known limitation.

## How did you test this code?

Agent-authored (Claude Code); automated tests only:

- `test_lazy_keeps_null_breakdown_rows` — seeds a genuinely-null Browser/OS/Device type event and asserts the precompute result equals raw including the "(none)" row, guarded so a silent fallback to the live path can't pass it trivially.
- `test_breakdown_having_matches_live_null_handling` — parameterized over every breakdown; asserts the precompute `HAVING` keep/drop-null decision matches the live `outer_where_breakdown`, so the two can't drift again.
- Confirmed both fail without the fix (10 failures) and pass with it; full `test_web_stats_lazy_precompute.py` 80/80; ruff clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while evaluating precompute-vs-raw parity across all web analytics tiles (each tile run through `WebStatsTableQueryRunner` with `useWebAnalyticsPrecompute` on vs off). The dimensional precompute path showed two divergences: dropped "(none)" rows and a Language region-label approximation.

The Language region suffix can't be reproduced exactly from the stored aggregates (no per-session frequency for `topK(1)`) and only affects the label, not counts — so it's documented rather than papered over with another approximation. A follow-up PR will write up the broader precompute decisions (top-k row cap, insert-time path cleaning) in the web analytics docs.

Skill invoked: /writing-tests.
