### PR TITLE
fix(github): surface friendly error when source validation hits a config issue

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/source.py
@@ -269,7 +269,15 @@ If automatic creation failed, your token needs webhook permissions — the **adm
             access_token = self._get_access_token(config, team_id)
             return validate_github_credentials(access_token, config.repository)
         except Exception as e:
-            return False, str(e)
+            # `_get_access_token` and the OAuth mixin raise deterministic config/credential errors
+            # (missing integration ID, missing token, integration deleted). The user-facing wording
+            # already lives in `get_non_retryable_errors`; reuse it so this path doesn't leak the
+            # internal developer string to the wizard. Fall back to the raw message if unmapped.
+            raw = str(e)
+            for pattern, friendly in self.get_non_retryable_errors().items():
+                if friendly and pattern in raw:
+                    return False, friendly
+            return False, raw
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[GithubResumeConfig]:
         return ResumableSourceManager[GithubResumeConfig](inputs, GithubResumeConfig)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/tests/test_github_source_class.py
@@ -110,3 +110,25 @@ class TestGithubSource:
                 self.source._get_access_token(config, self.team_id)
 
         assert "GitHub access token not found" in self.source.get_non_retryable_errors()
+
+    @pytest.mark.parametrize(
+        "selection,expected_message",
+        [
+            ("oauth", "No GitHub account is connected. Please reconnect your GitHub account."),
+            ("pat", "GitHub personal access token is not configured. Please update the source configuration."),
+        ],
+    )
+    def test_validate_credentials_maps_config_errors_to_friendly_message(self, selection, expected_message):
+        config = GithubSourceConfig(
+            auth_method=GithubAuthMethodConfig(
+                github_integration_id=None, selection=selection, personal_access_token=""
+            ),
+            repository="owner/repo",
+        )
+
+        valid, message = self.source.validate_credentials(config, self.team_id)
+
+        assert valid is False
+        # The wizard surfaces this string directly, so it must be the friendly copy, not the
+        # internal "Missing ..." developer string raised by `_get_access_token`.
+        assert message == expected_message


### PR DESCRIPTION
## Problem

When a GitHub data-warehouse source fails credential validation in the setup wizard, `GithubSource.validate_credentials` caught every exception and returned `str(e)` verbatim. For the deterministic config/credential errors raised by `_get_access_token` and the OAuth mixin, that surfaced a bare internal developer string to the user instead of an actionable message — even though a friendly user-facing copy for each case already exists in `get_non_retryable_errors`.

## Changes

Map the caught exception's message against `get_non_retryable_errors` and return the friendly copy, falling back to the raw message when nothing matches. This mirrors the existing pattern in `StripeSource.validate_credentials`. A missing-integration error now reads as a "reconnect your GitHub account" prompt, and a missing-PAT error as an "update the source configuration" prompt.

No change to sync behavior, schemas, or the error mappings themselves — only which message the wizard shows.

## How did you test this code?

I'm an agent. I added a parameterized regression test (`test_validate_credentials_maps_config_errors_to_friendly_message`) asserting that the OAuth-without-integration and PAT-without-token paths return the mapped friendly messages rather than the internal strings — a regression no existing test covered (the existing tests only check `_get_access_token` raises and that the mapping keys exist, not that `validate_credentials` applies them). `ruff check` passes on both touched files; the files compile. I could not run pytest in this environment (dependencies aren't installed in the available venv).

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of data-warehouse source-creation failures across many source types. Most messages were already clear and actionable (user misconfiguration) and needed no change; this was the one clear case of an internal string leaking to users. Verified against sibling sources — `StripeSource.validate_credentials` already applies the same `get_non_retryable_errors` mapping, so this aligns GitHub with the established pattern rather than inventing a new one. Checked for duplicate open PRs before opening this one; none addressed this path.