### PR TITLE
chore(django): migrate dev seed commands to raw sql

### DIFF
--- a/posthog/management/commands/export_distinct_ids.py
+++ b/posthog/management/commands/export_distinct_ids.py
@@ -1,8 +1,10 @@
 import random
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from posthog.models import Person, PersonDistinctId, Team
+from posthog.models import Team
+from posthog.persons_db import persons_db_connection
 
 
 class Command(BaseCommand):
@@ -64,19 +66,28 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Exporting distinct IDs for team: {team.name}"))
 
-        # Build the query
-        distinct_ids_query = PersonDistinctId.objects.filter(team=team)  # nosemgrep: no-direct-persons-db-orm
-
+        # Build the distinct-id query, joining to the person table only when filtering on
+        # person attributes (identified / demo).
+        conditions = ["pdi.team_id = %s"]
         if identified_only:
-            distinct_ids_query = distinct_ids_query.filter(person__is_identified=True)
+            conditions.append("p.is_identified = true")
             self.stdout.write("Filtering for identified persons only")
-
         if demo_only:
-            distinct_ids_query = distinct_ids_query.filter(person__properties__is_demo=True)
+            conditions.append("p.properties @> '{\"is_demo\": true}'::jsonb")
             self.stdout.write("Filtering for demo persons only")
 
-        # Get distinct IDs
-        distinct_ids = list(distinct_ids_query.values_list("distinct_id", flat=True))
+        person_join = (
+            f"JOIN {settings.PERSON_TABLE_NAME} p ON p.team_id = pdi.team_id AND p.id = pdi.person_id"
+            if (identified_only or demo_only)
+            else ""
+        )
+        query = (
+            f"SELECT pdi.distinct_id FROM posthog_persondistinctid pdi {person_join} "  # nosemgrep: no-direct-persons-db-orm
+            f"WHERE {' AND '.join(conditions)}"
+        )
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(query, [team.id])
+            distinct_ids = [row[0] for row in cursor.fetchall()]
 
         if not distinct_ids:
             self.stdout.write(self.style.WARNING("No distinct IDs found matching the criteria!"))
@@ -126,13 +137,17 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Error writing to file: {e}"))
 
         # Also show some stats
-        total_persons = Person.objects.filter(team=team).count()  # nosemgrep: no-direct-persons-db-orm
-        identified_persons = Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-            team=team, is_identified=True
-        ).count()  # nosemgrep: no-direct-persons-db-orm
-        demo_persons = Person.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-            team=team, properties__is_demo=True
-        ).count()  # nosemgrep: no-direct-persons-db-orm
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(
+                f"SELECT count(*), "  # nosemgrep: no-direct-persons-db-orm
+                "count(*) FILTER (WHERE is_identified), "
+                "count(*) FILTER (WHERE properties @> '{\"is_demo\": true}'::jsonb) "
+                f"FROM {settings.PERSON_TABLE_NAME} WHERE team_id = %s",
+                [team.id],
+            )
+            stats_row = cursor.fetchone()
+        assert stats_row is not None
+        total_persons, identified_persons, demo_persons = stats_row
 
         self.stdout.write(f"\nTeam statistics:")
         self.stdout.write(f"  Total persons: {total_persons}")

--- a/posthog/management/commands/export_distinct_ids.py
+++ b/posthog/management/commands/export_distinct_ids.py
@@ -82,8 +82,7 @@ class Command(BaseCommand):
             else ""
         )
         query = (
-            f"SELECT pdi.distinct_id FROM posthog_persondistinctid pdi {person_join} "  # nosemgrep: no-direct-persons-db-orm
-            f"WHERE {' AND '.join(conditions)}"
+            f"SELECT pdi.distinct_id FROM posthog_persondistinctid pdi {person_join} WHERE {' AND '.join(conditions)}"
         )
         with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
             cursor.execute(query, [team.id])
@@ -139,7 +138,7 @@ class Command(BaseCommand):
         # Also show some stats
         with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
             cursor.execute(
-                f"SELECT count(*), "  # nosemgrep: no-direct-persons-db-orm
+                f"SELECT count(*), "
                 "count(*) FILTER (WHERE is_identified), "
                 "count(*) FILTER (WHERE properties @> '{\"is_demo\": true}'::jsonb) "
                 f"FROM {settings.PERSON_TABLE_NAME} WHERE team_id = %s",

--- a/posthog/management/commands/generate_persons.py
+++ b/posthog/management/commands/generate_persons.py
@@ -852,8 +852,7 @@ class Command(BaseCommand):
         # Attach demo events to a random sample of the team's distinct_ids.
         with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
             cursor.execute(
-                "SELECT distinct_id FROM posthog_persondistinctid "  # nosemgrep: no-direct-persons-db-orm
-                "WHERE team_id = %s ORDER BY random() LIMIT %s",
+                "SELECT distinct_id FROM posthog_persondistinctid WHERE team_id = %s ORDER BY random() LIMIT %s",
                 (team.id, min(person_count, 50)),
             )
             distinct_ids = [row[0] for row in cursor.fetchall()]

--- a/posthog/management/commands/generate_persons.py
+++ b/posthog/management/commands/generate_persons.py
@@ -2,10 +2,11 @@ import random
 from typing import Any
 
 from django.core.management.base import BaseCommand
-from django.db import router, transaction
 
-from posthog.models import Person, PersonDistinctId, Team
+from posthog.models import Team
 from posthog.models.utils import UUIDT
+from posthog.persons_db import persons_db_connection
+from posthog.persons_seed import insert_seed_distinct_id, insert_seed_person
 
 
 class Command(BaseCommand):
@@ -62,28 +63,20 @@ class Command(BaseCommand):
 
         self.stdout.write(self.style.SUCCESS(f"Generating {count} persons for team: {team.name}"))
 
-        # Generate persons
-        # Use the correct database for Person writes (handles persons_db_writer routing in production)
-        db_alias = router.db_for_write(Person) or "default"
+        # Generate persons through a direct persons-DB connection (off the Django ORM).
+        # The connection commits when the block exits, before the ClickHouse sync reads them back.
         persons_created = 0
-        with transaction.atomic(using=db_alias):
+        with persons_db_connection(writer=True) as conn:
             for i in range(count):
                 person_data = self._generate_person_data(i, identified_ratio)
 
-                # Create person in Django only
-                person = Person.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team,
+                person_id = insert_seed_person(
+                    conn,
+                    team_id=team.id,
                     properties=person_data["properties"],
                     is_identified=person_data["is_identified"],
                 )
-
-                # Create distinct ID
-                distinct_id = str(UUIDT())
-                PersonDistinctId.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team,
-                    person=person,
-                    distinct_id=distinct_id,
-                )
+                insert_seed_distinct_id(conn, team_id=team.id, person_id=person_id, distinct_id=str(UUIDT()))
 
                 persons_created += 1
 
@@ -856,14 +849,17 @@ class Command(BaseCommand):
         event_types = ["pageview", "click", "form_submit", "signup", "purchase", "download"]
         pages = ["/", "/pricing", "/features", "/about", "/contact", "/blog", "/docs"]
 
+        # Attach demo events to a random sample of the team's distinct_ids.
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(
+                "SELECT distinct_id FROM posthog_persondistinctid "  # nosemgrep: no-direct-persons-db-orm
+                "WHERE team_id = %s ORDER BY random() LIMIT %s",
+                (team.id, min(person_count, 50)),
+            )
+            distinct_ids = [row[0] for row in cursor.fetchall()]
+
         events_created = 0
-        for _i in range(min(person_count, 50)):  # Limit events to avoid overwhelming
-            person = Person.objects.filter(team=team).order_by("?").first()  # nosemgrep: no-direct-persons-db-orm
-            if not person:
-                continue
-
-            distinct_id = person.distinct_ids[0] if person.distinct_ids else str(UUIDT())
-
+        for distinct_id in distinct_ids:
             # Generate 1-5 events per person
             for _j in range(random.randint(1, 5)):
                 event_type = random.choice(event_types)

--- a/posthog/management/commands/generate_random_product_tours.py
+++ b/posthog/management/commands/generate_random_product_tours.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.utils.text import slugify
@@ -15,7 +16,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX
 from posthog.models import Team, User
 from posthog.models.event.sql import BULK_INSERT_EVENT_SQL
-from posthog.models.person.person import Person, PersonDistinctId
+from posthog.persons_db import persons_db_connection
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.product_tours.backend.models import ProductTour
@@ -143,33 +144,27 @@ class Command(BaseCommand):
         tour.save(update_fields=["internal_targeting_flag"])
 
     def get_real_persons(self, team: Team, limit: int = 50) -> list[PersonData]:
-        """Fetch real persons from the database."""
-        persons_data: list[PersonData] = []
-
-        persons = (
-            Person.objects.filter(team_id=team.id)  # nosemgrep: no-direct-persons-db-orm
-            .prefetch_related("persondistinctid_set")
-            .order_by("-created_at")[:limit]
+        """Fetch the most recent persons (that have a distinct_id) from the persons database."""
+        query = (
+            "SELECT p.uuid, p.properties, p.created_at, pdi.distinct_id "  # nosemgrep: no-direct-persons-db-orm
+            f"FROM (SELECT id, uuid, properties, created_at FROM {settings.PERSON_TABLE_NAME} "
+            "WHERE team_id = %(team_id)s ORDER BY created_at DESC LIMIT %(limit)s) p "
+            "JOIN LATERAL (SELECT distinct_id FROM posthog_persondistinctid "
+            "WHERE team_id = %(team_id)s AND person_id = p.id LIMIT 1) pdi ON true"
         )
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(query, {"team_id": team.id, "limit": limit})
+            rows = cursor.fetchall()
 
-        for person in persons:
-            distinct_ids = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-                person=person, team_id=team.id
-            ).values_list(  # nosemgrep: no-direct-persons-db-orm
-                "distinct_id", flat=True
+        return [
+            PersonData(
+                distinct_id=row[3],
+                person_uuid=str(row[0]),
+                properties=row[1] or {},
+                created_at=row[2],
             )
-
-            if distinct_ids:
-                persons_data.append(
-                    PersonData(
-                        distinct_id=distinct_ids[0],
-                        person_uuid=str(person.uuid),
-                        properties=person.properties or {},
-                        created_at=person.created_at,
-                    )
-                )
-
-        return persons_data
+            for row in rows
+        ]
 
     def add_arguments(self, parser):
         parser.add_argument("count", type=int, help="Number of product tours to generate")

--- a/posthog/management/commands/generate_random_product_tours.py
+++ b/posthog/management/commands/generate_random_product_tours.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
-from django.conf import settings
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 from django.utils.text import slugify
@@ -16,7 +15,7 @@ from posthog.clickhouse.client import sync_execute
 from posthog.constants import PRODUCT_TOUR_TARGETING_FLAG_PREFIX
 from posthog.models import Team, User
 from posthog.models.event.sql import BULK_INSERT_EVENT_SQL
-from posthog.persons_db import persons_db_connection
+from posthog.persons_seed import PersonData, fetch_recent_persons_with_distinct_id
 
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 from products.product_tours.backend.models import ProductTour
@@ -89,16 +88,6 @@ TOUR_TEMPLATES: list[dict[str, Any]] = [
 ]
 
 
-class PersonData:
-    """Holds person data for event generation."""
-
-    def __init__(self, distinct_id: str, person_uuid: str, properties: dict, created_at: Any):
-        self.distinct_id = distinct_id
-        self.person_uuid = person_uuid
-        self.properties = properties
-        self.created_at = created_at
-
-
 class Command(BaseCommand):
     help = "Generate random product tours for development purposes"
 
@@ -142,29 +131,6 @@ class Command(BaseCommand):
 
         tour.internal_targeting_flag = flag
         tour.save(update_fields=["internal_targeting_flag"])
-
-    def get_real_persons(self, team: Team, limit: int = 50) -> list[PersonData]:
-        """Fetch the most recent persons (that have a distinct_id) from the persons database."""
-        query = (
-            "SELECT p.uuid, p.properties, p.created_at, pdi.distinct_id "  # nosemgrep: no-direct-persons-db-orm
-            f"FROM (SELECT id, uuid, properties, created_at FROM {settings.PERSON_TABLE_NAME} "
-            "WHERE team_id = %(team_id)s ORDER BY created_at DESC LIMIT %(limit)s) p "
-            "JOIN LATERAL (SELECT distinct_id FROM posthog_persondistinctid "
-            "WHERE team_id = %(team_id)s AND person_id = p.id LIMIT 1) pdi ON true"
-        )
-        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
-            cursor.execute(query, {"team_id": team.id, "limit": limit})
-            rows = cursor.fetchall()
-
-        return [
-            PersonData(
-                distinct_id=row[3],
-                person_uuid=str(row[0]),
-                properties=row[1] or {},
-                created_at=row[2],
-            )
-            for row in rows
-        ]
 
     def add_arguments(self, parser):
         parser.add_argument("count", type=int, help="Number of product tours to generate")
@@ -486,7 +452,7 @@ class Command(BaseCommand):
         # Fetch real persons if events are requested
         persons_data: list[PersonData] = []
         if num_events > 0:
-            persons_data = self.get_real_persons(team, limit=100)
+            persons_data = fetch_recent_persons_with_distinct_id(team.id, limit=100)
             if persons_data:
                 self.stdout.write(
                     self.style.SUCCESS(f"Found {len(persons_data)} persons in the database to use for events")

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -5,14 +5,13 @@ from datetime import timedelta
 from typing import Any, Literal, TypedDict
 from zoneinfo import ZoneInfo
 
-from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from posthog.clickhouse.client import sync_execute
 from posthog.models import Team, User
 from posthog.models.event.sql import BULK_INSERT_EVENT_SQL
-from posthog.persons_db import persons_db_connection
+from posthog.persons_seed import PersonData, fetch_recent_persons_with_distinct_id
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 from products.surveys.backend.models import Survey
@@ -245,16 +244,6 @@ LLM_NEGATIVE_FEEDBACK = [
 ]
 
 
-class PersonData:
-    """Holds person data for event generation."""
-
-    def __init__(self, distinct_id: str, person_uuid: str, properties: dict, created_at: Any):
-        self.distinct_id = distinct_id
-        self.person_uuid = person_uuid
-        self.properties = properties
-        self.created_at = created_at
-
-
 class Command(BaseCommand):
     help = "Generate random surveys for development purposes"
 
@@ -271,31 +260,6 @@ class Command(BaseCommand):
         """
         result = sync_execute(query, {"team_id": team.id, "limit": limit})
         return [row[0] for row in result if row[0]]
-
-    def get_real_persons(self, team: Team, limit: int = 50) -> list[PersonData]:
-        """Fetch the most recent persons (that have a distinct_id) from the persons database."""
-        query = (
-            "SELECT p.uuid, p.properties, p.created_at, pdi.distinct_id "  # nosemgrep: no-direct-persons-db-orm
-            f"FROM (SELECT id, uuid, properties, created_at FROM {settings.PERSON_TABLE_NAME} "
-            "WHERE team_id = %(team_id)s ORDER BY created_at DESC LIMIT %(limit)s) p "
-            "JOIN LATERAL (SELECT distinct_id FROM posthog_persondistinctid "
-            "WHERE team_id = %(team_id)s AND person_id = p.id LIMIT 1) pdi ON true"
-        )
-        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
-            cursor.execute(query, {"team_id": team.id, "limit": limit})
-            rows = cursor.fetchall()
-
-        persons_data = [
-            PersonData(
-                distinct_id=row[3],
-                person_uuid=str(row[0]),
-                properties=row[1] or {},
-                created_at=row[2],
-            )
-            for row in rows
-        ]
-
-        return persons_data
 
     def add_arguments(self, parser):
         parser.add_argument(
@@ -1141,7 +1105,7 @@ class Command(BaseCommand):
         # Fetch real persons from the database if responses are requested
         persons_data: list[PersonData] = []
         if num_responses > 0:
-            persons_data = self.get_real_persons(team, limit=100)
+            persons_data = fetch_recent_persons_with_distinct_id(team.id, limit=100)
             if persons_data:
                 self.stdout.write(
                     self.style.SUCCESS(f"Found {len(persons_data)} persons in the database to use for responses")

--- a/posthog/management/commands/generate_random_surveys.py
+++ b/posthog/management/commands/generate_random_surveys.py
@@ -5,13 +5,14 @@ from datetime import timedelta
 from typing import Any, Literal, TypedDict
 from zoneinfo import ZoneInfo
 
+from django.conf import settings
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
 from posthog.clickhouse.client import sync_execute
 from posthog.models import Team, User
 from posthog.models.event.sql import BULK_INSERT_EVENT_SQL
-from posthog.models.person.person import Person, PersonDistinctId
+from posthog.persons_db import persons_db_connection
 from posthog.settings.data_stores import CLICKHOUSE_CLUSTER
 
 from products.surveys.backend.models import Survey
@@ -272,33 +273,27 @@ class Command(BaseCommand):
         return [row[0] for row in result if row[0]]
 
     def get_real_persons(self, team: Team, limit: int = 50) -> list[PersonData]:
-        """Fetch real persons from the database that were created by demo data generation."""
-        persons_data: list[PersonData] = []
-
-        # Query persons with their distinct IDs
-        persons = (
-            Person.objects.filter(team_id=team.id)  # nosemgrep: no-direct-persons-db-orm
-            .prefetch_related("persondistinctid_set")
-            .order_by("-created_at")[:limit]
+        """Fetch the most recent persons (that have a distinct_id) from the persons database."""
+        query = (
+            "SELECT p.uuid, p.properties, p.created_at, pdi.distinct_id "  # nosemgrep: no-direct-persons-db-orm
+            f"FROM (SELECT id, uuid, properties, created_at FROM {settings.PERSON_TABLE_NAME} "
+            "WHERE team_id = %(team_id)s ORDER BY created_at DESC LIMIT %(limit)s) p "
+            "JOIN LATERAL (SELECT distinct_id FROM posthog_persondistinctid "
+            "WHERE team_id = %(team_id)s AND person_id = p.id LIMIT 1) pdi ON true"
         )
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(query, {"team_id": team.id, "limit": limit})
+            rows = cursor.fetchall()
 
-        for person in persons:
-            distinct_ids = PersonDistinctId.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-                person=person, team_id=team.id
-            ).values_list(  # nosemgrep: no-direct-persons-db-orm
-                "distinct_id", flat=True
+        persons_data = [
+            PersonData(
+                distinct_id=row[3],
+                person_uuid=str(row[0]),
+                properties=row[1] or {},
+                created_at=row[2],
             )
-
-            if distinct_ids:
-                # Use the first distinct_id for the person
-                persons_data.append(
-                    PersonData(
-                        distinct_id=distinct_ids[0],
-                        person_uuid=str(person.uuid),
-                        properties=person.properties or {},
-                        created_at=person.created_at,
-                    )
-                )
+            for row in rows
+        ]
 
         return persons_data
 

--- a/posthog/persons_seed.py
+++ b/posthog/persons_seed.py
@@ -1,20 +1,21 @@
-"""Direct person/distinct-id writes for local dev and seed management commands.
+"""Direct persons-database reads and writes for local dev and seed management commands.
 
-These helpers insert and update persons straight in the persons database via a raw
-psycopg connection (see :mod:`posthog.persons_db`), bypassing the Django ORM so the
-persons database can be dropped from Django's ``DATABASES``. They exist only for
-development and seed tooling that needs to fabricate persons locally — production
-person creation flows through ingestion and the personhog service, which has no
-create RPC by design.
+These helpers read, insert, and update persons/groups straight in the persons database via
+a raw psycopg connection (see :mod:`posthog.persons_db`), bypassing the Django ORM so the
+persons database can be dropped from Django's ``DATABASES``. They exist only for development
+and seed tooling that needs to fabricate or read persons locally — production person
+creation flows through ingestion and the personhog service, which has no create RPC by
+design.
 
-``created_at`` and ``uuid`` are ``NOT NULL`` with no database default (the ORM fills
-them application-side), so the inserts set them explicitly; ``team_id`` is required to
-route the row to the correct hash partition of the persons table.
+``created_at`` and ``uuid`` are ``NOT NULL`` with no database default (the ORM fills them
+application-side), so the inserts set them explicitly; ``team_id`` is required (and in
+production routes the row to the correct hash partition of the persons table).
 """
 
 from __future__ import annotations
 
 import uuid as uuid_lib
+import dataclasses
 from typing import Any
 
 from django.conf import settings
@@ -23,6 +24,7 @@ import psycopg
 from psycopg.types.json import Jsonb
 
 from posthog.models.utils import UUIDT
+from posthog.persons_db import persons_db_connection
 
 # Not configurable like the person table; the model uses Django's default db_table.
 PERSON_DISTINCT_ID_TABLE = "posthog_persondistinctid"
@@ -43,7 +45,7 @@ def insert_seed_person(
     """
     with conn.cursor() as cursor:
         cursor.execute(
-            f"INSERT INTO {settings.PERSON_TABLE_NAME} "  # nosemgrep: no-direct-persons-db-orm
+            f"INSERT INTO {settings.PERSON_TABLE_NAME} "
             "(created_at, properties, is_identified, uuid, team_id) "
             "VALUES (now(), %s, %s, %s, %s) RETURNING id",
             (Jsonb(properties), is_identified, uuid or UUIDT(), team_id),
@@ -63,9 +65,27 @@ def insert_seed_distinct_id(
     """Insert one distinct-id row linking ``distinct_id`` to ``person_id``."""
     with conn.cursor() as cursor:
         cursor.execute(
-            f"INSERT INTO {PERSON_DISTINCT_ID_TABLE} "  # nosemgrep: no-direct-persons-db-orm
-            "(distinct_id, person_id, team_id) VALUES (%s, %s, %s)",
+            f"INSERT INTO {PERSON_DISTINCT_ID_TABLE} (distinct_id, person_id, team_id) VALUES (%s, %s, %s)",
             (distinct_id, person_id, team_id),
+        )
+
+
+def insert_seed_group(
+    conn: psycopg.Connection[Any],
+    *,
+    team_id: int,
+    group_key: str,
+    group_type_index: int,
+    group_properties: dict[str, Any],
+    version: int = 0,
+) -> None:
+    """Insert one group row. ``created_at``/``version`` are NOT NULL with no DB default."""
+    with conn.cursor() as cursor:
+        cursor.execute(
+            "INSERT INTO posthog_group "
+            "(team_id, group_key, group_type_index, group_properties, created_at, version) "
+            "VALUES (%s, %s, %s, %s, now(), %s)",
+            (team_id, group_key, group_type_index, Jsonb(group_properties), version),
         )
 
 
@@ -80,7 +100,39 @@ def update_seed_person(
     """Overwrite ``properties`` and ``is_identified`` for an existing person."""
     with conn.cursor() as cursor:
         cursor.execute(
-            f"UPDATE {settings.PERSON_TABLE_NAME} "  # nosemgrep: no-direct-persons-db-orm
+            f"UPDATE {settings.PERSON_TABLE_NAME} "
             "SET properties = %s, is_identified = %s WHERE team_id = %s AND uuid = %s",
             (Jsonb(properties), is_identified, team_id, uuid),
         )
+
+
+@dataclasses.dataclass
+class PersonData:
+    """A person fetched from the persons database for dev/seed event generation."""
+
+    distinct_id: str
+    person_uuid: str
+    properties: dict[str, Any]
+    created_at: Any
+
+
+def fetch_recent_persons_with_distinct_id(team_id: int, *, limit: int = 50) -> list[PersonData]:
+    """Return up to ``limit`` most-recently-created persons that have a distinct ID.
+
+    Each person is paired with one of its distinct IDs; the inner lateral join drops
+    persons without one, so the result may be shorter than ``limit``.
+    """
+    query = (
+        "SELECT p.uuid, p.properties, p.created_at, pdi.distinct_id "
+        f"FROM (SELECT id, uuid, properties, created_at FROM {settings.PERSON_TABLE_NAME} "
+        "WHERE team_id = %(team_id)s ORDER BY created_at DESC LIMIT %(limit)s) p "
+        "JOIN LATERAL (SELECT distinct_id FROM posthog_persondistinctid "
+        "WHERE team_id = %(team_id)s AND person_id = p.id LIMIT 1) pdi ON true"
+    )
+    with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+        cursor.execute(query, {"team_id": team_id, "limit": limit})
+        rows = cursor.fetchall()
+    return [
+        PersonData(person_uuid=str(row[0]), properties=row[1] or {}, created_at=row[2], distinct_id=row[3])
+        for row in rows
+    ]

--- a/posthog/persons_seed.py
+++ b/posthog/persons_seed.py
@@ -1,0 +1,86 @@
+"""Direct person/distinct-id writes for local dev and seed management commands.
+
+These helpers insert and update persons straight in the persons database via a raw
+psycopg connection (see :mod:`posthog.persons_db`), bypassing the Django ORM so the
+persons database can be dropped from Django's ``DATABASES``. They exist only for
+development and seed tooling that needs to fabricate persons locally — production
+person creation flows through ingestion and the personhog service, which has no
+create RPC by design.
+
+``created_at`` and ``uuid`` are ``NOT NULL`` with no database default (the ORM fills
+them application-side), so the inserts set them explicitly; ``team_id`` is required to
+route the row to the correct hash partition of the persons table.
+"""
+
+from __future__ import annotations
+
+import uuid as uuid_lib
+from typing import Any
+
+from django.conf import settings
+
+import psycopg
+from psycopg.types.json import Jsonb
+
+from posthog.models.utils import UUIDT
+
+# Not configurable like the person table; the model uses Django's default db_table.
+PERSON_DISTINCT_ID_TABLE = "posthog_persondistinctid"
+
+
+def insert_seed_person(
+    conn: psycopg.Connection[Any],
+    *,
+    team_id: int,
+    properties: dict[str, Any],
+    is_identified: bool = False,
+    uuid: str | uuid_lib.UUID | None = None,
+) -> int:
+    """Insert one person row and return its database id.
+
+    Pass ``uuid`` when the caller needs to reference the person downstream (e.g. to
+    mirror it into ClickHouse); otherwise a fresh ``UUIDT`` is generated.
+    """
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"INSERT INTO {settings.PERSON_TABLE_NAME} "  # nosemgrep: no-direct-persons-db-orm
+            "(created_at, properties, is_identified, uuid, team_id) "
+            "VALUES (now(), %s, %s, %s, %s) RETURNING id",
+            (Jsonb(properties), is_identified, uuid or UUIDT(), team_id),
+        )
+        row = cursor.fetchone()
+        assert row is not None  # RETURNING always yields a row on a successful insert
+        return row[0]
+
+
+def insert_seed_distinct_id(
+    conn: psycopg.Connection[Any],
+    *,
+    team_id: int,
+    person_id: int,
+    distinct_id: str,
+) -> None:
+    """Insert one distinct-id row linking ``distinct_id`` to ``person_id``."""
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"INSERT INTO {PERSON_DISTINCT_ID_TABLE} "  # nosemgrep: no-direct-persons-db-orm
+            "(distinct_id, person_id, team_id) VALUES (%s, %s, %s)",
+            (distinct_id, person_id, team_id),
+        )
+
+
+def update_seed_person(
+    conn: psycopg.Connection[Any],
+    *,
+    team_id: int,
+    uuid: str | uuid_lib.UUID,
+    properties: dict[str, Any],
+    is_identified: bool,
+) -> None:
+    """Overwrite ``properties`` and ``is_identified`` for an existing person."""
+    with conn.cursor() as cursor:
+        cursor.execute(
+            f"UPDATE {settings.PERSON_TABLE_NAME} "  # nosemgrep: no-direct-persons-db-orm
+            "SET properties = %s, is_identified = %s WHERE team_id = %s AND uuid = %s",
+            (Jsonb(properties), is_identified, team_id, uuid),
+        )

--- a/posthog/test/test_persons_seed.py
+++ b/posthog/test/test_persons_seed.py
@@ -1,0 +1,83 @@
+from typing import Any
+
+import pytest
+
+from django.conf import settings
+
+import psycopg
+
+from posthog.persons_db import persons_db_connection
+from posthog.persons_seed import insert_seed_distinct_id, insert_seed_person, update_seed_person
+
+# Sentinel team id used only by these tests. The seed helpers write through a raw
+# psycopg connection that commits independently of Django's test transaction, so each
+# test cleans up its own rows to avoid leaking into the shared persons test database.
+SEED_TEST_TEAM_ID = 2_000_000_001
+
+pytestmark = pytest.mark.django_db(databases=["persons_db_writer", "persons_db_reader"])
+
+
+def _cleanup(conn: psycopg.Connection[Any]) -> None:
+    with conn.cursor() as cursor:
+        cursor.execute("DELETE FROM posthog_persondistinctid WHERE team_id = %s", (SEED_TEST_TEAM_ID,))
+        cursor.execute(f"DELETE FROM {settings.PERSON_TABLE_NAME} WHERE team_id = %s", (SEED_TEST_TEAM_ID,))
+
+
+class TestPersonsSeedHelpers:
+    def test_insert_person_persists_fields_and_sets_required_columns(self):
+        with persons_db_connection(writer=True) as conn:
+            try:
+                person_id = insert_seed_person(
+                    conn, team_id=SEED_TEST_TEAM_ID, properties={"email": "a@b.com"}, is_identified=True
+                )
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        f"SELECT properties, is_identified, uuid, created_at FROM {settings.PERSON_TABLE_NAME} WHERE id = %s",
+                        (person_id,),
+                    )
+                    row = cursor.fetchone()
+                assert row is not None
+                assert row[0] == {"email": "a@b.com"}
+                assert row[1] is True
+                assert row[2] is not None  # uuid filled (NOT NULL, no DB default)
+                assert row[3] is not None  # created_at filled (NOT NULL, no DB default)
+            finally:
+                _cleanup(conn)
+
+    def test_insert_distinct_id_links_to_person(self):
+        with persons_db_connection(writer=True) as conn:
+            try:
+                person_id = insert_seed_person(conn, team_id=SEED_TEST_TEAM_ID, properties={})
+                insert_seed_distinct_id(conn, team_id=SEED_TEST_TEAM_ID, person_id=person_id, distinct_id="seed-did")
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        "SELECT person_id FROM posthog_persondistinctid WHERE team_id = %s AND distinct_id = %s",
+                        (SEED_TEST_TEAM_ID, "seed-did"),
+                    )
+                    row = cursor.fetchone()
+                assert row is not None
+                assert row[0] == person_id
+            finally:
+                _cleanup(conn)
+
+    def test_update_person_overwrites_properties_and_identified(self):
+        with persons_db_connection(writer=True) as conn:
+            try:
+                person_uuid = "00000000-0000-0000-0000-000000000abc"
+                insert_seed_person(
+                    conn, team_id=SEED_TEST_TEAM_ID, properties={"v": 1}, is_identified=False, uuid=person_uuid
+                )
+                update_seed_person(
+                    conn, team_id=SEED_TEST_TEAM_ID, uuid=person_uuid, properties={"v": 2}, is_identified=True
+                )
+                with conn.cursor() as cursor:
+                    cursor.execute(
+                        f"SELECT properties, is_identified FROM {settings.PERSON_TABLE_NAME} WHERE team_id = %s AND uuid = %s",
+                        (SEED_TEST_TEAM_ID, person_uuid),
+                    )
+                    row = cursor.fetchone()
+                assert row is not None
+                assert row[0] == {"v": 2}
+                assert row[1] is True
+            finally:
+                _cleanup(conn)

--- a/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
@@ -24,8 +24,9 @@ from uuid import uuid4
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
-from posthog.models import Group, OrganizationMembership, Team, User
+from posthog.models import OrganizationMembership, Team, User
 from posthog.models.scoping import team_scope
+from posthog.persons_db import persons_db_connection
 
 from products.customer_analytics.backend.models.account import Account, AccountAssignment, AccountProperties
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
@@ -97,14 +98,13 @@ class Command(BaseCommand):
             raise CommandError(f"Team {team_id} does not exist.")
 
     def _read_account_groups(self, team: Team, limit: int | None) -> list[tuple[str, dict[str, Any]]]:
-        rows = [
-            (group_key, props or {})
-            for group_key, props in Group.objects.filter(  # nosemgrep: no-direct-persons-db-orm
-                team_id=team.pk, group_type_index=ACCOUNT_GROUP_TYPE_INDEX
-            )
-            .order_by("group_key")
-            .values_list("group_key", "group_properties")
-        ]
+        query = (
+            "SELECT group_key, group_properties FROM posthog_group "  # nosemgrep: no-direct-persons-db-orm
+            "WHERE team_id = %(team_id)s AND group_type_index = %(gti)s ORDER BY group_key"
+        )
+        with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:
+            cursor.execute(query, {"team_id": team.pk, "gti": ACCOUNT_GROUP_TYPE_INDEX})
+            rows = [(group_key, props or {}) for group_key, props in cursor.fetchall()]
         return rows[:limit] if limit is not None else rows
 
     def _set_config(self, team: Team) -> None:

--- a/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/seed_customer_analytics_accounts.py
@@ -99,7 +99,7 @@ class Command(BaseCommand):
 
     def _read_account_groups(self, team: Team, limit: int | None) -> list[tuple[str, dict[str, Any]]]:
         query = (
-            "SELECT group_key, group_properties FROM posthog_group "  # nosemgrep: no-direct-persons-db-orm
+            "SELECT group_key, group_properties FROM posthog_group "
             "WHERE team_id = %(team_id)s AND group_type_index = %(gti)s ORDER BY group_key"
         )
         with persons_db_connection(writer=False) as conn, conn.cursor() as cursor:

--- a/products/customer_analytics/backend/management/commands/test/test_seed_customer_analytics_accounts.py
+++ b/products/customer_analytics/backend/management/commands/test/test_seed_customer_analytics_accounts.py
@@ -5,7 +5,9 @@ from posthog.test.base import BaseTest
 from django.core.management import call_command
 from django.core.management.base import CommandError
 
-from posthog.models import Group, OrganizationMembership, User
+from posthog.models import OrganizationMembership, User
+from posthog.persons_db import persons_db_connection
+from posthog.persons_seed import insert_seed_group
 
 from products.customer_analytics.backend.models.account import Account
 from products.customer_analytics.backend.models.team_customer_analytics_config import TeamCustomerAnalyticsConfig
@@ -13,14 +15,24 @@ from products.notebooks.backend.models import Notebook, ResourceNotebook
 
 
 class TestSeedCustomerAnalyticsAccounts(BaseTest):
+    def tearDown(self):
+        # _make_group commits rows outside the test transaction, so remove them here to
+        # avoid leaking into other tests that share the persons database.
+        with persons_db_connection(writer=True) as conn, conn.cursor() as cursor:
+            cursor.execute("DELETE FROM posthog_group WHERE team_id = %s", (self.team.pk,))
+        super().tearDown()
+
     def _make_group(self, group_key: str, name: str) -> None:
-        Group.objects.create(
-            team_id=self.team.pk,
-            group_key=group_key,
-            group_type_index=0,
-            group_properties={"name": name, "industry": "tech", "team_size": 3},
-            version=0,
-        )
+        # The command reads groups via a raw persons-DB connection, so fixtures must be
+        # committed — a Django ORM create would be invisible across the connection boundary.
+        with persons_db_connection(writer=True) as conn:
+            insert_seed_group(
+                conn,
+                team_id=self.team.pk,
+                group_key=group_key,
+                group_type_index=0,
+                group_properties={"name": name, "industry": "tech", "team_size": 3},
+            )
 
     def _run(self, **kwargs) -> str:
         out = StringIO()

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -5,8 +5,6 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
-import psycopg
-
 from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.event.util import create_event
@@ -15,7 +13,7 @@ from posthog.models.scoping import team_scope
 from posthog.models.team.team import Team
 from posthog.models.utils import UUIDT, uuid7
 from posthog.personhog_client.caller_tag import personhog_caller_tag
-from posthog.persons_db import persons_db_url
+from posthog.persons_db import persons_db_connection
 from posthog.persons_seed import insert_seed_distinct_id, insert_seed_person, update_seed_person
 
 from products.mcp_analytics.backend.models import MCPSession
@@ -213,41 +211,38 @@ class Command(BaseCommand):
         # person-on-events join (Top users table) keeps them — without a real person the
         # inner join drops every row.
         person_cache: dict[str, tuple[str, dict[str, Any]]] = {}
-        # One persons-DB connection for the whole seed, opened lazily on the first write.
-        persons_conn: psycopg.Connection[Any] | None = None
 
         def ensure_person(
             distinct_id: str, properties: dict[str, Any], is_identified: bool
         ) -> tuple[str, dict[str, Any]]:
-            nonlocal persons_conn
             if distinct_id in person_cache:
                 return person_cache[distinct_id]
             with personhog_caller_tag("mcp-analytics/seed-sessions"):
                 existing_person = get_person_by_distinct_id(
                     team_id=team.id, distinct_id=distinct_id, distinct_id_limit=0
                 )
-            if persons_conn is None:
-                persons_conn = psycopg.connect(persons_db_url(writer=True), autocommit=True)
             if existing_person:
                 person_uuid = str(existing_person.uuid)
                 if properties:
-                    update_seed_person(
-                        persons_conn,
-                        team_id=team.id,
-                        uuid=person_uuid,
-                        properties=properties,
-                        is_identified=is_identified,
-                    )
+                    with persons_db_connection(writer=True) as conn:
+                        update_seed_person(
+                            conn,
+                            team_id=team.id,
+                            uuid=person_uuid,
+                            properties=properties,
+                            is_identified=is_identified,
+                        )
             else:
                 person_uuid = str(UUIDT())
-                person_id = insert_seed_person(
-                    persons_conn,
-                    team_id=team.id,
-                    properties=properties,
-                    is_identified=is_identified,
-                    uuid=person_uuid,
-                )
-                insert_seed_distinct_id(persons_conn, team_id=team.id, person_id=person_id, distinct_id=distinct_id)
+                with persons_db_connection(writer=True) as conn:
+                    person_id = insert_seed_person(
+                        conn,
+                        team_id=team.id,
+                        properties=properties,
+                        is_identified=is_identified,
+                        uuid=person_uuid,
+                    )
+                    insert_seed_distinct_id(conn, team_id=team.id, person_id=person_id, distinct_id=distinct_id)
             create_person(
                 team_id=team.id,
                 uuid=person_uuid,
@@ -367,9 +362,6 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  session {session_idx + 1}/{session_count}: {calls} tool calls (session_id={session_id})"
             )
-
-        if persons_conn is not None:
-            persons_conn.close()
 
         self.stdout.write(
             self.style.SUCCESS(f"Seeded {session_count} sessions ({total_events} events) for team {team_id}.")

--- a/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
+++ b/products/mcp_analytics/backend/management/commands/seed_mcp_sessions.py
@@ -5,15 +5,18 @@ from typing import Any
 
 from django.core.management.base import BaseCommand, CommandParser
 
+import psycopg
+
 from posthog.clickhouse.client import sync_execute
 from posthog.models.event.sql import EVENTS_DATA_TABLE
 from posthog.models.event.util import create_event
-from posthog.models.person import Person, PersonDistinctId
 from posthog.models.person.util import create_person, create_person_distinct_id, get_person_by_distinct_id
 from posthog.models.scoping import team_scope
 from posthog.models.team.team import Team
-from posthog.models.utils import uuid7
+from posthog.models.utils import UUIDT, uuid7
 from posthog.personhog_client.caller_tag import personhog_caller_tag
+from posthog.persons_db import persons_db_url
+from posthog.persons_seed import insert_seed_distinct_id, insert_seed_person, update_seed_person
 
 from products.mcp_analytics.backend.models import MCPSession
 
@@ -210,30 +213,41 @@ class Command(BaseCommand):
         # person-on-events join (Top users table) keeps them — without a real person the
         # inner join drops every row.
         person_cache: dict[str, tuple[str, dict[str, Any]]] = {}
+        # One persons-DB connection for the whole seed, opened lazily on the first write.
+        persons_conn: psycopg.Connection[Any] | None = None
 
         def ensure_person(
             distinct_id: str, properties: dict[str, Any], is_identified: bool
         ) -> tuple[str, dict[str, Any]]:
+            nonlocal persons_conn
             if distinct_id in person_cache:
                 return person_cache[distinct_id]
             with personhog_caller_tag("mcp-analytics/seed-sessions"):
                 existing_person = get_person_by_distinct_id(
                     team_id=team.id, distinct_id=distinct_id, distinct_id_limit=0
                 )
+            if persons_conn is None:
+                persons_conn = psycopg.connect(persons_db_url(writer=True), autocommit=True)
             if existing_person:
-                person = existing_person
+                person_uuid = str(existing_person.uuid)
                 if properties:
-                    person.properties = properties
-                    person.is_identified = is_identified
-                    person.save(update_fields=["properties", "is_identified"])
+                    update_seed_person(
+                        persons_conn,
+                        team_id=team.id,
+                        uuid=person_uuid,
+                        properties=properties,
+                        is_identified=is_identified,
+                    )
             else:
-                person = Person.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team, properties=properties, is_identified=is_identified
+                person_uuid = str(UUIDT())
+                person_id = insert_seed_person(
+                    persons_conn,
+                    team_id=team.id,
+                    properties=properties,
+                    is_identified=is_identified,
+                    uuid=person_uuid,
                 )
-                PersonDistinctId.objects.create(  # nosemgrep: no-direct-persons-db-orm
-                    team=team, distinct_id=distinct_id, person=person
-                )
-            person_uuid = str(person.uuid)
+                insert_seed_distinct_id(persons_conn, team_id=team.id, person_id=person_id, distinct_id=distinct_id)
             create_person(
                 team_id=team.id,
                 uuid=person_uuid,
@@ -353,6 +367,9 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  session {session_idx + 1}/{session_count}: {calls} tool calls (session_id={session_id})"
             )
+
+        if persons_conn is not None:
+            persons_conn.close()
 
         self.stdout.write(
             self.style.SUCCESS(f"Seeded {session_count} sessions ({total_events} events) for team {team_id}.")


### PR DESCRIPTION
## Problem

local dev data seeding commands still rely on the orm

## Changes

- migrate the commands to raw sql

