### PR TITLE
fix(toolbar): stop hedgehog config save from logging users out

### DIFF
--- a/frontend/src/lib/components/HedgehogMode/hedgehogModeLogic.ts
+++ b/frontend/src/lib/components/HedgehogMode/hedgehogModeLogic.ts
@@ -65,26 +65,23 @@ export const hedgehogModeLogic = kea<hedgehogModeLogicType>([
                 },
 
                 updateRemoteConfig: async ({ config }) => {
+                    const endpoint = '/api/users/@me/hedgehog_config'
+                    const payload = {
+                        ...values.hedgehogConfig,
+                        ...config,
+                    }
+
+                    const mountedToolbarConfigLogic = toolbarConfigLogic.findMounted()
+                    if (mountedToolbarConfigLogic) {
+                        // Inside the Toolbar the OAuth token is scoped to `user:read` only
+                        // (TOOLBAR_OAUTH_SCOPES grants no `user:write`), so persisting the hedgehog
+                        // config would 403 — and toolbarFetch turns any 403 into a session reset,
+                        // kicking the user out of the Toolbar. Keep the config local to this session.
+                        return mountedToolbarConfigLogic.values.isAuthenticated ? payload : null
+                    }
+
                     try {
-                        const endpoint = '/api/users/@me/hedgehog_config'
-                        let newConfig: Partial<HedgehogConfig>
-
-                        const payload = {
-                            ...values.hedgehogConfig,
-                            ...config,
-                        }
-
-                        const mountedToolbarConfigLogic = toolbarConfigLogic.findMounted()
-                        if (mountedToolbarConfigLogic) {
-                            // If toolbarConfigLogic is mounted, we're inside the Toolbar
-                            if (!mountedToolbarConfigLogic.values.isAuthenticated) {
-                                return null
-                            }
-                            newConfig = await (await toolbarFetch(endpoint, 'PATCH', payload)).json()
-                        } else {
-                            newConfig = await api.update(endpoint, payload)
-                        }
-
+                        const newConfig: Partial<HedgehogConfig> = await api.update(endpoint, payload)
                         return newConfig ?? null
                     } catch (e) {
                         console.error('Failed to update hedgehog remote config', e)

--- a/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
+++ b/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
@@ -36,6 +36,14 @@ describe('shim consumer integration', () => {
     })
 
     describe('hedgehogModeLogic with shims', () => {
+        // MSW installs a never-resolving global.fetch in a beforeAll and never restores it per test,
+        // so a test that swaps global.fetch must put it back or the swap leaks into later tests.
+        let restoreFetch: (() => void) | undefined
+        afterEach(() => {
+            restoreFetch?.()
+            restoreFetch = undefined
+        })
+
         it('mounts without error and has shimmed defaults', async () => {
             const { hedgehogModeLogic } = await import('~/lib/components/HedgehogMode/hedgehogModeLogic')
             const logic = hedgehogModeLogic.build()
@@ -58,7 +66,11 @@ describe('shim consumer integration', () => {
             // The Toolbar OAuth token is scoped to `user:read` but not `user:write`, so the real
             // backend 403s the PATCH while the GET still succeeds. toolbarFetch turns any 403 into a
             // session reset, which used to log the user out of the Toolbar whenever hedgehog mode
-            // moved the hedgehog around. The MSW harness owns global.fetch, so reassign it here.
+            // moved the hedgehog around. Swap in our own mock and let afterEach restore the original.
+            const originalFetch = global.fetch
+            restoreFetch = () => {
+                global.fetch = originalFetch
+            }
             const fetchMock = jest.fn((_url: string, options?: RequestInit) =>
                 Promise.resolve({
                     ok: options?.method !== 'PATCH',

--- a/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
+++ b/frontend/src/toolbar/shims/shimConsumerIntegration.test.ts
@@ -53,6 +53,45 @@ describe('shim consumer integration', () => {
                 logic.mount()
             }).toDispatchActions(['loadRemoteConfig'])
         })
+
+        it('does not PATCH hedgehog_config from the Toolbar, keeping the session alive', async () => {
+            // The Toolbar OAuth token is scoped to `user:read` but not `user:write`, so the real
+            // backend 403s the PATCH while the GET still succeeds. toolbarFetch turns any 403 into a
+            // session reset, which used to log the user out of the Toolbar whenever hedgehog mode
+            // moved the hedgehog around. The MSW harness owns global.fetch, so reassign it here.
+            const fetchMock = jest.fn((_url: string, options?: RequestInit) =>
+                Promise.resolve({
+                    ok: options?.method !== 'PATCH',
+                    status: options?.method === 'PATCH' ? 403 : 200,
+                    json: () => Promise.resolve({}),
+                } as Response)
+            )
+            global.fetch = fetchMock as unknown as typeof fetch
+
+            // Authenticate the Toolbar session — this is the path that used to break.
+            toolbarConfigLogic.actions.setOAuthTokens('access-token', 'refresh-token', 'client-id')
+            expect(toolbarConfigLogic.values.isAuthenticated).toBe(true)
+
+            const { hedgehogModeLogic } = await import('~/lib/components/HedgehogMode/hedgehogModeLogic')
+            const logic = hedgehogModeLogic.build()
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.updateRemoteConfig({ enabled: true })
+            }).toDispatchActions(['updateRemoteConfigSuccess'])
+
+            // The write must never hit the network — a 403 there resets the Toolbar session.
+            const patchCalls = fetchMock.mock.calls.filter(([, options]) => options?.method === 'PATCH')
+            expect(patchCalls).toHaveLength(0)
+
+            // Session survives: the user is not kicked out of the Toolbar.
+            expect(toolbarConfigLogic.values.isAuthenticated).toBe(true)
+
+            // The change is still applied locally so the hedgehog reflects it this session.
+            expect(logic.values.remoteConfig).toMatchObject({ enabled: true })
+
+            logic.unmount()
+        })
     })
 
     describe('themeLogic with shims', () => {


### PR DESCRIPTION
## Problem

Fixes #60375

Users reported the toolbar "crashing" when hedgehog mode is on — they'd get bounced out with a "Please re-authenticate to continue using the toolbar" toast. Under the hood it was a `403` on `PATCH /api/users/@me/hedgehog_config`.

The toolbar's OAuth token is intentionally scoped to `user:read` only (`TOOLBAR_OAUTH_SCOPES`), with no `user:write`. The `hedgehog_config` endpoint requires `user:write` for PATCH, so the write always 403s from the toolbar. `toolbarFetch` treats any 403 as a lost session and clears the OAuth tokens — and because the hedgehog's `syncFromState` saves its position every second while it walks around, the user got logged out almost immediately.

Closes GROW-38

## Changes

In `hedgehogModeLogic.updateRemoteConfig`, when running inside the toolbar, keep the hedgehog config local to the session instead of PATCHing the user endpoint the token can't write to. The hedgehog still works visually; it just doesn't persist appearance back to the account (which the toolbar fundamentally can't do anyway). The main-app save path (session-authenticated `api.update`) is untouched.

Rejected alternatives: granting the toolbar `user:write` (broadens its permissions — a security downgrade), and softening `toolbarFetch`'s 403→logout (a deliberate, transport-wide behavior; riskier to change). Not making a request the token isn't allowed to make is the contained fix.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual browser testing.

- Added a regression test in `shimConsumerIntegration.test.ts`: with a realistic GET-200 / PATCH-403 fetch mock and an authenticated toolbar session, saving hedgehog config makes **no** PATCH, keeps the session authenticated, and applies the change locally. It fails on the old code (it caught the exact `PATCH .../hedgehog_config` carrying the bearer token) and passes on the fix — no existing test covered the toolbar 403→logout path.
- `shimConsumerIntegration.test.ts`: 6/6 pass. Sibling `toolbarConfigLogic.test.ts` (the `toolbarFetch` transport): 159/159 pass.
- `oxlint` and `oxfmt` clean on both files; `kea-typegen` generates the logic type without errors.
- Repo-wide `tsgo` couldn't run clean in this fresh checkout (no generated `*Type.ts` files exist yet), but the change alters neither any action payload nor the loader's return type, so the generated types are structurally unchanged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed — this is an internal bug fix with no user-facing surface change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus 4.8).
- Skills invoked: `/adopting-generated-api-types` (confirmed the `hedgehog_config` endpoint's generated client functions are typed `void` because the backend `@action` lacks a response schema, so I kept the existing `api.update` call rather than expand scope into a backend serializer change + codegen) and `/writing-tests` (shaped the single regression test and checked it against the gate).
- Decision: fix in the frontend logic rather than in backend scopes or the shared `toolbarFetch` 403 handler — narrowest blast radius, no security or transport-wide behavior change.
