### PR TITLE
fix(inbox): Show First seen and Last updated on report detail

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportDetail.tsx
@@ -95,9 +95,16 @@ function ReportDetailMeta({
             </span>
         )
     }
+    // Mirrors error tracking's "First seen" / "Last seen": surface both lifecycle moments as distinct facts.
     stats.push(
         <span className="flex items-center gap-1">
-            <span>Updated</span>
+            <span>First seen</span>
+            <TZLabel time={report.created_at} />
+        </span>
+    )
+    stats.push(
+        <span className="flex items-center gap-1">
+            <span>Last updated</span>
             <TZLabel time={report.updated_at ?? report.created_at} />
         </span>
     )


### PR DESCRIPTION
## Problem

#65808 collapsed the report detail's timestamps down to a single "Updated" line. As a user, the creation moment still matters — much like error tracking's "First seen" / "Last seen", knowing when a report first appeared is meaningful alongside when it last changed.

## Changes

Restores both timestamps on the report detail meta row, relabeled to match error tracking terminology:
- **First seen** → `created_at`
- **Last updated** → `updated_at`

## How did you test this code?

I'm an agent. I made a focused frontend label/markup change and reviewed the diff; I did not run the frontend tooling (not installed in this environment) or manually test in-browser.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Michael Matloka in a Slack thread reviewing inbox UI nits, following up on #65808. The earlier PR removed the created timestamp; Michael asked to restore it framed as "First seen" with "Updated" becoming "Last updated", drawing the analogy to error tracking's first/last seen. Both timestamps now render unconditionally as distinct facts (the prior "only when they differ" heuristic was already gone post-#65808).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782295851492719?thread_ts=1782295851.492719&cid=C09SK2PAGKF)*
