### PR TITLE
feat(growht): improve identity matching UI [POS-32]

### DIFF
--- a/products/growth/backend/api/identity_matching.py
+++ b/products/growth/backend/api/identity_matching.py
@@ -21,6 +21,8 @@ from rest_framework.response import Response
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.clickhouse.client import sync_execute
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.models import Person
+from posthog.models.person.util import get_persons_mapped_by_distinct_id
 from posthog.permissions import IsStaffUser
 
 from products.growth.backend.constants import (
@@ -28,6 +30,7 @@ from products.growth.backend.constants import (
     IDENTITY_MATCHING_CANDIDATE_PAIRS_STRUCTURE,
     IDENTITY_MATCHING_LINKS_DATASET,
     IDENTITY_MATCHING_LINKS_STRUCTURE,
+    IDENTITY_MATCHING_PERSON_PROPERTY_MAP,
     IDENTITY_MATCHING_S3_UNCONFIGURED_MESSAGE,
     IDENTITY_MATCHING_TIERS,
     identity_matching_dataset_read_args,
@@ -36,12 +39,68 @@ from products.growth.backend.constants import (
 
 MAX_RUNS_LISTED = 50
 
+
+def _person_summary(distinct_id: str, persons_by_distinct_id: dict[str, Person]) -> dict[str, Any] | None:
+    """Curated, display-ready summary of the person behind a distinct ID, or None when unresolved.
+
+    Only the properties in IDENTITY_MATCHING_PERSON_PROPERTY_MAP are surfaced (renamed to clean API
+    keys), so the payload stays bounded and the reviewer sees exactly the dimensions the models score
+    on. Anonymous orphans with no person profile (e.g. personless capture) resolve to None.
+    """
+    person = persons_by_distinct_id.get(distinct_id)
+    if person is None:
+        return None
+    properties = person.properties or {}
+    summary: dict[str, Any] = {
+        "distinct_id": distinct_id,
+        "first_seen": person.created_at,
+        "last_seen": person.last_seen_at,
+    }
+    for source_key, api_key in IDENTITY_MATCHING_PERSON_PROPERTY_MAP.items():
+        value = properties.get(source_key)
+        summary[api_key] = str(value) if value is not None else None
+    return summary
+
+
 # Let a glob matching no objects return zero rows (the "no run yet" path) instead of erroring.
 _S3_READ_SETTINGS = {"s3_throw_on_zero_files_match": "0"}
 
 # All-runs glob for one team: `<prefix>/team_<team_id>/*/links/*.parquet`. links is the smallest
 # dataset, so enumerating every run of a team this way is cheap.
 _ALL_RUNS = "*"
+
+
+class IdentityMatchingPersonSerializer(serializers.Serializer):
+    """The resolved person behind one side of a link, with a curated set of properties that mirror
+    the match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible."""
+
+    distinct_id = serializers.CharField(help_text="Distinct ID this person was resolved from.")
+    first_seen = serializers.DateTimeField(
+        allow_null=True, help_text="When this person was first seen — person created_at (UTC)."
+    )
+    last_seen = serializers.DateTimeField(
+        allow_null=True, help_text="When this person was last seen, when tracked — person last_seen_at (UTC)."
+    )
+    email = serializers.CharField(allow_null=True, help_text="Person's email, when set.")
+    name = serializers.CharField(allow_null=True, help_text="Person's name property, when set.")
+    city = serializers.CharField(allow_null=True, help_text="GeoIP city ($geoip_city_name).")
+    country = serializers.CharField(allow_null=True, help_text="GeoIP country code ($geoip_country_code).")
+    browser = serializers.CharField(allow_null=True, help_text="Browser ($browser).")
+    os = serializers.CharField(allow_null=True, help_text="Operating system ($os).")
+    device_type = serializers.CharField(
+        allow_null=True, help_text="Device type, e.g. Desktop or Mobile ($device_type)."
+    )
+    timezone = serializers.CharField(allow_null=True, help_text="Browser timezone ($timezone).")
+    utm_source = serializers.CharField(allow_null=True, help_text="Initial campaign source ($initial_utm_source).")
+    utm_medium = serializers.CharField(allow_null=True, help_text="Initial campaign medium ($initial_utm_medium).")
+    utm_campaign = serializers.CharField(allow_null=True, help_text="Initial campaign name ($initial_utm_campaign).")
+    referring_domain = serializers.CharField(
+        allow_null=True, help_text="Initial referring domain ($initial_referring_domain)."
+    )
+    gclid = serializers.CharField(
+        allow_null=True,
+        help_text="Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.",
+    )
 
 
 class IdentityMatchingLinkSerializer(serializers.Serializer):
@@ -85,6 +144,14 @@ class IdentityMatchingLinkSerializer(serializers.Serializer):
     )
     anchor_paid_touch = serializers.BooleanField(
         help_text="The matched person already had a paid click ID inside the window."
+    )
+    orphan_person = IdentityMatchingPersonSerializer(
+        allow_null=True,
+        help_text="Resolved person behind the anonymous distinct ID; null when no profile exists for it.",
+    )
+    anchor_person = IdentityMatchingPersonSerializer(
+        allow_null=True,
+        help_text="Resolved identified person behind the matched person key; null when no profile exists for it.",
     )
 
 
@@ -318,6 +385,18 @@ class IdentityMatchingLinkViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
             "anchor_paid_touch",
         ]
         results = [dict(zip(field_names, row, strict=True)) for row in rows]
+
+        # Resolve the real persons behind each link (one batched lookup for the whole page) so the
+        # UI can show identity and the properties the models score on — letting a reviewer eyeball
+        # whether a match is plausible rather than guessing from a distinct ID string.
+        distinct_ids = {r["orphan_distinct_id"] for r in results} | {r["anchor_person_key"] for r in results}
+        persons_by_distinct_id = (
+            get_persons_mapped_by_distinct_id(self.team.pk, list(distinct_ids)) if distinct_ids else {}
+        )
+        for result in results:
+            result["orphan_person"] = _person_summary(result["orphan_distinct_id"], persons_by_distinct_id)
+            result["anchor_person"] = _person_summary(result["anchor_person_key"], persons_by_distinct_id)
+
         response = IdentityMatchingLinksResponseSerializer({"results": results, "count": count})
         return Response(response.data)
 

--- a/products/growth/backend/api/test_identity_matching.py
+++ b/products/growth/backend/api/test_identity_matching.py
@@ -4,6 +4,7 @@ from typing import Any
 from uuid import uuid4
 
 from posthog.test.base import APIBaseTest
+from unittest.mock import patch
 
 from django.test import override_settings
 
@@ -11,6 +12,7 @@ from parameterized import parameterized
 from rest_framework import status
 
 from posthog.clickhouse.client import sync_execute
+from posthog.models import Person
 
 from products.growth.backend.constants import (
     IDENTITY_MATCHING_CANDIDATE_PAIRS_DATASET,
@@ -221,3 +223,51 @@ class TestIdentityMatchingLinksAPI(APIBaseTest):
         assert run_a_rules["high_confidence"] == 1
         assert run_a_rules["medium_confidence"] == 1
         assert run_a_rules["low_confidence"] == 0
+
+    def test_links_are_enriched_with_resolved_persons(self) -> None:
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["phone-1"],
+            properties={
+                "$geoip_city_name": "Lisbon",
+                "$browser": "Mobile Safari",
+                "$initial_utm_source": "google",
+                "$initial_gclid": "Cj0KexampleABC",
+            },
+            last_seen_at=datetime(2026, 6, 1, 12, 0, tzinfo=UTC),
+        )
+        Person.objects.create(
+            team=self.team,
+            distinct_ids=["anna@x.com"],
+            properties={"email": "anna@x.com", "name": "Anna", "$geoip_city_name": "Lisbon"},
+        )
+        self._insert_link(self.team.pk, RUN_A, "phone-1", "anna@x.com", score=7.0, tier="high", orphan_paid_touch=1)
+        # An orphan with no person profile must resolve to null, not error.
+        self._insert_link(self.team.pk, RUN_A, "ghost-2", "anna@x.com", score=4.0, tier="medium")
+
+        # Pin person resolution to the ORM path so it reads the persons created above; personhog
+        # keeps its own store (unseeded here), and its routing is covered in test_util_personhog_routing.
+        with patch("posthog.personhog_client.gate.use_personhog", return_value=False):
+            response = self.client.get(f"/api/projects/{self.team.pk}/identity_matching_links/")
+        assert response.status_code == status.HTTP_200_OK
+        by_orphan = {row["orphan_distinct_id"]: row for row in response.json()["results"]}
+
+        # Curated properties are surfaced under clean keys ($geoip_city_name -> city, etc.).
+        orphan = by_orphan["phone-1"]["orphan_person"]
+        assert orphan["city"] == "Lisbon"
+        assert orphan["browser"] == "Mobile Safari"
+        assert orphan["utm_source"] == "google"
+        assert orphan["gclid"] == "Cj0KexampleABC"
+        assert orphan["email"] is None
+        # Timestamps: created_at always present; last_seen_at surfaced when set.
+        assert orphan["first_seen"] is not None
+        assert orphan["last_seen"].startswith("2026-06-01")
+        anchor = by_orphan["phone-1"]["anchor_person"]
+        assert anchor["email"] == "anna@x.com"
+        assert anchor["name"] == "Anna"
+        assert anchor["first_seen"] is not None
+        assert anchor["last_seen"] is None  # last_seen_at unset on this person
+
+        # Unresolved orphan -> null person; its anchor still resolves.
+        assert by_orphan["ghost-2"]["orphan_person"] is None
+        assert by_orphan["ghost-2"]["anchor_person"]["email"] == "anna@x.com"

--- a/products/growth/backend/constants.py
+++ b/products/growth/backend/constants.py
@@ -78,6 +78,27 @@ IDENTITY_MATCHING_RULES_MODEL_VERSION = "rules_v1"
 IDENTITY_MATCHING_LOGREG_MODEL_VERSION = "logreg_v1"
 IDENTITY_MATCHING_TIERS = ["high", "medium", "low"]
 
+# Person properties surfaced per link so a reviewer can sanity-check a match at a glance: identity
+# (email/name) plus the dimensions the models score on — geo, device, and campaign attribution.
+# Maps raw person-property keys to clean API field names (the `$`-prefixed keys can't be serializer
+# field names). Kept curated rather than dumping every property: the payload stays bounded, and the
+# chosen fields mirror the match signals so "same city? same browser? same campaign?" is one glance.
+IDENTITY_MATCHING_PERSON_PROPERTY_MAP: dict[str, str] = {
+    "email": "email",
+    "name": "name",
+    "$geoip_city_name": "city",
+    "$geoip_country_code": "country",
+    "$browser": "browser",
+    "$os": "os",
+    "$device_type": "device_type",
+    "$timezone": "timezone",
+    "$initial_utm_source": "utm_source",
+    "$initial_utm_medium": "utm_medium",
+    "$initial_utm_campaign": "utm_campaign",
+    "$initial_referring_domain": "referring_domain",
+    "$initial_gclid": "gclid",
+}
+
 # Parquet column schemas, passed as the explicit `structure` argument to `s3(...)`. They are
 # *required* for the VALUES-based writes (person_timeline, logreg links) and used on every read
 # so that a glob matching no objects returns zero rows instead of failing schema inference (the

--- a/products/growth/frontend/IdentityMatchingDetail.tsx
+++ b/products/growth/frontend/IdentityMatchingDetail.tsx
@@ -1,4 +1,4 @@
-import { IconArrowRight, IconBrowser, IconExternal, IconGlobe, IconLaptop, IconTarget } from '@posthog/icons'
+import { IconArrowRight, IconCheck, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { dayjs } from 'lib/dayjs'
@@ -7,22 +7,24 @@ import { urls } from 'scenes/urls'
 
 import type { IdentityMatchingLinkApi } from './generated/api.schemas'
 import {
-    CATEGORY_DESCRIPTIONS,
     CATEGORY_LABELS,
     CATEGORY_ORDER,
-    type Signal,
+    PERSON_CAMPAIGN_FIELDS,
+    PERSON_SIGNAL_FIELDS,
+    type PersonFieldSpec,
     type SignalCategory,
     extractEmail,
     extractSignals,
+    linkPersonDisplay,
     normalizedScore,
-    personFromDistinctId,
+    personField,
 } from './identityMatchingUtils'
 
-const CATEGORY_ICON: Record<SignalCategory, JSX.Element> = {
-    network: <IconGlobe />,
-    device: <IconLaptop />,
-    behavior: <IconBrowser />,
-    attribution: <IconTarget />,
+const CATEGORY_TAG_TYPE: Record<SignalCategory, 'default' | 'highlight' | 'completion'> = {
+    network: 'highlight',
+    device: 'highlight',
+    behavior: 'default',
+    attribution: 'completion',
 }
 
 const STRENGTH_LABELS: Record<number, string> = {
@@ -31,56 +33,111 @@ const STRENGTH_LABELS: Record<number, string> = {
     3: 'Strong signal',
 }
 
+// Shared 3-column grid so the header and every comparison row line up: label · visitor · person.
+const COMPARE_GRID = 'grid grid-cols-[7rem_minmax(0,1fr)_minmax(0,1fr)] gap-x-3'
+
 function matchSummary(link: IdentityMatchingLinkApi, confidence: number): string {
     const signals = extractSignals(link)
     const topSignals = signals.filter((s) => s.strength >= 2).slice(0, 2)
     const reasons = topSignals.map((s) => s.label.toLowerCase()).join(' and ')
     const pct = Math.round(confidence * 100)
-    const personLabel = extractEmail(link.anchor_person_key) ?? 'this identified person'
+    const personLabel = link.anchor_person?.email ?? extractEmail(link.anchor_person_key) ?? 'this identified person'
     if (reasons) {
         return `We're ${pct}% confident this anonymous visitor is ${personLabel}, because they ${reasons}.`
     }
     return `We're ${pct}% confident this anonymous visitor is ${personLabel}.`
 }
 
-function SignalRow({ signal }: { signal: Signal }): JSX.Element {
+function CompareSection({
+    title,
+    fields,
+    link,
+}: {
+    title: string
+    fields: PersonFieldSpec[]
+    link: IdentityMatchingLinkApi
+}): JSX.Element | null {
+    const rows = fields
+        .map((field) => ({
+            label: field.label,
+            orphan: personField(link.orphan_person, field.key),
+            anchor: personField(link.anchor_person, field.key),
+        }))
+        .filter((row) => row.orphan !== null || row.anchor !== null)
+
+    if (rows.length === 0) {
+        return null
+    }
+
     return (
-        <div className="flex items-start gap-2 py-1.5">
-            <Tooltip title={STRENGTH_LABELS[signal.strength]}>
-                <div className="flex shrink-0 pt-0.5">
-                    {Array.from({ length: 3 }, (_, i) => (
+        <div>
+            <div className="text-xs font-semibold text-tertiary mb-1">{title}</div>
+            <div className="flex flex-col">
+                {rows.map((row) => {
+                    const isMatch =
+                        row.orphan !== null &&
+                        row.anchor !== null &&
+                        row.orphan.toLowerCase() === row.anchor.toLowerCase()
+                    return (
                         <div
-                            key={i}
-                            className={`size-1.5 rounded-full mr-0.5 ${
-                                i < signal.strength ? 'bg-accent' : 'bg-border'
-                            }`}
-                        />
-                    ))}
-                </div>
-            </Tooltip>
-            <div className="min-w-0">
-                <span className="text-sm font-medium">{signal.label}</span>
-                <p className="text-xs text-tertiary mt-0.5">{signal.description}</p>
+                            key={row.label}
+                            className={`${COMPARE_GRID} items-center py-1 border-b border-border last:border-0`}
+                        >
+                            <span className="text-xs text-tertiary">{row.label}</span>
+                            <span className="text-sm truncate" title={row.orphan ?? undefined}>
+                                {row.orphan ?? <span className="text-muted">—</span>}
+                            </span>
+                            <span
+                                className={`text-sm flex items-center gap-1 ${isMatch ? 'text-success font-medium' : ''}`}
+                            >
+                                <span className="truncate" title={row.anchor ?? undefined}>
+                                    {row.anchor ?? <span className="text-muted">—</span>}
+                                </span>
+                                {isMatch && (
+                                    <Tooltip title="Same value on both sides">
+                                        <IconCheck className="shrink-0" />
+                                    </Tooltip>
+                                )}
+                            </span>
+                        </div>
+                    )
+                })}
             </div>
         </div>
     )
 }
 
-function EvidenceSection({ category, signals }: { category: SignalCategory; signals: Signal[] }): JSX.Element | null {
-    if (signals.length === 0) {
-        return null
-    }
+function PersonCard({
+    label,
+    link,
+    side,
+}: {
+    label: string
+    link: IdentityMatchingLinkApi
+    side: 'orphan' | 'anchor'
+}): JSX.Element {
+    const person = side === 'orphan' ? link.orphan_person : link.anchor_person
+    const distinctId = side === 'orphan' ? link.orphan_distinct_id : link.anchor_person_key
+    const email = person?.email ?? extractEmail(distinctId)
+
     return (
-        <div>
-            <div className="flex items-center gap-2 mb-2">
-                <span className="text-base text-secondary">{CATEGORY_ICON[category]}</span>
-                <h4 className="text-sm font-semibold">{CATEGORY_LABELS[category]}</h4>
-            </div>
-            <p className="text-xs text-tertiary mb-2">{CATEGORY_DESCRIPTIONS[category]}</p>
-            <div className="divide-y divide-border">
-                {signals.map((signal, i) => (
-                    <SignalRow key={i} signal={signal} />
-                ))}
+        <div className="flex-1 min-w-0 rounded-lg border border-primary p-3">
+            <div className="text-xs text-tertiary mb-1">{label}</div>
+            <PersonDisplay person={linkPersonDisplay(person, distinctId)} noPopover withIcon="sm" />
+            {!email && <div className="font-mono text-xs text-muted mt-1 truncate">{distinctId}</div>}
+            <div className="mt-2 space-y-0.5 text-xs text-tertiary">
+                {person?.first_seen && (
+                    <div>
+                        First seen{' '}
+                        <span className="text-secondary">{dayjs(person.first_seen).format('MMM D, YYYY HH:mm')}</span>
+                    </div>
+                )}
+                {person?.last_seen && (
+                    <div>
+                        Last seen{' '}
+                        <span className="text-secondary">{dayjs(person.last_seen).format('MMM D, YYYY HH:mm')}</span>
+                    </div>
+                )}
             </div>
         </div>
     )
@@ -89,89 +146,107 @@ function EvidenceSection({ category, signals }: { category: SignalCategory; sign
 export function IdentityMatchingDetail({ link }: { link: IdentityMatchingLinkApi }): JSX.Element {
     const confidence = normalizedScore(link)
     const signals = extractSignals(link)
-    const orphanEmail = extractEmail(link.orphan_distinct_id)
-    const anchorEmail = extractEmail(link.anchor_person_key)
     const pct = Math.round(confidence * 100)
+    const tagType = pct >= 70 ? 'success' : pct >= 40 ? 'warning' : 'default'
+    const barColor = pct >= 70 ? 'bg-success' : pct >= 40 ? 'bg-warning' : 'bg-muted'
 
     return (
-        <div className="space-y-6">
+        <div className="space-y-4">
             {/* The match */}
             <div>
-                <div className="flex items-center gap-4 mb-3">
-                    <div className="flex-1 rounded-lg border border-primary p-3">
-                        <div className="text-xs text-tertiary mb-1">Anonymous visitor</div>
-                        <PersonDisplay person={personFromDistinctId(link.orphan_distinct_id)} noPopover withIcon="sm" />
-                        {!orphanEmail && (
-                            <div className="font-mono text-xs text-muted mt-1">{link.orphan_distinct_id}</div>
-                        )}
-                    </div>
+                <div className="flex items-center gap-3 mb-2">
+                    <PersonCard label="Anonymous visitor" link={link} side="orphan" />
                     <IconArrowRight className="text-xl text-tertiary shrink-0" />
-                    <div className="flex-1 rounded-lg border border-primary p-3">
-                        <div className="text-xs text-tertiary mb-1">Identified person</div>
-                        <PersonDisplay person={personFromDistinctId(link.anchor_person_key)} noPopover withIcon="sm" />
-                        {!anchorEmail && (
-                            <div className="font-mono text-xs text-muted mt-1">{link.anchor_person_key}</div>
-                        )}
-                    </div>
+                    <PersonCard label="Identified person" link={link} side="anchor" />
                 </div>
                 <p className="text-sm text-secondary">{matchSummary(link, confidence)}</p>
             </div>
 
-            {/* Confidence */}
+            {/* At a glance — the two persons' properties, side by side, for human validation */}
             <div className="rounded-lg border border-primary p-4">
                 <div className="flex items-center justify-between mb-2">
-                    <h4 className="text-sm font-semibold">Confidence assessment</h4>
-                    <LemonTag
-                        type={pct >= 70 ? 'success' : pct >= 40 ? 'warning' : 'default'}
-                    >{`${pct}% confident`}</LemonTag>
+                    <h4 className="text-sm font-semibold">At a glance</h4>
+                    <span className="text-xs text-tertiary">Green = same value on both sides</span>
                 </div>
-                <div className="flex items-center gap-2 mb-3">
-                    <div className="flex-1 h-2 rounded-full bg-bg-light overflow-hidden">
-                        <div
-                            className={`h-full rounded-full ${
-                                pct >= 70 ? 'bg-success' : pct >= 40 ? 'bg-warning' : 'bg-muted'
-                            }`}
-                            style={{ width: `${pct}%` }}
-                        />
-                    </div>
+                <div className={`${COMPARE_GRID} text-xs font-semibold text-tertiary border-b border-border pb-1 mb-1`}>
+                    <span />
+                    <span>Visitor</span>
+                    <span>Person</span>
                 </div>
-                <div className="grid grid-cols-2 gap-2 text-xs">
-                    <div>
-                        <span className="text-tertiary">Model</span>
-                        <div className="mt-0.5">
-                            <LemonTag>{link.model_version}</LemonTag>
-                        </div>
-                    </div>
-                    <div>
-                        <span className="text-tertiary">Confidence gap</span>
-                        <Tooltip title="How much this score exceeds the next-best candidate. A larger gap means fewer competing matches.">
-                            <div className="mt-0.5 font-mono">{link.margin.toFixed(2)}</div>
-                        </Tooltip>
-                    </div>
-                    <div>
-                        <span className="text-tertiary">Raw score</span>
-                        <Tooltip title="The model's unnormalized score. For rules_v1 this is a weighted point sum; for logreg_v1 it's a 0–1 probability.">
-                            <div className="mt-0.5 font-mono">{link.score.toFixed(2)}</div>
-                        </Tooltip>
-                    </div>
-                    <div>
-                        <span className="text-tertiary">Computed</span>
-                        <div className="mt-0.5">{dayjs(link.computed_at).format('MMM D, YYYY HH:mm')}</div>
-                    </div>
+                <div className="space-y-2">
+                    <CompareSection title="Location & device" fields={PERSON_SIGNAL_FIELDS} link={link} />
+                    <CompareSection title="Campaign" fields={PERSON_CAMPAIGN_FIELDS} link={link} />
+                </div>
+                {!link.orphan_person && !link.anchor_person && (
+                    <p className="text-xs text-tertiary mt-1">
+                        No person profiles were resolved for these distinct IDs, so there are no properties to compare.
+                    </p>
+                )}
+            </div>
+
+            {/* Why we matched — compact: one row per category, descriptions in tooltips */}
+            <div>
+                <h4 className="text-sm font-semibold mb-2">Why we matched them</h4>
+                <div className="flex flex-col gap-1.5">
+                    {CATEGORY_ORDER.map((category) => {
+                        const catSignals = signals.filter((s) => s.category === category)
+                        if (catSignals.length === 0) {
+                            return null
+                        }
+                        return (
+                            <div key={category} className="flex items-start gap-2">
+                                <span className="text-xs text-tertiary w-20 shrink-0 pt-1">
+                                    {CATEGORY_LABELS[category]}
+                                </span>
+                                <div className="flex flex-wrap gap-1">
+                                    {catSignals.map((signal, i) => (
+                                        <Tooltip
+                                            key={i}
+                                            title={`${STRENGTH_LABELS[signal.strength]} — ${signal.description}`}
+                                        >
+                                            <LemonTag type={CATEGORY_TAG_TYPE[category]}>{signal.label}</LemonTag>
+                                        </Tooltip>
+                                    ))}
+                                </div>
+                            </div>
+                        )
+                    })}
                 </div>
             </div>
 
-            {/* Evidence by category */}
-            <div className="space-y-5">
-                <h4 className="text-sm font-semibold">Why we matched them</h4>
-                {CATEGORY_ORDER.map((category) => {
-                    const catSignals = signals.filter((s) => s.category === category)
-                    return <EvidenceSection key={category} category={category} signals={catSignals} />
-                })}
+            {/* Confidence — compact single line */}
+            <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs border-t border-border pt-3">
+                <span className="flex items-center gap-2">
+                    <span className="text-tertiary">Confidence</span>
+                    <span className="inline-block w-20 h-1.5 rounded-full bg-bg-light overflow-hidden">
+                        <span className={`block h-full rounded-full ${barColor}`} style={{ width: `${pct}%` }} />
+                    </span>
+                    <LemonTag type={tagType}>{pct}%</LemonTag>
+                </span>
+                <span className="flex items-center gap-1.5">
+                    <span className="text-tertiary">Model</span>
+                    <LemonTag>{link.model_version}</LemonTag>
+                </span>
+                <Tooltip title="The model's unnormalized score. For rules_v1 a weighted point sum; for logreg_v1 a 0–1 probability.">
+                    <span>
+                        <span className="text-tertiary">Raw score</span>{' '}
+                        <span className="font-mono">{link.score.toFixed(2)}</span>
+                    </span>
+                </Tooltip>
+                <Tooltip title="How much this score exceeds the next-best candidate. A larger gap means fewer competing matches.">
+                    <span>
+                        <span className="text-tertiary">Gap</span>{' '}
+                        <span className="font-mono">{link.margin.toFixed(2)}</span>
+                    </span>
+                </Tooltip>
+                <span>
+                    <span className="text-tertiary">Computed</span>{' '}
+                    {dayjs(link.computed_at).format('MMM D, YYYY HH:mm')}
+                </span>
             </div>
 
             {/* Actions */}
-            <div className="flex items-center gap-2 pt-2 border-t border-border">
+            <div className="flex items-center gap-2">
                 <LemonButton
                     size="small"
                     type="secondary"

--- a/products/growth/frontend/IdentityMatchingScene.stories.tsx
+++ b/products/growth/frontend/IdentityMatchingScene.stories.tsx
@@ -5,12 +5,38 @@ import { urls } from 'scenes/urls'
 
 import { mswDecorator } from '~/mocks/browser'
 
-import type { IdentityMatchingLinkApi, IdentityMatchingRunApi } from './generated/api.schemas'
+import type {
+    IdentityMatchingLinkApi,
+    IdentityMatchingPersonApi,
+    IdentityMatchingRunApi,
+} from './generated/api.schemas'
 
 const RUN_A = '0197a4a6-06d9-7000-34fe-daa2e2afb501'
 const RUN_B = '0197a4a6-06d9-7000-34fe-daa2e2afb502'
 
-const LINKS_RESULT: IdentityMatchingLinkApi[] = [
+function person(distinct_id: string, overrides: Partial<IdentityMatchingPersonApi>): IdentityMatchingPersonApi {
+    return {
+        distinct_id,
+        first_seen: '2023-01-15T10:20:00Z',
+        last_seen: '2023-02-01T09:25:00Z',
+        email: null,
+        name: null,
+        city: null,
+        country: null,
+        browser: null,
+        os: null,
+        device_type: null,
+        timezone: null,
+        utm_source: null,
+        utm_medium: null,
+        utm_campaign: null,
+        referring_domain: null,
+        gclid: null,
+        ...overrides,
+    }
+}
+
+const BASE_LINKS: Omit<IdentityMatchingLinkApi, 'orphan_person' | 'anchor_person'>[] = [
     {
         job_id: RUN_A,
         model_version: 'rules_v1',
@@ -150,6 +176,110 @@ const LINKS_RESULT: IdentityMatchingLinkApi[] = [
         anchor_paid_touch: false,
     },
 ]
+
+// Resolved persons keyed by distinct ID. Links to the same identity (e.g. the rules + logreg links
+// for Anna) share these. A null entry exercises the "no profile resolved" fallback.
+const PERSON_BY_DISTINCT_ID: Record<string, IdentityMatchingPersonApi | null> = {
+    '0190a1b2-phone-3c4d-5e6f-anna00000001': person('0190a1b2-phone-3c4d-5e6f-anna00000001', {
+        city: 'Lisbon',
+        country: 'PT',
+        browser: 'Mobile Safari',
+        os: 'iOS',
+        device_type: 'Mobile',
+        timezone: 'Europe/Lisbon',
+        utm_source: 'google',
+        utm_medium: 'cpc',
+        utm_campaign: 'spring_sale_2026',
+        referring_domain: 'google.com',
+        gclid: 'Cj0KCQiAexampleLISBON',
+    }),
+    'anna@example.com': person('anna@example.com', {
+        email: 'anna@example.com',
+        name: 'Anna Müller',
+        city: 'Lisbon',
+        country: 'PT',
+        browser: 'Chrome',
+        os: 'macOS',
+        device_type: 'Desktop',
+        timezone: 'Europe/Lisbon',
+    }),
+    '0190a1b2-webview-3c4d-5e6f-cara00000001': person('0190a1b2-webview-3c4d-5e6f-cara00000001', {
+        city: 'Berlin',
+        country: 'DE',
+        browser: 'Chrome WebView',
+        os: 'Android',
+        device_type: 'Mobile',
+        timezone: 'Europe/Berlin',
+        utm_source: 'linkedin',
+        utm_medium: 'paid',
+        utm_campaign: 'q2_webinar',
+        referring_domain: 'lnkd.in',
+    }),
+    'cara@example.com': person('cara@example.com', {
+        email: 'cara@example.com',
+        name: 'Cara Lopes',
+        city: 'Berlin',
+        country: 'DE',
+        browser: 'Chrome WebView',
+        os: 'Android',
+        device_type: 'Mobile',
+        timezone: 'Europe/Berlin',
+        utm_source: 'linkedin',
+        utm_medium: 'paid',
+        utm_campaign: 'q2_webinar',
+        referring_domain: 'lnkd.in',
+    }),
+    '0190a1b2-phone-3c4d-5e6f-bob000000001': person('0190a1b2-phone-3c4d-5e6f-bob000000001', {
+        city: 'New York',
+        country: 'US',
+        browser: 'Mobile Safari',
+        os: 'iOS',
+        device_type: 'Mobile',
+        timezone: 'America/New_York',
+    }),
+    'bob@example.com': person('bob@example.com', {
+        email: 'bob@example.com',
+        city: 'New York',
+        country: 'US',
+        browser: 'Chrome',
+        os: 'Windows',
+        device_type: 'Desktop',
+        timezone: 'America/New_York',
+    }),
+    '0190a1b2-tablet-3c4d-5e6f-dana00000001': person('0190a1b2-tablet-3c4d-5e6f-dana00000001', {
+        city: 'London',
+        country: 'GB',
+        browser: 'Safari',
+        os: 'iPadOS',
+        device_type: 'Tablet',
+        timezone: 'Europe/London',
+    }),
+    'dana@example.com': person('dana@example.com', {
+        email: 'dana@example.com',
+        city: 'Manchester',
+        country: 'GB',
+        browser: 'Chrome',
+        os: 'Windows',
+        device_type: 'Desktop',
+        timezone: 'Europe/London',
+        utm_source: 'bing',
+        utm_medium: 'cpc',
+        utm_campaign: 'brand',
+    }),
+    '0190a1b2-anon-3c4d-5e6f-eve0000000001': null,
+    '0190a1b2-user-3c4d-5e6f-eve0000000002': person('0190a1b2-user-3c4d-5e6f-eve0000000002', {
+        browser: 'Firefox',
+        os: 'Linux',
+        device_type: 'Desktop',
+        timezone: 'UTC',
+    }),
+}
+
+const LINKS_RESULT: IdentityMatchingLinkApi[] = BASE_LINKS.map((link) => ({
+    ...link,
+    orphan_person: PERSON_BY_DISTINCT_ID[link.orphan_distinct_id] ?? null,
+    anchor_person: PERSON_BY_DISTINCT_ID[link.anchor_person_key] ?? null,
+}))
 
 const RUNS_RESULT: IdentityMatchingRunApi[] = [
     {

--- a/products/growth/frontend/IdentityMatchingScene.tsx
+++ b/products/growth/frontend/IdentityMatchingScene.tsx
@@ -6,6 +6,7 @@ import {
     LemonBanner,
     LemonButton,
     LemonInput,
+    LemonModal,
     LemonSegmentedButton,
     LemonSelect,
     LemonTab,
@@ -22,7 +23,6 @@ import { AccessDenied } from 'lib/components/AccessDenied'
 import { downloadBlob } from 'lib/components/ExportButton/exporter'
 import { dayjs } from 'lib/dayjs'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
-import { LemonDrawer } from 'lib/lemon-ui/LemonDrawer/LemonDrawer'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
@@ -41,8 +41,8 @@ import {
     type SignalCategory,
     computeTierStats,
     extractSignals,
+    linkPersonDisplay,
     normalizedScore,
-    personFromDistinctId,
 } from './identityMatchingUtils'
 import { PaidAttributionTimeline } from './PaidAttributionTimeline'
 import { RunsHistory } from './RunsHistory'
@@ -224,7 +224,7 @@ export function IdentityMatchingScene(): JSX.Element {
     } = useValues(identityMatchingLogic)
     const { setFilters, setPage, setActiveTab } = useActions(identityMatchingLogic)
 
-    const [drawerLink, setDrawerLink] = useState<IdentityMatchingLinkApi | null>(null)
+    const [detailLink, setDetailLink] = useState<IdentityMatchingLinkApi | null>(null)
 
     if (!user?.is_staff) {
         return <AccessDenied object="page" reason="Identity matching is limited to staff users while in development." />
@@ -238,7 +238,11 @@ export function IdentityMatchingScene(): JSX.Element {
             dataIndex: 'orphan_distinct_id',
             render: (_, link) => (
                 <Link to={urls.personByDistinctId(link.orphan_distinct_id)}>
-                    <PersonDisplay person={personFromDistinctId(link.orphan_distinct_id)} noPopover withIcon="sm" />
+                    <PersonDisplay
+                        person={linkPersonDisplay(link.orphan_person, link.orphan_distinct_id)}
+                        noPopover
+                        withIcon="sm"
+                    />
                 </Link>
             ),
         },
@@ -247,7 +251,11 @@ export function IdentityMatchingScene(): JSX.Element {
             dataIndex: 'anchor_person_key',
             render: (_, link) => (
                 <Link to={urls.personByDistinctId(link.anchor_person_key)}>
-                    <PersonDisplay person={personFromDistinctId(link.anchor_person_key)} noPopover withIcon="sm" />
+                    <PersonDisplay
+                        person={linkPersonDisplay(link.anchor_person, link.anchor_person_key)}
+                        noPopover
+                        withIcon="sm"
+                    />
                 </Link>
             ),
         },
@@ -434,7 +442,7 @@ export function IdentityMatchingScene(): JSX.Element {
                             }}
                             nouns={['link', 'links']}
                             onRow={(link) => ({
-                                onClick: () => setDrawerLink(link),
+                                onClick: () => setDetailLink(link),
                                 className: 'cursor-pointer',
                             })}
                         />
@@ -485,10 +493,10 @@ export function IdentityMatchingScene(): JSX.Element {
                 tabs={tabs}
                 sceneInset
             />
-            <LemonDrawer
-                isOpen={drawerLink !== null}
-                onClose={() => setDrawerLink(null)}
-                width="60vw"
+            <LemonModal
+                isOpen={detailLink !== null}
+                onClose={() => setDetailLink(null)}
+                width="56rem"
                 title={
                     <div className="flex items-center gap-2">
                         <IconPerson className="text-lg" />
@@ -496,8 +504,8 @@ export function IdentityMatchingScene(): JSX.Element {
                     </div>
                 }
             >
-                {drawerLink && <IdentityMatchingDetail link={drawerLink} />}
-            </LemonDrawer>
+                {detailLink && <IdentityMatchingDetail link={detailLink} />}
+            </LemonModal>
         </SceneContent>
     )
 }

--- a/products/growth/frontend/PaidAttributionTimeline.tsx
+++ b/products/growth/frontend/PaidAttributionTimeline.tsx
@@ -5,8 +5,61 @@ import { dayjs } from 'lib/dayjs'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { urls } from 'scenes/urls'
 
-import type { IdentityMatchingLinkApi } from './generated/api.schemas'
-import { normalizedScore, personFromDistinctId } from './identityMatchingUtils'
+import type { IdentityMatchingLinkApi, IdentityMatchingPersonApi } from './generated/api.schemas'
+import {
+    PERSON_CAMPAIGN_FIELDS,
+    hasCampaign,
+    linkPersonDisplay,
+    normalizedScore,
+    personField,
+} from './identityMatchingUtils'
+
+/** Compact one-line campaign descriptor for a person, e.g. "google · cpc · spring_sale" or a referrer. */
+function campaignLabel(person: IdentityMatchingPersonApi | null | undefined): string | null {
+    const parts = [
+        personField(person, 'utm_source'),
+        personField(person, 'utm_medium'),
+        personField(person, 'utm_campaign'),
+    ].filter((value): value is string => value !== null)
+    if (parts.length > 0) {
+        return parts.join(' · ')
+    }
+    return personField(person, 'referring_domain')
+}
+
+function CampaignAttribution({ link }: { link: IdentityMatchingLinkApi }): JSX.Element | null {
+    if (!hasCampaign(link.orphan_person) && !hasCampaign(link.anchor_person)) {
+        return null
+    }
+    const rows = PERSON_CAMPAIGN_FIELDS.map((field) => ({
+        label: field.label,
+        orphan: personField(link.orphan_person, field.key),
+        anchor: personField(link.anchor_person, field.key),
+    })).filter((row) => row.orphan !== null || row.anchor !== null)
+
+    return (
+        <div className="rounded-md bg-bg-light border border-border p-2 text-xs">
+            <div className="grid grid-cols-[6rem_minmax(0,1fr)_minmax(0,1fr)] gap-x-3 font-semibold text-tertiary pb-1 mb-1 border-b border-border">
+                <span>Campaign</span>
+                <span>Visitor</span>
+                <span>Person</span>
+            </div>
+            <div className="flex flex-col gap-0.5">
+                {rows.map((row) => (
+                    <div key={row.label} className="grid grid-cols-[6rem_minmax(0,1fr)_minmax(0,1fr)] gap-x-3">
+                        <span className="text-tertiary">{row.label}</span>
+                        <span className="truncate" title={row.orphan ?? undefined}>
+                            {row.orphan ?? <span className="text-muted">—</span>}
+                        </span>
+                        <span className="truncate" title={row.anchor ?? undefined}>
+                            {row.anchor ?? <span className="text-muted">—</span>}
+                        </span>
+                    </div>
+                ))}
+            </div>
+        </div>
+    )
+}
 
 interface TimelineStep {
     label: string
@@ -76,12 +129,20 @@ function PaidTimelineCard({ link }: { link: IdentityMatchingLinkApi }): JSX.Elem
             <div className="flex items-center gap-3">
                 <div className="flex-1 min-w-0">
                     <div className="text-xs text-tertiary mb-0.5">Anonymous visitor</div>
-                    <PersonDisplay person={personFromDistinctId(link.orphan_distinct_id)} noPopover withIcon="sm" />
+                    <PersonDisplay
+                        person={linkPersonDisplay(link.orphan_person, link.orphan_distinct_id)}
+                        noPopover
+                        withIcon="sm"
+                    />
                 </div>
                 <IconArrowRight className="text-lg text-tertiary shrink-0" />
                 <div className="flex-1 min-w-0">
                     <div className="text-xs text-tertiary mb-0.5">Identified person</div>
-                    <PersonDisplay person={personFromDistinctId(link.anchor_person_key)} noPopover withIcon="sm" />
+                    <PersonDisplay
+                        person={linkPersonDisplay(link.anchor_person, link.anchor_person_key)}
+                        noPopover
+                        withIcon="sm"
+                    />
                 </div>
                 <div className="shrink-0 text-right">
                     <LemonTag type={pct >= 70 ? 'success' : pct >= 40 ? 'warning' : 'default'}>{pct}%</LemonTag>
@@ -109,6 +170,9 @@ function PaidTimelineCard({ link }: { link: IdentityMatchingLinkApi }): JSX.Elem
                     </div>
                 </div>
             </div>
+
+            {/* Campaign attribution — the recovered paid touch, plus the identified person's own campaign */}
+            <CampaignAttribution link={link} />
 
             {/* Footer */}
             <div className="flex items-center justify-between pt-2 border-t border-border">
@@ -144,15 +208,39 @@ function PaidAttributionTable({ links }: { links: IdentityMatchingLinkApi[] }): 
             title: 'Anonymous visitor',
             dataIndex: 'orphan_distinct_id',
             render: (_, link) => (
-                <PersonDisplay person={personFromDistinctId(link.orphan_distinct_id)} noPopover withIcon="sm" />
+                <PersonDisplay
+                    person={linkPersonDisplay(link.orphan_person, link.orphan_distinct_id)}
+                    noPopover
+                    withIcon="sm"
+                />
             ),
+        },
+        {
+            title: 'Visitor campaign',
+            key: 'orphan_campaign',
+            render: (_, link) => {
+                const label = campaignLabel(link.orphan_person)
+                return label ? <span className="text-xs">{label}</span> : <span className="text-muted">—</span>
+            },
         },
         {
             title: 'Identified person',
             dataIndex: 'anchor_person_key',
             render: (_, link) => (
-                <PersonDisplay person={personFromDistinctId(link.anchor_person_key)} noPopover withIcon="sm" />
+                <PersonDisplay
+                    person={linkPersonDisplay(link.anchor_person, link.anchor_person_key)}
+                    noPopover
+                    withIcon="sm"
+                />
             ),
+        },
+        {
+            title: 'Person campaign',
+            key: 'anchor_campaign',
+            render: (_, link) => {
+                const label = campaignLabel(link.anchor_person)
+                return label ? <span className="text-xs">{label}</span> : <span className="text-muted">—</span>
+            },
         },
         {
             title: 'Confidence',

--- a/products/growth/frontend/generated/api.schemas.ts
+++ b/products/growth/frontend/generated/api.schemas.ts
@@ -20,6 +20,90 @@ export const TierEnumApi = {
     Low: 'low',
 } as const
 
+/**
+ * The resolved person behind one side of a link, with a curated set of properties that mirror
+ * the match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.
+ */
+export interface IdentityMatchingPersonApi {
+    /** Distinct ID this person was resolved from. */
+    distinct_id: string
+    /**
+     * When this person was first seen — person created_at (UTC).
+     * @nullable
+     */
+    first_seen: string | null
+    /**
+     * When this person was last seen, when tracked — person last_seen_at (UTC).
+     * @nullable
+     */
+    last_seen: string | null
+    /**
+     * Person's email, when set.
+     * @nullable
+     */
+    email: string | null
+    /**
+     * Person's name property, when set.
+     * @nullable
+     */
+    name: string | null
+    /**
+     * GeoIP city ($geoip_city_name).
+     * @nullable
+     */
+    city: string | null
+    /**
+     * GeoIP country code ($geoip_country_code).
+     * @nullable
+     */
+    country: string | null
+    /**
+     * Browser ($browser).
+     * @nullable
+     */
+    browser: string | null
+    /**
+     * Operating system ($os).
+     * @nullable
+     */
+    os: string | null
+    /**
+     * Device type, e.g. Desktop or Mobile ($device_type).
+     * @nullable
+     */
+    device_type: string | null
+    /**
+     * Browser timezone ($timezone).
+     * @nullable
+     */
+    timezone: string | null
+    /**
+     * Initial campaign source ($initial_utm_source).
+     * @nullable
+     */
+    utm_source: string | null
+    /**
+     * Initial campaign medium ($initial_utm_medium).
+     * @nullable
+     */
+    utm_medium: string | null
+    /**
+     * Initial campaign name ($initial_utm_campaign).
+     * @nullable
+     */
+    utm_campaign: string | null
+    /**
+     * Initial referring domain ($initial_referring_domain).
+     * @nullable
+     */
+    referring_domain: string | null
+    /**
+     * Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.
+     * @nullable
+     */
+    gclid: string | null
+}
+
 export interface IdentityMatchingLinkApi {
     /** Identity matching run that produced this link. */
     job_id: string
@@ -67,6 +151,10 @@ export interface IdentityMatchingLinkApi {
     orphan_paid_touch: boolean
     /** The matched person already had a paid click ID inside the window. */
     anchor_paid_touch: boolean
+    /** Resolved person behind the anonymous distinct ID; null when no profile exists for it. */
+    orphan_person: IdentityMatchingPersonApi | null
+    /** Resolved identified person behind the matched person key; null when no profile exists for it. */
+    anchor_person: IdentityMatchingPersonApi | null
 }
 
 export interface IdentityMatchingLinksResponseApi {

--- a/products/growth/frontend/generated/api.zod.schemas.ts
+++ b/products/growth/frontend/generated/api.zod.schemas.ts
@@ -16,6 +16,43 @@ export const TierEnumApi = zod
 export type TierEnumApi = zod.input<typeof TierEnumApi>
 export type TierEnumApiOutput = zod.output<typeof TierEnumApi>
 
+export const IdentityMatchingPersonApi = zod
+    .object({
+        distinct_id: zod.string().describe('Distinct ID this person was resolved from.'),
+        first_seen: zod.iso
+            .datetime({ offset: true })
+            .nullable()
+            .describe('When this person was first seen — person created_at (UTC).'),
+        last_seen: zod.iso
+            .datetime({ offset: true })
+            .nullable()
+            .describe('When this person was last seen, when tracked — person last_seen_at (UTC).'),
+        email: zod.string().nullable().describe("Person's email, when set."),
+        name: zod.string().nullable().describe("Person's name property, when set."),
+        city: zod.string().nullable().describe('GeoIP city ($geoip_city_name).'),
+        country: zod.string().nullable().describe('GeoIP country code ($geoip_country_code).'),
+        browser: zod.string().nullable().describe('Browser ($browser).'),
+        os: zod.string().nullable().describe('Operating system ($os).'),
+        device_type: zod.string().nullable().describe('Device type, e.g. Desktop or Mobile ($device_type).'),
+        timezone: zod.string().nullable().describe('Browser timezone ($timezone).'),
+        utm_source: zod.string().nullable().describe('Initial campaign source ($initial_utm_source).'),
+        utm_medium: zod.string().nullable().describe('Initial campaign medium ($initial_utm_medium).'),
+        utm_campaign: zod.string().nullable().describe('Initial campaign name ($initial_utm_campaign).'),
+        referring_domain: zod.string().nullable().describe('Initial referring domain ($initial_referring_domain).'),
+        gclid: zod
+            .string()
+            .nullable()
+            .describe(
+                'Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.'
+            ),
+    })
+    .describe(
+        'The resolved person behind one side of a link, with a curated set of properties that mirror\nthe match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.'
+    )
+
+export type IdentityMatchingPersonApi = zod.input<typeof IdentityMatchingPersonApi>
+export type IdentityMatchingPersonApiOutput = zod.output<typeof IdentityMatchingPersonApi>
+
 export const IdentityMatchingLinkApi = zod.object({
     job_id: zod.uuid().describe('Identity matching run that produced this link.'),
     model_version: zod.string().describe("Scoring model that produced the link, e.g. 'rules_v1' or 'logreg_v1'."),
@@ -49,6 +86,94 @@ export const IdentityMatchingLinkApi = zod.object({
         .boolean()
         .describe('The orphan arrived via a paid click ID (gclid, li_fat_id, ...) inside the window.'),
     anchor_paid_touch: zod.boolean().describe('The matched person already had a paid click ID inside the window.'),
+    orphan_person: zod
+        .union([
+            zod
+                .object({
+                    distinct_id: zod.string().describe('Distinct ID this person was resolved from.'),
+                    first_seen: zod.iso
+                        .datetime({ offset: true })
+                        .nullable()
+                        .describe('When this person was first seen — person created_at (UTC).'),
+                    last_seen: zod.iso
+                        .datetime({ offset: true })
+                        .nullable()
+                        .describe('When this person was last seen, when tracked — person last_seen_at (UTC).'),
+                    email: zod.string().nullable().describe("Person's email, when set."),
+                    name: zod.string().nullable().describe("Person's name property, when set."),
+                    city: zod.string().nullable().describe('GeoIP city ($geoip_city_name).'),
+                    country: zod.string().nullable().describe('GeoIP country code ($geoip_country_code).'),
+                    browser: zod.string().nullable().describe('Browser ($browser).'),
+                    os: zod.string().nullable().describe('Operating system ($os).'),
+                    device_type: zod
+                        .string()
+                        .nullable()
+                        .describe('Device type, e.g. Desktop or Mobile ($device_type).'),
+                    timezone: zod.string().nullable().describe('Browser timezone ($timezone).'),
+                    utm_source: zod.string().nullable().describe('Initial campaign source ($initial_utm_source).'),
+                    utm_medium: zod.string().nullable().describe('Initial campaign medium ($initial_utm_medium).'),
+                    utm_campaign: zod.string().nullable().describe('Initial campaign name ($initial_utm_campaign).'),
+                    referring_domain: zod
+                        .string()
+                        .nullable()
+                        .describe('Initial referring domain ($initial_referring_domain).'),
+                    gclid: zod
+                        .string()
+                        .nullable()
+                        .describe(
+                            'Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.'
+                        ),
+                })
+                .describe(
+                    'The resolved person behind one side of a link, with a curated set of properties that mirror\nthe match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.'
+                ),
+            zod.null(),
+        ])
+        .describe('Resolved person behind the anonymous distinct ID; null when no profile exists for it.'),
+    anchor_person: zod
+        .union([
+            zod
+                .object({
+                    distinct_id: zod.string().describe('Distinct ID this person was resolved from.'),
+                    first_seen: zod.iso
+                        .datetime({ offset: true })
+                        .nullable()
+                        .describe('When this person was first seen — person created_at (UTC).'),
+                    last_seen: zod.iso
+                        .datetime({ offset: true })
+                        .nullable()
+                        .describe('When this person was last seen, when tracked — person last_seen_at (UTC).'),
+                    email: zod.string().nullable().describe("Person's email, when set."),
+                    name: zod.string().nullable().describe("Person's name property, when set."),
+                    city: zod.string().nullable().describe('GeoIP city ($geoip_city_name).'),
+                    country: zod.string().nullable().describe('GeoIP country code ($geoip_country_code).'),
+                    browser: zod.string().nullable().describe('Browser ($browser).'),
+                    os: zod.string().nullable().describe('Operating system ($os).'),
+                    device_type: zod
+                        .string()
+                        .nullable()
+                        .describe('Device type, e.g. Desktop or Mobile ($device_type).'),
+                    timezone: zod.string().nullable().describe('Browser timezone ($timezone).'),
+                    utm_source: zod.string().nullable().describe('Initial campaign source ($initial_utm_source).'),
+                    utm_medium: zod.string().nullable().describe('Initial campaign medium ($initial_utm_medium).'),
+                    utm_campaign: zod.string().nullable().describe('Initial campaign name ($initial_utm_campaign).'),
+                    referring_domain: zod
+                        .string()
+                        .nullable()
+                        .describe('Initial referring domain ($initial_referring_domain).'),
+                    gclid: zod
+                        .string()
+                        .nullable()
+                        .describe(
+                            'Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.'
+                        ),
+                })
+                .describe(
+                    'The resolved person behind one side of a link, with a curated set of properties that mirror\nthe match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.'
+                ),
+            zod.null(),
+        ])
+        .describe('Resolved identified person behind the matched person key; null when no profile exists for it.'),
 })
 
 export type IdentityMatchingLinkApi = zod.input<typeof IdentityMatchingLinkApi>
@@ -102,6 +227,118 @@ export const IdentityMatchingLinksResponseApi = zod.object({
                 anchor_paid_touch: zod
                     .boolean()
                     .describe('The matched person already had a paid click ID inside the window.'),
+                orphan_person: zod
+                    .union([
+                        zod
+                            .object({
+                                distinct_id: zod.string().describe('Distinct ID this person was resolved from.'),
+                                first_seen: zod.iso
+                                    .datetime({ offset: true })
+                                    .nullable()
+                                    .describe('When this person was first seen — person created_at (UTC).'),
+                                last_seen: zod.iso
+                                    .datetime({ offset: true })
+                                    .nullable()
+                                    .describe(
+                                        'When this person was last seen, when tracked — person last_seen_at (UTC).'
+                                    ),
+                                email: zod.string().nullable().describe("Person's email, when set."),
+                                name: zod.string().nullable().describe("Person's name property, when set."),
+                                city: zod.string().nullable().describe('GeoIP city ($geoip_city_name).'),
+                                country: zod.string().nullable().describe('GeoIP country code ($geoip_country_code).'),
+                                browser: zod.string().nullable().describe('Browser ($browser).'),
+                                os: zod.string().nullable().describe('Operating system ($os).'),
+                                device_type: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Device type, e.g. Desktop or Mobile ($device_type).'),
+                                timezone: zod.string().nullable().describe('Browser timezone ($timezone).'),
+                                utm_source: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign source ($initial_utm_source).'),
+                                utm_medium: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign medium ($initial_utm_medium).'),
+                                utm_campaign: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign name ($initial_utm_campaign).'),
+                                referring_domain: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial referring domain ($initial_referring_domain).'),
+                                gclid: zod
+                                    .string()
+                                    .nullable()
+                                    .describe(
+                                        'Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.'
+                                    ),
+                            })
+                            .describe(
+                                'The resolved person behind one side of a link, with a curated set of properties that mirror\nthe match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.'
+                            ),
+                        zod.null(),
+                    ])
+                    .describe('Resolved person behind the anonymous distinct ID; null when no profile exists for it.'),
+                anchor_person: zod
+                    .union([
+                        zod
+                            .object({
+                                distinct_id: zod.string().describe('Distinct ID this person was resolved from.'),
+                                first_seen: zod.iso
+                                    .datetime({ offset: true })
+                                    .nullable()
+                                    .describe('When this person was first seen — person created_at (UTC).'),
+                                last_seen: zod.iso
+                                    .datetime({ offset: true })
+                                    .nullable()
+                                    .describe(
+                                        'When this person was last seen, when tracked — person last_seen_at (UTC).'
+                                    ),
+                                email: zod.string().nullable().describe("Person's email, when set."),
+                                name: zod.string().nullable().describe("Person's name property, when set."),
+                                city: zod.string().nullable().describe('GeoIP city ($geoip_city_name).'),
+                                country: zod.string().nullable().describe('GeoIP country code ($geoip_country_code).'),
+                                browser: zod.string().nullable().describe('Browser ($browser).'),
+                                os: zod.string().nullable().describe('Operating system ($os).'),
+                                device_type: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Device type, e.g. Desktop or Mobile ($device_type).'),
+                                timezone: zod.string().nullable().describe('Browser timezone ($timezone).'),
+                                utm_source: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign source ($initial_utm_source).'),
+                                utm_medium: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign medium ($initial_utm_medium).'),
+                                utm_campaign: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial campaign name ($initial_utm_campaign).'),
+                                referring_domain: zod
+                                    .string()
+                                    .nullable()
+                                    .describe('Initial referring domain ($initial_referring_domain).'),
+                                gclid: zod
+                                    .string()
+                                    .nullable()
+                                    .describe(
+                                        'Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.'
+                                    ),
+                            })
+                            .describe(
+                                'The resolved person behind one side of a link, with a curated set of properties that mirror\nthe match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.'
+                            ),
+                        zod.null(),
+                    ])
+                    .describe(
+                        'Resolved identified person behind the matched person key; null when no profile exists for it.'
+                    ),
             })
         )
         .describe('Links ordered by score, descending.'),

--- a/products/growth/frontend/identityMatchingUtils.ts
+++ b/products/growth/frontend/identityMatchingUtils.ts
@@ -1,4 +1,4 @@
-import type { IdentityMatchingLinkApi } from './generated/api.schemas'
+import type { IdentityMatchingLinkApi, IdentityMatchingPersonApi } from './generated/api.schemas'
 
 /** Very permissive email format — matches the person-utils pattern. */
 const EMAIL_REGEX = /.+@.+\..+/i
@@ -8,13 +8,62 @@ export function extractEmail(identifier: string): string | null {
     return EMAIL_REGEX.test(identifier) ? identifier : null
 }
 
-/** Build a PersonPropType-shaped object from a distinct ID, attaching email when it looks like one. */
-export function personFromDistinctId(distinctId: string): {
-    properties?: Record<string, unknown>
-    distinct_id: string
-} {
-    const email = extractEmail(distinctId)
-    return email ? { properties: { email }, distinct_id: distinctId } : { distinct_id: distinctId }
+/**
+ * Build a PersonDisplay-shaped object for one side of a link, preferring the resolved person's real
+ * email/name and falling back to a distinct ID that already looks like an email. This is what makes
+ * people show by their email everywhere — table, dialog, and paid attribution.
+ */
+export function linkPersonDisplay(
+    person: IdentityMatchingPersonApi | null | undefined,
+    distinctId: string
+): { properties?: Record<string, unknown>; distinct_id: string } {
+    const email = person?.email ?? extractEmail(distinctId)
+    const properties: Record<string, unknown> = {}
+    if (email) {
+        properties.email = email
+    }
+    if (person?.name) {
+        properties.name = person.name
+    }
+    return Object.keys(properties).length > 0 ? { properties, distinct_id: distinctId } : { distinct_id: distinctId }
+}
+
+/** A non-empty property value to show, or null when the person is missing or the value is unset. */
+export function personField(
+    person: IdentityMatchingPersonApi | null | undefined,
+    key: keyof IdentityMatchingPersonApi
+): string | null {
+    const value = person?.[key]
+    return value != null && value !== '' ? String(value) : null
+}
+
+export interface PersonFieldSpec {
+    key: keyof IdentityMatchingPersonApi
+    label: string
+}
+
+/** Location/device fields shown side-by-side for match validation — they mirror the match signals. */
+export const PERSON_SIGNAL_FIELDS: PersonFieldSpec[] = [
+    { key: 'city', label: 'City' },
+    { key: 'country', label: 'Country' },
+    { key: 'browser', label: 'Browser' },
+    { key: 'os', label: 'OS' },
+    { key: 'device_type', label: 'Device' },
+    { key: 'timezone', label: 'Timezone' },
+]
+
+/** Campaign attribution fields — surfaced prominently in the paid attribution tab. */
+export const PERSON_CAMPAIGN_FIELDS: PersonFieldSpec[] = [
+    { key: 'utm_source', label: 'Source' },
+    { key: 'utm_medium', label: 'Medium' },
+    { key: 'utm_campaign', label: 'Campaign' },
+    { key: 'referring_domain', label: 'Referrer' },
+    { key: 'gclid', label: 'Google click ID' },
+]
+
+/** True when this person carries any campaign attribution worth showing. */
+export function hasCampaign(person: IdentityMatchingPersonApi | null | undefined): boolean {
+    return PERSON_CAMPAIGN_FIELDS.some((field) => personField(person, field.key) !== null)
 }
 
 export type Tier = 'high' | 'medium' | 'low'

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26126,6 +26126,90 @@ export namespace Schemas {
       Low: 'low',
     } as const;
 
+    /**
+     * The resolved person behind one side of a link, with a curated set of properties that mirror
+     * the match signals (geo, device, campaign) so a reviewer can judge whether the link is plausible.
+     */
+    export interface IdentityMatchingPerson {
+      /** Distinct ID this person was resolved from. */
+      distinct_id: string;
+      /**
+         * When this person was first seen — person created_at (UTC).
+         * @nullable
+         */
+      first_seen: string | null;
+      /**
+         * When this person was last seen, when tracked — person last_seen_at (UTC).
+         * @nullable
+         */
+      last_seen: string | null;
+      /**
+         * Person's email, when set.
+         * @nullable
+         */
+      email: string | null;
+      /**
+         * Person's name property, when set.
+         * @nullable
+         */
+      name: string | null;
+      /**
+         * GeoIP city ($geoip_city_name).
+         * @nullable
+         */
+      city: string | null;
+      /**
+         * GeoIP country code ($geoip_country_code).
+         * @nullable
+         */
+      country: string | null;
+      /**
+         * Browser ($browser).
+         * @nullable
+         */
+      browser: string | null;
+      /**
+         * Operating system ($os).
+         * @nullable
+         */
+      os: string | null;
+      /**
+         * Device type, e.g. Desktop or Mobile ($device_type).
+         * @nullable
+         */
+      device_type: string | null;
+      /**
+         * Browser timezone ($timezone).
+         * @nullable
+         */
+      timezone: string | null;
+      /**
+         * Initial campaign source ($initial_utm_source).
+         * @nullable
+         */
+      utm_source: string | null;
+      /**
+         * Initial campaign medium ($initial_utm_medium).
+         * @nullable
+         */
+      utm_medium: string | null;
+      /**
+         * Initial campaign name ($initial_utm_campaign).
+         * @nullable
+         */
+      utm_campaign: string | null;
+      /**
+         * Initial referring domain ($initial_referring_domain).
+         * @nullable
+         */
+      referring_domain: string | null;
+      /**
+         * Initial Google click ID ($initial_gclid); present when the person arrived via a paid Google ad.
+         * @nullable
+         */
+      gclid: string | null;
+    }
+
     export interface IdentityMatchingLink {
       /** Identity matching run that produced this link. */
       job_id: string;
@@ -26173,6 +26257,10 @@ export namespace Schemas {
       orphan_paid_touch: boolean;
       /** The matched person already had a paid click ID inside the window. */
       anchor_paid_touch: boolean;
+      /** Resolved person behind the anonymous distinct ID; null when no profile exists for it. */
+      orphan_person: IdentityMatchingPerson | null;
+      /** Resolved identified person behind the matched person key; null when no profile exists for it. */
+      anchor_person: IdentityMatchingPerson | null;
     }
 
     export interface IdentityMatchingLinksResponse {


### PR DESCRIPTION
## Problem

Identity matching surfaces probable links between anonymous visitors and identified persons, but the staff review UI couldn't answer the one question a reviewer actually has — "does this match make sense?" It only showed distinct-ID strings (pulling out an email when the ID happened to be one), never the real people behind a link or the dimensions the models scored on. Validating the algorithm by eye wasn't possible, and the recovered paid-attribution view didn't show which campaign a recovered touch came from.

## Changes

- The backend resolves the real person on each side of a link and attaches a curated, bounded set of properties chosen to mirror the match signals — email/name, geo, device, browser, timezone, and initial campaign attribution (utm/referrer/gclid) — plus each person's first/last-seen timestamps. Resolution is one batched lookup per page through the personhog-routed helper.
- The link detail moved from a side drawer to a centered **dialog** with an "At a glance" side-by-side comparison of the two people's properties, matching values highlighted, so a reviewer can judge a match in one look.
- "Why we matched" collapsed from large description blocks into compact chips with tooltips.
- The recovered paid-attribution view now shows the campaign attached to both the visitor and the identified person.
- People show by email everywhere (table, dialog, paid tab) when one resolves.

No schema or migration changes — this stays read-only over the existing stored links.

_Frontend changes; I'm an agent and didn't capture screenshots. The `IdentityMatching` Storybook stories were updated to exercise the dialog, comparison, campaign, and timestamp UI (visual regression runs in CI)._

## How did you test this code?

I'm an agent (Claude Code); automated checks I actually ran:

- Backend: `ruff` clean; the identity-matching API tests pass (16), including a new test that creates real persons and asserts the enriched property, email, campaign, and timestamp fields resolve — and that an unresolved distinct ID returns `null` rather than erroring. No existing test exercised person resolution.
- Frontend: `oxlint` clean, `oxfmt` applied, `tsgo` type-check clean for the changed files.
- Regenerated API types with `hogli build:openapi`.

No manual click-through in a running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Staff-gated feature still in development; no docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints`, `/adopting-generated-api-types`, `/writing-tests`.

The root issue was that the review UI never loaded real person data. I enriched on the backend — one batched, personhog-routed person lookup per page — rather than N per-row frontend fetches, so email, properties, and campaign all flow from one place and the table avoids ~100 calls per page. The returned property set is curated to mirror the match signals (so the comparison doubles as a validation tool) rather than dumping every property, keeping the payload bounded. The new backend test pins resolution to the ORM path because personhog is enabled in dev and keeps its own store that tests don't seed; its routing is covered elsewhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)