### PR TITLE
fix(cdp-email): bump blast-radius timeout + retry once on failure

### DIFF
--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.test.ts
@@ -19,6 +19,8 @@ const createFetchResponse = (status: number, body: unknown): { status: number; t
     }
 }
 
+const FETCH_TIMEOUT_MS = 30_000
+
 describe('HogFlowBatchPersonQueryService', () => {
     const team = { id: 123 } as Team
     const filters = { properties: [], filter_test_accounts: true }
@@ -29,8 +31,10 @@ describe('HogFlowBatchPersonQueryService', () => {
         fetchMock = jest.fn()
     })
 
+    // retryBackoffMs: 0 keeps tests fast — the retry mechanics are what we care about,
+    // not the wall-clock backoff.
     const createService = (): HogFlowBatchPersonQueryService => {
-        return new HogFlowBatchPersonQueryService({ fetch: fetchMock } as any)
+        return new HogFlowBatchPersonQueryService({ fetch: fetchMock } as any, { retryBackoffMs: 0 })
     }
 
     describe('getBlastRadius', () => {
@@ -54,6 +58,7 @@ describe('HogFlowBatchPersonQueryService', () => {
                         filters,
                         group_type_index: 1,
                     }),
+                    timeoutMs: FETCH_TIMEOUT_MS,
                 },
             })
         })
@@ -76,11 +81,12 @@ describe('HogFlowBatchPersonQueryService', () => {
                         filters,
                         group_type_index: undefined,
                     }),
+                    timeoutMs: FETCH_TIMEOUT_MS,
                 },
             })
         })
 
-        it('throws when Django responds with non-200 status', async () => {
+        it('retries once on 5xx and throws when both attempts fail', async () => {
             const service = createService()
 
             fetchMock.mockResolvedValue({
@@ -89,19 +95,55 @@ describe('HogFlowBatchPersonQueryService', () => {
             })
 
             await expect(service.getBlastRadius(team, filters)).rejects.toThrow(
-                'Failed to fetch blast radius: 500 server exploded'
+                'HTTP 500 from /api/projects/123/internal/hog_flows/user_blast_radius: server exploded'
             )
+            expect(fetchMock).toHaveBeenCalledTimes(2)
         })
 
-        it('throws fetchError when internal fetch fails', async () => {
+        it('does NOT retry on 4xx — client errors are non-retryable', async () => {
+            const service = createService()
+
+            fetchMock.mockResolvedValue({
+                fetchResponse: createFetchResponse(403, 'forbidden'),
+                fetchError: null,
+            })
+
+            await expect(service.getBlastRadius(team, filters)).rejects.toThrow(
+                'HTTP 403 from /api/projects/123/internal/hog_flows/user_blast_radius: forbidden'
+            )
+            expect(fetchMock).toHaveBeenCalledTimes(1)
+        })
+
+        it('retries once on fetchError and throws when both attempts fail', async () => {
             const service = createService()
 
             fetchMock.mockResolvedValue({
                 fetchResponse: null,
-                fetchError: new Error('network down'),
+                fetchError: new Error('The operation was aborted due to timeout'),
             })
 
-            await expect(service.getBlastRadius(team, filters)).rejects.toThrow('network down')
+            await expect(service.getBlastRadius(team, filters)).rejects.toThrow(
+                'The operation was aborted due to timeout'
+            )
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('retries once on fetchError and returns the response on second attempt', async () => {
+            const service = createService()
+            const response: BlastRadiusResponse = { users_affected: 7, total_users: 100 }
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    fetchResponse: null,
+                    fetchError: new Error('The operation was aborted due to timeout'),
+                })
+                .mockResolvedValueOnce({
+                    fetchResponse: createFetchResponse(200, response),
+                    fetchError: null,
+                })
+
+            await expect(service.getBlastRadius(team, filters)).resolves.toEqual(response)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
         })
     })
 
@@ -143,6 +185,7 @@ describe('HogFlowBatchPersonQueryService', () => {
                         group_type_index: 2,
                         cursor: null,
                     }),
+                    timeoutMs: FETCH_TIMEOUT_MS,
                 },
             })
             expect(fetchMock).toHaveBeenNthCalledWith(2, {
@@ -154,6 +197,7 @@ describe('HogFlowBatchPersonQueryService', () => {
                         group_type_index: 2,
                         cursor: 'next-cursor',
                     }),
+                    timeoutMs: FETCH_TIMEOUT_MS,
                 },
             })
         })
@@ -181,11 +225,12 @@ describe('HogFlowBatchPersonQueryService', () => {
                         group_type_index: undefined,
                         cursor: null,
                     }),
+                    timeoutMs: FETCH_TIMEOUT_MS,
                 },
             })
         })
 
-        it('throws when persons endpoint responds with non-200 status', async () => {
+        it('does NOT retry on 4xx — client errors are non-retryable', async () => {
             const service = createService()
 
             fetchMock.mockResolvedValue({
@@ -194,19 +239,45 @@ describe('HogFlowBatchPersonQueryService', () => {
             })
 
             await expect(service.getBlastRadiusPersons(team, filters)).rejects.toThrow(
-                'Failed to fetch blast radius persons: 403 forbidden'
+                'HTTP 403 from /api/projects/123/internal/hog_flows/user_blast_radius_persons: forbidden'
             )
+            expect(fetchMock).toHaveBeenCalledTimes(1)
         })
 
-        it('throws fetchError when persons fetch fails', async () => {
+        it('retries once on fetchError (e.g. AbortSignal timeout) before failing', async () => {
             const service = createService()
 
             fetchMock.mockResolvedValue({
                 fetchResponse: null,
-                fetchError: new Error('timeout'),
+                fetchError: new Error('The operation was aborted due to timeout'),
             })
 
-            await expect(service.getBlastRadiusPersons(team, filters)).rejects.toThrow('timeout')
+            await expect(service.getBlastRadiusPersons(team, filters)).rejects.toThrow(
+                'The operation was aborted due to timeout'
+            )
+            expect(fetchMock).toHaveBeenCalledTimes(2)
+        })
+
+        it('returns successful response when first attempt times out and retry succeeds', async () => {
+            const service = createService()
+            const response: BlastRadiusPersonsResponse = {
+                users_affected: ['person_a', 'person_b'],
+                cursor: 'cursor-1',
+                has_more: false,
+            }
+
+            fetchMock
+                .mockResolvedValueOnce({
+                    fetchResponse: null,
+                    fetchError: new Error('The operation was aborted due to timeout'),
+                })
+                .mockResolvedValueOnce({
+                    fetchResponse: createFetchResponse(200, response),
+                    fetchError: null,
+                })
+
+            await expect(service.getBlastRadiusPersons(team, filters)).resolves.toEqual(response)
+            expect(fetchMock).toHaveBeenCalledTimes(2)
         })
     })
 })

--- a/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-batch-person-query.service.ts
@@ -16,13 +16,92 @@ export interface BlastRadiusPersonsResponse {
     has_more: boolean
 }
 
+export interface HogFlowBatchPersonQueryServiceOptions {
+    /** Per-call HTTP timeout for blast-radius fetches. Default: 30s. */
+    fetchTimeoutMs?: number
+    /** Backoff between the initial attempt and the single retry. Default: 500ms. */
+    retryBackoffMs?: number
+}
+
+// The default external-request budget (3s, EXTERNAL_REQUEST_TIMEOUT_MS) is sized for
+// outbound webhooks. Blast-radius fetches hit an internal Django endpoint that runs a
+// HogQL → ClickHouse person scan, which routinely takes 1–3s per page. At 100 pages
+// for a 50k audience, a 97% per-call success rate collapses to ~5% batch success
+// through geometric tail compounding. 30s leaves plenty of headroom; the one retry
+// catches occasional spikes without dropping the whole batch.
+const DEFAULT_FETCH_TIMEOUT_MS = 30_000
+const DEFAULT_RETRY_BACKOFF_MS = 500
+const MAX_ATTEMPTS = 2
+
 /**
  * Service for querying persons via Django internal API for batch HogFlow processing.
  * Calls internal endpoints authenticated with INTERNAL_API_SECRET.
  * Endpoints: /internal/hog_flows/user_blast_radius and /internal/hog_flows/user_blast_radius_persons
  */
 export class HogFlowBatchPersonQueryService {
-    constructor(private internalFetchService: InternalFetchService) {}
+    private readonly fetchTimeoutMs: number
+    private readonly retryBackoffMs: number
+
+    constructor(
+        private internalFetchService: InternalFetchService,
+        options: HogFlowBatchPersonQueryServiceOptions = {}
+    ) {
+        this.fetchTimeoutMs = options.fetchTimeoutMs ?? DEFAULT_FETCH_TIMEOUT_MS
+        this.retryBackoffMs = options.retryBackoffMs ?? DEFAULT_RETRY_BACKOFF_MS
+    }
+
+    /**
+     * POST to an internal endpoint with one retry on timeout / network error / 5xx.
+     * 4xx responses are non-retryable (client error) and throw immediately.
+     */
+    private async fetchInternalEndpoint<T>(urlPath: `/${string}`, body: Record<string, unknown>): Promise<T> {
+        let lastError: Error | null = null
+
+        for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+            if (attempt > 1) {
+                await new Promise<void>((resolve) => setTimeout(resolve, this.retryBackoffMs))
+            }
+
+            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
+                urlPath,
+                fetchParams: {
+                    method: 'POST',
+                    body: JSON.stringify(body),
+                    timeoutMs: this.fetchTimeoutMs,
+                },
+            })
+
+            if (fetchError) {
+                lastError = fetchError
+            } else if (!fetchResponse) {
+                lastError = new Error('Empty response from internal API')
+            } else if (fetchResponse.status === 200) {
+                return parseJSON(await fetchResponse.text()) as T
+            } else if (fetchResponse.status >= 500) {
+                const errorText = await fetchResponse.text()
+                lastError = new Error(`HTTP ${fetchResponse.status} from ${urlPath}: ${errorText}`)
+            } else {
+                // 4xx — client error, not retryable
+                const errorText = await fetchResponse.text()
+                throw new Error(`HTTP ${fetchResponse.status} from ${urlPath}: ${errorText}`)
+            }
+
+            if (attempt < MAX_ATTEMPTS) {
+                logger.warn('Retrying internal blast-radius fetch', {
+                    urlPath,
+                    attempt,
+                    error: serializeError(lastError),
+                })
+            }
+        }
+
+        logger.error('Internal blast-radius fetch failed after retries', {
+            urlPath,
+            attempts: MAX_ATTEMPTS,
+            error: serializeError(lastError),
+        })
+        throw lastError ?? new Error(`Internal blast-radius fetch failed: ${urlPath}`)
+    }
 
     /**
      * Get count of users affected by filters
@@ -32,46 +111,11 @@ export class HogFlowBatchPersonQueryService {
         filters: Pick<HogFunctionFilters, 'properties' | 'filter_test_accounts'>,
         groupTypeIndex?: number
     ): Promise<BlastRadiusResponse> {
-        // The /internal endpoints aren't exposed publicly and require INTERNAL_API_SECRET for authentication
         const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius` as const
-
-        try {
-            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
-                urlPath,
-                fetchParams: {
-                    method: 'POST',
-                    body: JSON.stringify({
-                        filters,
-                        group_type_index: groupTypeIndex,
-                    }),
-                },
-            })
-
-            if (!fetchResponse || fetchError) {
-                logger.error('Error fetching blast radius from Django', {
-                    error: serializeError(fetchError),
-                    urlPath,
-                })
-                throw fetchError
-            }
-
-            if (fetchResponse.status !== 200) {
-                const errorText = await fetchResponse.text()
-                logger.error('Failed to fetch blast radius from Django', {
-                    status: fetchResponse.status,
-                    error: errorText,
-                    urlPath,
-                })
-                throw new Error(`Failed to fetch blast radius: ${fetchResponse.status} ${errorText}`)
-            }
-
-            const data = parseJSON(await fetchResponse.text()) as BlastRadiusResponse
-
-            return data
-        } catch (error) {
-            logger.error('Error calling blast radius endpoint', { error: serializeError(error), urlPath })
-            throw error
-        }
+        return this.fetchInternalEndpoint<BlastRadiusResponse>(urlPath, {
+            filters,
+            group_type_index: groupTypeIndex,
+        })
     }
 
     /**
@@ -87,44 +131,10 @@ export class HogFlowBatchPersonQueryService {
         cursor?: string | null
     ): Promise<BlastRadiusPersonsResponse> {
         const urlPath = `/api/projects/${team.id}/internal/hog_flows/user_blast_radius_persons` as const
-
-        try {
-            const { fetchResponse, fetchError } = await this.internalFetchService.fetch({
-                urlPath,
-                fetchParams: {
-                    method: 'POST',
-                    body: JSON.stringify({
-                        filters,
-                        group_type_index: groupTypeIndex,
-                        cursor: cursor || null,
-                    }),
-                },
-            })
-
-            if (!fetchResponse || fetchError) {
-                logger.error('Error fetching blast radius persons from Django', {
-                    error: serializeError(fetchError),
-                    urlPath,
-                })
-                throw fetchError
-            }
-
-            if (fetchResponse.status !== 200) {
-                const errorText = await fetchResponse.text()
-                logger.error('Failed to fetch blast radius persons from Django', {
-                    status: fetchResponse.status,
-                    error: errorText,
-                    urlPath,
-                })
-                throw new Error(`Failed to fetch blast radius persons: ${fetchResponse.status} ${errorText}`)
-            }
-
-            const data = parseJSON(await fetchResponse.text()) as BlastRadiusPersonsResponse
-
-            return data
-        } catch (error) {
-            logger.error('Error calling blast radius persons endpoint', { error: serializeError(error), urlPath })
-            throw error
-        }
+        return this.fetchInternalEndpoint<BlastRadiusPersonsResponse>(urlPath, {
+            filters,
+            group_type_index: groupTypeIndex,
+            cursor: cursor || null,
+        })
     }
 }


### PR DESCRIPTION
## Problem

A 50k-person batch trigger dispatched in prod resolved only ~4,300 persons before failing with `Failed to resolve batch audience: The operation was aborted due to timeout`. The audience-resolution loop in `cdp-batch-hogflow.consumer.ts` paginates through Django's `/internal/hog_flows/user_blast_radius_persons` endpoint in 500-person pages — so 50k = ~100 round trips, each running a HogQL → ClickHouse person scan.

Two compounding issues:

1. **3s timeout is wrong for these calls.** `HogFlowBatchPersonQueryService` calls `internalFetchService.fetch` without overriding `timeoutMs`, inheriting `EXTERNAL_REQUEST_TIMEOUT_MS = 3000` from `common/config.ts:194`. That default is sized for outbound webhooks, not for an internal Django call that runs a ClickHouse query. Per-page latency is routinely 1–3s under normal load and spikes higher when the cluster is busy or pages are cold.

2. **Geometric tail compounding turns a small per-call risk into near-certain batch failure.** If the per-call success rate against the 3s budget is `p`, batch success is `p^N` for `N` pages. A 97% per-call rate (sounds healthy) becomes:

   | Pages | Batch success |
   |---|---:|
   | 10 (5k cap) | 74% |
   | 100 (50k cap) | **5%** |
   | 1000 (500k cap) | 0% |

   Same per-call latency, totally different outcome. The 4,300 number we saw is ~8–9 successful pages × 500 — exactly what you'd predict for the first call to tip over the 3s budget at this scale.

3. **One failed page wipes everything.** The `catch` in `createHogFlowInvocations` (consumer:190-210) logs the error and returns `[]` — the persons we'd already paginated through are dropped, and the Kafka message is committed (no retry).

## Changes

Both changes live in `HogFlowBatchPersonQueryService` — the consumer's outer behavior is unchanged.

- **Per-call timeout overridden to 30s** (`DEFAULT_FETCH_TIMEOUT_MS`). 10× the default, plenty of headroom for the expected 1–3s per page even with spikes.
- **One retry on transient failure** (`MAX_ATTEMPTS = 2`, `DEFAULT_RETRY_BACKOFF_MS = 500`). Retries on `fetchError` (abort/network) and 5xx. 4xx stays non-retryable — those are client errors that won't get better.
- Both timeouts/backoffs are constructor-overridable via a new `HogFlowBatchPersonQueryServiceOptions` so tests can run with `retryBackoffMs: 0`.

Both `getBlastRadius` and `getBlastRadiusPersons` now route through a private `fetchInternalEndpoint` helper that owns the retry loop and error shaping.

## Math after the fix

If 30s captures essentially all the tail latency (per-call p ≥ 0.999), 100 pages succeeds with probability ~0.999^100 ≈ 90% even with no retry. With one retry, even genuine flake (~5%) survives: `1 - (0.05)^2 = 99.75%` per page. So 1M batches become viable.

## How did you test this code?

I'm an agent (Claude Opus 4.7). No manual prod testing.

11 unit tests in `hogflow-batch-person-query.service.test.ts`, all passing:

- Existing happy-path assertions updated to include the new `timeoutMs: 30_000` in fetch params.
- Two new tests asserting retry on 5xx and on `fetchError` (1 + 1 retry = 2 attempts before throwing).
- Two new tests asserting **no** retry on 4xx (client error stays a single call).
- Two new tests asserting success when the first attempt times out and the second succeeds.

Tests run with `retryBackoffMs: 0` to keep them fast; production defaults stay at 500ms.

Typescript check passes.

## Follow-on (not in this PR)

The deeper issue is that batch audience resolution shouldn't ride on Kafka one-shot semantics at all — a failed batch today loses all progress because Kafka commits the offset after the catch. Moving the batch resolver to a cyclotron job (with cursor in job state) would give us retry + partial-progress + backpressure for free. Tracking that as a separate, larger conversation. **This PR is the stop-the-bleed.**

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs needed — internal config + retry behavior only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by @meikelratz; tooling: Claude Code (Opus 4.7). No PostHog skills invoked.

Decisions worth flagging:

- **Retry in the service, not in the consumer.** The consumer's outer catch is the final guard for unrecoverable errors. The retry belongs in the service because it knows the call shape (internal ClickHouse-backed endpoint, transient failures are expected and recoverable).
- **4xx is non-retryable.** Saves the wasted call when the request is malformed (e.g. a filter validation failure on the Django side).
- **Constants over env vars.** Kept the timeout / backoff as module constants for now rather than plumbing through `PluginsServerConfig`. Tests override them via the constructor options. If prod ops want to tune these without a deploy, a follow-up can wire them through config.