### PR TITLE
perf(signals): resolve inbox list sort via set-based joins

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/signals/backend/migrations/0050_signalreportartefact_team_type_index.py
+++ b/products/signals/backend/migrations/0050_signalreportartefact_team_type_index.py
@@ -1,0 +1,37 @@
+# Resolving the latest status artefact per report across a whole team in one pass —
+# `WHERE team=? AND type=? ORDER BY report, created_at DESC` (DISTINCT ON). Backs the set-based
+# join the inbox report-list sort uses instead of a per-row correlated subquery. atomic=False +
+# SeparateDatabaseAndState because CONCURRENTLY cannot run in a transaction and bin/migrate
+# re-runs a failed migration in full — non-idempotent ops must not share it.
+
+from django.db import migrations, models
+
+from posthog.migration_helpers import CreateIndexConcurrently
+
+
+class Migration(migrations.Migration):
+    atomic = False  # Required for CONCURRENTLY
+
+    dependencies = [
+        ("signals", "0049_turn_on_scout_source_by_default"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AddIndex(
+                    model_name="signalreportartefact",
+                    index=models.Index(
+                        fields=["team", "type", "report", "-created_at"], name="signals_sig_team_type_rpt_idx"
+                    ),
+                ),
+            ],
+            database_operations=[
+                CreateIndexConcurrently(
+                    index_name="signals_sig_team_type_rpt_idx",
+                    table_name="signals_signalreportartefact",
+                    columns="(team_id, type, report_id, created_at DESC)",
+                ),
+            ],
+        ),
+    ]

--- a/products/signals/backend/migrations/max_migration.txt
+++ b/products/signals/backend/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0049_turn_on_scout_source_by_default
+0050_signalreportartefact_team_type_index

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -745,6 +745,10 @@ class SignalReportArtefact(UUIDModel):
             # Latest-wins lookups: artefacts are append-only, so deriving the current status / log
             # tail is `WHERE report=? AND type=? ORDER BY created_at DESC` — this makes it a seek.
             models.Index(fields=["report", "type", "-created_at"], name="signals_sig_rpt_type_ct_idx"),
+            # Resolving the latest status artefact per report across a whole team in one pass —
+            # `WHERE team=? AND type=? ORDER BY report, created_at DESC` (DISTINCT ON). Backs the
+            # set-based join the inbox list sort uses instead of a per-row correlated subquery.
+            models.Index(fields=["team", "type", "report", "-created_at"], name="signals_sig_team_type_rpt_idx"),
         ]
 
     @classmethod

--- a/products/signals/backend/report_list_query.py
+++ b/products/signals/backend/report_list_query.py
@@ -1,0 +1,190 @@
+"""Ordered, paginated resolution of the inbox report list.
+
+The inbox list sorts on derived, latest-wins status artefacts — current priority
+(`priority_judgment`) and the ready/not-actionable split (`actionability_judgment`).
+Expressing those as correlated subqueries (one per ordering field, per row) makes the
+sort touch the artefact table once for *every* report in the team's set — a full-set
+scan of random index seeks that is fine on a warm cache but turns into multi-second
+cold-cache I/O on large teams (the inbox's 20s loads).
+
+This module resolves each latest-wins value *once* via a `DISTINCT ON` join, then sorts
+the joined result — a couple of bounded index scans plus a hash join instead of N seeks.
+Ordering semantics are identical to the old correlated form; only the plan shape changes.
+
+The supporting index is `signals_signalreportartefact (team_id, type, report_id,
+created_at DESC)`.
+"""
+
+from __future__ import annotations
+
+from django.db import connection
+
+from products.signals.backend.models import SignalReport
+
+# status -> semantic pipeline rank (lower sorts earlier in the inbox). `ready` splits into
+# rank 0 (actionable, or not yet judged) and rank 1 (not actionable) via the latest
+# actionability judgment. Single source of truth for both the ORM annotation
+# (`_annotate_signal_report_status_rank`, used by non-list actions) and the SQL below.
+STATUS_RANK: dict[str, int] = {
+    SignalReport.Status.READY: 0,
+    SignalReport.Status.PENDING_INPUT: 2,
+    SignalReport.Status.IN_PROGRESS: 3,
+    SignalReport.Status.CANDIDATE: 4,
+    SignalReport.Status.POTENTIAL: 5,
+    SignalReport.Status.FAILED: 6,
+    SignalReport.Status.RESOLVED: 7,
+    SignalReport.Status.SUPPRESSED: 8,
+    SignalReport.Status.DELETED: 9,
+}
+READY_NOT_ACTIONABLE_RANK = 1
+STATUS_RANK_DEFAULT = 50
+PRIORITY_FALLBACK = "~"  # sorts after P0–P4 for reports without a priority judgment
+
+
+def _status_rank_sql() -> str:
+    # Built from STATUS_RANK so it can't drift from the ORM annotation. `status` values are
+    # enum constants, never user input, so this CASE is safe to interpolate.
+    whens = [
+        f"WHEN r.status='{SignalReport.Status.READY}' AND la.actionability='not_actionable' "
+        f"THEN {READY_NOT_ACTIONABLE_RANK}"
+    ]
+    whens += [f"WHEN r.status='{status}' THEN {rank}" for status, rank in STATUS_RANK.items()]
+    return "CASE " + " ".join(whens) + f" ELSE {STATUS_RANK_DEFAULT} END"
+
+
+def _priority_sql() -> str:
+    return f"COALESCE(lp.priority, '{PRIORITY_FALLBACK}')"
+
+
+def _is_suggested_reviewer_sql(has_github_login: bool) -> str:
+    # Mirrors `_annotate_is_suggested_reviewer`: never true for ready+not-actionable or failed
+    # reports; otherwise true when the current user is in the latest suggested_reviewers artefact.
+    # The containment value is bound as a parameter (one `%s`) when `has_github_login`.
+    if not has_github_login:
+        return "false"
+    reviewer_exists = (
+        "EXISTS(SELECT 1 FROM signals_signalreportartefact v0 "
+        "WHERE v0.report_id=r.id AND v0.type='suggested_reviewers' "
+        "AND NOT EXISTS(SELECT 1 FROM signals_signalreportartefact u0 "
+        "WHERE u0.report_id=v0.report_id AND u0.type='suggested_reviewers' AND u0.created_at>v0.created_at) "
+        "AND v0.content::jsonb @> %s::jsonb)"
+    )
+    return (
+        f"CASE WHEN r.status='{SignalReport.Status.READY}' AND la.actionability='not_actionable' THEN false "
+        f"WHEN r.status='{SignalReport.Status.FAILED}' THEN false ELSE {reviewer_exists} END"
+    )
+
+
+# Ordering field -> (sort expression, whether it consumes the github_login param). A None
+# expression is a no-op sort key to drop entirely — used when is_suggested_reviewer can't be
+# resolved (no github login), where every row is False and the key would be a bare SQL constant
+# (which Postgres rejects in ORDER BY) that contributes nothing to the order anyway.
+def _order_expr(field: str, has_github_login: bool) -> tuple[str | None, bool]:
+    if field == "status":
+        return _status_rank_sql(), False
+    if field == "priority":
+        return _priority_sql(), False
+    if field == "is_suggested_reviewer":
+        if not has_github_login:
+            return None, False
+        return _is_suggested_reviewer_sql(True), True
+    # Remaining fields are plain report columns, validated against the allowlist upstream.
+    return f"r.{field}", False
+
+
+# DISTINCT ON join that resolves the latest value of one jsonb key from a latest-wins status
+# artefact type. team_id + type are bound parameters; `key` and `type` are fixed constants.
+def _latest_value_cte(alias: str, artefact_type: str, json_key: str, out_col: str) -> str:
+    return (
+        f"{alias} AS (SELECT DISTINCT ON (report_id) report_id, "
+        f"jsonb_extract_path_text(content::jsonb, '{json_key}') AS {out_col} "
+        f"FROM signals_signalreportartefact "
+        f"WHERE team_id=%s AND type='{artefact_type}' AND content LIKE '{{%%' "
+        f"ORDER BY report_id, created_at DESC)"
+    )
+
+
+def resolve_ordered_report_page(
+    *,
+    team_id: int,
+    base_ids_sql: str,
+    base_ids_params: list,
+    order_fields: list[tuple[str, bool]],  # (field, descending)
+    github_login: str | None,
+    actionability_filter: list[str] | None,
+    priority_filter: list[str] | None,
+    reviewer_containment_param: str | None,
+    limit: int,
+    offset: int,
+) -> tuple[list[str], int]:
+    """Return (ordered page of report ids, total count) for the filtered set.
+
+    `base_ids_sql` / `base_ids_params` is a queryset selecting `id` with every filter that does
+    not depend on the latest-wins artefacts already applied. The actionability / priority filters
+    are applied here against the joined values so they share the single resolution.
+    """
+    has_login = github_login is not None
+
+    ctes = [
+        f"base AS ({base_ids_sql})",
+        _latest_value_cte("latest_prio", "priority_judgment", "priority", "priority"),
+        _latest_value_cte("latest_act", "actionability_judgment", "actionability", "actionability"),
+    ]
+    from_join = (
+        "FROM signals_signalreport r "
+        "JOIN base ON base.id = r.id "
+        "LEFT JOIN latest_prio lp ON lp.report_id = r.id "
+        "LEFT JOIN latest_act la ON la.report_id = r.id"
+    )
+
+    where_parts: list[str] = []
+    where_params: list = []
+    if actionability_filter:
+        where_parts.append("la.actionability = ANY(%s)")
+        where_params.append(actionability_filter)
+    if priority_filter:
+        where_parts.append(f"{_priority_sql()} = ANY(%s)")
+        where_params.append(priority_filter)
+    where_sql = (" WHERE " + " AND ".join(where_parts)) if where_parts else ""
+
+    order_terms: list[str] = []
+    order_params: list = []
+    for field, descending in order_fields:
+        expr, uses_login = _order_expr(field, has_login)
+        if expr is None:
+            continue
+        order_terms.append(f"({expr}) {'DESC' if descending else 'ASC'}")
+        if uses_login and reviewer_containment_param is not None:
+            order_params.append(reviewer_containment_param)
+    order_sql = ", ".join(order_terms)
+
+    # Parameter order must match textual placeholder order: base CTE, the two latest-value
+    # CTEs (team_id each), WHERE (derived filters), ORDER BY (reviewer containment), LIMIT/OFFSET.
+    cte_sql = "WITH " + ", ".join(ctes)
+
+    page_sql = f"{cte_sql} SELECT r.id::text {from_join}{where_sql} ORDER BY {order_sql} LIMIT %s OFFSET %s"
+    page_params = [
+        *base_ids_params,
+        team_id,
+        team_id,
+        *where_params,
+        *order_params,
+        limit,
+        offset,
+    ]
+
+    with connection.cursor() as cursor:
+        cursor.execute(page_sql, page_params)
+        ids = [row[0] for row in cursor.fetchall()]
+
+        if where_parts:
+            # Derived filters need the joins to count; reuse the same CTEs without order/paging.
+            count_sql = f"{cte_sql} SELECT COUNT(*) {from_join}{where_sql}"
+            count_params = [*base_ids_params, team_id, team_id, *where_params]
+            cursor.execute(count_sql, count_params)
+        else:
+            # No derived filter -> count the filtered base directly (indexable, no artefact joins).
+            cursor.execute(f"SELECT COUNT(*) FROM ({base_ids_sql}) base", base_ids_params)
+        total = cursor.fetchone()[0]
+
+    return ids, total

--- a/products/signals/backend/views.py
+++ b/products/signals/backend/views.py
@@ -79,6 +79,12 @@ from products.signals.backend.report_generation.resolve_reviewers import (
     normalized_github_logins_from_suggested_reviewer_artefacts,
     resolve_org_github_login_to_users,
 )
+from products.signals.backend.report_list_query import (
+    READY_NOT_ACTIONABLE_RANK,
+    STATUS_RANK,
+    STATUS_RANK_DEFAULT,
+    resolve_ordered_report_page,
+)
 from products.signals.backend.serializers import (
     CommitDiffResponseSerializer,
     SignalReportArtefactLogCreateSerializer,
@@ -741,17 +747,16 @@ class SignalReportViewSet(
             raise serializers.ValidationError({"task_id": f"Invalid task UUID: {e}"})
         return queryset.filter(SignalReport.reports_for_task_filter(task_uuid))
 
-    def _apply_signal_report_priority_filter(self, queryset):
-        # Filters on the `priority_rank` annotation, which must be applied first.
-        # Reports without a priority artefact (coalesced to "~") are excluded when this filter is set.
+    def _parse_priority_filter_values(self) -> list[str] | None:
+        # `priority` query param -> validated P0–P4 list, or None when absent/empty. An
+        # unrecognized value is a 400. Reports without a priority artefact are excluded
+        # when this filter is set (the list query coalesces missing priorities to "~").
         priority_filter = self.request.query_params.get("priority")
         if not priority_filter:
-            return queryset
-
+            return None
         values = [p.strip().upper() for p in priority_filter.split(",") if p.strip()]
         if not values:
-            return queryset
-
+            return None
         allowed = set(AutonomyPriority.values)
         invalid = [v for v in values if v not in allowed]
         if invalid:
@@ -760,25 +765,26 @@ class SignalReportViewSet(
                     "priority": f"Invalid priority value(s): {', '.join(sorted(set(invalid)))}. Allowed: {', '.join(sorted(allowed))}."
                 }
             )
+        return values
 
+    def _apply_signal_report_priority_filter(self, queryset):
+        # Filters on the `priority_rank` annotation, which must be applied first.
+        values = self._parse_priority_filter_values()
+        if values is None:
+            return queryset
         return queryset.filter(priority_rank__in=values)
 
-    def _apply_signal_report_actionability_filter(self, queryset):
-        # Filters on the `latest_actionability_value` annotation (the actionability
-        # choice from the latest actionability_judgment artefact), which must be
-        # annotated first. Powers the inbox's actionability-keyed tabs: the Reports
-        # tab passes the two actionable values, the staff-only Not-actionable tab
-        # passes `not_actionable`. Reports without an actionability judgment
-        # (annotation is NULL) are excluded when this filter is set. Absent or empty
-        # param leaves the list unchanged; an unrecognized value is a 400.
+    def _parse_actionability_filter_values(self) -> list[str] | None:
+        # `actionability` query param -> validated list, or None when absent/empty. Powers the
+        # inbox's actionability-keyed tabs: the Reports tab passes the two actionable values, the
+        # staff-only Not-actionable tab passes `not_actionable`. Reports without an actionability
+        # judgment are excluded when this filter is set; an unrecognized value is a 400.
         actionability_filter = self.request.query_params.get("actionability")
         if not actionability_filter:
-            return queryset
-
+            return None
         values = [a.strip() for a in actionability_filter.split(",") if a.strip()]
         if not values:
-            return queryset
-
+            return None
         allowed = {choice.value for choice in ActionabilityChoice}
         invalid = [v for v in values if v not in allowed]
         if invalid:
@@ -788,28 +794,24 @@ class SignalReportViewSet(
                     f"Allowed: {', '.join(sorted(allowed))}."
                 }
             )
+        return values
 
+    def _apply_signal_report_actionability_filter(self, queryset):
+        # Filters on the `latest_actionability_value` annotation, which must be annotated first.
+        values = self._parse_actionability_filter_values()
+        if values is None:
+            return queryset
         return queryset.filter(latest_actionability_value__in=values)
 
     def _annotate_signal_report_status_rank(self, queryset):
         # `ordering=status` uses semantic stage rank (annotation), not lexicographic `status` column order.
         # `status=ready` splits into two virtual stages (requires `latest_actionability_value`):
         # 0 = ready + actionable (or no judgment yet), 1 = ready + not_actionable; then other stages.
+        # Rank mapping is shared with the list query's SQL via STATUS_RANK so the two can't drift.
+        whens = [When(self._Q_READY_NOT_ACTIONABLE, then=Value(READY_NOT_ACTIONABLE_RANK))]
+        whens += [When(status=status_value, then=Value(rank)) for status_value, rank in STATUS_RANK.items()]
         return queryset.annotate(
-            pipeline_status_rank=Case(
-                When(self._Q_READY_NOT_ACTIONABLE, then=Value(1)),
-                When(status=SignalReport.Status.READY, then=Value(0)),
-                When(status=SignalReport.Status.PENDING_INPUT, then=Value(2)),
-                When(status=SignalReport.Status.IN_PROGRESS, then=Value(3)),
-                When(status=SignalReport.Status.CANDIDATE, then=Value(4)),
-                When(status=SignalReport.Status.POTENTIAL, then=Value(5)),
-                When(status=SignalReport.Status.FAILED, then=Value(6)),
-                When(status=SignalReport.Status.RESOLVED, then=Value(7)),
-                When(status=SignalReport.Status.SUPPRESSED, then=Value(8)),
-                When(status=SignalReport.Status.DELETED, then=Value(9)),
-                default=Value(50),
-                output_field=IntegerField(),
-            )
+            pipeline_status_rank=Case(*whens, default=Value(STATUS_RANK_DEFAULT), output_field=IntegerField())
         )
 
     def _annotate_signal_report_priority(self, queryset):
@@ -957,6 +959,58 @@ class SignalReportViewSet(
             clauses = [*clauses, "id"]
         return queryset.order_by(*clauses)
 
+    def _list_ordering_fields(self) -> list[tuple[str, bool]]:
+        # (public field name, descending) pairs for the list query, validated against the
+        # allowlist, with `id` appended as a stable tiebreak. Field names — not db columns —
+        # because the list query maps each to its own SQL sort expression.
+        raw = self.request.query_params.get("ordering", self._DEFAULT_SIGNAL_REPORT_ORDERING)
+        raw = str(raw).strip() or self._DEFAULT_SIGNAL_REPORT_ORDERING
+        fields: list[tuple[str, bool]] = []
+        for part in (p.strip() for p in raw.split(",")):
+            if not part:
+                continue
+            descending = part.startswith("-")
+            name = part[1:] if descending else part
+            if name in self._SIGNAL_REPORT_ORDERING_FIELDS:
+                fields.append((name, descending))
+        if not fields:
+            fields = [
+                (c[1:] if c.startswith("-") else c, c.startswith("-"))
+                for c in self._DEFAULT_SIGNAL_REPORT_ORDERING.split(",")
+            ]
+        if not any(name == "id" for name, _ in fields):
+            fields.append(("id", False))
+        return fields
+
+    def _base_filtered_report_ids_queryset(self):
+        # Every list filter that does NOT depend on a latest-wins status artefact. The
+        # actionability / priority filters and the sort are resolved against the joined
+        # latest values in `resolve_ordered_report_page`, so the base stays index-friendly.
+        qs = SignalReport.objects.filter(team=self.team)
+        qs = self._exclude_deleted_signal_reports(qs)
+        qs = self._apply_signal_report_status_filter(qs)
+        qs = self._apply_signal_report_search_filter(qs)
+        qs = self._apply_signal_report_source_product_filter(qs)
+        qs = self._apply_signal_report_implementation_pr_filter(qs)
+        qs = self._apply_signal_report_suggested_reviewer_filter(qs)
+        qs = self._apply_signal_report_task_filter(qs)
+        return qs.values("id")
+
+    def _hydrate_reports(self, ids: list[str]) -> list[SignalReport]:
+        # Load the page's reports with only the display annotations + prefetches, in the
+        # order the resolver returned. is_suggested_reviewer + artefact_count run on <=50
+        # rows here (cheap), not across the whole set.
+        if not ids:
+            return []
+        qs = SignalReport.objects.filter(team=self.team, id__in=ids)
+        qs = self._scope_signal_report_queryset(qs)
+        qs = self._prefetch_signal_report_priority_artefacts(qs)
+        # is_suggested_reviewer's ready/not-actionable guard reads latest_actionability_value.
+        qs = self._annotate_latest_actionability_value(qs)
+        qs = self._annotate_is_suggested_reviewer(qs)
+        by_id = {str(report.id): report for report in qs}
+        return [by_id[report_id] for report_id in ids if report_id in by_id]
+
     @staticmethod
     def _get_github_login(user) -> str | None:
         login = user.get_github_login()
@@ -1076,13 +1130,35 @@ class SignalReportViewSet(
     )
     @tracer.start_as_current_span("signals.reports.list")
     def list(self, request, *args, **kwargs):
-        # The reports list is the primary inbox-load endpoint. Each phase gets its own child span
-        # so a slow load can be attributed to Postgres (queryset annotations), ClickHouse (source
-        # products), the task facade (PR urls), or serialization, rather than one opaque request.
+        # The reports list is the primary inbox-load endpoint. Its sort keys (priority, the
+        # ready/not-actionable split) live in latest-wins status artefacts; resolving them once
+        # via set-based joins instead of a correlated subquery per row keeps the sort off a
+        # full-set artefact scan — the cause of multi-second cold-cache loads on large teams.
+        # Each phase gets its own child span so a slow load can be attributed to a specific stage.
+        paginator = self.paginator
+        if paginator is None:
+            return super().list(request, *args, **kwargs)
+
+        limit = paginator.get_limit(request)
+        offset = paginator.get_offset(request)
+
         with tracer.start_as_current_span("signals.reports.list.queryset"):
-            queryset = self.filter_queryset(self.get_queryset())
-            page = self.paginate_queryset(queryset)
-            reports = list(page if page is not None else queryset)
+            base_ids_sql, base_ids_params = self._base_filtered_report_ids_queryset().query.sql_with_params()
+            github_login = self._get_github_login(request.user)
+            reviewer_containment = json.dumps([{"github_login": github_login}]) if github_login else None
+            ids, total_count = resolve_ordered_report_page(
+                team_id=self.team.id,
+                base_ids_sql=base_ids_sql,
+                base_ids_params=list(base_ids_params),
+                order_fields=self._list_ordering_fields(),
+                github_login=github_login,
+                actionability_filter=self._parse_actionability_filter_values(),
+                priority_filter=self._parse_priority_filter_values(),
+                reviewer_containment_param=reviewer_containment,
+                limit=limit,
+                offset=offset,
+            )
+            reports = self._hydrate_reports(ids)
 
         report_ids = [str(r.id) for r in reports]
         trace.get_current_span().set_attribute("signals.reports.list.count", len(report_ids))
@@ -1103,9 +1179,13 @@ class SignalReportViewSet(
         with tracer.start_as_current_span("signals.reports.list.serialize"):
             data = serializer.data
 
-        if page is not None:
-            return self.get_paginated_response(data)
-        return Response(data)
+        # Drive the LimitOffsetPagination envelope (count / next / previous) from the resolved
+        # page instead of paginate_queryset, which would re-run an unconditional COUNT(*).
+        paginator.count = total_count
+        paginator.limit = limit
+        paginator.offset = offset
+        paginator.request = request
+        return paginator.get_paginated_response(data)
 
     @extend_schema(exclude=True)
     @action(detail=False, methods=["get"], url_path="available_reviewers", required_scopes=["task:read"])


### PR DESCRIPTION
## Problem

The inbox report list is slow to load — multi-second, up to ~20s, on teams with a large report/artefact history.

The list sorts on values derived from latest-wins **status artefacts** — the current priority (`priority_judgment`) and the ready/not-actionable split (`actionability_judgment`). The ORM expressed each sort key as a correlated subquery, so to sort, Postgres recomputed those for **every report in the team's set** — one random index seek into the artefact table per report. Warm that's cheap; cold on a large team it's hundreds of MB of random I/O on every load. The cost scales with the team's whole artefact history, not the 50-row page.

This is not JIT (a ~190ms red herring) and not a missing index on the report table — the sort key lives in an append-only artefact table and was being re-derived per row.

## Changes

Resolve each latest-wins value **once** via a `DISTINCT ON` join, then sort the joined result — a couple of bounded index scans plus a hash join instead of N random seeks. This is the "resolve the page, then hydrate" shape: the ordered page of ids is computed with the joins, and the derived display fields (priority, actionability, reviewer flag) are then computed on the 50 hydrated rows instead of across the whole set.

- `report_list_query.py` — set-based resolver for the ordered, paginated page of ids + count. The status-rank mapping is shared with the ORM annotation so they can't drift.
- `views.py` — `list()` uses the resolver + a 50-row hydration query. All existing filters and validation are reused unchanged; the actionability/priority filters now apply against the joined values so they share the single resolution.
- New `(team_id, type, report_id, created_at DESC)` index on the artefact table so the latest-per-type resolution is an index scan. This is a general "latest status artefact per team" index, not a content-specific one.

**Ordering and filtering semantics are unchanged** — this is a pure plan-shape change.

On a seeded 20k-report / 90k-artefact team, the default inbox load (`priority,status,-updated_at`):

| | shared buffers (root) | warm ms |
|---|---|---|
| Before (correlated subqueries) | 98,174 | 36.8 |
| After (join + index) | 1,129 | 15.5 |

Cold-cache, those ~98k random buffer touches were the multi-second/20s loads; ~1.1k bounded scans is sub-second.

## How did you test this code?

I'm an agent (Claude Opus 4.8). Automated only — no manual UI testing claimed.

- **Equivalence harness:** drove the old ORM ordering and the new resolver over the same seeded data and compared the ordered id lists. **13/13 cases byte-for-byte identical** — every ordering (default, priority, newest, reviewer-first), every filter (status, actionability, priority, search, has_implementation_pr), offset pagination, and combined filters.
- **Existing suites: 259 pass** — `test_signal_report_api` (148), plus telemetry / task-run / artefact-api (111). The list endpoint, its filters, counts, and pagination are well covered there; no new tests were added because the existing ones already pin the behavior this change must preserve.
- Lint clean: ruff, ruff format, semgrep (0 findings across `p/python` + `p/security-audit` + `.semgrep/rules`), no migration drift, migration applied locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints` (viewset change) and `/django-migrations` (the concurrent index migration mirrors the existing `0048` pattern — `SeparateDatabaseAndState` + `CreateIndexConcurrently`, `atomic=False`).

Investigation pulled the real query plan on a seeded large team to attribute the cost. Two structural fixes were considered and **rejected** per reviewer guidance: denormalizing current priority/actionability onto the report row (a write-path dual-write against the append-only log) and a narrow content-specific index. The chosen fix avoids both — it's a query rewrite plus one general index, and keeps the append-only log as the single source of truth.