### PR TITLE
feat(surveys): sync survey search bar with url query param

### DIFF
--- a/frontend/src/scenes/surveys/surveysLogic.test.ts
+++ b/frontend/src/scenes/surveys/surveysLogic.test.ts
@@ -134,6 +134,64 @@ describe('surveysLogic', () => {
         })
     })
 
+    describe('url syncing', () => {
+        let logic: ReturnType<typeof surveysLogic.build>
+
+        beforeEach(async () => {
+            initKeaTests()
+
+            useMocks({
+                get: {
+                    '/api/projects/:team/surveys/': () => [200, { count: 0, results: [], next: null, previous: null }],
+                    '/api/projects/:team/surveys/responses_count': () => [200, {}],
+                },
+            })
+
+            logic = surveysLogic()
+            logic.mount()
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        it('writes the search term to the search query param', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSearchTerm('checkout')
+            }).toFinishAllListeners()
+
+            expect(router.values.searchParams.search).toEqual('checkout')
+        })
+
+        it('removes the search query param when the term is cleared', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSearchTerm('checkout')
+            }).toFinishAllListeners()
+            await expectLogic(logic, () => {
+                logic.actions.setSearchTerm('')
+            }).toFinishAllListeners()
+
+            expect(router.values.searchParams.search).toBeUndefined()
+        })
+
+        it('reads the search term from the search query param on navigation', async () => {
+            router.actions.push('/surveys', { search: 'onboarding' })
+
+            await expectLogic(logic).toFinishAllListeners().toMatchValues({
+                searchTerm: 'onboarding',
+            })
+        })
+
+        it('clears a stale search term when navigating to surveys without a search param', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setSearchTerm('onboarding')
+            }).toFinishAllListeners()
+
+            router.actions.push('/surveys')
+
+            await expectLogic(logic).toFinishAllListeners().toMatchValues({
+                searchTerm: '',
+            })
+        })
+    })
+
     describe('product intent tracking', () => {
         let logic: ReturnType<typeof surveysLogic.build>
         let capturedIntentRequests: any[]

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -494,8 +494,9 @@ export const surveysLogic = kea<surveysLogicType>([
             if (tab) {
                 actions.setTab(tab)
             }
-            if (search !== undefined && search !== values.searchTerm) {
-                actions.setSearchTerm(search)
+            const nextSearchTerm = search ?? ''
+            if (nextSearchTerm !== values.searchTerm) {
+                actions.setSearchTerm(nextSearchTerm)
             }
             actions.addProductIntent({
                 product_type: ProductKey.SURVEYS,

--- a/frontend/src/scenes/surveys/surveysLogic.tsx
+++ b/frontend/src/scenes/surveys/surveysLogic.tsx
@@ -473,13 +473,29 @@ export const surveysLogic = kea<surveysLogicType>([
     }),
     actionToUrl(({ values }) => ({
         setTab: () => {
-            return [router.values.location.pathname, { ...router.values.searchParams, tab: values.tab }]
+            return [
+                router.values.location.pathname,
+                { ...router.values.searchParams, tab: values.tab },
+                router.values.hashParams,
+            ]
+        },
+        setSearchTerm: () => {
+            const searchParams = { ...router.values.searchParams }
+            if (values.searchTerm) {
+                searchParams.search = values.searchTerm
+            } else {
+                delete searchParams.search
+            }
+            return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         },
     })),
-    urlToAction(({ actions }) => ({
-        [urls.surveys()]: (_, { tab }) => {
+    urlToAction(({ actions, values }) => ({
+        [urls.surveys()]: (_, { tab, search }) => {
             if (tab) {
                 actions.setTab(tab)
+            }
+            if (search !== undefined && search !== values.searchTerm) {
+                actions.setSearchTerm(search)
             }
             actions.addProductIntent({
                 product_type: ProductKey.SURVEYS,


### PR DESCRIPTION
## Problem

The surveys list search bar kept its state only in memory, so a search couldn't be shared via URL and was lost on reload or back/forward navigation. This addresses a request to sync the search bar with a URL query param.

## Changes

`surveysLogic` now syncs `searchTerm` to a `search` URL query param, mirroring the existing `tab` sync:
- Typing in the search box updates `?search=...` (using `replace: true` so keystrokes don't flood browser history).
- Loading a URL with `?search=...` populates the box and runs the search.
- Clearing the box removes the param.

The search input in `SurveysTable` already binds to the same `searchTerm` value, so the sync is bidirectional with no component changes needed.

## How did you test this code?

I'm an agent. I ran the frontend TypeScript check (`pnpm --filter=@posthog/frontend typescript:check`), which passed. No manual browser testing was performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: sync the surveys search bar with a URL query param. The logic already wired `tab` into the URL through kea-router's `actionToUrl`/`urlToAction`, so I followed that same pattern for `searchTerm` rather than introducing a filters object. Chose `replace: true` on search updates so per-keystroke changes don't create browser history entries, and guarded the `urlToAction` handler against re-dispatching when the term already matches to avoid redundant search reloads.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1782312235076429?thread_ts=1782312235.076429&cid=C07QD3LT8U9)*
