### PR TITLE
feat(slack_app): re-auth PostHog MCP per slack followup actor

### DIFF
--- a/posthog/temporal/ai/slack_app/activities/task_creation.py
+++ b/posthog/temporal/ai/slack_app/activities/task_creation.py
@@ -556,12 +556,14 @@ def forward_posthog_code_followup_activity(
     slack = SlackIntegration(integration)
 
     followup_user_text_prefix: str | None = None
+    actor_user = mapping.task.created_by
     if slack_user_id != mapping.mentioning_slack_user_id:
-        # The follow-up is from a different Slack user than the one who started the
-        # thread. Try to resolve them to a PostHog user with access to the same team
-        # — if so, let them participate; the message is still relayed in the original
-        # author's name (their sandbox token, their identity to the agent), with the
-        # actual sender's name prefixed onto the text so the agent sees who spoke.
+        # Follow-up from someone other than the original mentioner. Resolve them to a
+        # PostHog user with access to the same team; if they qualify, they participate
+        # under their own identity — the sandbox JWT and the PostHog MCP OAuth token
+        # are both rebound to them via send_refresh_session below, so their actions
+        # (insights, dashboards, etc.) attribute to them rather than the task creator.
+        # The actor's name is still prefixed onto the text so the agent sees who spoke.
         resolved = resolve_slack_user(slack, integration, slack_user_id, channel, thread_ts)
         if not resolved:
             logger.info(
@@ -577,6 +579,7 @@ def forward_posthog_code_followup_activity(
         # into the LLM-forwarded prefix when both name and slack_email are absent.
         actor_name = resolved.user.get_full_name() or resolved.slack_email or resolved.user.email
         followup_user_text_prefix = f"{actor_name}: "
+        actor_user = resolved.user
         logger.info(
             "posthog_code_followup_cross_user_authorized",
             channel=channel,
@@ -676,12 +679,35 @@ def forward_posthog_code_followup_activity(
         safe_react(slack.client, channel, user_message_ts, "eyes")
 
     auth_token = None
-    created_by = mapping.task.created_by
-    if created_by and created_by.id:
-        distinct_id = created_by.distinct_id or f"user_{created_by.id}"
+    if actor_user and actor_user.id:
+        distinct_id = actor_user.distinct_id or f"user_{actor_user.id}"
         auth_token = tasks_facade.create_sandbox_connection_token(
-            task_run.id, user_id=created_by.id, distinct_id=distinct_id
+            task_run.id, user_id=actor_user.id, distinct_id=distinct_id
         )
+
+    # On cross-user follow-ups, swap the agent's PostHog MCP credentials to the live
+    # actor *before* sending the message — so the next ACP query mints insights /
+    # dashboards under their identity, not the original creator's. ``force=True``
+    # bypasses the per-(run, user) rate limit so an identity transition is never
+    # silently skipped. -32002 (mid-turn) is best-effort: we log and proceed —
+    # ``send_user_message`` will queue under the *old* identity, which is a known
+    # downside we accept rather than dropping the user's message.
+    if actor_user and actor_user.id and mapping.task.created_by_id and actor_user.id != mapping.task.created_by_id:
+        try:
+            tasks_facade.refresh_sandbox_mcp_for_user(
+                task_run.id,
+                actor_user.id,
+                scopes="full",
+                auth_token=auth_token,
+                force=True,
+            )
+        except Exception:
+            logger.exception(
+                "posthog_code_followup_mcp_reauth_failed",
+                channel=channel,
+                thread_ts=thread_ts,
+                actor_user_id=actor_user.id,
+            )
 
     result = tasks_facade.send_user_message(task_run.id, user_text, auth_token=auth_token, timeout=90)
     if not result.success and result.retryable and result.status_code != 504:

--- a/products/slack_app/backend/tests/test_followup_forwarding.py
+++ b/products/slack_app/backend/tests/test_followup_forwarding.py
@@ -703,6 +703,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         mock_resolve.assert_called_once_with(mock_slack_instance, self.integration, "U_BOB", "C123", "1234.5678")
         mock_slack_instance.client.chat_postMessage.assert_not_called()
 
+    @patch("products.tasks.backend.facade.api.refresh_sandbox_mcp_for_user")
     @patch(
         "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
         return_value="jwt-token",
@@ -711,11 +712,13 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("posthog.models.integration.SlackIntegration")
     def test_cross_user_followup_authorized_prefixes_actor_name(
-        self, mock_slack_cls, mock_resolve, mock_send, mock_token
+        self, mock_slack_cls, mock_resolve, mock_send, mock_token, mock_reauth
     ):
-        # A second user in the same PostHog org and team should be allowed to chip in
-        # on the thread; their message is forwarded under the original author's identity
-        # but their name is prepended so the agent knows who actually spoke.
+        # A second user in the same PostHog org and team chips in on the thread:
+        # we re-bind the sandbox JWT and the PostHog MCP credentials to *them*, so
+        # subsequent agent writes (insights, dashboards) attribute to the live
+        # actor rather than the long-gone task creator. Their name is also
+        # prepended onto the text so the agent knows who spoke.
         self._create_mapping(mentioning_user="U_ALICE")
         bob = User.objects.create(email="bob@test.com", first_name="Bob")
         mock_slack_instance = MagicMock()
@@ -729,6 +732,13 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         )
 
         assert result is True
+        # JWT is minted for Bob (the live actor), not Alice (the original creator).
+        # The facade forwards user_id/distinct_id positionally to the underlying mint,
+        # so the mock sees args = (run, user_id, distinct_id).
+        assert mock_token.call_args.args[1] == bob.id
+        # MCP credentials are forcibly rebound to Bob before the follow-up is delivered,
+        # so the agent's next ACP query talks to PostHog as Bob.
+        mock_reauth.assert_called_once_with(self.task_run.id, bob.id, scopes="full", auth_token="jwt-token", force=True)
         mock_send.assert_called_once_with(
             self.task_run, "Bob: please retry the build", auth_token="jwt-token", timeout=90
         )
@@ -740,6 +750,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         ]
         assert not post_calls
 
+    @patch("products.tasks.backend.facade.api.refresh_sandbox_mcp_for_user")
     @patch(
         "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
         return_value="jwt-token",
@@ -748,7 +759,7 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
     @patch("products.slack_app.backend.api.resolve_slack_user")
     @patch("posthog.models.integration.SlackIntegration")
     def test_cross_user_followup_falls_back_to_email_when_no_full_name(
-        self, mock_slack_cls, mock_resolve, mock_send, mock_token
+        self, mock_slack_cls, mock_resolve, mock_send, mock_token, mock_reauth
     ):
         self._create_mapping(mentioning_user="U_ALICE")
         bob = User.objects.create(email="bob@test.com")  # no full name
@@ -760,6 +771,38 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         forward_posthog_code_followup_activity(inputs, "C123", "1234.5678", "U_BOB", "<@BOT> ping", "1234.5679")
 
         mock_send.assert_called_once_with(self.task_run, "bob@test.com: ping", auth_token="jwt-token", timeout=90)
+
+    @patch("products.tasks.backend.facade.api.refresh_sandbox_mcp_for_user")
+    @patch(
+        "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
+        return_value="jwt-token",
+    )
+    @patch("products.tasks.backend.logic.services.agent_command.send_user_message")
+    @patch("products.slack_app.backend.api.resolve_slack_user")
+    @patch("posthog.models.integration.SlackIntegration")
+    def test_cross_user_followup_proceeds_when_mcp_reauth_raises(
+        self, mock_slack_cls, mock_resolve, mock_send, mock_token, mock_reauth
+    ):
+        # If the MCP rebind fails (e.g. the agent rejects with -32002 mid-turn or the
+        # OAuth mint blows up), we still deliver the user's message rather than dropping
+        # it on the floor. The cost is that the *first* tool call after this follow-up
+        # may still attribute to the original creator — an accepted downside vs. losing
+        # the user's input entirely.
+        self._create_mapping(mentioning_user="U_ALICE")
+        bob = User.objects.create(email="bob@test.com", first_name="Bob")
+        mock_slack_cls.return_value = MagicMock()
+        mock_resolve.return_value = SlackUserContext(user=bob, slack_email="bob@test.com")
+        mock_send.return_value = _command_result(success=True, status_code=200)
+        mock_reauth.side_effect = RuntimeError("refresh failed")
+
+        inputs = _make_inputs(self.integration.id)
+        result = forward_posthog_code_followup_activity(
+            inputs, "C123", "1234.5678", "U_BOB", "<@BOT> ping", "1234.5679"
+        )
+
+        assert result is True
+        mock_reauth.assert_called_once()
+        mock_send.assert_called_once_with(self.task_run, "Bob: ping", auth_token="jwt-token", timeout=90)
 
     @patch("products.slack_app.backend.api.resolve_slack_user", return_value=None)
     @patch("posthog.models.integration.SlackIntegration")
@@ -823,13 +866,14 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
         call_kwargs = mock_slack_instance.client.chat_postMessage.call_args.kwargs
         assert "still starting up" in call_kwargs["text"]
 
+    @patch("products.tasks.backend.facade.api.refresh_sandbox_mcp_for_user")
     @patch(
         "products.tasks.backend.logic.services.connection_token.create_sandbox_connection_token",
         return_value="jwt-token",
     )
     @patch("products.tasks.backend.logic.services.agent_command.send_user_message")
     @patch("posthog.models.integration.SlackIntegration")
-    def test_successful_forwarding(self, mock_slack_cls, mock_send, mock_token):
+    def test_successful_forwarding(self, mock_slack_cls, mock_send, mock_token, mock_reauth):
         mapping = self._create_mapping()
         mock_slack_instance = MagicMock()
         mock_slack_cls.return_value = mock_slack_instance
@@ -846,6 +890,10 @@ class TestForwardPostHogCodeFollowupActivity(TestCase):
 
         assert result is True
         mock_token.assert_called_once()
+        # Same-user follow-up: actor matches the task creator, so the agent's
+        # MCP credentials don't need to be rebound. Skipping this preserves the
+        # cached MCP rate-limit and avoids a no-op `send_refresh_session` round-trip.
+        mock_reauth.assert_not_called()
         mock_send.assert_called_once_with(self.task_run, "do something", auth_token="jwt-token", timeout=90)
         # Agent is now working on the message, so the :eyes: reaction stays up — it is
         # not swapped to :hedgehog: until the task genuinely completes.

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -149,6 +149,7 @@ __all__ = [
     "read_task_run_logs",
     "read_task_run_session_log_content",
     "redeem_code_invite",
+    "refresh_sandbox_mcp_for_user",
     "refresh_team_code_workstreams",
     "relay_task_run_message",
     "reset_code_workflow_bindings",
@@ -3624,3 +3625,30 @@ def send_cancel(run_id: str | UUID, *, auth_token: str | None = None):
 
     run = TaskRun.objects.select_related("task").get(id=run_id)
     return _send_cancel(run, auth_token=auth_token)
+
+
+def refresh_sandbox_mcp_for_user(
+    run_id: str | UUID,
+    user_id: int,
+    *,
+    scopes: str = "full",
+    auth_token: str | None = None,
+    force: bool = False,
+):
+    """Mint an MCP OAuth token scoped to ``user_id`` and push fresh MCP server
+    configs into a run's live sandbox so subsequent agent actions act under
+    that user's identity.
+
+    Used by Slack follow-ups when a teammate other than the original task
+    creator takes over the conversation, so PostHog MCP writes are attributed
+    to the live actor rather than the long-gone task creator.
+    """
+    from posthog.models import User  # noqa: PLC0415 — keep ORM off the api import path
+
+    from products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox import (  # noqa: PLC0415 — keep sandbox deps off the api import path
+        refresh_sandbox_mcp_for_user as _refresh,
+    )
+
+    run = TaskRun.objects.select_related("task__created_by").get(id=run_id)
+    user = User.objects.get(id=user_id)
+    return _refresh(run, user, scopes=scopes, auth_token=auth_token, force=force)

--- a/products/tasks/backend/temporal/oauth.py
+++ b/products/tasks/backend/temporal/oauth.py
@@ -16,10 +16,11 @@ __all__ = [
     "ARRAY_APP_CLIENT_ID_US",
     "create_oauth_access_token",
     "create_oauth_access_token_for_user",
+    "oauth_application_for_task",
 ]
 
 
-def _oauth_application_for_task(task: Task) -> SandboxOAuthApplication:
+def oauth_application_for_task(task: Task) -> SandboxOAuthApplication:
     if task.origin_product == Task.OriginProduct.POSTHOG_AI:
         return "posthog_ai"
     return "array"
@@ -41,7 +42,7 @@ def create_oauth_access_token(task: Task, *, scopes: PosthogMcpScopes = "read_on
         task.created_by,
         task.team_id,
         scopes=scopes,
-        application=_oauth_application_for_task(task),
+        application=oauth_application_for_task(task),
     )
 
 

--- a/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/send_followup_to_sandbox.py
@@ -21,7 +21,7 @@ from products.tasks.backend.logic.services.staged_artifacts import get_task_run_
 from products.tasks.backend.logic.stream.redis_stream import get_task_run_stream_key
 from products.tasks.backend.models import TaskRun
 from products.tasks.backend.redis import get_tasks_stream_redis_sync, run_uses_dedicated_stream
-from products.tasks.backend.temporal.oauth import create_oauth_access_token
+from products.tasks.backend.temporal.oauth import create_oauth_access_token_for_user, oauth_application_for_task
 from products.tasks.backend.temporal.process_task.utils import (
     get_sandbox_ph_mcp_configs,
     get_user_mcp_server_configs,
@@ -117,25 +117,60 @@ def _refresh_sandbox_mcp(
     scopes: PosthogMcpScopes,
     auth_token: str | None,
 ) -> None:
-    """Mint a fresh OAuth token and push updated MCP configs to the sandbox.
+    """Best-effort MCP refresh for the web-layer follow-up flow.
 
-    Best-effort: retries once on failure, then logs and returns. Never raises
-    — a failed refresh should not block an otherwise-valid follow-up.
+    Scopes the OAuth token to the task creator; the web-layer follow-up signal
+    has no per-turn actor concept. The Slack follow-up path calls
+    :func:`refresh_sandbox_mcp_for_user` directly so the live mentioner's
+    identity is used.
+    """
+    created_by = task_run.task.created_by
+    if not created_by:
+        logger.info("refresh_mcp_skipped_no_user", run_id=str(task_run.id))
+        return
+    refresh_sandbox_mcp_for_user(task_run, created_by, scopes=scopes, auth_token=auth_token)
 
-    Skipped entirely if a token was issued for this run within the last
-    MCP_TOKEN_REFRESH_INTERVAL_SECONDS — the in-sandbox token is still fresh.
+
+def refresh_sandbox_mcp_for_user(
+    task_run: TaskRun,
+    user: Any,
+    *,
+    scopes: PosthogMcpScopes,
+    auth_token: str | None,
+    force: bool = False,
+) -> CommandResult | None:
+    """Mint a fresh OAuth token scoped to ``user`` and push updated MCP configs
+    to the sandbox via ``send_refresh_session``.
+
+    Retries once on failure, then logs and returns. Never raises — a failed
+    refresh should not block an otherwise-valid follow-up.
+
+    Rate-limited per ``(run_id, user_id)``: skipped if the same user already
+    had a token issued within the ``MCP_TOKEN_REFRESH_INTERVAL_SECONDS`` window,
+    unless ``force=True``. Cross-user transitions (Slack follow-ups by a
+    teammate other than the task creator) pass ``force=True`` so the identity
+    swap isn't blocked by a recent same-run refresh.
+
+    Returns the last ``CommandResult`` from ``send_refresh_session``, or
+    ``None`` when skipped (rate limit, no configs, mint failure).
     """
     run_id = str(task_run.id)
-    if not should_refresh_mcp_token(run_id):
-        logger.info("refresh_mcp_skipped_within_interval", run_id=run_id)
-        return
+    rate_limit_key = f"{run_id}:{user.id}"
+    if not force and not should_refresh_mcp_token(rate_limit_key):
+        logger.info("refresh_mcp_skipped_within_interval", run_id=run_id, user_id=user.id)
+        return None
 
     task = task_run.task
     try:
-        access_token = create_oauth_access_token(task, scopes=scopes)
+        access_token = create_oauth_access_token_for_user(
+            user,
+            task_run.team_id,
+            scopes=scopes,
+            application=oauth_application_for_task(task),
+        )
     except Exception as e:
-        logger.warning("refresh_mcp_token_mint_failed", run_id=run_id, error=str(e))
-        return
+        logger.warning("refresh_mcp_token_mint_failed", run_id=run_id, user_id=user.id, error=str(e))
+        return None
 
     mcp_configs = get_sandbox_ph_mcp_configs(
         token=access_token,
@@ -144,19 +179,18 @@ def _refresh_sandbox_mcp(
         interaction_origin=(task_run.state or {}).get("interaction_origin"),
         task_id=str(task_run.task_id),
     )
-    if task.created_by_id:
-        user_mcp_configs = get_user_mcp_server_configs(
-            token=access_token,
-            team_id=task_run.team_id,
-            user_id=task.created_by_id,
-            interaction_origin=(task_run.state or {}).get("interaction_origin"),
-        )
-        if user_mcp_configs:
-            mcp_configs = mcp_configs + user_mcp_configs
+    user_mcp_configs = get_user_mcp_server_configs(
+        token=access_token,
+        team_id=task_run.team_id,
+        user_id=user.id,
+        interaction_origin=(task_run.state or {}).get("interaction_origin"),
+    )
+    if user_mcp_configs:
+        mcp_configs = mcp_configs + user_mcp_configs
 
     if not mcp_configs:
-        logger.info("refresh_mcp_skipped_no_configs", run_id=run_id)
-        return
+        logger.info("refresh_mcp_skipped_no_configs", run_id=run_id, user_id=user.id)
+        return None
 
     mcp_servers = [config.to_dict() for config in mcp_configs]
 
@@ -167,13 +201,14 @@ def _refresh_sandbox_mcp(
         timeout=REFRESH_TIMEOUT_SECONDS,
     )
     if result.success:
-        mark_mcp_token_issued(run_id)
-        logger.info("refresh_mcp_delivered", run_id=run_id, attempts=1)
-        return
+        mark_mcp_token_issued(rate_limit_key)
+        logger.info("refresh_mcp_delivered", run_id=run_id, user_id=user.id, attempts=1)
+        return result
 
     logger.info(
         "refresh_mcp_retrying",
         run_id=run_id,
+        user_id=user.id,
         error=result.error,
         status_code=result.status_code,
     )
@@ -185,16 +220,18 @@ def _refresh_sandbox_mcp(
         timeout=REFRESH_TIMEOUT_SECONDS,
     )
     if retry.success:
-        mark_mcp_token_issued(run_id)
-        logger.info("refresh_mcp_delivered", run_id=run_id, attempts=2)
-        return
+        mark_mcp_token_issued(rate_limit_key)
+        logger.info("refresh_mcp_delivered", run_id=run_id, user_id=user.id, attempts=2)
+        return retry
 
     logger.warning(
         "refresh_mcp_failed",
         run_id=run_id,
+        user_id=user.id,
         error=retry.error,
         status_code=retry.status_code,
     )
+    return retry
 
 
 def _get_stop_reason(result_data: dict[str, Any] | None) -> str:

--- a/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_send_followup_to_sandbox.py
@@ -8,6 +8,7 @@ from products.tasks.backend.temporal.process_task.activities.send_followup_to_sa
     REFRESH_RETRY_DELAY_SECONDS,
     SendFollowupToSandboxInput,
     _refresh_sandbox_mcp,
+    refresh_sandbox_mcp_for_user,
     send_followup_to_sandbox,
 )
 from products.tasks.backend.temporal.process_task.utils import (
@@ -22,10 +23,15 @@ pytestmark = pytest.mark.django_db
 @pytest.fixture(autouse=True)
 def _clear_mcp_token_cache():
     """Ensure each test starts with no recorded token issuances so the
-    refresh gate doesn't carry state between tests."""
-    cache.delete(_mcp_token_issued_cache_key("run-1"))
+    refresh gate doesn't carry state between tests. The rate-limit cache key
+    is scoped to ``(run_id, user_id)`` so cross-user follow-ups don't get
+    silently blocked by a same-run prior refresh — clear both shapes."""
+    keys = [_mcp_token_issued_cache_key("run-1"), _mcp_token_issued_cache_key("run-1:42")]
+    for key in keys:
+        cache.delete(key)
     yield
-    cache.delete(_mcp_token_issued_cache_key("run-1"))
+    for key in keys:
+        cache.delete(key)
 
 
 def _make_mcp_config(name: str = "posthog", token: str = "tok") -> McpServerConfig:
@@ -40,6 +46,7 @@ def _make_mcp_config(name: str = "posthog", token: str = "tok") -> McpServerConf
 def _make_task_run_mock(team_id: int = 7, created_by_id: int | None = 42, state: dict | None = None) -> MagicMock:
     task = MagicMock()
     task.created_by_id = created_by_id
+    task.created_by = MagicMock(id=created_by_id) if created_by_id is not None else None
     task_run = MagicMock()
     task_run.id = "run-1"
     task_run.team_id = team_id
@@ -52,25 +59,53 @@ def _make_task_run_mock(team_id: int = 7, created_by_id: int | None = 42, state:
     return task_run
 
 
-class TestRefreshSandboxMcp:
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
-    def test_success_path_single_call(self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh):
+def _make_user_mock(user_id: int = 42) -> MagicMock:
+    user = MagicMock()
+    user.id = user_id
+    return user
+
+
+_OAUTH_FOR_USER_PATH = "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token_for_user"
+_OAUTH_APP_PATH = (
+    "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.oauth_application_for_task"
+)
+_PH_CONFIGS_PATH = (
+    "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
+)
+_USER_CONFIGS_PATH = (
+    "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
+)
+_SEND_REFRESH_PATH = (
+    "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session"
+)
+_TIME_SLEEP_PATH = "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep"
+
+
+class TestRefreshSandboxMcpForUser:
+    """Covers the actor-parameterized helper that the Slack and web follow-up
+    paths share. The legacy ``_refresh_sandbox_mcp`` is now a thin wrapper that
+    fills in ``task.created_by`` and delegates here."""
+
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
+    def test_success_path_single_call(
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh
+    ):
         mock_oauth.return_value = "fresh-token"
+        mock_oauth_app.return_value = "array"
         mock_ph_configs.return_value = [_make_mcp_config(token="fresh-token")]
         mock_user_configs.return_value = []
         mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
 
         task_run = _make_task_run_mock()
-        _refresh_sandbox_mcp(task_run, "read_only", auth_token="jwt")
+        user = _make_user_mock(user_id=42)
+        result = refresh_sandbox_mcp_for_user(task_run, user, scopes="read_only", auth_token="jwt")
 
-        mock_oauth.assert_called_once_with(task_run.task, scopes="read_only")
+        assert result is not None and result.success is True
+        mock_oauth.assert_called_once_with(user, 7, scopes="read_only", application="array")
         mock_ph_configs.assert_called_once_with(
             token="fresh-token", project_id=7, scopes="read_only", interaction_origin=None, task_id="task-1"
         )
@@ -83,17 +118,14 @@ class TestRefreshSandboxMcp:
         mcp_servers = mock_send_refresh.call_args.args[1]
         assert mcp_servers == [_make_mcp_config(token="fresh-token").to_dict()]
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_TIME_SLEEP_PATH)
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_retries_once_on_first_failure(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, mock_sleep
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh, mock_sleep
     ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = [_make_mcp_config()]
@@ -103,22 +135,19 @@ class TestRefreshSandboxMcp:
             CommandResult(success=True, status_code=200),
         ]
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         assert mock_send_refresh.call_count == 2
         mock_sleep.assert_called_once_with(REFRESH_RETRY_DELAY_SECONDS)
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_TIME_SLEEP_PATH)
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_two_failures_are_non_fatal(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
     ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = [_make_mcp_config()]
@@ -126,137 +155,139 @@ class TestRefreshSandboxMcp:
         mock_send_refresh.return_value = CommandResult(success=False, status_code=502, error="down")
 
         # Must not raise.
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         assert mock_send_refresh.call_count == 2
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_token_mint_failure_is_non_fatal_and_skips_send(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh
     ):
         mock_oauth.side_effect = RuntimeError("oauth service down")
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         mock_ph_configs.assert_not_called()
         mock_user_configs.assert_not_called()
         mock_send_refresh.assert_not_called()
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_skips_send_when_no_mcp_configs_resolved(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh
     ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = []
         mock_user_configs.return_value = []
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         mock_send_refresh.assert_not_called()
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
-    def test_user_mcp_configs_skipped_when_no_creator(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
-    ):
-        mock_oauth.return_value = "fresh-token"
-        mock_ph_configs.return_value = [_make_mcp_config()]
-        mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
-
-        _refresh_sandbox_mcp(_make_task_run_mock(created_by_id=None), "read_only", auth_token=None)
-
-        mock_user_configs.assert_not_called()
-        mock_send_refresh.assert_called_once()
-
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_scopes_propagate_to_oauth_and_configs(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh
     ):
         mock_oauth.return_value = "fresh-token"
+        mock_oauth_app.return_value = "array"
         mock_ph_configs.return_value = [_make_mcp_config()]
         mock_user_configs.return_value = []
         mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "full", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="full", auth_token=None)
 
-        mock_oauth.assert_called_once_with(mock_oauth.call_args.args[0], scopes="full")
+        mock_oauth.assert_called_once_with(mock_oauth.call_args.args[0], 7, scopes="full", application="array")
         mock_ph_configs.assert_called_once_with(
             token="fresh-token", project_id=7, scopes="full", interaction_origin=None, task_id="task-1"
         )
 
-
-class TestRefreshIntervalGate:
-    """Refreshes within MCP_TOKEN_REFRESH_INTERVAL_SECONDS of a previous
-    successful issuance must be skipped without minting a new token or
-    contacting the sandbox."""
-
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
-    def test_skipped_when_token_recently_issued(self, mock_oauth, mock_send_refresh):
-        mark_mcp_token_issued("run-1")
-
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
+    def test_legacy_wrapper_skips_when_no_creator(self, mock_oauth, mock_send_refresh):
+        """``_refresh_sandbox_mcp`` (the no-actor wrapper used by the web-layer
+        signal path) short-circuits when the task has no ``created_by``. The
+        prior implementation would try to mint and log a warning; the new
+        wrapper just skips, since the helper requires an explicit user."""
+        _refresh_sandbox_mcp(_make_task_run_mock(created_by_id=None), "read_only", auth_token=None)
 
         mock_oauth.assert_not_called()
         mock_send_refresh.assert_not_called()
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
-    def test_marks_after_successful_refresh(self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh):
+
+class TestRefreshIntervalGate:
+    """Refreshes within MCP_TOKEN_REFRESH_INTERVAL_SECONDS of a previous
+    successful issuance for the *same actor* must be skipped without minting a
+    new token or contacting the sandbox. The rate-limit key is scoped to
+    ``(run_id, user_id)`` so a cross-user follow-up isn't silently blocked by
+    a prior same-run refresh under a different identity."""
+
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
+    def test_skipped_when_token_recently_issued(self, mock_oauth, mock_send_refresh):
+        mark_mcp_token_issued("run-1:42")
+
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
+
+        mock_oauth.assert_not_called()
+        mock_send_refresh.assert_not_called()
+
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
+    def test_force_bypasses_rate_limit(self, mock_oauth, mock_send_refresh):
+        """Cross-user follow-ups pass ``force=True`` so an identity transition
+        is never silently dropped on a recent same-run refresh."""
+        mark_mcp_token_issued("run-1:42")
+        mock_oauth.return_value = "fresh-token"
+        mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
+        with (
+            patch(_PH_CONFIGS_PATH, return_value=[_make_mcp_config()]),
+            patch(_USER_CONFIGS_PATH, return_value=[]),
+            patch(_OAUTH_APP_PATH, return_value="array"),
+        ):
+            refresh_sandbox_mcp_for_user(
+                _make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None, force=True
+            )
+
+        mock_oauth.assert_called_once()
+        mock_send_refresh.assert_called_once()
+
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
+    def test_marks_after_successful_refresh(
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh
+    ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = [_make_mcp_config()]
         mock_user_configs.return_value = []
         mock_send_refresh.return_value = CommandResult(success=True, status_code=200)
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         # Cache entry now exists → next refresh within the interval is gated.
-        assert cache.get(_mcp_token_issued_cache_key("run-1")) is True
+        assert cache.get(_mcp_token_issued_cache_key("run-1:42")) is True
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_TIME_SLEEP_PATH)
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_marks_after_successful_retry(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
     ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = [_make_mcp_config()]
@@ -266,31 +297,28 @@ class TestRefreshIntervalGate:
             CommandResult(success=True, status_code=200),
         ]
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
-        assert cache.get(_mcp_token_issued_cache_key("run-1")) is True
+        assert cache.get(_mcp_token_issued_cache_key("run-1:42")) is True
 
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.time.sleep")
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.send_refresh_session")
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_user_mcp_server_configs"
-    )
-    @patch(
-        "products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.get_sandbox_ph_mcp_configs"
-    )
-    @patch("products.tasks.backend.temporal.process_task.activities.send_followup_to_sandbox.create_oauth_access_token")
+    @patch(_TIME_SLEEP_PATH)
+    @patch(_SEND_REFRESH_PATH)
+    @patch(_USER_CONFIGS_PATH)
+    @patch(_PH_CONFIGS_PATH)
+    @patch(_OAUTH_APP_PATH)
+    @patch(_OAUTH_FOR_USER_PATH)
     def test_does_not_mark_after_two_failures(
-        self, mock_oauth, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
+        self, mock_oauth, mock_oauth_app, mock_ph_configs, mock_user_configs, mock_send_refresh, _mock_sleep
     ):
         mock_oauth.return_value = "fresh-token"
         mock_ph_configs.return_value = [_make_mcp_config()]
         mock_user_configs.return_value = []
         mock_send_refresh.return_value = CommandResult(success=False, status_code=502, error="down")
 
-        _refresh_sandbox_mcp(_make_task_run_mock(), "read_only", auth_token=None)
+        refresh_sandbox_mcp_for_user(_make_task_run_mock(), _make_user_mock(), scopes="read_only", auth_token=None)
 
         # Cache stays empty so the next follow-up retries the dispatch.
-        assert cache.get(_mcp_token_issued_cache_key("run-1")) is None
+        assert cache.get(_mcp_token_issued_cache_key("run-1:42")) is None
 
 
 class TestSendFollowupActivityRefreshOrdering:


### PR DESCRIPTION
## Problem

Today, when a teammate other than the original task creator follows up in a Twig (PostHog Code) Slack thread, the agent keeps acting under the original creator's PostHog identity. Anything the agent writes to PostHog — insights, dashboards, MCP-driven changes — gets attributed to whoever started the thread, not whoever actually asked for the change.

Investigation confirmed the agent already correctly identifies the live actor (it resolves their Slack ID → PostHog user and authorizes them on the team), but then deliberately re-uses the creator's sandbox JWT and the creator's MCP OAuth token. The code comment at the cross-user branch documents the limitation directly.

## Changes

When a follow-up arrives from someone other than the original mentioner:

- Mint the sandbox connection JWT for the **live actor** (the resolved PostHog user behind the Slack follow-up), not the task creator.
- Before forwarding the user's message to the live sandbox, push a fresh MCP server list scoped to the live actor's PostHog OAuth token via the existing \`send_refresh_session\` channel. The agent-server treats this as a normal MCP rotation, rebuilds its session's MCP servers, resumes the ACP query, and the next tool call talks to PostHog as the live actor.
- Same-user follow-ups are unchanged — no needless refresh round-trip, the per-(run, user) rate limit still applies.
- Refresh failures are non-fatal: we log and still deliver the follow-up, accepting that the next tool call may still attribute to the original creator rather than dropping the user's message.

Refactor in support of the above:

- Extract \`refresh_sandbox_mcp_for_user(task_run, user, *, scopes, auth_token, force)\` out of \`_refresh_sandbox_mcp\`. The legacy wrapper now delegates with \`user = task.created_by\`, preserving web-layer follow-up behavior.
- Rate-limit key is now scoped to \`(run_id, user_id)\` so a cross-user transition isn't silently blocked by a recent same-run refresh under a different identity.
- Expose the helper on the tasks facade as \`refresh_sandbox_mcp_for_user(run_id, user_id, ...)\`.
- Promote \`_oauth_application_for_task\` → \`oauth_application_for_task\` so cross-module callers don't have to import a private name.

### Out of scope

- GitHub identity inside the sandbox (\`gh\` CLI, git commit/PR author) — that's bound at workspace-server spawn time and won't follow the per-turn swap. PRs and commits still attribute to the boot-time identity. Fixing this needs sandbox-side credential plumbing and is filed as a follow-up.
- Resume-on-terminal-run path (\`_resume_task_with_new_run\`) — that's a fresh sandbox bootstrap, different semantics, not changed.
- \`process.env.POSTHOG_API_KEY\` raw-env access. The agent funnels PostHog access through MCP tools, so this is theoretical; flagged for completeness.

## How did you test this code?

Automated only — I'm an agent, not a human, so no manual sandbox/Slack verification.

- New tests in \`test_followup_forwarding.py\`:
  - cross-user follow-up mints the JWT for the actor (catches the regression where the JWT still goes to the task creator)
  - cross-user follow-up calls \`refresh_sandbox_mcp_for_user\` once with \`force=True\` and the actor's user_id (catches a regression where MCP creds stay on the creator)
  - cross-user follow-up where the reauth call raises still delivers the message (catches a regression that drops the user's message on a transient mid-turn or mint failure)
  - same-user follow-up does NOT trigger reauth (catches a regression that would burn refresh round-trips on every chatty message)
- \`test_send_followup_to_sandbox.py\` rewritten around \`refresh_sandbox_mcp_for_user\`; legacy wrapper covered by a no-creator skip case; new test confirms \`force=True\` bypasses the rate limit. Cache assertions check the new \`(run_id, user_id)\` key shape.
- \`ruff format\` + \`tach check --dependencies --interfaces\` clean.
- 57 relevant tests green. Broader \`process_task\` suite has 14 failures unrelated to this change — they need a Temporal test server that fails to download in this environment (\`temporal.download\` unreachable).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Vojta directed the work. Started as a conversation about whether the Slack-Twig bot can re-auth per turn; we ruled out broader-scope options (Slack-side OAuth, per-turn ephemeral agent process) once we discovered the existing \`send_refresh_session\` channel already does exactly what we need — it's just never wired to the Slack follow-up path. The chosen design re-uses that primitive instead of inventing a new credential-swap API.

Decisions worth flagging:
- Used \`force=True\` for cross-user transitions (rather than narrowing the rate-limit window) so an identity swap is never silently dropped by a recent same-run refresh. Same-user follow-ups still observe the rate limit.
- Kept legacy \`_refresh_sandbox_mcp\` as a wrapper so the web-layer signal path keeps working without per-call changes; only the Slack path opted into the actor-scoped version.
- Did not change \`_resume_task_with_new_run\` — restarting a terminated task means continuing the original work, so original-creator identity there is arguably correct. Left as an open question rather than a silent semantic change.
- Did not touch \`posthog/code\` (agent-server). Tracing the agent-server's MCP refresh code confirmed it rebuilds servers from whatever credentials it's handed; pushing a different user's token is treated as a normal rotation.

No skills were invoked for this change (the relevant ones — \`/improving-drf-endpoints\`, \`/django-migrations\`, \`/clickhouse-migrations\` — didn't apply; no DRF, migrations, or ClickHouse touched).