### PR TITLE
feat(signals): show scout description on hover in inbox scouts list

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -42,6 +42,9 @@ export function ScoutRowCard({
     const { closeSetupModal } = useActions(agentSetupModalLogic)
     const displayName = prettifyScoutSkillName(config.skill_name)
 
+    // What the scout investigates, from the skill frontmatter — surfaced on hover over the name.
+    const description = config.description?.trim()
+
     return (
         <div
             className={clsx(
@@ -58,7 +61,9 @@ export function ScoutRowCard({
                         {asHeader ? (
                             // min-w keeps the name from being squeezed to zero width by the
                             // trailing badges — truncate should clip to an ellipsis, never vanish.
-                            <span className="truncate font-medium text-sm min-w-[6rem]">{displayName}</span>
+                            <Tooltip title={description}>
+                                <span className="truncate font-medium text-sm min-w-[6rem]">{displayName}</span>
+                            </Tooltip>
                         ) : (
                             <Tooltip
                                 title={


### PR DESCRIPTION
## Problem

On the Inbox scouts list, hovering a scout's name only showed the raw skill name and a "view scout" hint — not what the scout actually investigates. The desktop app (`../code`) already surfaces the scout's description (sourced from the skill's frontmatter) on hover. This brings cloud to parity.

## Changes

The cloud backend already returns this: `SignalScoutConfigSerializer` exposes a `description` field resolved from the scout skill's `description` metadata (the SKILL.md frontmatter, via `LLMSkill.description`). It just wasn't wired through the frontend.

- Added the optional `description` field to the `SignalScoutConfig` frontend type so the already-returned API field is typed.
- The scout name's tooltip in `ScoutRowCard` now shows the description. In the list row it sits above the existing `skill_name · view scout` hint (so the link affordance survives); on the scout detail header (previously no tooltip) the name now shows the description on hover.

Scouts whose skill is absent or carries no description degrade cleanly — Lemon's `Tooltip` renders the child with no tooltip when `title` is falsy, matching the previous behavior.

One deliberate difference from desktop: cloud's name tooltip already carried a "view scout" hint, so rather than replacing it with just the description (as desktop does), both are kept — description on top, hint muted below.

## How did you test this code?

I'm an agent. I ran the frontend `typescript:check`; the two files I touched produce no errors (the remaining errors are the pre-existing kea-typegen cascade present on master). No automated tests were added — this is a presentational tooltip change against a field the backend already serializes, and no existing test asserts tooltip content.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this work, pointing at how `../code`'s `ScoutRowCard` shows the scout description on hover and asking for the same in cloud. Investigation found the backend already serializes the `description` field, so the change was frontend-only: type the field and surface it in the existing name tooltip. No repo skills were invoked — the change didn't touch a DRF endpoint, migration, or API-client surface (the `description` field was already exposed by the serializer).
