### PR TITLE
fix(mcp): return authorize redirect url for code

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/mcp_store/backend/presentation/views.py
+++ b/products/mcp_store/backend/presentation/views.py
@@ -127,6 +127,15 @@ def _get_oauth_redirect_uri() -> str:
     return f"{settings.SITE_URL}/api/mcp_store/oauth_redirect/"
 
 
+def _oauth_authorize_response(authorize_url: str, install_source: str) -> HttpResponse:
+    if install_source == "posthog-code":
+        return Response({"redirect_url": authorize_url}, status=status.HTTP_200_OK)
+
+    response = HttpResponse(status=302)
+    response["Location"] = authorize_url
+    return response
+
+
 def _template_uses_dcr(template: MCPServerTemplate) -> bool:
     """Is this template configured for per-user Dynamic Client Registration?
 
@@ -1033,9 +1042,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
             team=self.team,
         )
 
-        response = HttpResponse(status=302)
-        response["Location"] = authorize_url
-        return response
+        return _oauth_authorize_response(authorize_url, install_source)
 
     def _authorize_for_installation(
         self,
@@ -1101,9 +1108,7 @@ class MCPServerInstallationViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet
         except OAuthAuthorizeURLError:
             return Response({"detail": "Authorization endpoint must use HTTPS"}, status=status.HTTP_400_BAD_REQUEST)
 
-        response = HttpResponse(status=302)
-        response["Location"] = authorize_url
-        return response
+        return _oauth_authorize_response(authorize_url, install_source)
 
     @extend_schema(responses={200: OpenApiResponse(response=MCPServerInstallationToolSerializer(many=True))})
     @action(detail=True, methods=["get"], url_path="tools")

--- a/products/mcp_store/backend/test/test_api.py
+++ b/products/mcp_store/backend/test/test_api.py
@@ -1048,6 +1048,82 @@ class TestOAuthIssuerSpoofingProtection(ClickhouseTestMixin, APIBaseTest, QueryM
         assert second_callback.status_code == status.HTTP_400_BAD_REQUEST
 
 
+class TestMCPAuthorizePosthogCodeResponse(APIBaseTest):
+    def _create_template(self) -> MCPServerTemplate:
+        return MCPServerTemplate.objects.create(
+            name="Test Template",
+            url="https://mcp.test.example.com/mcp",
+            auth_type="oauth",
+            is_active=True,
+            oauth_metadata={
+                "authorization_endpoint": "https://auth.test.example.com/authorize",
+                "token_endpoint": "https://auth.test.example.com/token",
+            },
+            oauth_credentials={"client_id": "test-client-id"},
+        )
+
+    @ALLOW_URL
+    @patch("products.mcp_store.backend.presentation.views.discover_oauth_metadata")
+    def test_authorize_returns_redirect_url_for_custom_installation(self, mock_discover, _allow):
+        installation = MCPServerInstallation.objects.create(
+            team=self.team,
+            user=self.user,
+            url="https://mcp.example.com",
+            display_name="Test",
+            auth_type="oauth",
+            oauth_issuer_url="https://auth.example.com",
+            oauth_metadata={
+                "authorization_endpoint": "https://auth.example.com/authorize",
+                "token_endpoint": "https://auth.example.com/token",
+            },
+            sensitive_configuration={"dcr_client_id": "existing-client-id", "dcr_is_user_provided": False},
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/mcp_server_installations/authorize/",
+            {
+                "installation_id": str(installation.id),
+                "install_source": "posthog-code",
+                "posthog_code_callback_url": "posthog-code://oauth/callback",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "Location" not in response
+        redirect_url = response.json()["redirect_url"]
+        assert urlparse(redirect_url).netloc == "auth.example.com"
+        mock_discover.assert_not_called()
+        params = parse_qs(urlparse(redirect_url).query)
+        assert params["client_id"][0] == "existing-client-id"
+
+    @ALLOW_URL
+    def test_authorize_returns_redirect_url_for_template_installation(self, _allow):
+        template = self._create_template()
+        installation = MCPServerInstallation.objects.create(
+            team=self.team,
+            user=self.user,
+            template=template,
+            url=template.url,
+            auth_type="oauth",
+        )
+
+        response = self.client.get(
+            f"/api/environments/{self.team.id}/mcp_server_installations/authorize/",
+            {
+                "installation_id": str(installation.id),
+                "install_source": "posthog-code",
+                "posthog_code_callback_url": "posthog-code://oauth/callback",
+            },
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+        assert "Location" not in response
+        redirect_url = response.json()["redirect_url"]
+        assert urlparse(redirect_url).netloc == "auth.test.example.com"
+        params = parse_qs(urlparse(redirect_url).query)
+        assert params["client_id"][0] == "test-client-id"
+
+
 class TestInstallTemplateAPI(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
     def _template(self, **overrides) -> MCPServerTemplate:
         import uuid as _uuid


### PR DESCRIPTION
## Problem

PostHog Code starts MCP OAuth reconnects from a browser fetch with bearer auth. The existing `authorize` endpoint returned a `302`, which works for the PostHog web app but leaves Code unable to read the cross-origin `Location` header. In Chromium this shows up as an opaque redirect with status `0`, so Code cannot open the provider authorize URL.

## Changes

- Return `{ "redirect_url": ... }` from the MCP authorize endpoint when `install_source=posthog-code`.
- Keep the existing `302 Location` response for the regular PostHog web flow.
- Add endpoint coverage for both custom OAuth installations and template-backed installations reconnected by installation ID.

## How did you test this code?

I did not do a manual app walkthrough.

The new tests catch the HTTP contract regression where a Code reconnect would receive a browser-hidden redirect instead of a JSON redirect URL.

Automated checks run:

- `flox activate -- bash -c 'uv run ruff check products/mcp_store/backend/presentation/views.py products/mcp_store/backend/test/test_api.py'`
- `flox activate -- bash -c 'uv run ruff format --check products/mcp_store/backend/presentation/views.py products/mcp_store/backend/test/test_api.py'`
- `git diff --check`
- `flox activate -- bash -c 'uv run python -m py_compile products/mcp_store/backend/presentation/views.py products/mcp_store/backend/test/test_api.py'`

The pre-commit hook also ran `bin/hogli lint:python:fix`, `bin/hogli format:python`, and `uv run ty check` for the staged Python files.

I attempted `flox activate -- bash -c './bin/hogli test products/mcp_store/backend/test/test_api.py::TestMCPAuthorizePosthogCodeResponse'`, but local pytest setup failed while creating ClickHouse tables with `EOFError: Unexpected EOF while reading bytes`, before either new test ran.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this preserves the existing API shape documented for the Code source.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex in the desktop app made this change. Skills invoked: `/improving-drf-endpoints`, `/writing-tests`, and `writing-pr-descriptions`.

The key decision was to fix the backend contract for `posthog-code` instead of trying to inspect manual redirects in Code. Browser fetch intentionally hides cross-origin redirect locations, so Code needs the authorize URL as JSON while PostHog web should keep using the normal `302` redirect.
