### PR TITLE
feat(inbox): Restore priority filter

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5525,21 +5525,21 @@ snapshots:
     scenes-app-inbox-scene--self-driving-paused--light:
         hash: v1.k794b7964.f9b5a6f1ecd482963d9850ced2d07c1ea729d2d63be8679db907709e5a6fde89.upcV4EokxFjnADvyUmiBiIp7UTjShqKZHDv2EKVV6HM
     scenes-app-inbox-tabs--pull-requests--dark:
-        hash: v1.k794b7964.2eca881c5c5611bb0fe54188f74652897fec431ea1520db0318a3879ec27130c.oLFR4bQxt-ZvTWUbNWiEzp77LmoZzhdcez_af_uUEaw
+        hash: v1.k794b7964.11604af39f8cbad07e09035046b16759db67a56de3ad19fd06819caad5b24ed5.rGskj00SLZ2xZ4V6yxFlFc1nIjY72Onz5qMCA-bEnoQ
     scenes-app-inbox-tabs--pull-requests--light:
-        hash: v1.k794b7964.632aab4de9cb18ff597a8682dd0e8c18e9bf998f4182e87d51504b4da402939c.AMKsEcESbmhTBPwqC8bM91E0dKfv3grLtCPO96R-6_o
+        hash: v1.k794b7964.09dbc3f3bcae78373799a7b94e78b6f5e4db0563b574cc113a6fbe17d78e6370.OwwMTUJayZJXM6JRxMBhh0tXoLuN8GOMHqUOWwg9Qwk
     scenes-app-inbox-tabs--pull-requests-empty--dark:
-        hash: v1.k794b7964.46c7e27bcf7c8eeff940cd1ba52c379fa29c6fd26efa8e5511ce6fae0ebb97f2.LxZ71depKylIFoMgKmsEJGRnkU8SZ7UIOrqU_wn8QQY
+        hash: v1.k794b7964.9b390ad19aedaaa476d130dc222fd5b0368aca4a6732c39177692aad29cbe263.41aWwmc6v-L71uqBHygCwsBQjF-NlDDy-GMztVXC8zc
     scenes-app-inbox-tabs--pull-requests-empty--light:
-        hash: v1.k794b7964.167de2b957533bcc5780f9ddac38b19a4d4892d6fcbb92e985b9a71d8c3fd7d4.rpDhhtvsIxoxhtaVy23_PS6KE1PyvOtTjeh-GlVvaq8
+        hash: v1.k794b7964.eb3678563e1b3c74bd914e79075e382adeaf644def03c839d360bc4642aa4fb3.G1dqQueQiJCQ59w8_Wr4bMAu1Jcu4PeR030bTPQK7Mk
     scenes-app-inbox-tabs--reports--dark:
-        hash: v1.k794b7964.32f343cb491d531f7d372709d963bed63b86fb2e48d344aaf03071311b470970.9OnV2RodRDxAS2qQ0MSo5NEEUIaXnovzjRSZ1hrk5ss
+        hash: v1.k794b7964.bb1f8bd3d7437d2c02b0067430cd69f728b6e015326837e0e6a42ad8b3072bd9.WgZror3SowCR_FTpiNv8NJ_pe7d74BLFRRvJd676CyU
     scenes-app-inbox-tabs--reports--light:
-        hash: v1.k794b7964.e6f65ea9a96eaf3f3c696a4e59c24df35703951113e588e2c7ff80ebe8fef792.VUS7SPVjs3icWdFx-VePID_zbUkqKwfclso_dYE9NQs
+        hash: v1.k794b7964.2704d061b90791a05919c8eae6e7336d81b5420b60af8799fa567cb999c2ae9d.OrXyQaQbKS3WHPWtAYwmY2rDznX-0fB3b4ACxWByQ2s
     scenes-app-inbox-tabs--reports-empty--dark:
-        hash: v1.k794b7964.c3c5ebc57b2f0370c61ca952ce372725898e6242c8c938be810948012c97b49f.1uja5-2bTIAszcF7RaIDcEIAcf3lctJMAzJEuNGWMdQ
+        hash: v1.k794b7964.2c0cfa02b7c9abf92fc69e984158c85d95d60dfd8f28a1bf848cafd939454eea.cuvfv9WFi6TvUSaq3b0yVD8_9nM1M8AE7WdVc5zgGIg
     scenes-app-inbox-tabs--reports-empty--light:
-        hash: v1.k794b7964.95f6f7ea9cae6c59d6151a4c0a09f48c7a076f5893ecf569fbce27f4a48bee18.IbGFUypZB0-MWlRLFTf7EStrtqNJrOMJUZAhSMcHt6A
+        hash: v1.k794b7964.d550598f1d02e5892b8f9ebf9e0d90eac6440ab1ccd5670db561ba31dbd4ccce.eeGeADdZ1xItGIG3A4hNiK2qsFy3xvNWT0Y2K4P42Wo
     scenes-app-inbox-tabs--runs-empty--dark:
         hash: v1.k794b7964.4d9d8f081534a1d495b60435f0074dc19527f811d235b9627c605e91db1b5beb.8eFwrG5Hl906n9bTGTp56vy2OiMGtSXrmKGy1OpcfkQ
     scenes-app-inbox-tabs--runs-empty--light:

--- a/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
@@ -1,12 +1,15 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconCheck, IconChevronDown, IconRefresh, IconSearch, IconSort, IconTarget } from '@posthog/icons'
+import { IconCheck, IconChevronDown, IconFlag, IconRefresh, IconSearch, IconSort, IconTarget } from '@posthog/icons'
 import { LemonButton, LemonDropdown, LemonInput } from '@posthog/lemon-ui'
 
 import {
+    INBOX_PRIORITY_OPTIONS,
     INBOX_SORT_OPTIONS,
     INBOX_SOURCE_OPTIONS,
+    PRIORITY_ACCENT,
+    inboxPriorityFilterLabel,
     inboxSortOptionKey,
     inboxSourceFilterLabel,
 } from '../../filterOptions'
@@ -40,10 +43,17 @@ function FilterPopover({
             <button
                 type="button"
                 aria-label={`${label}: ${value}`}
-                className="flex h-8 shrink-0 items-center gap-1.5 rounded border border-primary bg-surface-primary px-2.5 text-sm text-default transition-colors hover:border-secondary hover:bg-surface-secondary"
+                // Quiet at rest: an unused filter is a muted, borderless chip showing its category
+                // (e.g. "Source"). Once active it gains a solid border, its selected value, and the
+                // accent dot — so the bar only draws attention to filters actually in use.
+                className={`flex h-8 shrink-0 items-center gap-1.5 rounded border px-2.5 text-sm transition-colors ${
+                    active
+                        ? 'border-primary bg-surface-primary text-default hover:border-secondary hover:bg-surface-secondary'
+                        : 'border-transparent text-muted hover:border-primary hover:bg-surface-secondary hover:text-default'
+                }`}
             >
                 <span className="flex shrink-0 items-center text-tertiary [&>svg]:size-3.5">{icon}</span>
-                <span className="max-w-[150px] truncate">{value}</span>
+                <span className="max-w-[150px] truncate">{active ? value : label}</span>
                 {active && <span className="size-1.5 shrink-0 rounded-full bg-accent" />}
                 <IconChevronDown className="shrink-0 text-sm text-tertiary" />
             </button>
@@ -86,9 +96,10 @@ interface InboxSearchFilterBarProps {
 }
 
 /**
- * Search input + Source / Sort filter popovers + refresh. One-to-one
- * port of desktop `InboxSearchFilterBar`. There is no status filter (desktop
- * dropped it; status is a fixed request constant). Filter state is persisted via
+ * Search input + Sort / Source / Priority filter popovers + refresh. There is no
+ * status filter (desktop dropped it; status is a fixed request constant). Each
+ * popover stays a quiet, muted chip until its filter is in use, then gains a
+ * solid border and shows its value. Filter state is persisted via
  * `inboxFiltersLogic`; the central scene reloads on change.
  */
 export function InboxSearchFilterBar({
@@ -96,8 +107,8 @@ export function InboxSearchFilterBar({
     onRefresh,
     refreshing,
 }: InboxSearchFilterBarProps): JSX.Element {
-    const { searchQuery, sortField, sortDirection, sourceProductFilter } = useValues(inboxFiltersLogic)
-    const { setSearchQuery, setSort, toggleSourceProduct } = useActions(inboxFiltersLogic)
+    const { searchQuery, sortField, sortDirection, sourceProductFilter, priorityFilter } = useValues(inboxFiltersLogic)
+    const { setSearchQuery, setSort, toggleSourceProduct, togglePriority } = useActions(inboxFiltersLogic)
 
     const activeSort = INBOX_SORT_OPTIONS.find((o) => o.field === sortField && o.direction === sortDirection)
     const activeSortKey = inboxSortOptionKey(sortField, sortDirection)
@@ -113,6 +124,23 @@ export function InboxSearchFilterBar({
                 prefix={<IconSearch />}
                 size="small"
             />
+
+            <FilterPopover
+                label="Sort"
+                value={activeSort?.label ?? 'Priority first'}
+                icon={<IconSort />}
+                active={activeSortKey !== 'priority:asc'}
+            >
+                {INBOX_SORT_OPTIONS.map((option) => (
+                    <FilterItem
+                        key={inboxSortOptionKey(option.field, option.direction)}
+                        icon={option.icon}
+                        label={option.label}
+                        active={sortField === option.field && sortDirection === option.direction}
+                        onClick={() => setSort(option.field, option.direction)}
+                    />
+                ))}
+            </FilterPopover>
 
             <FilterPopover
                 label="Source"
@@ -132,18 +160,24 @@ export function InboxSearchFilterBar({
             </FilterPopover>
 
             <FilterPopover
-                label="Sort"
-                value={activeSort?.label ?? 'Priority first'}
-                icon={<IconSort />}
-                active={activeSortKey !== 'priority:asc'}
+                label="Priority"
+                value={inboxPriorityFilterLabel(priorityFilter)}
+                icon={<IconFlag />}
+                active={priorityFilter.length > 0}
             >
-                {INBOX_SORT_OPTIONS.map((option) => (
+                {INBOX_PRIORITY_OPTIONS.map((priority) => (
                     <FilterItem
-                        key={inboxSortOptionKey(option.field, option.direction)}
-                        icon={option.icon}
-                        label={option.label}
-                        active={sortField === option.field && sortDirection === option.direction}
-                        onClick={() => setSort(option.field, option.direction)}
+                        key={priority}
+                        icon={
+                            <span
+                                className="size-2 rounded-full"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={{ backgroundColor: PRIORITY_ACCENT[priority] }}
+                            />
+                        }
+                        label={priority}
+                        active={priorityFilter.includes(priority)}
+                        onClick={() => togglePriority(priority)}
                     />
                 ))}
             </FilterPopover>

--- a/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxSearchFilterBar.tsx
@@ -44,8 +44,8 @@ function FilterPopover({
                 type="button"
                 aria-label={`${label}: ${value}`}
                 // Quiet at rest: an unused filter is a muted, borderless chip showing its category
-                // (e.g. "Source"). Once active it gains a solid border, its selected value, and the
-                // accent dot — so the bar only draws attention to filters actually in use.
+                // (e.g. "Source"). Once active it gains a solid border and its selected value — so
+                // the bar only draws attention to filters actually in use.
                 className={`flex h-8 shrink-0 items-center gap-1.5 rounded border px-2.5 text-sm transition-colors ${
                     active
                         ? 'border-primary bg-surface-primary text-default hover:border-secondary hover:bg-surface-secondary'
@@ -54,7 +54,6 @@ function FilterPopover({
             >
                 <span className="flex shrink-0 items-center text-tertiary [&>svg]:size-3.5">{icon}</span>
                 <span className="max-w-[150px] truncate">{active ? value : label}</span>
-                {active && <span className="size-1.5 shrink-0 rounded-full bg-accent" />}
                 <IconChevronDown className="shrink-0 text-sm text-tertiary" />
             </button>
         </LemonDropdown>

--- a/frontend/src/scenes/inbox/filterOptions.tsx
+++ b/frontend/src/scenes/inbox/filterOptions.tsx
@@ -72,8 +72,19 @@ export const INBOX_SOURCE_OPTIONS: { value: string; label: string; icon: JSX.Ele
     { value: 'signals_scout', label: 'Scout', icon: <IconCompass /> },
 ]
 
+/** Priority codes in rank order (P0 highest → P4 lowest), driving the Priority filter popover. */
+export const INBOX_PRIORITY_OPTIONS: SignalReportPriority[] = ['P0', 'P1', 'P2', 'P3', 'P4']
+
 export function inboxSortOptionKey(field: InboxSortField, direction: InboxSortDirection): string {
     return `${field}:${direction}`
+}
+
+export function inboxPriorityFilterLabel(selected: SignalReportPriority[]): string {
+    if (selected.length === 0) {
+        return 'All priorities'
+    }
+    // Codes are short (P0–P4), so list them in rank order rather than collapsing to a count.
+    return [...selected].sort().join(', ')
 }
 
 export function inboxSourceFilterLabel(selected: string[]): string {


### PR DESCRIPTION
## Problem

The inbox filter bar lost its Priority filter in a recent simplification pass, but it's genuinely useful. At the same time, the remaining filter buttons feel too prominent when no filter is set.

## Changes

Let's restore the Priority filter. Reordering the popovers to Sort → Source → Priority.

To alleviate prominence issue, making the filter bar quiet at rest: an unused filter is now a muted, borderless chip showing its category name. Once active it gains a solid border.

<img width="1190" height="116" alt="filters" src="https://github.com/user-attachments/assets/11c1df19-0420-4d15-a7b9-2d58b3571218" />

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782376599331389?thread_ts=1782376599.331389&cid=C09SK2PAGKF)*
