### PR TITLE
test(oauth): cover inlined allowed_origins and RS256 validation

### DIFF
--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -3,6 +3,7 @@ from datetime import timedelta
 
 from freezegun import freeze_time
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.test import TestCase, override_settings
 from django.utils import timezone
@@ -446,6 +447,29 @@ class TestOAuthModels(TestCase):
                 organization=self.organization,
                 algorithm="RS256",
             )
+
+    def test_valid_allowed_origins_accepted(self):
+        app = self._make_app(
+            "Allowed Origins App",
+            "allowed_origins_client",
+            allowed_origins="https://app.example.com https://www.example.com",
+        )
+        self.assertIn("app.example.com", app.allowed_origins)
+
+    @parameterized.expand(
+        [
+            ("non-https scheme", "http://app.example.com"),
+            ("origin with path", "https://app.example.com/callback"),
+        ]
+    )
+    def test_invalid_allowed_origins_rejected(self, _name, allowed_origins):
+        with self.assertRaises(ValidationError):
+            self._make_app("Bad Origin App", "bad_origin_client", allowed_origins=allowed_origins)
+
+    def test_rs256_without_private_key_rejected(self):
+        with override_settings(OAUTH2_PROVIDER={**settings.OAUTH2_PROVIDER, "OIDC_RSA_PRIVATE_KEY": ""}):
+            with self.assertRaises(ValidationError):
+                self._make_app("No Key App", "no_key_client")
 
     def test_invalid_redirect_uri_no_host(self):
         with self.assertRaises(ValidationError):


### PR DESCRIPTION
## Problem

[PR #65856](https://github.com/PostHog/posthog/pull/65856) rewrote `OAuthApplication.clean()` to stop calling `super().clean()` and instead re-implement django-oauth-toolkit's non-redirect model checks inline (`_validate_application_config`). Two of those hand-rolled checks shipped with no test coverage:

- `allowed_origins` validation (scheme + shape via `AllowedURIValidator`) — zero references in the test suite.
- The RS256-without-`OIDC_RSA_PRIVATE_KEY` rejection — only the positive path runs, because test settings always generate a key.

A regression in either inlined copy (a dropped loop, a wrong validator construction) would pass CI silently.

## Changes

Adds three tests to `posthog/models/test/test_oauth.py`:

- `test_valid_allowed_origins_accepted` — a well-formed `allowed_origins` value is accepted.
- `test_invalid_allowed_origins_rejected` — parameterized: a non-https origin and an origin carrying a path are both rejected.
- `test_rs256_without_private_key_rejected` — with `OIDC_RSA_PRIVATE_KEY` cleared via `override_settings` (which triggers django-oauth-toolkit's settings reload), creating an RS256 app raises `ValidationError`.

No production code changes. Follow-up to #65856.

## How did you test this code?

I'm an agent. I added the three automated tests above. Local verification was blocked by a ClickHouse/Keeper infra issue in this environment (the conftest CH-table reset fails with `TableIsReadOnly` before the tests run); the validations under test raise in `full_clean()` before any DB write, so they don't depend on ClickHouse. CI runs the real backend matrix with services up — that's the verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to a review of #65856. The reviewer flagged that the two inlined checks copied out of django-oauth-toolkit had no tests; this PR adds them. Test inputs (path-bearing origin, non-https origin) were chosen against the actual `AllowedURIValidator` config used in `_validate_application_config` (no `allow_path`/`allow_query`, `ALLOWED_SCHEMES = ["https"]`). RS256 negative path uses `override_settings(OAUTH2_PROVIDER=...)` since the toolkit reloads its cached settings on that signal.
