### PR TITLE
fix: run the query_log_archive export schedule by default

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -163,4 +163,5 @@ query_log_archive_export_schedule = dagster.build_schedule_from_partitioned_job(
     export_query_log_archive_to_s3,
     hour_of_day=6,
     minute_of_hour=0,
+    default_status=dagster.DefaultScheduleStatus.RUNNING,
 )

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')


### PR DESCRIPTION
## Problem

The daily `query_log_archive` export schedule never fired

## Changes

- Set `default_status=dagster.DefaultScheduleStatus.RUNNING` on `query_log_archive_export_schedule` 

## How did you test this code?

na

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up after the assignee noticed the daily schedule didn't fire overnight. Root cause was the missing `default_status`; fix aligns with the existing backups-schedule convention.
