### PR TITLE
fix(oauth): allow native-app redirect URIs for CIMD clients

### DIFF
--- a/posthog/models/oauth.py
+++ b/posthog/models/oauth.py
@@ -20,6 +20,8 @@ from oauth2_provider.models import (
     AbstractIDToken,
     AbstractRefreshToken,
 )
+from oauth2_provider.settings import oauth2_settings
+from oauth2_provider.validators import AllowedURIValidator
 
 from posthog.helpers.encrypted_fields import EncryptedCharField
 from posthog.models.activity_logging.model_activity import ModelActivityMixin
@@ -285,64 +287,100 @@ class OAuthApplication(ModelActivityMixin, AbstractApplication):  # type: ignore
         )
 
     def clean(self):
-        super().clean()
+        # Full override of AbstractApplication.clean(). We run django-oauth-toolkit's redirect_uri
+        # validator ourselves with a carve-out for authority-less native-app schemes (com.example.app:/oauth),
+        # and re-implement its remaining model checks in _validate_application_config — rather than
+        # calling super().clean(), which would re-run the redirect validation and reject those native schemes.
+        self._validate_redirect_uris()
+        self._validate_optional_scopes()
+        self._validate_application_config()
 
-        if self.optional_scopes:
-            if not self.scopes:
-                raise ValidationError(
-                    {"optional_scopes": "Declaring optional scopes requires a non-empty required set in `scopes`."}
-                )
-            for field, values in (("scopes", self.scopes), ("optional_scopes", self.optional_scopes)):
-                non_resource = [scope for scope in values if ":" not in scope]
-                if non_resource:
-                    # `*` or identity scopes in a required set either brick /authorize
-                    # (explicit ceilings reject `*`) or 400 every consent the client
-                    # didn't request them on, with no UI recourse.
-                    raise ValidationError(
-                        {
-                            field: f"With optional scopes declared, every entry must be a resource scope "
-                            f"(object:action); invalid: {', '.join(non_resource)}"
-                        }
-                    )
-
-        for uri in self.redirect_uris.split(" "):
-            if not uri:
-                continue
-
+    def _validate_redirect_uris(self):
+        validator = AllowedURIValidator(
+            {scheme.lower() for scheme in self.get_allowed_schemes()},
+            name="redirect uri",
+            allow_path=True,
+            allow_query=True,
+            allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
+        )
+        for uri in self.redirect_uris.split():
             parsed_uri = urlparse(uri)
 
-            if parsed_uri.fragment:
-                raise ValidationError({"redirect_uris": f"Redirect URI {uri} cannot contain fragments"})
-
-            # Custom URL schemes for native apps (RFC 8252 Section 7.1)
-            # These look like: myapp://callback, posthog-code://oauth
-            is_custom_scheme = parsed_uri.scheme not in ["http", "https", ""]
-
-            if is_custom_scheme:
-                # Block dangerous schemes that could be used for attacks (XSS, data exfiltration, etc.)
-                # Since we use DCR with pre-registration, clients can use any scheme not in this blocklist
+            # RFC 8252 Section 7.1 private-use scheme redirects (e.g. com.example.app:/oauth)
+            # are authority-less by design; django-oauth-toolkit validator rejects them solely for lacking a host.
+            # Everything else goes through validator unchanged.
+            if parsed_uri.scheme not in ("http", "https", "") and parsed_uri.hostname is None:
                 if parsed_uri.scheme in self.get_blocked_schemes():
                     raise ValidationError(
                         {
                             "redirect_uris": f"Redirect URI scheme '{parsed_uri.scheme}' is not allowed for security reasons"
                         }
                     )
-            else:
-                # Standard HTTP(S) validation
-                if not parsed_uri.netloc:
-                    raise ValidationError({"redirect_uris": f"Redirect URI {uri} must contain a host"})
+                if parsed_uri.fragment:
+                    raise ValidationError({"redirect_uris": f"Redirect URI {uri} cannot contain fragments"})
+                continue
 
-                is_loopback = is_loopback_host(parsed_uri.hostname)
+            # django-oauth-toolkit validates scheme, fragment, and URL shape
+            validator(uri)
 
-                # http is only allowed for loopback addresses (localhost, 127.x.x.x)
-                allowed_schemes = ["http", "https"] if is_loopback else ["https"]
+            # django-oauth-toolkit permits any allowlisted scheme; we additionally require https except on loopback.
+            if parsed_uri.scheme == "http" and not is_loopback_host(parsed_uri.hostname):
+                raise ValidationError(
+                    {
+                        "redirect_uris": f"Redirect URI {uri} must use https (http is only allowed for loopback addresses)"
+                    }
+                )
 
-                if parsed_uri.scheme not in allowed_schemes:
-                    raise ValidationError(
-                        {
-                            "redirect_uris": f"Redirect URI {uri} must start with one of the following schemes: {', '.join(allowed_schemes)}"
-                        }
-                    )
+    def _validate_optional_scopes(self):
+        if not self.optional_scopes:
+            return
+        if not self.scopes:
+            raise ValidationError(
+                {"optional_scopes": "Declaring optional scopes requires a non-empty required set in `scopes`."}
+            )
+        for field, values in (("scopes", self.scopes), ("optional_scopes", self.optional_scopes)):
+            non_resource = [scope for scope in values if ":" not in scope]
+            if non_resource:
+                # `*` or identity scopes in a required set either brick /authorize
+                # (explicit ceilings reject `*`) or 400 every consent the client
+                # didn't request them on, with no UI recourse.
+                raise ValidationError(
+                    {
+                        field: f"With optional scopes declared, every entry must be a resource scope "
+                        f"(object:action); invalid: {', '.join(non_resource)}"
+                    }
+                )
+
+    def _validate_application_config(self):
+        # Mirror of AbstractApplication.clean()'s non-redirect checks (grant type, allowed origins,
+        # signing algorithm). Re-implemented here because clean() does not call super().clean()
+        code_grant_types = (
+            AbstractApplication.GRANT_AUTHORIZATION_CODE,
+            AbstractApplication.GRANT_IMPLICIT,
+            AbstractApplication.GRANT_OPENID_HYBRID,
+        )
+        if not self.redirect_uris.split() and self.authorization_grant_type in code_grant_types:
+            raise ValidationError(f"redirect_uris cannot be empty with grant_type {self.authorization_grant_type}")
+
+        allowed_origins = self.allowed_origins.split()
+        if allowed_origins:
+            origin_validator = AllowedURIValidator(
+                oauth2_settings.ALLOWED_SCHEMES,
+                name="allowed origin",
+                allow_hostname_wildcard=oauth2_settings.ALLOW_URI_WILDCARDS,
+            )
+            for origin in allowed_origins:
+                origin_validator(origin)
+
+        if self.algorithm == AbstractApplication.RS256_ALGORITHM and not oauth2_settings.OIDC_RSA_PRIVATE_KEY:
+            raise ValidationError("You must set OIDC_RSA_PRIVATE_KEY to use RSA algorithm")
+
+        if self.algorithm == AbstractApplication.HS256_ALGORITHM and (
+            self.authorization_grant_type
+            in (AbstractApplication.GRANT_IMPLICIT, AbstractApplication.GRANT_OPENID_HYBRID)
+            or self.client_type == AbstractApplication.CLIENT_PUBLIC
+        ):
+            raise ValidationError("You cannot use HS256 with public grants or clients")
 
     def save(self, *args, **kwargs):
         self.full_clean()

--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -346,6 +346,7 @@ class TestOAuthModels(TestCase):
         ("reverse domain style", "com.posthog.code://oauth"),
         ("cursor scheme", "cursor://oauth"),
         ("vscode scheme", "vscode://oauth"),
+        ("authority-less native scheme", "com.example.app:/oauth"),
     ]
 
     @parameterized.expand(valid_custom_scheme_uris)
@@ -363,7 +364,13 @@ class TestOAuthModels(TestCase):
         )
         self.assertEqual(app.redirect_uris, redirect_uri)
 
-    def test_custom_scheme_with_fragment_still_rejected(self):
+    @parameterized.expand(
+        [
+            ("authority form", "myapp://callback#fragment"),
+            ("authority-less native", "com.example.app:/oauth#fragment"),
+        ]
+    )
+    def test_custom_scheme_with_fragment_still_rejected(self, _name, redirect_uri):
         with self.assertRaises(ValidationError):
             OAuthApplication.objects.create(
                 name="Invalid Custom Scheme App",
@@ -371,7 +378,7 @@ class TestOAuthModels(TestCase):
                 client_secret="invalid_custom_scheme_client_secret",
                 client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
                 authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-                redirect_uris="myapp://callback#fragment",
+                redirect_uris=redirect_uri,
                 organization=self.organization,
                 algorithm="RS256",
             )
@@ -423,6 +430,19 @@ class TestOAuthModels(TestCase):
                 client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
                 authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
                 redirect_uris="https://example.com/callback#fragment",
+                organization=self.organization,
+                algorithm="RS256",
+            )
+
+    def test_code_grant_application_requires_redirect_uri(self):
+        with self.assertRaises(ValidationError):
+            OAuthApplication.objects.create(
+                name="No Redirect App",
+                client_id="no_redirect_client_id",
+                client_secret="no_redirect_client_secret",
+                client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
+                authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+                redirect_uris="",
                 organization=self.organization,
                 algorithm="RS256",
             )

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')


### PR DESCRIPTION
## Problem

Native OAuth clients that register via Client ID Metadata Document (CIMD) couldn't sign in to PostHog's MCP OAuth server — the `/oauth/authorize` consent step returns a `server_error` (HTTP 500). The redirect URI format these clients use (for example `com.example-app.development:/oauth`) is rejected. 

`django-oauth-toolkit` redirect-URI validator (`AllowedURIValidator`, run from `AbstractApplication.clean()`) assumes every redirect URI is a web URL shaped `scheme://host/...`. It reconstructs the URI and runs Django's `URLValidator`, which requires a non-empty host. Authority-less native schemes have none, so it raises `ValidationError('Enter a valid URL.')`.

These URIs are correct: RFC 8252 §7.1 prescribes exactly this form for native apps, and providers like Google require it. `django-oauth-toolkit` rejecting it is a web-only assumption, not a security policy — and there is no setting that fixes it (allowlisting the scheme isn't enough; the host requirement fails after the scheme check passes).

## Changes

`OAuthApplication.clean()` now fully overrides `AbstractApplication.clean()` instead of calling `super().clean()`:

- Runs django-oauth-toolkit's real redirect-URI validator on http(s) and authority-form URIs (same strictness as before) — still reject blocked schemes (`javascript:`, `data:`, …) and fragments.
- Re-implements `django-oauth-toolkit` remaining model checks (redirect-URI-required for code grants, `allowed_origins` validation, signing-algorithm rules) inline, because we can no longer call `super().clean()` — it would re-run the redirect validation and re-reject the native schemes.

Request-time redirect matching already handles these URIs (it's an exact scheme/host/path comparison, not a format check), so no other layer needed changes.

## How did you test this code?

- `posthog/models/test/test_oauth.py` (64), plus `test_cimd.py`, `test_dcr.py`, `test_application.py` — 206 tests, all passing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

Diagnosis used PostHog's error-tracking tools to pull the live `ValidationError` and the exact failing redirect URI, then fetched published client-metadata document and OAuth docs to confirm the format that is used. 

Decisions worth flagging for review:

- **No setting can fix this.** Confirmed empirically: with the custom scheme allowlisted, `com.example.app://oauth` (authority form) passes but `com.example.app:/oauth` (authority-less) still fails — the host requirement is enforced after the scheme check, so `ALLOWED_REDIRECT_URI_SCHEMES` / `get_allowed_schemes()` don't reach it.
- **Why a full override rather than tricking the validator.** Earlier drafts swapped a placeholder redirect URI into `super().clean()` so it wouldn't choke. That works but feeds the validator a stand-in. The full override instead runs django-oauth-toolkit's real validator on every URI and overrides only the single RFC 8252 assumption (host required) — nothing is faked. The cost is re-implementing django-oauth-toolkit's four non-redirect checks in `_validate_application_config`; that duplication is deliberate, and the inline comment flags it must stay in sync with django-oauth-toolkit on upgrade. If reviewers prefer inheriting those checks, the alternative is to call `super().clean()` with the redirect URIs shielded
- **Where redirect URIs are validated.** Format/well-formedness is checked only at registration; the authorize, token, and final-redirect stages are exact-match or scheme-allowlist, not format checks. So keeping http(s) URIs strictly validated has to happen in `clean()`, which is why the carve-out runs the real validator rather than dropping it.
