### PR TITLE
fix(dashboards): add logs widget group icon and re-land review fixes

### DIFF
--- a/products/dashboards/backend/api/test/test_run_widgets.py
+++ b/products/dashboards/backend/api/test/test_run_widgets.py
@@ -107,6 +107,9 @@ class TestWidgetRegistry(APIBaseTest):
         [
             ("invalid_order_by", {"orderBy": "not_a_field"}),
             ("invalid_severity_level", {"severityLevels": ["not_a_level"]}),
+            ("invalid_timezone", {"timezone": "America/New_York"}),
+            ("invalid_wrap_lines", {"wrapLines": "yes"}),
+            ("invalid_saved_view_id", {"savedViewId": 123}),
         ]
     )
     def test_validate_logs_list_config_rejects_invalid_values(self, _label: str, config: dict) -> None:
@@ -182,17 +185,6 @@ class TestWidgetRegistry(APIBaseTest):
         assert validated["wrapLines"] is True
         assert validated["timezone"] == "local"
         assert validated["savedViewId"] == "abc123"
-
-    @parameterized.expand(
-        [
-            ("invalid_timezone", {"timezone": "America/New_York"}),
-            ("invalid_wrap_lines", {"wrapLines": "yes"}),
-            ("invalid_saved_view_id", {"savedViewId": 123}),
-        ]
-    )
-    def test_validate_logs_list_config_rejects_invalid_display_values(self, _label: str, config: dict) -> None:
-        with self.assertRaises(Exception):
-            validate_widget_config(LOGS_LIST_WIDGET_TYPE, config)
 
     @parameterized.expand(
         [("activity_events", ACTIVITY_EVENTS_LIST_WIDGET_TYPE, date_from) for date_from in ["-1h", "-3h", "-24h"]]

--- a/products/dashboards/frontend/widget_types/catalog.ts
+++ b/products/dashboards/frontend/widget_types/catalog.ts
@@ -1,6 +1,6 @@
 import type { ComponentType } from 'react'
 
-import { IconFlask, IconLive, IconRewindPlay, IconWarning } from '@posthog/icons'
+import { IconFlask, IconList, IconLive, IconRewindPlay, IconWarning } from '@posthog/icons'
 
 import { urls } from 'scenes/urls'
 
@@ -94,6 +94,7 @@ export const DASHBOARD_WIDGET_GROUP_ICONS = {
     error_tracking: IconWarning,
     session_replay: IconRewindPlay,
     experiments: IconFlask,
+    logs: IconList,
 } as const satisfies Record<keyof typeof DASHBOARD_WIDGET_GROUP_LABELS, ComponentType<{ className?: string }>>
 
 export function getDashboardWidgetGroupIcon(groupId: string): ComponentType<{ className?: string }> | undefined {

--- a/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
+++ b/products/dashboards/frontend/widgets/logs/LogsWidget.tsx
@@ -43,12 +43,14 @@ type LogsDeepLinkParams = {
  *
  * Forwarding the tile's filters + orderBy + a matching `initialLogsLimit` makes the logs page's first
  * page equal the tile's visible rows, so the linked log is loaded and `linkToLogId` can open it. A
- * saved-view tile can't replay the view's filters client-side, so it links by date window + id only. */
+ * saved-view tile can't replay the view's filters (or its date range) client-side, so it links by id
+ * only and lets the logs page use its own range — forwarding the tile's `-1h` default would likely
+ * exclude the clicked log. */
 function buildLogHref(line: LogsWidgetLogLine, params: LogsDeepLinkParams): string {
     return combineUrl(urls.logs(), {
         activeTab: 'viewer',
         linkToLogId: line.uuid,
-        dateRange: { date_from: params.dateFrom ?? null, date_to: null },
+        ...(params.hasSavedView ? {} : { dateRange: { date_from: params.dateFrom ?? null, date_to: null } }),
         ...(params.orderBy ? { orderBy: params.orderBy } : {}),
         ...(params.limit ? { initialLogsLimit: params.limit } : {}),
         ...(!params.hasSavedView && params.severityLevels.length ? { severityLevels: params.severityLevels } : {}),


### PR DESCRIPTION
## Problem

CI on the logs widget feature branch (#64416) was red on **Frontend typechecking**, and two trusted-review fixes were dropped from the codebase by a merge race on #65883.

## Changes

- **Typecheck fix (the CI breaker):** `DASHBOARD_WIDGET_GROUP_ICONS` in `catalog.ts` was missing a `logs` entry, but its `satisfies Record<keyof typeof DASHBOARD_WIDGET_GROUP_LABELS, …>` requires every group. Added `logs: IconList`.
- **Re-land Greptile fix — deep link:** when a saved view is active, omit `dateRange` from the per-row link so the logs page uses its own range (the tile's `-1h` default could exclude the clicked log → "Log not found").
- **Re-land Greptile fix — tests:** collapse the two logs config rejection tests into one parameterized case.

## How did you test this code?

I'm an agent (human-driven), re-entering to fix CI.

- `tsgo` typecheck: `catalog.ts` and the logs widget files are clean (the prior `catalog.ts(97)` error is gone). Remaining local errors are all missing kea-typegen artifacts across unrelated files — resolved by CI's typegen step.
- `logsWidgetConfigValidation.test.ts` and `widgetConfigSchemaParity.test.ts` pass locally; `ruff`/`oxfmt` clean.
- The earlier "Jest test (EE - 1)" red was a 15-minute job timeout (infra), not an assertion failure; "Visual regression" is expected new-snapshot churn from the new widget stories.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to #65875 / #65883. The signed-commit tooling protects the feature branch as a base, so this lands as a small stacked PR into it (same pattern as before). Single commit, so it can't be split by a merge-head race this time.
