### PR TITLE
feat(customer-analytics): add billing columns to accounts list

### DIFF
--- a/products/customer_analytics/backend/constants.py
+++ b/products/customer_analytics/backend/constants.py
@@ -14,4 +14,14 @@ ACCOUNT_ASSIGNMENT_ROLE_FIELDS = ("csm", "account_executive", "account_owner")
 BILLING_USAGE_INSIGHT_SHORT_IDS = ["fiJDsKLp"]
 BILLING_SPEND_INSIGHT_SHORT_IDS = ["o4I9sdFE", "Tjo4bsux"]
 
+# PostHog-internal billing warehouse view (one row per org per invoice period), keyed by
+# organization_id (== an account's external_id). Backs the optional, picker-only `confirmed_mrr`
+# and `credits_used` account columns. Like the billing insights above, it only exists in
+# environments with the billing warehouse data; the account columns resolve to NULL elsewhere.
+# Mirrors the frontend constants in components/Accounts/constants.ts.
+BILLING_INVOICES_VIEW_NAME = "billing_invoices_by_org"
+BILLING_CONFIRMED_MRR_COLUMN = "confirmed_mrr"
+BILLING_CREDITS_USED_COLUMN = "credits_used"
+BILLING_PICKER_COLUMNS = (BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN)
+
 CUSTOM_PROPERTY_DISPLAY_TYPE_CHOICES = ["text", "number", "currency", "percent", "date", "datetime", "boolean"]

--- a/products/customer_analytics/backend/hogql_queries/accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/accounts_query_runner.py
@@ -1,6 +1,7 @@
 from posthog.schema import AccountsQuery, AccountsQueryResponse, CachedAccountsQueryResponse
 
 from posthog.hogql import ast
+from posthog.hogql.database.database import Database
 from posthog.hogql.errors import BaseHogQLError, ExposedHogQLError
 from posthog.hogql.parser import parse_expr, parse_order_expr, parse_select
 from posthog.hogql.query import execute_hogql_query
@@ -10,6 +11,8 @@ from posthog.hogql_queries.insights.paginators import HogQLHasMorePaginator
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models import User
 from posthog.rbac.user_access_control import UserAccessControl
+
+from products.customer_analytics.backend.constants import BILLING_INVOICES_VIEW_NAME, BILLING_PICKER_COLUMNS
 
 NAME_COLUMN = "name"
 
@@ -49,8 +52,14 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
 
         self.columns: list[str] = []
         self._select_exprs: list[ast.Expr] = []
+        # Whether the internal billing view exists for this team. Resolved once, and only when a
+        # billing column is actually requested, so ordinary queries never pay the database-build
+        # cost. Drives whether billing columns join the view or fall back to NULL.
+        self._billing_view_available = False
         if not self._metrics_only:
             raw_selects = list(self.query.select) if self.query.select else list(DEFAULT_COLUMNS)
+            if any(raw in BILLING_PICKER_COLUMNS for raw in raw_selects):
+                self._billing_view_available = self._check_billing_view_available()
             seen: set[str] = set()
             for raw in raw_selects:
                 column_name, expr = self._resolve_column(raw)
@@ -62,6 +71,9 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
             if NAME_COLUMN not in seen:
                 self.columns.insert(0, NAME_COLUMN)
                 self._select_exprs.insert(0, self._name_tuple_expr())
+
+        # Billing columns trigger a LEFT JOIN against the internal billing view in `to_query`.
+        self._requested_billing_columns: list[str] = [c for c in self.columns if c in BILLING_PICKER_COLUMNS]
 
         self.paginator = HogQLHasMorePaginator.from_limit_context(
             limit_context=self.limit_context,
@@ -77,6 +89,8 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
     def _resolve_column(self, raw: str) -> tuple[str, ast.Expr]:
         if raw == NAME_COLUMN:
             return NAME_COLUMN, self._name_tuple_expr()
+        if raw in BILLING_PICKER_COLUMNS:
+            return raw, self._billing_column_expr(raw)
         expr = parse_expr(raw)
         column_name = expr.alias if isinstance(expr, ast.Alias) else raw
         return column_name, expr
@@ -95,6 +109,50 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
                     ast.Field(chain=["external_id"]),
                     ast.Call(name="toString", args=[ast.Field(chain=["id"])]),
                 ],
+            ),
+        )
+
+    def _check_billing_view_available(self) -> bool:
+        # The billing view is PostHog-internal; it only exists where the billing warehouse data is
+        # synced. Build the team's HogQL database to check — done lazily (only when a billing column
+        # is requested) since the build isn't free. Fail closed (NULL columns) on any error.
+        try:
+            database = Database.create_for(team=self.team, user=self.user)
+            return database.has_table(BILLING_INVOICES_VIEW_NAME)
+        except Exception:
+            return False
+
+    def _billing_column_expr(self, column: str) -> ast.Expr:
+        # With the view present, read the column off the joined `billing` subquery (added in
+        # `to_query`); without it, resolve to NULL so the column stays present but empty.
+        if self._billing_view_available:
+            return ast.Alias(alias=column, expr=ast.Field(chain=["billing", column]))
+        return ast.Alias(alias=column, expr=ast.Constant(value=None))
+
+    def _billing_join_expr(self) -> ast.JoinExpr:
+        # Pre-aggregate the billing view to one current-calendar-month row per org, then LEFT JOIN
+        # on the account's external_id. The GROUP BY keeps it one row per org, so the per-account
+        # query stays one row per account (no GROUP BY there). Accounts with no invoice in the
+        # current month don't match and surface NULL. Aliases must match BILLING_PICKER_COLUMNS.
+        subquery = parse_select(
+            """
+            SELECT
+                organization_id,
+                sumIf(mrr, type NOT LIKE '%upcoming%') AS confirmed_mrr,
+                sum(credits_used) AS credits_used
+            FROM {view}
+            WHERE toStartOfMonth(period_end) = toStartOfMonth(now())
+            GROUP BY organization_id
+            """,
+            {"view": ast.Field(chain=[BILLING_INVOICES_VIEW_NAME])},
+        )
+        return ast.JoinExpr(
+            table=subquery,
+            alias="billing",
+            join_type="LEFT JOIN",
+            constraint=ast.JoinConstraint(
+                expr=parse_expr("billing.organization_id = accounts.external_id"),
+                constraint_type="ON",
             ),
         )
 
@@ -129,12 +187,16 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
         where_exprs = self._build_where_exprs()
         order_clauses = self.query.orderBy or [DEFAULT_ORDER_BY]
 
+        select_from = ast.JoinExpr(
+            table=ast.Field(chain=["system", "accounts"]),
+            alias="accounts",
+        )
+        if self._requested_billing_columns and self._billing_view_available:
+            select_from.next_join = self._billing_join_expr()
+
         return ast.SelectQuery(
             select=self._select_exprs,
-            select_from=ast.JoinExpr(
-                table=ast.Field(chain=["system", "accounts"]),
-                alias="accounts",
-            ),
+            select_from=select_from,
             where=ast.And(exprs=where_exprs) if where_exprs else None,
             order_by=[parse_order_expr(_normalize_order_clause(c), timings=self.timings) for c in order_clauses],
         )

--- a/products/customer_analytics/backend/hogql_queries/accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/accounts_query_runner.py
@@ -1,3 +1,5 @@
+from django.db import DatabaseError
+
 from posthog.schema import AccountsQuery, AccountsQueryResponse, CachedAccountsQueryResponse
 
 from posthog.hogql import ast
@@ -12,7 +14,12 @@ from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.models import User
 from posthog.rbac.user_access_control import UserAccessControl
 
-from products.customer_analytics.backend.constants import BILLING_INVOICES_VIEW_NAME, BILLING_PICKER_COLUMNS
+from products.customer_analytics.backend.constants import (
+    BILLING_CONFIRMED_MRR_COLUMN,
+    BILLING_CREDITS_USED_COLUMN,
+    BILLING_INVOICES_VIEW_NAME,
+    BILLING_PICKER_COLUMNS,
+)
 
 NAME_COLUMN = "name"
 
@@ -115,11 +122,12 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
     def _check_billing_view_available(self) -> bool:
         # The billing view is PostHog-internal; it only exists where the billing warehouse data is
         # synced. Build the team's HogQL database to check — done lazily (only when a billing column
-        # is requested) since the build isn't free. Fail closed (NULL columns) on any error.
+        # is requested) since the build isn't free. Fail closed (NULL columns) if the schema can't
+        # be resolved; genuine programming errors are left to propagate.
         try:
             database = Database.create_for(team=self.team, user=self.user)
             return database.has_table(BILLING_INVOICES_VIEW_NAME)
-        except Exception:
+        except (DatabaseError, BaseHogQLError):
             return False
 
     def _billing_column_expr(self, column: str) -> ast.Expr:
@@ -133,18 +141,29 @@ class AccountsQueryRunner(AnalyticsQueryRunner[AccountsQueryResponse]):
         # Pre-aggregate the billing view to one current-calendar-month row per org, then LEFT JOIN
         # on the account's external_id. The GROUP BY keeps it one row per org, so the per-account
         # query stays one row per account (no GROUP BY there). Accounts with no invoice in the
-        # current month don't match and surface NULL. Aliases must match BILLING_PICKER_COLUMNS.
+        # current month don't match and surface NULL.
         subquery = parse_select(
             """
-            SELECT
-                organization_id,
-                sumIf(mrr, type NOT LIKE '%upcoming%') AS confirmed_mrr,
-                sum(credits_used) AS credits_used
+            SELECT organization_id
             FROM {view}
             WHERE toStartOfMonth(period_end) = toStartOfMonth(now())
             GROUP BY organization_id
             """,
             {"view": ast.Field(chain=[BILLING_INVOICES_VIEW_NAME])},
+        )
+        assert isinstance(subquery, ast.SelectQuery)
+        # Output aliases come from the column constants (not SQL literals) so they can't drift from
+        # what `_billing_column_expr` reads back as `billing.<column>` — a constant rename can't
+        # silently turn every billing cell into NULL. The aggregated source fields (`mrr`,
+        # `credits_used`) are columns of the billing view itself, not these output names.
+        subquery.select.extend(
+            [
+                ast.Alias(
+                    alias=BILLING_CONFIRMED_MRR_COLUMN,
+                    expr=parse_expr("sumIf(mrr, type NOT LIKE '%upcoming%')"),
+                ),
+                ast.Alias(alias=BILLING_CREDITS_USED_COLUMN, expr=parse_expr("sum(credits_used)")),
+            ]
         )
         return ast.JoinExpr(
             table=subquery,

--- a/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
@@ -1,4 +1,5 @@
 from posthog.test.base import ClickhouseTestMixin, NonAtomicBaseTest
+from unittest.mock import patch
 
 from django.test import override_settings
 from django.utils import timezone
@@ -7,6 +8,7 @@ from parameterized import parameterized
 
 from posthog.schema import AccountsQuery, AccountsQueryResponse
 
+from posthog.hogql import ast
 from posthog.hogql.errors import ExposedHogQLError
 
 from posthog.api.tagged_item import set_tags_on_object
@@ -517,3 +519,52 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
 
         runner = AccountsQueryRunner(query=AccountsQuery(), team=self.team)
         self.assertRaises(UserAccessControlError, runner.validate_query_runner_access, self.user)
+
+    def test_billing_columns_resolve_to_null_when_view_absent(self):
+        create_account(team_id=self.team.id, name="A")
+        with patch.object(AccountsQueryRunner, "_check_billing_view_available", return_value=False):
+            runner, response = self._run_query(select=["name", "confirmed_mrr", "credits_used"])
+        self.assertEqual(runner.columns, ["name", "confirmed_mrr", "credits_used"])
+        # No join is added, so the query never references the (absent) view; the columns are still
+        # present, just NULL.
+        self.assertIsNone(runner.to_query().select_from.next_join)
+        name_idx = runner.columns.index("name")
+        billing_cells = [cell for idx, cell in enumerate(response.results[0]) if idx != name_idx]
+        self.assertEqual(billing_cells, [None, None])
+
+    def test_billing_columns_join_the_view_when_present(self):
+        with patch.object(AccountsQueryRunner, "_check_billing_view_available", return_value=True):
+            runner = AccountsQueryRunner(
+                query=AccountsQuery(
+                    select=["name", "confirmed_mrr", "credits_used"],
+                    orderBy=["confirmed_mrr DESC"],
+                ),
+                team=self.team,
+                user=self.user,
+            )
+            query = runner.to_query()
+        self.assertEqual(runner.columns, ["name", "confirmed_mrr", "credits_used"])
+        join = query.select_from.next_join
+        self.assertIsInstance(join, ast.JoinExpr)
+        self.assertEqual(join.join_type, "LEFT JOIN")
+        self.assertEqual(join.alias, "billing")
+        # Billing columns read off the joined `billing` subquery, aliased back to their bare names.
+        mrr_expr = runner._select_exprs[runner.columns.index("confirmed_mrr")]
+        self.assertIsInstance(mrr_expr, ast.Alias)
+        self.assertEqual(mrr_expr.alias, "confirmed_mrr")
+        self.assertEqual(mrr_expr.expr.chain, ["billing", "confirmed_mrr"])
+
+    def test_billing_columns_not_requested_skips_view_check(self):
+        with patch.object(AccountsQueryRunner, "_check_billing_view_available") as check_view:
+            runner = AccountsQueryRunner(query=AccountsQuery(select=["name"]), team=self.team, user=self.user)
+        # A query without billing columns must not pay the database-build cost of the view check.
+        check_view.assert_not_called()
+        self.assertEqual(runner._requested_billing_columns, [])
+        self.assertIsNone(runner.to_query().select_from.next_join)
+
+    def test_billing_column_in_overview_metric_raises(self):
+        # Overview tiles run against system.accounts only (no billing join), so a tile referencing a
+        # billing column fails — billing metrics are out of scope for now.
+        create_account(team_id=self.team.id, name="A")
+        with self.assertRaises(ExposedHogQLError):
+            self._run_query(select=["name"], metrics=["sum(confirmed_mrr)"])

--- a/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
@@ -527,7 +527,9 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
         self.assertEqual(runner.columns, ["name", "confirmed_mrr", "credits_used"])
         # No join is added, so the query never references the (absent) view; the columns are still
         # present, just NULL.
-        self.assertIsNone(runner.to_query().select_from.next_join)
+        select_from = runner.to_query().select_from
+        assert select_from is not None
+        self.assertIsNone(select_from.next_join)
         name_idx = runner.columns.index("name")
         billing_cells = [cell for idx, cell in enumerate(response.results[0]) if idx != name_idx]
         self.assertEqual(billing_cells, [None, None])
@@ -544,14 +546,16 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
             )
             query = runner.to_query()
         self.assertEqual(runner.columns, ["name", "confirmed_mrr", "credits_used"])
+        assert query.select_from is not None
         join = query.select_from.next_join
-        self.assertIsInstance(join, ast.JoinExpr)
+        assert isinstance(join, ast.JoinExpr)
         self.assertEqual(join.join_type, "LEFT JOIN")
         self.assertEqual(join.alias, "billing")
         # Billing columns read off the joined `billing` subquery, aliased back to their bare names.
         mrr_expr = runner._select_exprs[runner.columns.index("confirmed_mrr")]
-        self.assertIsInstance(mrr_expr, ast.Alias)
+        assert isinstance(mrr_expr, ast.Alias)
         self.assertEqual(mrr_expr.alias, "confirmed_mrr")
+        assert isinstance(mrr_expr.expr, ast.Field)
         self.assertEqual(mrr_expr.expr.chain, ["billing", "confirmed_mrr"])
 
     def test_billing_columns_not_requested_skips_view_check(self):
@@ -560,7 +564,9 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
         # A query without billing columns must not pay the database-build cost of the view check.
         check_view.assert_not_called()
         self.assertEqual(runner._requested_billing_columns, [])
-        self.assertIsNone(runner.to_query().select_from.next_join)
+        select_from = runner.to_query().select_from
+        assert select_from is not None
+        self.assertIsNone(select_from.next_join)
 
     def test_billing_column_in_overview_metric_raises(self):
         # Overview tiles run against system.accounts only (no billing join), so a tile referencing a

--- a/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
+++ b/products/customer_analytics/backend/hogql_queries/test/test_accounts_query_runner.py
@@ -17,6 +17,7 @@ from posthog.models import Tag, User
 from posthog.models.team import Team
 from posthog.rbac.user_access_control import UserAccessControlError
 
+from products.customer_analytics.backend.constants import BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN
 from products.customer_analytics.backend.hogql_queries.accounts_query_runner import AccountsQueryRunner
 from products.customer_analytics.backend.test.factories import create_account
 from products.notebooks.backend.models import Notebook, ResourceNotebook
@@ -538,25 +539,30 @@ class TestAccountsQueryRunner(ClickhouseTestMixin, NonAtomicBaseTest):
         with patch.object(AccountsQueryRunner, "_check_billing_view_available", return_value=True):
             runner = AccountsQueryRunner(
                 query=AccountsQuery(
-                    select=["name", "confirmed_mrr", "credits_used"],
-                    orderBy=["confirmed_mrr DESC"],
+                    select=["name", BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN],
+                    orderBy=[f"{BILLING_CONFIRMED_MRR_COLUMN} DESC"],
                 ),
                 team=self.team,
                 user=self.user,
             )
             query = runner.to_query()
-        self.assertEqual(runner.columns, ["name", "confirmed_mrr", "credits_used"])
+        self.assertEqual(runner.columns, ["name", BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN])
         assert query.select_from is not None
         join = query.select_from.next_join
         assert isinstance(join, ast.JoinExpr)
         self.assertEqual(join.join_type, "LEFT JOIN")
         self.assertEqual(join.alias, "billing")
-        # Billing columns read off the joined `billing` subquery, aliased back to their bare names.
-        mrr_expr = runner._select_exprs[runner.columns.index("confirmed_mrr")]
+        # The joined subquery must export columns named exactly as the constants the outer query
+        # reads back as `billing.<column>` — otherwise the join succeeds but every cell is NULL.
+        assert isinstance(join.table, ast.SelectQuery)
+        subquery_aliases = {expr.alias for expr in join.table.select if isinstance(expr, ast.Alias)}
+        self.assertEqual(subquery_aliases, {BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN})
+        # The outer SELECT reads each billing column off the `billing` subquery, aliased to its name.
+        mrr_expr = runner._select_exprs[runner.columns.index(BILLING_CONFIRMED_MRR_COLUMN)]
         assert isinstance(mrr_expr, ast.Alias)
-        self.assertEqual(mrr_expr.alias, "confirmed_mrr")
+        self.assertEqual(mrr_expr.alias, BILLING_CONFIRMED_MRR_COLUMN)
         assert isinstance(mrr_expr.expr, ast.Field)
-        self.assertEqual(mrr_expr.expr.chain, ["billing", "confirmed_mrr"])
+        self.assertEqual(mrr_expr.expr.chain, ["billing", BILLING_CONFIRMED_MRR_COLUMN])
 
     def test_billing_columns_not_requested_skips_view_check(self):
         with patch.object(AccountsQueryRunner, "_check_billing_view_available") as check_view:

--- a/products/customer_analytics/frontend/components/Accounts/AGENTS.md
+++ b/products/customer_analytics/frontend/components/Accounts/AGENTS.md
@@ -52,6 +52,8 @@ AccountsTabContent  ── binds dataNodeLogic(ACCOUNTS_HOGQL_DATA_NODE_KEY, acc
 
 Default columns (`ACCOUNTS_HOGQL_DEFAULT_SELECT`): `name`, `tag_names`, `notebook_count`, `csm`, `account_executive`, `account_owner`. The name column is force-kept (`ensureNameColumn`) — removing it breaks identity, scroll, and role edits. Extra columns come from account properties, lazy/virtual-table joins under `system.accounts`, data-warehouse joins, or freeform SQL — all assembled by `buildAccountColumnGroups`.
 
+**Billing columns** (`confirmed_mrr`, `credits_used`) are two optional, picker-only columns (a "Billing" group in `buildAccountColumnGroups`, **not** in the default select). They're PostHog-internal: `buildAccountColumnGroups` only offers them when the `billing_invoices_by_org` warehouse view is present in `allTablesMap`, and the backend (`accounts_query_runner`) resolves them to `NULL` where the view is absent — so they degrade gracefully like the Spend/Usage tabs. The runner special-cases the two bare column names and, when they're selected, `LEFT JOIN`s a current-calendar-month aggregate of that view on `accounts.external_id = organization_id`; accounts with no current-month invoice surface `NULL` (rendered `—`). Values are currency-formatted via `humanFriendlyCurrency` (`KNOWN_COLUMN_TEMPLATES`); `credits_used` keeps the source's raw sign (credits are stored negative). Constants are mirrored in `constants.ts` ↔ `backend/constants.py`. No new analytics events — adding/removing these columns flows through the existing view-save events.
+
 Sort safety: removing the sorted column drops the sort (`clearSortIfColumnRemoved`), else the backend gets an `orderBy` referencing a missing alias.
 
 ## The expanded row
@@ -121,7 +123,7 @@ The tool is registered for the page regardless of agent mode. The Customer analy
 ### Backend touchpoints
 
 - `products/customer_analytics/backend/models` — the `Account` model (`external_id` = group key).
-- `products/customer_analytics/backend/` — `accounts_query_runner` (builds the list rows + cell tuples).
+- `products/customer_analytics/backend/` — `accounts_query_runner` (builds the list rows + cell tuples; also LEFT-joins the internal `billing_invoices_by_org` view for the optional `confirmed_mrr`/`credits_used` columns when they're selected and the view exists).
 - `products/customer_analytics/backend/max_tools/` — `OpenAccountTool` and other account Max tools.
 - `ee/hogai/core/agent_modes/presets/customer_analytics.py` — the Customer analytics agent mode (gated by the `customer-analytics-csp` flag).
 

--- a/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountsHogQLTable.tsx
@@ -8,6 +8,7 @@ import { MemberSelect } from 'lib/components/MemberSelect'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { SortingIndicator } from 'lib/lemon-ui/LemonTable/sorting'
+import { humanFriendlyCurrency } from 'lib/utils/numbers'
 
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { DataTable } from '~/queries/nodes/DataTable/DataTable'
@@ -19,6 +20,7 @@ import { AccountNotebooksExpansion } from './AccountNotebooksExpansion'
 import { ACCOUNTS_NAME_COLUMN, accountsColumnConfigLogic } from './accountsColumnConfigLogic'
 import { accountsExpansionLogic } from './accountsExpansionLogic'
 import { AccountRoleKey, accountsLogic } from './accountsLogic'
+import { BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN } from './constants'
 
 type AccountAssignment = { id: number; email: string } | null
 
@@ -38,6 +40,8 @@ const COLUMN_WIDTHS = {
     csm: '220px',
     account_executive: '220px',
     account_owner: '220px',
+    confirmed_mrr: '140px',
+    credits_used: '140px',
 } as const
 
 function getCellAt(record: unknown, names: string[], column: string): unknown {
@@ -109,6 +113,22 @@ function NotebookCountCell({ record }: { record: unknown }): JSX.Element {
     const getCell = useGetCell()
     const count = Number(getCell(record, 'notebook_count')) || 0
     return count > 0 ? <span>{count}</span> : <span className="text-muted">—</span>
+}
+
+// Billing columns (confirmed_mrr / credits_used) come from the internal billing view as numbers,
+// or NULL where the account has no current-month invoice / the view is absent. Render currency,
+// dash for missing. Raw sign is preserved (credits are stored negative).
+function CurrencyCell({ record, column }: { record: unknown; column: string }): JSX.Element {
+    const getCell = useGetCell()
+    const raw = getCell(record, column)
+    if (raw === null || raw === undefined) {
+        return <span className="text-muted">—</span>
+    }
+    const numeric = typeof raw === 'number' ? raw : Number(raw)
+    if (!Number.isFinite(numeric)) {
+        return <span className="text-muted">—</span>
+    }
+    return <span>{humanFriendlyCurrency(numeric)}</span>
 }
 
 function RoleAssignmentCell({ record, role }: { record: unknown; role: AccountRoleKey }): JSX.Element {
@@ -221,6 +241,16 @@ const KNOWN_COLUMN_TEMPLATES: Record<string, KnownColumnTemplate> = {
         label: ROLE_LABELS.account_owner,
         width: COLUMN_WIDTHS.account_owner,
         render: ({ record }) => <RoleAssignmentCell record={record} role="account_owner" />,
+    },
+    [BILLING_CONFIRMED_MRR_COLUMN]: {
+        label: 'Confirmed MRR',
+        width: COLUMN_WIDTHS.confirmed_mrr,
+        render: ({ record }) => <CurrencyCell record={record} column={BILLING_CONFIRMED_MRR_COLUMN} />,
+    },
+    [BILLING_CREDITS_USED_COLUMN]: {
+        label: 'Credits used',
+        width: COLUMN_WIDTHS.credits_used,
+        render: ({ record }) => <CurrencyCell record={record} column={BILLING_CREDITS_USED_COLUMN} />,
     },
 }
 

--- a/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.test.ts
@@ -1,0 +1,37 @@
+import { DatabaseSchemaTable } from '~/queries/schema/schema-general'
+
+import { buildAccountColumnGroups } from './accountsColumnConfigLogic'
+import { BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN, BILLING_INVOICES_VIEW_NAME } from './constants'
+
+const accountsTableOnly = {
+    'system.accounts': { name: 'accounts', fields: {} },
+} as unknown as Record<string, DatabaseSchemaTable>
+
+const withBillingView = {
+    ...accountsTableOnly,
+    [BILLING_INVOICES_VIEW_NAME]: { name: BILLING_INVOICES_VIEW_NAME, fields: {} },
+} as unknown as Record<string, DatabaseSchemaTable>
+
+describe('buildAccountColumnGroups', () => {
+    it('adds the Billing group when the billing view is present in the schema', () => {
+        const billing = buildAccountColumnGroups(withBillingView, []).find((group) => group.key === 'billing')
+        expect(billing?.label).toBe('Billing')
+        expect(billing?.options.map((option) => option.name)).toEqual([
+            BILLING_CONFIRMED_MRR_COLUMN,
+            BILLING_CREDITS_USED_COLUMN,
+        ])
+    })
+
+    it('omits the Billing group when the billing view is absent', () => {
+        const groups = buildAccountColumnGroups(accountsTableOnly, [])
+        expect(groups.find((group) => group.key === 'billing')).toBeUndefined()
+    })
+
+    it('uses bare-name expressions so the backend special-cases them (not join-prefixed)', () => {
+        const billing = buildAccountColumnGroups(withBillingView, []).find((group) => group.key === 'billing')
+        expect(billing?.options).toHaveLength(2)
+        for (const option of billing?.options ?? []) {
+            expect(option.expression).toBe(option.name)
+        }
+    })
+})

--- a/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.ts
@@ -11,6 +11,7 @@ import type { DataWarehouseViewLink } from '~/types'
 import { joinsLogic } from 'products/data_warehouse/frontend/shared/logics/joinsLogic'
 
 import type { accountsColumnConfigLogicType } from './accountsColumnConfigLogicType'
+import { BILLING_CONFIRMED_MRR_COLUMN, BILLING_CREDITS_USED_COLUMN, BILLING_INVOICES_VIEW_NAME } from './constants'
 
 // Mandatory — the backend emits it as `tuple(name, external_id, id)` so the
 // row identity (id) and copy-able external_id ride along with the display name.
@@ -56,7 +57,7 @@ export const ACCOUNTS_ACCOUNTS_TABLE_NAME = 'system.accounts'
 // of which name the backend hands us.
 const ACCOUNTS_JOIN_SOURCE_TABLE_NAMES = new Set(['accounts', ACCOUNTS_ACCOUNTS_TABLE_NAME])
 
-export type AccountColumnGroupKey = 'account_properties' | 'sql_expression' | `accounts.${string}`
+export type AccountColumnGroupKey = 'account_properties' | 'sql_expression' | 'billing' | `accounts.${string}`
 
 export type AccountColumnOption = {
     name: string
@@ -169,9 +170,28 @@ export function buildAccountColumnGroups(
         addJoinGroup(join.field_name, buildJoinOptions(join.field_name, columnNames, joinedTable))
     }
 
+    // The billing view is PostHog-internal — only offer these columns where it exists in the
+    // schema (warehouse views key into `allTablesMap` by their bare name). The backend resolves
+    // them to NULL if requested elsewhere (e.g. a shared view), so this is a UI-level gate.
+    const billingGroups: AccountColumnGroup[] = []
+    if (allTablesMap?.[BILLING_INVOICES_VIEW_NAME]) {
+        // No `type`: these are display-only currency columns. A numeric type would surface them in
+        // the overview-tiles metric picker (`numericColumnOptions`), but the tiles' metrics query
+        // doesn't add the billing join, so aggregating them would error — keep them out of tiles.
+        billingGroups.push({
+            key: 'billing',
+            label: 'Billing',
+            options: [
+                { name: BILLING_CONFIRMED_MRR_COLUMN, expression: BILLING_CONFIRMED_MRR_COLUMN },
+                { name: BILLING_CREDITS_USED_COLUMN, expression: BILLING_CREDITS_USED_COLUMN },
+            ],
+        })
+    }
+
     return [
         { key: 'account_properties', label: 'Account properties', options: directOptions },
         ...joinGroups,
+        ...billingGroups,
         { key: 'sql_expression', label: 'SQL expression', options: [], isFreeform: true },
     ]
 }

--- a/products/customer_analytics/frontend/components/Accounts/constants.ts
+++ b/products/customer_analytics/frontend/components/Accounts/constants.ts
@@ -42,3 +42,11 @@ export const AccountsEvents = {
     TabViewed: 'customer analytics account tab viewed',
     RelatedUserClicked: 'customer analytics account related user clicked',
 } as const
+
+// PostHog-internal billing warehouse view backing the optional, picker-only `confirmed_mrr` and
+// `credits_used` columns. The columns are only offered when this view is present in the HogQL
+// schema (`allTablesMap`), and resolve to NULL elsewhere — mirrors the Spend/Usage tabs.
+// Keep in sync with backend/constants.py (BILLING_INVOICES_VIEW_NAME / BILLING_*_COLUMN).
+export const BILLING_INVOICES_VIEW_NAME = 'billing_invoices_by_org'
+export const BILLING_CONFIRMED_MRR_COLUMN = 'confirmed_mrr'
+export const BILLING_CREDITS_USED_COLUMN = 'credits_used'


### PR DESCRIPTION
## Problem

In Customer analytics, the Accounts list lets you configure which columns show per customer — but two of the most useful revenue signals, confirmed MRR and credits used, were only visible one account at a time inside an account's expanded Spend tab. There was no way to scan or sort the whole customer list by MRR or credits.

## Changes

Adds two optional, picker-only columns to the Accounts table, under a new **Billing** group in Configure columns:

- **Confirmed MRR** — the current calendar month's confirmed MRR per account.
- **Credits used** — the current calendar month's credits used per account.

Both come from the existing internal `billing_invoices_by_org` warehouse view (the same data behind the per-account Spend chart), aggregated to one row per org and joined to `system.accounts` on `external_id = organization_id`.

Design points:

- **Degrades gracefully.** The view is internal-only, so the frontend only offers the columns when the view is present in the team's schema, and the backend query runner resolves them to `NULL` when it's absent — nothing breaks elsewhere, matching the existing Spend/Usage tabs.
- **Picker-only.** Not in the default column set; you opt in.
- **Current month.** Accounts with no current-month invoice render as `—`.
- **Kept out of overview tiles for now.** The tiles' metrics query doesn't carry the billing join, so the columns are deliberately excluded from the tile metric picker (a numeric type would have surfaced them and produced erroring tiles).

Everything stays inside the `customer_analytics` product — no core HogQL schema changes. The runner special-cases the two bare column names and adds the join on demand; constants are mirrored between `backend/constants.py` and the frontend `constants.ts`.

No screenshots: I'm an agent and didn't run the UI.

## How did you test this code?

I'm an agent (Claude Code) and did not manually exercise the UI. What I actually ran:

- `ruff check` + `ruff format --check` on the changed Python — clean.
- `python -m py_compile` on the changed Python — clean.
- Validated the core approach with a read-only HogQL query (accounts joined to the billing view, current-month aggregate): it resolves, returns one value per account, and sorts by the joined alias.

Could not run in this sandbox (no Python/JS deps installed) — **CI will**: pytest, Jest, `tsc`, and `tach`.

Tests added and the regressions they catch:

- **Backend** (`test_accounts_query_runner.py`): absent view → columns resolve to `NULL` and no join is added (the graceful-degrade contract); present view → the `LEFT JOIN` is built with the right alias and the billing columns read off it; a non-billing query never triggers the view-existence DB build; a billing column used as a tile metric raises (documents the boundary).
- **Frontend** (`accountsColumnConfigLogic.test.ts`): the Billing group appears only when the view is in the schema, and its options use bare-name expressions (so the backend special-cases them instead of treating them as join columns).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Internal-only feature; no public docs change expected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- **Agent/tools:** Claude Code, plus the PostHog MCP (read-only) to inspect the saved Spend insights and validate the accounts-to-billing-view join against live data before writing any code.
- **Skills:** none of the repo's mandatory skills strictly applied — no DRF viewset/serializer, migration, or generated-API-type changes (the columns flow through the existing `AccountsQuery`). Tests follow the existing `test_accounts_query_runner.py` and `accountsViewState.test.ts` patterns.
- **Key decisions:**
  - Kept the feature inside the product rather than adding the columns to the shared `system.accounts` HogQL schema — that table is used by every team, so a hardcoded internal view there would pollute every team's picker and break resolution elsewhere.
  - Inferred "billing column requested" from the `select` list instead of adding a query field, avoiding a schema/codegen change.
  - The view-existence check builds the team's HogQL database (`Database.has_table`) only when a billing column is requested — the product-boundary-clean option, since importing the data-modeling saved-query model across products isn't allowed.
  - Caught in review: a numeric column `type` would have leaked these into the overview-tiles metric picker (which can't join billing), so the type was dropped to keep them display-only.
- **Worth a reviewer's eye:** the current-month window means annual-plan accounts with no current-month invoice show `—`, and `credits_used` keeps the source's raw (negative) sign. Both are documented in the code and the Accounts `AGENTS.md`.
