### PR TITLE
feat(posthog_ai): surface console debug messages in sandbox thread for staff

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
+++ b/frontend/src/scenes/inbox/components/detail/AgentRunDetail.tsx
@@ -190,7 +190,7 @@ function TaskLogBody({
 
     if (task && runId) {
         return (
-            <div className="h-[calc(100vh-22rem)] min-h-[420px] w-full overflow-y-auto rounded border border-primary bg-surface-primary">
+            <div className="h-[calc(100dvh-22rem)] min-h-[420px] w-full overflow-hidden rounded border border-primary bg-surface-primary">
                 {/* In-progress runs stream live; terminal runs show the static replay. */}
                 <SandboxRunViewer taskId={task.id} runId={runId} replayOnly={replayOnly} />
             </div>

--- a/frontend/src/scenes/max/Thread.tsx
+++ b/frontend/src/scenes/max/Thread.tsx
@@ -136,7 +136,8 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                     logic={sandboxStreamLogic}
                     props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
                 >
-                    <SandboxThreadView />
+                    {/* The live Max column owns scroll via ThreadAutoScroller — render rows in flow, not virtualized. */}
+                    <SandboxThreadView virtualized={false} />
                 </BindLogic>
             </div>
         )
@@ -156,7 +157,7 @@ export function Thread({ className }: { className?: string }): JSX.Element | nul
                     logic={sandboxStreamLogic}
                     props={{ streamKey: sandboxConversationKey, conversationId: sandboxConversationKey }}
                 >
-                    <SandboxThreadView />
+                    <SandboxThreadView virtualized={false} />
                 </BindLogic>
             </div>
         )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3808,6 +3808,9 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      react-window:
+        specifier: '*'
+        version: 2.2.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tailwind-merge:
         specifier: '*'
         version: 2.2.2

--- a/products/posthog_ai/frontend/sandbox/ActivityPrimitives.tsx
+++ b/products/posthog_ai/frontend/sandbox/ActivityPrimitives.tsx
@@ -130,6 +130,19 @@ export function ActivityHeader({
                 hasDetails && isDetailsExpanded && 'bg-fill-button-tertiary-active'
             )}
             onClick={hasDetails ? onToggleDetails : undefined}
+            onKeyDown={
+                hasDetails
+                    ? (e) => {
+                          if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault()
+                              onToggleDetails()
+                          }
+                      }
+                    : undefined
+            }
+            role={hasDetails ? 'button' : undefined}
+            tabIndex={hasDetails ? 0 : undefined}
+            aria-expanded={hasDetails ? isDetailsExpanded : undefined}
             aria-label={hasDetails ? (isDetailsExpanded ? 'Collapse history' : 'Expand history') : undefined}
         >
             {icon && (

--- a/products/posthog_ai/frontend/sandbox/ActivityPrimitives.tsx
+++ b/products/posthog_ai/frontend/sandbox/ActivityPrimitives.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx'
 import React, { useLayoutEffect, useState } from 'react'
 
-import { IconCheck, IconChevronRight, IconX } from '@posthog/icons'
+import { IconCheck, IconChevronDown, IconChevronRight, IconX } from '@posthog/icons'
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
 import { MarkdownMessage } from './MarkdownMessage'
@@ -122,7 +122,7 @@ export function ActivityHeader({
     return (
         <div
             className={clsx(
-                'transition-all duration-500 flex select-none min-w-0',
+                'group/activity-header transition-all duration-500 flex select-none min-w-0',
                 (isPending || isFailed) && 'text-muted',
                 !isInProgress && !isPending && !isFailed && 'text-default',
                 hasDetails ? 'cursor-pointer' : 'cursor-default',
@@ -133,18 +133,28 @@ export function ActivityHeader({
             aria-label={hasDetails ? (isDetailsExpanded ? 'Collapse history' : 'Expand history') : undefined}
         >
             {icon && (
-                <div className="flex items-center justify-center size-5">
-                    {isInProgress && animate ? (
-                        <ShimmeringContent>{icon}</ShimmeringContent>
-                    ) : (
-                        <span className={clsx('inline-flex', isInProgress && 'text-muted')}>{icon}</span>
+                <div className="relative flex items-center justify-center size-5 shrink-0 overflow-hidden">
+                    <span
+                        className={clsx(
+                            'inline-flex transition-all duration-200 ease-out',
+                            isInProgress && 'text-muted',
+                            hasDetails &&
+                                'group-hover/activity-header:-translate-x-1 group-hover/activity-header:scale-90 group-hover/activity-header:opacity-0 group-focus-within/activity-header:-translate-x-1 group-focus-within/activity-header:scale-90 group-focus-within/activity-header:opacity-0'
+                        )}
+                    >
+                        {isInProgress && animate ? <ShimmeringContent>{icon}</ShimmeringContent> : icon}
+                    </span>
+                    {hasDetails && (
+                        <span className="absolute inline-flex translate-x-1 scale-90 text-tertiary opacity-0 transition-all duration-200 ease-out group-hover/activity-header:translate-x-0 group-hover/activity-header:scale-100 group-hover/activity-header:text-primary group-hover/activity-header:opacity-100 group-focus-within/activity-header:translate-x-0 group-focus-within/activity-header:scale-100 group-focus-within/activity-header:text-primary group-focus-within/activity-header:opacity-100">
+                            <IconChevronDown className="size-5" />
+                        </span>
                     )}
                 </div>
             )}
             <div className="flex items-center gap-1 flex-1 min-w-0 h-full">
                 {children ? (
                     // The title/subtitle column grows to fill the row, so the subtitle (second line) gets the
-                    // full available width before it truncates and the chevron stays pinned to the right.
+                    // full available width before it truncates.
                     <div className="flex flex-col flex-1 min-w-0">
                         {/* Status icon rides the first line with the title; the second line is the subtitle. */}
                         <div className="flex items-center gap-1 min-w-0">
@@ -155,15 +165,6 @@ export function ActivityHeader({
                     </div>
                 ) : (
                     <div className="min-w-0">{titleNode}</div>
-                )}
-                {hasDetails && (
-                    <div className="relative shrink-0 flex flex-col items-start justify-center h-full">
-                        <button className="inline-flex items-center hover:opacity-70 transition-opacity shrink-0 cursor-pointer">
-                            <span className={clsx('transform transition-transform', isDetailsExpanded && 'rotate-90')}>
-                                <IconChevronRight />
-                            </span>
-                        </button>
-                    </div>
                 )}
                 {!children && statusIcon}
             </div>

--- a/products/posthog_ai/frontend/sandbox/components/SandboxRunViewer.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxRunViewer.tsx
@@ -73,12 +73,7 @@ function SandboxRunViewerContent({
     const showSpinner = bootstrapLoading && threadItems.length === 0
 
     return (
-        <div
-            className={cn(
-                '@container/thread flex flex-col items-stretch w-full max-w-180 self-center gap-1.5 grow mx-auto',
-                className
-            )}
-        >
+        <div className={cn('flex flex-col h-full min-h-0 w-full', className)}>
             {showSpinner ? (
                 <div className="flex justify-center py-8">
                     <Spinner className="text-2xl" />

--- a/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
@@ -162,7 +162,7 @@ export const SandboxThreadRow = memo(function SandboxThreadRow({
         return <SandboxProgressItem item={item} />
     }
     if (item.type === 'debug') {
-        return <SandboxDebugMessage id={item.id} text={item.text ?? ''} level={item.debugLevel ?? 'info'} />
+        return <SandboxDebugMessage text={item.text ?? ''} level={item.debugLevel ?? 'info'} />
     }
     return null
 })

--- a/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
@@ -10,6 +10,7 @@ import { MarkdownMessage } from '../MarkdownMessage'
 import { AssistantFailureMessage } from '../messages/AssistantFailureMessage'
 import { MessageTemplate } from '../messages/MessageTemplate'
 import { ReasoningAnswer } from '../messages/ReasoningAnswer'
+import { SandboxDebugMessage } from '../messages/SandboxDebugMessage'
 import { SandboxActivity } from '../SandboxActivity'
 import { sandboxStreamLogic } from '../sandboxStreamLogic'
 import { SandboxCompactBoundaryItem, SandboxStatusItem, SandboxTaskNotificationItem } from '../SandboxThreadItems'
@@ -159,6 +160,9 @@ export const SandboxThreadRow = memo(function SandboxThreadRow({
     }
     if (item.type === 'progress') {
         return <SandboxProgressItem item={item} />
+    }
+    if (item.type === 'debug') {
+        return <SandboxDebugMessage id={item.id} text={item.text ?? ''} level={item.debugLevel ?? 'info'} />
     }
     return null
 })

--- a/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxThreadRow.tsx
@@ -1,0 +1,164 @@
+import { memo } from 'react'
+
+import { IconWrench } from '@posthog/icons'
+
+import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
+
+import type { SandboxToolCallMessage } from 'products/posthog_ai/frontend/sandbox/types/sandboxToolTypes'
+
+import { MarkdownMessage } from '../MarkdownMessage'
+import { AssistantFailureMessage } from '../messages/AssistantFailureMessage'
+import { MessageTemplate } from '../messages/MessageTemplate'
+import { ReasoningAnswer } from '../messages/ReasoningAnswer'
+import { SandboxActivity } from '../SandboxActivity'
+import { sandboxStreamLogic } from '../sandboxStreamLogic'
+import { SandboxCompactBoundaryItem, SandboxStatusItem, SandboxTaskNotificationItem } from '../SandboxThreadItems'
+import { resolveToolCall } from '../sandboxToolResolver'
+import type { SandboxProgressStep, ThreadItem as SandboxThreadItem } from '../types/sandboxStreamTypes'
+import { SandboxToolCall } from './tool/SandboxToolCall'
+
+type ToolInvocations = typeof sandboxStreamLogic.values.toolInvocations
+
+/** Maps a raw merged `ToolInvocation` into the flat `SandboxToolCallMessage` the registry renderers read. */
+function toolInvocationToMessage(invocation: ReturnType<ToolInvocations['get']>): SandboxToolCallMessage | null {
+    if (!invocation) {
+        return null
+    }
+    const resolved = resolveToolCall(invocation)
+    return {
+        id: invocation.toolCallId,
+        resolvedKey: resolved.resolvedKey,
+        rawServerName: invocation.rawServerName,
+        rawToolName: invocation.rawToolName,
+        innerToolName: resolved.innerToolName,
+        claudeToolName: resolved.claudeToolName,
+        rawInput: invocation.input,
+        innerInput: resolved.innerInput,
+        rawOutput: invocation.output,
+        content: invocation.contentBlocks,
+        status: invocation.status,
+        title: invocation.title,
+        kind: invocation.kind,
+        locations: invocation.locations,
+        error: invocation.error,
+    }
+}
+
+function progressStepText(step: SandboxProgressStep): string {
+    return step.detail ? `${step.label}\n\n${step.detail}` : step.label
+}
+
+function resolveSandboxProgressState(steps: SandboxProgressStep[]): ExecutionStatus {
+    if (steps.some((step) => step.status === 'failed')) {
+        return ExecutionStatus.Failed
+    }
+    if (steps.some((step) => step.status === 'in_progress')) {
+        return ExecutionStatus.InProgress
+    }
+    if (steps.length > 0 && steps.every((step) => step.status === 'pending')) {
+        return ExecutionStatus.Pending
+    }
+    return ExecutionStatus.Completed
+}
+
+function resolveSandboxProgressHeadline(steps: SandboxProgressStep[]): string {
+    const active = steps.find((step) => step.status === 'in_progress')
+    if (active) {
+        return active.label
+    }
+    return steps.at(-1)?.label ?? 'Working'
+}
+
+function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element | null {
+    const steps = item.progressSteps ?? []
+    if (!steps.length) {
+        return null
+    }
+
+    const headline = resolveSandboxProgressHeadline(steps)
+    const substeps = steps.length > 1 ? steps.map(progressStepText) : []
+    const state = resolveSandboxProgressState(steps)
+
+    return (
+        <SandboxActivity
+            id={item.id}
+            content={headline}
+            substeps={substeps}
+            state={state}
+            icon={<IconWrench />}
+            showCompletionIcon={true}
+        />
+    )
+}
+
+export interface SandboxThreadRowProps {
+    item: SandboxThreadItem
+    /** Last item in the thread — drives reasoning collapse alongside `isThinking`. */
+    isLast: boolean
+    isThinking: boolean
+    toolInvocations: ToolInvocations
+    turnComplete: boolean
+    turnCancelled: boolean
+}
+
+/**
+ * Renders a single sandbox thread item by type. Memoized and keyed by stable `item.id` so a re-projected
+ * `threadItems` array only re-renders rows whose data actually changed.
+ */
+export const SandboxThreadRow = memo(function SandboxThreadRow({
+    item,
+    isLast,
+    isThinking,
+    toolInvocations,
+    turnComplete,
+    turnCancelled,
+}: SandboxThreadRowProps): JSX.Element | null {
+    if (item.type === 'human_message') {
+        return (
+            <MessageTemplate type="human">
+                <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
+            </MessageTemplate>
+        )
+    }
+    if (item.type === 'assistant_message') {
+        return (
+            <MessageTemplate type="ai">
+                <MarkdownMessage content={item.text ?? ''} id={item.id} />
+            </MessageTemplate>
+        )
+    }
+    if (item.type === 'assistant_thought') {
+        // Empty chunks prime the stream before any reasoning text arrives — skip them so a contentless
+        // "Thought" never shows; the bottom indicator covers that gap.
+        if (!item.text?.trim()) {
+            return null
+        }
+        // Collapse to "Thought" once a later block starts or the run stops thinking — mirrors the LangGraph
+        // thread's reasoning-complete rule.
+        const completed = !isLast || !isThinking
+        return <ReasoningAnswer content={item.text} id={item.id} completed={completed} showCompletionIcon={false} />
+    }
+    if (item.type === 'tool_invocation' && item.toolCallId) {
+        const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
+        if (!message) {
+            return null
+        }
+        return <SandboxToolCall message={message} turnComplete={turnComplete} turnCancelled={turnCancelled} />
+    }
+    if (item.type === 'error') {
+        return <AssistantFailureMessage id={item.id} content={item.errorMessage} />
+    }
+    if (item.type === 'status') {
+        return <SandboxStatusItem item={item} />
+    }
+    if (item.type === 'compact_boundary') {
+        return <SandboxCompactBoundaryItem item={item} />
+    }
+    if (item.type === 'task_notification') {
+        return <SandboxTaskNotificationItem item={item} />
+    }
+    if (item.type === 'progress') {
+        return <SandboxProgressItem item={item} />
+    }
+    return null
+})

--- a/products/posthog_ai/frontend/sandbox/components/SandboxThreadView.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxThreadView.tsx
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useCallback, useMemo } from 'react'
+import { memo, useCallback, useMemo } from 'react'
 
 import { ReasoningAnswer } from '../messages/ReasoningAnswer'
 import { SandboxPullRequestCard } from '../SandboxPullRequestCard'
@@ -9,6 +9,11 @@ import type { ThreadItem } from '../types/sandboxStreamTypes'
 import { getRandomThinkingMessage } from '../utils/thinkingMessages'
 import { SandboxThreadRow } from './SandboxThreadRow'
 import { VirtualizedThread } from './VirtualizedThread'
+
+/** Stable row key — defined at module scope so `getItemKey` never changes identity across renders. */
+function getThreadItemKey(item: ThreadItem): string {
+    return item.id
+}
 
 /**
  * Sandbox-runtime thread presenter. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
@@ -23,37 +28,43 @@ import { VirtualizedThread } from './VirtualizedThread'
  * then render in document flow, unchanged from the pre-virtualized layout.
  */
 export function SandboxThreadView({ virtualized = true }: { virtualized?: boolean } = {}): JSX.Element {
-    // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
-    // message while the run is active, falling back to the canned rotation.
-    const {
-        threadItems,
-        toolInvocations,
-        currentProgress,
-        isThinking,
-        streamPhase,
-        runArtifacts,
-        turnComplete,
-        currentRunStatus,
-    } = useValues(sandboxStreamLogic)
+    const { threadItems, toolInvocations, isThinking, streamPhase, runArtifacts, turnComplete, currentRunStatus } =
+        useValues(sandboxStreamLogic)
     const turnCancelled = currentRunStatus === 'cancelled'
     const hasActiveProgressItem = threadItems.some(
         (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
     )
 
-    const header = runArtifacts.branch ? (
-        <SandboxRunContext branch={runArtifacts.branch} baseBranch={runArtifacts.baseBranch} repo={runArtifacts.repo} />
-    ) : undefined
+    // Header/footer are kept as memoized leaf components with stable element identity so they don't rebuild
+    // `VirtualizedThread`'s `renderRow` (and re-sweep visible rows) on every streamed frame. Each is wrapped
+    // in `VirtualizedThread.Row` like the item rows so it gets react-window positioning + height measurement.
+    const { branch, baseBranch, repo } = runArtifacts
+    const header = useMemo(
+        () =>
+            branch ? (
+                <VirtualizedThread.Row>
+                    <SandboxThreadHeader branch={branch} baseBranch={baseBranch} repo={repo} />
+                </VirtualizedThread.Row>
+            ) : undefined,
+        [branch, baseBranch, repo]
+    )
 
     const showThinking = streamPhase === 'thinking' && !hasActiveProgressItem
     // Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking.
     const pullRequestUrl = !isThinking ? runArtifacts.prUrl : undefined
-    const footer =
-        showThinking || pullRequestUrl ? (
-            <>
-                {showThinking && <SandboxThinkingIndicator progress={currentProgress} />}
-                {pullRequestUrl && <SandboxPullRequestCard prUrl={pullRequestUrl} branch={runArtifacts.branch} />}
-            </>
-        ) : undefined
+    const footer = useMemo(
+        () =>
+            showThinking || pullRequestUrl ? (
+                <VirtualizedThread.Row>
+                    <SandboxThreadFooter
+                        showThinking={showThinking}
+                        pullRequestUrl={pullRequestUrl}
+                        prBranch={branch}
+                    />
+                </VirtualizedThread.Row>
+            ) : undefined,
+        [showThinking, pullRequestUrl, branch]
+    )
 
     const renderItem = useCallback(
         (item: ThreadItem, index: number): JSX.Element => (
@@ -74,7 +85,7 @@ export function SandboxThreadView({ virtualized = true }: { virtualized?: boolea
     return (
         <VirtualizedThread.Root
             items={threadItems}
-            getItemKey={(item) => item.id}
+            getItemKey={getThreadItemKey}
             header={header}
             footer={footer}
             stickToBottom
@@ -84,6 +95,42 @@ export function SandboxThreadView({ virtualized = true }: { virtualized?: boolea
         </VirtualizedThread.Root>
     )
 }
+
+/** Leading run-context row. Memoized so it only re-renders when the run's branch/repo refs change. */
+const SandboxThreadHeader = memo(function SandboxThreadHeader({
+    branch,
+    baseBranch,
+    repo,
+}: {
+    branch: string
+    baseBranch?: string
+    repo?: string
+}): JSX.Element {
+    return <SandboxRunContext branch={branch} baseBranch={baseBranch} repo={repo} />
+})
+
+/**
+ * Trailing row: the "what's it doing now" thinking line and/or the produced PR card. Subscribes to
+ * `currentProgress` itself so the frequently-updating progress text stays isolated here — it never
+ * re-renders `SandboxThreadView` or destabilizes the footer's element identity during streaming.
+ */
+const SandboxThreadFooter = memo(function SandboxThreadFooter({
+    showThinking,
+    pullRequestUrl,
+    prBranch,
+}: {
+    showThinking: boolean
+    pullRequestUrl?: string
+    prBranch?: string
+}): JSX.Element {
+    const { currentProgress } = useValues(sandboxStreamLogic)
+    return (
+        <>
+            {showThinking && <SandboxThinkingIndicator progress={currentProgress} />}
+            {pullRequestUrl && <SandboxPullRequestCard prUrl={pullRequestUrl} branch={prBranch} />}
+        </>
+    )
+})
 
 /**
  * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest

--- a/products/posthog_ai/frontend/sandbox/components/SandboxThreadView.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/SandboxThreadView.tsx
@@ -1,52 +1,14 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { useCallback, useMemo } from 'react'
 
-import { IconWrench } from '@posthog/icons'
-
-import { TaskExecutionStatus as ExecutionStatus } from '~/queries/schema/schema-assistant-messages'
-
-import type { SandboxToolCallMessage } from 'products/posthog_ai/frontend/sandbox/types/sandboxToolTypes'
-
-import { MarkdownMessage } from '../MarkdownMessage'
-import { AssistantFailureMessage } from '../messages/AssistantFailureMessage'
-import { MessageTemplate } from '../messages/MessageTemplate'
 import { ReasoningAnswer } from '../messages/ReasoningAnswer'
-import { SandboxActivity } from '../SandboxActivity'
 import { SandboxPullRequestCard } from '../SandboxPullRequestCard'
 import { SandboxRunContext } from '../SandboxRunContext'
 import { sandboxStreamLogic } from '../sandboxStreamLogic'
-import { SandboxCompactBoundaryItem, SandboxStatusItem, SandboxTaskNotificationItem } from '../SandboxThreadItems'
-import { resolveToolCall } from '../sandboxToolResolver'
-import type { SandboxProgressStep, ThreadItem as SandboxThreadItem } from '../types/sandboxStreamTypes'
+import type { ThreadItem } from '../types/sandboxStreamTypes'
 import { getRandomThinkingMessage } from '../utils/thinkingMessages'
-import { SandboxToolCall } from './tool/SandboxToolCall'
-
-/** Maps a raw merged `ToolInvocation` into the flat `SandboxToolCallMessage` the registry renderers read. */
-function toolInvocationToMessage(
-    invocation: ReturnType<typeof sandboxStreamLogic.values.toolInvocations.get>
-): SandboxToolCallMessage | null {
-    if (!invocation) {
-        return null
-    }
-    const resolved = resolveToolCall(invocation)
-    return {
-        id: invocation.toolCallId,
-        resolvedKey: resolved.resolvedKey,
-        rawServerName: invocation.rawServerName,
-        rawToolName: invocation.rawToolName,
-        innerToolName: resolved.innerToolName,
-        claudeToolName: resolved.claudeToolName,
-        rawInput: invocation.input,
-        innerInput: resolved.innerInput,
-        rawOutput: invocation.output,
-        content: invocation.contentBlocks,
-        status: invocation.status,
-        title: invocation.title,
-        kind: invocation.kind,
-        locations: invocation.locations,
-        error: invocation.error,
-    }
-}
+import { SandboxThreadRow } from './SandboxThreadRow'
+import { VirtualizedThread } from './VirtualizedThread'
 
 /**
  * Sandbox-runtime thread presenter. Reads `sandboxStreamLogic.values.threadItems` (assistant text,
@@ -54,8 +16,13 @@ function toolInvocationToMessage(
  * instance is bound above it — a live PostHog AI conversation or a read-only run viewer — and
  * dispatches tool cards through the sandbox tool registry. Conversation-agnostic by design: it knows
  * only the bound stream logic, never langgraph vs sandbox or the conversation.
+ *
+ * Rows are virtualized through `VirtualizedThread`, which owns scroll and stick-to-bottom; the leading
+ * run context and trailing thinking indicator / PR card ride along as the header/footer rows. Pass
+ * `virtualized={false}` when an ancestor already owns scroll (the live Max column + auto-scroller) — rows
+ * then render in document flow, unchanged from the pre-virtualized layout.
  */
-export function SandboxThreadView(): JSX.Element {
+export function SandboxThreadView({ virtualized = true }: { virtualized?: boolean } = {}): JSX.Element {
     // Drive the thinking indicator from real agent progress: show the latest `_posthog/progress`
     // message while the run is active, falling back to the canned rotation.
     const {
@@ -73,135 +40,48 @@ export function SandboxThreadView(): JSX.Element {
         (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
     )
 
-    return (
-        <>
-            {runArtifacts.branch && (
-                <SandboxRunContext
-                    branch={runArtifacts.branch}
-                    baseBranch={runArtifacts.baseBranch}
-                    repo={runArtifacts.repo}
+    const header = runArtifacts.branch ? (
+        <SandboxRunContext branch={runArtifacts.branch} baseBranch={runArtifacts.baseBranch} repo={runArtifacts.repo} />
+    ) : undefined
+
+    const showThinking = streamPhase === 'thinking' && !hasActiveProgressItem
+    // Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking.
+    const pullRequestUrl = !isThinking ? runArtifacts.prUrl : undefined
+    const footer =
+        showThinking || pullRequestUrl ? (
+            <>
+                {showThinking && <SandboxThinkingIndicator progress={currentProgress} />}
+                {pullRequestUrl && <SandboxPullRequestCard prUrl={pullRequestUrl} branch={runArtifacts.branch} />}
+            </>
+        ) : undefined
+
+    const renderItem = useCallback(
+        (item: ThreadItem, index: number): JSX.Element => (
+            <VirtualizedThread.Row>
+                <SandboxThreadRow
+                    item={item}
+                    isLast={index === threadItems.length - 1}
+                    isThinking={isThinking}
+                    toolInvocations={toolInvocations}
+                    turnComplete={turnComplete}
+                    turnCancelled={turnCancelled}
                 />
-            )}
-            {threadItems.map((item, index) => {
-                if (item.type === 'human_message') {
-                    return (
-                        <MessageTemplate key={item.id} type="human">
-                            <MarkdownMessage content={item.text || '*No text.*'} id={item.id} />
-                        </MessageTemplate>
-                    )
-                }
-                if (item.type === 'assistant_message') {
-                    return (
-                        <MessageTemplate key={item.id} type="ai">
-                            <MarkdownMessage content={item.text ?? ''} id={item.id} />
-                        </MessageTemplate>
-                    )
-                }
-                if (item.type === 'assistant_thought') {
-                    // Empty chunks prime the stream before any reasoning text arrives — skip them so
-                    // a contentless "Thought" never shows; the bottom indicator covers that gap.
-                    if (!item.text?.trim()) {
-                        return null
-                    }
-                    // Collapse to "Thought" once a later block starts or the run stops thinking —
-                    // mirrors the LangGraph thread's reasoning-complete rule.
-                    const completed = index !== threadItems.length - 1 || !isThinking
-                    return (
-                        <ReasoningAnswer
-                            key={item.id}
-                            content={item.text}
-                            id={item.id}
-                            completed={completed}
-                            showCompletionIcon={false}
-                        />
-                    )
-                }
-                if (item.type === 'tool_invocation' && item.toolCallId) {
-                    const message = toolInvocationToMessage(toolInvocations.get(item.toolCallId))
-                    if (!message) {
-                        return null
-                    }
-                    return (
-                        <SandboxToolCall
-                            key={item.id}
-                            message={message}
-                            turnComplete={turnComplete}
-                            turnCancelled={turnCancelled}
-                        />
-                    )
-                }
-                if (item.type === 'error') {
-                    return <AssistantFailureMessage key={item.id} id={item.id} content={item.errorMessage} />
-                }
-                if (item.type === 'status') {
-                    return <SandboxStatusItem key={item.id} item={item} />
-                }
-                if (item.type === 'compact_boundary') {
-                    return <SandboxCompactBoundaryItem key={item.id} item={item} />
-                }
-                if (item.type === 'task_notification') {
-                    return <SandboxTaskNotificationItem key={item.id} item={item} />
-                }
-                if (item.type === 'progress') {
-                    return <SandboxProgressItem key={item.id} item={item} />
-                }
-                return null
-            })}
-            {streamPhase === 'thinking' && !hasActiveProgressItem && (
-                <SandboxThinkingIndicator progress={currentProgress} />
-            )}
-            {/* Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking. */}
-            {!isThinking && runArtifacts.prUrl && (
-                <SandboxPullRequestCard prUrl={runArtifacts.prUrl} branch={runArtifacts.branch} />
-            )}
-        </>
+            </VirtualizedThread.Row>
+        ),
+        [threadItems.length, isThinking, toolInvocations, turnComplete, turnCancelled]
     )
-}
-
-function progressStepText(step: SandboxProgressStep): string {
-    return step.detail ? `${step.label}\n\n${step.detail}` : step.label
-}
-
-function resolveSandboxProgressState(steps: SandboxProgressStep[]): ExecutionStatus {
-    if (steps.some((step) => step.status === 'failed')) {
-        return ExecutionStatus.Failed
-    }
-    if (steps.some((step) => step.status === 'in_progress')) {
-        return ExecutionStatus.InProgress
-    }
-    if (steps.length > 0 && steps.every((step) => step.status === 'pending')) {
-        return ExecutionStatus.Pending
-    }
-    return ExecutionStatus.Completed
-}
-
-function resolveSandboxProgressHeadline(steps: SandboxProgressStep[]): string {
-    const active = steps.find((step) => step.status === 'in_progress')
-    if (active) {
-        return active.label
-    }
-    return steps.at(-1)?.label ?? 'Working'
-}
-
-function SandboxProgressItem({ item }: { item: SandboxThreadItem }): JSX.Element | null {
-    const steps = item.progressSteps ?? []
-    if (!steps.length) {
-        return null
-    }
-
-    const headline = resolveSandboxProgressHeadline(steps)
-    const substeps = steps.length > 1 ? steps.map(progressStepText) : []
-    const state = resolveSandboxProgressState(steps)
 
     return (
-        <SandboxActivity
-            id={item.id}
-            content={headline}
-            substeps={substeps}
-            state={state}
-            icon={<IconWrench />}
-            showCompletionIcon={true}
-        />
+        <VirtualizedThread.Root
+            items={threadItems}
+            getItemKey={(item) => item.id}
+            header={header}
+            footer={footer}
+            stickToBottom
+            virtualized={virtualized}
+        >
+            {renderItem}
+        </VirtualizedThread.Root>
     )
 }
 

--- a/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
@@ -95,6 +95,9 @@ function Root<T>({
     virtualized = true,
     children,
 }: VirtualizedThreadRootProps<T>): JSX.Element {
+    // Shared per-row height cache (Map keyed by row index). Survives re-renders and react-window's
+    // row recycling, so scrolling back to an already-measured row reuses its height without a flash;
+    // rows are re-measured on resize via `observeRowElements` (see `Row`).
     const dynamicRowHeight = useDynamicRowHeight({ defaultRowHeight })
     const listRef = useListRef(null)
 
@@ -254,6 +257,12 @@ function Row({ children, className }: { children: ReactNode; className?: string 
     const { style, ariaAttributes, index } = row
     const rowRef = useRef<HTMLDivElement>(null)
 
+    // Cache + recalc: `observeRowElements` attaches a ResizeObserver to the measured row element and
+    // writes its border-box height into the shared cache. So when this row's content changes height —
+    // tool output expand/collapse, streaming markdown, a late-loading image — it is re-measured and the
+    // list re-lays-out automatically. We observe the outer element (which is never given a fixed height,
+    // only react-window's position/transform), and the gap padding lives on its child, so the cached
+    // height always includes inter-row spacing and content growth.
     useEffect(() => {
         if (virtualized && rowRef.current) {
             return dynamicRowHeight.observeRowElements([rowRef.current])

--- a/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
@@ -1,0 +1,280 @@
+import {
+    createContext,
+    CSSProperties,
+    ReactNode,
+    UIEvent,
+    useCallback,
+    useContext,
+    useEffect,
+    useMemo,
+    useRef,
+} from 'react'
+import { List, RowComponentProps, useDynamicRowHeight, useListRef } from 'react-window'
+
+import { AutoSizer } from 'lib/components/AutoSizer'
+import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
+import { cn } from 'lib/utils/css-classes'
+
+/** Within this many px of the bottom still counts as "pinned" — absorbs iOS momentum/rubber-band jitter. */
+const BOTTOM_THRESHOLD = 32
+
+const EMPTY_STYLE: CSSProperties = {}
+const EMPTY_ARIA: Record<string, unknown> = {}
+
+interface RootContextValue {
+    dynamicRowHeight: ReturnType<typeof useDynamicRowHeight>
+    /** Inter-row spacing (px), applied as bottom padding on the measured row so heights include it. */
+    gap: number
+    maxWidthClassName: string
+    /** When false, rows render in document flow (no react-window) and an ancestor owns scroll. */
+    virtualized: boolean
+}
+
+interface RowContextValue {
+    index: number
+    style: CSSProperties
+    ariaAttributes: Record<string, unknown>
+}
+
+const RootContext = createContext<RootContextValue | null>(null)
+const RowContext = createContext<RowContextValue | null>(null)
+
+interface InternalRowProps {
+    renderRow: (index: number) => ReactNode
+}
+
+/** react-window row shell: publishes per-row positioning via context and defers content to `renderRow`. */
+function InternalRow({ index, style, ariaAttributes, renderRow }: RowComponentProps<InternalRowProps>): JSX.Element {
+    const value = useMemo<RowContextValue>(() => ({ index, style, ariaAttributes }), [index, style, ariaAttributes])
+    return <RowContext.Provider value={value}>{renderRow(index)}</RowContext.Provider>
+}
+
+export interface VirtualizedThreadRootProps<T> {
+    items: T[]
+    /** Stable key per item — used for stick-to-bottom change detection (react-window keys rows by index). */
+    getItemKey: (item: T, index: number) => string
+    /** Rendered as a measured leading row (e.g. run context). */
+    header?: ReactNode
+    /** Rendered as a measured trailing row (e.g. thinking indicator, PR card). */
+    footer?: ReactNode
+    /** Inter-row spacing in px (default 6, matching `gap-1.5`). */
+    gap?: number
+    /** Height used until a row is measured. */
+    defaultRowHeight?: number
+    overscanCount?: number
+    /** Follow the bottom as rows grow/append; unpins when the user scrolls up. */
+    stickToBottom?: boolean
+    maxWidthClassName?: string
+    className?: string
+    /**
+     * Virtualize and own scroll (default `true` — requires a height-bounded parent). Pass `false` to render
+     * rows in document flow and let an ancestor own the scroll (e.g. an external auto-scroller); the wrapper
+     * adds no chrome in this mode, so the parent supplies layout (gap, centering, container query).
+     */
+    virtualized?: boolean
+    children: (item: T, index: number) => ReactNode
+}
+
+/**
+ * Embeddable virtualized thread. Fills any height-bounded parent (`h-full`/`flex-1 min-h-0`/fixed) via
+ * `AutoSizer`, virtualizes rows with react-window, measures dynamic heights, owns its own scroll and an
+ * optional stick-to-bottom that follows streaming growth. Render rows through the `children` render-prop,
+ * each wrapped in `VirtualizedThread.Row`.
+ */
+function Root<T>({
+    items,
+    getItemKey,
+    header,
+    footer,
+    gap = 6,
+    defaultRowHeight = 56,
+    overscanCount = 10,
+    stickToBottom = true,
+    maxWidthClassName = 'max-w-180',
+    className,
+    virtualized = true,
+    children,
+}: VirtualizedThreadRootProps<T>): JSX.Element {
+    const dynamicRowHeight = useDynamicRowHeight({ defaultRowHeight })
+    const listRef = useListRef(null)
+
+    const hasHeader = header != null
+    const hasFooter = footer != null
+    const rowCount = items.length + (hasHeader ? 1 : 0) + (hasFooter ? 1 : 0)
+
+    const pinnedRef = useRef(stickToBottom)
+
+    const renderRow = useCallback(
+        (index: number): ReactNode => {
+            let i = index
+            if (hasHeader) {
+                if (i === 0) {
+                    return header
+                }
+                i -= 1
+            }
+            if (i < items.length) {
+                return children(items[i], i)
+            }
+            return footer
+        },
+        [items, header, footer, hasHeader, children]
+    )
+
+    const scrollToBottom = useCallback((): void => {
+        if (rowCount > 0) {
+            listRef.current?.scrollToRow({ index: rowCount - 1, align: 'end' })
+        }
+    }, [listRef, rowCount])
+
+    const handleScroll = useCallback(
+        (event: UIEvent<HTMLDivElement>): void => {
+            if (!stickToBottom) {
+                return
+            }
+            const el = event.currentTarget
+            pinnedRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= BOTTOM_THRESHOLD
+        },
+        [stickToBottom]
+    )
+
+    const handleRowsRendered = useCallback((): void => {
+        // Re-assert while pinned so a growing last row (streaming) keeps the bottom in view.
+        if (stickToBottom && pinnedRef.current) {
+            scrollToBottom()
+        }
+    }, [stickToBottom, scrollToBottom])
+
+    // Scroll on append / last-item change while pinned.
+    const lastKey = items.length > 0 ? getItemKey(items[items.length - 1], items.length - 1) : null
+    useEffect(() => {
+        if (!virtualized || !stickToBottom || !pinnedRef.current) {
+            return
+        }
+        const raf = requestAnimationFrame(scrollToBottom)
+        return () => cancelAnimationFrame(raf)
+    }, [virtualized, stickToBottom, scrollToBottom, rowCount, lastKey])
+
+    // Mobile Safari: the soft keyboard shrinks the visual (not layout) viewport, so a pinned bottom can
+    // slip behind it. Re-assert on visualViewport changes.
+    useEffect(() => {
+        if (!virtualized || !stickToBottom || typeof window === 'undefined' || !window.visualViewport) {
+            return
+        }
+        const viewport = window.visualViewport
+        const onViewportChange = (): void => {
+            if (pinnedRef.current) {
+                requestAnimationFrame(scrollToBottom)
+            }
+        }
+        viewport.addEventListener('resize', onViewportChange)
+        viewport.addEventListener('scroll', onViewportChange)
+        return () => {
+            viewport.removeEventListener('resize', onViewportChange)
+            viewport.removeEventListener('scroll', onViewportChange)
+        }
+    }, [virtualized, stickToBottom, scrollToBottom])
+
+    const rootValue = useMemo<RootContextValue>(
+        () => ({ dynamicRowHeight, gap, maxWidthClassName, virtualized }),
+        [dynamicRowHeight, gap, maxWidthClassName, virtualized]
+    )
+
+    // Flow mode: render rows directly so an ancestor scroll container (and its auto-scroller) keeps working.
+    // No chrome here — the parent supplies gap/centering/container-query context, matching the pre-virtualized
+    // layout exactly.
+    if (!virtualized) {
+        return (
+            <RootContext.Provider value={rootValue}>
+                {hasHeader && (
+                    <RowContext.Provider
+                        key="header"
+                        value={{ index: 0, style: EMPTY_STYLE, ariaAttributes: EMPTY_ARIA }}
+                    >
+                        {header}
+                    </RowContext.Provider>
+                )}
+                {items.map((item, index) => (
+                    <RowContext.Provider
+                        key={getItemKey(item, index)}
+                        value={{ index, style: EMPTY_STYLE, ariaAttributes: EMPTY_ARIA }}
+                    >
+                        {children(item, index)}
+                    </RowContext.Provider>
+                ))}
+                {hasFooter && (
+                    <RowContext.Provider
+                        key="footer"
+                        value={{ index: rowCount - 1, style: EMPTY_STYLE, ariaAttributes: EMPTY_ARIA }}
+                    >
+                        {footer}
+                    </RowContext.Provider>
+                )}
+            </RootContext.Provider>
+        )
+    }
+
+    return (
+        <RootContext.Provider value={rootValue}>
+            <div className={cn('flex flex-col h-full min-h-0 w-full', className)}>
+                <AutoSizer
+                    renderProp={({ height, width }: SizeProps) =>
+                        height && width ? (
+                            <List<InternalRowProps>
+                                style={{ height, width }}
+                                className="overscroll-contain"
+                                overscanCount={overscanCount}
+                                rowCount={rowCount}
+                                rowHeight={dynamicRowHeight}
+                                rowComponent={InternalRow}
+                                rowProps={{ renderRow }}
+                                listRef={listRef}
+                                onRowsRendered={handleRowsRendered}
+                                onScroll={handleScroll}
+                            />
+                        ) : null
+                    }
+                />
+            </div>
+        </RootContext.Provider>
+    )
+}
+
+/**
+ * Row shell for content rendered inside `VirtualizedThread.Root`. Applies react-window positioning, measures
+ * its own height (gap included via bottom padding), and centers content with the thread's container-query context.
+ */
+function Row({ children, className }: { children: ReactNode; className?: string }): JSX.Element {
+    const root = useContext(RootContext)
+    const row = useContext(RowContext)
+    if (!root || !row) {
+        throw new Error('VirtualizedThread.Row must be rendered inside VirtualizedThread.Root')
+    }
+    const { dynamicRowHeight, gap, maxWidthClassName, virtualized } = root
+    const { style, ariaAttributes, index } = row
+    const rowRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (virtualized && rowRef.current) {
+            return dynamicRowHeight.observeRowElements([rowRef.current])
+        }
+    }, [virtualized, dynamicRowHeight])
+
+    // Flow mode: transparent — the parent container provides spacing and centering.
+    if (!virtualized) {
+        return <>{children}</>
+    }
+
+    return (
+        <div ref={rowRef} style={style} data-index={index} {...ariaAttributes}>
+            <div
+                className={cn('w-full mx-auto @container/thread', maxWidthClassName, className)}
+                style={{ paddingBottom: gap }}
+            >
+                {children}
+            </div>
+        </div>
+    )
+}
+
+export const VirtualizedThread = { Root, Row }

--- a/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
+++ b/products/posthog_ai/frontend/sandbox/components/VirtualizedThread.tsx
@@ -148,15 +148,20 @@ function Root<T>({
         }
     }, [stickToBottom, scrollToBottom])
 
-    // Scroll on append / last-item change while pinned.
+    // Scroll on append / last-item change while pinned — and as dynamic measurements settle. Pinned by
+    // default, so this also scrolls to the bottom on open. The first scroll fires before rows are measured
+    // (they start at `defaultRowHeight`) and lands short; depending on the measured average row height
+    // re-fires it as ResizeObserver grows the rows, so it settles at the true bottom. The same signal keeps
+    // a streaming last row pinned as it grows.
     const lastKey = items.length > 0 ? getItemKey(items[items.length - 1], items.length - 1) : null
+    const measuredAverageHeight = dynamicRowHeight.getAverageRowHeight()
     useEffect(() => {
         if (!virtualized || !stickToBottom || !pinnedRef.current) {
             return
         }
         const raf = requestAnimationFrame(scrollToBottom)
         return () => cancelAnimationFrame(raf)
-    }, [virtualized, stickToBottom, scrollToBottom, rowCount, lastKey])
+    }, [virtualized, stickToBottom, scrollToBottom, rowCount, lastKey, measuredAverageHeight])
 
     // Mobile Safari: the soft keyboard shrinks the visual (not layout) viewport, so a pinned bottom can
     // slip behind it. Re-assert on visualViewport changes.
@@ -221,10 +226,16 @@ function Root<T>({
         <RootContext.Provider value={rootValue}>
             <div className={cn('flex flex-col h-full min-h-0 w-full', className)}>
                 <AutoSizer
-                    renderProp={({ height, width }: SizeProps) =>
-                        height && width ? (
+                    renderProp={({ height, width }: SizeProps) => {
+                        if (!height || !width) {
+                            return null
+                        }
+                        // react-window sets only `overflowY: auto`, which makes the unset `overflow-x` compute
+                        // to `auto` too — pin it to `hidden` so the thread never scrolls sideways (wide blocks
+                        // like tool output scroll within their own containers).
+                        return (
                             <List<InternalRowProps>
-                                style={{ height, width }}
+                                style={{ height, width, overflowX: 'hidden' }}
                                 className="overscroll-contain"
                                 overscanCount={overscanCount}
                                 rowCount={rowCount}
@@ -235,8 +246,8 @@ function Root<T>({
                                 onRowsRendered={handleRowsRendered}
                                 onScroll={handleScroll}
                             />
-                        ) : null
-                    }
+                        )
+                    }}
                 />
             </div>
         </RootContext.Provider>

--- a/products/posthog_ai/frontend/sandbox/messages/SandboxDebugMessage.tsx
+++ b/products/posthog_ai/frontend/sandbox/messages/SandboxDebugMessage.tsx
@@ -5,7 +5,6 @@ import { IconTerminal } from '@posthog/icons'
 import { cn } from 'lib/utils/css-classes'
 
 export interface SandboxDebugMessageProps {
-    id: string
     text: string
     level: string
 }

--- a/products/posthog_ai/frontend/sandbox/messages/SandboxDebugMessage.tsx
+++ b/products/posthog_ai/frontend/sandbox/messages/SandboxDebugMessage.tsx
@@ -1,0 +1,43 @@
+import { memo } from 'react'
+
+import { IconTerminal } from '@posthog/icons'
+
+import { cn } from 'lib/utils/css-classes'
+
+export interface SandboxDebugMessageProps {
+    id: string
+    text: string
+    level: string
+}
+
+const LEVEL_STYLES: Record<string, string> = {
+    error: 'border-l-danger text-danger',
+    warn: 'border-l-warning text-warning',
+    debug: 'border-l-muted',
+    info: 'border-l-muted',
+}
+
+/**
+ * Staff-only inline console line rendered from `_posthog/console` wire frames. Not a chat bubble —
+ * a muted, monospace debug row visually distinct from assistant failures (`AssistantFailureMessage`).
+ */
+export const SandboxDebugMessage = memo(function SandboxDebugMessage({
+    text,
+    level,
+}: SandboxDebugMessageProps): JSX.Element {
+    const levelStyle = LEVEL_STYLES[level] ?? LEVEL_STYLES.info
+    return (
+        <div
+            className={cn(
+                'flex items-start gap-1.5 w-full py-1 px-2 text-xs text-muted',
+                'border-l-2 bg-surface-tertiary/50 font-mono',
+                levelStyle
+            )}
+            data-message-type="debug"
+            data-debug-level={level}
+        >
+            <IconTerminal className="size-3 shrink-0 mt-0.5 opacity-70" />
+            <span className="whitespace-pre-wrap break-words">{text}</span>
+        </div>
+    )
+})

--- a/products/posthog_ai/frontend/sandbox/sandboxStreamLogic.ts
+++ b/products/posthog_ai/frontend/sandbox/sandboxStreamLogic.ts
@@ -8,6 +8,7 @@ import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { preflightLogic } from 'scenes/PreflightCheck/preflightLogic'
 import { projectLogic } from 'scenes/projectLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { tasksRunsCommandCreate, tasksRunsStreamTokenRetrieve } from 'products/tasks/frontend/generated/api'
 import type { TaskRunBootstrapCreateRequestInitialPermissionModeEnumApi } from 'products/tasks/frontend/generated/api.schemas'
@@ -686,6 +687,7 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
     let statusSeq = 0
     let compactSeq = 0
     let taskSeq = 0
+    let consoleSeq = 0
 
     const pushHuman = (text: string): void => {
         items = insertHumanMessageAtTurnStart(items, {
@@ -944,8 +946,21 @@ export function foldLogToThread(entries: StoredEntry[], options: { isResumeRun: 
             }
             continue
         }
+        if (method === '_posthog/console') {
+            const message = typeof params.message === 'string' ? params.message : ''
+            const level = typeof params.level === 'string' ? params.level : 'info'
+            if (message) {
+                items.push({
+                    id: `console-${consoleSeq++}`,
+                    type: 'debug',
+                    text: message,
+                    debugLevel: level,
+                })
+            }
+            continue
+        }
         if (method?.startsWith('_posthog/')) {
-            // run_started, usage_update, resources_used, sdk_session, console, sandbox_output, … — no thread item.
+            // run_started, usage_update, resources_used, sdk_session, sandbox_output, … — no thread item.
             continue
         }
         if (method !== 'session/update') {
@@ -1041,7 +1056,16 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
     key((props) => (props.replayOnly ? `replay:${props.streamKey}` : props.streamKey)),
     path((key) => ['products', 'posthog_ai', 'sandbox', 'sandboxStreamLogic', key]),
     connect(() => ({
-        values: [projectLogic, ['currentProjectId'], featureFlagLogic, ['featureFlags'], preflightLogic, ['preflight']],
+        values: [
+            projectLogic,
+            ['currentProjectId'],
+            featureFlagLogic,
+            ['featureFlags'],
+            preflightLogic,
+            ['preflight', 'isDev'],
+            userLogic,
+            ['user'],
+        ],
     })),
     actions({
         /**
@@ -1425,7 +1449,22 @@ export const sandboxStreamLogic = kea<sandboxStreamLogicType>([
             (s) => [s.log, s.isBootstrapResumeRun],
             (log, isResumeRun): FoldedThread => foldLogToThread(log.entries, { isResumeRun }),
         ],
-        threadItems: [(s) => [s.foldedThread], (foldedThread): ThreadItem[] => foldedThread.threadItems],
+        /**
+         * Whether `_posthog/console` debug rows should surface in the thread. Derived from the current
+         * user's staff/impersonation flag and dev environment, so debug items are filtered out of
+         * `threadItems` for non-privileged users — never reaching the virtualizer as empty rows.
+         */
+        showDebugItems: [
+            (s) => [s.user, s.isDev],
+            (user, isDev): boolean => !!user?.is_staff || !!user?.is_impersonated || isDev,
+        ],
+        threadItems: [
+            (s) => [s.foldedThread, s.showDebugItems],
+            (foldedThread, showDebugItems): ThreadItem[] =>
+                showDebugItems
+                    ? foldedThread.threadItems
+                    : foldedThread.threadItems.filter((item) => item.type !== 'debug'),
+        ],
         toolInvocations: [
             (s) => [s.foldedThread],
             (foldedThread): Map<string, ToolInvocation> => foldedThread.toolInvocations,

--- a/products/posthog_ai/frontend/sandbox/types/sandboxStreamTypes.ts
+++ b/products/posthog_ai/frontend/sandbox/types/sandboxStreamTypes.ts
@@ -60,6 +60,7 @@ export type ThreadItemType =
     | 'compact_boundary'
     | 'task_notification'
     | 'progress'
+    | 'debug'
 
 /**
  * An ordered, append-only entry the renderer consumes. Human messages, text chunks, streamed
@@ -100,6 +101,8 @@ export interface ThreadItem {
     progressGroup?: string
     /** For `progress` items — ordered setup/runtime progress rows. */
     progressSteps?: SandboxProgressStep[]
+    /** For `debug` items — the `_posthog/console` level (debug/info/warn/error). */
+    debugLevel?: string
 }
 
 /** One PostHog product the agent grounded an answer in, accumulated across the whole session. */

--- a/products/posthog_ai/package.json
+++ b/products/posthog_ai/package.json
@@ -8,6 +8,7 @@
         "kea-subscriptions": "catalog:",
         "marked": "*",
         "posthog-js": "catalog:",
+        "react-window": "*",
         "tailwind-merge": "*"
     },
     "devDependencies": {

--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -363,7 +363,7 @@ function TaskRunLogState({
     }
     if (taskId && selectedRun) {
         return (
-            <div className="flex-1 min-h-0 overflow-hidden w-full">
+            <div className="flex-1 min-h-0 overflow-hidden -mr-4 pr-4">
                 <TaskRunChat taskId={taskId} runId={selectedRun.id} />
             </div>
         )

--- a/products/tasks/frontend/components/TaskDetailPage.tsx
+++ b/products/tasks/frontend/components/TaskDetailPage.tsx
@@ -363,7 +363,7 @@ function TaskRunLogState({
     }
     if (taskId && selectedRun) {
         return (
-            <div className="flex-1 min-h-0 overflow-hidden max-w-6xl mx-auto w-full">
+            <div className="flex-1 min-h-0 overflow-hidden w-full">
                 <TaskRunChat taskId={taskId} runId={selectedRun.id} />
             </div>
         )

--- a/products/tasks/frontend/components/TaskRunChat.tsx
+++ b/products/tasks/frontend/components/TaskRunChat.tsx
@@ -69,7 +69,7 @@ function TaskRunChatContent({ taskId, runId }: TaskRunChatProps): JSX.Element {
 
     return (
         <div className="flex flex-col h-full overflow-hidden">
-            <div className="flex-1 overflow-y-auto flex flex-col gap-3">
+            <div className="flex-1 min-h-0">
                 {isLogPending ? (
                     <TaskRunLogSkeleton />
                 ) : showBootstrapError && bootstrapError?.status === 404 ? (

--- a/products/tasks/frontend/components/TaskRunChat.tsx
+++ b/products/tasks/frontend/components/TaskRunChat.tsx
@@ -91,41 +91,53 @@ function TaskRunChatContent({ taskId, runId }: TaskRunChatProps): JSX.Element {
                 )}
             </div>
 
-            {!isBlockingBootstrapState && <SandboxResourcesBar />}
+            {!isBlockingBootstrapState && (
+                <div className="w-full max-w-180 mx-auto">
+                    <SandboxResourcesBar />
+                </div>
+            )}
 
             {pendingPermissionRequest && !isTerminal && !isBlockingBootstrapState && (
                 <div className="border-t px-4 py-3">
-                    {isQuestion ? (
-                        <SandboxQuestionInput streamKey={runId} request={pendingPermissionRequest} />
-                    ) : (
-                        <SandboxPermissionInput streamKey={runId} request={pendingPermissionRequest} />
-                    )}
+                    <div className="w-full max-w-180 mx-auto">
+                        {isQuestion ? (
+                            <SandboxQuestionInput streamKey={runId} request={pendingPermissionRequest} />
+                        ) : (
+                            <SandboxPermissionInput streamKey={runId} request={pendingPermissionRequest} />
+                        )}
+                    </div>
                 </div>
             )}
 
             {!isTerminal && !pendingPermissionRequest && !isBlockingBootstrapState && (
-                <div className="border-t px-4 py-3 flex gap-2 items-end">
-                    <LemonTextArea
-                        className="flex-1"
-                        value={composerText}
-                        onChange={setComposerText}
-                        placeholder="Send a follow-up message…"
-                        minRows={1}
-                        maxRows={8}
-                        onPressCmdEnter={handleSend}
-                    />
-                    <LemonButton
-                        type="primary"
-                        onClick={handleSend}
-                        loading={sendingMessage}
-                        disabledReason={!composerText.trim() ? 'Type a message first' : undefined}
-                    >
-                        Send
-                    </LemonButton>
+                <div className="border-t px-4 py-3">
+                    <div className="w-full max-w-180 mx-auto flex gap-2 items-end">
+                        <LemonTextArea
+                            className="flex-1"
+                            value={composerText}
+                            onChange={setComposerText}
+                            placeholder="Send a follow-up message…"
+                            minRows={1}
+                            maxRows={8}
+                            onPressCmdEnter={handleSend}
+                        />
+                        <LemonButton
+                            type="primary"
+                            onClick={handleSend}
+                            loading={sendingMessage}
+                            disabledReason={!composerText.trim() ? 'Type a message first' : undefined}
+                        >
+                            Send
+                        </LemonButton>
+                    </div>
                 </div>
             )}
 
-            {!isBlockingBootstrapState && <SandboxContextUsage />}
+            {!isBlockingBootstrapState && (
+                <div className="w-full max-w-180 mx-auto">
+                    <SandboxContextUsage />
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Problem

Staff debugging live PostHog AI sandbox runs had no visibility into the console wire frames (`_posthog/console`) the sandbox emits — they were dropped before reaching the thread, so debugging agent behavior required going outside the UI.

<!-- Closes #ISSUE_ID -->

## Changes

- Add a `debug` thread-item type folded from `_posthog/console` wire frames (level + message) to the sandbox stream types.
- A `showDebugItems` selector in `sandboxStreamLogic` derives the staff / impersonated / dev gate from `userLogic` + `preflightLogic`, so debug items are filtered out of `threadItems` for non-privileged users before they reach the virtualizer — no empty rows for end users.
- `SandboxThreadRow` renders the new `debug` leaf via `SandboxDebugMessage`, a muted monospace console line with a level-colored left border.

## How did you test this code?

I'm an agent and did not run these changes manually. No automated tests were added in this PR; the gating logic is exercised through the existing `userLogic` / `preflightLogic` selectors. The author validated the staff/dev gating and rendering during development.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed. Add the `skip-inkeep-docs` label if preferred for internal-only sandbox tooling.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR is agent-assisted work directed by the branch author (see `Co-Authored-By` trailers on the commit). The submitting agent's only contribution this session was retargeting the base, and assembling this description — no code was written here.

Skills invoked: none this session.

Reviewer-facing decisions worth flagging:
- Debug items are filtered in the `showDebugItems` selector rather than in the virtualizer, so non-privileged users never render empty rows.
- Reused the existing `userLogic` + `preflightLogic` gates (staff / impersonated / dev) instead of introducing a new privilege check.
