### PR TITLE
fix(warehouse_sources): exclude deleted sources and dedupe digest

### DIFF
--- a/products/data_warehouse/backend/external_data_source/notifications.py
+++ b/products/data_warehouse/backend/external_data_source/notifications.py
@@ -45,6 +45,7 @@ def get_team_ids_with_recent_sync_failures(lookback: dt.timedelta = dt.timedelta
     ).filter(Q(schema__last_error_notified_at__isnull=True) | Q(finished_at__gt=OuterRef("last_error_notified_at")))
     return list(
         ExternalDataSchema.objects.exclude(deleted=True)
+        .exclude(source__deleted=True)
         .filter(status=ExternalDataSchema.Status.FAILED)
         .filter(Exists(unnotified_failed_job))
         .values_list("team_id", flat=True)
@@ -53,17 +54,28 @@ def get_team_ids_with_recent_sync_failures(lookback: dt.timedelta = dt.timedelta
 
 
 def notify_external_data_sync_failures(team_id: int) -> None:
-    """Email the team a digest of every currently-failing external data schema.
+    """Email the team a digest of failing external data schemas with an un-communicated failure.
 
-    Runs inside the digest Celery task; exceptions are swallowed so a notification
-    problem never crash-loops the task. Throttling to one email per team per digest
-    day happens in the email layer via the MessagingRecord campaign key, so
+    A failure is reported once: a schema is listed only if it was never notified or
+    has a failed run newer than its last notification. A stuck-but-stopped sync
+    (deleted source, paused schema) has no newer run, so it drops out after the first
+    digest instead of riding every later one. Schemas of a deleted source are excluded
+    entirely. Runs inside the digest Celery task; exceptions are swallowed so a
+    notification problem never crash-loops the task. Throttling to one email per team
+    per digest day happens in the email layer via the MessagingRecord campaign key, so
     scheduling this for every failed job is safe.
     """
     try:
+        newer_failed_job = ExternalDataJob.objects.filter(
+            schema_id=OuterRef("id"),
+            status=ExternalDataJob.Status.FAILED,
+            finished_at__gt=OuterRef("last_error_notified_at"),
+        )
         failing_schemas = list(
             ExternalDataSchema.objects.exclude(deleted=True)
+            .exclude(source__deleted=True)
             .filter(team_id=team_id, status=ExternalDataSchema.Status.FAILED)
+            .filter(Q(last_error_notified_at__isnull=True) | Exists(newer_failed_job))
             .select_related("source")
             # Paused (should_sync=False) schemas first — they need user action.
             .order_by("should_sync", "name")

--- a/products/data_warehouse/backend/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_notifications.py
@@ -213,6 +213,50 @@ class TestNotifyExternalDataSyncFailures:
         schema.refresh_from_db()
         assert schema.last_error_notified_at is None
 
+    def test_excludes_schemas_of_deleted_source(self):
+        team, source = _create_team_and_source()
+        ExternalDataSource.objects.filter(id=source.id).update(deleted=True)
+        ExternalDataSchema.objects.create(
+            name="Charge",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            latest_error="boom",
+        )
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        mock_sender.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "run_offset,expected_sent",
+        [
+            (dt.timedelta(hours=1), True),  # failed run after the last notification -> report again
+            (dt.timedelta(hours=-1), False),  # no run since the last notification -> stay silent
+        ],
+    )
+    def test_already_notified_failure_renotifies_only_on_newer_run(self, run_offset, expected_sent):
+        team, source = _create_team_and_source()
+        notified_at = dt.datetime.now(dt.UTC) - dt.timedelta(hours=2)
+        schema = ExternalDataSchema.objects.create(
+            name="Charge",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            latest_error="boom",
+            last_error_notified_at=notified_at,
+        )
+        job = ExternalDataJob.objects.create(
+            team=team, pipeline=source, schema=schema, status=ExternalDataJob.Status.FAILED
+        )
+        ExternalDataJob.objects.filter(id=job.id).update(finished_at=notified_at + run_offset)
+
+        with patch(SENDER_PATH) as mock_sender:
+            notify_external_data_sync_failures(team.pk)
+
+        assert mock_sender.called == expected_sent
+
 
 class TestGetTeamIdsWithRecentSyncFailures:
     def _create_schema_with_job(
@@ -221,9 +265,12 @@ class TestGetTeamIdsWithRecentSyncFailures:
         schema_status: str,
         job_finished_at: dt.datetime,
         schema_deleted: bool = False,
+        source_deleted: bool = False,
         last_error_notified_at: dt.datetime | None = None,
     ) -> Team:
         team, source = _create_team_and_source()
+        if source_deleted:
+            ExternalDataSource.objects.filter(id=source.id).update(deleted=True)
         schema = ExternalDataSchema.objects.create(
             name="Charge",
             team=team,
@@ -251,18 +298,20 @@ class TestGetTeamIdsWithRecentSyncFailures:
         assert get_team_ids_with_recent_sync_failures() == [team.pk]
 
     @pytest.mark.parametrize(
-        "schema_status,job_age,schema_deleted",
+        "schema_status,job_age,schema_deleted,source_deleted",
         [
-            (ExternalDataSchema.Status.FAILED, dt.timedelta(hours=30), False),
-            (ExternalDataSchema.Status.COMPLETED, dt.timedelta(hours=2), False),
-            (ExternalDataSchema.Status.FAILED, dt.timedelta(hours=2), True),
+            (ExternalDataSchema.Status.FAILED, dt.timedelta(hours=30), False, False),
+            (ExternalDataSchema.Status.COMPLETED, dt.timedelta(hours=2), False, False),
+            (ExternalDataSchema.Status.FAILED, dt.timedelta(hours=2), True, False),
+            (ExternalDataSchema.Status.FAILED, dt.timedelta(hours=2), False, True),
         ],
     )
-    def test_excludes_non_actionable_teams(self, schema_status, job_age, schema_deleted):
+    def test_excludes_non_actionable_teams(self, schema_status, job_age, schema_deleted, source_deleted):
         self._create_schema_with_job(
             schema_status=schema_status,
             job_finished_at=dt.datetime.now(dt.UTC) - job_age,
             schema_deleted=schema_deleted,
+            source_deleted=source_deleted,
         )
 
         assert get_team_ids_with_recent_sync_failures() == []


### PR DESCRIPTION
## Problem

Deleted data-warehouse sources leave their schema rows behind. When an `ExternalDataSource` is soft-deleted, its Temporal schedules are torn down, but the `ExternalDataSchema` rows are never retired — they stay `deleted=False` with a frozen `FAILED`/`Completed` status. The "Data warehouse syncs failing" digest filters `schema.deleted` but **not** `source.deleted`, so these dead rows show up in the email. (One project had 152 of them across 15 deleted Slack sources, rendering as several identical "Slack" cards — they aren't duplicate notifications, they're distinct dead sources.)

Separately, the digest body lists *every* currently-`FAILED` schema with no recency gate. `last_error_notified_at` only gates the daily catch-up's team selection, not the body — so a team with any ongoing failure re-receives the same stuck failures in every daily digest.

## Changes

In `notify_external_data_sync_failures` and the catch-up team selector `get_team_ids_with_recent_sync_failures`:

- **Exclude deleted-source schemas** (`exclude(source__deleted=True)`) — mirrors what every other consumer and the API already do (`data_load/service.py`, the `DataWarehouseTable` manager, signals views).
- **Gate the body to un-communicated failures**: a schema is listed only if it was never notified, or it has a `FAILED` job newer than its `last_error_notified_at`. A stuck-but-stopped sync (deleted source, paused schema) has no newer run, so it's reported once and then drops out instead of riding every later digest. A genuinely live-recurring failure still notifies — it always has a newer run.

Retiring the orphaned rows themselves is the stacked follow-up PR (#66001).

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- `test_notifications.py`: deleted-source schemas excluded from both the team selector and the body; a notified failure re-notifies only when a newer failed run exists; existing listing/ordering/cap/stamping behavior preserved.
- `hogli test products/data_warehouse/backend/external_data_source/test/test_notifications.py` → 25 passed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a real failure-digest email: traced the digest query path, confirmed against prod via the PostHog MCP (152 orphan rows under 15 deleted Slack sources) and prod Temporal (the schedules are already torn down — these are stale DB rows, not live syncs). Tool: Claude Code. Skill invoked: `/writing-tests`.

Two independent fixes were split into a Graphite stack: this PR fixes what the digest *includes*; the stacked PR (#66001) adds the periodic sweep that retires the orphan rows.
