### PR TITLE
chore(dashboards): regenerate MCP snapshots and format logs widget

### DIFF
--- a/products/dashboards/frontend/widgets/logs/EditLogsWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/logs/EditLogsWidgetModal.tsx
@@ -34,8 +34,16 @@ function EditLogsWidgetModalContents(): JSX.Element {
         onClose,
         defaultTitle,
     } = useValues(editLogsWidgetModalLogic)
-    const { setLimit, setWrapLines, setTimezone, setDateFrom, setTileName, setTileDescription, clearFieldError, submit } =
-        useActions(editLogsWidgetModalLogic)
+    const {
+        setLimit,
+        setWrapLines,
+        setTimezone,
+        setDateFrom,
+        setTileName,
+        setTileDescription,
+        clearFieldError,
+        submit,
+    } = useActions(editLogsWidgetModalLogic)
 
     return (
         <LemonModal

--- a/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
@@ -1,7 +1,6 @@
 import { combineUrl } from 'kea-router'
 
 import { DetectiveHog } from 'lib/components/hedgehogs'
-
 import { urls } from 'scenes/urls'
 
 import {
@@ -12,8 +11,8 @@ import {
     WidgetListCount,
 } from '../../components/WidgetCard'
 import type { DashboardWidgetComponentProps } from '../registry'
-import { LogsWidgetRow, LogsWidgetRowSkeleton, type LogsWidgetLogLine } from './LogsWidgetRow'
 import { parseLogsWidgetConfig } from './logsWidgetConfigValidation'
+import { LogsWidgetRow, LogsWidgetRowSkeleton, type LogsWidgetLogLine } from './LogsWidgetRow'
 
 export type LogsWidgetResult = {
     results?: LogsWidgetLogLine[]

--- a/products/dashboards/frontend/widgets/logs/LogsWidgetRow.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidgetRow.tsx
@@ -1,6 +1,6 @@
 import { TZLabel } from 'lib/components/TZLabel'
-import { Link } from 'lib/lemon-ui/Link'
 import { LemonSkeleton } from 'lib/lemon-ui/LemonSkeleton'
+import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { cn } from 'lib/utils/css-classes'
 

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-update.json
@@ -730,9 +730,9 @@
                                                 ]
                                             },
                                             "limit": {
-                                                "default": 10,
+                                                "default": 50,
                                                 "description": "Maximum number of log lines to return.",
-                                                "maximum": 25,
+                                                "maximum": 100,
                                                 "minimum": 1,
                                                 "type": "number"
                                             },
@@ -741,6 +741,17 @@
                                                 "description": "Sort by newest (latest) or oldest (earliest) first.",
                                                 "enum": ["latest", "earliest"],
                                                 "type": "string"
+                                            },
+                                            "savedViewId": {
+                                                "anyOf": [
+                                                    {
+                                                        "type": "string"
+                                                    },
+                                                    {
+                                                        "type": "null"
+                                                    }
+                                                ],
+                                                "description": "short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply."
                                             },
                                             "serviceNames": {
                                                 "description": "Only show logs from these services. Empty shows all services.",
@@ -756,6 +767,17 @@
                                                     "type": "string"
                                                 },
                                                 "type": "array"
+                                            },
+                                            "timezone": {
+                                                "default": "UTC",
+                                                "description": "Render log timestamps in UTC or in each viewer's local timezone.",
+                                                "enum": ["UTC", "local"],
+                                                "type": "string"
+                                            },
+                                            "wrapLines": {
+                                                "default": false,
+                                                "description": "Wrap long log lines instead of truncating them to a single row.",
+                                                "type": "boolean"
                                             }
                                         },
                                         "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-add.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-add.json
@@ -1016,9 +1016,9 @@
                                         ]
                                     },
                                     "limit": {
-                                        "default": 10,
+                                        "default": 50,
                                         "description": "Maximum number of log lines to return.",
-                                        "maximum": 25,
+                                        "maximum": 100,
                                         "minimum": 1,
                                         "type": "number"
                                     },
@@ -1027,6 +1027,17 @@
                                         "description": "Sort by newest (latest) or oldest (earliest) first.",
                                         "enum": ["latest", "earliest"],
                                         "type": "string"
+                                    },
+                                    "savedViewId": {
+                                        "anyOf": [
+                                            {
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "short_id of a saved logs view to use as the source. When set, the saved view owns the date range, severity, service, and property filters; only orderBy and limit still apply."
                                     },
                                     "serviceNames": {
                                         "description": "Only show logs from these services. Empty shows all services.",
@@ -1042,6 +1053,17 @@
                                             "type": "string"
                                         },
                                         "type": "array"
+                                    },
+                                    "timezone": {
+                                        "default": "UTC",
+                                        "description": "Render log timestamps in UTC or in each viewer's local timezone.",
+                                        "enum": ["UTC", "local"],
+                                        "type": "string"
+                                    },
+                                    "wrapLines": {
+                                        "default": false,
+                                        "description": "Wrap long log lines instead of truncating them to a single row.",
+                                        "type": "boolean"
                                     }
                                 },
                                 "type": "object"


### PR DESCRIPTION
## Problem

After the logs widget changes (#65875) merged into `posthog-code/logs-dashboard-widget`, CI on the parent PR (#64416) went red on two checks:

- **MCP Tests Pass / Unit Tests** — the MCP tool-schema snapshots (`dashboard-update`, `dashboard-widgets-batch-add`) were stale. The OpenAPI codegen regenerated the generated sources (frontend zod/schemas, `services/mcp/src/generated`), but the MCP vitest snapshots are produced by a separate `test -u` step that wasn't run, so they still encoded the old logs config (limit max 25, no `wrapLines`/`timezone`/`savedViewId`).
- **Frontend formatting** — three logs widget components weren't oxfmt-clean (import ordering / wrapping).

## Changes

- Regenerated the two MCP snapshots with `pnpm --filter=@posthog/mcp run test -u` (all 1926 MCP unit tests pass). They now carry the logs config's `maximum: 100` / `default: 50` and the new `wrapLines` / `timezone` / `savedViewId` properties.
- Ran oxfmt on `EditLogsWidgetModal.tsx`, `LogsWidget.tsx`, `LogsWidgetRow.tsx`.

## How did you test this code?

I'm an agent (human-driven by the assignee), re-entering to fix CI on the parent PR. I installed deps and ran the real generators locally:

- `pnpm --filter=@posthog/mcp run test -u` → 2 snapshots updated, 74 files / 1926 tests pass.
- `oxfmt --check` on the logs widget files → clean after the fix.
- `pnpm --filter=@posthog/frontend typescript:check` → no errors in any logs widget file (the only reported errors are pre-existing in `products/workflows/**`, unrelated to this change and caused by kea-typegen not running in this local env).

No source-logic changes — snapshots + formatting only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #65875. The signed-commit tooling protects `posthog-code/logs-dashboard-widget` as a base branch, so these fixes land as a small stacked PR into it (same pattern as #65875); merging re-runs #64416's CI.
