### PR TITLE
fix(flags): ignore stale hash-key override when continuity off

### DIFF
--- a/rust/feature-flags/src/flags/flag_matching.rs
+++ b/rust/feature-flags/src/flags/flag_matching.rs
@@ -1804,16 +1804,20 @@ impl FeatureFlagMatcher {
                 }
             }
 
-            // Use hash key overrides for experience continuity
+            // Use hash key overrides for experience continuity. Only consult overrides
+            // when the flag *currently* has continuity enabled — a stored override row
+            // is never deleted when continuity is turned off, so a stale row must not
+            // steer a flag whose continuity is now off (which would keep every distinct_id
+            // of the person bucketing on the old key).
             // Priority: DB override > request's anon_distinct_id > distinct_id
-            if let Some(hash_key_override) = hash_key_overrides
-                .as_ref()
-                .and_then(|h| h.get(&feature_flag.key))
-            {
-                Ok(hash_key_override.clone())
-            } else if feature_flag.has_experience_continuity() {
-                // For EEC flags, use the request's anon_distinct_id as fallback when no DB override exists
-                if let Some(request_override) = request_hash_key_override {
+            if feature_flag.has_experience_continuity() {
+                if let Some(hash_key_override) = hash_key_overrides
+                    .as_ref()
+                    .and_then(|h| h.get(&feature_flag.key))
+                {
+                    Ok(hash_key_override.clone())
+                } else if let Some(request_override) = request_hash_key_override {
+                    // Use the request's anon_distinct_id as fallback when no DB override exists
                     Ok(request_override.clone())
                 } else {
                     Ok(self.distinct_id.clone())
@@ -2445,6 +2449,53 @@ mod tests {
             assert!(!stub.deleted);
             assert!(stub.filters.groups.is_empty());
         }
+    }
+
+    /// A stored hash-key override must only steer bucketing while the flag *currently*
+    /// has experience continuity enabled. When continuity is turned off, the row written
+    /// back while it was on is never deleted — so the matcher must fall back to the raw
+    /// distinct_id and ignore the stale override, otherwise every distinct_id of the
+    /// person keeps bucketing on the old key and resolves to the same stale value.
+    #[rstest::rstest]
+    #[case::continuity_off_ignores_stale_override(Some(false), "logged-in-username")]
+    #[case::continuity_unset_ignores_stale_override(None, "logged-in-username")]
+    #[case::continuity_on_applies_override(Some(true), "stale-anon-id")]
+    #[tokio::test]
+    async fn test_hashed_identifier_respects_current_continuity_for_stored_override(
+        #[case] ensure_experience_continuity: Option<bool>,
+        #[case] expected_identifier: &str,
+    ) {
+        use crate::utils::test_utils::{mock_group_type_cache, TestContext};
+
+        let context = TestContext::new(None).await;
+        let cohort_cache = Arc::new(CohortCacheManager::new(
+            context.non_persons_reader.clone(),
+            None,
+            None,
+        ));
+        let matcher = FeatureFlagMatcher::new(
+            "logged-in-username".to_string(),
+            None, // device_id
+            1,
+            context.create_postgres_router(),
+            cohort_cache,
+            mock_group_type_cache(HashMap::new()),
+            None,
+        );
+
+        // Override left behind from when this flag still had continuity enabled.
+        let overrides = HashMap::from([("my_flag".to_string(), "stale-anon-id".to_string())]);
+        let flag = FeatureFlag {
+            key: "my_flag".to_string(),
+            ensure_experience_continuity,
+            ..Default::default()
+        };
+
+        let identifier = matcher
+            .hashed_identifier(&flag, None, Some(&overrides), &None)
+            .unwrap();
+
+        assert_eq!(identifier, expected_identifier);
     }
 
     #[rstest::rstest]


### PR DESCRIPTION
## Problem

When a feature flag has experience continuity turned off, evaluation can still return a stale value.

Turning continuity off does not delete the `FeatureFlagHashKeyOverride` rows written while it was on, and nothing else removes them. The matcher then re-applies the stored hash key, so the flag buckets on the old key instead of the raw `distinct_id`. Because overrides are keyed by `person_id`, every `distinct_id` for that person resolves to the same stale value.

This affects live `/flags` traffic, not just the Persons page lookup that surfaced it: any full-payload evaluation fetches the person's override rows (the lookup fires whenever any other flag in the batch has continuity), and the stale row gets applied.

## Changes

The bug is in `hashed_identifier`. The DB-override branch fired purely on "is there a row for this flag key", and only the no-override fallback checked the flag's continuity. So a non-continuity flag with a stale row used the override.

Fix: gate the whole override block on `feature_flag.has_experience_continuity()`. A flag with continuity off now always buckets on the raw `distinct_id`. Continuity flags keep the exact same priority (DB override, then request override, then `distinct_id`).

## How did you test this code?

- Added a new regression test for this specific case. Fails on master, passes on this branch
- All existing tests passes

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 4.8). The human traced the bug to `hashed_identifier` and asked me to verify the analysis against the code, then write a regression test, confirm it fails, implement the fix, and confirm it passes.

The test targets `hashed_identifier` directly rather than the full evaluate path. The function is the seam where the bug lives, it is pure and deterministic, and a unit test avoids the heavier DB setup and brittle hash-bucket assertions an end-to-end test would need. No repo skills were invoked.
