### PR TITLE
fix(growth): keep identity-matching eval labels under edge truncation

### DIFF
--- a/products/growth/dags/identity_matching.py
+++ b/products/growth/dags/identity_matching.py
@@ -212,6 +212,14 @@ class IdentityMatchingConfig(dagster.Config):
     )
     prob_tier_high: float = pydantic.Field(default=0.9, description="Probability at or above which tier is 'high'.")
     prob_tier_medium: float = pydantic.Field(default=0.7, description="Probability at or above which tier is 'medium'.")
+    logreg_min_prob: float = pydantic.Field(
+        default=0.5,
+        description="Minimum predicted probability for a logreg link to be kept (the logreg analogue of rule_min_score).",
+    )
+    logreg_min_margin: float = pydantic.Field(
+        default=0.0,
+        description="Minimum probability margin over the runner-up anchor for a logreg link to be kept.",
+    )
     query_max_execution_time_seconds: int = pydantic.Field(
         default=60 * 60,
         gt=0,
@@ -450,6 +458,26 @@ def prepare_run(
         f"edges from {run.edges_start}, eval until {run.eval_end}; "
         f"writing to s3 prefix {identity_matching_run_prefix(config.team_id, run.job_id)}/"
     )
+    # Training labels come from merges in [date_end, eval_end). If that horizon has not elapsed,
+    # those merges have not happened yet, so the logistic regression sees no labels and skips —
+    # which reads as a silent failure. Warn rather than fail: the rule model needs no labels.
+    now = datetime.datetime.now(datetime.UTC)
+    eval_end = datetime.datetime.fromisoformat(run.eval_end).replace(tzinfo=datetime.UTC)
+    if eval_end > now:
+        window_end = datetime.datetime.fromisoformat(run.date_end).replace(tzinfo=datetime.UTC)
+        if window_end >= now:
+            context.log.warning(
+                f"Evaluation horizon [{run.date_end}, {run.eval_end}) is entirely in the future "
+                f"(today is {now.date().isoformat()}): no post-window merges exist yet, so the logistic "
+                f"regression will have no training labels and will skip. Re-run with date_end at least "
+                f"eval_horizon_days ({config.eval_horizon_days}) in the past to train it."
+            )
+        else:
+            context.log.warning(
+                f"Evaluation horizon ends {run.eval_end}, after today ({now.date().isoformat()}): labels "
+                f"are only partially observed, so logistic regression will undercount positives. Re-run "
+                f"after {run.eval_end} for a complete evaluation."
+            )
     return run
 
 
@@ -562,6 +590,56 @@ class _UnionFind:
         return groups
 
 
+def _fetch_identity_edges(
+    context: dagster.OpExecutionContext,
+    cluster: ClickhouseCluster,
+    run: "MatchingRun",
+    *,
+    start: str,
+    end: str,
+    order: str,
+) -> list[tuple[str, str, datetime.datetime]]:
+    """Deduped (other_id, target_id, first_seen) identity edges with timestamp in [start, end).
+
+    Capped at config.max_identity_edges to bound the in-memory union-find. ``order`` ('ASC' or
+    'DESC', a trusted literal — never request input) decides which edges survive truncation:
+    anchor edges keep the most recent (DESC, closest to window end), eval edges keep the earliest
+    (ASC, each orphan's first post-window merge).
+    """
+    query = f"""
+        SELECT other_id, target_id, min(ts) AS first_seen
+        FROM (
+            SELECT
+                if(event = '$identify', {_prop("$anon_distinct_id")}, {_prop("alias")}) AS other_id,
+                distinct_id AS target_id,
+                timestamp AS ts
+            FROM {settings.CLICKHOUSE_DATABASE}.events
+            WHERE team_id = %(team_id)s
+              AND event IN %(identity_events)s
+              AND timestamp >= toDateTime(%(start)s)
+              AND timestamp < toDateTime(%(end)s)
+        )
+        WHERE other_id != '' AND other_id != target_id
+        GROUP BY other_id, target_id
+        ORDER BY first_seen {order}, other_id, target_id
+        LIMIT %(max_edges)s
+    """
+    return cluster.any_host(
+        partial(
+            _execute,
+            query=query,
+            parameters={
+                "team_id": run.config.team_id,
+                "identity_events": tuple(IDENTITY_EVENTS),
+                "start": start,
+                "end": end,
+                "max_edges": run.config.max_identity_edges,
+            },
+            query_settings=_read_settings(context, run),
+        )
+    ).result()
+
+
 @dagster.op
 def extract_person_timeline(
     context: dagster.OpExecutionContext,
@@ -574,60 +652,31 @@ def extract_person_timeline(
     window end; state tables (person.is_identified, overrides) have no time-travel semantics.
     """
     config = run.config
-    edges_query = f"""
-        SELECT other_id, target_id, min(ts) AS first_seen
-        FROM (
-            SELECT
-                if(
-                    event = '$identify',
-                    {_prop("$anon_distinct_id")},
-                    {_prop("alias")}
-                ) AS other_id,
-                distinct_id AS target_id,
-                timestamp AS ts
-            FROM {settings.CLICKHOUSE_DATABASE}.events
-            WHERE team_id = %(team_id)s
-              AND event IN %(identity_events)s
-              AND timestamp >= toDateTime(%(edges_start)s)
-              AND timestamp < toDateTime(%(eval_end)s)
+    # Anchor edges (identity events strictly before window end) classify anchors "as of" window
+    # end; eval edges (merges in [date_end, eval_end)) are the ONLY source of training labels.
+    # They are fetched as two separate capped queries on purpose: folding both into one query and
+    # truncating oldest-first let the high-volume anchor edges silently drop the recent eval edges,
+    # which on a large team zeroed out the labels (logreg then skips on 0 positives).
+    anchor_edges = _fetch_identity_edges(context, cluster, run, start=run.edges_start, end=run.date_end, order="DESC")
+    if len(anchor_edges) >= config.max_identity_edges:
+        context.log.warning(
+            f"Anchor identity edges truncated at {len(anchor_edges)} (kept the most recent); anchor "
+            "classification is incomplete — raise max_identity_edges for full coverage on large teams"
         )
-        WHERE other_id != '' AND other_id != target_id
-        GROUP BY other_id, target_id
-        ORDER BY first_seen
-        LIMIT %(max_edges)s
-    """
-    edges: list[tuple[str, str, datetime.datetime]] = cluster.any_host(
-        partial(
-            _execute,
-            query=edges_query,
-            parameters={
-                "team_id": config.team_id,
-                "identity_events": tuple(IDENTITY_EVENTS),
-                "edges_start": run.edges_start,
-                "eval_end": run.eval_end,
-                "max_edges": config.max_identity_edges,
-            },
-            query_settings=_read_settings(context, run),
-        )
-    ).result()
-    if len(edges) >= config.max_identity_edges:
-        context.log.warning(f"Identity edges truncated at {len(edges)}; anchor classification is incomplete")
+    # Earliest-first so the per-orphan dedup below keeps each orphan's first post-window merge.
+    eval_edges = _fetch_identity_edges(context, cluster, run, start=run.date_end, end=run.eval_end, order="ASC")
+    if len(eval_edges) >= config.max_identity_edges:
+        context.log.warning(f"Eval identity edges truncated at {len(eval_edges)}; some training labels are missing")
 
-    # ClickHouse returns timezone-aware datetimes for DateTime64(..., 'UTC') columns.
-    window_end = datetime.datetime.fromisoformat(run.date_end).replace(tzinfo=datetime.UTC)
     union_find = _UnionFind()
     first_seen_by_id: dict[str, datetime.datetime] = {}
-    eval_edges: list[tuple[str, str, datetime.datetime]] = []
     identified_ids: set[str] = set()
-    for other_id, target_id, first_seen in edges:
-        if first_seen < window_end:
-            union_find.union(target_id, other_id)
-            identified_ids.add(target_id)
-            for member in (other_id, target_id):
-                if member not in first_seen_by_id or first_seen < first_seen_by_id[member]:
-                    first_seen_by_id[member] = first_seen
-        else:
-            eval_edges.append((other_id, target_id, first_seen))
+    for other_id, target_id, first_seen in anchor_edges:
+        union_find.union(target_id, other_id)
+        identified_ids.add(target_id)
+        for member in (other_id, target_id):
+            if member not in first_seen_by_id or first_seen < first_seen_by_id[member]:
+                first_seen_by_id[member] = first_seen
 
     # The canonical key prefers identified-side ids (merge targets): a bare lexicographic
     # minimum could crown an anonymous device id, which then surfaces as the matched person
@@ -666,7 +715,8 @@ def extract_person_timeline(
     anchor_persons = len(set(person_key_by_id.values()))
     context.add_output_metadata(
         {
-            "identity_edges": dagster.MetadataValue.int(len(edges)),
+            "anchor_edges": dagster.MetadataValue.int(len(anchor_edges)),
+            "eval_edges": dagster.MetadataValue.int(len(eval_edges)),
             "anchor_distinct_ids": dagster.MetadataValue.int(len(person_key_by_id)),
             "anchor_persons": dagster.MetadataValue.int(anchor_persons),
             "eval_labeled_orphans": dagster.MetadataValue.int(labeled),
@@ -1093,6 +1143,10 @@ def train_logreg_and_score(
                 best_by_orphan[orphan_id] = (best[0], best[1], prob)
         computed_at = datetime.datetime.now(datetime.UTC)
         for orphan_id, (prob, anchor_key, runner_up) in best_by_orphan.items():
+            # Mirror the rule model's min-score / min-margin gate so logreg emits confident links
+            # instead of one row per orphan-with-candidates regardless of predicted probability.
+            if prob < config.logreg_min_prob or (prob - runner_up) < config.logreg_min_margin:
+                continue
             tier = "high" if prob >= config.prob_tier_high else "medium" if prob >= config.prob_tier_medium else "low"
             link_rows.append(
                 (
@@ -1308,8 +1362,18 @@ def evaluate_and_report(
         ).result()
 
         if not link_rows:
-            summary_lines.append(f"\n{model_version}: no links")
-            model_headlines.append(f"*{model_version}*: no links")
+            note = ""
+            if model_version == LOGREG_MODEL_VERSION:
+                # logreg writes no links when it skips training; surface the likely reason rather
+                # than a bare "no links" (see the label-count gate in train_logreg_and_score).
+                note = (
+                    f" — logreg needs ≥{config.min_training_positives} positive / "
+                    f"≥{config.min_training_negatives} negative labels; this run had {gradable_orphans} "
+                    f"gradable labeled orphans. If that is ~0, the eval horizon has not elapsed "
+                    f"(eval until {run.eval_end}) or identity edges were truncated."
+                )
+            summary_lines.append(f"\n{model_version}: no links{note}")
+            model_headlines.append(f"*{model_version}*: no links{note}")
             continue
 
         table_lines = [

--- a/products/growth/dags/tests/test_identity_matching.py
+++ b/products/growth/dags/tests/test_identity_matching.py
@@ -181,6 +181,9 @@ def _run_job(cluster: ClickhouseCluster, **config_overrides: Any) -> tuple[dagst
         "ip_window_device_cap": 20,
         "rule_min_score": 1.0,
         "rule_min_margin": 0.0,
+        # Keep every best-per-orphan logreg link on the tiny fixture; the prod default (0.5) would
+        # filter on the model's unstable probabilities and make link assertions flaky.
+        "logreg_min_prob": 0.0,
         "min_training_positives": 2,
         "min_training_negatives": 1,
         **config_overrides,
@@ -267,6 +270,24 @@ def test_logreg_skips_without_labels(cluster: ClickhouseCluster) -> None:
         return count
 
     assert cluster.any_host(get_logreg_link_count).result() == 0
+
+
+def test_eval_labels_survive_edge_truncation(cluster: ClickhouseCluster) -> None:
+    cluster.any_host(_insert_fixture_events).result()
+
+    # Exactly 4 identity edges precede window end and 2 post-window merges follow. Capping at 4
+    # fills the anchor-edge budget entirely, so the single oldest-first query the job used to run
+    # would drop both post-window merges and yield zero labels; the split fetch keeps them.
+    result, job_id = _run_job(cluster, max_identity_edges=4)
+    assert result.success
+
+    def get_labels(client: Client) -> dict[str, str]:
+        rows = _read_dataset(
+            client, PERSON_TIMELINE, job_id, "distinct_id, label_person_key", "WHERE label_person_key != ''"
+        )
+        return dict(rows)
+
+    assert cluster.any_host(get_labels).result() == {"phone-anna": "anna@x.com", "phone-bob": "bob@x.com"}
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

Fixes POS-31.

The identity matching job can produce many `rules_v1` links while `logreg_v1` produces **none**. The logistic regression skips when it has too few training labels, and on a high-volume project it was getting **zero**.

Two compounding causes:

1. **The identity-edge fetch truncated from the wrong end.** `extract_person_timeline` pulled anchor and evaluation edges in a single query ordered `first_seen ASC` and capped at `max_identity_edges`. When a project has more identity edges than the cap over the lookback-to-horizon span, the **newest** edges are silently dropped — exactly where the post-window merges live. Those merges are the only source of logreg training labels, so the model saw none and skipped. Anchor classification was also built from the oldest edges (the "anchor classification is incomplete" warning fired). The rule model is unaffected because it needs no labels.
2. **The evaluation horizon could be in the future.** Labels come from merges in `[date_end, eval_end)`; if that window ends after today, those merges have not happened yet, and nothing guarded against running with such a window.

## Changes

- **Split the edge fetch** into two independent capped queries: anchor edges `[edges_start, date_end)` ordered `DESC` (keep the most recent under truncation, closest to window end), and evaluation edges `[date_end, eval_end)` ordered `ASC` (keep each orphan's first post-window merge). Evaluation labels can no longer be crowded out by anchor-edge volume; both truncations warn distinctly and report separate counts in op metadata.
- **Guard the evaluation horizon** in `prepare_run` — warns (does not fail; the rule model needs no labels) when the horizon is wholly or partly in the future.
- **Threshold logreg link emission** with new `logreg_min_prob` / `logreg_min_margin` config, mirroring the rule model's `rule_min_score` / `rule_min_margin`, so logreg emits confident links instead of one row per orphan-with-candidates.
- **Make the report self-explaining** when logreg emits no links — it states the label requirement and the likely cause (horizon not elapsed, or edges truncated).

## How did you test this code?

I'm an agent (Claude Code); I have not manually run the full job. Automated tests I actually ran locally: `ruff check` + `ruff format` (clean), `pytest --collect-only` (the new test is discovered), and the pure-Python guard tests `test_team_guard_per_environment` + `test_job_registration_per_environment` (12 passed).

New regression test `test_eval_labels_survive_edge_truncation` runs the job with `max_identity_edges` low enough to fill the anchor-edge budget on the fixture, then asserts both post-window labels still survive. The previous oldest-first single query dropped them, and no existing test exercised truncation — so this catches exactly the regression this PR fixes. The ClickHouse-backed tests (including this one) run in CI; they could not run in my local environment due to an unrelated persons-DB test-bootstrap issue.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact — internal Dagster job, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8). Skill invoked: `/writing-tests` (gated the new regression test). The bug was diagnosed from the job's op metadata — zero evaluation-labeled orphans alongside an identity-edge truncation warning — then confirmed by reading the DAG.

Key decisions:
- **Split the fetch rather than just raising `max_identity_edges`.** Raising the cap alone is fragile: a large enough project re-hits it, and oldest-first order would still drop the newest (label-bearing) edges. Two queries make evaluation labels structurally independent of anchor-edge volume.
- **Anchor edges `DESC`, eval edges `ASC`.** Anchor state is "as of window end", so under truncation keep the most recent; evaluation dedup keeps each orphan's first post-window merge, so keep the earliest.
- **Guard warns, does not fail.** A future-dated horizon is a valid rules-only run; failing would block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
