### PR TITLE
fix(logs): remove duplicate date control on services page

### DIFF
--- a/products/logs/frontend/components/LogsServices/LogsServices.tsx
+++ b/products/logs/frontend/components/LogsServices/LogsServices.tsx
@@ -2,17 +2,8 @@ import { useActions, useValues } from 'kea'
 import { combineUrl } from 'kea-router'
 import { useEffect, useMemo, useState } from 'react'
 
-import { IconEllipsis, IconShare } from '@posthog/icons'
-import {
-    LemonBanner,
-    LemonButton,
-    LemonMenu,
-    LemonSelect,
-    LemonTable,
-    LemonTag,
-    Tooltip,
-    lemonToast,
-} from '@posthog/lemon-ui'
+import { IconShare } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonSelect, LemonTable, LemonTag, Tooltip, lemonToast } from '@posthog/lemon-ui'
 import type { LemonTableColumns } from '@posthog/lemon-ui'
 
 import { Sparkline } from 'lib/components/Sparkline'
@@ -186,11 +177,6 @@ export function LogsServices(): JSX.Element {
         setRulesExpandedByService((prev) => ({ ...prev, [serviceName]: !prev[serviceName] }))
     }
 
-    const presetItems = DATE_OPTIONS.map((opt) => ({
-        label: opt.label,
-        onClick: () => setDateFrom(opt.value),
-    }))
-
     const columns: LemonTableColumns<ServiceRow> = [
         {
             title: 'Service name',
@@ -317,19 +303,12 @@ export function LogsServices(): JSX.Element {
             )}
             <div className="flex items-center justify-between gap-2">
                 <h3 className="m-0">Services</h3>
-                <div className="flex items-center gap-2">
-                    <LemonMenu items={presetItems} placement="bottom-end">
-                        <LemonButton size="small" type="secondary" icon={<IconEllipsis />}>
-                            Date presets
-                        </LemonButton>
-                    </LemonMenu>
-                    <LemonSelect
-                        size="small"
-                        value={dateFrom}
-                        onChange={(value) => value && setDateFrom(value)}
-                        options={DATE_OPTIONS}
-                    />
-                </div>
+                <LemonSelect
+                    size="small"
+                    value={dateFrom}
+                    onChange={(value) => value && setDateFrom(value)}
+                    options={DATE_OPTIONS}
+                />
             </div>
             <LemonTable
                 columns={columns}


### PR DESCRIPTION
## Problem

The Logs services page rendered two date controls side by side that did the exact same thing: a "Date presets" dropdown button and a select. Both were backed by the same `dateFrom` state and the same four options (last hour / 24 hours / 7 days / 30 days), so picking from one was indistinguishable from picking from the other — just redundant UI.

## Changes

Removed the redundant "Date presets" `LemonMenu` dropdown and kept the `LemonSelect`, which already shows the active value and handles selection inline. Also cleaned up the now-unused `presetItems` array and the `IconEllipsis` / `LemonMenu` imports.

Single file touched: `products/logs/frontend/components/LogsServices/LogsServices.tsx`.

## How did you test this code?

I'm an agent. I ran the frontend formatter (`pnpm --filter=@posthog/frontend format`) which passed clean, and verified there are no stale references to the removed symbols. No manual UI testing was performed — the change is a straightforward removal of duplicated UI with no behavior change to the surviving control.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — no user-facing docs cover this control.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Daniel spotted the duplicate date controls on the logs services page and asked to remove one. Used PostHog Code (Claude Opus) to locate the two controls, confirm both wrote to the same `dateFrom` reducer in `logsServicesLogic`, and remove the one with no added value. Kept the `LemonSelect` over the `LemonMenu` since it surfaces the active selection rather than hiding it behind a button. No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
