### PR TITLE
feat(dashboards): add logs widget saved views, wrapping, and timezone

### DIFF
--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -28,6 +28,8 @@ from products.dashboards.backend.constants import (
     ACTIVITY_EVENTS_DEFAULT_LIMIT,
     ACTIVITY_EVENTS_MAX_LIMIT,
     DEFAULT_WIDGET_LIST_LIMIT,
+    LOGS_LIST_DEFAULT_LIMIT,
+    LOGS_LIST_MAX_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
     MAX_WIDGETS_BATCH_SIZE,
 )
@@ -49,6 +51,7 @@ from products.dashboards.backend.widgets.activity_events_list import (
 from products.dashboards.backend.widgets.error_tracking_list import run_error_tracking_list_widget
 from products.dashboards.backend.widgets.session_replay_list import run_session_replay_list_widget
 from products.error_tracking.backend.facade.query_utils import ERROR_TRACKING_LISTING_VOLUME_RESOLUTION
+from products.logs.backend.models import LogsView
 
 
 class TestWidgetRegistry(APIBaseTest):
@@ -82,13 +85,22 @@ class TestWidgetRegistry(APIBaseTest):
         [
             ("error_tracking", ERROR_TRACKING_LIST_WIDGET_TYPE, "occurrences"),
             ("session_replay", SESSION_REPLAY_LIST_WIDGET_TYPE, "start_time"),
-            ("logs", LOGS_LIST_WIDGET_TYPE, "latest"),
         ]
     )
     def test_validate_list_config_defaults(self, _label: str, widget_type: str, default_order_by: str) -> None:
         validated = validate_widget_config(widget_type, {})
         assert validated["limit"] == DEFAULT_WIDGET_LIST_LIMIT
         assert validated["orderBy"] == default_order_by
+        assert "filterTestAccounts" not in validated
+
+    def test_validate_logs_list_config_defaults(self) -> None:
+        # Logs has its own larger page than other list widgets.
+        validated = validate_widget_config(LOGS_LIST_WIDGET_TYPE, {})
+        assert validated["limit"] == LOGS_LIST_DEFAULT_LIMIT
+        assert validated["orderBy"] == "latest"
+        assert validated["wrapLines"] is False
+        assert validated["timezone"] == "UTC"
+        assert "savedViewId" not in validated
         assert "filterTestAccounts" not in validated
 
     @parameterized.expand(
@@ -148,12 +160,39 @@ class TestWidgetRegistry(APIBaseTest):
             ("activity_events", ACTIVITY_EVENTS_LIST_WIDGET_TYPE),
             ("error_tracking", ERROR_TRACKING_LIST_WIDGET_TYPE),
             ("session_replay", SESSION_REPLAY_LIST_WIDGET_TYPE),
-            ("logs", LOGS_LIST_WIDGET_TYPE),
         ]
     )
     def test_validate_list_config_rejects_high_limit(self, _label: str, widget_type: str) -> None:
         with self.assertRaises(Exception):
             validate_widget_config(widget_type, {"limit": 100})
+
+    def test_validate_logs_list_config_accepts_limit_up_to_max(self) -> None:
+        validated = validate_widget_config(LOGS_LIST_WIDGET_TYPE, {"limit": LOGS_LIST_MAX_LIMIT})
+        assert validated["limit"] == LOGS_LIST_MAX_LIMIT
+
+    def test_validate_logs_list_config_rejects_limit_above_max(self) -> None:
+        with self.assertRaises(Exception):
+            validate_widget_config(LOGS_LIST_WIDGET_TYPE, {"limit": LOGS_LIST_MAX_LIMIT + 1})
+
+    def test_validate_logs_list_config_accepts_display_and_saved_view(self) -> None:
+        validated = validate_widget_config(
+            LOGS_LIST_WIDGET_TYPE,
+            {"wrapLines": True, "timezone": "local", "savedViewId": "abc123"},
+        )
+        assert validated["wrapLines"] is True
+        assert validated["timezone"] == "local"
+        assert validated["savedViewId"] == "abc123"
+
+    @parameterized.expand(
+        [
+            ("invalid_timezone", {"timezone": "America/New_York"}),
+            ("invalid_wrap_lines", {"wrapLines": "yes"}),
+            ("invalid_saved_view_id", {"savedViewId": 123}),
+        ]
+    )
+    def test_validate_logs_list_config_rejects_invalid_display_values(self, _label: str, config: dict) -> None:
+        with self.assertRaises(Exception):
+            validate_widget_config(LOGS_LIST_WIDGET_TYPE, config)
 
     @parameterized.expand(
         [("activity_events", ACTIVITY_EVENTS_LIST_WIDGET_TYPE, date_from) for date_from in ["-1h", "-3h", "-24h"]]
@@ -417,6 +456,89 @@ class TestDashboardRunWidgets(APIBaseTest):
         self.assertEqual(query.serviceNames, ["api"])
         self.assertTrue(query.excludeAttributes)
         self.assertEqual(query.limit, 10)
+
+    @patch("products.dashboards.backend.widgets.logs_list.LogsQueryRunner")
+    def test_runs_logs_widget_with_saved_view(self, mock_runner_cls: MagicMock) -> None:
+        mock_runner_cls.return_value.calculate.return_value = MagicMock(
+            model_dump=lambda mode="json": {"results": [], "hasMore": False}
+        )
+        view = LogsView.objects.create(
+            team=self.team,
+            name="My view",
+            filters={
+                "severityLevels": ["warn"],
+                "serviceNames": ["worker"],
+                "searchTerm": "timeout",
+                "dateRange": {"date_from": "-3h", "date_to": None},
+            },
+        )
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id,
+            widget_type="logs_list",
+            config={
+                "limit": 20,
+                "orderBy": "earliest",
+                "savedViewId": view.short_id,
+                # These are ignored once a saved view is selected — the view owns them.
+                "severityLevels": ["error"],
+                "serviceNames": ["api"],
+            },
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        self._run(dashboard_id, [tile_id])
+
+        query = mock_runner_cls.call_args.kwargs["query"]
+        self.assertEqual(query.severityLevels, ["warn"])
+        self.assertEqual(query.serviceNames, ["worker"])
+        self.assertEqual(query.searchTerm, "timeout")
+        # Widget still owns sort + page size.
+        self.assertEqual(query.orderBy, "earliest")
+        self.assertEqual(query.limit, 20)
+
+    @patch("products.dashboards.backend.widgets.logs_list.LogsQueryRunner")
+    def test_runs_logs_widget_falls_back_when_saved_view_missing(self, mock_runner_cls: MagicMock) -> None:
+        mock_runner_cls.return_value.calculate.return_value = MagicMock(
+            model_dump=lambda mode="json": {"results": [], "hasMore": False}
+        )
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id,
+            widget_type="logs_list",
+            config={"limit": 15, "orderBy": "latest", "savedViewId": "missing", "severityLevels": ["error"]},
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        self._run(dashboard_id, [tile_id])
+
+        # Unknown view falls back to the widget's own config rather than erroring.
+        query = mock_runner_cls.call_args.kwargs["query"]
+        self.assertEqual(query.severityLevels, ["error"])
+        self.assertEqual(query.limit, 15)
+
+    @patch("products.dashboards.backend.widgets.logs_list.LogsQueryRunner")
+    def test_runs_logs_widget_falls_back_when_saved_view_filters_invalid(self, mock_runner_cls: MagicMock) -> None:
+        mock_runner_cls.return_value.calculate.return_value = MagicMock(
+            model_dump=lambda mode="json": {"results": [], "hasMore": False}
+        )
+        # `filters` has no inner schema validation on write, so a stored level outside the enum is possible.
+        view = LogsView.objects.create(team=self.team, name="Bad view", filters={"severityLevels": ["critical"]})
+        dashboard_id, _ = self.dashboard_api.create_dashboard({"name": "dash"})
+        _, dashboard_json = self.dashboard_api.create_widget_tile(
+            dashboard_id,
+            widget_type="logs_list",
+            config={"limit": 12, "orderBy": "latest", "savedViewId": view.short_id, "severityLevels": ["warn"]},
+        )
+        tile_id = dashboard_json["tiles"][0]["id"]
+
+        body = self._run(dashboard_id, [tile_id])
+
+        # A malformed view degrades to the widget's own config instead of 500-ing the tile.
+        self.assertIsNone(body["results"][0]["error"])
+        query = mock_runner_cls.call_args.kwargs["query"]
+        self.assertEqual(query.severityLevels, ["warn"])
+        self.assertEqual(query.limit, 12)
 
     @patch("products.dashboards.backend.widgets.activity_events_list.EventsQueryRunner")
     def test_activity_events_widget_applies_date_range_and_widget_filters(self, mock_runner_cls: MagicMock) -> None:

--- a/products/dashboards/backend/api/test/test_widget_config_schema_parity.py
+++ b/products/dashboards/backend/api/test/test_widget_config_schema_parity.py
@@ -4,15 +4,18 @@ from products.dashboards.backend.constants import (
     ACTIVITY_EVENTS_DEFAULT_LIMIT,
     ACTIVITY_EVENTS_MAX_LIMIT,
     DEFAULT_WIDGET_LIST_LIMIT,
+    LOGS_LIST_DEFAULT_LIMIT,
+    LOGS_LIST_MAX_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
 )
 from products.dashboards.backend.widget_catalog import WIDGET_CATALOG
-from products.dashboards.backend.widget_specs.configs import ACTIVITY_EVENTS_LIST_WIDGET_TYPE
+from products.dashboards.backend.widget_specs.configs import ACTIVITY_EVENTS_LIST_WIDGET_TYPE, LOGS_LIST_WIDGET_TYPE
 from products.dashboards.backend.widget_specs.registry import WIDGET_SPECS
 
-# Activity events allows a larger page than other list widgets; other types share the default bounds.
+# Activity events and logs allow a larger page than other list widgets; other types share the default bounds.
 WIDGET_LIMIT_BOUNDS = {
     ACTIVITY_EVENTS_LIST_WIDGET_TYPE: (ACTIVITY_EVENTS_MAX_LIMIT, ACTIVITY_EVENTS_DEFAULT_LIMIT),
+    LOGS_LIST_WIDGET_TYPE: (LOGS_LIST_MAX_LIMIT, LOGS_LIST_DEFAULT_LIMIT),
 }
 
 

--- a/products/dashboards/backend/constants.py
+++ b/products/dashboards/backend/constants.py
@@ -11,6 +11,10 @@ DEFAULT_WIDGET_LIST_LIMIT = 10
 ACTIVITY_EVENTS_MAX_LIMIT = 50
 ACTIVITY_EVENTS_DEFAULT_LIMIT = 25
 
+# Logs list allows the largest page — log rows are cheap and users scan many at once.
+LOGS_LIST_MAX_LIMIT = 100
+LOGS_LIST_DEFAULT_LIMIT = 50
+
 # Cap widgets per batch create / run-widgets request.
 MAX_WIDGETS_BATCH_SIZE = 10
 

--- a/products/dashboards/backend/widget_specs/common.py
+++ b/products/dashboards/backend/widget_specs/common.py
@@ -8,6 +8,7 @@ from posthog.schema import PropertyOperator
 
 from products.dashboards.backend.constants import (
     ACTIVITY_EVENTS_MAX_LIMIT,
+    LOGS_LIST_MAX_LIMIT,
     MAX_WIDGET_RESULT_LIMIT,
     WIDGET_DATE_FROM_VALUES_ORDERED,
 )
@@ -96,3 +97,4 @@ class WidgetListConfigBase(WidgetDateRangeConfigBase):
 
 WidgetLimit = Annotated[int, Field(ge=1, le=MAX_WIDGET_RESULT_LIMIT)]
 ActivityWidgetLimit = Annotated[int, Field(ge=1, le=ACTIVITY_EVENTS_MAX_LIMIT)]
+LogsWidgetLimit = Annotated[int, Field(ge=1, le=LOGS_LIST_MAX_LIMIT)]

--- a/products/dashboards/backend/widget_specs/configs.py
+++ b/products/dashboards/backend/widget_specs/configs.py
@@ -4,9 +4,14 @@ from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from products.dashboards.backend.constants import ACTIVITY_EVENTS_DEFAULT_LIMIT, DEFAULT_WIDGET_LIST_LIMIT
+from products.dashboards.backend.constants import (
+    ACTIVITY_EVENTS_DEFAULT_LIMIT,
+    DEFAULT_WIDGET_LIST_LIMIT,
+    LOGS_LIST_DEFAULT_LIMIT,
+)
 from products.dashboards.backend.widget_specs.common import (
     ActivityWidgetLimit,
+    LogsWidgetLimit,
     WidgetDateRangeConfigBase,
     WidgetLimit,
     WidgetListConfigBase,
@@ -31,6 +36,8 @@ ExperimentsWidgetOrderBy = Literal["created_at", "name", "start_date"]
 # Matches the logs scene: `earliest` sorts ascending by timestamp, `latest` (default) descending.
 LogsOrderBy = Literal["latest", "earliest"]
 LogSeverityLevel = Literal["trace", "debug", "info", "warn", "error", "fatal"]
+# How log timestamps render on the tile: in UTC, or in each viewer's local timezone.
+LogsTimezone = Literal["UTC", "local"]
 
 
 class WidgetAssigneeFilter(BaseModel):
@@ -101,7 +108,9 @@ class ExperimentResultsWidgetConfig(BaseModel):
 
 
 class LogsListWidgetConfig(WidgetDateRangeConfigBase):
-    limit: WidgetLimit = Field(default=DEFAULT_WIDGET_LIST_LIMIT, description="Maximum number of log lines to return.")
+    limit: LogsWidgetLimit = Field(
+        default=LOGS_LIST_DEFAULT_LIMIT, description="Maximum number of log lines to return."
+    )
     orderBy: LogsOrderBy = Field(default="latest", description="Sort by newest (latest) or oldest (earliest) first.")
     severityLevels: list[LogSeverityLevel] = Field(
         default_factory=list,
@@ -111,3 +120,27 @@ class LogsListWidgetConfig(WidgetDateRangeConfigBase):
         default_factory=list,
         description="Only show logs from these services. Empty shows all services.",
     )
+    wrapLines: bool = Field(
+        default=False,
+        description="Wrap long log lines instead of truncating them to a single row.",
+    )
+    timezone: LogsTimezone = Field(
+        default="UTC",
+        description="Render log timestamps in UTC or in each viewer's local timezone.",
+    )
+    savedViewId: str | None = Field(
+        default=None,
+        description=(
+            "short_id of a saved logs view to use as the source. When set, the saved view owns the date range, "
+            "severity, service, and property filters; only orderBy and limit still apply."
+        ),
+    )
+
+    @field_validator("savedViewId", mode="before")
+    @classmethod
+    def validate_saved_view_id(cls, value: object) -> str | None:
+        if value is None or value == "":
+            return None
+        if not isinstance(value, str):
+            raise ValueError("savedViewId must be a string.")
+        return value

--- a/products/dashboards/backend/widget_specs/registry.py
+++ b/products/dashboards/backend/widget_specs/registry.py
@@ -183,7 +183,7 @@ def _load_widget_specs() -> dict[str, WidgetSpec]:
             # No cheap team-flag setup check for logs (availability would need a ClickHouse
             # has-logs query, which we keep off the widget-add path) — leave ungated like activity.
             availability_requirements=(),
-            form_fields=("limit", "dateRange"),
+            form_fields=("limit", "dateRange", "wrapLines", "timezone"),
             filter_fields=("severityLevels", "serviceNames"),
         ),
     }

--- a/products/dashboards/backend/widgets/logs_list.py
+++ b/products/dashboards/backend/widgets/logs_list.py
@@ -8,11 +8,11 @@ from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.models.team import Team
 from posthog.models.user import User
 
-from products.dashboards.backend.constants import MAX_WIDGET_RESULT_LIMIT
+from products.dashboards.backend.constants import LOGS_LIST_MAX_LIMIT
 from products.dashboards.backend.widget_specs.configs import LOGS_LIST_WIDGET_TYPE
 from products.dashboards.backend.widget_specs.registry import validate_widget_config
 from products.dashboards.backend.widgets.list_widget import ListWidgetPage, run_list_widget
-from products.logs.backend.facade.queries import LogsQueryRunner
+from products.logs.backend.facade.queries import LogsQueryRunner, build_logs_query_for_saved_view
 
 ValidatedLogsListWidgetConfig = dict[str, Any]
 
@@ -34,7 +34,21 @@ def _resolve_date_from(config: ValidatedLogsListWidgetConfig) -> str:
     return DEFAULT_LOGS_WIDGET_DATE_FROM
 
 
-def _build_logs_query(config: ValidatedLogsListWidgetConfig, limit: int) -> LogsQuery:
+def _build_logs_query(team: Team, config: ValidatedLogsListWidgetConfig, limit: int) -> LogsQuery:
+    saved_view_id = config.get("savedViewId")
+    if saved_view_id:
+        query = build_logs_query_for_saved_view(
+            team,
+            saved_view_id,
+            order_by=config["orderBy"],
+            limit=limit,
+            offset=0,
+            exclude_attributes=True,
+        )
+        if query is not None:
+            return query
+        # Saved view was deleted or never existed — fall back to the widget's own config.
+
     return LogsQuery(
         kind="LogsQuery",
         dateRange=DateRange(date_from=_resolve_date_from(config), date_to=None),
@@ -70,7 +84,7 @@ def run_logs_list_widget(
     typed_config = validate_widget_config(LOGS_LIST_WIDGET_TYPE, config)
 
     def fetch_page(page_limit: int) -> ListWidgetPage:
-        data = _run_logs_query(team, _build_logs_query(typed_config, page_limit))
+        data = _run_logs_query(team, _build_logs_query(team, typed_config, page_limit))
         raw_results = data.get("results")
         return ListWidgetPage(
             results=raw_results if isinstance(raw_results, list) else [],
@@ -79,7 +93,7 @@ def run_logs_list_widget(
 
     return run_list_widget(
         limit=typed_config["limit"],
-        count_cap=MAX_WIDGET_RESULT_LIMIT,
+        count_cap=LOGS_LIST_MAX_LIMIT,
         include_total_count=include_total_count,
         fetch_page=fetch_page,
         transform_row=lambda row: _transform_row(cast(dict[str, Any], row)),

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -717,12 +717,23 @@ export const LogsListWidgetConfigApiSeverityLevelsItem = {
     Fatal: 'fatal',
 } as const
 
+/**
+ * Render log timestamps in UTC or in each viewer's local timezone.
+ */
+export type LogsListWidgetConfigApiTimezone =
+    (typeof LogsListWidgetConfigApiTimezone)[keyof typeof LogsListWidgetConfigApiTimezone]
+
+export const LogsListWidgetConfigApiTimezone = {
+    Utc: 'UTC',
+    Local: 'local',
+} as const
+
 export interface LogsListWidgetConfigApi {
     dateRange?: WidgetDateRangeApi | null
     /**
      * Maximum number of log lines to return.
      * @minimum 1
-     * @maximum 25
+     * @maximum 100
      */
     limit?: number
     /** Sort by newest (latest) or oldest (earliest) first. */
@@ -731,6 +742,12 @@ export interface LogsListWidgetConfigApi {
     severityLevels?: LogsListWidgetConfigApiSeverityLevelsItem[]
     /** Only show logs from these services. Empty shows all services. */
     serviceNames?: string[]
+    /** Wrap long log lines instead of truncating them to a single row. */
+    wrapLines?: boolean
+    /** Render log timestamps in UTC or in each viewer's local timezone. */
+    timezone?: LogsListWidgetConfigApiTimezone
+    /** short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply. */
+    savedViewId?: string | null
 }
 
 export type DashboardWidgetConfigApi =

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -237,10 +237,12 @@ export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourLimitMax 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourOrderByDefault = `created_at`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourOrderDirectionDefault = `DESC`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourStatusDefault = `all`
-export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitDefault = 10
-export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitMax = 25
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitDefault = 50
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitMax = 100
 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixOrderByDefault = `latest`
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixWrapLinesDefault = false
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixTimezoneDefault = `UTC`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneNameMax = 400
 
 export const dashboardsPartialUpdateBodyDeleteInsightsDefault = false
@@ -722,6 +724,28 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                             .array(zod.string())
                                             .optional()
                                             .describe('Only show logs from these services. Empty shows all services.'),
+                                        wrapLines: zod
+                                            .boolean()
+                                            .default(
+                                                dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixWrapLinesDefault
+                                            )
+                                            .describe(
+                                                'Wrap long log lines instead of truncating them to a single row.'
+                                            ),
+                                        timezone: zod
+                                            .enum(['UTC', 'local'])
+                                            .default(
+                                                dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixTimezoneDefault
+                                            )
+                                            .describe(
+                                                "Render log timestamps in UTC or in each viewer's local timezone."
+                                            ),
+                                        savedViewId: zod
+                                            .union([zod.string(), zod.null()])
+                                            .optional()
+                                            .describe(
+                                                'short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply.'
+                                            ),
                                     }),
                                 ])
                                 .optional()
@@ -940,10 +964,12 @@ export const dashboardsWidgetsBatchCreateBodyWidgetsItemFiveNameMax = 400
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixNameMax = 400
 
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitDefault = 10
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitMax = 25
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitDefault = 50
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitMax = 100
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneOrderByDefault = `latest`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneWrapLinesDefault = false
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneTimezoneDefault = `UTC`
 export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
 
 export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
@@ -1690,6 +1716,20 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .array(zod.string())
                                     .optional()
                                     .describe('Only show logs from these services. Empty shows all services.'),
+                                wrapLines: zod
+                                    .boolean()
+                                    .default(dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneWrapLinesDefault)
+                                    .describe('Wrap long log lines instead of truncating them to a single row.'),
+                                timezone: zod
+                                    .enum(['UTC', 'local'])
+                                    .default(dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneTimezoneDefault)
+                                    .describe("Render log timestamps in UTC or in each viewer's local timezone."),
+                                savedViewId: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        'short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply.'
+                                    ),
                             })
                             .describe('Configuration for the recent logs widget.'),
                     }),

--- a/products/dashboards/frontend/generated/widget-config-property-keys.json
+++ b/products/dashboards/frontend/generated/widget-config-property-keys.json
@@ -22,7 +22,16 @@
         ],
         "experiments_list": ["createdBy", "limit", "orderBy", "orderDirection", "status"],
         "experiment_results": ["experimentId"],
-        "logs_list": ["dateRange", "limit", "orderBy", "serviceNames", "severityLevels"]
+        "logs_list": [
+            "dateRange",
+            "limit",
+            "orderBy",
+            "savedViewId",
+            "serviceNames",
+            "severityLevels",
+            "timezone",
+            "wrapLines"
+        ]
     },
     "configPropertyTrees": {
         "activity_events_list": {
@@ -302,6 +311,15 @@
                 "$array": {
                     "$type": "string"
                 }
+            },
+            "wrapLines": {
+                "$type": "boolean"
+            },
+            "timezone": {
+                "$enum": ["UTC", "local"]
+            },
+            "savedViewId": {
+                "$type": "string"
             }
         }
     }

--- a/products/dashboards/frontend/generated/widget-config-schemas/logsListWidgetConfig.zod.ts
+++ b/products/dashboards/frontend/generated/widget-config-schemas/logsListWidgetConfig.zod.ts
@@ -8,10 +8,12 @@ import { z as zod } from 'zod'
 
 import { WidgetDateRange } from './widgetDateRange.zod'
 
-export const logsListWidgetConfigLimitDefault = 10
-export const logsListWidgetConfigLimitMax = 25
+export const logsListWidgetConfigLimitDefault = 50
+export const logsListWidgetConfigLimitMax = 100
 
 export const logsListWidgetConfigOrderByDefault = `latest`
+export const logsListWidgetConfigWrapLinesDefault = false
+export const logsListWidgetConfigTimezoneDefault = `UTC`
 
 export const LogsListWidgetConfig = /* @__PURE__ */ zod.object({
     dateRange: zod.union([WidgetDateRange, zod.null()]).optional(),
@@ -33,6 +35,20 @@ export const LogsListWidgetConfig = /* @__PURE__ */ zod.object({
         .array(zod.string())
         .optional()
         .describe('Only show logs from these services. Empty shows all services.'),
+    wrapLines: zod
+        .boolean()
+        .default(logsListWidgetConfigWrapLinesDefault)
+        .describe('Wrap long log lines instead of truncating them to a single row.'),
+    timezone: zod
+        .enum(['UTC', 'local'])
+        .default(logsListWidgetConfigTimezoneDefault)
+        .describe("Render log timestamps in UTC or in each viewer's local timezone."),
+    savedViewId: zod
+        .union([zod.string(), zod.null()])
+        .optional()
+        .describe(
+            'short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply.'
+        ),
 })
 
 export type LogsListWidgetConfig = zod.input<typeof LogsListWidgetConfig>

--- a/products/dashboards/frontend/generated/widget-configs.zod.ts
+++ b/products/dashboards/frontend/generated/widget-configs.zod.ts
@@ -61,6 +61,8 @@ export const experimentsWidgetFormSchema = experimentsWidgetConfigSchema.pick({
 export const logsWidgetFormSchema = logsWidgetConfigSchema.pick({
     limit: true,
     dateRange: true,
+    wrapLines: true,
+    timezone: true,
 })
 
 export const sessionReplayWidgetFormSchema = sessionReplayWidgetConfigSchema.pick({

--- a/products/dashboards/frontend/generated/widget-form-fields.json
+++ b/products/dashboards/frontend/generated/widget-form-fields.json
@@ -28,7 +28,7 @@
             "configSchemaExport": "logsWidgetConfigSchema",
             "configTypeExport": "LogsWidgetConfig",
             "formSchemaExport": "logsWidgetFormSchema",
-            "formFields": ["limit", "dateRange"]
+            "formFields": ["limit", "dateRange", "wrapLines", "timezone"]
         },
         "session_replay_list": {
             "configSchemaExport": "sessionReplayWidgetConfigSchema",

--- a/products/dashboards/frontend/widgets/logs/EditLogsWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/logs/EditLogsWidgetModal.tsx
@@ -6,16 +6,25 @@ import { LemonField } from 'lib/lemon-ui/LemonField/LemonField'
 import { LemonInput } from 'lib/lemon-ui/LemonInput/LemonInput'
 import { LemonModal } from 'lib/lemon-ui/LemonModal'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 
 import { getDashboardWidgetGroupLabel } from '../../widget_types/catalog'
 import { WIDGET_DATE_RANGE_SELECT_OPTIONS, type WidgetDateFromValue } from '../../widget_types/widgetConfigShared'
 import { EditWidgetModalTileDetailsSection } from '../EditWidgetModalTileDetailsSection'
 import type { DashboardWidgetEditModalProps } from '../registry'
 import { editLogsWidgetModalLogic } from './editLogsWidgetModalLogic'
+import type { LogsTimezone } from './logsWidgetConfigValidation'
+
+const TIMEZONE_OPTIONS: { value: LogsTimezone; label: string }[] = [
+    { value: 'UTC', label: 'UTC' },
+    { value: 'local', label: 'Local time' },
+]
 
 function EditLogsWidgetModalContents(): JSX.Element {
     const {
         limit,
+        wrapLines,
+        timezone,
         dateFrom,
         tileName,
         tileDescription,
@@ -25,7 +34,7 @@ function EditLogsWidgetModalContents(): JSX.Element {
         onClose,
         defaultTitle,
     } = useValues(editLogsWidgetModalLogic)
-    const { setLimit, setDateFrom, setTileName, setTileDescription, clearFieldError, submit } =
+    const { setLimit, setWrapLines, setTimezone, setDateFrom, setTileName, setTileDescription, clearFieldError, submit } =
         useActions(editLogsWidgetModalLogic)
 
     return (
@@ -84,13 +93,13 @@ function EditLogsWidgetModalContents(): JSX.Element {
                         </LemonField.Pure>
                         <LemonField.Pure
                             label="Number of log lines"
-                            help="Show up to 25 log lines on the tile."
+                            help="Show up to 100 log lines on the tile."
                             error={activeFieldErrors.limit}
                         >
                             <LemonInput
                                 type="number"
                                 min={1}
-                                max={25}
+                                max={100}
                                 fullWidth
                                 value={limit}
                                 onChange={(value) => {
@@ -99,7 +108,27 @@ function EditLogsWidgetModalContents(): JSX.Element {
                                 }}
                             />
                         </LemonField.Pure>
+                        <LemonField.Pure label="Timestamps" help="Display log times in UTC or your local timezone.">
+                            <LemonSelect
+                                value={timezone}
+                                disabled={saving}
+                                options={TIMEZONE_OPTIONS}
+                                onChange={(value) => {
+                                    if (value) {
+                                        setTimezone(value)
+                                    }
+                                }}
+                                fullWidth
+                            />
+                        </LemonField.Pure>
                     </div>
+                    <LemonSwitch
+                        checked={wrapLines}
+                        onChange={setWrapLines}
+                        disabled={saving}
+                        label="Wrap long log lines"
+                        bordered
+                    />
                 </section>
             </div>
         </LemonModal>

--- a/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
@@ -1,4 +1,8 @@
+import { combineUrl } from 'kea-router'
+
 import { DetectiveHog } from 'lib/components/hedgehogs'
+
+import { urls } from 'scenes/urls'
 
 import {
     WIDGET_LIST_COUNT_LOGS,
@@ -9,6 +13,7 @@ import {
 } from '../../components/WidgetCard'
 import type { DashboardWidgetComponentProps } from '../registry'
 import { LogsWidgetRow, LogsWidgetRowSkeleton, type LogsWidgetLogLine } from './LogsWidgetRow'
+import { parseLogsWidgetConfig } from './logsWidgetConfigValidation'
 
 export type LogsWidgetResult = {
     results?: LogsWidgetLogLine[]
@@ -18,9 +23,55 @@ export type LogsWidgetResult = {
     totalCountCapped?: boolean
 }
 
-export function LogsWidget({ result, loading }: DashboardWidgetComponentProps): JSX.Element {
+/** 'local' renders in the viewer's own timezone; 'UTC' (default) renders the same for everyone. */
+function resolveDisplayTimezone(timezone: string | null | undefined): string {
+    if (timezone === 'local') {
+        return Intl.DateTimeFormat().resolvedOptions().timeZone
+    }
+    return 'UTC'
+}
+
+type LogsDeepLinkParams = {
+    dateFrom: string | null | undefined
+    orderBy: string | null | undefined
+    limit: number | null | undefined
+    severityLevels: string[]
+    serviceNames: string[]
+    hasSavedView: boolean
+}
+
+/** Deep-link that opens this log on the logs page (new tab), reproducing the tile's filtered view.
+ *
+ * Forwarding the tile's filters + orderBy + a matching `initialLogsLimit` makes the logs page's first
+ * page equal the tile's visible rows, so the linked log is loaded and `linkToLogId` can open it. A
+ * saved-view tile can't replay the view's filters client-side, so it links by date window + id only. */
+function buildLogHref(line: LogsWidgetLogLine, params: LogsDeepLinkParams): string {
+    return combineUrl(urls.logs(), {
+        activeTab: 'viewer',
+        linkToLogId: line.uuid,
+        dateRange: { date_from: params.dateFrom ?? null, date_to: null },
+        ...(params.orderBy ? { orderBy: params.orderBy } : {}),
+        ...(params.limit ? { initialLogsLimit: params.limit } : {}),
+        ...(!params.hasSavedView && params.severityLevels.length ? { severityLevels: params.severityLevels } : {}),
+        ...(!params.hasSavedView && params.serviceNames.length ? { serviceNames: params.serviceNames } : {}),
+    }).url
+}
+
+export function LogsWidget({ result, loading, config }: DashboardWidgetComponentProps): JSX.Element {
     const payload = result as LogsWidgetResult | null | undefined
     const logLines = payload?.results ?? []
+
+    const parsedConfig = parseLogsWidgetConfig(config)
+    const wrapLines = parsedConfig.wrapLines ?? false
+    const displayTimezone = resolveDisplayTimezone(parsedConfig.timezone)
+    const deepLinkParams: LogsDeepLinkParams = {
+        dateFrom: parsedConfig.dateRange?.date_from,
+        orderBy: parsedConfig.orderBy,
+        limit: parsedConfig.limit,
+        severityLevels: parsedConfig.severityLevels ?? [],
+        serviceNames: parsedConfig.serviceNames ?? [],
+        hasSavedView: !!parsedConfig.savedViewId,
+    }
 
     if (loading) {
         return (
@@ -58,7 +109,13 @@ export function LogsWidget({ result, loading }: DashboardWidgetComponentProps): 
             <WidgetCardContent>
                 <div className="flex flex-col divide-y divide-border">
                     {logLines.map((line) => (
-                        <LogsWidgetRow key={line.uuid} line={line} />
+                        <LogsWidgetRow
+                            key={line.uuid}
+                            line={line}
+                            wrapLines={wrapLines}
+                            displayTimezone={displayTimezone}
+                            href={buildLogHref(line, deepLinkParams)}
+                        />
                     ))}
                 </div>
             </WidgetCardContent>

--- a/products/dashboards/frontend/widgets/logs/LogsWidgetRow.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidgetRow.tsx
@@ -1,5 +1,12 @@
 import { TZLabel } from 'lib/components/TZLabel'
+import { Link } from 'lib/lemon-ui/Link'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { cn } from 'lib/utils/css-classes'
+
+import type { LogMessage } from '~/queries/schema/schema-general'
+
+import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 
 export type LogsWidgetLogLine = {
     uuid: string
@@ -11,54 +18,80 @@ export type LogsWidgetLogLine = {
     trace_id?: string | null
 }
 
-/** Tailwind chip colors per severity bucket; unknown levels fall back to a neutral chip. */
-const SEVERITY_CHIP_CLASSES: Record<string, string> = {
-    trace: 'bg-surface-secondary text-muted',
-    debug: 'bg-surface-secondary text-muted',
-    info: 'bg-primary-highlight text-primary',
-    warn: 'bg-warning-highlight text-warning',
-    error: 'bg-danger-highlight text-danger',
-    fatal: 'bg-danger-highlight text-danger',
+function severityKey(line: LogsWidgetLogLine): string {
+    return (line.severity_text ?? line.level ?? '').toLowerCase()
 }
 
 function severityLabel(line: LogsWidgetLogLine): string {
     return (line.severity_text ?? line.level ?? 'log').toUpperCase()
 }
 
-function severityChipClass(line: LogsWidgetLogLine): string {
-    const key = (line.severity_text ?? line.level ?? '').toLowerCase()
-    return SEVERITY_CHIP_CLASSES[key] ?? 'bg-surface-secondary text-muted'
+/** Reuse the logs viewer's severity bar colors so a row reads the same as on the logs page. */
+function severityBarClass(line: LogsWidgetLogLine): string {
+    return SEVERITY_BAR_COLORS[severityKey(line) as LogMessage['severity_text']] ?? 'bg-muted-3000'
 }
 
 export function LogsWidgetRowSkeleton(): JSX.Element {
     return (
-        <div className="flex items-center gap-2 px-3 py-2">
-            <LemonSkeleton className="h-4 w-12 shrink-0 rounded" />
-            <LemonSkeleton className="h-4 flex-1" />
-            <LemonSkeleton className="h-3 w-20 shrink-0" />
+        <div className="flex items-center gap-2 px-3 py-1.5">
+            <LemonSkeleton className="h-4 w-1 shrink-0 rounded-full" />
+            <LemonSkeleton className="h-3 w-32 shrink-0" />
+            <LemonSkeleton className="h-3 flex-1" />
         </div>
     )
 }
 
-export function LogsWidgetRow({ line }: { line: LogsWidgetLogLine }): JSX.Element {
-    return (
+export function LogsWidgetRow({
+    line,
+    wrapLines = false,
+    displayTimezone,
+    href,
+}: {
+    line: LogsWidgetLogLine
+    wrapLines?: boolean
+    displayTimezone?: string
+    href?: string
+}): JSX.Element {
+    const content = (
         <div
-            className="@container flex items-center gap-2 px-3 py-2 hover:bg-surface-secondary"
+            className={cn(
+                'group flex gap-2 px-3 py-1.5 hover:bg-fill-highlight-100',
+                wrapLines ? 'items-start' : 'items-center'
+            )}
             data-attr="logs-widget-row"
         >
+            <Tooltip title={severityLabel(line)}>
+                <div className={cn('w-1 shrink-0 self-stretch rounded-full', severityBarClass(line))} />
+            </Tooltip>
+            <span className="shrink-0 font-mono text-xs text-muted">
+                <TZLabel
+                    time={line.timestamp}
+                    formatDate="YYYY-MM-DD"
+                    formatTime="HH:mm:ss.SSS"
+                    displayTimezone={displayTimezone}
+                    timestampStyle="absolute"
+                    showPopover={false}
+                />
+            </span>
             <span
-                className={`shrink-0 rounded px-1.5 py-0.5 font-mono text-[10px] font-semibold uppercase ${severityChipClass(
-                    line
-                )}`}
+                className={cn(
+                    'min-w-0 flex-1 font-mono text-xs text-primary',
+                    wrapLines ? 'whitespace-pre-wrap break-all' : 'truncate'
+                )}
+                title={wrapLines ? undefined : line.body}
             >
-                {severityLabel(line)}
-            </span>
-            <span className="min-w-0 flex-1 truncate font-mono text-xs text-primary" title={line.body}>
                 {line.body}
-            </span>
-            <span className="w-20 shrink-0 truncate text-right text-xs text-muted">
-                <TZLabel time={line.timestamp} />
             </span>
         </div>
     )
+
+    if (href) {
+        return (
+            <Link to={href} target="_blank" className="block text-current hover:text-current" subtle>
+                {content}
+            </Link>
+        )
+    }
+
+    return content
 }

--- a/products/dashboards/frontend/widgets/logs/LogsWidgetTileFilters.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidgetTileFilters.tsx
@@ -1,6 +1,12 @@
-import { useRef } from 'react'
+import { useActions, useValues } from 'kea'
+import { useEffect, useMemo, useRef } from 'react'
 
+import { IconExternal } from '@posthog/icons'
+
+import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { urls } from 'scenes/urls'
 
 import type { DateRange, LogMessage } from '~/queries/schema/schema-general'
 
@@ -18,6 +24,7 @@ import {
     type LogsOrderByValue,
     type LogsSeverityLevel,
 } from './logsWidgetConfigValidation'
+import { logsWidgetSavedViewsLogic } from './logsWidgetSavedViewsLogic'
 
 export type LogsWidgetTileFiltersProps = DashboardWidgetTileFiltersProps
 
@@ -27,6 +34,9 @@ const SORT_OPTIONS: { value: LogsOrderByValue; label: string }[] = [
 ]
 
 const ALL_SEVERITY_LEVELS = 6
+
+const NO_SAVED_VIEW_OPTION = { value: null as string | null, label: 'No saved view' }
+const CREATE_SAVED_VIEW_VALUE = '__create_saved_view__'
 
 function severityReadOnlyLabel(levels: LogsSeverityLevel[]): string {
     if (levels.length === 0 || levels.length === ALL_SEVERITY_LEVELS) {
@@ -55,6 +65,36 @@ export function LogsWidgetTileFilters({
     const serviceNames = parsed.serviceNames ?? []
     const orderBy = (parsed.orderBy ?? 'latest') as LogsOrderByValue
     const dateFrom = (parsed.dateRange?.date_from ?? LOGS_DEFAULT_DATE_FROM) as WidgetDateFromValue
+    const savedViewId = parsed.savedViewId ?? null
+    const hasSavedView = !!savedViewId
+
+    const { featureFlags } = useValues(featureFlagLogic)
+    const savedViewsEnabled = !!featureFlags[FEATURE_FLAGS.LOGS_SAVED_VIEWS]
+    // Keep the picker reachable when a view is already persisted, even if the flag is later turned
+    // off — otherwise the tile would be stuck on that view with no way to clear it.
+    const showSavedViewPicker = savedViewsEnabled || hasSavedView
+    const { savedViewOptions, savedViewsLoading, savedViewLabelById } = useValues(logsWidgetSavedViewsLogic)
+    const { ensureSavedViewsLoaded } = useActions(logsWidgetSavedViewsLogic)
+
+    useEffect(() => {
+        if (showSavedViewPicker) {
+            ensureSavedViewsLoaded()
+        }
+    }, [showSavedViewPicker, ensureSavedViewsLoaded])
+
+    const savedViewSelectOptions = useMemo(
+        () => [
+            NO_SAVED_VIEW_OPTION,
+            ...savedViewOptions,
+            {
+                value: CREATE_SAVED_VIEW_VALUE,
+                label: 'Create a saved view',
+                sideIcon: <IconExternal className="size-3.5" />,
+            },
+        ],
+        [savedViewOptions]
+    )
+    const savedViewLabel = savedViewId ? (savedViewLabelById[savedViewId] ?? savedViewId) : savedViewId
 
     const configRef = useRef(config)
     configRef.current = config
@@ -68,21 +108,39 @@ export function LogsWidgetTileFilters({
         severityLevels?: LogsSeverityLevel[]
         serviceNames?: string[]
         orderBy?: LogsOrderByValue
+        savedViewId?: string | null
     }): Promise<void> => {
         const nextConfig = patchLogsWidgetFilterFields(configRef.current, patch)
         configRef.current = nextConfig
         await persistConfigNow(nextConfig)
     }
 
+    const applySavedView = async (value: string | null): Promise<void> => {
+        // The "create" item is a navigation shortcut, not a persisted value.
+        if (value === CREATE_SAVED_VIEW_VALUE) {
+            window.open(urls.logs(), '_blank', 'noopener,noreferrer')
+            return
+        }
+        await applyPatch({ savedViewId: value })
+    }
+
     if (!canUpdate) {
         return (
             <WidgetTileFiltersBar dataAttr="logs-widget-tile-filters-readonly">
-                <WidgetTileFilterReadOnlyValue>
-                    <span className="text-secondary">Levels:</span> {severityReadOnlyLabel(severityLevels)}
-                </WidgetTileFilterReadOnlyValue>
-                <WidgetTileFilterReadOnlyValue>
-                    <span className="text-secondary">Services:</span> {servicesReadOnlyLabel(serviceNames)}
-                </WidgetTileFilterReadOnlyValue>
+                {hasSavedView ? (
+                    <WidgetTileFilterReadOnlyValue>
+                        <span className="text-secondary">Saved view:</span> {savedViewLabel}
+                    </WidgetTileFilterReadOnlyValue>
+                ) : (
+                    <>
+                        <WidgetTileFilterReadOnlyValue>
+                            <span className="text-secondary">Levels:</span> {severityReadOnlyLabel(severityLevels)}
+                        </WidgetTileFilterReadOnlyValue>
+                        <WidgetTileFilterReadOnlyValue>
+                            <span className="text-secondary">Services:</span> {servicesReadOnlyLabel(serviceNames)}
+                        </WidgetTileFilterReadOnlyValue>
+                    </>
+                )}
                 <WidgetTileFilterReadOnlyValue>
                     {SORT_OPTIONS.find((option) => option.value === orderBy)?.label ?? orderBy}
                 </WidgetTileFilterReadOnlyValue>
@@ -94,15 +152,29 @@ export function LogsWidgetTileFilters({
 
     return (
         <WidgetTileFiltersBar dataAttr="logs-widget-tile-filters">
-            <SeverityLevelsFilter
-                value={severityLevels as LogMessage['severity_text'][]}
-                onChange={(levels) => void applyPatch({ severityLevels: levels as LogsSeverityLevel[] })}
-            />
-            <ServiceFilter
-                value={serviceNames}
-                dateRange={serviceDateRange}
-                onChange={(services) => void applyPatch({ serviceNames: services ?? [] })}
-            />
+            {showSavedViewPicker ? (
+                <LemonSelect
+                    size="small"
+                    value={savedViewId}
+                    loading={savedViewsLoading}
+                    options={savedViewSelectOptions}
+                    placeholder="Saved view"
+                    onChange={(value) => void applySavedView(value ?? null)}
+                />
+            ) : null}
+            {!hasSavedView ? (
+                <>
+                    <SeverityLevelsFilter
+                        value={severityLevels as LogMessage['severity_text'][]}
+                        onChange={(levels) => void applyPatch({ severityLevels: levels as LogsSeverityLevel[] })}
+                    />
+                    <ServiceFilter
+                        value={serviceNames}
+                        dateRange={serviceDateRange}
+                        onChange={(services) => void applyPatch({ serviceNames: services ?? [] })}
+                    />
+                </>
+            ) : null}
             <LemonSelect
                 size="small"
                 value={orderBy}

--- a/products/dashboards/frontend/widgets/logs/editLogsWidgetModalLogic.ts
+++ b/products/dashboards/frontend/widgets/logs/editLogsWidgetModalLogic.ts
@@ -16,6 +16,7 @@ import {
     LOGS_DEFAULT_DATE_FROM,
     parseLogsWidgetConfig,
     validateLogsWidgetConfigInput,
+    type LogsTimezone,
     type LogsWidgetFieldErrors,
 } from './logsWidgetConfigValidation'
 
@@ -36,6 +37,8 @@ export const editLogsWidgetModalLogic = kea<editLogsWidgetModalLogicType>([
     actions({
         ...widgetEditModalListFieldActions,
         ...widgetEditModalTileActions,
+        setWrapLines: (wrapLines: boolean) => ({ wrapLines }),
+        setTimezone: (timezone: LogsTimezone) => ({ timezone }),
         setFieldErrors: (fieldErrors: LogsWidgetFieldErrors) => ({ fieldErrors }),
         clearFieldError: (field: keyof LogsWidgetFieldErrors) => ({ field }),
         submit: true,
@@ -45,9 +48,21 @@ export const editLogsWidgetModalLogic = kea<editLogsWidgetModalLogicType>([
 
     reducers({
         limit: [
-            10,
+            50,
             {
                 setLimit: (_: number, { limit }: { limit: number }) => limit,
+            },
+        ],
+        wrapLines: [
+            false,
+            {
+                setWrapLines: (_: boolean, { wrapLines }: { wrapLines: boolean }) => wrapLines,
+            },
+        ],
+        timezone: [
+            'UTC' as LogsTimezone,
+            {
+                setTimezone: (_: LogsTimezone, { timezone }: { timezone: LogsTimezone }) => timezone,
             },
         ],
         dateFrom: [
@@ -97,10 +112,12 @@ export const editLogsWidgetModalLogic = kea<editLogsWidgetModalLogicType>([
         widgetConfig: [(_, p) => [p.config], (config): LogsWidgetConfig => parseLogsWidgetConfig(config)],
         ...widgetEditModalPropSelectors,
         validation: [
-            (s) => [s.limit, s.dateFrom, s.widgetConfig],
-            (limit, dateFrom, widgetConfig) =>
+            (s) => [s.limit, s.wrapLines, s.timezone, s.dateFrom, s.widgetConfig],
+            (limit, wrapLines, timezone, dateFrom, widgetConfig) =>
                 validateLogsWidgetConfigInput({
                     limit,
+                    wrapLines,
+                    timezone,
                     dateFrom,
                     baseConfig: widgetConfig,
                 }),
@@ -133,6 +150,8 @@ export const editLogsWidgetModalLogic = kea<editLogsWidgetModalLogicType>([
 
         return {
             limit: baseConfig.limit,
+            wrapLines: baseConfig.wrapLines ?? false,
+            timezone: (baseConfig.timezone ?? 'UTC') as LogsTimezone,
             dateFrom: baseConfig.dateRange?.date_from ?? LOGS_DEFAULT_DATE_FROM,
             ...getWidgetEditModalTileDefaults(props),
             fieldErrors: {},

--- a/products/dashboards/frontend/widgets/logs/logsWidgetConfigValidation.test.ts
+++ b/products/dashboards/frontend/widgets/logs/logsWidgetConfigValidation.test.ts
@@ -11,14 +11,16 @@ import {
 describe('logsWidgetConfigValidation', () => {
     it('parses defaults for an empty config', () => {
         const config = parseLogsWidgetConfig({})
-        expect(config.limit).toBe(10)
+        expect(config.limit).toBe(50)
         expect(config.orderBy).toBe('latest')
+        expect(config.wrapLines).toBe(false)
+        expect(config.timezone).toBe('UTC')
         expect(config.severityLevels ?? []).toEqual([])
         expect(config.serviceNames ?? []).toEqual([])
     })
 
     it('patches on-tile filter fields without touching the date range', () => {
-        const base = { dateRange: { date_from: '-24h' }, limit: 10, orderBy: 'latest' }
+        const base = { dateRange: { date_from: '-24h' }, limit: 50, orderBy: 'latest' }
         const patched = patchLogsWidgetFilterFields(base, {
             severityLevels: ['error', 'warn'],
             serviceNames: ['api'],
@@ -37,6 +39,16 @@ describe('logsWidgetConfigValidation', () => {
         expect(patched.serviceNames).toEqual(['api'])
     })
 
+    it('sets and clears the saved view id', () => {
+        const withView = patchLogsWidgetFilterFields({}, { savedViewId: 'abc123' })
+        expect(withView.savedViewId).toBe('abc123')
+        // An explicit null clears it; an omitted key would have preserved it.
+        const cleared = patchLogsWidgetFilterFields(withView, { savedViewId: null })
+        expect(cleared.savedViewId ?? null).toBeNull()
+        const preserved = patchLogsWidgetFilterFields(withView, { orderBy: 'earliest' })
+        expect(preserved.savedViewId).toBe('abc123')
+    })
+
     it('falls back to the default date range when none is set', () => {
         const patched = patchLogsWidgetFilterFields({}, { orderBy: 'earliest' })
         expect(patched.dateRange?.date_from).toBe(LOGS_DEFAULT_DATE_FROM)
@@ -45,19 +57,36 @@ describe('logsWidgetConfigValidation', () => {
     it('validates a well-formed form input', () => {
         const result = validateLogsWidgetConfigInput({
             limit: 15,
+            wrapLines: true,
+            timezone: 'local',
             dateFrom: '-24h',
             baseConfig: parseLogsWidgetConfig({}),
         })
         expect(result.success).toBe(true)
         if (result.success) {
             expect(result.config.limit).toBe(15)
+            expect(result.config.wrapLines).toBe(true)
+            expect(result.config.timezone).toBe('local')
             expect(result.config.dateRange?.date_from).toBe('-24h')
         }
     })
 
-    it('rejects a limit above the cap', () => {
+    it('accepts a limit at the cap', () => {
         const result = validateLogsWidgetConfigInput({
             limit: 100,
+            wrapLines: false,
+            timezone: 'UTC',
+            dateFrom: '-1h',
+            baseConfig: parseLogsWidgetConfig({}),
+        })
+        expect(result.success).toBe(true)
+    })
+
+    it('rejects a limit above the cap', () => {
+        const result = validateLogsWidgetConfigInput({
+            limit: 101,
+            wrapLines: false,
+            timezone: 'UTC',
             dateFrom: '-1h',
             baseConfig: parseLogsWidgetConfig({}),
         })
@@ -69,7 +98,7 @@ describe('logsWidgetConfigValidation', () => {
 
     it('maps an API error to a field error', () => {
         const error = new ApiError('limit too big', 400, undefined, { config: 'limit too big' })
-        const fieldErrors = parseLogsWidgetConfigApiError(error, { limit: 100, orderBy: 'latest' })
+        const fieldErrors = parseLogsWidgetConfigApiError(error, { limit: 101, orderBy: 'latest' })
         expect(fieldErrors?.limit).toBeTruthy()
     })
 

--- a/products/dashboards/frontend/widgets/logs/logsWidgetConfigValidation.ts
+++ b/products/dashboards/frontend/widgets/logs/logsWidgetConfigValidation.ts
@@ -10,6 +10,7 @@ export const LOGS_DEFAULT_DATE_FROM: WidgetDateFromValue = '-1h'
 
 export type LogsOrderByValue = NonNullable<LogsWidgetConfig['orderBy']>
 export type LogsSeverityLevel = NonNullable<LogsWidgetConfig['severityLevels']>[number]
+export type LogsTimezone = NonNullable<LogsWidgetConfig['timezone']>
 
 export const LOGS_WIDGET_FORM_FIELD_NAMES = Object.keys(
     logsWidgetFormSchema.shape
@@ -21,6 +22,8 @@ export type LogsWidgetFieldErrors = Partial<Record<LogsWidgetFormField, string>>
 
 export type LogsWidgetFormInput = {
     limit: number
+    wrapLines: boolean
+    timezone: LogsTimezone
     dateRange: { date_from?: string | null } | null
 }
 
@@ -30,7 +33,7 @@ export function parseLogsWidgetConfig(config: Record<string, unknown>): LogsWidg
     return parseWidgetConfig(logsWidgetConfigSchema, config)
 }
 
-/** On-tile filter changes (severity, services, sort) — keeps the rest of the config untouched. */
+/** On-tile filter changes (severity, services, sort, saved view) — keeps the rest of the config untouched. */
 export function patchLogsWidgetFilterFields(
     config: Record<string, unknown>,
     patch: {
@@ -38,6 +41,7 @@ export function patchLogsWidgetFilterFields(
         serviceNames?: string[]
         orderBy?: LogsOrderByValue
         dateFrom?: WidgetDateFromValue
+        savedViewId?: string | null
     }
 ): LogsWidgetConfig {
     const base = parseLogsWidgetConfig(config)
@@ -48,6 +52,8 @@ export function patchLogsWidgetFilterFields(
         serviceNames: patch.serviceNames ?? base.serviceNames,
         orderBy: patch.orderBy ?? base.orderBy,
         dateRange: { date_from: patch.dateFrom ?? base.dateRange?.date_from ?? LOGS_DEFAULT_DATE_FROM },
+        // `savedViewId` is intentionally read with `in` so an explicit `null` clears it.
+        savedViewId: 'savedViewId' in patch ? patch.savedViewId : base.savedViewId,
     })
 }
 
@@ -60,11 +66,15 @@ export function buildLogsWidgetConfig(formInput: LogsWidgetFormInput, baseConfig
 
 export function validateLogsWidgetConfigInput(input: {
     limit: number
+    wrapLines: boolean
+    timezone: LogsTimezone
     dateFrom: WidgetDateFromValue
     baseConfig: LogsWidgetConfig
 }): { success: true; config: LogsWidgetConfig } | { success: false; fieldErrors: LogsWidgetFieldErrors } {
     const parsed = logsWidgetFormSchema.safeParse({
         limit: input.limit,
+        wrapLines: input.wrapLines,
+        timezone: input.timezone,
         dateRange: { date_from: input.dateFrom },
     })
 
@@ -74,6 +84,8 @@ export function validateLogsWidgetConfigInput(input: {
 
     const formInput: LogsWidgetFormInput = {
         limit: parsed.data.limit,
+        wrapLines: parsed.data.wrapLines,
+        timezone: parsed.data.timezone,
         dateRange: parsed.data.dateRange ?? null,
     }
 
@@ -98,6 +110,8 @@ export function parseLogsWidgetConfigApiError(
 
     const parsedForm = logsWidgetFormSchema.safeParse({
         limit: (config.limit as number) ?? logsConfigDefaults.limit ?? 0,
+        wrapLines: (config.wrapLines as boolean) ?? logsConfigDefaults.wrapLines ?? false,
+        timezone: (config.timezone as LogsTimezone) ?? logsConfigDefaults.timezone ?? 'UTC',
         dateRange: (config.dateRange as { date_from?: string | null } | undefined) ?? {
             date_from: LOGS_DEFAULT_DATE_FROM,
         },

--- a/products/dashboards/frontend/widgets/logs/logsWidgetSavedViewsLogic.ts
+++ b/products/dashboards/frontend/widgets/logs/logsWidgetSavedViewsLogic.ts
@@ -1,0 +1,61 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import { teamLogic } from 'scenes/teamLogic'
+
+import { logsViewsList } from 'products/logs/frontend/generated/api'
+import type { LogsViewApi } from 'products/logs/frontend/generated/api.schemas'
+
+import type { logsWidgetSavedViewsLogicType } from './logsWidgetSavedViewsLogicType'
+
+// One page is plenty — saved views are few, so we never paginate the dropdown.
+const SAVED_VIEWS_LIMIT = 100
+
+// Saved logs filters are LogsView rows ("saved views" on the logs page). The fetch is lazy —
+// only tiles that actually surface the picker (feature flag on, or a saved view already persisted)
+// trigger it, so tiles without the feature never hit the API.
+export const logsWidgetSavedViewsLogic = kea<logsWidgetSavedViewsLogicType>([
+    path(['products', 'dashboards', 'widgets', 'logs', 'logsWidgetSavedViewsLogic']),
+    connect(() => ({
+        values: [teamLogic, ['currentProjectId']],
+    })),
+    actions({
+        ensureSavedViewsLoaded: true,
+    }),
+    reducers({
+        hasLoadedSavedViews: [false, { loadSavedViewsSuccess: () => true }],
+    }),
+    loaders(({ values }) => ({
+        savedViews: {
+            __default: [] as LogsViewApi[],
+            loadSavedViews: async () => {
+                const response = await logsViewsList(String(values.currentProjectId), { limit: SAVED_VIEWS_LIMIT })
+                return response.results ?? []
+            },
+        },
+    })),
+    selectors({
+        savedViewOptions: [
+            (s) => [s.savedViews],
+            (savedViews): { value: string; label: string }[] =>
+                savedViews.map((view) => ({
+                    value: view.short_id,
+                    label: view.name || 'Unnamed view',
+                })),
+        ],
+        // Single source for resolving a saved-view short_id to its display label, shared by the
+        // tile filter bar and the read-only summary.
+        savedViewLabelById: [
+            (s) => [s.savedViewOptions],
+            (savedViewOptions): Record<string, string> =>
+                Object.fromEntries(savedViewOptions.map((option) => [option.value, option.label])),
+        ],
+    }),
+    listeners(({ actions, values }) => ({
+        ensureSavedViewsLoaded: () => {
+            if (!values.hasLoadedSavedViews && !values.savedViewsLoading) {
+                actions.loadSavedViews()
+            }
+        },
+    })),
+])

--- a/products/logs/backend/facade/queries.py
+++ b/products/logs/backend/facade/queries.py
@@ -9,5 +9,6 @@ them onto the ``django.setup()`` path.
 """
 
 from products.logs.backend.logs_query_runner import LogsQueryRunner
+from products.logs.backend.saved_view_query import build_logs_query_for_saved_view
 
-__all__ = ["LogsQueryRunner"]
+__all__ = ["LogsQueryRunner", "build_logs_query_for_saved_view"]

--- a/products/logs/backend/saved_view_query.py
+++ b/products/logs/backend/saved_view_query.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import logging
+
+from pydantic import ValidationError
+
+from posthog.schema import DateRange, FilterLogicalOperator, LogsOrderBy, LogsQuery, PropertyGroupFilter
+
+from posthog.models.team import Team
+
+from products.logs.backend.models import LogsView
+
+logger = logging.getLogger(__name__)
+
+
+def _filter_group_from_filters(filters: dict) -> PropertyGroupFilter:
+    filter_group = filters.get("filterGroup")
+    if filter_group:
+        return PropertyGroupFilter.model_validate(filter_group)
+    return PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[])
+
+
+def build_logs_query_for_saved_view(
+    team: Team,
+    short_id: str,
+    *,
+    order_by: LogsOrderBy,
+    limit: int,
+    offset: int = 0,
+    exclude_attributes: bool = True,
+) -> LogsQuery | None:
+    """Resolve a saved logs view into a LogsQuery. Returns None if the view is missing or unusable.
+
+    The saved view owns the date range, severity, service, search, and property filters; the
+    caller still controls orderBy and limit. A `None` return lets the caller fall back to its own
+    config — this covers both a deleted view and a view whose stored `filters` blob no longer
+    matches the schema (the `filters` JSON has no inner validation on write).
+    """
+    view = LogsView.objects.filter(team=team, short_id=short_id).first()
+    if view is None:
+        return None
+
+    filters = view.filters or {}
+    date_range_raw = filters.get("dateRange") or {}
+    try:
+        return LogsQuery(
+            kind="LogsQuery",
+            dateRange=DateRange(date_from=date_range_raw.get("date_from"), date_to=date_range_raw.get("date_to")),
+            severityLevels=filters.get("severityLevels") or [],
+            serviceNames=filters.get("serviceNames") or [],
+            searchTerm=filters.get("searchTerm"),
+            filterGroup=_filter_group_from_filters(filters),
+            orderBy=order_by,
+            limit=limit,
+            offset=offset,
+            excludeAttributes=exclude_attributes,
+        )
+    except ValidationError:
+        logger.warning("logs_widget_saved_view_filters_invalid", extra={"short_id": short_id, "team_id": team.pk})
+        return None

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -4394,12 +4394,23 @@ export namespace Schemas {
       Fatal: 'fatal',
     } as const;
 
+    /**
+     * Render log timestamps in UTC or in each viewer's local timezone.
+     */
+    export type LogsListWidgetConfigTimezone = typeof LogsListWidgetConfigTimezone[keyof typeof LogsListWidgetConfigTimezone];
+
+
+    export const LogsListWidgetConfigTimezone = {
+      Utc: 'UTC',
+      Local: 'local',
+    } as const;
+
     export interface LogsListWidgetConfig {
       dateRange?: WidgetDateRange | null;
       /**
          * Maximum number of log lines to return.
          * @minimum 1
-         * @maximum 25
+         * @maximum 100
          */
       limit?: number;
       /** Sort by newest (latest) or oldest (earliest) first. */
@@ -4408,6 +4419,12 @@ export namespace Schemas {
       severityLevels?: LogsListWidgetConfigSeverityLevelsItem[];
       /** Only show logs from these services. Empty shows all services. */
       serviceNames?: string[];
+      /** Wrap long log lines instead of truncating them to a single row. */
+      wrapLines?: boolean;
+      /** Render log timestamps in UTC or in each viewer's local timezone. */
+      timezone?: LogsListWidgetConfigTimezone;
+      /** short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply. */
+      savedViewId?: string | null;
     }
 
     export interface LogsListWidgetAddRequestOpenApi {

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -141,10 +141,12 @@ export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourLimitMax 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourOrderByDefault = `created_at`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourOrderDirectionDefault = `DESC`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneFourStatusDefault = `all`
-export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitDefault = 10
-export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitMax = 25
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitDefault = 50
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixLimitMax = 100
 
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixOrderByDefault = `latest`
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixWrapLinesDefault = false
+export const dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixTimezoneDefault = `UTC`
 export const dashboardsPartialUpdateBodyTilesItemWidgetOneNameMax = 400
 
 export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
@@ -624,6 +626,28 @@ export const DashboardsPartialUpdateBody = /* @__PURE__ */ zod
                                             .array(zod.string())
                                             .optional()
                                             .describe('Only show logs from these services. Empty shows all services.'),
+                                        wrapLines: zod
+                                            .boolean()
+                                            .default(
+                                                dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixWrapLinesDefault
+                                            )
+                                            .describe(
+                                                'Wrap long log lines instead of truncating them to a single row.'
+                                            ),
+                                        timezone: zod
+                                            .enum(['UTC', 'local'])
+                                            .default(
+                                                dashboardsPartialUpdateBodyTilesItemWidgetOneConfigOneSixTimezoneDefault
+                                            )
+                                            .describe(
+                                                "Render log timestamps in UTC or in each viewer's local timezone."
+                                            ),
+                                        savedViewId: zod
+                                            .union([zod.string(), zod.null()])
+                                            .optional()
+                                            .describe(
+                                                'short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply.'
+                                            ),
                                     }),
                                 ])
                                 .optional()
@@ -994,10 +1018,12 @@ export const dashboardsWidgetsBatchCreateBodyWidgetsItemFiveNameMax = 400
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixNameMax = 400
 
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitDefault = 10
-export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitMax = 25
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitDefault = 50
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneLimitMax = 100
 
 export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneOrderByDefault = `latest`
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneWrapLinesDefault = false
+export const dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneTimezoneDefault = `UTC`
 export const dashboardsWidgetsBatchCreateBodyWidgetsMax = 10
 
 export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
@@ -1744,6 +1770,20 @@ export const DashboardsWidgetsBatchCreateBody = /* @__PURE__ */ zod
                                     .array(zod.string())
                                     .optional()
                                     .describe('Only show logs from these services. Empty shows all services.'),
+                                wrapLines: zod
+                                    .boolean()
+                                    .default(dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneWrapLinesDefault)
+                                    .describe('Wrap long log lines instead of truncating them to a single row.'),
+                                timezone: zod
+                                    .enum(['UTC', 'local'])
+                                    .default(dashboardsWidgetsBatchCreateBodyWidgetsItemSixConfigOneTimezoneDefault)
+                                    .describe("Render log timestamps in UTC or in each viewer's local timezone."),
+                                savedViewId: zod
+                                    .union([zod.string(), zod.null()])
+                                    .optional()
+                                    .describe(
+                                        'short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply.'
+                                    ),
                             })
                             .describe('Configuration for the recent logs widget.'),
                     }),


### PR DESCRIPTION
## Problem

Follow-up to the recent logs dashboard widget (#64416). The widget showed a small, fixed page of truncated log lines with no way to open a log in context, no display controls, and no reuse of saved logs filters. This PR adds the requested display and source options so a logs tile reads and behaves more like the logs page.

## Changes

- **Bigger page by default.** Default page size is now 50 (max 100) — log rows are cheap to scan. Logs carries its own `LogsWidgetLimit` / `LOGS_LIST_*` constants, mirroring the activity-events precedent, rather than sharing the generic list-widget bounds.
- **Rows look like the logs page.** Each row reuses the logs viewer's `SEVERITY_BAR_COLORS` severity bar and a monospace timestamp.
- **Click a log to open it.** Each row links to that log on the logs page in a new tab. The deep link forwards the tile's filters + sort + `initialLogsLimit` so the logs page's first page matches the tile's rows and the linked log is actually loaded.
- **Wrap toggle.** A per-tile setting wraps long log lines instead of truncating them.
- **UTC / local timestamps.** A per-tile setting renders timestamps in UTC (shared for all viewers) or each viewer's local timezone.
- **Saved views.** Behind the `logs-saved-views` flag, a tile can source from a saved `LogsView`. The view owns the date range / severity / service / property filters; the tile still owns sort and limit. Resolution lives in the logs product and is exposed through its facade. A missing **or** malformed saved view degrades to the tile's own config instead of erroring.

The Pydantic config (`LogsListWidgetConfig`) is the source of truth. The generated frontend/MCP types (zod, `api.schemas`, MCP snapshots) are **not** included here — they are regenerated by `hogli build:openapi` from the updated SSOT. Until that runs, the frontend type-check will flag the new `wrapLines` / `timezone` / `savedViewId` fields.

## How did you test this code?

I'm an agent (human-driven by the PR assignee). This environment has no Python/Node toolchain, so I could not run the suites or `hogli build:openapi` locally — CI must do so. I added/updated automated tests:

- **`test_run_widgets.py`** — logs split out to its own defaults test (limit 50), accepts-100 / rejects-101 boundary, accepts wrap/timezone/savedViewId and rejects invalid values, and **saved-view resolution**: view-owns-filters vs tile-owns-sort/limit, fallback when the view is missing, and fallback when the view's stored `filters` are malformed (the path that would otherwise 500 the tile).
- **`test_widget_config_schema_parity.py`** — logs added to the per-widget limit-bounds map so the catalog/Pydantic parity check covers its larger bounds.
- **`logsWidgetConfigValidation.test.ts`** — default 50, accepts-100 / rejects-101, wrap/timezone threading, and saved-view set/clear/preserve semantics.

`ruff check`/`format` pass on the changed Python; files compile.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code). The work extends an existing logs-widget branch; this PR is stacked on `posthog-code/logs-dashboard-widget` so the diff is scoped to just these additions.

Skills invoked while shaping this: `/adopting-generated-api-types` (the new saved-views logic consumes the generated `logsViewsList` client), `/writing-tests` (test gating), and `/improving-drf-endpoints` (config/serializer surface). Reviews run before opening: `/code-review` plus the team `xp-reviewer` skill from the PostHog skills store.

Key decisions:
- **Saved-view query building lives in the logs product** (`saved_view_query.py`, exposed via `facade/queries.py`) rather than in the dashboards widget, so logs owns its filter semantics. Reuses the same `filters`→`LogsQuery` conversion shape as the logs alert path.
- **Malformed saved views degrade to fallback** instead of erroring — the `LogsView.filters` JSON has no inner schema validation on write, so a stored value outside the enum is possible; a `ValidationError` there now returns `None` and the tile uses its own config.
- **Deep-link param shape is deliberately duplicated** (not extracted into a shared helper with `logsViewerLogic.copyLinkToLog`) — the two builders have divergent inputs, so per ThreeStrikesAndYouRefactor it's left duplicated with a note rather than forced into the wrong abstraction.
- **Saved-views fetch is lazy** — only tiles that actually surface the picker (flag on, or a view already persisted) trigger the `logsViewsList` request; the picker also stays reachable when the flag is off but a view is persisted, so a tile can never get stuck on a view with no way to clear it.
