### PR TITLE
feat(signals): raise scout scratchpad search cap to 500 with date cursor

### DIFF
--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -289,6 +289,18 @@ class SearchMemoryQuerySerializer(serializers.Serializer):
         allow_blank=True,
         help_text="ILIKE substring match against `content`. Omit to return the most recent entries.",
     )
+    date_from = serializers.DateTimeField(
+        required=False,
+        help_text="ISO-8601 inclusive lower bound on `updated_at`. Omit to skip the lower bound.",
+    )
+    date_to = serializers.DateTimeField(
+        required=False,
+        help_text=(
+            "ISO-8601 exclusive upper bound on `updated_at`. Pass to walk back past the result "
+            "cap on subsequent calls (cursor-style: set to the `updated_at` of the oldest entry "
+            "from the prior page)."
+        ),
+    )
     keys_only = serializers.BooleanField(
         required=False,
         help_text=(
@@ -308,8 +320,8 @@ class SearchMemoryQuerySerializer(serializers.Serializer):
     limit = serializers.IntegerField(
         required=False,
         min_value=1,
-        max_value=100,
-        help_text="Max rows to return (default 20, hard cap 100).",
+        max_value=500,
+        help_text="Max rows to return (default 20, hard cap 500).",
     )
 
 

--- a/products/signals/backend/scout_harness/tools/scratchpad.py
+++ b/products/signals/backend/scout_harness/tools/scratchpad.py
@@ -12,6 +12,7 @@ dropped (none were earning their keep on the stack). Retrieval is ILIKE on
 from __future__ import annotations
 
 from dataclasses import asdict, dataclass
+from datetime import datetime
 from typing import Any
 
 from django.db import IntegrityError, transaction
@@ -21,7 +22,7 @@ from products.signals.backend.scout_harness.tools.runs import _build_task_url
 
 # Defensive cap on search results.
 DEFAULT_SCRATCHPAD_SEARCH_LIMIT = 20
-MAX_SCRATCHPAD_SEARCH_LIMIT = 100
+MAX_SCRATCHPAD_SEARCH_LIMIT = 500
 
 # Keys/content are agent-chosen prose. Match the model's column lengths so callers
 # get a clean error before hitting the DB.
@@ -55,14 +56,21 @@ def search_scratchpad(
     *,
     team_id: int,
     text: str | None = None,
+    date_from: datetime | None = None,
+    date_to: datetime | None = None,
     limit: int = DEFAULT_SCRATCHPAD_SEARCH_LIMIT,
     keys_only: bool = False,
     content_max_chars: int | None = None,
 ) -> list[ScratchpadEntry]:
-    """Return memories the agent should consider when planning a run.
+    """Return memories the agent should consider when planning a run, newest first.
 
     `text` matches ILIKE against `content` and `key`. The previous `tags` filter
     + GIN index were dropped in PR 2 review.
+
+    `date_from` / `date_to` are a half-open window on `updated_at` (the entry's
+    sort key) — `updated_at >= date_from` and `updated_at < date_to`. Pass `date_to`
+    (the `updated_at` of the oldest entry seen) to walk backwards past the result
+    cap on subsequent calls (cursor-style iteration), mirroring `search_recent_runs`.
 
     Result-scoping projections keep an orientation/dedupe scan from pulling every
     entry's full body — `content` is an unbounded TextField, so a wide scan can
@@ -81,6 +89,10 @@ def search_scratchpad(
         from django.db.models import Q
 
         qs = qs.filter(Q(content__icontains=text) | Q(key__icontains=text))
+    if date_from is not None:
+        qs = qs.filter(updated_at__gte=date_from)
+    if date_to is not None:
+        qs = qs.filter(updated_at__lt=date_to)
     qs = qs.order_by("-updated_at", "-id")[:clamped_limit]
     return [_to_entry(row, keys_only=keys_only, content_max_chars=content_max_chars) for row in qs]
 

--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -487,7 +487,7 @@ class SignalScratchpadViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
     authentication_classes = [SessionAuthentication, PersonalAPIKeyAuthentication, OAuthAccessTokenAuthentication]
     permission_classes = [IsAuthenticated, APIScopePermission]
     scope_object = "signal_scout"
-    # `list` returns a raw newest-first array (capped at limit=100 by the query serializer),
+    # `list` returns a raw newest-first array (capped at limit=500 by the query serializer),
     # not a paginated wrapper. See SignalScoutRunViewSet for the same rationale.
     pagination_class = None
 
@@ -510,22 +510,28 @@ class SignalScratchpadViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         },
         summary="Search the scout scratchpad",
         description=(
-            "Return `SignalScratchpad` entries for this project. ILIKE matches on `content` and `key`. "
-            "Pass `keys_only=true` to scan keys without pulling entry bodies, or `content_max_chars` to "
-            "cap each `content` to a preview — both keep a wide orientation scan from returning every "
-            "entry's full prose."
+            "Return `SignalScratchpad` entries for this project, newest-first. ILIKE matches on `content` "
+            "and `key`. `date_from` / `date_to` are a half-open window on `updated_at` (`>= date_from`, "
+            "`< date_to`); pass `date_to` (the `updated_at` of the oldest entry seen) on subsequent calls "
+            "to walk past the cap. Pass `keys_only=true` to scan keys without pulling entry bodies, or "
+            "`content_max_chars` to cap each `content` to a preview — both keep a wide orientation scan "
+            "from returning every entry's full prose. Results capped at 500."
         ),
         operation_id="signals_scout_scratchpad_search",
     )
     def list(self, request: Request, *args, **kwargs) -> Response:
         validated = getattr(request, "validated_query_data", {}) or {}
         text = validated.get("text") or None
+        date_from = validated.get("date_from")
+        date_to = validated.get("date_to")
         keys_only = bool(validated.get("keys_only", False))
         content_max_chars = validated.get("content_max_chars")
         limit = validated.get("limit") or 20
         rows = search_scratchpad(
             team_id=_canonical_team_id(self),
             text=text,
+            date_from=date_from,
+            date_to=date_to,
             limit=limit,
             keys_only=keys_only,
             content_max_chars=content_max_chars,

--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -446,6 +446,21 @@ class TestSearchScratchpad(BaseTest):
 
         assert [e.key for e in results] == ["old"]
 
+    def test_filters_by_date_from(self) -> None:
+        """`date_from` is an inclusive lower bound on `updated_at` — a separate ORM
+        branch from `date_to`, so it gets its own assertion (a `__gte`/`__gt` or
+        wrong-field typo would otherwise pass undetected)."""
+        for key in ("old", "recent"):
+            SignalScratchpad.objects.create(team=self.team, key=key, content=key)
+        SignalScratchpad.objects.filter(team=self.team, key="old").update(
+            updated_at=timezone.now() - timedelta(days=10)
+        )
+        SignalScratchpad.objects.filter(team=self.team, key="recent").update(updated_at=timezone.now())
+
+        results = search_scratchpad(team_id=self.team.id, date_from=timezone.now() - timedelta(days=1))
+
+        assert [e.key for e in results] == ["recent"]
+
     def test_limit_clamped_to_max(self) -> None:
         # bulk_create over per-row remember() — one round-trip for the cap-sized fixture.
         SignalScratchpad.objects.bulk_create(

--- a/products/signals/backend/test/test_scout_harness_tools.py
+++ b/products/signals/backend/test/test_scout_harness_tools.py
@@ -425,9 +425,33 @@ class TestSearchScratchpad(BaseTest):
 
         assert all(e.key == "mine" for e in results)
 
+    def test_filters_by_date_to_for_cursor_iteration(self) -> None:
+        """`date_to` is the upper bound the caller uses to walk past the result cap.
+
+        Entries sort by `updated_at`; set `date_to` to the oldest entry seen on the
+        prior page and the next call returns the next older slice. `.update()`
+        bypasses `auto_now` so we can pin `updated_at` deterministically.
+        """
+        for key in ("old", "middle", "recent"):
+            SignalScratchpad.objects.create(team=self.team, key=key, content=key)
+        middle_ts = timezone.now() - timedelta(days=7)
+        SignalScratchpad.objects.filter(team=self.team, key="old").update(
+            updated_at=timezone.now() - timedelta(days=14)
+        )
+        SignalScratchpad.objects.filter(team=self.team, key="middle").update(updated_at=middle_ts)
+        SignalScratchpad.objects.filter(team=self.team, key="recent").update(updated_at=timezone.now())
+
+        # Strict `<` bound: middle's own timestamp is excluded, only `old` is returned.
+        results = search_scratchpad(team_id=self.team.id, date_to=middle_ts)
+
+        assert [e.key for e in results] == ["old"]
+
     def test_limit_clamped_to_max(self) -> None:
-        for i in range(MAX_SCRATCHPAD_SEARCH_LIMIT + 5):
-            remember(team_id=self.team.id, key=f"k{i:03d}", content=f"c{i}")
+        # bulk_create over per-row remember() — one round-trip for the cap-sized fixture.
+        SignalScratchpad.objects.bulk_create(
+            SignalScratchpad(team=self.team, key=f"k{i:04d}", content=f"c{i}")
+            for i in range(MAX_SCRATCHPAD_SEARCH_LIMIT + 5)
+        )
 
         results = search_scratchpad(team_id=self.team.id, limit=MAX_SCRATCHPAD_SEARCH_LIMIT + 50)
 

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1666,13 +1666,21 @@ export type SignalsScoutScratchpadSearchParams = {
      */
     content_max_chars?: number
     /**
+     * ISO-8601 inclusive lower bound on `updated_at`. Omit to skip the lower bound.
+     */
+    date_from?: string
+    /**
+     * ISO-8601 exclusive upper bound on `updated_at`. Pass to walk back past the result cap on subsequent calls (cursor-style: set to the `updated_at` of the oldest entry from the prior page).
+     */
+    date_to?: string
+    /**
      * When true, blank each entry's `content` and return only keys + metadata. Use to scan which memories exist without pulling their (potentially large) bodies, then re-query the ones worth a full read. Takes precedence over `content_max_chars`.
      */
     keys_only?: boolean
     /**
-     * Max rows to return (default 20, hard cap 100).
+     * Max rows to return (default 20, hard cap 500).
      * @minimum 1
-     * @maximum 100
+     * @maximum 500
      */
     limit?: number
     /**

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -640,7 +640,7 @@ export const getSignalsScoutScratchpadSearchUrl = (projectId: string, params?: S
 }
 
 /**
- * Return `SignalScratchpad` entries for this project. ILIKE matches on `content` and `key`. Pass `keys_only=true` to scan keys without pulling entry bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation scan from returning every entry's full prose.
+ * Return `SignalScratchpad` entries for this project, newest-first. ILIKE matches on `content` and `key`. `date_from` / `date_to` are a half-open window on `updated_at` (`>= date_from`, `< date_to`); pass `date_to` (the `updated_at` of the oldest entry seen) on subsequent calls to walk past the cap. Pass `keys_only=true` to scan keys without pulling entry bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation scan from returning every entry's full prose. Results capped at 500.
  * @summary Search the scout scratchpad
  */
 export const signalsScoutScratchpadSearch = async (

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -540,9 +540,12 @@ tools:
         title: Search the scout scratchpad
         description: >
             Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive
-            substring match on the entry's `content` and `key`. Pass `keys_only=true` to scan which memories exist
-            without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview
-            — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 100.
+            substring match on the entry's `content` and `key`. Pass `date_from` / `date_to` (ISO-8601, inclusive
+            lower / exclusive upper bound on `updated_at`) to scope to a window — set `date_to` to the `updated_at`
+            of the oldest entry from the prior page to walk past the cap. Pass `keys_only=true` to scan which memories
+            exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a
+            preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped
+            at 500.
     users-signal-autonomy-create:
         operation: users_signal_autonomy_create
         enabled: false

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -540,12 +540,11 @@ tools:
         title: Search the scout scratchpad
         description: >
             Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive
-            substring match on the entry's `content` and `key`. Pass `date_from` / `date_to` (ISO-8601, inclusive
-            lower / exclusive upper bound on `updated_at`) to scope to a window — set `date_to` to the `updated_at`
-            of the oldest entry from the prior page to walk past the cap. Pass `keys_only=true` to scan which memories
-            exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a
-            preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped
-            at 500.
+            substring match on the entry's `content` and `key`. Pass `date_from` / `date_to` (ISO-8601, inclusive lower
+            / exclusive upper bound on `updated_at`) to scope to a window — set `date_to` to the `updated_at` of the
+            oldest entry from the prior page to walk past the cap. Pass `keys_only=true` to scan which memories exist
+            without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview
+            — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 500.
     users-signal-autonomy-create:
         operation: users_signal_autonomy_create
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6347,7 +6347,7 @@
         }
     },
     "signals-scout-scratchpad-search": {
-        "description": "Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive substring match on the entry's `content` and `key`. Pass `keys_only=true` to scan which memories exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 100.",
+        "description": "Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive substring match on the entry's `content` and `key`. Pass `date_from` / `date_to` (ISO-8601, inclusive lower / exclusive upper bound on `updated_at`) to scope to a window — set `date_to` to the `updated_at` of the oldest entry from the prior page to walk past the cap. Pass `keys_only=true` to scan which memories exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 500.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Search the scout scratchpad",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6842,7 +6842,7 @@
         }
     },
     "signals-scout-scratchpad-search": {
-        "description": "Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive substring match on the entry's `content` and `key`. Pass `keys_only=true` to scan which memories exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 100.",
+        "description": "Return `SignalScratchpad` entries for this project, newest first. Pass `text` for a case-insensitive substring match on the entry's `content` and `key`. Pass `date_from` / `date_to` (ISO-8601, inclusive lower / exclusive upper bound on `updated_at`) to scope to a window — set `date_to` to the `updated_at` of the oldest entry from the prior page to walk past the cap. Pass `keys_only=true` to scan which memories exist without pulling their (potentially large) bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation/dedupe scan from returning every entry's full prose. Results capped at 500.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Search the scout scratchpad",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -62807,13 +62807,21 @@ export namespace Schemas {
      */
     content_max_chars?: number;
     /**
+     * ISO-8601 inclusive lower bound on `updated_at`. Omit to skip the lower bound.
+     */
+    date_from?: string;
+    /**
+     * ISO-8601 exclusive upper bound on `updated_at`. Pass to walk back past the result cap on subsequent calls (cursor-style: set to the `updated_at` of the oldest entry from the prior page).
+     */
+    date_to?: string;
+    /**
      * When true, blank each entry's `content` and return only keys + metadata. Use to scan which memories exist without pulling their (potentially large) bodies, then re-query the ones worth a full read. Takes precedence over `content_max_chars`.
      */
     keys_only?: boolean;
     /**
-     * Max rows to return (default 20, hard cap 100).
+     * Max rows to return (default 20, hard cap 500).
      * @minimum 1
-     * @maximum 100
+     * @maximum 500
      */
     limit?: number;
     /**

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -645,7 +645,7 @@ export const SignalsScoutEmitSignalBody = /* @__PURE__ */ zod
     .describe('Request body for `emit-finding`. Run attribution is taken from the URL path.')
 
 /**
- * Return `SignalScratchpad` entries for this project. ILIKE matches on `content` and `key`. Pass `keys_only=true` to scan keys without pulling entry bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation scan from returning every entry's full prose.
+ * Return `SignalScratchpad` entries for this project, newest-first. ILIKE matches on `content` and `key`. `date_from` / `date_to` are a half-open window on `updated_at` (`>= date_from`, `< date_to`); pass `date_to` (the `updated_at` of the oldest entry seen) on subsequent calls to walk past the cap. Pass `keys_only=true` to scan keys without pulling entry bodies, or `content_max_chars` to cap each `content` to a preview — both keep a wide orientation scan from returning every entry's full prose. Results capped at 500.
  * @summary Search the scout scratchpad
  */
 export const SignalsScoutScratchpadSearchParams = /* @__PURE__ */ zod.object({
@@ -658,7 +658,7 @@ export const SignalsScoutScratchpadSearchParams = /* @__PURE__ */ zod.object({
 
 export const signalsScoutScratchpadSearchQueryContentMaxCharsMin = 0
 
-export const signalsScoutScratchpadSearchQueryLimitMax = 100
+export const signalsScoutScratchpadSearchQueryLimitMax = 500
 
 export const SignalsScoutScratchpadSearchQueryParams = /* @__PURE__ */ zod.object({
     content_max_chars: zod
@@ -667,6 +667,16 @@ export const SignalsScoutScratchpadSearchQueryParams = /* @__PURE__ */ zod.objec
         .optional()
         .describe(
             "Truncate each entry's `content` to the first N characters (a preview). Omit for the full body. Ignored when `keys_only=true`."
+        ),
+    date_from: zod.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe('ISO-8601 inclusive lower bound on `updated_at`. Omit to skip the lower bound.'),
+    date_to: zod.iso
+        .datetime({ offset: true })
+        .optional()
+        .describe(
+            'ISO-8601 exclusive upper bound on `updated_at`. Pass to walk back past the result cap on subsequent calls (cursor-style: set to the `updated_at` of the oldest entry from the prior page).'
         ),
     keys_only: zod
         .boolean()
@@ -679,7 +689,7 @@ export const SignalsScoutScratchpadSearchQueryParams = /* @__PURE__ */ zod.objec
         .min(1)
         .max(signalsScoutScratchpadSearchQueryLimitMax)
         .optional()
-        .describe('Max rows to return (default 20, hard cap 100).'),
+        .describe('Max rows to return (default 20, hard cap 500).'),
     text: zod
         .string()
         .optional()

--- a/services/mcp/src/tools/generated/signals.ts
+++ b/services/mcp/src/tools/generated/signals.ts
@@ -769,6 +769,8 @@ const signalsScoutScratchpadSearch = (): ToolBase<
             path: `/api/projects/${encodeURIComponent(String(projectId))}/signals/scout/scratchpad/`,
             query: {
                 content_max_chars: params.content_max_chars,
+                date_from: params.date_from,
+                date_to: params.date_to,
                 keys_only: params.keys_only,
                 limit: params.limit,
                 text: params.text,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-search.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-search.json
@@ -6,13 +6,25 @@
             "minimum": 0,
             "type": "number"
         },
+        "date_from": {
+            "description": "ISO-8601 inclusive lower bound on `updated_at`. Omit to skip the lower bound.",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+        },
+        "date_to": {
+            "description": "ISO-8601 exclusive upper bound on `updated_at`. Pass to walk back past the result cap on subsequent calls (cursor-style: set to the `updated_at` of the oldest entry from the prior page).",
+            "format": "date-time",
+            "pattern": "^(?:(?:\\d\\d[2468][048]|\\d\\d[13579][26]|\\d\\d0[48]|[02468][048]00|[13579][26]00)-02-29|\\d{4}-(?:(?:0[13578]|1[02])-(?:0[1-9]|[12]\\d|3[01])|(?:0[469]|11)-(?:0[1-9]|[12]\\d|30)|(?:02)-(?:0[1-9]|1\\d|2[0-8])))T(?:(?:[01]\\d|2[0-3]):[0-5]\\d(?::[0-5]\\d(?:\\.\\d+)?)?(?:Z|([+-](?:[01]\\d|2[0-3]):[0-5]\\d)))$",
+            "type": "string"
+        },
         "keys_only": {
             "description": "When true, blank each entry's `content` and return only keys + metadata. Use to scan which memories exist without pulling their (potentially large) bodies, then re-query the ones worth a full read. Takes precedence over `content_max_chars`.",
             "type": "boolean"
         },
         "limit": {
-            "description": "Max rows to return (default 20, hard cap 100).",
-            "maximum": 100,
+            "description": "Max rows to return (default 20, hard cap 500).",
+            "maximum": 500,
             "minimum": 1,
             "type": "number"
         },


### PR DESCRIPTION
## Problem

The scout inbox / scratchpad list endpoint (`signals-scout-scratchpad-search`) capped results at the 100 most recent entries, ordered newest-first, with no way to page past that. Once a team's scout fleet accumulates more than 100 durable memories, the older ones simply fall off the end — invisible to the inbox UI, MCP tools, and the scout harness itself. The existing code already flagged this as a follow-up ("a team that ever exceeds this wants a count + cursor").

## Changes

- Bump `MAX_SCRATCHPAD_SEARCH_LIMIT` 100 → 500, and the matching `limit` `max_value` on `SearchMemoryQuerySerializer`.
- Add `date_from` / `date_to` to `search_scratchpad` — a half-open window on `updated_at` (the entry's sort key): `>= date_from`, `< date_to`. Pass `date_to` = the `updated_at` of the oldest entry seen to walk backwards past the cap, cursor-style.
- This is a verbatim copy of the cursor pattern the sibling `search_recent_runs` / `SignalScoutRunViewSet` already uses in this product — same shape, same docstrings, so callers that already know the runs endpoint get the scratchpad one for free.
- Regenerated OpenAPI → TS / Zod / MCP tool schemas from the serializer change (the generated `products/signals/frontend/generated/*` and `services/mcp/*` files).

The frontend "load more" wiring is intentionally **not** here — the inbox just pulls the wider 500 window in one read and keeps grouping client-side. The cursor exists on the endpoint for MCP/agents and a future UI. The matching frontend bump (`SCRATCHPAD_FETCH_LIMIT` 100 → 500) ships as a separate small FE PR.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- `products/signals/backend/test/test_scout_harness_tools.py::TestSearchScratchpad` (9 passed) — added `test_filters_by_date_to_for_cursor_iteration`, which locks in the new `updated_at` window: it catches a regression where the `date_to` filter is dropped or inverted (cursor would silently return the wrong slice). Also switched the cap-clamp test to `bulk_create` so the now-larger fixture stays cheap.
- `products/signals/backend/test/test_scout_harness_api.py::TestScoutHarnessScratchpadAPI` (13 passed) — confirms the endpoint still round-trips end-to-end.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked whether the scout-list inbox only pulls the 100 most recent scratchpad entries (it did), then asked to raise that to ~500 and add pagination using an existing codebase pattern. I traced the chain (frontend `scratchpadLogic` → `signals_scout_scratchpad_search` → `search_scratchpad`) and found the `search_recent_runs` `date_from`/`date_to` cursor already solving the identical "walk past the 100-row cap" problem one class over — so this mirrors it rather than inventing a new scheme. Confirmed with Andy that the frontend should just pull the wider window (no "load more" yet), which keeps the client-side topic/recent grouping correct over the full set.

Skills invoked: `/improving-drf-endpoints` (serializer + viewset change) and `/writing-tests` (gating the one new test).
