### PR TITLE
fix(flags): include $feature_flag_has_experiment in dedup key

### DIFF
--- a/nodejs/src/ingestion/common/steps/event-preprocessing/dedupe-feature-flag-called.test.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/dedupe-feature-flag-called.test.ts
@@ -114,7 +114,7 @@ describe('createDedupeFeatureFlagCalledStep', () => {
         expect(results).toHaveLength(2)
         // Two identical tuples produce the same claim key in one claimKeys
         // call, each tagged with its own event uuid.
-        const expectedKey = featureFlagCalledDedupKey(1, 'user-1', 'my-flag', true, undefined)
+        const expectedKey = featureFlagCalledDedupKey(1, 'user-1', 'my-flag', true, undefined, undefined)
         expect(service.claimKeys).toHaveBeenCalledWith([
             { key: expectedKey, claimId: 'uuid-1' },
             { key: expectedKey, claimId: 'uuid-2' },
@@ -171,7 +171,7 @@ describe('createDedupeFeatureFlagCalledStep', () => {
         expect(isOkResult(results[1])).toBe(true)
         expect(isOkResult(results[2])).toBe(true)
         expect(isDropResult(results[3])).toBe(true)
-        const expectedKey = featureFlagCalledDedupKey(1, 'user-1', 'my-flag', true, undefined)
+        const expectedKey = featureFlagCalledDedupKey(1, 'user-1', 'my-flag', true, undefined, undefined)
         expect(service.claimKeys).toHaveBeenCalledWith([
             { key: expectedKey, claimId: 'uuid-1' },
             { key: expectedKey, claimId: 'uuid-2' },
@@ -206,6 +206,22 @@ describe('createDedupeFeatureFlagCalledStep', () => {
 
         const claims = service.claimKeys.mock.calls[0][0]
         expect(new Set(claims.map((claim) => claim.key)).size).toBe(4)
+    })
+
+    it('builds different claim keys when only $feature_flag_has_experiment differs', async () => {
+        // Experiment exposures must not be deduped against otherwise-identical
+        // non-experiment calls, so the property has to reach the key.
+        const service = createMockService('drop')
+        service.claimKeys.mockResolvedValue([true, true])
+        const step = createDedupeFeatureFlagCalledStep(service)
+
+        await step([
+            createInput({ $feature_flag: 'flag-a', $feature_flag_response: true, $feature_flag_has_experiment: true }),
+            createInput({ $feature_flag: 'flag-a', $feature_flag_response: true, $feature_flag_has_experiment: false }),
+        ])
+
+        const claims = service.claimKeys.mock.calls[0][0]
+        expect(claims[0].key).not.toBe(claims[1].key)
     })
 
     it('builds identical claim keys for identical tuples', async () => {

--- a/nodejs/src/ingestion/common/steps/event-preprocessing/dedupe-feature-flag-called.ts
+++ b/nodejs/src/ingestion/common/steps/event-preprocessing/dedupe-feature-flag-called.ts
@@ -15,12 +15,12 @@ export interface DedupeFeatureFlagCalledStepInput {
 
 /**
  * Drops redundant $feature_flag_called events using a keep-first Redis claim
- * keyed on (team, distinct_id, flag, response, groups). Server-side SDKs on
- * multi-process fleets re-emit the same exposure from every worker; only the
- * first copy carries signal, so the survivors preserve experiment exposure
- * semantics while the bulk of the volume is dropped. Note that "last called"
- * timestamps become TTL-granular: within a dedup window they reflect the
- * first call, not the most recent one.
+ * keyed on (team, distinct_id, flag, response, groups, has_experiment).
+ * Server-side SDKs on multi-process fleets re-emit the same exposure from every
+ * worker; only the first copy carries signal, so the survivors preserve
+ * experiment exposure semantics while the bulk of the volume is dropped.
+ * Note that "last called" timestamps become TTL-granular: within a dedup
+ * window they reflect the first call, not the most recent one.
  *
  * Claims are tagged with the event uuid, so a batch replayed by at-least-once
  * Kafka delivery recognizes its own claims from a failed prior attempt
@@ -58,7 +58,8 @@ export function createDedupeFeatureFlagCalledStep<T extends DedupeFeatureFlagCal
                     input.event.distinct_id,
                     flagKey,
                     properties['$feature_flag_response'],
-                    properties['$groups']
+                    properties['$groups'],
+                    properties['$feature_flag_has_experiment']
                 ),
                 claimId: input.event.uuid,
             }

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
@@ -194,9 +194,9 @@ describe('RedisFeatureFlagCalledDedupService', () => {
                 [1, 'user-1', 'flag-a', true, { org: 'o1' }, null],
                 [1, 'user-1', 'flag-a', true, undefined, null],
             ],
-            ['has_experiment', [1, 'user-1', 'flag-a', true, null, true], [1, 'user-1', 'flag-a', true, null, false]],
-            // The property is optional and absent on events today (no SDK sets it yet),
-            // so cover the experiment-vs-absent axis alongside the explicit true/false above.
+            // false and null/undefined both mean "not an experiment exposure" — the key
+            // only distinguishes true (experiment) from everything else.
+            ['has_experiment', [1, 'user-1', 'flag-a', true, null, true], [1, 'user-1', 'flag-a', true, null, null]],
             [
                 'has_experiment true vs absent',
                 [1, 'user-1', 'flag-a', true, null, true],

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
@@ -156,42 +156,56 @@ describe('RedisFeatureFlagCalledDedupService', () => {
         it('has a compact, team-scannable shape', () => {
             // Key bytes are paid per live key at prod cardinality, so the
             // shape (short prefix, truncated digest) is a memory contract.
-            expect(featureFlagCalledDedupKey(42, 'user-1', 'flag-a', 'variant-1', { org: 'o1' })).toMatch(
+            expect(featureFlagCalledDedupKey(42, 'user-1', 'flag-a', 'variant-1', { org: 'o1' }, true)).toMatch(
                 /^ffcd:42:[A-Za-z0-9_-]{22}$/
             )
         })
 
         it('is stable for the same tuple', () => {
-            expect(featureFlagCalledDedupKey(1, 'user-1', 'flag-a', 'variant-1', { org: 'o1' })).toBe(
-                featureFlagCalledDedupKey(1, 'user-1', 'flag-a', 'variant-1', { org: 'o1' })
+            expect(featureFlagCalledDedupKey(1, 'user-1', 'flag-a', 'variant-1', { org: 'o1' }, true)).toBe(
+                featureFlagCalledDedupKey(1, 'user-1', 'flag-a', 'variant-1', { org: 'o1' }, true)
             )
         })
 
         it('is independent of $groups property ordering', () => {
-            expect(featureFlagCalledDedupKey(1, 'user-1', 'flag-a', true, { a: '1', b: '2' })).toBe(
-                featureFlagCalledDedupKey(1, 'user-1', 'flag-a', true, { b: '2', a: '1' })
+            expect(featureFlagCalledDedupKey(1, 'user-1', 'flag-a', true, { a: '1', b: '2' }, false)).toBe(
+                featureFlagCalledDedupKey(1, 'user-1', 'flag-a', true, { b: '2', a: '1' }, false)
             )
         })
 
-        it.each([
-            ['team', [1, 'user-1', 'flag-a', true, null], [2, 'user-1', 'flag-a', true, null]],
-            ['distinct_id', [1, 'user-1', 'flag-a', true, null], [1, 'user-2', 'flag-a', true, null]],
-            ['flag', [1, 'user-1', 'flag-a', true, null], [1, 'user-1', 'flag-b', true, null]],
-            ['response', [1, 'user-1', 'flag-a', true, null], [1, 'user-1', 'flag-a', false, null]],
-            ['response null vs "null"', [1, 'user-1', 'flag-a', null, null], [1, 'user-1', 'flag-a', 'null', null]],
-            ['groups', [1, 'user-1', 'flag-a', true, { org: 'o1' }], [1, 'user-1', 'flag-a', true, { org: 'o2' }]],
-            ['groups vs none', [1, 'user-1', 'flag-a', true, { org: 'o1' }], [1, 'user-1', 'flag-a', true, undefined]],
+        type KeyArgs = Parameters<typeof featureFlagCalledDedupKey>
+        it.each<[string, KeyArgs, KeyArgs]>([
+            ['team', [1, 'user-1', 'flag-a', true, null, null], [2, 'user-1', 'flag-a', true, null, null]],
+            ['distinct_id', [1, 'user-1', 'flag-a', true, null, null], [1, 'user-2', 'flag-a', true, null, null]],
+            ['flag', [1, 'user-1', 'flag-a', true, null, null], [1, 'user-1', 'flag-b', true, null, null]],
+            ['response', [1, 'user-1', 'flag-a', true, null, null], [1, 'user-1', 'flag-a', false, null, null]],
+            [
+                'response null vs "null"',
+                [1, 'user-1', 'flag-a', null, null, null],
+                [1, 'user-1', 'flag-a', 'null', null, null],
+            ],
+            [
+                'groups',
+                [1, 'user-1', 'flag-a', true, { org: 'o1' }, null],
+                [1, 'user-1', 'flag-a', true, { org: 'o2' }, null],
+            ],
+            [
+                'groups vs none',
+                [1, 'user-1', 'flag-a', true, { org: 'o1' }, null],
+                [1, 'user-1', 'flag-a', true, undefined, null],
+            ],
+            ['has_experiment', [1, 'user-1', 'flag-a', true, null, true], [1, 'user-1', 'flag-a', true, null, false]],
+            // The property is optional and absent on events today (no SDK sets it yet),
+            // so cover the experiment-vs-absent axis alongside the explicit true/false above.
+            [
+                'has_experiment true vs absent',
+                [1, 'user-1', 'flag-a', true, null, true],
+                [1, 'user-1', 'flag-a', true, null, undefined],
+            ],
             // The delimiter-injection collision class: components must not concatenate
-            ['component boundary', [1, 'user:1', 'flag', true, null], [1, 'user', ':1flag', true, null]],
+            ['component boundary', [1, 'user:1', 'flag', true, null, null], [1, 'user', ':1flag', true, null, null]],
         ])('differs by %s', (_label, a, b) => {
-            const [teamA, distinctA, flagA, responseA, groupsA] = a
-            const [teamB, distinctB, flagB, responseB, groupsB] = b
-
-            expect(
-                featureFlagCalledDedupKey(teamA as number, distinctA as string, flagA as string, responseA, groupsA)
-            ).not.toBe(
-                featureFlagCalledDedupKey(teamB as number, distinctB as string, flagB as string, responseB, groupsB)
-            )
+            expect(featureFlagCalledDedupKey(...a)).not.toBe(featureFlagCalledDedupKey(...b))
         })
     })
 

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
@@ -94,7 +94,14 @@ export function featureFlagCalledDedupKey(
     // teamId stays in the key so operators can SCAN or purge one team's claims.
     const hash = createHash('sha256')
         .update(
-            JSON.stringify([teamId, distinctId, flagKey, response ?? null, normalizedGroups, hasExperiment ?? null])
+            JSON.stringify([
+                teamId,
+                distinctId,
+                flagKey,
+                response ?? null,
+                normalizedGroups,
+                hasExperiment === true ? true : null,
+            ])
         )
         .digest('base64url')
         .slice(0, HASH_LENGTH)

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
@@ -82,7 +82,8 @@ export function featureFlagCalledDedupKey(
     distinctId: string,
     flagKey: string,
     response: unknown,
-    groups: unknown
+    groups: unknown,
+    hasExperiment: unknown
 ): string {
     const normalizedGroups =
         groups && typeof groups === 'object' && !Array.isArray(groups)
@@ -92,7 +93,9 @@ export function featureFlagCalledDedupKey(
     // a future code path assembles a key without the prefix. The plaintext
     // teamId stays in the key so operators can SCAN or purge one team's claims.
     const hash = createHash('sha256')
-        .update(JSON.stringify([teamId, distinctId, flagKey, response ?? null, normalizedGroups]))
+        .update(
+            JSON.stringify([teamId, distinctId, flagKey, response ?? null, normalizedGroups, hasExperiment ?? null])
+        )
         .digest('base64url')
         .slice(0, HASH_LENGTH)
     return `${REDIS_KEY_PREFIX}${teamId}:${hash}`


### PR DESCRIPTION
## Problem

The dedup key for `$feature_flag_called` events didn't include `$feature_flag_has_experiment`. An experiment exposure and a regular call for the same flag, distinct_id, and response would hash to the same key, so one would be dropped as a duplicate. The surviving event might not be the experiment exposure, which breaks experiment exposure counting.

> [!IMPORTANT]
> No SDK sends `$feature_flag_has_experiment` yet, so this change is pretty much a no-op other than the existing de-dupe cache will be invalidated. Better to get it right now than when we start raising events.

## Changes

Added `$feature_flag_has_experiment` as the sixth component of the dedup key in `featureFlagCalledDedupKey`. It defaults to `null` when absent, so events without the property still deduplicate against each other as before.

## How did you test this code?

Added a test asserting that two otherwise-identical events differing only in `$feature_flag_has_experiment` produce distinct claim keys. The existing parameterized suite now covers `true/false` and `true/absent` on the `has_experiment` axis.

All existing tests were updated to pass the new parameter. There's no behavior change for events that don't carry the property.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Phil Haack (@haacked) directed the work. Used Claude Code (claude-sonnet-4-6[1m]) via the `/create-pr` skill. Added `hasExperiment` as the sixth argument to `featureFlagCalledDedupKey`, threaded it through `createDedupeFeatureFlagCalledStep`, and updated all tests including the parameterized key-collision suite.