### PR TITLE
chore(web-analytics): fix coalesce and gotcha in bot-traffic skill

### DIFF
--- a/products/web_analytics/skills/filtering-bot-traffic/SKILL.md
+++ b/products/web_analytics/skills/filtering-bot-traffic/SKILL.md
@@ -52,8 +52,10 @@ so you don't pass anything in. Available wherever you pick an event property.
 
 ### HogQL functions (raw SQL)
 
-Pass the user agent explicitly. Use `coalesce(properties.$raw_user_agent, properties.$user_agent)`
-to cover both server-side (`$raw_user_agent`) and JS SDK (`$user_agent`) captures.
+Pass the user agent explicitly. Use `coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent)`
+to cover both server-side (`$raw_user_agent`) and JS SDK (`$user_agent`) captures. The `nullIf`
+keeps an empty `$raw_user_agent` from shadowing a real `$user_agent` and being misread as a bot —
+this mirrors the expression the virtual properties use internally.
 
 | Function                 | Returns                                                                      |
 | ------------------------ | ---------------------------------------------------------------------------- |
@@ -133,16 +135,16 @@ which tools (OpenAI, Anthropic, Perplexity, …) read your site and which pages 
 SELECT count() AS human_pageviews
 FROM events
 WHERE event = '$pageview'
-    AND NOT isLikelyBot(coalesce(properties.$raw_user_agent, properties.$user_agent))
+    AND NOT isLikelyBot(coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent))
 
 -- top bots by hits
 SELECT
-    getBotName(coalesce(properties.$raw_user_agent, properties.$user_agent)) AS bot,
-    getBotOperator(coalesce(properties.$raw_user_agent, properties.$user_agent)) AS operator,
+    getBotName(coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent)) AS bot,
+    getBotOperator(coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent)) AS operator,
     count() AS hits
 FROM events
 WHERE event = '$pageview'
-    AND isLikelyBot(coalesce(properties.$raw_user_agent, properties.$user_agent))
+    AND isLikelyBot(coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent))
 GROUP BY bot, operator
 ORDER BY hits DESC
 ```
@@ -158,9 +160,11 @@ the capture API) before building bot insights.
 
 ## Gotchas
 
-- **Not retroactive.** `$virt_*` properties only exist on events processed after the
-  classifier shipped. Keep `dateRange.date_from` within the last few months for reliable
-  results; older events won't classify.
+- **Needs a captured user agent.** Classification is computed at query time from the event's
+  `$raw_user_agent` / `$user_agent`, so it works on any historical event — there's no need to
+  restrict `dateRange.date_from`. The one requirement is that a user agent was captured; events
+  from sources that never set one can't be classified (and empty UAs fall through to
+  `Automation` / `no_user_agent`, below).
 - **`isLikelyBot` is "likely".** Detection is a user-agent heuristic — some bots spoof
   real browser UAs, and some legit tools use bot-like ones. Treat it as best-effort, not
   ground truth.


### PR DESCRIPTION
## Problem

Two P2 review comments from Codex on #65347 (now merged) were never addressed. Both are in the new `filtering-bot-traffic` skill and would steer an agent wrong:

1. **Empty user agent misclassified as a bot.** The SQL examples extract the UA with `coalesce(properties.$raw_user_agent, properties.$user_agent)`. `$raw_user_agent` is often an empty string rather than null, so it shadows a real `$user_agent`, and `isLikelyBot('')` returns `true` — legitimate traffic gets dropped. The real implementation (`user_agent_expr()` in `posthog/hogql/database/schema/traffic_type.py`) wraps it in `nullIf(..., '')`; the skill didn't.
2. **False "Not retroactive" gotcha.** The skill claimed `$virt_*` properties only exist on events ingested after the classifier shipped, and told agents to restrict `dateRange.date_from`. They're actually query-time `ExpressionField`s (registered in `posthog/hogql/database/database.py`) computed from stored UA data, so they classify any historical event. The advice to limit the date range was wrong.

## Changes

- All 5 UA-extraction sites (one explanatory sentence + 4 raw-SQL examples) now use `coalesce(nullIf(properties.$raw_user_agent, ''), properties.$user_agent)`, with a one-line note on why `nullIf` matters.
- Replaced the "Not retroactive" bullet with a "Needs a captured user agent" caveat that drops the bogus date cutoff and explains the actual requirement.

## How did you test this code?

I'm an agent; I did not do manual UI testing. Automated checks:

- Ran the skill linter (`products/posthog_ai/scripts/build_skills.py --lint`) — all 94 skills pass, including the modified one.
- Executed the corrected expression as live HogQL via MCP using string literals: the old form `coalesce('', real_ua)` → `isLikelyBot` returns `true` (the bug); the new form `coalesce(nullIf('', ''), real_ua)` falls through to the real browser UA and classifies it as human. Confirms the expression parses and fixes the misclassification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The companion docs PR `PostHog/posthog.com#17837` from the original change likely repeats both issues and should get the same fix — that repo isn't part of this one, so it's a separate follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Lucas directed the work (assigned as DRI).

Follow-up to merged #65347, addressing its two outstanding Codex P2 comments. Both claims were verified against source before editing: the `nullIf` form against `user_agent_expr()` in `traffic_type.py`, and the query-time-`ExpressionField` registration in `database.py` (so classification is not gated on ingest date). Scoped a grep across sibling skills/docs to confirm the buggy `coalesce` pattern and the false gotcha appear nowhere else — this is a single-file fix. No mandatory skills applied (markdown content fix, not DRF/migration/test code); validation used the skill linter and the `execute-sql` MCP tool.
