### PR TITLE
fix(data-warehouse): dedupe and enforce one live backing table per view

### DIFF
--- a/products/data_warehouse/backend/data_load/create_table.py
+++ b/products/data_warehouse/backend/data_load/create_table.py
@@ -2,6 +2,7 @@ import uuid
 import dataclasses
 
 from django.conf import settings
+from django.db import IntegrityError
 
 from asgiref.sync import sync_to_async
 from clickhouse_driver.errors import ServerException
@@ -51,6 +52,22 @@ async def calculate_table_size(saved_query: DataWarehouseSavedQuery, team_id: in
     return total_mib
 
 
+@database_sync_to_async
+def aget_live_backing_table_by_name(team_id: int, name: str) -> DataWarehouseTable | None:
+    # Self-managed (no external source) == a materialized view's backing table.
+    return (
+        DataWarehouseTable.objects.filter(team_id=team_id, name=name, external_data_source__isnull=True)
+        .exclude(deleted=True)
+        .order_by("-created_at")
+        .first()
+    )
+
+
+@database_sync_to_async
+def asoft_delete_table(table: DataWarehouseTable) -> None:
+    table.soft_delete()
+
+
 async def create_table_from_saved_query(
     job_id: str,
     saved_query_id: str,
@@ -84,16 +101,27 @@ async def create_table_from_saved_query(
             "queryable_folder": queryable_folder,
         }
 
-        # create or update
         table_created: DataWarehouseTable | None = await aget_table_by_saved_query_id(saved_query_id_converted, team_id)
-        if table_created:
-            table_created.format = table_format
-            table_created.url_pattern = url_pattern
-            table_created.queryable_folder = queryable_folder
-            await asave_datawarehousetable(table_created)
+        if table_created is not None and table_created.deleted:
+            table_created = None
 
-        if not table_created:
-            table_created = await acreate_datawarehousetable(**table_params)
+        # No live linked table: retire any leftover backing row for this name, then create a fresh one.
+        if table_created is None:
+            leftover = await aget_live_backing_table_by_name(team_id, table_name)
+            if leftover is not None:
+                await asoft_delete_table(leftover)
+            try:
+                table_created = await acreate_datawarehousetable(**table_params)
+            except IntegrityError:
+                # Lost the create race to a concurrent run; reuse its row.
+                table_created = await aget_live_backing_table_by_name(team_id, table_name)
+                if table_created is None:
+                    raise
+
+        table_created.format = table_format
+        table_created.url_pattern = url_pattern
+        table_created.queryable_folder = queryable_folder
+        await asave_datawarehousetable(table_created)
 
         assert isinstance(table_created, DataWarehouseTable) and table_created is not None
 

--- a/products/data_warehouse/backend/data_load/test/test_create_table.py
+++ b/products/data_warehouse/backend/data_load/test/test_create_table.py
@@ -1,0 +1,135 @@
+import uuid
+import datetime as dt
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from django.db import IntegrityError, transaction
+from django.utils import timezone
+
+from asgiref.sync import async_to_sync
+
+from posthog.api.test.test_organization import create_organization
+from posthog.api.test.test_team import create_team
+
+from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
+from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
+from products.data_warehouse.backend.data_load.create_table import (
+    aget_live_backing_table_by_name,
+    create_table_from_saved_query,
+)
+from products.data_warehouse.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.models.table import DataWarehouseTable
+
+pytestmark = [pytest.mark.django_db]
+
+
+@pytest.fixture
+def team():
+    return create_team(organization=create_organization(name="org"))
+
+
+@pytest.fixture
+def credential(team):
+    return DataWarehouseCredential.objects.create(team=team, access_key="k", access_secret="s")
+
+
+def _make_table(team, name, credential, *, created_at=None, deleted=None, source=None):
+    table = DataWarehouseTable.objects.create(
+        team=team,
+        name=name,
+        format=DataWarehouseTable.TableFormat.DeltaS3Wrapper,
+        url_pattern="",
+        columns={},
+        credential=credential,
+        external_data_source=source,
+        deleted=deleted,
+    )
+    if created_at is not None:
+        DataWarehouseTable.objects.filter(id=table.id).update(created_at=created_at)
+        table.refresh_from_db()
+    return table
+
+
+def test_aget_live_backing_table_by_name_returns_newest_live_self_managed(team, credential):
+    now = timezone.now()
+    _make_table(team, "v", credential, created_at=now - dt.timedelta(days=2), deleted=True)
+    newest = _make_table(team, "v", credential, created_at=now)
+
+    found = async_to_sync(aget_live_backing_table_by_name)(team.id, "v")
+    assert found is not None
+    assert found.id == newest.id
+
+
+def test_unique_constraint_blocks_a_second_live_self_managed_table(team, credential):
+    _make_table(team, "tb_p3a_agg_torrent", credential)
+
+    with pytest.raises(IntegrityError), transaction.atomic():
+        _make_table(team, "tb_p3a_agg_torrent", credential)
+
+
+@pytest.mark.parametrize(
+    "first_deleted,second_source",
+    [
+        (True, None),  # first soft-deleted -> a new live self-managed row is fine
+        (None, "stripe"),  # second is source-backed -> partial index excludes it
+    ],
+)
+def test_unique_constraint_scope(team, credential, first_deleted, second_source):
+    _make_table(team, "ride_duration", credential, deleted=first_deleted)
+
+    source = None
+    if second_source:
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=team,
+            status="Completed",
+            source_type=ExternalDataSourceType.STRIPE,
+            access_method=ExternalDataSource.AccessMethod.WAREHOUSE,
+            job_inputs={},
+        )
+
+    _make_table(team, "ride_duration", credential, source=source)
+
+
+def test_create_soft_deletes_leftover_then_creates_new(team, credential):
+    saved_query = DataWarehouseSavedQuery.objects.create(
+        team=team,
+        name="ride_duration",
+        query={"query": "SELECT 1", "kind": "HogQLQuery"},
+        is_materialized=True,
+    )
+    job = DataModelingJob.objects.create(
+        team=team, saved_query=saved_query, status=DataModelingJob.Status.RUNNING, workflow_id="wf"
+    )
+    leftover = _make_table(team, "ride_duration", credential)
+
+    with (
+        patch.object(DataWarehouseTable, "get_columns", lambda self, *a, **k: {}),
+        patch.object(DataWarehouseTable, "get_count", lambda self, *a, **k: 0),
+        patch(
+            "products.data_warehouse.backend.data_load.create_table.calculate_table_size",
+            AsyncMock(return_value=0.0),
+        ),
+    ):
+        result = async_to_sync(create_table_from_saved_query)(
+            str(job.id), str(saved_query.id), team.id, "ride_duration__query_1"
+        )
+
+    leftover.refresh_from_db()
+    saved_query.refresh_from_db()
+
+    assert leftover.deleted is True
+    assert result.table.id != leftover.id
+    assert saved_query.table_id == result.table.id
+
+    live = list(
+        DataWarehouseTable.objects.filter(
+            team_id=team.id, name="ride_duration", external_data_source__isnull=True
+        ).exclude(deleted=True)
+    )
+    assert live == [result.table]

--- a/products/warehouse_sources/backend/migrations/0042_dedupe_live_backing_tables.py
+++ b/products/warehouse_sources/backend/migrations/0042_dedupe_live_backing_tables.py
@@ -1,0 +1,30 @@
+from django.db import migrations
+from django.db.models import Count
+from django.utils import timezone
+
+
+def dedupe_live_backing_tables(apps, schema_editor):
+    # Keep the newest live self-managed backing table per (team, name); soft-delete the rest so the
+    # partial unique index added next can be built.
+    DataWarehouseTable = apps.get_model("warehouse_sources", "DataWarehouseTable")
+
+    live = DataWarehouseTable.objects.filter(external_data_source__isnull=True).exclude(deleted=True)
+    duplicate_groups = live.values("team_id", "name").annotate(n=Count("id")).filter(n__gt=1)
+
+    now = timezone.now()
+    for group in duplicate_groups.iterator():
+        rows = list(live.filter(team_id=group["team_id"], name=group["name"]).order_by("-created_at", "-id"))
+        for old_table in rows[1:]:
+            old_table.deleted = True
+            old_table.deleted_at = now
+            old_table.save(update_fields=["deleted", "deleted_at"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("warehouse_sources", "0041_alter_externaldatasource_source_type_and_more"),
+    ]
+
+    operations = [
+        migrations.RunPython(dedupe_live_backing_tables, migrations.RunPython.noop),
+    ]

--- a/products/warehouse_sources/backend/migrations/0043_unique_live_self_managed_dwh_table.py
+++ b/products/warehouse_sources/backend/migrations/0043_unique_live_self_managed_dwh_table.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False  # required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("warehouse_sources", "0042_dedupe_live_backing_tables"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="datawarehousetable",
+                    constraint=models.UniqueConstraint(
+                        fields=["team", "name"],
+                        condition=Q(external_data_source__isnull=True) & (Q(deleted=False) | Q(deleted__isnull=True)),
+                        name="unique_live_self_managed_dwh_table",
+                    ),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="unique_live_self_managed_dwh_table",
+                    table_name="posthog_datawarehousetable",
+                    columns="(team_id, name)",
+                    unique=True,
+                    where="WHERE external_data_source_id IS NULL AND (deleted = false OR deleted IS NULL)",
+                ),
+            ],
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0041_alter_externaldatasource_source_type_and_more
+0043_unique_live_self_managed_dwh_table

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -162,6 +162,14 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
 
     class Meta:
         db_table = "posthog_datawarehousetable"
+        constraints = [
+            # At most one live self-managed backing table per (team, name). Live mirrors queryable().
+            models.UniqueConstraint(
+                fields=["team", "name"],
+                condition=Q(external_data_source__isnull=True) & (Q(deleted=False) | Q(deleted__isnull=True)),
+                name="unique_live_self_managed_dwh_table",
+            )
+        ]
 
     @property
     def name_chain(self) -> list[str]:


### PR DESCRIPTION
## Problem

A materialized view's backing `DataWarehouseTable` can be duplicated by a concurrent or interrupted materialization, leaving a live row that is no longer linked to the saved query. That orphan then shadows the view in HogQL name resolution: it shows up twice in autocomplete, surfaces as a phantom entry under "Self-managed data warehouse sources", and queries resolve to the orphan's now-superseded `queryable_folder` snapshot (which later runs garbage-collect) — so the view returns 0 rows even though it has freshly synced data. Disabling and re-enabling materialisation made it worse, since each cycle minted another live backing row.

## Changes

Two migrations plus a small lifecycle fix on the create path:

- **`0042_dedupe_live_backing_tables`** — collapses any existing duplicate live self-managed backing tables down to the newest per `(team, name)`, soft-deleting the rest. Heals current orphans and clears the way for the index.
- **`0043_unique_live_self_managed_dwh_table`** — a partial unique index on `(team_id, name)` for live self-managed tables (predicate `external_data_source_id IS NULL AND (deleted = false OR deleted IS NULL)`, mirroring `queryable()`; `deleted` is nullable, so both false and null are covered). Built with `CreateIndexConcurrently` (`atomic = False`) wrapped in `SeparateDatabaseAndState`, with a matching `Meta.UniqueConstraint` so model state and the database agree. Source-backed tables are excluded by the predicate.
- **`create_table_from_saved_query`** updates the saved query's linked backing table in place. When the saved query has no live linked table, it soft-deletes any leftover live backing row for that name (an orphan from an interrupted or concurrent run) and creates a fresh one, recovering from the unique-index race. Without this, an interrupted-before-link run would hit the new constraint on every retry and get stuck; with it, interrupted and concurrent runs heal instead of leaking duplicates.

## How did you test this code?

I'm an agent (Claude Code). I did not do manual testing. Automated tests I ran (`products/data_warehouse/backend/data_load/test/test_create_table.py`):

- A materialization with a pre-existing live leftover backing table soft-deletes the leftover and creates a fresh linked row, leaving exactly one live backing table.
- The database rejects a second live self-managed table with the same `(team, name)` — the constraint is built into the test schema from `Meta`, so this exercises the real enforcement.
- Scope: a new live row is allowed once the prior one is soft-deleted; a source-backed table with the same name is allowed (partial predicate excludes it).
- `posthog/temporal/tests/data_modeling/test_materialize_view_activities.py` (queryable-table subset) still passes; `makemigrations --check` reports no drift; `sqlmigrate` shows `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ... WHERE ...`; ruff and `ty` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus). Skills invoked: `/django-migrations`.
- Root cause found empirically: a view had two live backing rows sharing a name but differing in `queryable_folder`, and the reader keys the S3 path on `queryable_folder` (not `url_pattern`), so the orphan pointed at a pruned snapshot. An earlier hypothesis (a recent RBAC dedup change) was investigated and rejected.
- Started as a two-PR stack (cleanup → index); merged into this single PR at the reviewer's request. The create path retires a leftover backing row and creates a fresh one per materialization (the system's intended one-row-per-run lifecycle), rather than mutating an orphan in place — and is required for the index to be safe (an interrupted run would otherwise get stuck on `IntegrityError`). Used `CreateIndexConcurrently` per the repo migration guidance rather than Django's `AddIndexConcurrently`.
