### PR TITLE
chore(flags): update hideMatchOptions JSDoc for v2 targeting UI

### DIFF
--- a/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagReleaseConditionsCollapsible.tsx
@@ -93,7 +93,7 @@ interface FeatureFlagReleaseConditionsCollapsibleProps extends FeatureFlagReleas
     bucketingIdentifier?: FeatureFlagBucketingIdentifier | null
     onBucketingIdentifierChange?: (value: FeatureFlagBucketingIdentifier | null) => void
     evaluationRuntime?: FeatureFlagEvaluationRuntime
-    /** When true, hides the "Match by" User/Group selector. Use when the aggregation type is inherited from the parent flag. */
+    /** When true, hides the Properties/Device top-level selector. Use when the bucketing type is inherited from the parent flag. */
     hideMatchOptions?: boolean
     /** When true, hides the early exit toggle. Use in contexts where early_exit cannot be persisted (e.g. default release conditions). */
     hideEarlyExit?: boolean


### PR DESCRIPTION
## Problem

The `hideMatchOptions` JSDoc comment in `FeatureFlagReleaseConditionsCollapsible.tsx` described the old v1 targeting UI terminology ("Match by" User/Group selector, "aggregation type"). The v2 UI replaced this with a Properties/Device radio group and uses "bucketing type" semantics.

## Changes

Updated the JSDoc comment on `hideMatchOptions` to reflect the v2 UI: Properties/Device top-level selector and "bucketing type" instead of "aggregation type".

## How did you test this code?

Comment-only change; existing tests remain valid.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Companion docs PR: PostHog/posthog.com#(see posthog.com PR)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Part of the docs and copy sweep for issue #57002 (step 3: update docs to reflect v2 feature flag targeting UI). The JSDoc comment was identified as stale during a grep for "Match by"/"aggregation" references in the codebase. Updated to match the v2 terminology visible in `matchByOptions` (lines 957–978) and `onBucketingIdentifierChange`.