### PR TITLE
fix(ci): pass --repo to gh pr diff in docs check

### DIFF
--- a/.github/workflows/ci-docs-check.yml
+++ b/.github/workflows/ci-docs-check.yml
@@ -47,7 +47,9 @@ jobs:
               run: |
                   # Regenerate when the data file OR any additional source (e.g. the generator) changes,
                   # so a generator-only edit can't pass without validating the committed output.
-                  changed_files=$(gh pr diff "$PR_NUMBER" --name-only)
+                  # --repo is required because this step runs before checkout, so gh has no
+                  # local git remote to infer the repo from (otherwise: "not a git repository").
+                  changed_files=$(gh pr diff "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --name-only)
                   if printf '%s\n' "$changed_files" \
                       | grep -qFf <(printf '%s\n' "$SOURCE_FILE" "$ADDITIONAL_SOURCE_FILES" | grep -v '^$'); then
                       echo "changed=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Problem

The `Check Generated Docs` reusable workflow (`.github/workflows/ci-docs-check.yml`) fails on **every** PR that uses it. Its first step, `Check if source file changed`, runs:

```bash
changed_files=$(gh pr diff "$PR_NUMBER" --name-only)
```

`gh pr diff` infers the target repo from the local git remote, but this step now runs **before** the checkout step — #65235 made `Checkout` conditional on this step's output to prune redundant CI overhead. With no `.git` present, `gh` exits 1 with `fatal: not a git repository`, so the docs check fails before it can compare anything.

This surfaced on the survey SDK docs check (which invokes this workflow with `fail_on_outdated: true`), e.g. run [28120251895](https://github.com/PostHog/posthog/actions/runs/28120251895/job/83270063656).

## Changes

Pass `--repo "$GITHUB_REPOSITORY"` to `gh pr diff` so it resolves the PR over the API instead of relying on a local checkout. `GITHUB_REPOSITORY` is a default Actions env var available in every step, so no extra wiring is needed and the pre-checkout optimization from #65235 is preserved.

## How did you test this code?

I'm an agent (Claude Code). I did not run CI manually. The change is a one-line flag addition to a workflow; correctness rests on `gh pr diff --repo <owner/repo>` not requiring a local git repo, which is the documented behavior. Real validation is this PR's own `Check Generated Docs` run going green.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a failing CI job from a run URL: pulled the failed-step log via `gh run view --log-failed`, identified the `fatal: not a git repository` error from `gh pr diff` running pre-checkout, and `git blame`d the line to #65235 (which made checkout conditional). Fix is the minimal `--repo` flag so the command no longer depends on a local checkout. Tools: Claude Code with `gh` and `git`. No repo skills were applicable to a one-line CI fix.
