### PR TITLE
chore(workflows): Editable fields for workflow step details

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -24,7 +24,7 @@ import { workflowLogic } from '../../workflowLogic'
 import { HogFlowPropertyFilters } from '../filters/HogFlowFilters'
 import { hogFlowEditorLogic } from '../hogFlowEditorLogic'
 import { useHogFlowStep } from '../steps/HogFlowSteps'
-import { isOptOutEligibleAction } from '../steps/types'
+import { isOptOutEligibleAction, isScheduleTrigger } from '../steps/types'
 import type { HogFlowAction } from '../types'
 import { hogFlowOutputMappingLogic } from './hogFlowOutputMappingLogic'
 import { OutputTestResultTree } from './OutputTestResultTree'
@@ -59,7 +59,6 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
     }
 
     const action = selectedNode.data
-    const isScheduleTrigger = action.type === 'trigger' && (action.config as any)?.type === 'schedule'
 
     const isBranchingStep = ['conditional_branch', 'wait_until_condition', 'random_cohort_branch'].includes(action.type)
     const actionFilters = action.filters ?? {}
@@ -100,7 +99,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                         className="font-semibold text-base"
                         data-attr="workflow-step-name"
                     />
-                    {!isScheduleTrigger && (
+                    {!isScheduleTrigger(action) && (
                         <EditableField
                             name="step-description"
                             value={action.description || ''}

--- a/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/panel/HogFlowEditorPanelBuildDetail.tsx
@@ -13,6 +13,7 @@ import {
     LemonSelect,
 } from '@posthog/lemon-ui'
 
+import { EditableField } from 'lib/components/EditableField/EditableField'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { urls } from 'scenes/urls'
@@ -58,6 +59,7 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
     }
 
     const action = selectedNode.data
+    const isScheduleTrigger = action.type === 'trigger' && (action.config as any)?.type === 'schedule'
 
     const isBranchingStep = ['conditional_branch', 'wait_until_condition', 'random_cohort_branch'].includes(action.type)
     const actionFilters = action.filters ?? {}
@@ -79,6 +81,42 @@ export function HogFlowEditorPanelBuildDetail(): JSX.Element | null {
                 innerClassName="flex flex-col gap-2 p-3"
                 styledScrollbars
             >
+                <div className="flex flex-col gap-1">
+                    <EditableField
+                        name="step-name"
+                        value={action.name}
+                        onSave={(value) => {
+                            const trimmed = value.trim()
+                            if (trimmed) {
+                                setWorkflowAction(action.id, { ...action, name: trimmed })
+                            }
+                        }}
+                        placeholder="Step name"
+                        minLength={1}
+                        saveOnBlur
+                        clickToEdit
+                        compactButtons
+                        compactIcon
+                        className="font-semibold text-base"
+                        data-attr="workflow-step-name"
+                    />
+                    {!isScheduleTrigger && (
+                        <EditableField
+                            name="step-description"
+                            value={action.description || ''}
+                            onSave={(value) => setWorkflowAction(action.id, { ...action, description: value.trim() })}
+                            placeholder="Add a description (optional)"
+                            multiline
+                            saveOnBlur
+                            clickToEdit
+                            compactButtons
+                            compactIcon
+                            className="text-sm text-secondary"
+                            data-attr="workflow-step-description"
+                        />
+                    )}
+                </div>
+                <LemonDivider className="my-2" />
                 {Step?.renderConfiguration(selectedNode)}
             </ScrollableShadows>
 

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/StepView.tsx
@@ -14,6 +14,7 @@ import { hogFlowEditorLogic } from '../../hogFlowEditorLogic'
 import { NODE_HEIGHT, NODE_WIDTH } from '../../react_flow_utils/constants'
 import { HogFlowAction } from '../../types'
 import { useHogFlowStep } from '../HogFlowSteps'
+import { isScheduleTrigger } from '../types'
 import { buildSummary } from './rrule-helpers'
 import { StepViewLogicProps, stepViewLogic } from './stepViewLogic'
 import { StepViewMetrics } from './StepViewMetrics'
@@ -33,9 +34,8 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
         useValues(workflowLogic)
     const { deleteElements } = useReactFlow()
 
-    const isScheduleTrigger = action.type === 'trigger' && (action.config as any)?.type === 'schedule'
     const scheduleDescription = useMemo(() => {
-        if (!isScheduleTrigger) {
+        if (!isScheduleTrigger(action)) {
             return null
         }
         if (!scheduleStartsAt) {
@@ -45,7 +45,7 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
             return 'One-time run'
         }
         return buildSummary(scheduleState, scheduleStartsAt)
-    }, [isScheduleTrigger, scheduleState, scheduleStartsAt, isScheduleRepeating])
+    }, [action, scheduleState, scheduleStartsAt, isScheduleRepeating])
 
     const isSelected = selectedNode?.id === action.id
     const node = nodesById[action.id]
@@ -186,9 +186,9 @@ export function StepView({ action }: { action: HogFlowAction }): JSX.Element {
                     ) : (
                         <Tooltip title={scheduleDescription ?? action.description ?? ''}>
                             <div
-                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 !rounded-sm px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 min-h-[0.45rem] overflow-hidden ${isSelected && !isScheduleTrigger ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
+                                className={`text-[0.3rem]/1.5 text-muted line-clamp-2 !rounded-sm px-0.5 -mx-0.5 transition-colors pl-1 min-w-0 min-h-[0.45rem] overflow-hidden ${isSelected && !isScheduleTrigger(action) ? 'cursor-text hover:bg-fill-button-tertiary-hover' : ''}`}
                                 onClick={(e) => {
-                                    if (isSelected && !isScheduleTrigger) {
+                                    if (isSelected && !isScheduleTrigger(action)) {
                                         e.stopPropagation()
                                         startEditingDescription()
                                     }

--- a/products/workflows/frontend/Workflows/hogflows/steps/types.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/types.ts
@@ -316,6 +316,14 @@ export const isTriggerFunction = (
     return ['webhook', 'tracking_pixel', 'manual'].includes(trigger.config.type)
 }
 
+export const isScheduleTrigger = (action: HogFlowAction): boolean => {
+    if (action.type !== 'trigger') {
+        return false
+    }
+    const trigger = action as Extract<HogFlowAction, { type: 'trigger' }>
+    return trigger.config.type === 'schedule'
+}
+
 export interface HogflowTestResult {
     status: 'success' | 'error' | 'skipped'
     logs?: LogEntry[]


### PR DESCRIPTION
## Problem

After duplicating a workflow step, a customer couldn't work out how to rename the step and change its description. I have to agree the UX for this isn't super clear, given you have to click the node before the name/description hover appears - by which point you've probably moved your cursor away to the side panel.

## Changes

Add the name and description into the side panel

<img width="800" height="546" alt="CleanShot 2026-06-24 at 17 03 04" src="https://github.com/user-attachments/assets/8a861dc6-58c3-4894-8184-9a572f297a68" />


## How did you test this code?

Tested locally