### PR TITLE
fix(ingestion): add turbo to the IngestionLane type

### DIFF
--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -78,7 +78,7 @@ export type KafkaConsumerBaseConfig = Pick<
 export type PersonBatchWritingDbWriteMode = 'NO_ASSERT' | 'ASSERT_VERSION'
 export type PersonBatchWritingMode = 'BATCH' | 'SHADOW' | 'NONE'
 
-export type IngestionLane = 'main' | 'overflow' | 'historical' | 'async'
+export type IngestionLane = 'main' | 'overflow' | 'turbo' | 'historical' | 'async'
 
 export type IngestionConsumerConfig = {
     INGESTION_LANE: IngestionLane | null


### PR DESCRIPTION
## Problem

The `turbo` ingestion lane runs in prod-us but was never in the `IngestionLane` type, which only listed `main | overflow | historical | async`. The deployed consumer boots with `INGESTION_LANE="turbo"` (charts: `apps/ingestion-analytics-turbo/values.yaml`) and consumes `ingestion-analytics-turbo-1024` (`apps/ingestion-analytics-turbo/values.prod-us.yaml`), with the same real-time SLO as main. Its autoscaling lag triggers explicitly mirror main's. So the app's own type has drifted from what is actually deployed. The lane predates the type: the topic was stood up in early 2026, mirroring the older legacy `ingestion-general-turbo` deployment.

That drift has a downstream consequence worth flagging. The `$feature_flag_called` dedup allowlist (`DEDUP_ALLOWED_LANES`) was built from this incomplete type. The PR that introduced it (#62793) reasoned explicitly about main and overflow deduping while historical and async never do, which is exactly the four lanes the type knew about. turbo was never considered, so a real-time lane silently skips dedup. That reads as an oversight downstream of the type gap, not a decision that turbo should not dedup.

## Changes

Add `turbo` to the `IngestionLane` union. That is the whole change.

It is purely additive. Nothing switches on the lane type exhaustively, and dedup behavior is unchanged: `DEDUP_ALLOWED_LANES` stays `['main', 'overflow', null]`, so turbo still does not dedup today. The point is to make the type recognize a lane that is already running, and to surface the question rather than answer it.

## Open question for reviewers

turbo is real-time and shares main's SLO, so should it dedup `$feature_flag_called` like main and overflow? And was its omission from the allowlist deliberate, or just downstream of this type drift? A related real-time lane, `team2`, is also missing from the type and is handled in a separate branch.

## How did you test this code?

One-line type addition with no runtime behavior change. `tsc --noEmit` on the nodejs package reports no errors in `config.ts`, the dedup service, or anything that consumes `IngestionLane`. The only failures are unrelated workspace-package imports that are not built in a fresh worktree. The existing dedup lane test is unchanged because the allowlist is unchanged. No new tests, since there is no new behavior to cover.