### PR TITLE
chore(mcp): add local tool-search debugger and root-cause writeup

### DIFF
--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -39,6 +39,7 @@
         "generate-cli-agent-scopes": "tsx scripts/build-cli-agent-scopes.ts",
         "scaffold-yaml": "tsx scripts/scaffold-yaml.ts",
         "lint-tool-names": "tsx scripts/lint-tool-names.ts",
+        "tool-search-debug": "tsx scripts/tool-search-debug.ts",
         "format": "oxlint --fix --fix-suggestions --fix-dangerously --quiet && oxfmt \"./**/*.{js,mjs,ts,tsx,json,yaml,yml,css,scss}\""
     },
     "dependencies": {

--- a/services/mcp/scripts/tool-search-debug.md
+++ b/services/mcp/scripts/tool-search-debug.md
@@ -1,0 +1,134 @@
+# Tool search: local debugger + why results look irrelevant
+
+`scripts/tool-search-debug.ts` reproduces PostHog MCP tool search **without booting the MCP server**,
+so you can see what a query matches and iterate on tool names/descriptions in a tight loop.
+This doc also explains why a request like "create a dashboard" can surface completely irrelevant
+tools in a coding-agent client.
+
+## TL;DR
+
+When a coding-agent client (Claude Code / PostHog Code) is asked to create a dashboard and its first
+move is a "tool search" that returns Notion / Task / Cron / Worktree tools, **that search is the
+client's own tool picker, not the PostHog MCP.** Three layers stack up:
+
+1. **Single-exec mode** — for coding-agent clients the server advertises exactly one tool,
+   `mcp__posthog__exec`. All ~611 real tools (`dashboard-create`, `insight-create`, …) live behind
+   `exec`'s subcommands, so there is no `dashboard-create` for the client to find.
+2. **`exec` is undiscoverable** — the client defers `exec` and must search to surface it, but
+   `exec`'s advertised description is pure procedure ("Pass CLI-style commands", "Discover tools
+   first") with zero product vocabulary. Nothing in it matches "create dashboard insight", so the
+   client returns the nearest literal _create_ tools from other connected servers instead.
+3. **`exec search` is brittle** — even once `exec` is in hand, `exec search <text>` compiles the text
+   as a single case-insensitive **regex**, so `search create dashboard insight` →
+   `/create dashboard insight/i` → matches the literal phrase → **0 tools**. You have to search a
+   single token (`search dashboard`).
+
+The slowness is the serial round-trips this forces: client tool search → `exec search` →
+`exec info` → `exec call`, each a separate model turn and network hop before any real work begins.
+
+## The two "tool searches" — don't conflate them
+
+|                 | Client tool picker                                                           | PostHog `exec search`                                  |
+| --------------- | ---------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Who runs it     | The coding-agent harness (closed; **not** in this repo)                      | The PostHog MCP server                                 |
+| Input shape     | `{ "query": "...", "max_results": N }` → `{ "type": "tool_reference", ... }` | `exec({ "command": "search <regex>" })`                |
+| Scope of search | Every connected tool universe (harness builtins + all MCP servers)           | PostHog tools only                                     |
+| Algorithm       | Proprietary ranking                                                          | One case-insensitive regex over name/title/description |
+
+The irrelevant `tool_reference` results come from the left column. This script reproduces the right
+column — the part we own and can fix. The harness ranking is not in this repo, so it can't be
+byte-reproduced here.
+
+## Using the debugger
+
+```bash
+cd services/mcp
+npx tsx scripts/tool-search-debug.ts "<query>"                       # regex mode (default)
+npx tsx scripts/tool-search-debug.ts --mode tokens "<query>"          # candidate ranked search
+npx tsx scripts/tool-search-debug.ts --mode both   "<query>" --limit 10
+npx tsx scripts/tool-search-debug.ts --json "<query>"                 # machine-readable
+```
+
+It loads the real catalog from `schema/tool-definitions-all.json` (the full, **unfiltered** set — no
+scope or feature-flag gating — so it shows the upper bound of what a query could match).
+
+- **`regex`** is a faithful copy of the server's `search` predicate (`src/tools/exec.ts:220-262`,
+  predicate at line 237): same 200-char cap, same invalid-regex guard, same fields.
+- **`tokens`** is a _candidate_ ranked search (not what the server runs today): it splits the query on
+  whitespace and ranks tools by a field-weighted score (name 3 > title 2 > description 1) over the
+  distinct query tokens they contain.
+
+## The failure, reproduced
+
+```text
+$ npx tsx scripts/tool-search-debug.ts --mode regex "create dashboard insight"
+▶ regex mode  (exact reproduction of `exec search`)
+  pattern: /create dashboard insight/i
+  0 matches — the query is tested as one literal regex, so a multi-word phrase rarely matches.
+```
+
+A single token works, because it's a substring the regex can find:
+
+```text
+$ npx tsx scripts/tool-search-debug.ts --mode regex "dashboard" --limit 8
+  33 match(es), showing 8:
+    activity-log-list      ← noise: its *description* mentions "dashboard"
+    comments-list          ← noise
+    dashboard-create
+    dashboard-create-text-tile
+    dashboard-delete
+    ...
+```
+
+## What a token-ranked search would surface instead
+
+```text
+$ npx tsx scripts/tool-search-debug.ts --mode tokens "create dashboard insight" --limit 6
+  207 match(es), showing top 6:
+    score  cover matched in         tool
+    7      3/3   name+description   dashboard-create
+    7      3/3   name+description   dashboard-create-text-tile
+    6      2/3   name               dashboard-insights-run
+    6      2/3   name               insight-create
+    5      3/3   name+description   subscriptions-create
+    4      2/3   name+description   action-create
+```
+
+The same natural-language query now leads with the tools the agent actually wants. Field weighting is
+what keeps `dashboard-create` (tokens in the _name_) above a tool that merely mentions
+create/dashboard/insight in prose.
+
+## End-to-end against the real server (this _does_ use the MCP)
+
+To confirm the script matches the served `exec search` path, run the Hono server and call it over
+JSON-RPC:
+
+```bash
+cd services/mcp
+pnpm run dev:hono            # http://localhost:3001/mcp  (needs Redis; set POSTHOG_API_BASE_URL + a Bearer token)
+
+# initialize → grab the Mcp-Session-Id response header, then:
+curl -s -X POST http://localhost:3001/mcp \
+  -H "Authorization: Bearer phx_..." \
+  -H "Mcp-Session-Id: <session-id>" \
+  -H "Content-Type: application/json" \
+  -H "Accept: application/json, text/event-stream" \
+  -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"exec","arguments":{"command":"search dashboard"}}}'
+```
+
+The returned tool names match the script's `regex` mode for the same pattern. `pnpm run inspector`
+(MCP Inspector GUI) is the point-and-click equivalent.
+
+## Fixing it (out of scope for this debugger)
+
+The debugger exists to iterate on exactly these before committing to a change:
+
+- **Make `exec search` forgiving** — token/relevance ranking (as `tokens` mode prototypes) so
+  multi-word intents return the right tools instead of nothing. Lives in the `search` case of
+  `src/tools/exec.ts`. The natural first refactor is to extract the predicate into a shared
+  `src/tools/tool-search.ts` consumed by both `exec.ts` and this script (kills the copy here).
+- **Make `exec` discoverable** — enrich its advertised description
+  (`src/templates/sections/exec-tool-blurb.md`, via `buildExecToolDescription` in
+  `src/lib/instructions-formatter.ts`) with product vocabulary (dashboards, insights, funnels, flags,
+  experiments, error tracking, session recordings, …) so a harness tool search can match it for
+  analytics intents — and/or arrange for clients not to defer it.

--- a/services/mcp/scripts/tool-search-debug.ts
+++ b/services/mcp/scripts/tool-search-debug.ts
@@ -1,0 +1,269 @@
+#!/usr/bin/env tsx
+/**
+ * tool-search-debug — reproduce PostHog MCP tool search locally, no MCP server.
+ *
+ * In single-exec mode the server exposes only `exec`; agents discover the real
+ * tools via `exec search <pattern>`. That search compiles the pattern as ONE
+ * case-insensitive regex over name/title/description (src/tools/exec.ts:237), so a
+ * natural-language query like "create dashboard insight" becomes
+ * /create dashboard insight/i and matches nothing — no tool contains that literal
+ * phrase. This script runs that exact predicate against the real tool catalog so
+ * you can see what `exec search` returns, plus a token-ranked mode for comparison,
+ * without booting the MCP. It searches the full unfiltered catalog (no scope or
+ * feature-flag gating), so it shows the upper bound of what a query could match.
+ *
+ * Usage:
+ *   npx tsx scripts/tool-search-debug.ts "<query>"
+ *   npx tsx scripts/tool-search-debug.ts --mode regex  "dashboard"
+ *   npx tsx scripts/tool-search-debug.ts --mode tokens "create dashboard insight"
+ *   npx tsx scripts/tool-search-debug.ts --mode both   "create dashboard insight"
+ *   npx tsx scripts/tool-search-debug.ts --json --limit 30 "insight"
+ *
+ * Modes:
+ *   regex  (default) — faithful copy of exec's search predicate
+ *   tokens           — whitespace-split, ranked by distinct query tokens matched
+ *   both             — run both, side by side
+ */
+import * as fs from 'node:fs'
+import * as path from 'node:path'
+
+const MCP_ROOT = path.resolve(__dirname, '..')
+const CATALOG_PATH = path.resolve(MCP_ROOT, 'schema', 'tool-definitions-all.json')
+
+/** Mirrors MAX_SEARCH_PATTERN_LENGTH in src/tools/exec.ts. */
+const MAX_SEARCH_PATTERN_LENGTH = 200
+
+const FIELD_WEIGHT = { name: 3, title: 2, description: 1 } as const
+type Field = keyof typeof FIELD_WEIGHT
+
+type Mode = 'regex' | 'tokens' | 'both'
+
+interface ToolEntry {
+    name: string
+    title: string
+    description: string
+}
+
+interface RegexResult {
+    pattern: string
+    matches: string[]
+    error?: string
+}
+
+interface ScoredTool {
+    name: string
+    /** Distinct query tokens found in any field — the primary relevance signal. */
+    tokensMatched: number
+    /** Field-weighted score, tie-breaker once token coverage is equal. */
+    score: number
+    fields: Field[]
+}
+
+interface Args {
+    mode: Mode
+    json: boolean
+    limit: number
+    query: string
+}
+
+function loadCatalog(): ToolEntry[] {
+    const raw = JSON.parse(fs.readFileSync(CATALOG_PATH, 'utf-8')) as Record<
+        string,
+        { title?: string; description?: string }
+    >
+    return Object.entries(raw).map(([name, def]) => ({
+        name,
+        title: def.title ?? '',
+        description: def.description ?? '',
+    }))
+}
+
+// Faithful copy of the `search` predicate in src/tools/exec.ts:220-262 — same
+// length cap, same invalid-regex guard, same case-insensitive test over
+// name/title/description. Kept as a copy (not an import) so this debug script
+// stays decoupled from the server runtime; the line reference flags drift.
+function searchRegex(tools: ToolEntry[], pattern: string): RegexResult {
+    if (pattern.length > MAX_SEARCH_PATTERN_LENGTH) {
+        return {
+            pattern,
+            matches: [],
+            error: `pattern too long (${pattern.length} chars, max ${MAX_SEARCH_PATTERN_LENGTH})`,
+        }
+    }
+    let regex: RegExp
+    try {
+        regex = new RegExp(pattern, 'i')
+    } catch {
+        return { pattern, matches: [], error: `invalid regex pattern: "${pattern}"` }
+    }
+    const matches = tools
+        .filter((t) => regex.test(t.name) || regex.test(t.title) || regex.test(t.description))
+        .map((t) => t.name)
+    return { pattern, matches }
+}
+
+// Candidate ranked search for comparison — not what the server runs today.
+// Splits the query into tokens and ranks by how many distinct tokens appear in a
+// tool's metadata, so multi-word intents like "create dashboard insight" surface
+// dashboard-create / insight-create instead of returning nothing.
+function searchTokens(tools: ToolEntry[], query: string): ScoredTool[] {
+    const tokens = [...new Set(query.toLowerCase().split(/\s+/).filter(Boolean))]
+    if (tokens.length === 0) {
+        return []
+    }
+    const scored: ScoredTool[] = []
+    for (const t of tools) {
+        const haystack: Record<Field, string> = {
+            name: t.name.toLowerCase(),
+            title: t.title.toLowerCase(),
+            description: t.description.toLowerCase(),
+        }
+        let tokensMatched = 0
+        let score = 0
+        const fields = new Set<Field>()
+        for (const token of tokens) {
+            // Count each token once, at its highest-weight field, so a token in the
+            // name outweighs the same token buried in a description.
+            const field = (['name', 'title', 'description'] as Field[]).find((f) => haystack[f].includes(token))
+            if (field) {
+                tokensMatched += 1
+                score += FIELD_WEIGHT[field]
+                fields.add(field)
+            }
+        }
+        if (tokensMatched > 0) {
+            scored.push({ name: t.name, tokensMatched, score, fields: [...fields] })
+        }
+    }
+    // Field-weighted score first: a token in the tool name beats the same token
+    // buried in a description, so dashboard-create outranks a tool that merely
+    // mentions "create"/"dashboard"/"insight" in prose. Token coverage breaks ties.
+    scored.sort((a, b) => b.score - a.score || b.tokensMatched - a.tokensMatched || a.name.localeCompare(b.name))
+    return scored
+}
+
+function parseArgs(argv: string[]): Args {
+    let mode: Mode = 'regex'
+    let json = false
+    let limit = 20
+    const rest: string[] = []
+    for (let i = 0; i < argv.length; i++) {
+        const arg = argv[i]
+        if (arg === '--mode') {
+            const next = argv[++i]
+            if (next !== undefined) {
+                mode = next as Mode
+            }
+        } else if (arg === '--json') {
+            json = true
+        } else if (arg === '--limit') {
+            const next = argv[++i]
+            if (next !== undefined) {
+                limit = Number(next)
+            }
+        } else if (arg === '--help' || arg === '-h') {
+            printUsage()
+            process.exit(0)
+        } else if (arg !== undefined) {
+            rest.push(arg)
+        }
+    }
+    return { mode, json, limit, query: rest.join(' ') }
+}
+
+function printUsage(): void {
+    process.stdout.write(
+        [
+            'Usage: tsx scripts/tool-search-debug.ts [--mode regex|tokens|both] [--json] [--limit N] "<query>"',
+            '',
+            '  regex  (default)  faithful reproduction of `exec search` (single case-insensitive regex)',
+            '  tokens            candidate ranked search (whitespace-split, ranked by tokens matched)',
+            '  both              run both side by side',
+            '',
+        ].join('\n')
+    )
+}
+
+function renderRegex(result: RegexResult, limit: number): string {
+    const lines = [`▶ regex mode  (exact reproduction of \`exec search\`)`, `  pattern: /${result.pattern}/i`]
+    if (result.error) {
+        lines.push(`  error: ${result.error}`)
+        return lines.join('\n')
+    }
+    if (result.matches.length === 0) {
+        lines.push('  0 matches — the query is tested as one literal regex, so a multi-word phrase rarely matches.')
+        return lines.join('\n')
+    }
+    lines.push(`  ${result.matches.length} match(es)${result.matches.length > limit ? `, showing ${limit}` : ''}:`)
+    for (const name of result.matches.slice(0, limit)) {
+        lines.push(`    ${name}`)
+    }
+    return lines.join('\n')
+}
+
+function renderTokens(scored: ScoredTool[], query: string, limit: number): string {
+    const tokens = [...new Set(query.toLowerCase().split(/\s+/).filter(Boolean))]
+    const lines = [`▶ tokens mode  (candidate ranked search)`, `  tokens: ${tokens.join(', ')}`]
+    if (scored.length === 0) {
+        lines.push('  0 matches.')
+        return lines.join('\n')
+    }
+    lines.push(`  ${scored.length} match(es)${scored.length > limit ? `, showing top ${limit}` : ''}:`)
+    lines.push(`    ${'score'.padEnd(6)} ${'cover'.padEnd(5)} ${'matched in'.padEnd(18)} tool`)
+    for (const t of scored.slice(0, limit)) {
+        const score = String(t.score).padEnd(6)
+        const cover = `${t.tokensMatched}/${tokens.length}`.padEnd(5)
+        const where = t.fields.join('+').padEnd(18)
+        lines.push(`    ${score} ${cover} ${where} ${t.name}`)
+    }
+    return lines.join('\n')
+}
+
+function main(): void {
+    const args = parseArgs(process.argv.slice(2))
+    if (!args.query) {
+        printUsage()
+        process.exitCode = 1
+        return
+    }
+    if (args.mode !== 'regex' && args.mode !== 'tokens' && args.mode !== 'both') {
+        process.stderr.write(`Unknown mode: "${args.mode}". Use regex, tokens, or both.\n`)
+        process.exitCode = 1
+        return
+    }
+
+    const tools = loadCatalog()
+    const regex = args.mode !== 'tokens' ? searchRegex(tools, args.query) : undefined
+    const tokens = args.mode !== 'regex' ? searchTokens(tools, args.query) : undefined
+
+    if (args.json) {
+        process.stdout.write(
+            JSON.stringify(
+                {
+                    query: args.query,
+                    catalog: { path: path.relative(MCP_ROOT, CATALOG_PATH), tools: tools.length },
+                    ...(regex ? { regex } : {}),
+                    ...(tokens ? { tokens: tokens.slice(0, args.limit) } : {}),
+                },
+                null,
+                2
+            ) + '\n'
+        )
+        return
+    }
+
+    const blocks = [
+        `Catalog: ${tools.length} tools (${path.relative(MCP_ROOT, CATALOG_PATH)})`,
+        `Query:   "${args.query}"`,
+        '',
+    ]
+    if (regex) {
+        blocks.push(renderRegex(regex, args.limit), '')
+    }
+    if (tokens) {
+        blocks.push(renderTokens(tokens, args.query, args.limit), '')
+    }
+    process.stdout.write(blocks.join('\n'))
+}
+
+main()


### PR DESCRIPTION
## Problem

Coding-agent MCP clients (Claude Code / PostHog Code) feel slow on PostHog tasks, and a request like "create a dashboard" often opens with a tool search that returns completely irrelevant tools (Notion / Task / Cron / Worktree). There was no way to inspect PostHog's tool search locally, and the reason for the bad results wasn't written down anywhere.

## Changes

Adds a standalone, server-free debugger plus a root-cause writeup. No production code paths are touched.

- `services/mcp/scripts/tool-search-debug.ts` — loads the real catalog (`schema/tool-definitions-all.json`) and runs tool search with no MCP server in the loop. `regex` mode is a faithful copy of the server's `exec search` predicate (`src/tools/exec.ts`); `tokens` mode prototypes a forgiving, field-weighted ranked search for comparison. Supports `--mode`, `--json`, `--limit`; runnable via `pnpm tool-search-debug`.
- `services/mcp/scripts/tool-search-debug.md` — explains why coding-agent clients surface irrelevant tools: the offending results come from the *client's own* tool picker (not PostHog — that `tool_reference`/`max_results` shape exists nowhere in this repo), compounded by single-exec mode exposing only `exec`, an `exec` description with zero product vocabulary, and `exec search` compiling a multi-word query as one literal regex (so "create dashboard insight" matches nothing).

The client-side ranking is closed and not in this repo, so the debugger reproduces PostHog's own `exec search` — the part we can actually fix. Concrete fixes (forgiving ranked search, richer `exec` description) are noted in the doc but deliberately out of scope here.

## How did you test this code?

I'm an agent — no manual UI testing. Local checks I actually ran:

- `pnpm typecheck` (tsgo) — passes.
- `oxlint` + `oxfmt` on the new script — clean.
- Ran the debugger against the real catalog: `--mode regex "create dashboard insight"` → **0 matches** (reproduces the failure), `--mode regex "dashboard"` → 33 matches, `--mode tokens "create dashboard insight"` → ranks `dashboard-create` / `insight-create` at the top.

No new automated tests: this is a dev-only debug script plus a doc with no production code path, so there's no runtime regression for a test to guard. Happy to add a unit test if the `tokens` ranking graduates into `exec search`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thomas asked (1) how to reproduce the MCP tool-search call locally like an API debugger and (2) why the results are so bad. Built with PostHog Code (Claude Code). Investigation traced the pasted junk to the client harness's own ToolSearch rather than PostHog, then to single-exec mode + an undiscoverable `exec` + literal-regex `exec search`. Scope was explicitly confined to a debugger + writeup; no production search or description changes in this PR. No repo-provided skills were required.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
