### PR TITLE
fix(query-performance): tag export runs for backfill concurrency capping

### DIFF
--- a/posthog/dags/export_query_log_archive_to_s3.py
+++ b/posthog/dags/export_query_log_archive_to_s3.py
@@ -153,7 +153,10 @@ SETTINGS s3_truncate_on_insert = 1
     resource_defs={
         "cluster": OpsClickhouseClusterResource(max_execution_time=2 * 60 * 60, max_memory_usage=20 * ONE_GB)
     },
-    tags={"owner": JobOwners.TEAM_QUERY_PERFORMANCE.value},
+    tags={
+        "owner": JobOwners.TEAM_QUERY_PERFORMANCE.value,
+        "query_log_archive_backfill_concurrency": "query_log_archive_v1",
+    },
 )
 def export_query_log_archive_to_s3():
     export_query_log_archive_day()


### PR DESCRIPTION
## Problem

A backfill of the `query_log_archive` export launches one run per day, with nothing capping how many run at once. Each day is a heavy ~45-60 min query on the single shared OPS node, and stacking them risks the total-node-memory OOMs we already saw during the manual backfill.

## Changes

- Add `query_log_archive_backfill_concurrency=query_log_archive_v1` as a job tag, so every export run (daily and backfill) carries it.

This is the posthog half of a two-part change. The other half is a matching run-queue `tag_concurrency_limits` entry in charts (`managed_tag_concurrency_limits.yaml`, limit 1). Together they cap these runs to one at a time, so backfill days run serially and the daily never overlaps a backfill day. The tag is harmless on its own; it only throttles once the charts limit is deployed.

## How did you test this code?

Agent (Claude Code). `ruff` + `ty check` clean; confirmed the job now reports both tags (`owner` + `query_log_archive_backfill_concurrency`). No behavior change until the paired charts limit deploys.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Pairs with the charts `tag_concurrency_limits` entry. Job tags reach runs (unlike asset tags), so tagging the job caps daily + backfill runs against one shared slot once the limit is live.
