### PR TITLE
chore(cdp): always fair-dequeue the email queue

### DIFF
--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -95,12 +95,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_SES_RATE_LIMIT_CAPACITY: number
     CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: number
 
-    // When true, the email worker dequeues ordered by `dequeue_seq` (per-team
-    // round-robin) instead of FIFO. `dequeue_seq` is always assigned at insert
-    // (cheap), so flipping this on/off is purely a worker-side decision —
-    // rollback is a single env-var change with no SQL revert needed.
-    CDP_CYCLOTRON_EMAIL_FAIR_DEQUEUE: boolean
-
     CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: boolean
     CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: string
     CDP_FETCH_RETRIES: number
@@ -219,8 +213,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_SES_RATE_LIMIT_REFILL_PER_SECOND: 100,
         CDP_SES_RATE_LIMIT_CAPACITY: 50,
         CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS: 250,
-
-        CDP_CYCLOTRON_EMAIL_FAIR_DEQUEUE: false,
 
         CDP_EVENT_PROCESSOR_EXECUTE_FIRST_STEP: true,
         CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN: '',

--- a/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/cyclotron-v2.test.ts
@@ -996,8 +996,10 @@ describe('Cyclotron V2', () => {
         })
 
         describe('Worker: fairDequeue ordering', () => {
+            // The email queue is intrinsically fair-dequeued — the worker derives
+            // it from the queue name, so an EMAIL_QUEUE worker is already fair.
             const createFairWorker = (overrides?: Record<string, unknown>): CyclotronV2Worker =>
-                createWorker(EMAIL_QUEUE, { fairDequeue: true, ...overrides })
+                createWorker(EMAIL_QUEUE, overrides)
 
             it('picks small-tenant jobs into the same batch as big-tenant jobs', async () => {
                 // The 2M-vs-1 scenario at a smaller scale: team A enqueues 5,
@@ -1153,21 +1155,19 @@ describe('Cyclotron V2', () => {
                 ])
             })
 
-            it('preserves FIFO when fairDequeue is false (default)', async () => {
-                // Same scenario, but with the flag off, all team-A jobs come first.
+            it('keeps non-email queues on FIFO (priority, scheduled) ordering', async () => {
+                // Fair dequeue is intrinsic to the email queue; a non-email
+                // queue worker stays strict FIFO. Team A enqueues 5 then team B
+                // enqueues 1 on the default (hog) queue — A's 5 come first.
                 const teamA = 100
                 const teamB = 200
-                await manager.bulkCreateJobs(
-                    Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: EMAIL_QUEUE }))
-                )
-                await manager.bulkCreateJobs([{ teamId: teamB, queueName: EMAIL_QUEUE }])
+                await manager.bulkCreateJobs(Array.from({ length: 5 }, () => ({ teamId: teamA, queueName: QUEUE })))
+                await manager.bulkCreateJobs([{ teamId: teamB, queueName: QUEUE }])
 
-                const worker = createWorker(EMAIL_QUEUE, { batchMaxSize: 2 })
+                const worker = createWorker(QUEUE, { batchMaxSize: 2 })
                 const jobs = await dequeueOneBatch(worker)
 
                 expect(jobs).toHaveLength(2)
-                // FIFO: both jobs are team A (their dequeue_seq is ignored by the
-                // ordering, scheduled-time wins, A came first).
                 expect(jobs.every((j) => j.teamId === teamA)).toBe(true)
             })
 

--- a/nodejs/src/cdp/services/cyclotron-v2/types.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/types.ts
@@ -85,13 +85,6 @@ export type CyclotronV2WorkerConfig = {
     pollDelayMs?: number
     heartbeatTimeoutMs?: number
     includeEmptyBatches?: boolean
-    /**
-     * When true, dequeue orders by `dequeue_seq ASC NULLS FIRST` (per-team
-     * round-robin via the sort key assigned at insert time) instead of the
-     * default `priority, scheduled` FIFO. Intended for the email queue
-     * specifically; non-email queues should leave this off.
-     */
-    fairDequeue?: boolean
 }
 
 export type CyclotronV2JanitorConfig = {

--- a/nodejs/src/cdp/services/cyclotron-v2/worker.ts
+++ b/nodejs/src/cdp/services/cyclotron-v2/worker.ts
@@ -54,7 +54,11 @@ export class CyclotronV2Worker {
         this.pollDelayMs = config.pollDelayMs ?? 50
         this.heartbeatTimeoutMs = config.heartbeatTimeoutMs ?? 30000
         this.includeEmptyBatches = config.includeEmptyBatches ?? false
-        this.fairDequeue = config.fairDequeue ?? false
+        // Fair (per-team round-robin) dequeue is the email queue's ordering.
+        // `dequeue_seq` is only ever assigned for email jobs (see
+        // CyclotronV2Manager), so deriving this from the queue name keeps the
+        // worker's ORDER BY in lockstep with where the sort key actually exists.
+        this.fairDequeue = config.queueName === 'email'
     }
 
     async connect(processBatch: (jobs: CyclotronV2DequeuedJob[]) => Promise<void>): Promise<void> {

--- a/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-postgres-v2.ts
@@ -47,11 +47,7 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             | 'CDP_CYCLOTRON_INSERT_MAX_BATCH_SIZE'
             | 'CDP_CYCLOTRON_INSERT_PARALLEL_BATCHES'
             | 'CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS'
-        >,
-        // Worker-level options the queue passes through to the worker on
-        // construction. Currently just fair dequeue; other per-worker tweaks
-        // could go here without bloating the constructor signature further.
-        private workerOptions: { fairDequeue?: boolean } = {}
+        >
     ) {
         this.sanitizer = createInvocationSanitizer(config)
     }
@@ -96,7 +92,6 @@ export class CyclotronJobQueuePostgresV2 implements JobQueue {
             batchMaxSize: this.consumerBatchSize,
             pollDelayMs: this.config.CDP_CYCLOTRON_BATCH_DELAY_MS,
             includeEmptyBatches: true,
-            fairDequeue: this.workerOptions.fairDequeue,
         })
 
         await this.worker.connect(async (jobs) => {

--- a/nodejs/src/cdp/services/job-queue/job-queue-rate-limited-postgres-v2.ts
+++ b/nodejs/src/cdp/services/job-queue/job-queue-rate-limited-postgres-v2.ts
@@ -28,10 +28,9 @@ export class CyclotronJobQueueRateLimitedPostgresV2 extends CyclotronJobQueuePos
     constructor(
         consumerBatchSize: number,
         config: ConstructorParameters<typeof CyclotronJobQueuePostgresV2>[1],
-        private rateLimit: RateLimitedQueueOptions,
-        workerOptions: ConstructorParameters<typeof CyclotronJobQueuePostgresV2>[2] = {}
+        private rateLimit: RateLimitedQueueOptions
     ) {
-        super(consumerBatchSize, config, workerOptions)
+        super(consumerBatchSize, config)
     }
 
     public override async startAsConsumer(

--- a/nodejs/src/server.ts
+++ b/nodejs/src/server.ts
@@ -286,25 +286,19 @@ export class PluginServer implements NodeServer {
                 // the env var (typical for local dev outside k8s) we fall back to the
                 // plain queue and dequeue is unthrottled.
                 //
-                // Fair dequeue (per-team round-robin) is independent — it's wired
-                // into the worker via workerOptions and applies regardless of whether
-                // rate limiting is on.
+                // Fair dequeue (per-team round-robin) is intrinsic to the email queue —
+                // the worker derives it from its queue name — and applies regardless of
+                // whether rate limiting is on.
                 const sesValkey = createSesRateLimiterValkeyPool(this.config)
-                const workerOptions = { fairDequeue: this.config.CDP_CYCLOTRON_EMAIL_FAIR_DEQUEUE }
                 const queue = sesValkey
-                    ? new CyclotronJobQueueRateLimitedPostgresV2(
-                          this.config.CONSUMER_BATCH_SIZE,
-                          this.config,
-                          {
-                              limiter: new RateLimiterService(sesValkey, { name: 'ses' }),
-                              key: '@posthog/ses/global',
-                              capacity: this.config.CDP_SES_RATE_LIMIT_CAPACITY,
-                              refillPerSecond: this.config.CDP_SES_RATE_LIMIT_REFILL_PER_SECOND,
-                              throttledPollDelayMs: this.config.CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS,
-                          },
-                          workerOptions
-                      )
-                    : new CyclotronJobQueuePostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config, workerOptions)
+                    ? new CyclotronJobQueueRateLimitedPostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config, {
+                          limiter: new RateLimiterService(sesValkey, { name: 'ses' }),
+                          key: '@posthog/ses/global',
+                          capacity: this.config.CDP_SES_RATE_LIMIT_CAPACITY,
+                          refillPerSecond: this.config.CDP_SES_RATE_LIMIT_REFILL_PER_SECOND,
+                          throttledPollDelayMs: this.config.CDP_SES_RATE_LIMIT_THROTTLED_POLL_DELAY_MS,
+                      })
+                    : new CyclotronJobQueuePostgresV2(this.config.CONSUMER_BATCH_SIZE, this.config)
                 const worker = new CdpCyclotronWorkerEmail(this.config, cdpDeps!, queue)
                 await worker.start()
                 return worker.service


### PR DESCRIPTION
## Problem

Fair dequeue — per-team round-robin ordering on the email queue so a small tenant's email never sits behind a large tenant's backlog — shipped behind the `CDP_CYCLOTRON_EMAIL_FAIR_DEQUEUE` env var, defaulting off in every environment. The rollout is done; it should be on everywhere, and the toggle scaffolding can go.

## Changes

- Enable fair dequeue for the email queue in all environments.
- The worker now derives fair dequeue from its queue name (`queueName === 'email'`) instead of a config flag. This matches the real invariant — `dequeue_seq` is only ever assigned for email jobs (enforced in `CyclotronV2Manager`), so the worker's `ORDER BY` stays in lockstep with where the sort key actually exists.
- Remove the now-dead `CDP_CYCLOTRON_EMAIL_FAIR_DEQUEUE` env var and the `fairDequeue` / `workerOptions` plumbing threaded through the worker config type, both Postgres-v2 queue classes, and the server wiring.

Non-email queues are unaffected — they stay on strict FIFO (`priority, scheduled`).

## How did you test this code?

I'm an agent (PostHog Slack app). Automated checks I ran:

- `tsc --noEmit` — no type errors in any changed file.
- `eslint` on all changed files — clean.

I updated the unit tests in `cyclotron-v2.test.ts`: the fair-dequeue cases now rely on the email queue being intrinsically fair (no flag), and the old "FIFO when the flag is off" case was repurposed to assert a non-email queue still gets FIFO ordering (the behavior that case now protects — there's no longer a way to run the email queue in FIFO). The DB-backed worker tests require the cyclotron Postgres instance and were not run in this environment.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app (Claude) from a Slack thread. Meikel asked to enable fair dequeuing for all envs and clean up the code.

Decision worth flagging for review: rather than just flipping the env-var default to `true` (which would leave the toggle plumbing in place as dead weight), I removed the flag entirely and tied fair dequeue to `queueName === 'email'`. The worker is already email-aware (its `reschedule` path hardcodes `'email'` and calls `assignEmailDequeueSeq`), and `dequeue_seq` is only assigned for email jobs, so this couples the behavior to the actual invariant and deletes the parallel `fairDequeue`/`workerOptions` config path through three files. The trade-off: it's no longer possible to run the email queue in FIFO mode — intentional, since that was only ever a rollout safety valve.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1782372093157599)*
