### PR TITLE
feat(batch-exports): authenticate S3 batch exports via integrations

### DIFF
--- a/posthog/models/integration.py
+++ b/posthog/models/integration.py
@@ -3588,7 +3588,7 @@ class AwsS3Integration:
     aws_secret_access_key: str
 
     def __init__(self, integration: Integration) -> None:
-        if integration.kind != Integration.IntegrationKind.AWS_S3.value:
+        if integration.kind != Integration.IntegrationKind.AWS_S3:
             raise S3CredentialIntegrationError(
                 f"Integration provided is not an AWS S3 integration (got kind='{integration.kind}')"
             )
@@ -3651,7 +3651,7 @@ class AwsS3Integration:
         # treated as a secret. The account id is non-sensitive and kept for display/debugging.
         return _create_unique_s3_integration(
             team_id=team_id,
-            kind=Integration.IntegrationKind.AWS_S3.value,
+            kind=Integration.IntegrationKind.AWS_S3,
             name=name,
             config={"name": name, "aws_account_id": account_id},
             sensitive_config=_build_s3_sensitive_config(aws_access_key_id, aws_secret_access_key),
@@ -3680,7 +3680,7 @@ class S3CompatibleIntegration:
     endpoint_url: str
 
     def __init__(self, integration: Integration) -> None:
-        if integration.kind != Integration.IntegrationKind.S3_COMPATIBLE.value:
+        if integration.kind != Integration.IntegrationKind.S3_COMPATIBLE:
             raise S3CredentialIntegrationError(
                 f"Integration provided is not an S3-compatible integration (got kind='{integration.kind}')"
             )
@@ -3713,7 +3713,7 @@ class S3CompatibleIntegration:
 
         return _create_unique_s3_integration(
             team_id=team_id,
-            kind=Integration.IntegrationKind.S3_COMPATIBLE.value,
+            kind=Integration.IntegrationKind.S3_COMPATIBLE,
             name=name,
             config={"name": name, "endpoint_url": endpoint_url},
             sensitive_config=_build_s3_sensitive_config(aws_access_key_id, aws_secret_access_key),

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -354,8 +354,8 @@ class S3FamilyDestinationConfigSerializer(serializers.Serializer):
     """Shared non-credential configuration for S3-family batch-export destinations.
 
     Credentials (and, for S3-compatible providers, the `endpoint_url`) live in the linked
-    Integration, not in this config — legacy exports may still carry them inline. Mirrors the
-    non-credential fields of `S3FamilyBaseInputs` in `products/batch_exports/backend/service.py`.
+    Integration, not in this config. Mirrors the non-credential fields of `S3FamilyBaseInputs` in
+    `products/batch_exports/backend/service.py`.
     """
 
     bucket_name = serializers.CharField(help_text="Name of the destination bucket.")
@@ -1133,6 +1133,13 @@ class BatchExportSerializer(serializers.ModelSerializer):
         if destination_type in S3_FAMILY_TYPES:
             integration: Integration | None = destination_attrs.get("integration")
 
+            # TODO: remove this guard once integrations are mandatory for S3 and inline credentials are gone.
+            if instance is not None and instance.destination.integration is not None and integration is None:
+                raise serializers.ValidationError(
+                    "Cannot remove the integration from an S3 batch export that uses one. "
+                    "Re-send its `integration` to keep it (or a different one to swap)."
+                )
+
             # we already validate the required inputs in BatchExportDestinationSerializer::validate
             # so here we just ensure that the inputs are not empty
             required_non_empty_inputs = ["bucket_name", "region", "prefix"]
@@ -1147,10 +1154,17 @@ class BatchExportSerializer(serializers.ModelSerializer):
             if empty_inputs:
                 raise serializers.ValidationError(f"The following inputs are empty: {empty_inputs}")
 
-            # When an Integration is supplied it must belong to the team and match the destination kind.
-            if integration is not None and destination_type in S3_INTEGRATION_HANDLERS:
-                if integration.team_id != self.context["team_id"]:
-                    raise serializers.ValidationError("Integration does not belong to this team.")
+            # When an Integration is supplied it must match the destination kind. (Team ownership is
+            # already enforced by the team-scoped `integration` field, which can only resolve
+            # integrations belonging to the request's team.)
+            if integration is not None:
+                # An Integration only makes sense for the integration-backed S3 types. Reject it on the
+                # legacy "S3" type
+                # TODO: remove this branch once the legacy "S3" destination type is fully removed.
+                if destination_type not in S3_INTEGRATION_HANDLERS:
+                    raise serializers.ValidationError(
+                        f"{destination_type} destinations do not support integration-based credentials."
+                    )
                 try:
                     S3_INTEGRATION_HANDLERS[destination_type](integration)
                 except S3CredentialIntegrationError as e:
@@ -1180,14 +1194,10 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     raise serializers.ValidationError(f"Invalid endpoint_url: '{merged_config['endpoint_url']}'")
 
         if destination_type == BatchExportDestination.Destination.DATABRICKS:
-            team_id = self.context["team_id"]
-
             # validate the Integration is valid (this is mandatory for Databricks batch exports)
             integration = destination_attrs.get("integration")
             if integration is None:
                 raise serializers.ValidationError("Integration is required for Databricks batch exports")
-            if integration.team_id != team_id:
-                raise serializers.ValidationError("Integration does not belong to this team.")
             if integration.kind != Integration.IntegrationKind.DATABRICKS:
                 raise serializers.ValidationError("Integration is not a Databricks integration.")
             # try instantiate the integration to check if it's valid
@@ -1197,39 +1207,27 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError(str(e))
 
         if destination_type == BatchExportDestination.Destination.POSTGRES:
-            team_id = self.context["team_id"]
             integration = destination_attrs.get("integration")
             # New Postgres exports must use an Integration for credentials. Exports created before
             # integrations existed keep their inline credentials, so only require it on create
             # (`instance is None`); existing inline-credential exports stay valid when edited.
             if integration is None and instance is None:
                 raise serializers.ValidationError("Integration is required for Postgres batch exports")
-            if integration is not None:
-                if integration.team_id != team_id:
-                    raise serializers.ValidationError("Integration does not belong to this team.")
-                if integration.kind != Integration.IntegrationKind.POSTGRESQL:
-                    raise serializers.ValidationError("Integration is not a PostgreSQL integration.")
+            if integration is not None and integration.kind != Integration.IntegrationKind.POSTGRESQL:
+                raise serializers.ValidationError("Integration is not a PostgreSQL integration.")
 
         if destination_type == BatchExportDestination.Destination.BIGQUERY:
-            team_id = self.context["team_id"]
-
             integration = destination_attrs.get("integration")
             if integration is None:
                 raise serializers.ValidationError("Integration is required for BigQuery batch exports")
-            if integration.team_id != team_id:
-                raise serializers.ValidationError("Integration does not belong to this team.")
             if integration.kind != Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT:
                 raise serializers.ValidationError("Integration is not a Google Cloud service account integration.")
 
         if destination_type == BatchExportDestination.Destination.AZURE_BLOB:
-            team_id = self.context["team_id"]
-
             # validate the Integration is valid (this is mandatory for Azure Blob batch exports)
             integration = destination_attrs.get("integration")
             if integration is None:
                 raise serializers.ValidationError("Integration is required for Azure Blob batch exports")
-            if integration.team_id != team_id:
-                raise serializers.ValidationError("Integration does not belong to this team.")
             if integration.kind != Integration.IntegrationKind.AZURE_BLOB:
                 raise serializers.ValidationError("Integration is not an Azure Blob integration.")
             # try instantiate the integration to check if it's valid

--- a/products/batch_exports/backend/api/batch_export.py
+++ b/products/batch_exports/backend/api/batch_export.py
@@ -38,11 +38,14 @@ from posthog.api.utils import action
 from posthog.event_usage import groups
 from posthog.models import Team, User
 from posthog.models.integration import (
+    AwsS3Integration,
     AzureBlobIntegration,
     AzureBlobIntegrationError,
     DatabricksIntegration,
     DatabricksIntegrationError,
     Integration,
+    S3CompatibleIntegration,
+    S3CredentialIntegrationError,
 )
 from posthog.temporal.common.client import sync_connect
 from posthog.utils import relative_date_parse, str_to_bool
@@ -347,6 +350,75 @@ class AzureBlobDestinationConfigSerializer(serializers.Serializer):
     )
 
 
+class S3FamilyDestinationConfigSerializer(serializers.Serializer):
+    """Shared non-credential configuration for S3-family batch-export destinations.
+
+    Credentials (and, for S3-compatible providers, the `endpoint_url`) live in the linked
+    Integration, not in this config — legacy exports may still carry them inline. Mirrors the
+    non-credential fields of `S3FamilyBaseInputs` in `products/batch_exports/backend/service.py`.
+    """
+
+    bucket_name = serializers.CharField(help_text="Name of the destination bucket.")
+    region = serializers.CharField(help_text="Region the bucket is in (e.g. 'us-east-1').")
+    prefix = serializers.CharField(help_text="Object key prefix applied to every exported file.")
+    compression = serializers.ChoiceField(
+        choices=sorted({codec for codecs in S3_SUPPORTED_COMPRESSIONS.values() for codec in codecs}),
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Optional compression codec applied to exported files. Valid codecs depend on file_format.",
+    )
+    file_format = serializers.ChoiceField(
+        choices=list(S3_SUPPORTED_COMPRESSIONS.keys()),
+        required=False,
+        default="JSONLines",
+        help_text="File format used for exported objects.",
+    )
+    max_file_size_mb = serializers.IntegerField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="If set, rolls to a new file once the current file exceeds this size in MB.",
+    )
+
+
+class AwsS3DestinationConfigSerializer(S3FamilyDestinationConfigSerializer):
+    """Typed configuration for an AWS S3 batch-export destination.
+
+    AWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of
+    `AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.
+    """
+
+    encryption = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms').",
+    )
+    kms_key_id = serializers.CharField(
+        required=False,
+        allow_null=True,
+        default=None,
+        help_text="KMS key ID to use when encryption is 'aws:kms'.",
+    )
+
+
+class S3CompatibleDestinationConfigSerializer(S3FamilyDestinationConfigSerializer):
+    """Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,
+    DigitalOcean Spaces, etc.).
+
+    Credentials and the provider `endpoint_url` live in the linked s3-compatible Integration.
+    Mirrors the non-credential fields of `S3CompatibleBatchExportInputs` in
+    `products/batch_exports/backend/service.py`.
+    """
+
+    use_virtual_style_addressing = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Use virtual-hosted-style addressing rather than path-style.",
+    )
+
+
 @extend_schema_field(
     PolymorphicProxySerializer(
         component_name="BatchExportDestinationConfig",
@@ -355,6 +427,8 @@ class AzureBlobDestinationConfigSerializer(serializers.Serializer):
             "AzureBlob": AzureBlobDestinationConfigSerializer,
             "BigQuery": BigQueryDestinationConfigSerializer,
             "Postgres": PostgresDestinationConfigSerializer,
+            "AwsS3": AwsS3DestinationConfigSerializer,
+            "S3Compatible": S3CompatibleDestinationConfigSerializer,
         },
         resource_type_field_name="type",
     )
@@ -420,6 +494,34 @@ class PostgresDestinationRequestSerializer(serializers.Serializer):
     config = PostgresDestinationConfigSerializer()
 
 
+class AwsS3DestinationRequestSerializer(serializers.Serializer):
+    """Request shape for creating or updating an AWS S3 batch-export destination."""
+
+    type = serializers.ChoiceField(choices=["AwsS3"])
+    integration_id = serializers.IntegerField(
+        required=False,
+        help_text=(
+            "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. "
+            "Use the integrations-list MCP tool to find one."
+        ),
+    )
+    config = AwsS3DestinationConfigSerializer()
+
+
+class S3CompatibleDestinationRequestSerializer(serializers.Serializer):
+    """Request shape for creating or updating an S3-compatible batch-export destination."""
+
+    type = serializers.ChoiceField(choices=["S3Compatible"])
+    integration_id = serializers.IntegerField(
+        required=False,
+        help_text=(
+            "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. "
+            "Preferred over inline credentials. Use the integrations-list MCP tool to find one."
+        ),
+    )
+    config = S3CompatibleDestinationConfigSerializer()
+
+
 BatchExportDestinationRequest = PolymorphicProxySerializer(
     component_name="BatchExportDestinationRequest",
     serializers={
@@ -427,6 +529,8 @@ BatchExportDestinationRequest = PolymorphicProxySerializer(
         "AzureBlob": AzureBlobDestinationRequestSerializer,
         "BigQuery": BigQueryDestinationRequestSerializer,
         "Postgres": PostgresDestinationRequestSerializer,
+        "AwsS3": AwsS3DestinationRequestSerializer,
+        "S3Compatible": S3CompatibleDestinationRequestSerializer,
     },
     resource_type_field_name="type",
 )
@@ -436,10 +540,11 @@ BatchExportDestinationRequest = PolymorphicProxySerializer(
 class BatchExportDestinationRequestField(serializers.JSONField):
     """JSONField annotated with a polymorphic OpenAPI request schema.
 
-    Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are
-    exposed in the schema. integration_id is required when creating any of these. Existing
-    Postgres exports created before integrations keep their inline credentials. Runtime
-    validation remains `BatchExportDestinationSerializer.validate_destination`.
+    Only integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3,
+    S3Compatible) are exposed in the schema. integration_id is required for Databricks, AzureBlob
+    and BigQuery, and optional for the S3 family (inline credentials remain supported for the time
+    being). Existing Postgres and S3 exports created before integrations keep their inline
+    credentials. Runtime validation remains `BatchExportDestinationSerializer.validate_destination`.
     """
 
     pass
@@ -493,20 +598,29 @@ class BatchExportRequestSerializer(serializers.Serializer):
     )
 
 
+# S3-family destinations that may authenticate via an Integration, mapped to the handler that
+# validates the linked integration's kind and credentials. Adding a future S3-family destination
+# (e.g. a first-class GCS-via-S3 type) is a one-line addition here.
+S3_INTEGRATION_HANDLERS: dict[str, type[AwsS3Integration] | type[S3CompatibleIntegration]] = {
+    BatchExportDestination.Destination.AWS_S3: AwsS3Integration,
+    BatchExportDestination.Destination.S3_COMPATIBLE: S3CompatibleIntegration,
+}
+
+
 class BatchExportDestinationSerializer(serializers.ModelSerializer):
     """Serializer for an BatchExportDestination model.
 
     The `config` field is polymorphic and typed only for destinations that keep
-    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).
-    Other destination types accept the same JSON shape but without a typed
+    credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
+    AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
     OpenAPI schema. Secret fields are stripped from `config` on read.
     """
 
     config = TypedBatchExportDestinationConfigField(
         help_text=(
             "Destination-specific configuration. Fields depend on `type`. Credentials for "
-            "integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — "
-            "they live in the linked Integration. Secret fields are stripped from responses."
+            "integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) "
+            "are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses."
         ),
     )
     integration = TeamScopedPrimaryKeyRelatedField(
@@ -523,7 +637,8 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
         allow_null=True,
         help_text=(
             "ID of a team-scoped Integration providing credentials. Required when creating Databricks, "
-            "AzureBlob, BigQuery, and Postgres destinations; unused for other types."
+            "AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials "
+            "remain supported); unused for other types."
         ),
     )
 
@@ -561,11 +676,20 @@ class BatchExportDestinationSerializer(serializers.ModelSerializer):
             str_fields = ", ".join(f"'{extra_field}'" for extra_field in sorted(extra_fields))
             raise serializers.ValidationError(f"Configuration has unknown field/s: {str_fields}")
 
+        # S3-family credential fields are optional on the dataclass (integration-backed exports
+        # resolve them at run time), so they must be required here only when no Integration is linked.
+        # TODO: remove this code once integrations for S3 are enforced
+        conditionally_required: set[str] = set()
+        if export_type in S3_FAMILY_TYPES and attrs.get("integration") is None:
+            conditionally_required = {"aws_access_key_id", "aws_secret_access_key"}
+            if export_type == BatchExportDestination.Destination.S3_COMPATIBLE:
+                conditionally_required.add("endpoint_url")
+
         for destination_field in destination_fields:
             is_required = (
                 destination_field.default == dataclasses.MISSING
                 and destination_field.default_factory == dataclasses.MISSING
-            )
+            ) or destination_field.name in conditionally_required
             if destination_field.name not in config:
                 if is_required and not is_patch:
                     # When patching we expect a partial configuration. So, we don't
@@ -1007,15 +1131,14 @@ class BatchExportSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError("Private key is required if authentication type is key pair")
 
         if destination_type in S3_FAMILY_TYPES:
+            integration: Integration | None = destination_attrs.get("integration")
+
             # we already validate the required inputs in BatchExportDestinationSerializer::validate
             # so here we just ensure that the inputs are not empty
-            required_non_empty_inputs = (
-                "bucket_name",
-                "region",
-                "prefix",
-                "aws_access_key_id",
-                "aws_secret_access_key",
-            )
+            required_non_empty_inputs = ["bucket_name", "region", "prefix"]
+            # Credentials are only required inline when no Integration provides them.
+            if integration is None:
+                required_non_empty_inputs += ["aws_access_key_id", "aws_secret_access_key"]
             empty_inputs = []
             for required_input in required_non_empty_inputs:
                 value = config.get(required_input)
@@ -1023,6 +1146,15 @@ class BatchExportSerializer(serializers.ModelSerializer):
                     empty_inputs.append(required_input)
             if empty_inputs:
                 raise serializers.ValidationError(f"The following inputs are empty: {empty_inputs}")
+
+            # When an Integration is supplied it must belong to the team and match the destination kind.
+            if integration is not None and destination_type in S3_INTEGRATION_HANDLERS:
+                if integration.team_id != self.context["team_id"]:
+                    raise serializers.ValidationError("Integration does not belong to this team.")
+                try:
+                    S3_INTEGRATION_HANDLERS[destination_type](integration)
+                except S3CredentialIntegrationError as e:
+                    raise serializers.ValidationError(str(e))
 
             # JSONLines is the default file format for S3 exports for legacy reasons
             file_format = merged_config.get("file_format", "JSONLines")
@@ -1051,7 +1183,7 @@ class BatchExportSerializer(serializers.ModelSerializer):
             team_id = self.context["team_id"]
 
             # validate the Integration is valid (this is mandatory for Databricks batch exports)
-            integration: Integration | None = destination_attrs.get("integration")
+            integration = destination_attrs.get("integration")
             if integration is None:
                 raise serializers.ValidationError("Integration is required for Databricks batch exports")
             if integration.team_id != team_id:
@@ -1365,8 +1497,8 @@ def recursive_dict_merge(
 @extend_schema(tags=["batch_exports"])
 @extend_schema_view(
     # Request bodies use a polymorphic destination schema so that integration-backed types
-    # (Databricks, AzureBlob, BigQuery, Postgres) advertise integration_id up front — required
-    # for all of them except Postgres, where it is optional.
+    # (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) advertise integration_id up
+    # front — required for Databricks, AzureBlob and BigQuery, optional for Postgres and the S3 family.
     # Responses continue to use BatchExportSerializer.
     create=extend_schema(request=BatchExportRequestSerializer),
     update=extend_schema(request=BatchExportRequestSerializer),

--- a/products/batch_exports/backend/service.py
+++ b/products/batch_exports/backend/service.py
@@ -264,8 +264,10 @@ class S3BatchExportInputs(BaseBatchExportInputs):
         bucket_name: The S3 bucket we are exporting to.
         region: The AWS region where the bucket is located.
         prefix: A prefix for the file name to be created in S3.
-        aws_access_key_id: Access key id used to authenticate with S3.
-        aws_secret_access_key: Secret access key used to authenticate with S3.
+        aws_access_key_id: Access key id used to authenticate with S3. Optional; integration-backed
+            exports resolve credentials from the linked Integration at run time (see `integration_id`),
+            while legacy exports carry them inline.
+        aws_secret_access_key: Secret access key used to authenticate with S3. See `aws_access_key_id`.
         compression: Compression algorithm to apply to exported files (e.g. "gzip", "brotli"), or None.
         file_format: File format of exported objects (e.g. "JSONLines", "Parquet"). Defaults to JSONLines.
         max_file_size_mb: The maximum file size in MB for each file to be uploaded.
@@ -279,8 +281,8 @@ class S3BatchExportInputs(BaseBatchExportInputs):
     bucket_name: str
     region: str
     prefix: str
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
     compression: str | None = None
     file_format: str = "JSONLines"
     max_file_size_mb: int | None = None
@@ -294,14 +296,16 @@ class S3BatchExportInputs(BaseBatchExportInputs):
 class S3FamilyBaseInputs(BaseBatchExportInputs):
     """Shared fields for every S3-family destination.
 
-    Per-destination dataclasses extend this with provider-specific fields.
+    Per-destination dataclasses extend this with provider-specific fields. Credentials are optional:
+    integration-backed exports resolve them from the linked Integration at run time (see
+    `integration_id`), while legacy exports carry them inline.
     """
 
     bucket_name: str
     region: str
     prefix: str
-    aws_access_key_id: str
-    aws_secret_access_key: str
+    aws_access_key_id: str | None = None
+    aws_secret_access_key: str | None = None
     compression: str | None = None
     file_format: str = "JSONLines"
     max_file_size_mb: int | None = None
@@ -319,11 +323,12 @@ class AwsS3BatchExportInputs(S3FamilyBaseInputs):
 class S3CompatibleBatchExportInputs(S3FamilyBaseInputs):
     """Inputs for a non-AWS S3-compatible batch export.
 
-    Covers providers like MinIO, DigitalOcean Spaces, Cloudflare R2, Hetzner, OVH,
-    Backblaze, etc. `endpoint_url` is required.
+    Covers providers like DigitalOcean Spaces, Cloudflare R2, Hetzner, OVH, Backblaze, etc.
+    `endpoint_url` is resolved from the linked Integration at run time when `integration_id` is set,
+    otherwise carried inline (legacy).
     """
 
-    endpoint_url: str
+    endpoint_url: str | None = None
     use_virtual_style_addressing: bool = False
 
 

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -118,11 +118,8 @@ class UnsupportedCompressionError(Exception):
 class S3IntegrationNotFoundError(Exception):
     """Raised when an S3-family export references an Integration that can't be resolved."""
 
-    def __init__(self, integration_id: int | None, team_id: int):
-        if integration_id is None:
-            super().__init__(f"S3 integration ID not provided for team '{team_id}'")
-        else:
-            super().__init__(f"S3 integration with ID '{integration_id}' not found for team '{team_id}'")
+    def __init__(self, integration_id: int, team_id: int):
+        super().__init__(f"S3 integration with ID '{integration_id}' not found for team '{team_id}'")
 
 
 async def _get_s3_integration(integration_id: int, team_id: int) -> AwsS3Integration | S3CompatibleIntegration:

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -20,7 +20,12 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
-from posthog.models.integration import AwsS3Integration, Integration, S3CompatibleIntegration
+from posthog.models.integration import (
+    AwsS3Integration,
+    Integration,
+    S3CompatibleIntegration,
+    S3CredentialIntegrationError,
+)
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -75,6 +80,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "InvalidCredentialsError",
     # The linked Integration was deleted or doesn't belong to the team
     "S3IntegrationNotFoundError",
+    # The linked Integration is the wrong kind or has invalid/missing credentials
+    "S3CredentialIntegrationError",
 )
 
 FILE_FORMAT_EXTENSIONS = {
@@ -121,8 +128,10 @@ class S3IntegrationNotFoundError(Exception):
 async def _get_s3_integration(integration_id: int, team_id: int) -> AwsS3Integration | S3CompatibleIntegration:
     """Fetch an S3-family integration from the database.
 
-    The kind is validated on create by the batch export serializer, so the final branch is purely
-    defensive against an integration whose kind was changed out from under the export.
+    The kind is validated on create by the batch export serializer, so the wrong-kind branch is
+    purely defensive against an integration whose kind was changed out from under the export.
+    `AwsS3Integration`/`S3CompatibleIntegration` themselves raise `S3CredentialIntegrationError` if
+    the credentials are malformed.
     """
     try:
         integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
@@ -133,7 +142,10 @@ async def _get_s3_integration(integration_id: int, team_id: int) -> AwsS3Integra
         return AwsS3Integration(integration)
     if integration.kind == Integration.IntegrationKind.S3_COMPATIBLE:
         return S3CompatibleIntegration(integration)
-    raise S3IntegrationNotFoundError(integration_id, team_id)
+    raise S3CredentialIntegrationError(
+        f"Integration with ID '{integration_id}' for team '{team_id}' is not an S3 integration "
+        f"(kind='{integration.kind}')"
+    )
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/s3_batch_export.py
@@ -20,6 +20,7 @@ from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy
 
+from posthog.models.integration import AwsS3Integration, Integration, S3CompatibleIntegration
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.heartbeat import Heartbeater
 from posthog.temporal.common.logger import get_logger, get_write_only_logger
@@ -72,6 +73,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "UnsupportedCompressionError",
     # Invalid S3 credentials
     "InvalidCredentialsError",
+    # The linked Integration was deleted or doesn't belong to the team
+    "S3IntegrationNotFoundError",
 )
 
 FILE_FORMAT_EXTENSIONS = {
@@ -105,6 +108,34 @@ class UnsupportedCompressionError(Exception):
         super().__init__(f"'{compression}' is not a supported compression for S3 batch exports.")
 
 
+class S3IntegrationNotFoundError(Exception):
+    """Raised when an S3-family export references an Integration that can't be resolved."""
+
+    def __init__(self, integration_id: int | None, team_id: int):
+        if integration_id is None:
+            super().__init__(f"S3 integration ID not provided for team '{team_id}'")
+        else:
+            super().__init__(f"S3 integration with ID '{integration_id}' not found for team '{team_id}'")
+
+
+async def _get_s3_integration(integration_id: int, team_id: int) -> AwsS3Integration | S3CompatibleIntegration:
+    """Fetch an S3-family integration from the database.
+
+    The kind is validated on create by the batch export serializer, so the final branch is purely
+    defensive against an integration whose kind was changed out from under the export.
+    """
+    try:
+        integration = await Integration.objects.aget(id=integration_id, team_id=team_id)
+    except Integration.DoesNotExist:
+        raise S3IntegrationNotFoundError(integration_id, team_id)
+
+    if integration.kind == Integration.IntegrationKind.AWS_S3:
+        return AwsS3Integration(integration)
+    if integration.kind == Integration.IntegrationKind.S3_COMPATIBLE:
+        return S3CompatibleIntegration(integration)
+    raise S3IntegrationNotFoundError(integration_id, team_id)
+
+
 @dataclasses.dataclass(kw_only=True)
 class S3InsertInputs(BatchExportInsertInputs):
     """Inputs for S3 exports."""
@@ -116,6 +147,9 @@ class S3InsertInputs(BatchExportInsertInputs):
     bucket_name: str
     region: str
     prefix: str
+    # When set, credentials (and endpoint_url for S3-compatible) are resolved from this Integration
+    # at run time; otherwise the inline credentials below are used (legacy path).
+    integration_id: int | None = None
     aws_access_key_id: str | None = None
     aws_secret_access_key: str | None = None
     aws_session_token: str | None = None
@@ -266,6 +300,7 @@ class S3BatchExportWorkflow(PostHogWorkflow):
             region=inputs.region,
             prefix=inputs.prefix,
             team_id=inputs.team_id,
+            integration_id=inputs.integration_id,
             aws_access_key_id=inputs.aws_access_key_id,
             aws_secret_access_key=inputs.aws_secret_access_key,
             endpoint_url=inputs.endpoint_url or None,
@@ -305,18 +340,18 @@ class S3BatchExportResult(BatchExportResult):
 @activity.defn
 @handle_non_retryable_errors(NON_RETRYABLE_ERROR_TYPES)
 async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> S3BatchExportResult:
-    """Activity to batch export data to a customer's S3.
+    """Activity to batch export data from our internal S3 stage to a customer's S3.
 
-    This is a new version of the `insert_into_s3_activity` activity that reads data from our internal S3 stage
-    instead of ClickHouse.
+    We support both AWS S3 and S3-compatible destinations (eg Cloudflare R2, DigitalOcean Spaces, etc).
 
-    It will upload multiple files if the max_file_size_mb is set, otherwise it will upload a single file. File uploads
-    are done using multipart upload.
+    It will upload multiple files if the max_file_size_mb is set, otherwise it will upload a single
+    file. File uploads are done using multipart upload.
 
-    We could maybe optimize this by simply copying the data from the internal S3 stage to the customer's S3 bucket,
-    however, we've tried to keep the activity that writes the data to the internal S3 stage as generic as possible, as
-    it will be used by other destinations, not just S3. Our S3 batch exports also support customising the max S3 file
-    size, different file formats, compression, etc, which ClickHouse's S3 functions may not support.
+    We could maybe optimize this by simply copying the data from the internal S3 stage to the
+    customer's S3 bucket, however, we've tried to keep the activity that writes the data to the
+    internal S3 stage as generic as possible, as it will be used by other destinations, not just S3.
+    Our S3 batch exports also support customising the max S3 file size, different file formats,
+    compression, etc, which ClickHouse's S3 functions may not support.
     """
     bind_contextvars(
         team_id=inputs.team_id,
@@ -324,6 +359,15 @@ async def insert_into_s3_activity_from_stage(inputs: S3InsertInputs) -> S3BatchE
         data_interval_start=inputs.data_interval_start,
         data_interval_end=inputs.data_interval_end,
     )
+
+    # Integration-backed exports resolve credentials at run time; legacy exports carry them inline.
+    # TODO: require integration
+    if inputs.integration_id is not None:
+        integration = await _get_s3_integration(inputs.integration_id, inputs.team_id)
+        inputs.aws_access_key_id = integration.aws_access_key_id
+        inputs.aws_secret_access_key = integration.aws_secret_access_key
+        if isinstance(integration, S3CompatibleIntegration):
+            inputs.endpoint_url = integration.endpoint_url
 
     if inputs.file_format not in FILE_FORMAT_EXTENSIONS:
         raise UnsupportedFileFormatError(inputs.file_format)

--- a/products/batch_exports/backend/tests/api/test_create.py
+++ b/products/batch_exports/backend/tests/api/test_create.py
@@ -14,6 +14,7 @@ from rest_framework import status
 
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.models.integration import Integration
 
 from products.batch_exports.backend.models.batch_export import BatchExport
 from products.batch_exports.backend.tests.api.conftest import (
@@ -355,6 +356,50 @@ def test_cannot_create_a_batch_export_for_another_organization(client: HttpClien
     )
 
     assert response.status_code == status.HTTP_403_FORBIDDEN, response.json()
+
+
+@pytest.mark.parametrize(
+    "destination_type,integration_kind,config",
+    [
+        ("AwsS3", Integration.IntegrationKind.AWS_S3, {"bucket_name": "b", "region": "us-east-1", "prefix": "p/"}),
+        (
+            "Databricks",
+            Integration.IntegrationKind.DATABRICKS,
+            {"http_path": "p", "catalog": "c", "schema": "s", "table_name": "t"},
+        ),
+    ],
+)
+def test_cannot_create_batch_export_with_integration_from_another_team(
+    client: HttpClient, temporal, organization, team, user, destination_type, integration_kind, config
+):
+    """The team-scoped `integration` field rejects an integration owned by another team (IDOR).
+
+    This is common to every integration-backed destination — a foreign id reads as "does not exist"
+    at field resolution, before any destination-specific validation runs.
+    """
+    other_team = create_team(organization)
+    foreign_integration = Integration.objects.create(
+        team=other_team,
+        kind=integration_kind,
+        integration_id="foreign",
+        config={},
+        sensitive_config={},
+        created_by=user,
+    )
+
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {"type": destination_type, "config": config, "integration": foreign_integration.id},
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["attr"] == "destination__integration"
+    assert response.json()["code"] == "does_not_exist"
 
 
 def test_cannot_create_a_batch_export_with_higher_frequencies_if_not_enabled(

--- a/products/batch_exports/backend/tests/api/test_create_s3.py
+++ b/products/batch_exports/backend/tests/api/test_create_s3.py
@@ -6,8 +6,12 @@ from django.test import override_settings
 from django.test.client import Client as HttpClient
 
 from rest_framework import status
+from temporalio.client import ScheduleActionStartWorkflow
+
+from posthog.models.integration import Integration
 
 from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES
+from products.batch_exports.backend.tests.api.conftest import describe_schedule
 from products.batch_exports.backend.tests.api.operations import create_batch_export
 
 pytestmark = [
@@ -301,3 +305,94 @@ def test_creating_s3_family_batch_export_fails_if_using_invalid_endpoint_url(
 
     assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
     assert f"Invalid endpoint_url: '{endpoint_url}'" in response.json()["detail"]
+
+
+@pytest.fixture
+def aws_s3_integration(team, user):
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+
+
+@pytest.fixture
+def s3_compatible_integration(team, user):
+    return Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.S3_COMPATIBLE,
+        integration_id="my-r2",
+        config={"name": "my-r2", "endpoint_url": "https://account.r2.cloudflarestorage.com"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+
+
+@pytest.mark.parametrize(
+    "destination_type,integration_fixture",
+    [
+        ("AwsS3", "aws_s3_integration"),
+        ("S3Compatible", "s3_compatible_integration"),
+    ],
+)
+def test_create_s3_family_batch_export_using_integration(
+    client: HttpClient, temporal, organization, team, user, destination_type, integration_fixture, request
+):
+    """An S3-family export authenticates via a matching integration, with no inline credentials in config."""
+    integration = request.getfixturevalue(integration_fixture)
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {
+                "type": destination_type,
+                # No credentials (nor endpoint_url) inline — they come from the integration.
+                "config": {"bucket_name": "my-bucket", "region": "us-east-1", "prefix": "events/"},
+                "integration": integration.id,
+            },
+        },
+    )
+    assert response.status_code == status.HTTP_201_CREATED, response.json()
+    data = response.json()
+    assert data["destination"]["type"] == destination_type
+    assert "aws_access_key_id" not in data["destination"]["config"]
+    assert "aws_secret_access_key" not in data["destination"]["config"]
+
+    schedule = describe_schedule(temporal, data["id"])
+    assert isinstance(schedule.schedule.action, ScheduleActionStartWorkflow)
+    assert schedule.schedule.action.workflow == "s3-export"
+
+
+@pytest.mark.parametrize(
+    "destination_type,integration_fixture",
+    [
+        ("AwsS3", "s3_compatible_integration"),
+        ("S3Compatible", "aws_s3_integration"),
+    ],
+)
+def test_create_s3_family_batch_export_rejects_mismatched_integration_kind(
+    client: HttpClient, temporal, organization, team, user, destination_type, integration_fixture, request
+):
+    """An S3-family export rejects an integration whose kind doesn't match the destination type."""
+    integration = request.getfixturevalue(integration_fixture)
+    client.force_login(user)
+    response = create_batch_export(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {
+                "type": destination_type,
+                "config": {"bucket_name": "my-bucket", "region": "us-east-1", "prefix": "events/"},
+                "integration": integration.id,
+            },
+        },
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()

--- a/products/batch_exports/backend/tests/api/test_update_s3.py
+++ b/products/batch_exports/backend/tests/api/test_update_s3.py
@@ -4,6 +4,8 @@ from django.test.client import Client as HttpClient
 
 from rest_framework import status
 
+from posthog.models.integration import Integration
+
 from products.batch_exports.backend.models.batch_export import S3_CREATABLE_TYPES, BatchExportDestination
 from products.batch_exports.backend.tests.api.fixtures import create_batch_export as create_batch_export_orm
 from products.batch_exports.backend.tests.api.operations import create_batch_export_ok, patch_batch_export
@@ -82,3 +84,123 @@ def test_updating_legacy_s3_batch_export_validates_empty_inputs(client: HttpClie
 
     client.force_login(user)
     _assert_empty_inputs_rejected(client, team.pk, str(batch_export.id), "S3")
+
+
+_S3_FAMILY_INTEGRATIONS = [
+    ("AwsS3", Integration.IntegrationKind.AWS_S3, {"name": "prod-aws", "aws_account_id": "123456789012"}),
+    (
+        "S3Compatible",
+        Integration.IntegrationKind.S3_COMPATIBLE,
+        {"name": "my-r2", "endpoint_url": "https://account.r2.cloudflarestorage.com"},
+    ),
+]
+
+
+def _create_integration_backed_export(client: HttpClient, team, user, destination_type, kind, integration_config):
+    integration = Integration.objects.create(
+        team=team,
+        kind=kind,
+        integration_id=integration_config["name"],
+        config=integration_config,
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+    client.force_login(user)
+    batch_export = create_batch_export_ok(
+        client,
+        team.pk,
+        {
+            "name": "my-export",
+            "interval": "hour",
+            "destination": {
+                "type": destination_type,
+                # No inline credentials (nor endpoint_url) — they come from the integration.
+                "config": {"bucket_name": "my-bucket", "region": "us-east-1", "prefix": "events/"},
+                "integration": integration.id,
+            },
+        },
+    )
+    return integration, batch_export
+
+
+@pytest.mark.parametrize("destination_type,kind,integration_config", _S3_FAMILY_INTEGRATIONS)
+@pytest.mark.parametrize("integration_value", [None, "omitted"])
+def test_updating_s3_family_batch_export_rejects_removing_integration(
+    client: HttpClient,
+    temporal,
+    organization,
+    team,
+    user,
+    destination_type,
+    kind,
+    integration_config,
+    integration_value,
+):
+    """An integration-backed export can't drop back to inline credentials — whether the caller
+    sends `integration: null` or omits it entirely (clients re-send the full destination on update).
+    """
+    _, batch_export = _create_integration_backed_export(client, team, user, destination_type, kind, integration_config)
+
+    destination: dict = {"type": destination_type, "config": {}}
+    if integration_value is None:
+        destination["integration"] = None
+
+    response = patch_batch_export(client, team.pk, batch_export["id"], {"destination": destination})
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == (
+        "Cannot remove the integration from an S3 batch export that uses one. "
+        "Re-send its `integration` to keep it (or a different one to swap)."
+    )
+
+
+@pytest.mark.parametrize("destination_type,kind,integration_config", _S3_FAMILY_INTEGRATIONS)
+def test_updating_integration_backed_s3_export_allows_config_patch_with_integration(
+    client: HttpClient, temporal, organization, team, user, destination_type, kind, integration_config
+):
+    """Updating config while re-sending the integration succeeds and keeps it linked."""
+    integration, batch_export = _create_integration_backed_export(
+        client, team, user, destination_type, kind, integration_config
+    )
+
+    response = patch_batch_export(
+        client,
+        team.pk,
+        batch_export["id"],
+        {"destination": {"type": destination_type, "config": {"prefix": "new-prefix/"}, "integration": integration.id}},
+    )
+    assert response.status_code == status.HTTP_200_OK, response.json()
+    assert response.json()["destination"]["config"]["prefix"] == "new-prefix/"
+    assert response.json()["destination"]["integration"] == integration.id
+
+
+def test_updating_legacy_s3_batch_export_rejects_integration(client: HttpClient, temporal, organization, team, user):
+    """The legacy `S3` type doesn't support integration-based credentials, so linking one is rejected."""
+    destination = BatchExportDestination.objects.create(
+        type="S3",
+        config={
+            "bucket_name": "my-s3-bucket",
+            "region": "us-east-1",
+            "prefix": "events/",
+            "aws_access_key_id": "abc123",
+            "aws_secret_access_key": "secret",
+        },
+    )
+    batch_export = create_batch_export_orm(team, destination)
+    integration = Integration.objects.create(
+        team=team,
+        kind=Integration.IntegrationKind.AWS_S3,
+        integration_id="prod-aws",
+        config={"name": "prod-aws", "aws_account_id": "123456789012"},
+        sensitive_config={"aws_access_key_id": "key", "aws_secret_access_key": "secret"},
+        created_by=user,
+    )
+
+    client.force_login(user)
+    response = patch_batch_export(
+        client,
+        team.pk,
+        str(batch_export.id),
+        {"destination": {"type": "S3", "config": {}, "integration": integration.id}},
+    )
+    assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+    assert response.json()["detail"] == "S3 destinations do not support integration-based credentials."

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
@@ -6,6 +6,7 @@ from django.conf import settings
 
 from temporalio.testing._activity import ActivityEnvironment
 
+from posthog.models.integration import Integration
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
@@ -127,6 +128,80 @@ async def test_insert_into_s3_activity_puts_data_into_s3(
         file_format=file_format,
         backfill_details=None,
         sort_key=sort_key,
+    )
+
+
+@pytest.mark.parametrize("exclude_events", [None], indirect=True)
+@pytest.mark.parametrize("model", [BatchExportModel(name="events", schema=None)])
+@pytest.mark.parametrize("compression", [None], indirect=True)
+@pytest.mark.parametrize("file_format", ["JSONLines"], indirect=True)
+async def test_insert_into_s3_activity_resolves_credentials_from_integration(
+    clickhouse_client,
+    bucket_name,
+    minio_client,
+    activity_environment: ActivityEnvironment,
+    compression,
+    exclude_events,
+    file_format,
+    data_interval_start,
+    data_interval_end,
+    model: BatchExportModel,
+    generate_test_data,
+    ateam,
+):
+    """An integration-backed S3-compatible export resolves credentials and endpoint_url from the
+    linked Integration at run time, with none of them present on the activity inputs.
+    """
+    integration = await Integration.objects.acreate(
+        team_id=ateam.pk,
+        kind=Integration.IntegrationKind.S3_COMPATIBLE,
+        integration_id="minio-test",
+        config={"name": "minio-test", "endpoint_url": settings.OBJECT_STORAGE_ENDPOINT},
+        sensitive_config={
+            "aws_access_key_id": "object_storage_root_user",
+            "aws_secret_access_key": "object_storage_root_password",
+        },
+    )
+
+    prefix = str(uuid.uuid4())
+
+    insert_inputs = S3InsertInputs(
+        bucket_name=bucket_name,
+        region="us-east-1",
+        prefix=prefix,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start.isoformat(),
+        data_interval_end=data_interval_end.isoformat(),
+        # No inline credentials or endpoint_url — both are resolved from the integration.
+        integration_id=integration.id,
+        compression=compression,
+        exclude_events=exclude_events,
+        file_format=file_format,
+        batch_export_model=model,
+        batch_export_id=str(uuid.uuid4()),
+        destination_default_fields=s3_default_fields(),
+    )
+
+    result = await run_activity(activity_environment, insert_inputs)
+    assert result.error is None
+    assert result.records_completed is not None and result.records_completed > 0
+    assert result.bytes_exported is not None and result.bytes_exported > 0
+
+    await assert_clickhouse_records_in_s3(
+        s3_compatible_client=minio_client,
+        clickhouse_client=clickhouse_client,
+        bucket_name=bucket_name,
+        key_prefix=prefix,
+        team_id=ateam.pk,
+        data_interval_start=data_interval_start,
+        data_interval_end=data_interval_end,
+        batch_export_model=model,
+        exclude_events=exclude_events,
+        include_events=None,
+        compression=compression,
+        file_format=file_format,
+        backfill_details=None,
+        sort_key="uuid",
     )
 
 

--- a/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/s3/test_activity.py
@@ -6,7 +6,7 @@ from django.conf import settings
 
 from temporalio.testing._activity import ActivityEnvironment
 
-from posthog.models.integration import Integration
+from posthog.models.integration import Integration, S3CredentialIntegrationError
 from posthog.temporal.tests.utils.events import generate_test_events_in_clickhouse
 
 from products.batch_exports.backend.service import BatchExportModel, BatchExportSchema
@@ -15,6 +15,7 @@ from products.batch_exports.backend.temporal.destinations.s3_batch_export import
     FILE_FORMAT_EXTENSIONS,
     SUPPORTED_COMPRESSIONS,
     S3InsertInputs,
+    _get_s3_integration,
     s3_default_fields,
 )
 from products.batch_exports.backend.tests.temporal.destinations.s3.utils import (
@@ -25,6 +26,26 @@ from products.batch_exports.backend.tests.temporal.destinations.s3.utils import 
 from products.batch_exports.backend.tests.temporal.utils.s3 import assert_files_in_s3, read_json_file_from_s3
 
 pytestmark = [pytest.mark.asyncio, pytest.mark.django_db]
+
+
+async def test_get_s3_integration_rejects_wrong_kind(ateam):
+    """An integration whose kind is neither aws-s3 nor s3-compatible can't be resolved as an S3 one.
+
+    The serializer validates the kind on create/update, so this only happens if the integration's
+    kind is changed out from under an existing export (unlikely, but worth checking).
+    """
+    integration = await Integration.objects.acreate(
+        team_id=ateam.pk,
+        kind=Integration.IntegrationKind.SLACK,
+        integration_id="not-s3",
+        config={},
+        sensitive_config={},
+    )
+
+    with pytest.raises(S3CredentialIntegrationError) as exc_info:
+        await _get_s3_integration(integration.id, ateam.pk)
+    assert "not an S3 integration" in str(exc_info.value)
+    assert "kind='slack'" in str(exc_info.value)
 
 
 @pytest.mark.parametrize("compression", COMPRESSION_EXTENSIONS.keys(), indirect=True)

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -265,7 +265,8 @@ export const S3CompatibleDestinationConfigApiType = {
 } as const
 
 /**
- * Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).
+ * Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,
+ * DigitalOcean Spaces, etc.).
  *
  * Credentials and the provider `endpoint_url` live in the linked s3-compatible Integration.
  * Mirrors the non-credential fields of `S3CompatibleBatchExportInputs` in

--- a/products/batch_exports/frontend/generated/api.schemas.ts
+++ b/products/batch_exports/frontend/generated/api.schemas.ts
@@ -107,14 +107,14 @@ export const CompressionEnumApi = {
 } as const
 
 /**
- * * `JSONLines` - JSONLines
  * * `Parquet` - Parquet
+ * * `JSONLines` - JSONLines
  */
 export type FileFormatEnumApi = (typeof FileFormatEnumApi)[keyof typeof FileFormatEnumApi]
 
 export const FileFormatEnumApi = {
-    JSONLines: 'JSONLines',
     Parquet: 'Parquet',
+    JSONLines: 'JSONLines',
 } as const
 
 export type AzureBlobDestinationConfigApiType =
@@ -206,18 +206,115 @@ export interface PostgresDestinationConfigApi {
     type: PostgresDestinationConfigApiType
 }
 
+export type AwsS3DestinationConfigApiType =
+    (typeof AwsS3DestinationConfigApiType)[keyof typeof AwsS3DestinationConfigApiType]
+
+export const AwsS3DestinationConfigApiType = {
+    AwsS3: 'AwsS3',
+} as const
+
+/**
+ * Typed configuration for an AWS S3 batch-export destination.
+ *
+ * AWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of
+ * `AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.
+ */
+export interface AwsS3DestinationConfigApi {
+    /** Name of the destination bucket. */
+    bucket_name: string
+    /** Region the bucket is in (e.g. 'us-east-1'). */
+    region: string
+    /** Object key prefix applied to every exported file. */
+    prefix: string
+    /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
+     *
+     * * `brotli` - brotli
+     * * `gzip` - gzip
+     * * `lz4` - lz4
+     * * `snappy` - snappy
+     * * `zstd` - zstd */
+    compression?: CompressionEnumApi | null
+    /** File format used for exported objects.
+     *
+     * * `Parquet` - Parquet
+     * * `JSONLines` - JSONLines */
+    file_format?: FileFormatEnumApi
+    /**
+     * If set, rolls to a new file once the current file exceeds this size in MB.
+     * @nullable
+     */
+    max_file_size_mb?: number | null
+    /**
+     * Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms').
+     * @nullable
+     */
+    encryption?: string | null
+    /**
+     * KMS key ID to use when encryption is 'aws:kms'.
+     * @nullable
+     */
+    kms_key_id?: string | null
+    type: AwsS3DestinationConfigApiType
+}
+
+export type S3CompatibleDestinationConfigApiType =
+    (typeof S3CompatibleDestinationConfigApiType)[keyof typeof S3CompatibleDestinationConfigApiType]
+
+export const S3CompatibleDestinationConfigApiType = {
+    S3Compatible: 'S3Compatible',
+} as const
+
+/**
+ * Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).
+ *
+ * Credentials and the provider `endpoint_url` live in the linked s3-compatible Integration.
+ * Mirrors the non-credential fields of `S3CompatibleBatchExportInputs` in
+ * `products/batch_exports/backend/service.py`.
+ */
+export interface S3CompatibleDestinationConfigApi {
+    /** Name of the destination bucket. */
+    bucket_name: string
+    /** Region the bucket is in (e.g. 'us-east-1'). */
+    region: string
+    /** Object key prefix applied to every exported file. */
+    prefix: string
+    /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
+     *
+     * * `brotli` - brotli
+     * * `gzip` - gzip
+     * * `lz4` - lz4
+     * * `snappy` - snappy
+     * * `zstd` - zstd */
+    compression?: CompressionEnumApi | null
+    /** File format used for exported objects.
+     *
+     * * `Parquet` - Parquet
+     * * `JSONLines` - JSONLines */
+    file_format?: FileFormatEnumApi
+    /**
+     * If set, rolls to a new file once the current file exceeds this size in MB.
+     * @nullable
+     */
+    max_file_size_mb?: number | null
+    /** Use virtual-hosted-style addressing rather than path-style. */
+    use_virtual_style_addressing?: boolean
+    type: S3CompatibleDestinationConfigApiType
+}
+
 export type BatchExportDestinationConfigApi =
     | DatabricksDestinationConfigApi
     | AzureBlobDestinationConfigApi
     | BigQueryDestinationConfigApi
     | PostgresDestinationConfigApi
+    | AwsS3DestinationConfigApi
+    | S3CompatibleDestinationConfigApi
 
 /**
  * Serializer for an BatchExportDestination model.
  *
  * The `config` field is polymorphic and typed only for destinations that keep
- * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).
- * Other destination types accept the same JSON shape but without a typed
+ * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
+ * AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
  * OpenAPI schema. Secret fields are stripped from `config` on read.
  */
 export interface BatchExportDestinationApi {
@@ -237,7 +334,7 @@ export interface BatchExportDestinationApi {
      * * `NoOp` - Noop
      * * `FileDownload` - File Download */
     type: BatchExportDestinationTypeEnumApi
-    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+    /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
     config: BatchExportDestinationConfigApi
     /**
      * The integration for this destination.
@@ -245,7 +342,7 @@ export interface BatchExportDestinationApi {
      */
     integration?: number | null
     /**
-     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.
+     * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.
      * @nullable
      */
     integration_id?: number | null
@@ -1129,11 +1226,47 @@ export interface PostgresDestinationRequestApi {
     config: PostgresDestinationConfigApi
 }
 
+export type AwsS3DestinationRequestApiType =
+    (typeof AwsS3DestinationRequestApiType)[keyof typeof AwsS3DestinationRequestApiType]
+
+export const AwsS3DestinationRequestApiType = {
+    AwsS3: 'AwsS3',
+} as const
+
+/**
+ * Request shape for creating or updating an AWS S3 batch-export destination.
+ */
+export interface AwsS3DestinationRequestApi {
+    type: AwsS3DestinationRequestApiType
+    /** ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+    integration_id?: number
+    config: AwsS3DestinationConfigApi
+}
+
+export type S3CompatibleDestinationRequestApiType =
+    (typeof S3CompatibleDestinationRequestApiType)[keyof typeof S3CompatibleDestinationRequestApiType]
+
+export const S3CompatibleDestinationRequestApiType = {
+    S3Compatible: 'S3Compatible',
+} as const
+
+/**
+ * Request shape for creating or updating an S3-compatible batch-export destination.
+ */
+export interface S3CompatibleDestinationRequestApi {
+    type: S3CompatibleDestinationRequestApiType
+    /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+    integration_id?: number
+    config: S3CompatibleDestinationConfigApi
+}
+
 export type BatchExportDestinationRequestApi =
     | DatabricksDestinationRequestApi
     | AzureBlobDestinationRequestApi
     | BigQueryDestinationRequestApi
     | PostgresDestinationRequestApi
+    | AwsS3DestinationRequestApi
+    | S3CompatibleDestinationRequestApi
 
 /**
  * Request body for create/partial_update on BatchExportViewSet.
@@ -1657,6 +1790,26 @@ export type PostgresDestinationRequestTypeEnumApi =
 
 export const PostgresDestinationRequestTypeEnumApi = {
     Postgres: 'Postgres',
+} as const
+
+/**
+ * * `AwsS3` - AwsS3
+ */
+export type AwsS3DestinationRequestTypeEnumApi =
+    (typeof AwsS3DestinationRequestTypeEnumApi)[keyof typeof AwsS3DestinationRequestTypeEnumApi]
+
+export const AwsS3DestinationRequestTypeEnumApi = {
+    AwsS3: 'AwsS3',
+} as const
+
+/**
+ * * `S3Compatible` - S3Compatible
+ */
+export type S3CompatibleDestinationRequestTypeEnumApi =
+    (typeof S3CompatibleDestinationRequestTypeEnumApi)[keyof typeof S3CompatibleDestinationRequestTypeEnumApi]
+
+export const S3CompatibleDestinationRequestTypeEnumApi = {
+    S3Compatible: 'S3Compatible',
 } as const
 
 export type BatchExportsListParams = {

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -286,7 +286,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
@@ -853,7 +853,7 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
@@ -1175,7 +1175,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
@@ -1471,7 +1471,7 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     ])
                     .describe(
@@ -1802,7 +1802,7 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     ])
                     .describe(
@@ -2126,7 +2126,7 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     ])
                     .describe(
@@ -2461,7 +2461,7 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                                 type: zod.enum(['S3Compatible']),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
                             ),
                     ])
                     .describe(

--- a/products/batch_exports/frontend/generated/api.zod.ts
+++ b/products/batch_exports/frontend/generated/api.zod.ts
@@ -18,6 +18,9 @@ export const batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault =
 export const batchExportsCreateBodyDestinationOneFourConfigSchemaDefault = `public`
 export const batchExportsCreateBodyDestinationOneFourConfigTableNameDefault = `events`
 export const batchExportsCreateBodyDestinationOneFourConfigHasSelfSignedCertDefault = false
+export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -98,8 +101,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(batchExportsCreateBodyDestinationOneTwoConfigFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet'
@@ -177,6 +180,116 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a PostgreSQL batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['AwsS3']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an AWS S3 batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['S3Compatible']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -472,6 +585,9 @@ export const batchExportsUpdateBodyDestinationOneThreeConfigUseJsonTypeDefault =
 export const batchExportsUpdateBodyDestinationOneFourConfigSchemaDefault = `public`
 export const batchExportsUpdateBodyDestinationOneFourConfigTableNameDefault = `events`
 export const batchExportsUpdateBodyDestinationOneFourConfigHasSelfSignedCertDefault = false
+export const batchExportsUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
+export const batchExportsUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
+export const batchExportsUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsUpdateBodyOffsetDayMin = 0
 export const batchExportsUpdateBodyOffsetDayMax = 6
 
@@ -552,8 +668,8 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(batchExportsUpdateBodyDestinationOneTwoConfigFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet'
@@ -631,6 +747,116 @@ export const BatchExportsUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a PostgreSQL batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['AwsS3']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsUpdateBodyDestinationOneFiveConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an AWS S3 batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['S3Compatible']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsUpdateBodyDestinationOneSixConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -679,6 +905,9 @@ export const batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDe
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigSchemaDefault = `public`
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigTableNameDefault = `events`
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigHasSelfSignedCertDefault = false
+export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -759,8 +988,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(batchExportsPartialUpdateBodyDestinationOneTwoConfigFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet'
@@ -840,6 +1069,116 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a PostgreSQL batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['AwsS3']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an AWS S3 batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['S3Compatible']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
@@ -893,6 +1232,9 @@ export const batchExportsPauseCreateBodyDestinationOneConfigOneThreeUseJsonTypeD
 export const batchExportsPauseCreateBodyDestinationOneConfigOneFourSchemaDefault = `public`
 export const batchExportsPauseCreateBodyDestinationOneConfigOneFourTableNameDefault = `events`
 export const batchExportsPauseCreateBodyDestinationOneConfigOneFourHasSelfSignedCertDefault = false
+export const batchExportsPauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
+export const batchExportsPauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsPauseCreateBodyOffsetDayMin = 0
 export const batchExportsPauseCreateBodyOffsetDayMax = 6
 
@@ -984,8 +1326,8 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(batchExportsPauseCreateBodyDestinationOneConfigOneTwoFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet'
@@ -1043,20 +1385,108 @@ export const BatchExportsPauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a PostgreSQL batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or\ninline in this config (legacy). Mirrors the non-credential fields of\n`PostgresBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsPauseCreateBodyDestinationOneConfigOneSixFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsPauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1119,6 +1549,9 @@ export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneThreeUseJso
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFourSchemaDefault = `public`
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFourTableNameDefault = `events`
 export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFourHasSelfSignedCertDefault = false
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsRunTestStepCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepCreateBodyOffsetDayMax = 6
 
@@ -1212,8 +1645,8 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(
                                         batchExportsRunTestStepCreateBodyDestinationOneConfigOneTwoFileFormatDefault
                                     )
@@ -1279,20 +1712,112 @@ export const BatchExportsRunTestStepCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a PostgreSQL batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or\ninline in this config (legacy). Mirrors the non-credential fields of\n`PostgresBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneFiveFileFormatDefault
+                                    )
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixFileFormatDefault
+                                    )
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsRunTestStepCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1358,6 +1883,9 @@ export const batchExportsUnpauseCreateBodyDestinationOneConfigOneThreeUseJsonTyp
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFourSchemaDefault = `public`
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFourTableNameDefault = `events`
 export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFourHasSelfSignedCertDefault = false
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
+export const batchExportsUnpauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsUnpauseCreateBodyOffsetDayMin = 0
 export const batchExportsUnpauseCreateBodyOffsetDayMax = 6
 
@@ -1451,8 +1979,8 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneTwoFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet'
@@ -1512,20 +2040,108 @@ export const BatchExportsUnpauseCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a PostgreSQL batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or\ninline in this config (legacy). Mirrors the non-credential fields of\n`PostgresBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneFiveFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(batchExportsUnpauseCreateBodyDestinationOneConfigOneSixFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsUnpauseCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1588,6 +2204,9 @@ export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneThreeUse
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFourSchemaDefault = `public`
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFourTableNameDefault = `events`
 export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFourHasSelfSignedCertDefault = false
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFiveFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixFileFormatDefault = `JSONLines`
+export const batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault = false
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMin = 0
 export const batchExportsRunTestStepNewCreateBodyOffsetDayMax = 6
 
@@ -1683,8 +2302,8 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                                     .default(
                                         batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneTwoFileFormatDefault
                                     )
@@ -1752,20 +2371,112 @@ export const BatchExportsRunTestStepNewCreateBody = /* @__PURE__ */ zod
                             .describe(
                                 'Typed configuration for a PostgreSQL batch-export destination.\n\nConnection credentials may live in a linked Integration (when one is provided) or\ninline in this config (legacy). Mirrors the non-credential fields of\n`PostgresBatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
                             ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneFiveFileFormatDefault
+                                    )
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                                type: zod.enum(['AwsS3']),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products\/batch_exports\/backend\/service.py`.'
+                            ),
+                        zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n\* `brotli` - brotli\n\* `gzip` - gzip\n\* `lz4` - lz4\n\* `snappy` - snappy\n\* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixFileFormatDefault
+                                    )
+                                    .describe(
+                                        'File format used for exported objects.\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsRunTestStepNewCreateBodyDestinationOneConfigOneSixUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                                type: zod.enum(['S3Compatible']),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products\/batch_exports\/backend\/service.py`.'
+                            ),
                     ])
                     .describe(
-                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
+                        'Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses.'
                     ),
                 integration: zod.number().nullish().describe('The integration for this destination.'),
                 integration_id: zod
                     .number()
                     .nullish()
                     .describe(
-                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.'
+                        'ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.'
                     ),
             })
             .describe(
-                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).\nOther destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
+                'Serializer for an BatchExportDestination model.\n\nThe `config` field is polymorphic and typed only for destinations that keep\ncredentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,\nAwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed\nOpenAPI schema. Secret fields are stripped from `config` on read.'
             )
             .describe('Destination configuration (type, config, and optional integration).'),
         interval: zod
@@ -1837,8 +2548,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyOneFileFormatDefault)
                         .describe('File format\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'),
                     compression: zod
@@ -1873,8 +2584,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyTwoFileFormatDefault)
                         .describe('File format\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'),
                     compression: zod
@@ -1907,8 +2618,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyThreeFileFormatDefault)
                         .describe('File format\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'),
                     compression: zod
@@ -1949,8 +2660,8 @@ export const FileDownloadBatchExportsCancelCreateBody = /* @__PURE__ */ zod
         file: zod
             .object({
                 format: zod
-                    .enum(['JSONLines', 'Parquet'])
-                    .describe('\* `JSONLines` - JSONLines\n\* `Parquet` - Parquet')
+                    .enum(['Parquet', 'JSONLines'])
+                    .describe('\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines')
                     .default(fileDownloadBatchExportsCancelCreateBodyFileFormatDefault)
                     .describe('File format\n\n\* `Parquet` - Parquet\n\* `JSONLines` - JSONLines'),
                 compression: zod

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9920,11 +9920,11 @@ export namespace Schemas {
       UsePosthogInSlack: 'use_posthog_in_slack',
     } as const;
 
-    export type AzureBlobDestinationConfigType = typeof AzureBlobDestinationConfigType[keyof typeof AzureBlobDestinationConfigType];
+    export type AwsS3DestinationConfigType = typeof AwsS3DestinationConfigType[keyof typeof AwsS3DestinationConfigType];
 
 
-    export const AzureBlobDestinationConfigType = {
-      AzureBlob: 'AzureBlob',
+    export const AwsS3DestinationConfigType = {
+      AwsS3: 'AwsS3',
     } as const;
 
     /**
@@ -9946,15 +9946,93 @@ export namespace Schemas {
     } as const;
 
     /**
-     * * `JSONLines` - JSONLines
      * * `Parquet` - Parquet
+     * * `JSONLines` - JSONLines
      */
     export type FileFormatEnum = typeof FileFormatEnum[keyof typeof FileFormatEnum];
 
 
     export const FileFormatEnum = {
-      JSONLines: 'JSONLines',
       Parquet: 'Parquet',
+      JSONLines: 'JSONLines',
+    } as const;
+
+    /**
+     * Typed configuration for an AWS S3 batch-export destination.
+     *
+     * AWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of
+     * `AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.
+     */
+    export interface AwsS3DestinationConfig {
+      /** Name of the destination bucket. */
+      bucket_name: string;
+      /** Region the bucket is in (e.g. 'us-east-1'). */
+      region: string;
+      /** Object key prefix applied to every exported file. */
+      prefix: string;
+      /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
+       *
+       * * `brotli` - brotli
+       * * `gzip` - gzip
+       * * `lz4` - lz4
+       * * `snappy` - snappy
+       * * `zstd` - zstd */
+      compression?: CompressionEnum | null;
+      /** File format used for exported objects.
+       *
+       * * `Parquet` - Parquet
+       * * `JSONLines` - JSONLines */
+      file_format?: FileFormatEnum;
+      /**
+         * If set, rolls to a new file once the current file exceeds this size in MB.
+         * @nullable
+         */
+      max_file_size_mb?: number | null;
+      /**
+         * Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms').
+         * @nullable
+         */
+      encryption?: string | null;
+      /**
+         * KMS key ID to use when encryption is 'aws:kms'.
+         * @nullable
+         */
+      kms_key_id?: string | null;
+      type: AwsS3DestinationConfigType;
+    }
+
+    export type AwsS3DestinationRequestType = typeof AwsS3DestinationRequestType[keyof typeof AwsS3DestinationRequestType];
+
+
+    export const AwsS3DestinationRequestType = {
+      AwsS3: 'AwsS3',
+    } as const;
+
+    /**
+     * Request shape for creating or updating an AWS S3 batch-export destination.
+     */
+    export interface AwsS3DestinationRequest {
+      type: AwsS3DestinationRequestType;
+      /** ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+      integration_id?: number;
+      config: AwsS3DestinationConfig;
+    }
+
+    /**
+     * * `AwsS3` - AwsS3
+     */
+    export type AwsS3DestinationRequestTypeEnum = typeof AwsS3DestinationRequestTypeEnum[keyof typeof AwsS3DestinationRequestTypeEnum];
+
+
+    export const AwsS3DestinationRequestTypeEnum = {
+      AwsS3: 'AwsS3',
+    } as const;
+
+    export type AzureBlobDestinationConfigType = typeof AzureBlobDestinationConfigType[keyof typeof AzureBlobDestinationConfigType];
+
+
+    export const AzureBlobDestinationConfigType = {
+      AzureBlob: 'AzureBlob',
     } as const;
 
     /**
@@ -10559,14 +10637,58 @@ export namespace Schemas {
       type: PostgresDestinationConfigType;
     }
 
-    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig;
+    export type S3CompatibleDestinationConfigType = typeof S3CompatibleDestinationConfigType[keyof typeof S3CompatibleDestinationConfigType];
+
+
+    export const S3CompatibleDestinationConfigType = {
+      S3Compatible: 'S3Compatible',
+    } as const;
+
+    /**
+     * Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).
+     *
+     * Credentials and the provider `endpoint_url` live in the linked s3-compatible Integration.
+     * Mirrors the non-credential fields of `S3CompatibleBatchExportInputs` in
+     * `products/batch_exports/backend/service.py`.
+     */
+    export interface S3CompatibleDestinationConfig {
+      /** Name of the destination bucket. */
+      bucket_name: string;
+      /** Region the bucket is in (e.g. 'us-east-1'). */
+      region: string;
+      /** Object key prefix applied to every exported file. */
+      prefix: string;
+      /** Optional compression codec applied to exported files. Valid codecs depend on file_format.
+       *
+       * * `brotli` - brotli
+       * * `gzip` - gzip
+       * * `lz4` - lz4
+       * * `snappy` - snappy
+       * * `zstd` - zstd */
+      compression?: CompressionEnum | null;
+      /** File format used for exported objects.
+       *
+       * * `Parquet` - Parquet
+       * * `JSONLines` - JSONLines */
+      file_format?: FileFormatEnum;
+      /**
+         * If set, rolls to a new file once the current file exceeds this size in MB.
+         * @nullable
+         */
+      max_file_size_mb?: number | null;
+      /** Use virtual-hosted-style addressing rather than path-style. */
+      use_virtual_style_addressing?: boolean;
+      type: S3CompatibleDestinationConfigType;
+    }
+
+    export type BatchExportDestinationConfig = DatabricksDestinationConfig | AzureBlobDestinationConfig | BigQueryDestinationConfig | PostgresDestinationConfig | AwsS3DestinationConfig | S3CompatibleDestinationConfig;
 
     /**
      * Serializer for an BatchExportDestination model.
      *
      * The `config` field is polymorphic and typed only for destinations that keep
-     * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres).
-     * Other destination types accept the same JSON shape but without a typed
+     * credentials in the linked Integration (currently Databricks, AzureBlob, BigQuery, Postgres,
+     * AwsS3, S3Compatible). Other destination types accept the same JSON shape but without a typed
      * OpenAPI schema. Secret fields are stripped from `config` on read.
      */
     export interface BatchExportDestination {
@@ -10586,7 +10708,7 @@ export namespace Schemas {
        * * `NoOp` - Noop
        * * `FileDownload` - File Download */
       type: BatchExportDestinationTypeEnum;
-      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
+      /** Destination-specific configuration. Fields depend on `type`. Credentials for integration-backed destinations (Databricks, AzureBlob, BigQuery, Postgres, AwsS3, S3Compatible) are NOT stored here — they live in the linked Integration. Secret fields are stripped from responses. */
       config: BatchExportDestinationConfig;
       /**
          * The integration for this destination.
@@ -10594,7 +10716,7 @@ export namespace Schemas {
          */
       integration?: number | null;
       /**
-         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, BigQuery, and Postgres destinations; unused for other types.
+         * ID of a team-scoped Integration providing credentials. Required when creating Databricks, AzureBlob, and BigQuery destinations; optional for AwsS3 and S3Compatible (inline credentials remain supported); unused for other types.
          * @nullable
          */
       integration_id?: number | null;
@@ -11545,7 +11667,24 @@ export namespace Schemas {
       config: PostgresDestinationConfig;
     }
 
-    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest;
+    export type S3CompatibleDestinationRequestType = typeof S3CompatibleDestinationRequestType[keyof typeof S3CompatibleDestinationRequestType];
+
+
+    export const S3CompatibleDestinationRequestType = {
+      S3Compatible: 'S3Compatible',
+    } as const;
+
+    /**
+     * Request shape for creating or updating an S3-compatible batch-export destination.
+     */
+    export interface S3CompatibleDestinationRequest {
+      type: S3CompatibleDestinationRequestType;
+      /** ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one. */
+      integration_id?: number;
+      config: S3CompatibleDestinationConfig;
+    }
+
+    export type BatchExportDestinationRequest = DatabricksDestinationRequest | AzureBlobDestinationRequest | BigQueryDestinationRequest | PostgresDestinationRequest | AwsS3DestinationRequest | S3CompatibleDestinationRequest;
 
     /**
      * Request body for create/partial_update on BatchExportViewSet.
@@ -46509,6 +46648,16 @@ export namespace Schemas {
          */
       recommended_running_time_days: number | null;
     }
+
+    /**
+     * * `S3Compatible` - S3Compatible
+     */
+    export type S3CompatibleDestinationRequestTypeEnum = typeof S3CompatibleDestinationRequestTypeEnum[keyof typeof S3CompatibleDestinationRequestTypeEnum];
+
+
+    export const S3CompatibleDestinationRequestTypeEnum = {
+      S3Compatible: 'S3Compatible',
+    } as const;
 
     /**
      * Form fields that must be submitted verbatim with the file upload

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -10645,7 +10645,8 @@ export namespace Schemas {
     } as const;
 
     /**
-     * Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).
+     * Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,
+     * DigitalOcean Spaces, etc.).
      *
      * Credentials and the provider `endpoint_url` live in the linked s3-compatible Integration.
      * Mirrors the non-credential fields of `S3CompatibleBatchExportInputs` in

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -300,7 +300,7 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                                     .describe('Use virtual-hosted-style addressing rather than path-style.'),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
@@ -629,7 +629,7 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                                     .describe('Use virtual-hosted-style addressing rather than path-style.'),
                             })
                             .describe(
-                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                                'Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
                             ),
                     })
                     .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),

--- a/services/mcp/src/generated/batch_exports/api.ts
+++ b/services/mcp/src/generated/batch_exports/api.ts
@@ -38,6 +38,9 @@ export const batchExportsCreateBodyDestinationOneThreeConfigUseJsonTypeDefault =
 export const batchExportsCreateBodyDestinationOneFourConfigSchemaDefault = `public`
 export const batchExportsCreateBodyDestinationOneFourConfigTableNameDefault = `events`
 export const batchExportsCreateBodyDestinationOneFourConfigHasSelfSignedCertDefault = false
+export const batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
+export const batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsCreateBodyOffsetDayMin = 0
 export const batchExportsCreateBodyOffsetDayMax = 6
 
@@ -117,8 +120,8 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                                     .default(batchExportsCreateBodyDestinationOneTwoConfigFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n* `JSONLines` - JSONLines\n* `Parquet` - Parquet'
@@ -193,6 +196,114 @@ export const BatchExportsCreateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a PostgreSQL batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['AwsS3']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
+                                    .default(batchExportsCreateBodyDestinationOneFiveConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an AWS S3 batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['S3Compatible']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
+                                    .default(batchExportsCreateBodyDestinationOneSixConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsCreateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
             ])
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
         interval: zod
@@ -254,6 +365,9 @@ export const batchExportsPartialUpdateBodyDestinationOneThreeConfigUseJsonTypeDe
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigSchemaDefault = `public`
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigTableNameDefault = `events`
 export const batchExportsPartialUpdateBodyDestinationOneFourConfigHasSelfSignedCertDefault = false
+export const batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault = `JSONLines`
+export const batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault = false
 export const batchExportsPartialUpdateBodyOffsetDayMin = 0
 export const batchExportsPartialUpdateBodyOffsetDayMax = 6
 
@@ -333,8 +447,8 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                                         'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
                                     ),
                                 file_format: zod
-                                    .enum(['JSONLines', 'Parquet'])
-                                    .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                                     .default(batchExportsPartialUpdateBodyDestinationOneTwoConfigFileFormatDefault)
                                     .describe(
                                         'File format used for exported objects.\n\n* `JSONLines` - JSONLines\n* `Parquet` - Parquet'
@@ -411,6 +525,114 @@ export const BatchExportsPartialUpdateBody = /* @__PURE__ */ zod
                             ),
                     })
                     .describe('Request shape for creating or updating a PostgreSQL batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['AwsS3']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneFiveConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                encryption: zod
+                                    .string()
+                                    .nullish()
+                                    .describe(
+                                        "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                    ),
+                                kms_key_id: zod
+                                    .string()
+                                    .nullish()
+                                    .describe("KMS key ID to use when encryption is 'aws:kms'."),
+                            })
+                            .describe(
+                                'Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an AWS S3 batch-export destination.'),
+                zod
+                    .object({
+                        type: zod.enum(['S3Compatible']),
+                        integration_id: zod
+                            .number()
+                            .optional()
+                            .describe(
+                                'ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.'
+                            ),
+                        config: zod
+                            .object({
+                                bucket_name: zod.string().describe('Name of the destination bucket.'),
+                                region: zod.string().describe("Region the bucket is in (e.g. 'us-east-1')."),
+                                prefix: zod.string().describe('Object key prefix applied to every exported file.'),
+                                compression: zod
+                                    .union([
+                                        zod
+                                            .enum(['brotli', 'gzip', 'lz4', 'snappy', 'zstd'])
+                                            .describe(
+                                                '* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                            ),
+                                        zod.null(),
+                                    ])
+                                    .optional()
+                                    .describe(
+                                        'Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd'
+                                    ),
+                                file_format: zod
+                                    .enum(['Parquet', 'JSONLines'])
+                                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
+                                    .default(batchExportsPartialUpdateBodyDestinationOneSixConfigFileFormatDefault)
+                                    .describe(
+                                        'File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'
+                                    ),
+                                max_file_size_mb: zod
+                                    .number()
+                                    .nullish()
+                                    .describe(
+                                        'If set, rolls to a new file once the current file exceeds this size in MB.'
+                                    ),
+                                use_virtual_style_addressing: zod
+                                    .boolean()
+                                    .default(
+                                        batchExportsPartialUpdateBodyDestinationOneSixConfigUseVirtualStyleAddressingDefault
+                                    )
+                                    .describe('Use virtual-hosted-style addressing rather than path-style.'),
+                            })
+                            .describe(
+                                'Typed configuration for an S3-compatible batch-export destination (R2, MinIO, Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.'
+                            ),
+                    })
+                    .describe('Request shape for creating or updating an S3-compatible batch-export destination.'),
             ])
             .optional()
             .describe('Destination configuration. Required integration_id is enforced per destination type.'),
@@ -482,8 +704,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyOneFileFormatDefault)
                         .describe('File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'),
                     compression: zod
@@ -518,8 +740,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyTwoFileFormatDefault)
                         .describe('File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'),
                     compression: zod
@@ -552,8 +774,8 @@ export const FileDownloadBatchExportsCreateBody = /* @__PURE__ */ zod.union([
             file: zod
                 .object({
                     format: zod
-                        .enum(['JSONLines', 'Parquet'])
-                        .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                        .enum(['Parquet', 'JSONLines'])
+                        .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                         .default(fileDownloadBatchExportsCreateBodyThreeFileFormatDefault)
                         .describe('File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'),
                     compression: zod
@@ -619,8 +841,8 @@ export const FileDownloadBatchExportsCancelCreateBody = /* @__PURE__ */ zod
         file: zod
             .object({
                 format: zod
-                    .enum(['JSONLines', 'Parquet'])
-                    .describe('* `JSONLines` - JSONLines\n* `Parquet` - Parquet')
+                    .enum(['Parquet', 'JSONLines'])
+                    .describe('* `Parquet` - Parquet\n* `JSONLines` - JSONLines')
                     .default(fileDownloadBatchExportsCancelCreateBodyFileFormatDefault)
                     .describe('File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines'),
                 compression: zod

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-create.json
@@ -78,7 +78,7 @@
                                 "file_format": {
                                     "default": "JSONLines",
                                     "description": "File format used for exported objects.\n\n* `JSONLines` - JSONLines\n* `Parquet` - Parquet",
-                                    "enum": ["JSONLines", "Parquet"],
+                                    "enum": ["Parquet", "JSONLines"],
                                     "type": "string"
                                 },
                                 "max_file_size_mb": {
@@ -188,6 +188,161 @@
                         }
                     },
                     "required": ["type", "integration_id", "config"],
+                    "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating an AWS S3 batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "bucket_name": {
+                                    "description": "Name of the destination bucket.",
+                                    "type": "string"
+                                },
+                                "compression": {
+                                    "anyOf": [
+                                        {
+                                            "description": "* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd",
+                                            "enum": ["brotli", "gzip", "lz4", "snappy", "zstd"],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd"
+                                },
+                                "encryption": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                },
+                                "file_format": {
+                                    "default": "JSONLines",
+                                    "description": "File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
+                                    "enum": ["Parquet", "JSONLines"],
+                                    "type": "string"
+                                },
+                                "kms_key_id": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "KMS key ID to use when encryption is 'aws:kms'."
+                                },
+                                "max_file_size_mb": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If set, rolls to a new file once the current file exceeds this size in MB."
+                                },
+                                "prefix": {
+                                    "description": "Object key prefix applied to every exported file.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region the bucket is in (e.g. 'us-east-1').",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["bucket_name", "region", "prefix"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["AwsS3"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating an S3-compatible batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "bucket_name": {
+                                    "description": "Name of the destination bucket.",
+                                    "type": "string"
+                                },
+                                "compression": {
+                                    "anyOf": [
+                                        {
+                                            "description": "* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd",
+                                            "enum": ["brotli", "gzip", "lz4", "snappy", "zstd"],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd"
+                                },
+                                "file_format": {
+                                    "default": "JSONLines",
+                                    "description": "File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
+                                    "enum": ["Parquet", "JSONLines"],
+                                    "type": "string"
+                                },
+                                "max_file_size_mb": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If set, rolls to a new file once the current file exceeds this size in MB."
+                                },
+                                "prefix": {
+                                    "description": "Object key prefix applied to every exported file.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region the bucket is in (e.g. 'us-east-1').",
+                                    "type": "string"
+                                },
+                                "use_virtual_style_addressing": {
+                                    "default": false,
+                                    "description": "Use virtual-hosted-style addressing rather than path-style.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["bucket_name", "region", "prefix"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["S3Compatible"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
                     "type": "object"
                 }
             ],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/batch-export-update.json
@@ -77,7 +77,7 @@
                                 "file_format": {
                                     "default": "JSONLines",
                                     "description": "File format used for exported objects.\n\n* `JSONLines` - JSONLines\n* `Parquet` - Parquet",
-                                    "enum": ["JSONLines", "Parquet"],
+                                    "enum": ["Parquet", "JSONLines"],
                                     "type": "string"
                                 },
                                 "max_file_size_mb": {
@@ -187,6 +187,161 @@
                         }
                     },
                     "required": ["type", "integration_id", "config"],
+                    "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating an AWS S3 batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for an AWS S3 batch-export destination.\n\nAWS credentials live in the linked aws-s3 Integration. Mirrors the non-credential fields of\n`AwsS3BatchExportInputs` in `products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "bucket_name": {
+                                    "description": "Name of the destination bucket.",
+                                    "type": "string"
+                                },
+                                "compression": {
+                                    "anyOf": [
+                                        {
+                                            "description": "* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd",
+                                            "enum": ["brotli", "gzip", "lz4", "snappy", "zstd"],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd"
+                                },
+                                "encryption": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional S3 server-side encryption algorithm (e.g. 'AES256' or 'aws:kms')."
+                                },
+                                "file_format": {
+                                    "default": "JSONLines",
+                                    "description": "File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
+                                    "enum": ["Parquet", "JSONLines"],
+                                    "type": "string"
+                                },
+                                "kms_key_id": {
+                                    "anyOf": [
+                                        {
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "KMS key ID to use when encryption is 'aws:kms'."
+                                },
+                                "max_file_size_mb": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If set, rolls to a new file once the current file exceeds this size in MB."
+                                },
+                                "prefix": {
+                                    "description": "Object key prefix applied to every exported file.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region the bucket is in (e.g. 'us-east-1').",
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["bucket_name", "region", "prefix"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an aws-s3-kind Integration providing AWS credentials. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["AwsS3"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
+                    "type": "object"
+                },
+                {
+                    "description": "Request shape for creating or updating an S3-compatible batch-export destination.",
+                    "properties": {
+                        "config": {
+                            "description": "Typed configuration for an S3-compatible batch-export destination (Cloudflare R2,\nDigitalOcean Spaces, etc.).\n\nCredentials and the provider `endpoint_url` live in the linked s3-compatible Integration.\nMirrors the non-credential fields of `S3CompatibleBatchExportInputs` in\n`products/batch_exports/backend/service.py`.",
+                            "properties": {
+                                "bucket_name": {
+                                    "description": "Name of the destination bucket.",
+                                    "type": "string"
+                                },
+                                "compression": {
+                                    "anyOf": [
+                                        {
+                                            "description": "* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd",
+                                            "enum": ["brotli", "gzip", "lz4", "snappy", "zstd"],
+                                            "type": "string"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "Optional compression codec applied to exported files. Valid codecs depend on file_format.\n\n* `brotli` - brotli\n* `gzip` - gzip\n* `lz4` - lz4\n* `snappy` - snappy\n* `zstd` - zstd"
+                                },
+                                "file_format": {
+                                    "default": "JSONLines",
+                                    "description": "File format used for exported objects.\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
+                                    "enum": ["Parquet", "JSONLines"],
+                                    "type": "string"
+                                },
+                                "max_file_size_mb": {
+                                    "anyOf": [
+                                        {
+                                            "type": "number"
+                                        },
+                                        {
+                                            "type": "null"
+                                        }
+                                    ],
+                                    "description": "If set, rolls to a new file once the current file exceeds this size in MB."
+                                },
+                                "prefix": {
+                                    "description": "Object key prefix applied to every exported file.",
+                                    "type": "string"
+                                },
+                                "region": {
+                                    "description": "Region the bucket is in (e.g. 'us-east-1').",
+                                    "type": "string"
+                                },
+                                "use_virtual_style_addressing": {
+                                    "default": false,
+                                    "description": "Use virtual-hosted-style addressing rather than path-style.",
+                                    "type": "boolean"
+                                }
+                            },
+                            "required": ["bucket_name", "region", "prefix"],
+                            "type": "object"
+                        },
+                        "integration_id": {
+                            "description": "ID of an s3-compatible-kind Integration providing credentials and the provider endpoint URL. Preferred over inline credentials. Use the integrations-list MCP tool to find one.",
+                            "type": "number"
+                        },
+                        "type": {
+                            "enum": ["S3Compatible"],
+                            "type": "string"
+                        }
+                    },
+                    "required": ["type", "config"],
                     "type": "object"
                 }
             ],

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/file-download-batch-exports-cancel-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/file-download-batch-exports-cancel-create.json
@@ -36,7 +36,7 @@
                 "format": {
                     "default": "Parquet",
                     "description": "File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
-                    "enum": ["JSONLines", "Parquet"],
+                    "enum": ["Parquet", "JSONLines"],
                     "type": "string"
                 },
                 "max_size_mb": {

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/file-download-batch-exports-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/file-download-batch-exports-create.json
@@ -39,7 +39,7 @@
                         "format": {
                             "default": "Parquet",
                             "description": "File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
-                            "enum": ["JSONLines", "Parquet"],
+                            "enum": ["Parquet", "JSONLines"],
                             "type": "string"
                         },
                         "max_size_mb": {
@@ -103,7 +103,7 @@
                         "format": {
                             "default": "Parquet",
                             "description": "File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
-                            "enum": ["JSONLines", "Parquet"],
+                            "enum": ["Parquet", "JSONLines"],
                             "type": "string"
                         },
                         "max_size_mb": {
@@ -161,7 +161,7 @@
                         "format": {
                             "default": "Parquet",
                             "description": "File format\n\n* `Parquet` - Parquet\n* `JSONLines` - JSONLines",
-                            "enum": ["JSONLines", "Parquet"],
+                            "enum": ["Parquet", "JSONLines"],
                             "type": "string"
                         },
                         "max_size_mb": {


### PR DESCRIPTION
## Problem

`AwsS3` and `S3Compatible` batch exports store AWS credentials inline per destination — so they cannot be reused or rotated independently. Databricks and Azure Blob already use the shared `Integration` model; this brings the S3 family in line.

PR 2 of the migration. PR 1 (the `aws-s3` / `s3-compatible` integration kinds) is merged; this wires batch exports to use them.

## Changes

Wires `AwsS3` / `S3Compatible` batch exports to the shared `Integration` model:

- **`service.py` / `s3_batch_export.py`:** credentials (and the `S3Compatible` `endpoint_url`) are optional on the input dataclasses; the activity resolves them from the linked integration at run time when `integration_id` is set, else uses inline config.
- **`batch_export.py`:** typed `AwsS3` / `S3Compatible` request serializers; `integration_id` accepted; integration kind validated against the destination type via a data-driven map.

**Inline credentials are still supported for now and will be dropped later** once integrations are enforced. They stay accepted at runtime so existing exports keep working, but are deliberately NOT advertised in the request schema (only `integration_id` is) so new exports and agents are steered toward integrations.

Validation hardening from review:

- An export that uses an integration cannot drop back to inline credentials — updates must re-send `integration` (swapping is fine); matches Databricks/BigQuery/Azure.
- The legacy `S3` destination type cannot link an integration.
- Dropped the redundant per-destination `integration.team_id` checks — the team-scoped `integration` field already rejects cross-team ids (IDOR).
- Runtime credential/kind failures (wrong kind, missing credentials, deleted integration) are now non-retryable with clearer messages.

Backward compatible — inline creates and existing exports are unchanged. Migrating existing exports is a later PR.

## How did you test this code?

I am an agent; these are the automated tests I ran locally (Postgres + ClickHouse + MinIO up):

- **API (109 passing):** create via a matching integration; reject a mismatched kind; reject a cross-team integration (generic — catches IDOR for any destination); reject dropping or omitting the integration on update; allow a config patch that re-sends it; reject linking an integration to legacy `S3`.
- **Temporal:** integration-backed export resolves credentials + `endpoint_url` from the integration and writes real records to MinIO; a wrong-kind integration raises a clear, non-retryable error.
- `ruff` + `ty` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs — backend only. Frontend flow comes with PR 3.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @rossgray.

- Tool: PostHog Code. Skills: `/improving-drf-endpoints`, `/writing-tests`.
- Notable choices: `endpoint_url` resolved in the activity, not threaded through the workflow; destination→kind check is a data map; inline credentials accepted at runtime but kept out of the request schema (transitional); integration is sticky on update rather than allowing a downgrade to inline; reused `S3CredentialIntegrationError` (non-retryable) for runtime kind/credential failures instead of a misleading "not found".
