### PR TITLE
fix(rust): bump jemalloc to 5.3.1 to fix 16k-page arm64 startup abort

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -2206,7 +2206,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3438,7 +3438,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4775,7 +4775,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -5181,7 +5181,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5249,9 +5249,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.8.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d44c349cfe2654897fadcb9de4f0bfbf48288ec344f700b2bd59f152dd209"
+checksum = "0bb2dfa20a68824f4c8c1aa271617d0ee0d9b707a866d56b7d7ee39c60c235a8"
 dependencies = [
  "anyhow",
  "libc",
@@ -6471,7 +6471,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8380,7 +8380,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.37",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -8418,7 +8418,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -9081,7 +9081,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9183,7 +9183,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10637,15 +10637,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.26.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
  "getrandom 0.4.1",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10804,9 +10804,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-ctl"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "661f1f6a57b3a36dc9174a2c10f19513b4866816e13425d3e418b11cc37bc24c"
+checksum = "3a184c43b8ab2f41df2733b55556e3f5f632f4aeaa205b1bb018f574b7f5f142"
 dependencies = [
  "libc",
  "paste",
@@ -10815,9 +10815,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemalloc-sys"
-version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+version = "0.7.1+5.3.1-0-g81034ce1f1373e37dc865038e1bc8eeecf559ce8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+checksum = "1a2825c78386b4ae0314074867860ba9577875de945f05992c38815cbec327f0"
 dependencies = [
  "cc",
  "libc",
@@ -10825,9 +10825,9 @@ dependencies = [
 
 [[package]]
 name = "tikv-jemallocator"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+checksum = "249f09e49ab1609436f34c776e84231bead18d6a955f119f939bdc1d847561bd"
 dependencies = [
  "libc",
  "tikv-jemalloc-sys",
@@ -11935,7 +11935,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/rust/common/alloc/Cargo.toml
+++ b/rust/common/alloc/Cargo.toml
@@ -8,4 +8,4 @@ workspace = true
 
 [dependencies]
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = "0.6"
+tikv-jemallocator = "0.7"

--- a/rust/common/profiler/Cargo.toml
+++ b/rust/common/profiler/Cargo.toml
@@ -10,12 +10,12 @@ workspace = true
 anyhow = { workspace = true }
 axum = { workspace = true }
 flate2 = { workspace = true }
-jemalloc_pprof = { version = "0.8", features = ["flamegraph"] }
+jemalloc_pprof = { version = "0.9", features = ["flamegraph"] }
 pprof = { version = "0.15", features = ["protobuf-codec", "flamegraph"] }
 serde = { workspace = true }
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
+tikv-jemallocator = { version = "0.7", features = ["profiling", "unprefixed_malloc_on_supported_platforms"] }
 
 tokio = { workspace = true }
 


### PR DESCRIPTION
## Problem

PostHog's Rust services use `tikv-jemallocator` as their global allocator (via `common-alloc`). The pinned `0.6` bundles jemalloc 5.3.0, which aborts at startup with `<jemalloc>: Unsupported system page size` on aarch64 kernels built with 16 KB pages (e.g. Fedora Asahi on Apple Silicon, some arm64 distros). Every Rust service that links `common-alloc` — capture, replay-capture, property-defs-rs, feature-flags, cymbal — fails to boot there.

Closes #55189

## Changes

- `common-alloc`: `tikv-jemallocator` 0.6 → 0.7 (bundles jemalloc 5.3.1, which adds the runtime page-size support from upstream jemalloc#2864).
- `common-profiler`: `tikv-jemallocator` 0.6 → 0.7 and `jemalloc_pprof` 0.8 → 0.9 in lockstep. `tikv-jemalloc-sys` carries `links = "jemalloc"`, so the whole graph must agree on one major; `jemalloc_pprof` 0.9 is the first release on `tikv-jemalloc-ctl`/`-sys` 0.7. Both crates then resolve to a single `tikv-jemalloc-sys 0.7.1+5.3.1`. The `jemalloc_pprof` API the profiler uses (`PROF_CTL`, `JemallocProfCtl`, `dump_pprof`, `dump_flamegraph`, `activated`, `flamegraph` feature) is unchanged across 0.8→0.9.
- `Cargo.lock` regenerated. Only `tikv-jemalloc-sys 0.7.0` was yanked — the wrappers resolve to `tikv-jemallocator`/`-ctl` 0.7.0 and `-sys` 0.7.1+5.3.1. The remaining lock churn (`tempfile` 3.26→3.27, plus a few `windows-sys`/`socket2` re-pins) is transitive fallout of moving the jemalloc graph, not a blanket `cargo update`.

No source changes — dependency bump only.

## How did you test this code?

I'm an agent (Claude Code), human-directed. The fix is deterministic: it's the documented jemalloc 5.3.0 → 5.3.1 page-size change, and the lockfile resolves to exactly one `tikv-jemalloc-sys 0.7.1+5.3.1` (the `links = "jemalloc"` conflict is gone). Automated checks run locally on x86_64 macOS:

- `cargo build --locked` green for the two touched crates (`common-alloc`, `common-profiler`) and for the affected services that link `common-alloc`: `capture`, `feature-flags`, `property-defs-rs`, `cymbal`.
- `cargo clippy --locked` + `cargo fmt --check` on the touched crates — clean.

I can't verify the actual 16K-page boot locally — it only reproduces on an aarch64 kernel built with 16 KB pages, which I don't have. @ryanravn opened #55189 from such a box and is best placed to confirm the runtime boot on this branch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change (dependency bump). Safe to apply `skip-inkeep-docs`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @anatolykoptev (DRI). Research suggested a one-line `tikv-jemallocator` 0.6→0.7 bump, but a local build surfaced a `links = "jemalloc"` conflict: `common-profiler` pulls `jemalloc_pprof` 0.8, which pins `tikv-jemalloc-sys` 0.6, so a naive bump can't resolve. Chosen fix: move `jemalloc_pprof` to 0.9 (its first 0.7-sys release) so the workspace agrees on one `tikv-jemalloc-sys`. Verified the profiler's used API is stable across that major. No repo skills applied (dependency-only change).
