### PR TITLE
fix(experiments): guard SharedMetricModal against missing saved_metrics

### DIFF
--- a/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
+++ b/frontend/src/scenes/experiments/Metrics/SharedMetricModal.tsx
@@ -64,7 +64,8 @@ export function SharedMetricModal({
         closeSharedMetricModal()
     }
 
-    const alreadyAddedIdsList = experiment.saved_metrics.map((savedMetric) => savedMetric.saved_metric)
+    const savedMetrics = experiment.saved_metrics ?? []
+    const alreadyAddedIdsList = savedMetrics.map((savedMetric) => savedMetric.saved_metric)
     const alreadyAddedIds = new Set(alreadyAddedIdsList)
 
     // Ids of the currently displayed metrics (after tag filtering) that can still be added.
@@ -107,10 +108,10 @@ export function SharedMetricModal({
             <div className="deprecated-space-y-2">
                 {hasAnyCompatibleSharedMetrics || sharedMetricsResponseLoading ? (
                     <>
-                        {experiment.saved_metrics.length > 0 && (
+                        {savedMetrics.length > 0 && (
                             <LemonBanner type="info">
-                                {`${pluralize(experiment.saved_metrics.length, 'shared metric')} ${
-                                    experiment.saved_metrics.length > 1 ? 'are' : 'is'
+                                {`${pluralize(savedMetrics.length, 'shared metric')} ${
+                                    savedMetrics.length > 1 ? 'are' : 'is'
                                 } already in the experiment.`}
                             </LemonBanner>
                         )}


### PR DESCRIPTION
## Problem

The shared metric modal crashed with `TypeError: Cannot read properties of undefined (reading 'map')` on `SharedMetricModal.tsx`. `experiment.saved_metrics` is typed as `any[]` but can be `undefined` at render time, and the component mapped over it directly.

## Changes

Derive a single safe local (`savedMetrics = experiment.saved_metrics ?? []`) and use it for both the `.map` and the three `.length` reads. Guarding only the `.map` would have just moved the crash to the `.length` access a few lines down.

## How did you test this code?

I'm an agent (PostHog Slack app). No manual testing or automated tests were added (the requester asked for no tests). The change is a defensive null-guard matching the same `?? []` pattern already used elsewhere in the experiments code.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from the error-tracking issue: the top in-app frame pointed at the `experiment.saved_metrics.map(...)` line. Fix mirrors the existing `?? []` guards in `scenes/experiments/utils.ts`. Authored by the PostHog Slack app from a Slack thread, directed by Juraj.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07PXH2GTGV/p1782376825416379?thread_ts=1782376825.416379&cid=C07PXH2GTGV)*