### PR TITLE
fix(data-warehouse): don't partition an already-unpartitioned delta t…

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -284,6 +284,21 @@ class DeltaTableHelper:
             use_partitioning = True
             await self._logger.adebug(f"Using partitioning on {PARTITION_KEY}")
 
+        # An existing table can carry `_ph_partition_key` in its schema without being
+        # partitioned by it — e.g. a prior write committed with partition_by=None (the
+        # schema-mismatch fallback below), or evolve_pyarrow_schema re-adding the column
+        # to a batch bound for an unpartitioned table. Deriving partitioning from column
+        # presence then writes with partition_by against a table delta-rs considers
+        # unpartitioned, raising "Specified table partitioning does not match". The
+        # table's own partition_columns is the source of truth — defer to it.
+        if use_partitioning and delta_table is not None:
+            existing_partition_columns = getattr(delta_table.metadata(), "partition_columns", None) or []
+            if PARTITION_KEY not in existing_partition_columns:
+                use_partitioning = False
+                await self._logger.adebug(
+                    f"Existing table is not partitioned by {PARTITION_KEY}; skipping partitioning to match its layout"
+                )
+
         commit_properties: deltalake.CommitProperties | None = (
             deltalake.CommitProperties(custom_metadata=commit_metadata) if commit_metadata else None
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -284,13 +284,8 @@ class DeltaTableHelper:
             use_partitioning = True
             await self._logger.adebug(f"Using partitioning on {PARTITION_KEY}")
 
-        # An existing table can carry `_ph_partition_key` in its schema without being
-        # partitioned by it — e.g. a prior write committed with partition_by=None (the
-        # schema-mismatch fallback below), or evolve_pyarrow_schema re-adding the column
-        # to a batch bound for an unpartitioned table. Deriving partitioning from column
-        # presence then writes with partition_by against a table delta-rs considers
-        # unpartitioned, raising "Specified table partitioning does not match". The
-        # table's own partition_columns is the source of truth — defer to it.
+        # The column can exist without the table being partitioned by it; defer to the
+        # table's real partition_columns or delta-rs rejects the write as a mismatch.
         if use_partitioning and delta_table is not None:
             existing_partition_columns = getattr(delta_table.metadata(), "partition_columns", None) or []
             if PARTITION_KEY not in existing_partition_columns:

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -460,13 +460,25 @@ class TestUnpartitionedTableWithPartitionKeyColumn:
         assert PARTITION_KEY in dt.schema().to_arrow().names
 
     @pytest.mark.parametrize(
-        "write_type,primary_keys",
-        [("append", None), ("incremental", ["id"])],
-        ids=["append", "incremental_merge"],
+        "write_type,primary_keys,should_overwrite,expected_ids",
+        [
+            # append/incremental keep the existing rows; full_refresh overwrites them. Each
+            # routes through a distinct write branch, all of which previously raised against
+            # the unpartitioned-but-column-present table.
+            ("append", None, False, {1, 2, 3, 4}),
+            ("incremental", ["id"], False, {1, 2, 3, 4}),
+            ("full_refresh", None, True, {2, 3, 4}),
+        ],
+        ids=["append", "incremental_merge", "full_refresh_overwrite"],
     )
     @pytest.mark.asyncio
     async def test_write_does_not_partition_unpartitioned_table(
-        self, write_type: str, primary_keys: list[str] | None, tmp_path: Path
+        self,
+        write_type: str,
+        primary_keys: list[str] | None,
+        should_overwrite: bool,
+        expected_ids: set[int],
+        tmp_path: Path,
     ) -> None:
         delta_path = str(tmp_path / "table")
         self._seed_unpartitioned_table_with_partition_column(delta_path)
@@ -478,12 +490,12 @@ class TestUnpartitionedTableWithPartitionKeyColumn:
         result = await helper.write_to_deltalake(
             data=batch,
             write_type=write_type,  # type: ignore[arg-type]
-            should_overwrite_table=False,
+            should_overwrite_table=should_overwrite,
             primary_keys=primary_keys,
         )
 
         final = result.to_pyarrow_table()
-        assert set(final.column("id").to_pylist()) == {1, 2, 3, 4}
+        assert set(final.column("id").to_pylist()) == expected_ids
         # The table stays unpartitioned — we don't fight its existing layout.
         assert result.metadata().partition_columns == []
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -437,6 +437,57 @@ class TestIncrementalBatchDeduplication:
         assert final.column("name").to_pylist() == ["second_copy"]
 
 
+class TestUnpartitionedTableWithPartitionKeyColumn:
+    """A Delta table can carry `_ph_partition_key` in its schema while its
+    partition_columns metadata is empty `[]` — e.g. the SchemaMismatchError fallback in
+    write_to_deltalake rewrites with partition_by=None while the column is still in the
+    data, or evolve_pyarrow_schema re-adds the column to a batch headed for an
+    unpartitioned table. write_to_deltalake derives partitioning from column *presence*,
+    so it then passes partition_by=_ph_partition_key against a table delta-rs considers
+    unpartitioned and raises:
+        "Specified table partitioning does not match table partitioning: expected: [], got: [_ph_partition_key]"
+    """
+
+    def _seed_unpartitioned_table_with_partition_column(self, delta_path: str) -> None:
+        # _ph_partition_key is a plain column; the table is NOT partitioned by it.
+        deltalake.write_deltalake(
+            delta_path,
+            pa.table({"id": pa.array([1, 2]), PARTITION_KEY: pa.array(["p0", "p0"])}),
+            partition_by=None,
+        )
+        dt = deltalake.DeltaTable(delta_path)
+        assert dt.metadata().partition_columns == []
+        assert PARTITION_KEY in dt.schema().to_arrow().names
+
+    @pytest.mark.parametrize(
+        "write_type,primary_keys",
+        [("append", None), ("incremental", ["id"])],
+        ids=["append", "incremental_merge"],
+    )
+    @pytest.mark.asyncio
+    async def test_write_does_not_partition_unpartitioned_table(
+        self, write_type: str, primary_keys: list[str] | None, tmp_path: Path
+    ) -> None:
+        delta_path = str(tmp_path / "table")
+        self._seed_unpartitioned_table_with_partition_column(delta_path)
+
+        helper = _make_local_helper(delta_path)
+        # id=2 already exists (merge updates it); id=3,4 are new.
+        batch = pa.table({"id": pa.array([2, 3, 4]), PARTITION_KEY: pa.array(["p0", "p0", "p0"])})
+
+        result = await helper.write_to_deltalake(
+            data=batch,
+            write_type=write_type,  # type: ignore[arg-type]
+            should_overwrite_table=False,
+            primary_keys=primary_keys,
+        )
+
+        final = result.to_pyarrow_table()
+        assert set(final.column("id").to_pylist()) == {1, 2, 3, 4}
+        # The table stays unpartitioned — we don't fight its existing layout.
+        assert result.metadata().partition_columns == []
+
+
 class TestRealignDecimalBuffers:
     """delta-rs aborts the worker on 8-byte-aligned Decimal128 buffers; we realign them
     to pyarrow's 64-byte allocator before any Delta write. See delta-io/delta-rs#3884."""


### PR DESCRIPTION
## Problem

https://posthoghelp.zendesk.com/agent/tickets/61152 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/64055)

[error tracking](https://us.posthog.com/project/2/error_tracking/019edb47-43e5-7f10-9ec8-920b34b0f243?timestamp=2026-06-25%2003%3A24%3A02.014000-07%3A00&searchQuery=%22Specified%20table%20partitioning%20does%20not%20match%20table%20partitioning%22#panel=discussion)

```
19 hours ago	ERROR	External data job failed for external data schema <id> on job <id> with error: DeltaError: Generic error: Specified table partitioning does not match table partitioning: expected: [], got: ["_ph_partition_key"]
19 hours ago	ERROR	Generic error: Specified table partitioning does not match table partitioning: expected: [], got: ["_ph_partition_key"]
```

A Delta table can carry the _ph_partition_key column in its schema while not being partitioned by it — e.g. a prior write committed with `partition_by=None` via the schema-mismatch fallback, or `evolve_pyarrow_schema` re-adding the column to a batch bound for an unpartitioned table. `write_to_deltalake` derived `use_partitioning` purely from column presence, so it then wrote with `partition_by=_ph_partition_key` against a table delta-rs considers unpartitioned, and the write blew up. PR #56478 guarded the upstream "add the column" step, but `write_to_deltalake` re-derived partitioning independently, leaving this path exposed.

## Changes

`write_to_deltalake` now treats the existing table's actual `partition_columns` as the source of truth, if the column is present but the table isn't partitioned by it, we skip partitioning to match the table's real layout. Because this is the shared write function, it covers every write type (append, incremental, full_refresh) across both pipeline versions.

## How did you test this code?

New tests to cover

