### PR TITLE
fix(dev): cover ~/.gitconfig.local in dev sandbox git-config rules

### DIFF
--- a/bin/dev-sandbox.sb
+++ b/bin/dev-sandbox.sb
@@ -71,6 +71,7 @@
     ;; only, by exact path — credentials (~/.git-credentials, keychain) stay blocked.
     (literal (string-append (param "HOME") "/.gitconfig"))
     (literal (string-append (param "HOME") "/.config/git/config"))
+    (literal (string-append (param "HOME") "/.gitconfig.local"))   ; common [include] target of ~/.gitconfig
     ;; cargo registry/git cache — the cyclotron-node native module is built with
     ;; cargo during the nodejs service prestart. (crates.io token re-denied below.)
     (subpath (string-append (param "HOME") "/.cargo")))
@@ -111,5 +112,6 @@
     (subpath (string-append (param "PROJECT") "/.git/hooks"))     ; git hooks run unsandboxed
     (subpath (string-append (param "MAINREPO") "/.git/hooks"))    ; worktree main-repo hooks
     (literal (string-append (param "HOME") "/.gitconfig"))        ; core.hooksPath / credential.helper = !cmd
+    (literal (string-append (param "HOME") "/.gitconfig.local"))  ; included by ~/.gitconfig — same escape if writable
     (subpath (string-append (param "HOME") "/.config/git"))       ; XDG git config — same hooksPath/helper escape
     (subpath (string-append (param "HOME") "/.cargo/bin")))       ; binaries on PATH


### PR DESCRIPTION
## Problem

The dev sandbox allows reads of `~/.gitconfig` and `~/.config/git/config` (so git-aware tooling works) and denies writes to them (so a dependency can't plant a `core.hooksPath` / `credential.helper = !cmd` that runs the next time git executes outside the sandbox). But `~/.gitconfig.local` — the common `[include] path = ~/.gitconfig.local` target — was in **neither** list:

- Not read-allowed → git resolving the include inside the sandbox can't read it, so those settings drop (or git errors), breaking tooling for anyone using the split-config convention.
- Not write-denied → it's writable inside the sandbox today, so for anyone whose `~/.gitconfig` includes it, a dependency can write the same `core.hooksPath` / credential-helper escape there and bypass the deny on `~/.gitconfig` itself.

## Changes

Add `~/.gitconfig.local` to both lists in `bin/dev-sandbox.sb`, mirroring exactly how `~/.gitconfig` is handled:
- read-allow (config only, by exact `literal` path — `~/.git-credentials` / keychain stay denied)
- write-deny (it's an `[include]` target, so it carries the same escape if writable)

## How did you test this code?

I'm an agent (Claude Code), human-driven, on macOS:
- Profile compiles (`sandbox-exec -f bin/dev-sandbox.sb …`).
- `bin/dev-sandbox-selftest` passes — credential reads still blocked, persistence/escape writes still blocked, toolchain reads intact.
- Confirmed both new rules appear in the rendered active profile (read-allow + write-deny).

(No `~/.gitconfig.local` on the test machine to exercise the read directly; it's the same `literal`-allow form as `~/.gitconfig`, which the selftest covers.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the dev-sandbox work (#64392). The escape rationale is already documented inline in the profile for `~/.gitconfig`; this just extends the same read-allow + write-deny pairing to the standard `.local` include target so the split-config convention works without re-opening that vector. Deliberately no selftest assertion: the rule targets a `literal` path, so a probe filename wouldn't exercise it and writing the real path risks clobbering a dev's file — consistent with how `~/.gitconfig`'s write-deny is left untested.
