### PR TITLE
fix(dashboards): prevent stale PATCH from resetting display option state

### DIFF
--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -3,16 +3,14 @@ import './InsightCard.scss'
 import { useMergeRefs } from '@floating-ui/react'
 import clsx from 'clsx'
 import { BindLogic, useActions, useValues } from 'kea'
-import React, { useMemo, useRef, useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { LayoutItem } from 'react-grid-layout'
 import { useInView } from 'react-intersection-observer'
-import { useDebouncedCallback } from 'use-debounce'
 
 import { ApiError } from 'lib/api'
 import { Resizeable } from 'lib/components/Cards/CardMeta'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
-import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { accessLevelSatisfied, getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
@@ -25,14 +23,12 @@ import {
 } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
-import { insightsApi } from 'scenes/insights/utils/api'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
-import { insightsModel } from '~/models/insightsModel'
 import { extractValidationError } from '~/queries/nodes/InsightViz/utils'
 import { Query } from '~/queries/Query/Query'
-import { DashboardFilter, HogQLVariable, Node } from '~/queries/schema/schema-general'
+import { DashboardFilter, HogQLVariable } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -50,7 +46,6 @@ import { EditModeEdge, EditModeEdgeOverlay } from './EditModeEdgeOverlay'
 import { InsightMeta } from './InsightMeta'
 
 const IS_STORYBOOK = inStorybook() || inStorybookTestRunner()
-const DISPLAY_OPTIONS_PERSIST_DEBOUNCE_MS = 700
 
 export interface InsightCardProps extends Resizeable {
     /** Insight to display. */
@@ -178,52 +173,34 @@ function InsightCardInternal(
     const mergedRefs = useMergeRefs([ref, inViewRef])
 
     const { theme } = useValues(themeLogic)
-    const { renameInsightSuccess } = useActions(insightsModel)
 
-    // Display options edited from the card ⋯ menu mutate the saved insight directly (no per-tile
-    // override), mirroring the legend/labels/annotations quick toggles. Debounced so rapid edits
-    // (e.g. typing an axis label) collapse into a single PATCH.
-    //
-    // saveGenRef: only apply a PATCH response if it's still the latest one. Without this, an
-    // earlier in-flight PATCH returning after a newer one fires triggers propsChanged in
-    // insightDataLogic and resets the local query to stale data (options visually deselect).
-    const insightRef = useRef(insight)
-    insightRef.current = insight
-    const saveGenRef = useRef(0)
     const canEditInsight = insight.user_access_level
         ? accessLevelSatisfied(AccessControlResourceType.Insight, insight.user_access_level, AccessControlLevel.Editor)
         : true
     const canPersistDisplayOptions = !!dashboardId && canEditInsight
-    const persistDisplayOptions = useDebouncedCallback((node: Node) => {
-        const gen = ++saveGenRef.current
-        void insightsApi.update(insightRef.current.id, { query: node }).then(
-            (updatedItem) => {
-                // Skip if a newer save has started (gen mismatch) OR a newer save is still
-                // queued in the debounce (isPending). Either way the response is stale.
-                if (gen === saveGenRef.current && !persistDisplayOptions.isPending()) {
-                    renameInsightSuccess(updatedItem)
-                    lemonToast.success('Insight updated')
-                }
-            },
-            () => {
-                if (gen === saveGenRef.current && !persistDisplayOptions.isPending()) {
-                    lemonToast.error('Failed to update insight')
-                }
-            }
-        )
-    }, DISPLAY_OPTIONS_PERSIST_DEBOUNCE_MS)
 
-    // Stable reference so the memoized viz below isn't invalidated on every grid re-render.
-    const insightLogicProps: InsightLogicProps = useMemo(
+    // Base props without setQuery — used to mount insightDataLogic and retrieve the
+    // persistDisplayOptions action before wiring it back in as setQuery below.
+    const insightLogicPropsBase: InsightLogicProps = useMemo(
         () => ({
             dashboardItemId: insight.short_id,
             dashboardId: dashboardId,
             cachedInsight: insight,
             loadPriority,
             doNotLoad,
+        }),
+        [insight, dashboardId, loadPriority, doNotLoad]
+    )
+
+    const { persistDisplayOptions } = useActions(insightDataLogic(insightLogicPropsBase))
+
+    // Stable reference so the memoized viz below isn't invalidated on every grid re-render.
+    const insightLogicProps: InsightLogicProps = useMemo(
+        () => ({
+            ...insightLogicPropsBase,
             setQuery: canPersistDisplayOptions ? persistDisplayOptions : undefined,
         }),
-        [insight, dashboardId, loadPriority, doNotLoad, canPersistDisplayOptions, persistDisplayOptions]
+        [insightLogicPropsBase, canPersistDisplayOptions, persistDisplayOptions]
     )
 
     const { insightLoading } = useValues(insightLogic(insightLogicProps))

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -12,6 +12,7 @@ import { ApiError } from 'lib/api'
 import { Resizeable } from 'lib/components/Cards/CardMeta'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { usePageVisibility } from 'lib/hooks/usePageVisibility'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { accessLevelSatisfied, getAccessControlDisabledReason } from 'lib/utils/accessControlUtils'
 import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
@@ -24,6 +25,7 @@ import {
 } from 'scenes/insights/EmptyStates'
 import { insightDataLogic } from 'scenes/insights/insightDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { insightsApi } from 'scenes/insights/utils/api'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -176,19 +178,39 @@ function InsightCardInternal(
     const mergedRefs = useMergeRefs([ref, inViewRef])
 
     const { theme } = useValues(themeLogic)
-    const { updateInsightDirect } = useActions(insightsModel)
+    const { renameInsightSuccess } = useActions(insightsModel)
 
     // Display options edited from the card ⋯ menu mutate the saved insight directly (no per-tile
     // override), mirroring the legend/labels/annotations quick toggles. Debounced so rapid edits
     // (e.g. typing an axis label) collapse into a single PATCH.
+    //
+    // saveGenRef: only apply a PATCH response if it's still the latest one. Without this, an
+    // earlier in-flight PATCH returning after a newer one fires triggers propsChanged in
+    // insightDataLogic and resets the local query to stale data (options visually deselect).
     const insightRef = useRef(insight)
     insightRef.current = insight
+    const saveGenRef = useRef(0)
     const canEditInsight = insight.user_access_level
         ? accessLevelSatisfied(AccessControlResourceType.Insight, insight.user_access_level, AccessControlLevel.Editor)
         : true
     const canPersistDisplayOptions = !!dashboardId && canEditInsight
     const persistDisplayOptions = useDebouncedCallback((node: Node) => {
-        updateInsightDirect(insightRef.current, { query: node })
+        const gen = ++saveGenRef.current
+        void insightsApi.update(insightRef.current.id, { query: node }).then(
+            (updatedItem) => {
+                // Skip if a newer save has started (gen mismatch) OR a newer save is still
+                // queued in the debounce (isPending). Either way the response is stale.
+                if (gen === saveGenRef.current && !persistDisplayOptions.isPending()) {
+                    renameInsightSuccess(updatedItem)
+                    lemonToast.success('Insight updated')
+                }
+            },
+            () => {
+                if (gen === saveGenRef.current && !persistDisplayOptions.isPending()) {
+                    lemonToast.error('Failed to update insight')
+                }
+            }
+        )
     }, DISPLAY_OPTIONS_PERSIST_DEBOUNCE_MS)
 
     // Stable reference so the memoized viz below isn't invalidated on every grid re-render.

--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -10,6 +10,7 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { useMocks } from '~/mocks/jest'
+import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
 import { getDefaultQuery } from '~/queries/nodes/InsightViz/utils'
 import { performQuery } from '~/queries/query'
@@ -414,6 +415,60 @@ describe('insightDataLogic', () => {
             await expectLogic(logic).delay(0)
             expect(mockedPerformQuery).not.toHaveBeenCalled()
             logic.unmount()
+        })
+    })
+
+    describe('persistDisplayOptions', () => {
+        const insightId = 42
+        const Insight42 = '42' as InsightShortId
+        const baseQuery: InsightVizNode = {
+            kind: NodeKind.InsightVizNode,
+            source: { kind: NodeKind.TrendsQuery, series: [] },
+        }
+        const updatedQuery: InsightVizNode = {
+            kind: NodeKind.InsightVizNode,
+            source: { kind: NodeKind.TrendsQuery, series: [], trendsFilter: { showLegend: true } as any },
+        }
+
+        let logic: ReturnType<typeof insightDataLogic.build>
+        let patchSpy: jest.Mock
+
+        beforeEach(() => {
+            patchSpy = jest.fn().mockResolvedValue([200, { id: insightId, short_id: Insight42, query: updatedQuery }])
+            useMocks({
+                patch: { '/api/environments/:team_id/insights/:id': patchSpy },
+            })
+
+            const props = {
+                dashboardItemId: Insight42,
+                cachedInsight: { id: insightId, short_id: Insight42, query: baseQuery } as any,
+            }
+            insightsModel.mount()
+            insightLogic(props).mount()
+            logic = insightDataLogic(props)
+            logic.mount()
+        })
+
+        it('debounces and fires renameInsightSuccess on success', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.persistDisplayOptions(updatedQuery)
+            })
+                .toFinishAllListeners()
+                .toDispatchActions(['renameInsightSuccess'])
+
+            expect(patchSpy).toHaveBeenCalledTimes(1)
+        })
+
+        it('collapses multiple rapid dispatches into a single PATCH', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.persistDisplayOptions(updatedQuery)
+                logic.actions.persistDisplayOptions(updatedQuery)
+                logic.actions.persistDisplayOptions(updatedQuery)
+            })
+                .toFinishAllListeners()
+                .toDispatchActions(['renameInsightSuccess'])
+
+            expect(patchSpy).toHaveBeenCalledTimes(1)
         })
     })
 })

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -1,16 +1,32 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, propsChanged, reducers, selectors } from 'kea'
+import {
+    actions,
+    afterMount,
+    connect,
+    isBreakpoint,
+    kea,
+    key,
+    listeners,
+    path,
+    props,
+    propsChanged,
+    reducers,
+    selectors,
+} from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router } from 'kea-router'
 
 import api from 'lib/api'
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { eventUsageLogic } from 'lib/utils/eventUsageLogic'
 import { objectsEqual } from 'lib/utils/objects'
 import { keyForInsightLogicProps } from 'scenes/insights/sharedUtils'
+import { insightsApi } from 'scenes/insights/utils/api'
 import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { filterTestAccountsDefaultsLogic } from 'scenes/settings/environment/filterTestAccountDefaultsLogic'
 
 import { sceneLayoutLogic } from '~/layout/scenes/sceneLayoutLogic'
+import { insightsModel } from '~/models/insightsModel'
 import { examples } from '~/queries/examples'
 import { DataNodeLogicProps, dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { nodeKindToInsightType } from '~/queries/nodes/InsightQuery/utils/queryNodeToFilter'
@@ -80,6 +96,8 @@ export const insightDataLogic = kea<insightDataLogicType>([
             ['setInsight', 'setInsightMetadata', 'loadInsightSuccess'],
             dataNodeLogic({ key: insightVizDataNodeKey(props) } as DataNodeLogicProps),
             ['loadData', 'loadDataSuccess', 'loadDataFailure', 'setResponse as setInsightData'],
+            insightsModel,
+            ['renameInsightSuccess'],
         ],
         logic: [insightDataTimingLogic(props), insightUsageLogic(props)],
     })),
@@ -90,6 +108,7 @@ export const insightDataLogic = kea<insightDataLogicType>([
         toggleQueryEditorPanel: true,
         toggleDebugPanel: true,
         cancelChanges: true,
+        persistDisplayOptions: (query: Node) => ({ query }),
     }),
 
     reducers({
@@ -274,6 +293,23 @@ export const insightDataLogic = kea<insightDataLogicType>([
     }),
 
     listeners(({ actions, values, props }) => ({
+        persistDisplayOptions: async ({ query }, breakpoint) => {
+            // Debounce rapid clicks. insightDataLogic is keyed per insight, so breakpoint
+            // only cancels concurrent saves for THIS insight — not unrelated tiles.
+            await breakpoint(700)
+            try {
+                const updatedItem = await insightsApi.update(values.insight.id, { query })
+                // Drop the response if a newer save started while this request was in flight.
+                await breakpoint(0)
+                actions.renameInsightSuccess(updatedItem)
+                lemonToast.success('Insight updated')
+            } catch (e) {
+                if (!isBreakpoint(e)) {
+                    lemonToast.error('Failed to update insight')
+                }
+            }
+        },
+
         generateInsightMetadataSuccess: ({ generatedInsightMetadata }) => {
             if (generatedInsightMetadata) {
                 actions.setInsightMetadata({

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -297,14 +297,18 @@ export const insightDataLogic = kea<insightDataLogicType>([
             // Debounce rapid clicks. insightDataLogic is keyed per insight, so breakpoint
             // only cancels concurrent saves for THIS insight — not unrelated tiles.
             await breakpoint(700)
+            const insightId = values.insight.id
+            if (!insightId) {
+                return
+            }
             try {
-                const updatedItem = await insightsApi.update(values.insight.id, { query })
+                const updatedItem = await insightsApi.update(insightId, { query })
                 // Drop the response if a newer save started while this request was in flight.
                 await breakpoint(0)
                 actions.renameInsightSuccess(updatedItem)
                 lemonToast.success('Insight updated')
             } catch (e) {
-                if (!isBreakpoint(e)) {
+                if (!isBreakpoint(e as Error)) {
                     lemonToast.error('Failed to update insight')
                 }
             }


### PR DESCRIPTION
## Problem

Follow-up to #65857. After that fix, rapid clicks within the 700ms debounce window correctly collapse into one PATCH. But if you click one option, wait for the debounce to fire a PATCH, then click a second option before the first PATCH returns, you still get the deselect/reselect flash: the first PATCH's response triggers `propsChanged` in `insightDataLogic`, which resets `internalQuery` to stale data.

## Changes

Moves display-option saves from a React debounced callback in `InsightCard` into a proper kea listener on `insightDataLogic`.

`insightDataLogic` is keyed per insight, so its `breakpoint` only cancels concurrent saves for _this_ insight. A dual-breakpoint listener handles both races:

- `await breakpoint(700)` — debounces rapid toggle clicks into a single PATCH
- `await breakpoint(0)` after the API call — drops the response if a newer `persistDisplayOptions` was dispatched while this one was in flight, so `renameInsightSuccess` is never called with stale data

`InsightCard` now just dispatches `persistDisplayOptions()` instead of managing debounce timers, generation counters, and raw API calls in React.

## How did you test this code?

I'm an agent. No automated tests added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (claude-sonnet-4-6[1m]). @sampennington flagged that the first fix attempt did API calls in a React component, which doesn't follow PostHog's kea pattern. Rewrote to add `persistDisplayOptions` to `insightDataLogic` with a kea listener using dual breakpoints — the per-insight key scoping means breakpoint only cancels saves for the same tile.