### PR TITLE
fix(clickhouse): treat out-of-disk-space (243) as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -191,6 +191,14 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # Retrying just re-loads an already memory-pressured server, so stop
             # and tell them to act.
             "Code: 241": "Your ClickHouse server ran out of memory while we were reading a table. This usually means the database is too small for the table being synced. Try scaling up your ClickHouse service (or raising its memory limit), or sync a smaller table or use an incremental sync, then resume.",
+            # NOT_ENOUGH_SPACE — the source ClickHouse server couldn't reserve
+            # disk space for a temporary file while running our extraction query
+            # (spilling a sort or buffering query output to disk). Its local disk
+            # / filesystem cache is full and can't evict enough to continue. Like
+            # Code: 241 this is a capacity problem on the customer's database, not
+            # something we can change our side, so retrying just re-loads an
+            # already disk-pressured server.
+            "Code: 243": "Your ClickHouse server ran out of disk space while we were reading a table (it couldn't reserve space for a temporary file). Try scaling up your ClickHouse service or freeing disk space, or sync a smaller table or use an incremental sync, then resume.",
             # Raised from the shared `evolve_pyarrow_schema` in `pipelines/pipeline/utils.py`
             # when an integer column's source type was widened (e.g. `Int32` → `Int64`) after
             # the destination table was created with the narrower type. Delta Lake can't widen

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -631,6 +631,11 @@ class TestClickHouseSourceNonRetryableErrors:
             # MEMORY_LIMIT_EXCEEDED (code 241) — per-query `max_memory_usage` budget
             "Code: 241. DB::Exception: Query memory limit exceeded: would use 3.73 GiB "
             "(attempt to allocate chunk of 4.60 MiB), maximum: 3.73 GiB. (MEMORY_LIMIT_EXCEEDED)",
+            # NOT_ENOUGH_SPACE (code 243) — source server couldn't reserve disk for a
+            # temporary file (filesystem cache full while buffering query output to disk).
+            "HTTPDriver for https://host:8443 received ClickHouse error code 243\n Code: 243. "
+            "DB::Exception: Failed to reserve 1048576 bytes for temporary file: reason cannot evict "
+            "enough space: While executing BufferingToFileSink. (NOT_ENOUGH_SPACE)",
             # Source table no longer exists at sync time — dropped/renamed, or a materialized
             # view's `.inner_id.<uuid>` inner table whose UUID changed when the view was recreated.
             "Table soax_stage..inner_id.8c612ff0-b72c-4b20-8ea5-405ed002c2f6 not found or has no columns",


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `DatabaseError` from the ClickHouse data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019efbc0-ad2c-72a3-a6bb-2dad949da71c)). The source's ClickHouse server returns error code **243 (`NOT_ENOUGH_SPACE`)**:

> Failed to reserve 1048576 bytes for temporary file: reason cannot evict enough space … While executing BufferingToFileSink. (NOT_ENOUGH_SPACE)

The server can't reserve disk space for a temporary file while running our streaming extraction query (spilling a sort or buffering query output to disk) — its local disk / filesystem cache is full and can't evict enough to continue. The stack trace originates in `posthog/temporal/data_imports/sources/clickhouse/clickhouse.py`, in the streaming read path. Seen across multiple teams, recurring.

This is a capacity problem on the customer's database, not something we can fix our side. It's currently retried, so each attempt just re-loads an already disk-pressured server.

## Changes

Treat ClickHouse error code 243 as a non-retryable error, mirroring the existing handling of code 241 (`MEMORY_LIMIT_EXCEEDED`). The user-facing message points at the actual fix: scale up the ClickHouse service, free disk space, or sync a smaller table / use an incremental sync, then resume.

Matched on the stable `Code: 243` substring — same convention as the other ClickHouse error codes already in the list — never on volatile parts (host, byte counts, segment ids).

## How did you test this code?

I'm an agent. The dependency environment (pytest/Django) wasn't installed in my sandbox, so I could not run the full test suite. I:

- Added a regression case to `TestClickHouseSourceNonRetryableErrors` (host redacted) asserting a code-243 message is recognized as non-retryable, and confirmed the existing transient 502/503/timeout cases stay retryable.
- Verified the substring-match logic in isolation against both the new fixture and the real (redacted) error message, confirming no false positives on transient gateway codes.
- Ran `ruff check` and `ruff format --check` on both changed files — clean.

This regression catches the case where a future change drops or mis-keys the 243 entry, silently making out-of-disk-space errors retryable again.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in PostHog error tracking (code 243, source `clickhouse.py`, recurring across teams), read the source implementation, and classified it as an upstream capacity error rather than a bug in our code — there's nothing to change in how we issue the query; the customer's server is out of disk. Chose the `NonRetryableErrors` route over a code change, following the established code-241 precedent in the same file. Checked open PRs (clickhouse / NOT_ENOUGH_SPACE / 243, plus the maintainer's own open PRs) to rule out a duplicate.