### PR TITLE
fix(ci): run CLI release node-gyp step under bash for windows

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -437,6 +437,10 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
             - name: Fix node-gyp permissions
+              # This job also runs on the Windows runner, where the default
+              # shell is PowerShell and `find` resolves to Windows FIND.exe.
+              # Force bash (git-bash) so find/chmod are the Unix tools.
+              shell: bash
               run: find ~/setup-pnpm -name gyp_main.py -exec chmod +x {} +
             - name: Setup Node.js
               uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,10 @@ jobs:
             - name: Setup pnpm
               uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
             - name: Fix node-gyp permissions
+              # This job also runs on the Windows runner, where the default
+              # shell is PowerShell and `find` resolves to Windows FIND.exe.
+              # Force bash (git-bash) so find/chmod are the Unix tools.
+              shell: bash
               run: find ~/setup-pnpm -name gyp_main.py -exec chmod +x {} +
             - name: Setup Node.js
               uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0

--- a/cli/.sampo/changesets/windows-release-build-fix.md
+++ b/cli/.sampo/changesets/windows-release-build-fix.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Fix the CLI release workflow so the Windows (`x86_64-pc-windows-msvc`) build succeeds and ships with each release.


### PR DESCRIPTION
## Problem

The **Release CLI** workflow's Windows build (`x86_64-pc-windows-msvc`) fails at the "Fix node-gyp permissions" step. That step (added in #65364) runs `find ~/setup-pnpm -name gyp_main.py -exec chmod +x {} +` with no `shell:`, so on the Windows runner it executes under PowerShell — where `find` resolves to Windows `FIND.exe` and dies with `FIND: Parameter format not correct`, aborting the build.

0.7.30 shipped before #65364, so the 0.7.31 release was the first to hit it: the Windows build failed (plus a transient musl crates.io download flake), so nothing published. The release state is otherwise clean — still 0.7.30, no tag, and the `symbol-sets upload` changeset is still pending.

## Changes

- Force `shell: bash` on the `build-local-artifacts` node-gyp step in **both** release workflows so `find`/`chmod` run under git-bash on the Windows runner (no-op on Linux/mac):
  - `release-cli.yml` — the release pipeline, the one actually failing.
  - `release.yml` — the cargo-dist PR packaging check. It has the identical step in a Windows-capable matrix job, but runs `dist plan` only on PRs so the build is currently skipped (dormant); fixed here preventively so it can't bite if that ever changes.
- Add a `posthog-cli` patch changeset so merging this **re-triggers Release CLI** (it only fires on changeset pushes) and ships the pending `symbol-sets upload` release with Windows building again.

Every other workflow with that step runs it on Ubuntu only, so none were affected.

## How did you test this code?

I'm an agent. Automated checks I actually ran:

- `yaml.safe_load` on both workflows and the changeset frontmatter — all parse.
- `actionlint` on `release-cli.yml` — clean for the changed step (only pre-existing shellcheck style nits elsewhere, untouched).

I did not run the Windows build myself — real validation is the next Release CLI run after merge. `shell: bash` is the standard remedy for Unix commands on Windows runners.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Catalin flagged the failed Release CLI run. I diagnosed it — the Windows node-gyp step plus a transient musl flake — confirmed the release hadn't published and left no half-done state, and traced the Windows break to #65364. The fix is a one-line `shell: bash`, applied to both release workflows that carry the step in a Windows-capable job.

The changeset is the re-trigger: Release CLI only fires on changeset pushes. I double-checked that adding `workflow_dispatch` would also work (the flow is driven by master state, not the push payload), but the changeset path needs no new trigger and fires automatically on merge.

Skills invoked: `/pr-closeout`, `/autoreview` (codex — reported clean, "patch is correct" — on the release-cli.yml change; the identical release.yml follow-up was committed without a separate review pass).
