### PR TITLE
chore(hogai): add thread count logging to async_to_sync

### DIFF
--- a/ee/hogai/utils/aio.py
+++ b/ee/hogai/utils/aio.py
@@ -32,7 +32,14 @@ def async_to_sync(async_handler: Callable[[], AsyncGenerator[Any]]) -> Generator
 
     # Use non-daemon thread with explicit cleanup
     thread = threading.Thread(target=run_event_loop, daemon=False)
+
+    threads_before = threading.active_count()
     thread.start()
+    logger.info(
+        "hogai_stream_thread_started",
+        active_threads=threading.active_count(),
+        threads_before=threads_before,
+    )
 
     try:
         # Yield items progressively as they arrive
@@ -50,7 +57,16 @@ def async_to_sync(async_handler: Callable[[], AsyncGenerator[Any]]) -> Generator
             # Signal thread to stop if possible, or wait briefly
             thread.join(timeout=1)
             if thread.is_alive():
-                logger.warning("Thread did not terminate cleanly")
+                logger.warning(
+                    "hogai_stream_thread_leaked",
+                    active_threads=threading.active_count(),
+                )
+
+        logger.info(
+            "hogai_stream_thread_finished",
+            active_threads=threading.active_count(),
+            thread_alive=thread.is_alive(),
+        )
 
         if thread_exception:
             logger.error("Exception in async thread", exc_info=thread_exception)


### PR DESCRIPTION
## Problem

We have an ongoing OOM incident on `posthog-web-django`. The leading hypothesis is that `async_to_sync` in `ee/hogai/utils/aio.py` spawns one background thread per concurrent Max streaming conversation (under WSGI), and threads accumulate under slow AI response conditions, exhausting pod memory. We need empirical evidence — specifically thread count correlated with memory — before committing to a fix.

## Changes

Adds structured log events to `async_to_sync` at stream start and finish:

- `hogai_stream_thread_started` — logged when the background thread launches, with `active_threads` (after) and `threads_before` (before), so we can see the delta per stream open
- `hogai_stream_thread_finished` — logged in the `finally` block with final `active_threads` and `thread_alive` (whether the thread outlived the 1s join)
- Renames the existing silent `"Thread did not terminate cleanly"` warning to `hogai_stream_thread_leaked` and adds `active_threads` so we can query it in Loki

No behaviour changes. No performance impact — `threading.active_count()` is a cheap integer read.

## How did you test this code?

I'm an agent. No automated tests added — this is observability-only instrumentation with no logic change to test. The fields are verified by reading the code.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Produced during an OOM incident investigation session. The investigation used Grafana Loki and VictoriaMetrics queries to confirm: 154 pods OOMKilled on 2026-06-23, p99 stream iteration latency of 8–10s during the cascade, and a dominant "flat then spike" memory pattern (pods at 1–2 GB jumping to 7–12 GB in 1–2 minutes). The `aio.py` thread-per-stream mechanism is the primary hypothesis but hasn't been directly confirmed — `python_threads` is not scraped for this service, so there's no historical thread count to correlate with memory.

This PR adds the missing observability. Once deployed, the next OOM event will produce Loki logs showing `active_threads` at stream start/finish, making it possible to confirm whether thread count tracks memory growth or the OOM has a different cause (e.g. large LangGraph checkpoint deserialisation). A follow-up PR with the actual fix will come once the logs confirm the mechanism.

Skills invoked: none (investigation and logging addition).