### PR TITLE
fix(data-warehouse): unique index for live materialized-view backing tables

### DIFF
--- a/products/data_warehouse/backend/data_load/test/test_create_table.py
+++ b/products/data_warehouse/backend/data_load/test/test_create_table.py
@@ -1,7 +1,9 @@
+import uuid
 import datetime as dt
 
 import pytest
 
+from django.db import IntegrityError, transaction
 from django.utils import timezone
 
 from asgiref.sync import async_to_sync
@@ -10,7 +12,9 @@ from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 
 from products.data_warehouse.backend.data_load.create_table import aget_live_backing_table_by_name
+from products.data_warehouse.backend.types import ExternalDataSourceType
 from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 
 pytestmark = [pytest.mark.django_db]
@@ -51,3 +55,36 @@ def test_aget_live_backing_table_by_name_returns_newest_live_self_managed(team, 
     found = async_to_sync(aget_live_backing_table_by_name)(team.id, "v")
     assert found is not None
     assert found.id == newest.id
+
+
+def test_unique_constraint_blocks_a_second_live_self_managed_table(team, credential):
+    _make_table(team, "tb_p3a_agg_torrent", credential)
+
+    with pytest.raises(IntegrityError), transaction.atomic():
+        _make_table(team, "tb_p3a_agg_torrent", credential)
+
+
+@pytest.mark.parametrize(
+    "first_deleted,second_source",
+    [
+        (True, None),  # first soft-deleted -> a new live self-managed row is fine
+        (None, "stripe"),  # second is source-backed -> partial index excludes it
+    ],
+)
+def test_unique_constraint_scope(team, credential, first_deleted, second_source):
+    _make_table(team, "ride_duration", credential, deleted=first_deleted)
+
+    source = None
+    if second_source:
+        source = ExternalDataSource.objects.create(
+            source_id=str(uuid.uuid4()),
+            connection_id=str(uuid.uuid4()),
+            destination_id=str(uuid.uuid4()),
+            team=team,
+            status="Completed",
+            source_type=ExternalDataSourceType.STRIPE,
+            access_method=ExternalDataSource.AccessMethod.WAREHOUSE,
+            job_inputs={},
+        )
+
+    _make_table(team, "ride_duration", credential, source=source)

--- a/products/warehouse_sources/backend/migrations/0043_unique_live_self_managed_dwh_table.py
+++ b/products/warehouse_sources/backend/migrations/0043_unique_live_self_managed_dwh_table.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+from django.db.models import Q
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False  # required for CREATE INDEX CONCURRENTLY
+
+    dependencies = [
+        ("warehouse_sources", "0042_dedupe_live_backing_tables"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddConstraint(
+                    model_name="datawarehousetable",
+                    constraint=models.UniqueConstraint(
+                        fields=["team", "name"],
+                        condition=Q(external_data_source__isnull=True) & (Q(deleted=False) | Q(deleted__isnull=True)),
+                        name="unique_live_self_managed_dwh_table",
+                    ),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="unique_live_self_managed_dwh_table",
+                    table_name="posthog_datawarehousetable",
+                    columns="(team_id, name)",
+                    unique=True,
+                    where="WHERE external_data_source_id IS NULL AND (deleted = false OR deleted IS NULL)",
+                ),
+            ],
+        ),
+    ]

--- a/products/warehouse_sources/backend/migrations/max_migration.txt
+++ b/products/warehouse_sources/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0042_dedupe_live_backing_tables
+0043_unique_live_self_managed_dwh_table

--- a/products/warehouse_sources/backend/models/table.py
+++ b/products/warehouse_sources/backend/models/table.py
@@ -162,6 +162,16 @@ class DataWarehouseTable(CreatedMetaFields, UpdatedMetaFields, UUIDTModel, Delet
 
     class Meta:
         db_table = "posthog_datawarehousetable"
+        constraints = [
+            # A materialized view has one live backing table; enforce at most one live self-managed
+            # table per (team, name) so an interrupted/concurrent materialization can't leave a
+            # duplicate that shadows the view. "Live" mirrors `queryable()`: deleted is false or null.
+            models.UniqueConstraint(
+                fields=["team", "name"],
+                condition=Q(external_data_source__isnull=True) & (Q(deleted=False) | Q(deleted__isnull=True)),
+                name="unique_live_self_managed_dwh_table",
+            )
+        ]
 
     @property
     def name_chain(self) -> list[str]:


### PR DESCRIPTION
## Problem

Nothing in the schema guaranteed that a materialized view has a single live backing table. A concurrent or interrupted materialization could leave a second live self-managed `DataWarehouseTable` with the same name, and that orphan shadowed the view in query resolution (0 rows, duplicate in autocomplete, and a phantom entry under "Self-managed data warehouse sources"). The stacked PR below (#65858) stops new orphans from being created and cleans up existing ones, but only a constraint makes the duplicate state impossible.

## Changes

- Adds a partial unique index on `(team_id, name)` for live self-managed backing tables — predicate `external_data_source_id IS NULL AND (deleted = false OR deleted IS NULL)`, mirroring `queryable()`'s definition of "live". `deleted` is nullable, so the predicate explicitly covers both false and null.
- Built with `CreateIndexConcurrently` (non-blocking, `atomic = False`) wrapped in `SeparateDatabaseAndState`, with a matching `Meta.UniqueConstraint` so model state and the database agree (index name = constraint name).
- Source-backed tables are excluded by the partial predicate, so connected-source tables are unaffected.

Stacked on #65858 — that PR's cleanup migration removes existing duplicates so this index can build, and its idempotent create path turns the unique violation into a safe reuse rather than an error.

## How did you test this code?

I'm an agent (Claude Code). I did not do manual testing. Automated tests I ran (`products/data_warehouse/backend/data_load/test/test_create_table.py`):

- The database rejects a second live self-managed table with the same `(team, name)` (the constraint is built into the test schema from `Meta`, so this exercises the real enforcement).
- Scope check: a new live row is allowed once the prior one is soft-deleted, and a source-backed table with the same name is allowed (partial predicate excludes it).
- `makemigrations --check` reports no drift; `sqlmigrate` shows `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS ... WHERE ...`; ruff and `ty` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus). Skills invoked: `/django-migrations`.
- Used the `CreateIndexConcurrently` migration helper (concurrent + idempotent with invalid-index recovery) rather than Django's `AddIndexConcurrently`, per the repo's migration guidance. The unique index is expressed in model state as a conditional `UniqueConstraint` and built concurrently in the database via `SeparateDatabaseAndState`.
- Predicate matches `queryable()` exactly (covering nullable `deleted`) so the constraint can't be silently bypassed by a `deleted IS NULL` live row.
