### PR TITLE
chore(sidebar): remove cmd+k sidebar hint experiment code

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/ProjectTree.tsx
@@ -13,7 +13,6 @@ import {
     IconStar,
 } from '@posthog/icons'
 
-import { commandLogic } from 'lib/components/Command/commandLogic'
 import { itemSelectModalLogic } from 'lib/components/FileSystem/ItemSelectModal/itemSelectModalLogic'
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
@@ -32,13 +31,11 @@ import { ButtonPrimitive } from 'lib/ui/Button/ButtonPrimitives'
 import { ContextMenuGroup, ContextMenuItem } from 'lib/ui/ContextMenu/ContextMenu'
 import { DropdownMenuGroup } from 'lib/ui/DropdownMenu/DropdownMenu'
 import { cn } from 'lib/utils/css-classes'
-import { isMobile } from 'lib/utils/dom'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { removeProjectIdIfPresent } from 'lib/utils/kea-router'
 import { sceneConfigurations } from 'scenes/scenes'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 import { panelLayoutLogic } from '~/layout/panel-layout/panelLayoutLogic'
 import { customProductsLogic } from '~/layout/panel-layout/ProjectTree/customProductsLogic'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
@@ -73,7 +70,6 @@ let counter = 0
 
 const SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY = 'shortcut-dismissal'
 const CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY = 'custom-product-dismissal-v2'
-const CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY = 'cmd-k-helper-dismissal'
 const SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY = 'seen-custom-products'
 
 const USER_PRODUCT_LIST_REASON_DEFAULTS: { [key in UserProductListReason]?: string } = {
@@ -175,7 +171,6 @@ export function ProjectTree({
 
     const { customProducts, customProductsLoading } = useValues(customProductsLogic)
     const { seed } = useActions(customProductsLogic)
-    const { toggleCommand } = useActions(commandLogic)
 
     const [shortcutHelperDismissed, setShortcutHelperDismissed] = useLocalStorage<boolean>(
         SHORTCUT_DISMISSAL_LOCAL_STORAGE_KEY,
@@ -185,13 +180,6 @@ export function ProjectTree({
         CUSTOM_PRODUCT_DISMISSAL_LOCAL_STORAGE_KEY,
         false
     )
-    const [cmdKHelperDismissed, setCmdKHelperDismissed] = useLocalStorage<boolean>(
-        CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY,
-        false
-    )
-    // Capture the original-banner dismissal state once on mount so the Cmd+K hint only appears
-    // on subsequent sessions — dismissing the first banner shouldn't swap in the second immediately.
-    const [originalDismissedOnMount] = useState<boolean>(() => customProductHelperDismissed === true)
 
     const [seenCustomProducts, setSeenCustomProducts] = useLocalStorage<string[]>(
         `${currentTeamId ?? '*'}-${SEEN_CUSTOM_PRODUCTS_LOCAL_STORAGE_KEY}`,
@@ -249,8 +237,6 @@ export function ProjectTree({
             )
 
             const showOriginalBanner = fullFileSystemFiltered.length === 0 || !customProductHelperDismissed
-            const showCmdKBanner =
-                !showOriginalBanner && originalDismissedOnMount && !cmdKHelperDismissed && !isMobile()
 
             if (showOriginalBanner) {
                 treeData.push({
@@ -280,27 +266,6 @@ export function ProjectTree({
                                     </span>
                                 </>
                             )}
-                        </div>
-                    ),
-                })
-            } else if (showCmdKBanner) {
-                treeData.push({
-                    id: 'products/cmd-k-helper-category',
-                    name: 'Quick search tip',
-                    type: 'category',
-                    displayName: (
-                        <div className="border border-primary text-xs mb-2 font-normal rounded-xs p-2 -mx-1">
-                            Want to browse all tools or jump back into something recent? Press{' '}
-                            <span
-                                className="cursor-pointer inline-flex items-center gap-1"
-                                onClick={() => toggleCommand()}
-                            >
-                                <KeyboardShortcut command k />
-                            </span>{' '}
-                            to open search. It's faster than hunting through the sidebar.{' '}
-                            <span className="cursor-pointer underline" onClick={() => setCmdKHelperDismissed(true)}>
-                                Dismiss.
-                            </span>
                         </div>
                     ),
                 })


### PR DESCRIPTION
## Problem

The Cmd+K sidebar hint was a short-lived experiment to guide users to use the command palette from the custom products sidebar panel. The experiment has concluded and the hint is no longer needed.

## Changes

Removes the Cmd+K hint banner and all associated code from `ProjectTree.tsx`:
- Deleted the `CMD_K_HELPER_DISMISSAL_LOCAL_STORAGE_KEY` constant
- Removed `cmdKHelperDismissed` / `setCmdKHelperDismissed` state and `originalDismissedOnMount` snapshot
- Removed the `showCmdKBanner` condition and its JSX
- Cleaned up now-unused imports: `commandLogic`, `KeyboardShortcut`, `isMobile`

The original custom-products onboarding banner is untouched.

## How did you test this code?

Agent-authored. TypeScript check passed with no errors. No automated tests existed for this hint (it was localStorage-based UI only).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (claude-sonnet-4-6) following a direct instruction from Fernando Gomes to finish the Cmd+K sidebar hint experiment and remove the instrumentation code (Linear: GROW-42).

Explored the codebase to locate the hint code in `ProjectTree.tsx`, confirmed it was localStorage-based (no feature flag), then removed the hint banner and all related state/imports cleanly.