### PR TITLE
fix(google_ads): retry transient UNAVAILABLE wrapped in GoogleAdsException

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -512,7 +512,8 @@ def _search_with_transient_retry(
     """Call ``GoogleAdsService.search``, retrying a transient gRPC ``UNAVAILABLE`` with backoff.
 
     Only retries before any page is yielded or checkpointed, so there is no partial state to
-    reconcile. Non-transient errors (including ``GoogleAdsException``) re-raise immediately so the
+    reconcile. The transient ``UNAVAILABLE`` may itself arrive wrapped in a ``GoogleAdsException``
+    (see ``_is_transient_grpc_unavailable``). Non-transient errors re-raise immediately so the
     caller's ``INVALID_PAGE_TOKEN`` handling and Temporal's retry policy still apply.
     """
     attempt = 0

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -491,11 +491,15 @@ def _is_transient_grpc_unavailable(exc: BaseException) -> bool:
 
     The gapic transport usually surfaces it as ``google.api_core.exceptions.ServiceUnavailable``,
     but the raw ``grpc`` ``_InactiveRpcError`` (whose ``code()`` returns ``StatusCode.UNAVAILABLE``)
-    can also propagate, so we accept either shape.
+    can also propagate. The Google Ads SDK additionally re-wraps the transport error in a
+    ``GoogleAdsException`` when it can pull an ads ``failure`` from the trailing metadata (e.g. a
+    backend ``DEADLINE_EXCEEDED`` returned alongside an ``UNAVAILABLE`` status); the gRPC status
+    then lives on the wrapped ``error``, so we unwrap and inspect it too.
     """
     if isinstance(exc, google_api_exceptions.ServiceUnavailable):
         return True
-    code = getattr(exc, "code", None)
+    candidate: typing.Any = exc.error if isinstance(exc, GoogleAdsException) else exc
+    code = getattr(candidate, "code", None)
     return callable(code) and code() == grpc.StatusCode.UNAVAILABLE
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -547,16 +547,26 @@ def _grpc_unavailable_error() -> grpc.RpcError:
     return _UnavailableRpcError()
 
 
+def _google_ads_exception_wrapping(grpc_error: grpc.RpcError) -> GoogleAdsException:
+    """A ``GoogleAdsException`` carrying a transport-level error on ``error``, the shape the SDK
+    raises when it can pull an ads ``failure`` from the trailing metadata alongside the gRPC status.
+    """
+    return GoogleAdsException(error=grpc_error, call=None, failure=None, request_id="req-1")
+
+
 class TestTransientGrpcUnavailableDetection:
     @pytest.mark.parametrize(
         "exc, expected",
         [
             (google_api_exceptions.ServiceUnavailable("502:Bad Gateway"), True),
             (_grpc_unavailable_error(), True),
+            # The SDK wraps the transport UNAVAILABLE in a GoogleAdsException when an ads failure
+            # rides along (e.g. a backend DEADLINE_EXCEEDED) — still transient, so we unwrap it.
+            (_google_ads_exception_wrapping(_grpc_unavailable_error()), True),
             # A different gapic error must not be treated as transient-unavailable.
             (google_api_exceptions.PermissionDenied("PERMISSION_DENIED"), False),
-            # Google Ads API errors carry no UNAVAILABLE gRPC status — they route through
-            # the existing GoogleAdsException handling, not the transient retry.
+            # An ads-API GoogleAdsException carries no UNAVAILABLE gRPC status — it routes through
+            # the existing INVALID_PAGE_TOKEN handling, not the transient retry.
             (_google_ads_exception(RequestErrorEnum.RequestError.INVALID_PAGE_TOKEN), False),
             (ValueError("boom"), False),
         ],
@@ -587,6 +597,7 @@ class TestSearchTransientRetry:
         [
             google_api_exceptions.ServiceUnavailable("502:Bad Gateway"),
             _grpc_unavailable_error(),
+            _google_ads_exception_wrapping(_grpc_unavailable_error()),
         ],
     )
     def test_rides_out_transient_unavailable(self, error):


### PR DESCRIPTION
## Problem

A `google_ads` data-warehouse import surfaced a `GoogleAdsException` in error tracking that crashed the sync. The wrapped error was a transient gRPC `UNAVAILABLE` ("The service is currently unavailable.") carrying a backend `DEADLINE_EXCEEDED` ("The request took too long to respond.") ads failure.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019efc22-ccd7-7be2-a0d3-f9537d4a9374 — top in-app frame is `_search_with_transient_retry` in `google_ads.py`.

This source already has an in-process transient-retry path (`_search_with_transient_retry` / `_is_transient_grpc_unavailable`) whose whole purpose is to ride out exactly this kind of transient `UNAVAILABLE` blip and avoid failing the activity. But its detection only recognized the status when it was reachable via a `code()` method — the raw `_InactiveRpcError` or gapic `ServiceUnavailable`. The Google Ads SDK additionally re-wraps the transport error in a `GoogleAdsException` when it can extract an ads `failure` from the trailing metadata, and `GoogleAdsException` has no `code()` method — the gRPC status lives on its `error` attribute. So this wrapped shape fell through to the non-retry path and became captured noise.

## Changes

`_is_transient_grpc_unavailable` now unwraps a `GoogleAdsException` and inspects the carried gRPC status, so a wrapped `UNAVAILABLE` is ridden out in-process just like the unwrapped forms. Ads-API failures (e.g. `INVALID_PAGE_TOKEN`) carry no `UNAVAILABLE` transport status, so they still route through the existing `INVALID_PAGE_TOKEN` handling and Temporal's retry policy untouched — the change can't swallow a real ads-level error.

This is transient-infra handling, not a `NonRetryableErrors` change: the failure stays retryable, it just gets retried in-process first before falling back to a full activity restart.

## How did you test this code?

I'm an agent. Automated tests only — no manual testing:

- Extended `TestTransientGrpcUnavailableDetection` with a `GoogleAdsException`-wrapped `UNAVAILABLE` case (asserts it's now detected as transient) and clarified that an ads-API `GoogleAdsException` is still not transient.
- Extended `TestSearchTransientRetry::test_rides_out_transient_unavailable` to cover the wrapped shape end-to-end through `_search_as_arrow_tables` (retried, then page served, no data lost).
- `pytest posthog/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py` — 77 passed. `ruff check` / `ruff format` clean.

These catch the regression where a transient `UNAVAILABLE` arriving wrapped in a `GoogleAdsException` is treated as fatal instead of retried.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the `google_ads` source. Used Claude Code with the PostHog error-tracking MCP tools to confirm the issue (stack trace, frequency) and read the source.

Decision: the underlying gRPC status is `UNAVAILABLE`, the canonical retryable status, so this is transient infra — kept it retryable rather than adding to `NonRetryableErrors`, and fixed the detection gap that prevented the existing in-process retry from catching the SDK's wrapped shape.

Checked for duplicates: open PR #65846 (`fix(google_ads): retry transient INTERNAL gRPC errors in-process`) touches the same helper but does **not** address this — it only extends the `code()`-based detection (adding `INTERNAL`) and explicitly routes `GoogleAdsException` through the non-retry path (its test builds one with `error=None`). It would not fix a `GoogleAdsException` wrapping a transient transport status. The two changes are complementary and overlap textually in this helper, so a rebase will need a small conflict resolution.