### PR TITLE
fix(data-warehouse): set duckgres apply-marker applied_at explicitly

### DIFF
--- a/posthog/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/posthog/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -347,8 +347,11 @@ def _mark_duckgres_batch_applied(conn: psycopg.Connection[Any], duckgres_schema:
     cursor = conn.execute(
         sql.SQL(
             """
-            INSERT INTO {}.{} (schema_id, run_uuid, batch_index, batch_id)
-            VALUES (%s, %s, %s, %s)
+            -- applied_at is set explicitly: DuckLake does not apply the column's
+            -- DEFAULT now() on insert (unlike Postgres), so omitting it writes NULL
+            -- and trips the NOT NULL constraint.
+            INSERT INTO {}.{} (schema_id, run_uuid, batch_index, batch_id, applied_at)
+            VALUES (%s, %s, %s, %s, now())
             ON CONFLICT (schema_id, run_uuid, batch_index) DO NOTHING
             """
         ).format(


### PR DESCRIPTION
## Problem

The Duckgres v3 batch sink could not apply a single batch once it reached Duckgres. Every apply failed with:

```
Constraint Error: NOT NULL constraint failed: _posthog_source_batch_duckgres_apply.applied_at
```

The apply-marker table is created with `applied_at TIMESTAMPTZ NOT NULL DEFAULT now()`, but `_mark_duckgres_batch_applied` omitted the column and relied on the default. DuckLake (unlike Postgres) does not apply column `DEFAULT`s on insert, so `applied_at` was written `NULL` and tripped the NOT NULL constraint. This blocks the sink for **all** teams, not one — it was previously masked because an unrelated S3/IRSA permission failure stopped batches before they ever reached this insert.

## Changes

`_mark_duckgres_batch_applied` now sets `applied_at = now()` in the insert instead of relying on the column default. `now()` is already used in this same connection (the marker prune `DELETE ... WHERE applied_at < now() - INTERVAL ...`), so it's the consistent server-side fix. The CREATE keeps its `DEFAULT now()` for Postgres-compat/documentation; DuckLake just ignores it.

Swept the other inserts in `processor.py` (the parquet data load and the MERGE) — both list columns explicitly, so this marker insert was the only one relying on a default.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run: `ruff check` (passed), `ruff format` (no changes), and the pre-commit `ty` type check (passed). I did not add a unit test: the existing `test_processor.py` mocks `_mark_duckgres_batch_applied`/`_ensure_duckgres_apply_table`, so no test exercises real Duckgres SQL — a DuckLake-default-not-applied regression is only catchable with a live Duckgres connection the suite doesn't have, and an SQL-string assertion would test implementation detail without catching the real failure. The fix was validated against the live error: the failing run recorded exactly this constraint violation, and the change writes the column the constraint requires.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while debugging why the `warehouse-sources-duckgres-load` sink wasn't applying batches for a team. The investigation peeled back several independent "new namespace wasn't fully wired" gaps (rollout flag, S3 IRSA role, metrics scrape port) — each fix exposed the next layer. This is the final, code-level layer: once the sink could actually reach Duckgres, the apply-marker insert failed on the missing `applied_at`. Because the failures occurred before any data write (the marker shares the data write's transaction), no partial state results — affected batches just need requeueing via `reset_duckgres_failed_runs` once this lands.

Tooling: Claude Code. No repo skills were required for this one-line SQL fix; I verified the fix against the live `error_response` recorded by the failing run rather than reproducing locally (no local Duckgres).
