### PR TITLE
chore(health): add conversations service role

### DIFF
--- a/posthog/health.py
+++ b/posthog/health.py
@@ -39,7 +39,7 @@ from posthog.security.outbound_proxy import internal_requests
 
 logger = get_logger(__name__)
 
-ServiceRole = Literal["events", "web", "worker", "decide", "query", "report"]
+ServiceRole = Literal["events", "web", "worker", "decide", "query", "report", "conversations"]
 
 service_dependencies: dict[ServiceRole, list[str]] = {
     "events": ["http"],
@@ -72,6 +72,7 @@ service_dependencies: dict[ServiceRole, list[str]] = {
     "decide": ["http"],
     "query": ["http", "postgres", "cache"],
     "report": ["http"],
+    "conversations": ["http", "postgres", "cache"],
 }
 
 # if atleast one of the checks is True, then the service is considered healthy


### PR DESCRIPTION
## Problem

We run the Max AI `conversations` endpoint (`ee/api/conversation.py`) on the shared `posthog-web-django` deployment. It is a long-lived SSE streaming endpoint with a very different resource profile from ordinary web traffic, so we want to move it onto its own Django deployment — exactly as `query`, `report`, `admin`, and `toolbox` already have.

Those split-out deployments differentiate themselves only by their readiness probe role: `/_readyz?role=query` selects a subset of dependency checks via `service_dependencies` in `posthog/health.py`. There is no `conversations` role today, so a pod probing `?role=conversations` would get `400 InvalidRole` and never become ready.

This PR is the small app-side prerequisite. The deployment and ingress routing land in a separate `PostHog/charts` PR, which must not reference the new role until this is live.

## Changes

- Add `"conversations"` to the `ServiceRole` literal.
- Add a `conversations` entry to `service_dependencies` checking `["http", "postgres", "cache"]` — the same set as `query`. The endpoint authenticates and reads the `Conversation` model from Postgres, evaluates feature flags, and relays the response stream from cache/Redis; the LLM work itself runs in Temporal workers, so ClickHouse is deliberately not required.

## How did you test this code?

I'm an agent (PostHog Code). No manual testing. The change is a one-line addition to an enum and its lookup table; existing `posthog/test/test_health.py` exercises `readyz` role handling. No new tests added — the behaviour (a valid role selects its dependency subset) is already covered by the existing role cases, and a `conversations`-specific test would assert nothing those don't.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul directed this work: split the `conversations` endpoint into its own Django deployment, mirroring the existing `query-service` split, with an incremental traffic-migration path. Investigation showed the "split" is entirely an infra concern (a dedicated same-image deployment + Contour path routing); the only app coupling is the readiness role. This PR adds that role. Companion `PostHog/charts` PR stands up the deployment and wires `/api/environments/<id>/conversations` routing at weight 0 for a controlled ramp.

Tool: PostHog Code (Claude Opus). No repo skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
