### PR TITLE
feat(replay): add all-teams session replay export admin

### DIFF
--- a/products/replay/backend/admin.py
+++ b/products/replay/backend/admin.py
@@ -1,0 +1,56 @@
+from django.contrib import admin
+from django.http import HttpRequest
+from django.urls import reverse
+from django.utils.html import format_html
+
+from products.replay.backend.models.exported_recording import ExportedRecording
+
+_STATUS_COLORS = {
+    ExportedRecording.Status.COMPLETE: "green",
+    ExportedRecording.Status.FAILED: "red",
+    ExportedRecording.Status.RUNNING: "blue",
+    ExportedRecording.Status.PENDING: "orange",
+}
+
+
+@admin.register(ExportedRecording)
+class ExportedRecordingAdmin(admin.ModelAdmin):
+    list_display = ("session_id", "team_link", "status_display", "created_by", "created_at", "download_link")
+    list_filter = ("status", "created_at")
+    search_fields = ("session_id", "team__name", "team__id", "reason")
+    raw_id_fields = ("team", "created_by")
+    readonly_fields = (
+        "id",
+        "team",
+        "session_id",
+        "reason",
+        "export_location",
+        "status",
+        "error_message",
+        "created_by",
+        "created_at",
+    )
+
+    @admin.display(description="Team", ordering="team")
+    def team_link(self, obj: ExportedRecording) -> str:
+        url = reverse("admin:posthog_team_change", args=[obj.team_id])
+        return format_html('<a href="{}">{}</a>', url, obj.team)
+
+    @admin.display(description="Status", ordering="status")
+    def status_display(self, obj: ExportedRecording) -> str:
+        if obj.is_expired:
+            return format_html('<span style="color: gray;">Expired</span>')
+        color = _STATUS_COLORS.get(ExportedRecording.Status(obj.status), "black")
+        return format_html('<span style="color: {};">{}</span>', color, obj.get_status_display())
+
+    @admin.display(description="Download")
+    def download_link(self, obj: ExportedRecording) -> str:
+        if obj.is_expired or not obj.export_location:
+            return "-"
+        # Reuse the per-team download view, which streams the file from S3.
+        url = reverse("admin:posthog_team_download_export", args=[obj.team_id, obj.id])
+        return format_html('<a class="button" href="{}">Download</a>', url)
+
+    def has_add_permission(self, request: HttpRequest) -> bool:
+        # Exports are created by the recording-export workflow, never via admin.
+        return False


### PR DESCRIPTION
## Problem

Session replay exports are only visible per-team, via the custom `export-history` view on each team's admin page (e.g. `/admin/posthog/team/<id>/export-history/`). There's no way to see what exports are running across all teams, which makes it hard to spot what's generating export activity.

## Changes

Registers an `ExportedRecording` `ModelAdmin` (`products/replay/backend/admin.py`), giving a single project-wide changelist at `/admin/replay/exportedrecording/` that lists every export with:

- Session ID, team (linked to the team admin), status (color-coded, including "Expired"), creator, created-at
- A download link that reuses the existing per-team S3 download view
- Status + date filters and search by session ID / team / reason, all from the framework
- Read-only, with add disabled (exports are created by the recording-export workflow)

Mirrors the existing `replay_vision` admins — the standard Django changelist renders the UI, with only a few `format_html` helpers for the linked/colored columns. No custom template.

## How did you test this code?

I'm an agent. I ran `ruff check` and `ruff format --check` on the new file (both pass) and verified it follows the established `replay_vision` admin pattern. No automated tests added — this is a thin, declarative `ModelAdmin` registration with no new business logic. Not manually exercised in a running admin.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Code agent from a Slack thread, directed by @pauldambra. The original request named the URL `/admin/posthog/export-history/`; I chose a standard `ModelAdmin` instead of a hand-rolled custom admin view + template, which lands at `/admin/replay/exportedrecording/` (the model lives in the `replay` product) but gives filtering, search, and pagination for free and is lower-maintenance. Flagged the URL difference back in the thread. No skills were required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0BCY5Z78A0/p1782334771699679?thread_ts=1782334771.699679&cid=C0BCY5Z78A0)*
