### PR TITLE
fix(warehouse_sources): sweep orphaned schemas of deleted sources

### DIFF
--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -79,7 +79,10 @@ from products.conversations.backend.tasks import (
     wake_snoozed_tickets,
 )
 from products.data_modeling.backend.tasks.cleanup_test_saved_queries import cleanup_expired_test_saved_queries
-from products.data_warehouse.backend.tasks import send_external_data_failure_digest_catchup
+from products.data_warehouse.backend.tasks import (
+    send_external_data_failure_digest_catchup,
+    soft_delete_orphaned_external_data_schemas,
+)
 from products.endpoints.backend.tasks import deactivate_stale_materializations
 from products.feature_flags.backend.tasks import (
     cleanup_stale_flag_definitions_expiry_tracking_task,
@@ -436,6 +439,13 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
         crontab(hour=str(EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC), minute="15"),
         send_external_data_failure_digest_catchup.s(),
         name="send external data failure digest catch-up",
+    )
+
+    # Retire schemas orphaned by a deleted source so they stop showing as failing.
+    sender.add_periodic_task(
+        crontab(hour=str(EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC), minute="45"),
+        soft_delete_orphaned_external_data_schemas.s(),
+        name="soft-delete orphaned external data schemas",
     )
 
     # Every 30 minutes, send decide request counts to the main posthog instance

--- a/posthog/tasks/scheduled.py
+++ b/posthog/tasks/scheduled.py
@@ -442,8 +442,9 @@ def setup_periodic_tasks(sender: Celery, **kwargs: Any) -> None:
     )
 
     # Retire schemas orphaned by a deleted source so they stop showing as failing.
+    # Runs just before the catch-up digest below so swept rows never reach a digest build.
     sender.add_periodic_task(
-        crontab(hour=str(EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC), minute="45"),
+        crontab(hour=str(EXTERNAL_DATA_DIGEST_DAY_BOUNDARY_HOUR_UTC), minute="5"),
         soft_delete_orphaned_external_data_schemas.s(),
         name="soft-delete orphaned external data schemas",
     )

--- a/products/data_warehouse/backend/external_data_source/test/test_tasks.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_tasks.py
@@ -71,12 +71,15 @@ class TestSoftDeleteOrphanedExternalDataSchemas:
         schema = ExternalDataSchema.objects.create(
             name="Charge", team=team, source=source, status=ExternalDataSchema.Status.FAILED
         )
+        stale = dt.datetime(2020, 1, 1, tzinfo=dt.UTC)
+        ExternalDataSchema.objects.filter(id=schema.id).update(updated_at=stale)
 
         soft_delete_orphaned_external_data_schemas()
 
         schema.refresh_from_db()
         assert schema.deleted == expected_deleted
         assert (schema.deleted_at is not None) == expected_deleted
+        assert (schema.updated_at > stale) == expected_deleted
 
     def test_does_not_restamp_already_deleted_schema(self):
         team, source = _create_team_and_source(deleted=True)

--- a/products/data_warehouse/backend/external_data_source/test/test_tasks.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_tasks.py
@@ -1,11 +1,35 @@
+import uuid
+import datetime as dt
+
+import pytest
 from unittest.mock import patch
 
+from posthog.models import Organization, Team
 from posthog.redis import get_client
 
 from products.data_warehouse.backend.tasks import (
     send_external_data_failure_digest_catchup,
     send_external_data_failure_digest_task,
+    soft_delete_orphaned_external_data_schemas,
 )
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+
+
+def _create_team_and_source(deleted: bool = False) -> tuple[Team, ExternalDataSource]:
+    org = Organization.objects.create(name="Test Org")
+    team = Team.objects.create(organization=org, name="Test Team")
+    source = ExternalDataSource.objects.create(
+        team=team,
+        source_id=str(uuid.uuid4()),
+        connection_id=str(uuid.uuid4()),
+        destination_id=str(uuid.uuid4()),
+        status="running",
+        source_type="Stripe",
+    )
+    if deleted:
+        ExternalDataSource.objects.filter(id=source.id).update(deleted=True)
+    return team, source
 
 
 class TestExternalDataFailureDigestTasks:
@@ -37,3 +61,36 @@ class TestExternalDataFailureDigestTasks:
             send_external_data_failure_digest_catchup()
 
         assert [c.args for c in mock_task.delay.call_args_list] == [(1,), (2,)]
+
+
+@pytest.mark.django_db
+class TestSoftDeleteOrphanedExternalDataSchemas:
+    @pytest.mark.parametrize("source_deleted,expected_deleted", [(True, True), (False, False)])
+    def test_retires_only_schemas_of_deleted_sources(self, source_deleted, expected_deleted):
+        team, source = _create_team_and_source(deleted=source_deleted)
+        schema = ExternalDataSchema.objects.create(
+            name="Charge", team=team, source=source, status=ExternalDataSchema.Status.FAILED
+        )
+
+        soft_delete_orphaned_external_data_schemas()
+
+        schema.refresh_from_db()
+        assert schema.deleted == expected_deleted
+        assert (schema.deleted_at is not None) == expected_deleted
+
+    def test_does_not_restamp_already_deleted_schema(self):
+        team, source = _create_team_and_source(deleted=True)
+        original = dt.datetime(2020, 1, 1, tzinfo=dt.UTC)
+        schema = ExternalDataSchema.objects.create(
+            name="Charge",
+            team=team,
+            source=source,
+            status=ExternalDataSchema.Status.FAILED,
+            deleted=True,
+            deleted_at=original,
+        )
+
+        soft_delete_orphaned_external_data_schemas()
+
+        schema.refresh_from_db()
+        assert schema.deleted_at == original

--- a/products/data_warehouse/backend/external_data_source/test/test_tasks.py
+++ b/products/data_warehouse/backend/external_data_source/test/test_tasks.py
@@ -79,7 +79,7 @@ class TestSoftDeleteOrphanedExternalDataSchemas:
         schema.refresh_from_db()
         assert schema.deleted == expected_deleted
         assert (schema.deleted_at is not None) == expected_deleted
-        assert (schema.updated_at > stale) == expected_deleted
+        assert (schema.updated_at is not None and schema.updated_at > stale) == expected_deleted
 
     def test_does_not_restamp_already_deleted_schema(self):
         team, source = _create_team_and_source(deleted=True)

--- a/products/data_warehouse/backend/tasks.py
+++ b/products/data_warehouse/backend/tasks.py
@@ -1,3 +1,5 @@
+from django.db.models.functions import Now
+
 import structlog
 from celery import shared_task
 from prometheus_client import Counter
@@ -9,6 +11,7 @@ from products.data_warehouse.backend.external_data_source.notifications import (
     get_team_ids_with_recent_sync_failures,
     notify_external_data_sync_failures,
 )
+from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
 logger = structlog.get_logger(__name__)
 
@@ -81,3 +84,20 @@ def send_external_data_failure_digest_catchup() -> None:
     if team_ids:
         EXTERNAL_DATA_FAILURE_DIGEST_SCHEDULED_COUNTER.labels(trigger="catchup").inc(len(team_ids))
         logger.info("Dispatched external data failure digest catch-up for %d teams", len(team_ids))
+
+
+@shared_task(ignore_result=True)
+@skip_team_scope_audit
+def soft_delete_orphaned_external_data_schemas() -> None:
+    """Retire schemas whose source was soft-deleted but that were never cascaded.
+
+    A deleted source's Temporal schedules are torn down, so these rows never run
+    again to self-clean — they linger as FAILED zombies in the UI and the failure
+    digest. Soft-delete them in bulk (mirrors migration 0018_fix_orphaned_schemas)
+    so they drop out. Cross-team maintenance, hence the scope-audit skip.
+    """
+    count = ExternalDataSchema.objects.filter(source__deleted=True, deleted=False).update(
+        deleted=True, deleted_at=Now()
+    )
+    if count:
+        logger.info("Soft-deleted orphaned external data schemas", count=count)

--- a/products/data_warehouse/backend/tasks.py
+++ b/products/data_warehouse/backend/tasks.py
@@ -96,8 +96,10 @@ def soft_delete_orphaned_external_data_schemas() -> None:
     digest. Soft-delete them in bulk (mirrors migration 0018_fix_orphaned_schemas)
     so they drop out. Cross-team maintenance, hence the scope-audit skip.
     """
+    # Stamp updated_at too: the bulk update bypasses the auto_now save() path that
+    # the model's soft_delete() uses, so without this updated_at would stay frozen.
     count = ExternalDataSchema.objects.filter(source__deleted=True, deleted=False).update(
-        deleted=True, deleted_at=Now()
+        deleted=True, deleted_at=Now(), updated_at=Now()
     )
     if count:
         logger.info("Soft-deleted orphaned external data schemas", count=count)


### PR DESCRIPTION
## Problem

Schemas orphaned by a deleted source are never retired. A deleted `ExternalDataSource`'s Temporal schedules are torn down, so its `ExternalDataSchema` rows never run again to self-clean — they linger forever as `deleted=False`, `FAILED` "zombies" in the UI and (before the stacked base PR #66000) the failure digest. Migration `0018_fix_orphaned_schemas` swept these once, but new orphans keep appearing — e.g. the schema-discovery race re-creating rows just after a source is deleted, or deletes that bypass the viewset's cascade. One project had 152 such rows under 15 deleted Slack sources.

## Changes

Add a daily Celery beat task `soft_delete_orphaned_external_data_schemas` that bulk soft-deletes schemas where `source.deleted=True` and `deleted=False` — the ongoing version of migration `0018_fix_orphaned_schemas`. Registered in `scheduled.py` next to the existing digest catch-up.

- Bulk `.update()` matches the established pattern (migration 0018 and the source `destroy()` cascade) and scales to sources with thousands of channel-schemas.
- DB-only: any straggler Temporal schedule self-destructs via the existing `create_external_data_job_model_activity` check on its next fire.
- The existing backlog clears on the first scheduled run — no separate data migration needed.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- `test_tasks.py`: schemas under a deleted source are retired; schemas under a live source are untouched; already-deleted rows are not re-stamped.
- `hogli test products/data_warehouse/backend/external_data_source/test/test_tasks.py` → 6 passed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked on top of the digest-filter PR (#66000). Reactive cleanup inside the Temporal activities was considered and rejected: the orphaned schedules are already gone (verified in prod Temporal), so no workflow will ever fire again to self-clean these rows — a periodic sweep is the only mechanism that reaches them, including paused schemas that never fire. Tool: Claude Code. Skill invoked: `/writing-tests`.
