### PR TITLE
fix(logs): apply precise date range to services tab query

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -2,7 +2,7 @@ from typing import Any
 
 import re2
 
-from posthog.schema import CachedLogsQueryResponse, LogsQuery
+from posthog.schema import CachedLogsQueryResponse, HogQLFilters, LogsQuery
 
 from posthog.hogql import ast
 from posthog.hogql.parser import parse_select
@@ -170,6 +170,7 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
             workload=Workload.LOGS,
             timings=self.timings,
             limit_context=self.limit_context,
+            filters=HogQLFilters(dateRange=self.query.dateRange),
             settings=self.settings,
         )
 
@@ -181,6 +182,7 @@ class ServicesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
             workload=Workload.LOGS,
             timings=self.timings,
             limit_context=self.limit_context,
+            filters=HogQLFilters(dateRange=self.query.dateRange),
             settings=self.settings,
         )
 

--- a/products/logs/backend/test/test_services_query_runner.py
+++ b/products/logs/backend/test/test_services_query_runner.py
@@ -1,8 +1,15 @@
+import os
+import json
 from typing import Any
 
 import pytest
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 
 from parameterized import parameterized
+from rest_framework import status
+
+from posthog.clickhouse.client import sync_execute
 
 from products.logs.backend.services_query_runner import rule_could_apply_to_service
 
@@ -151,6 +158,54 @@ class TestRuleCouldApplyToService:
         # Conservative default: anything we can't parse keeps the rule visible.
         assert rule_could_apply_to_service({"type": "AND", "values": ["oops"]}, "api") is True
         assert rule_could_apply_to_service({"not_a_group": True}, "api") is True
+
+
+class TestServicesQueryDateRange(ClickhouseTestMixin, APIBaseTest):
+    CLASS_DATA_LEVEL_SETUP = True
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        with open(os.path.join(os.path.dirname(__file__), "test_logs.jsonnd")) as f:
+            sql = ""
+            for line in f:
+                log_item = json.loads(line)
+                log_item["team_id"] = cls.team.id
+                sql += json.dumps(log_item) + "\n"
+            sync_execute(f"""
+                INSERT INTO logs
+                FORMAT JSONEachRow
+                {sql}
+            """)
+
+    def _services(self, date_from: str, date_to: str) -> list[dict]:
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/logs/services",
+            data={
+                "query": {
+                    "dateRange": {"date_from": date_from, "date_to": date_to},
+                    "severityLevels": [],
+                    "filterGroup": {"type": "AND", "values": [{"type": "AND", "values": []}]},
+                    "serviceNames": [],
+                }
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return response.json()["services"]
+
+    @freeze_time("2025-12-16T10:33:00Z")
+    def test_services_honors_sub_day_date_range(self):
+        # The fixture has 1003 logs on 2025-12-16 across 12 services, but only the
+        # 10:32 batch (100 logs from cdp-legacy-events-consumer) falls in this
+        # 9-minute window. The day-level partition filter alone would return the
+        # whole day; the precise timestamp bound must narrow it to the window.
+        full_day = self._services("2025-12-16T00:00:00Z", "2025-12-16T23:59:59Z")
+        windowed = self._services("2025-12-16T10:24:00Z", "2025-12-16T10:33:00Z")
+
+        self.assertEqual(sum(s["log_count"] for s in full_day), 1003)
+        self.assertEqual(len(windowed), 1)
+        self.assertEqual(windowed[0]["service_name"], "cdp-legacy-events-consumer")
+        self.assertEqual(windowed[0]["log_count"], 100)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

In the logs Services tab, the date selector ("Last hour", "Last 24 hours", etc.) appeared not to work — switching it barely changed the results, unlike the viewer's time-range picker which works correctly.

The Services tab query runner constrained time only via the coarse `toStartOfDay(time_bucket)` partition-pruning filter. The precise timestamp bound — which the shared `{filters}` placeholder expands into — was never applied, because `ServicesQueryRunner._calculate()` called `execute_hogql_query()` without passing `filters=HogQLFilters(dateRange=...)`. When `filters` is absent the placeholder resolves to a no-op (`Constant(True)`), leaving day-level granularity as the only time constraint. So "Last hour" returned everything since midnight, and any change within the same day did nothing.

The logs viewer's `LogsQueryRunner` already passes this filter, which is why its time-range picker behaves correctly.

## Changes

Pass `filters=HogQLFilters(dateRange=self.query.dateRange)` to both the aggregates and sparkline `execute_hogql_query()` calls in `ServicesQueryRunner._calculate()`, mirroring the viewer runner. This expands the `{filters}` placeholder into the precise `timestamp >= date_from AND timestamp <= date_to` bound on top of the existing day-level partition filter.

## How did you test this code?

I'm an agent (PostHog Code). I added a ClickHouse-backed test and ran it locally — it passes.

`products/logs/backend/test/test_services_query_runner.py::TestServicesQueryDateRange::test_services_honors_sub_day_date_range` ingests the existing `test_logs.jsonnd` fixture (1003 logs on 2025-12-16 across 12 services) and asserts a 9-minute sub-day window returns only the 100 logs in that window from a single service, while a full-day query returns all 1003. No existing test exercised `ServicesQueryRunner` against ClickHouse, so this catches exactly the regression fixed here: drop the `filters=` argument and the windowed query falls back to the whole day (1003 rows / 12 services).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a user report that the Services-tab date selector did nothing. Traced it from the frontend (`logsServicesLogic` → `setDateFrom` → `loadServicesData`, which is wired correctly) down to the backend, where the divergence from the working viewer query runner was the missing `filters=HogQLFilters(dateRange=...)` argument. Confirmed via `posthog/hogql/filters.py` that an unfilled `{filters}` placeholder collapses to `Constant(True)`.

Invoked the `/writing-tests` skill before adding the test; chose a ClickHouse-backed API test (rather than a lower rung) because the bug lives in HogQL filter expansion and is only observable end-to-end.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
