### PR TITLE
fix(lemon-ui): seed Quill DatePicker time toggle from includeTime state

### DIFF
--- a/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.test.tsx
@@ -184,6 +184,7 @@ describe('DatePicker', () => {
             expect(within(container).getByRole('button', { name: /January 15, 2023/ }).textContent).toBe(
                 'January 15, 2023 09:30'
             )
+            expect(mockQuillPanelProps.showTime).toBe(true)
         })
 
         it('forwards maxDate to the Quill panel so future dates can be selected', async () => {

--- a/frontend/src/lib/components/DatePicker/DatePicker.tsx
+++ b/frontend/src/lib/components/DatePicker/DatePicker.tsx
@@ -146,7 +146,7 @@ function DatePickerQuill({
                     <QuillDatePicker
                         value={value ? value.toDate() : new Date()}
                         maxDate={maxDate?.toDate()}
-                        showTime={granularity === 'minute'}
+                        showTime={includeTime}
                         showTimeToggle={!!showTimeToggle}
                         onIncludeTimeChange={handleIncludeTimeChange}
                         onApply={applyDate}


### PR DESCRIPTION
## Problem

Follow-up to #65531 (Graphite flagged this on the merged PR). The seam passed `showTime={granularity === 'minute'}` to the Quill `DatePicker`. Quill uses `showTime` only to **seed** its internal `includeTime` via `useState` (mount-only) — so the prop is read once per mount, not on every render.

Base UI's Popover unmounts panel content when it closes. So with `granularity='day'` + `showTimeToggle`:

1. user opens the picker, toggles **time on**, picks a time, applies — the value keeps its time, and the trigger label shows it
2. user reopens the picker → the panel **remounts** and re-seeds `includeTime` from the stale `granularity`-based `showTime` (= `false`) → the toggle is **off**
3. a re-apply now floors the time off — silently dropping it, while the label and previously-applied value still carried it

The seam already mirrors the toggle in its own `includeTime` state (it drives the label). The fix is to seed Quill from that mirror.

## Changes

`showTime={granularity === 'minute'}` → `showTime={includeTime}`. One line. The seam's `includeTime` starts from `granularity === 'minute'` and updates via `onIncludeTimeChange`, so a panel remount now re-seeds with the user's actual toggle choice.

Extended the existing toggle test to assert the `showTime` prop tracks the toggled state (it would be `false` under the old code).

This only affects the flag-gated Quill path; the flag is off by default.

## How did you test this code?

I'm an agent (PostHog Code, agent-assisted). `DatePicker.test.tsx` — 18 pass, including the strengthened toggle test; format clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul flagged the unresolved Graphite comment on merged #65531; assigned as DRI.

Graphite's suggested fix was correct; its stated cause ("stale on next render") was slightly off — it's a remount-reseed, not a re-render, which is why the symptom is "reopen loses the toggle / re-apply drops the time" rather than a live display reset.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*