### PR TITLE
feat(flags): compute has_experiment in the flags PG fallback query

### DIFF
--- a/rust/feature-flags/src/flags/feature_flag_list.rs
+++ b/rust/feature-flags/src/flags/feature_flag_list.rs
@@ -2,8 +2,8 @@ use crate::api::errors::FlagError;
 use crate::cohorts::cohort_models::Cohort;
 use crate::database::get_connection_with_metrics;
 use crate::flags::flag_models::{
-    default_has_experiment, EvaluationMetadata, FeatureFlag, FeatureFlagList, FeatureFlagRow,
-    FlagPropertyGroup, HypercacheFlagsWrapper,
+    EvaluationMetadata, FeatureFlag, FeatureFlagList, FeatureFlagRow, FlagPropertyGroup,
+    HypercacheFlagsWrapper,
 };
 use crate::metrics::consts::TOMBSTONE_COUNTER;
 use common_database::PostgresReader;
@@ -150,7 +150,13 @@ impl FeatureFlagList {
                       ARRAY_AGG(ctx.name) FILTER (WHERE ctx.name IS NOT NULL),
                       '{}'::text[]
                   ) AS evaluation_tags,
-                  bucketing_identifier
+                  bucketing_identifier,
+                  -- Mirror the canonical Django cache writer (products/feature_flags/backend/flags_cache.py,
+                  -- Experiment.objects.filter(deleted=False)). Keep this predicate in lockstep with it.
+                  EXISTS (
+                      SELECT 1 FROM posthog_experiment e
+                      WHERE e.feature_flag_id = f.id AND e.deleted = false
+                  ) AS has_experiment
               FROM posthog_featureflag AS f
               JOIN posthog_team AS t ON (f.team_id = t.id)
               LEFT JOIN posthog_featureflagevaluationcontext AS ec ON (f.id = ec.feature_flag_id)
@@ -194,9 +200,7 @@ impl FeatureFlagList {
                         evaluation_runtime: row.evaluation_runtime,
                         evaluation_tags: row.evaluation_tags,
                         bucketing_identifier: row.bucketing_identifier,
-                        // The PG fallback query doesn't compute experiment linkage, so fall back
-                        // to the shared default (true) for this rare, transient cache-miss path.
-                        has_experiment: default_has_experiment(),
+                        has_experiment: row.has_experiment,
                     }),
                     Err(e) => {
                         // This is highly unlikely to happen, but if it does, we skip the flag.
@@ -315,6 +319,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_from_pg_computes_has_experiment() {
+        let context = TestContext::new(None).await;
+        let team = context
+            .insert_new_team(None)
+            .await
+            .expect("Failed to insert team");
+
+        let make_row = |key: &str| FeatureFlagRow {
+            team_id: team.id,
+            name: Some(key.to_string()),
+            key: key.to_string(),
+            filters: serde_json::json!({"groups": [{"properties": [], "rollout_percentage": 100}]}),
+            active: true,
+            ..Default::default()
+        };
+
+        let live = context
+            .insert_flag(team.id, Some(make_row("flag_with_live_experiment")))
+            .await
+            .expect("Failed to insert flag");
+        let deleted_only = context
+            .insert_flag(team.id, Some(make_row("flag_with_deleted_experiment")))
+            .await
+            .expect("Failed to insert flag");
+        context
+            .insert_flag(team.id, Some(make_row("flag_without_experiment")))
+            .await
+            .expect("Failed to insert flag");
+
+        context
+            .insert_experiment(live.id, team.id, false)
+            .await
+            .expect("Failed to insert live experiment");
+        // A deleted experiment must not count as linkage.
+        context
+            .insert_experiment(deleted_only.id, team.id, true)
+            .await
+            .expect("Failed to insert deleted experiment");
+
+        let flags = FeatureFlagList::from_pg(context.non_persons_reader.clone(), team.id)
+            .await
+            .expect("Failed to fetch flags from pg");
+
+        let by_key = |key: &str| {
+            flags
+                .iter()
+                .find(|f| f.key == key)
+                .unwrap_or_else(|| panic!("missing flag {key}"))
+                .has_experiment
+        };
+
+        assert!(by_key("flag_with_live_experiment"));
+        assert!(!by_key("flag_with_deleted_experiment"));
+        assert!(!by_key("flag_without_experiment"));
+    }
+
+    #[tokio::test]
     async fn test_fetch_empty_team_from_pg() {
         let context = TestContext::new(None).await;
 
@@ -369,6 +430,7 @@ mod tests {
             evaluation_runtime: Some("all".to_string()),
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         let flag2 = FeatureFlagRow {
@@ -384,6 +446,7 @@ mod tests {
             evaluation_runtime: Some("all".to_string()),
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         // Insert multiple flags for the team

--- a/rust/feature-flags/src/flags/flag_matching_utils.rs
+++ b/rust/feature-flags/src/flags/flag_matching_utils.rs
@@ -1660,6 +1660,7 @@ mod tests {
                 evaluation_runtime: None,
                 evaluation_tags: None,
                 bucketing_identifier: None,
+                has_experiment: false,
             };
             context
                 .insert_flag(team.id, Some(flag_row))
@@ -1776,6 +1777,7 @@ mod tests {
                 evaluation_runtime: None,
                 evaluation_tags: None,
                 bucketing_identifier: None,
+                has_experiment: false,
             };
             context
                 .insert_flag(team.id, Some(flag_row))
@@ -1897,6 +1899,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         let inactive_flag = FeatureFlagRow {
@@ -1912,6 +1915,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         let deleted_flag = FeatureFlagRow {
@@ -1927,6 +1931,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         let no_continuity_flag = FeatureFlagRow {
@@ -1942,6 +1947,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
 
         context
@@ -2034,6 +2040,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
         context
             .insert_flag(team.id, Some(flag_row))
@@ -2116,6 +2123,7 @@ mod tests {
             evaluation_runtime: None,
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         };
         context
             .insert_flag(team.id, Some(flag_row))

--- a/rust/feature-flags/src/flags/flag_models.rs
+++ b/rust/feature-flags/src/flags/flag_models.rs
@@ -287,14 +287,14 @@ pub struct FeatureFlag {
     /// Defaults to `true` (rather than the usual `#[serde(default)]` bool false) so cache
     /// entries written by older Django without the field over-preserve properties instead of
     /// stripping them. A spurious `true` only wastes bytes; a spurious `false` would strip
-    /// unrecoverable experiment-exposure data. The fallback query paths share this default via
-    /// `default_has_experiment()`.
+    /// unrecoverable experiment-exposure data. The panic fallback shares this default via
+    /// `default_has_experiment()`; the PG fallback query computes the real value.
     #[serde(default = "default_has_experiment")]
     pub has_experiment: bool,
 }
 
 /// Default for `FeatureFlag::has_experiment` when experiment linkage is unknowable — an
-/// older-Django cache payload missing the field, or a fallback query path that can't compute
+/// older-Django cache payload missing the field, or the panic fallback that can't compute
 /// it. See the field doc for why this is `true` rather than `false`.
 pub(crate) fn default_has_experiment() -> bool {
     true
@@ -330,6 +330,9 @@ pub struct FeatureFlagRow {
     pub evaluation_tags: Option<Vec<String>>,
     #[serde(default)]
     pub bucketing_identifier: Option<String>,
+    /// Populated by the from_pg fallback query via a correlated EXISTS over posthog_experiment.
+    #[serde(default)]
+    pub has_experiment: bool,
 }
 
 /// Request-scoped view of flag definitions plus the per-request filter set.

--- a/rust/feature-flags/src/flags/flag_operations.rs
+++ b/rust/feature-flags/src/flags/flag_operations.rs
@@ -355,6 +355,7 @@ mod tests {
                     evaluation_runtime: Some("all".to_string()),
                     evaluation_tags: None,
                     bucketing_identifier: None,
+                    has_experiment: false,
                 }),
             )
             .await
@@ -456,6 +457,7 @@ mod tests {
                     evaluation_runtime: Some("all".to_string()),
                     evaluation_tags: None,
                     bucketing_identifier: None,
+                    has_experiment: false,
                 }),
             )
             .await
@@ -595,6 +597,7 @@ mod tests {
                     evaluation_runtime: Some("all".to_string()),
                     evaluation_tags: None,
                     bucketing_identifier: None,
+                    has_experiment: false,
                 }),
             )
             .await
@@ -673,6 +676,7 @@ mod tests {
                     evaluation_runtime: Some("all".to_string()),
                     evaluation_tags: None,
                     bucketing_identifier: None,
+                    has_experiment: false,
                 }),
             )
             .await
@@ -768,6 +772,7 @@ mod tests {
                     evaluation_runtime: Some("all".to_string()),
                     evaluation_tags: None,
                     bucketing_identifier: None,
+                    has_experiment: false,
                 }),
             )
             .await
@@ -850,6 +855,7 @@ mod tests {
                         evaluation_runtime: Some("all".to_string()),
                         evaluation_tags: None,
                         bucketing_identifier: None,
+                        has_experiment: false,
                     }),
                 )
                 .await
@@ -943,6 +949,7 @@ mod tests {
                         evaluation_runtime: Some("all".to_string()),
                         evaluation_tags: None,
                         bucketing_identifier: None,
+                        has_experiment: false,
                     }),
                 )
                 .await
@@ -1026,6 +1033,7 @@ mod tests {
                         evaluation_runtime: Some("all".to_string()),
                         evaluation_tags: None,
                         bucketing_identifier: None,
+                        has_experiment: false,
                     }),
                 )
                 .await
@@ -1143,6 +1151,7 @@ mod tests {
                         evaluation_runtime: Some("all".to_string()),
                         evaluation_tags: None,
                         bucketing_identifier: None,
+                        has_experiment: false,
                     }),
                 )
                 .await

--- a/rust/feature-flags/src/utils/test_utils.rs
+++ b/rust/feature-flags/src/utils/test_utils.rs
@@ -631,6 +631,7 @@ pub async fn insert_flag_for_team_in_pg(
             evaluation_runtime: Some("all".to_string()),
             evaluation_tags: None,
             bucketing_identifier: None,
+            has_experiment: false,
         },
     };
 
@@ -688,6 +689,30 @@ pub async fn insert_evaluation_tags_for_flag_in_pg(
         .execute(&mut *conn)
         .await?;
     }
+
+    Ok(())
+}
+
+pub async fn insert_experiment_for_flag_in_pg(
+    client: Arc<dyn Client + Send + Sync>,
+    flag_id: i32,
+    team_id: i32,
+    deleted: bool,
+) -> Result<(), Error> {
+    let mut conn = client.get_connection().await?;
+    sqlx::query(
+        r#"
+        INSERT INTO posthog_experiment
+        (name, filters, feature_flag_id, team_id, deleted, archived,
+         only_count_matured_users, created_at, updated_at)
+        VALUES ('test experiment', '{}'::jsonb, $1, $2, $3, false, false, NOW(), NOW())
+        "#,
+    )
+    .bind(flag_id)
+    .bind(team_id)
+    .bind(deleted)
+    .execute(&mut *conn)
+    .await?;
 
     Ok(())
 }
@@ -1163,6 +1188,16 @@ impl TestContext {
         flag: Option<FeatureFlagRow>,
     ) -> Result<FeatureFlagRow, Error> {
         insert_flag_for_team_in_pg(self.non_persons_writer.clone(), team_id, flag).await
+    }
+
+    pub async fn insert_experiment(
+        &self,
+        flag_id: i32,
+        team_id: i32,
+        deleted: bool,
+    ) -> Result<(), Error> {
+        insert_experiment_for_flag_in_pg(self.non_persons_writer.clone(), flag_id, team_id, deleted)
+            .await
     }
 
     pub async fn insert_person(

--- a/rust/feature-flags/tests/test_batch_flag_evaluation.rs
+++ b/rust/feature-flags/tests/test_batch_flag_evaluation.rs
@@ -62,6 +62,7 @@ fn flag_row(team_id: i32, key: &str, filters: Value) -> FeatureFlagRow {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     }
 }
 

--- a/rust/feature-flags/tests/test_experience_continuity.rs
+++ b/rust/feature-flags/tests/test_experience_continuity.rs
@@ -38,6 +38,7 @@ async fn test_experience_continuity_matches_python() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 
@@ -164,6 +165,7 @@ async fn test_experience_continuity_with_merge() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 
@@ -324,6 +326,7 @@ async fn test_anon_distinct_id_from_person_properties() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 
@@ -449,6 +452,7 @@ async fn test_top_level_anon_distinct_id_takes_precedence() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 
@@ -573,6 +577,7 @@ async fn test_experience_continuity_without_person_uses_anon_distinct_id() -> Re
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 

--- a/rust/feature-flags/tests/test_skip_writes.rs
+++ b/rust/feature-flags/tests/test_skip_writes.rs
@@ -35,6 +35,7 @@ async fn test_skip_writes_prevents_hash_key_override_write() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 
@@ -144,6 +145,7 @@ async fn test_skip_writes_still_evaluates_flags_correctly() -> Result<()> {
         evaluation_runtime: None,
         evaluation_tags: None,
         bucketing_identifier: None,
+        has_experiment: false,
     };
     context.insert_flag(team.id, Some(flag_row)).await?;
 


### PR DESCRIPTION
## Problem

The `from_pg` cache-miss/fallback path in the Rust flags service stamped `has_experiment = true` on every flag, because it lacked the SQL to compute experiment linkage. SDKs use `has_experiment` to decide whether to preserve `$feature_flag_called` event properties. When requests fell back to Postgres (cache miss or cache warm via `cache_builder`), every flag looked experiment-linked, so SDKs kept properties that should have been stripped for non-experiment flags.

## Changes

- The `from_pg` query gains a correlated `EXISTS` subquery over `posthog_experiment` (matching `deleted = false`) that computes `has_experiment` per flag. This mirrors the canonical Django cache writer in `products/feature_flags/backend/flags_cache.py`.
- `FeatureFlagRow` gets a `has_experiment: bool` field (with `#[serde(default)]`) so sqlx can map the new column.
- The `FeatureFlagRow -> FeatureFlag` mapping in `from_pg` now passes `row.has_experiment` through instead of calling `default_has_experiment()`.
- `default_has_experiment()` (= `true`) is kept for the two genuinely unknowable cases: older Django cache payloads missing the field, and the panic fallback in `build_panic_fallback`.
- Adds `test_from_pg_computes_has_experiment` covering live experiment / deleted-only experiment / no experiment, plus `insert_experiment_for_flag_in_pg` and `TestContext::insert_experiment` test helpers.
- Updates existing test fixtures across 6 files to supply `has_experiment: false`.

## How did you test this code?

`test_from_pg_computes_has_experiment` in `feature_flag_list.rs` covers the three meaningful cases end-to-end against a real Postgres database. It inserts flags with a live experiment, a deleted-only experiment, and no experiment, then asserts the `has_experiment` value returned by `from_pg` for each.

Existing integration tests (experience continuity, batch evaluation, skip writes) compile and pass with the fixture additions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Worked with Claude Code (claude-opus-4-8) in a single session. The session identified that the `from_pg` path was stamping the default `true` on every flag and traced the canonical Django definition of "has a live experiment" to the `Exists(Experiment.objects.filter(deleted=False))` annotation in `flags_cache.py`. The Rust SQL was written to match that predicate exactly.

Skills invoked: `/review-code --fix`, `/squash`, `/create-pr`.

The review surfaced an initial concern about `deleted IS NULL` semantics, which deeper investigation resolved: the Django cache writer also uses `.filter(deleted=False)` (not `.exclude(deleted=True)`), so both paths agree on NULL-deleted rows. A drift-guard comment was added to the SQL to keep the two definitions in lockstep.