### PR TITLE
fix: one max image limit to slack and teams

### DIFF
--- a/products/conversations/backend/services/attachments.py
+++ b/products/conversations/backend/services/attachments.py
@@ -13,6 +13,8 @@ from posthog.models.uploaded_media import UploadedMedia, save_content_to_object_
 
 logger = structlog.get_logger(__name__)
 
+CONVERSATIONS_MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MiB
+
 
 def is_valid_image(content: bytes) -> bool:
     """Verify bytes are a real image (prevents serving disguised malicious content).

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -37,12 +37,13 @@ from .cache import (
 from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content
 from .models import Ticket
 from .models.constants import Channel, ChannelDetail, Status
-from .services.attachments import build_content_with_images, is_valid_image, save_file_to_uploaded_media
-from .support_slack import (
-    SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES,
-    SUPPORT_SLACK_MAX_IMAGE_BYTES,
-    get_support_slack_bot_token,
+from .services.attachments import (
+    CONVERSATIONS_MAX_IMAGE_BYTES,
+    build_content_with_images,
+    is_valid_image,
+    save_file_to_uploaded_media,
 )
+from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES, get_support_slack_bot_token
 
 logger = structlog.get_logger(__name__)
 SLACK_DOWNLOAD_TIMEOUT_SECONDS = 10
@@ -229,12 +230,12 @@ def _download_slack_image_bytes(url: str, bot_token: str) -> bytes | None:
             content_length_header = response.headers.get("Content-Length")
             if content_length_header:
                 try:
-                    if int(content_length_header) > SUPPORT_SLACK_MAX_IMAGE_BYTES:
+                    if int(content_length_header) > CONVERSATIONS_MAX_IMAGE_BYTES:
                         logger.warning(
                             "🖼️ slack_file_download_too_large_from_header",
                             url=next_url,
                             content_length=int(content_length_header),
-                            max_allowed=SUPPORT_SLACK_MAX_IMAGE_BYTES,
+                            max_allowed=CONVERSATIONS_MAX_IMAGE_BYTES,
                         )
                         return None
                 except ValueError:
@@ -242,13 +243,13 @@ def _download_slack_image_bytes(url: str, bot_token: str) -> bytes | None:
                         "🖼️ slack_file_download_invalid_content_length", url=next_url, value=content_length_header
                     )
                     return None
-            payload = response.read(SUPPORT_SLACK_MAX_IMAGE_BYTES + 1)
-            if len(payload) > SUPPORT_SLACK_MAX_IMAGE_BYTES:
+            payload = response.read(CONVERSATIONS_MAX_IMAGE_BYTES + 1)
+            if len(payload) > CONVERSATIONS_MAX_IMAGE_BYTES:
                 logger.warning(
                     "🖼️ slack_file_download_too_large_from_body",
                     url=next_url,
                     bytes_read=len(payload),
-                    max_allowed=SUPPORT_SLACK_MAX_IMAGE_BYTES,
+                    max_allowed=CONVERSATIONS_MAX_IMAGE_BYTES,
                 )
                 return None
             logger.debug("🖼️ slack_file_download_succeeded", url=next_url, bytes_read=len(payload))

--- a/products/conversations/backend/support_slack.py
+++ b/products/conversations/backend/support_slack.py
@@ -20,7 +20,6 @@ if TYPE_CHECKING:
     from posthog.models.team.team import Team
     from posthog.models.user import User
 
-SUPPORT_SLACK_MAX_IMAGE_BYTES = 4 * 1024 * 1024
 SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES = ("slack.com", "slack-edge.com", "slack-files.com")
 
 

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -49,6 +49,7 @@ from products.conversations.backend.models import (
 )
 from products.conversations.backend.models.constants import Channel, ChannelDetail, Status
 from products.conversations.backend.models.ticket import Ticket
+from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.slack import (
     get_slack_client,
     handle_member_joined_channel,
@@ -82,7 +83,7 @@ from products.conversations.backend.teams import (
 from products.conversations.backend.teams_attachments import extract_teams_graph_images
 from products.conversations.backend.teams_formatting import rich_content_to_teams_html
 
-from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES, SUPPORT_SLACK_MAX_IMAGE_BYTES
+from .support_slack import SUPPORT_SLACK_ALLOWED_HOST_SUFFIXES
 
 logger = structlog.get_logger(__name__)
 SUPPORTHOG_EVENT_IDEMPOTENCY_TTL_SECONDS = 6 * 60
@@ -425,7 +426,7 @@ def _read_image_bytes_for_slack_upload(team_id: int, image_url: str) -> bytes | 
         )
         return None
 
-    if len(payload) > SUPPORT_SLACK_MAX_IMAGE_BYTES:
+    if len(payload) > CONVERSATIONS_MAX_IMAGE_BYTES:
         logger.warning(
             "🖼️ slack_reply_image_too_large",
             team_id=team_id,

--- a/products/conversations/backend/teams_attachments.py
+++ b/products/conversations/backend/teams_attachments.py
@@ -14,12 +14,11 @@ import structlog
 
 from posthog.models.team.team import Team
 
-from .services.attachments import is_valid_image, save_file_to_uploaded_media
+from .services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES, is_valid_image, save_file_to_uploaded_media
 from .support_teams import is_trusted_teams_service_url
 
 logger = structlog.get_logger(__name__)
 
-TEAMS_MAX_IMAGE_BYTES = 20 * 1024 * 1024  # 20 MiB
 TEAMS_DOWNLOAD_TIMEOUT_SECONDS = 15
 
 GRAPH_API_BASE = "https://graph.microsoft.com/v1.0"
@@ -73,7 +72,7 @@ def _download_image(url: str, token: str) -> bytes | None:
     content_length = resp.headers.get("Content-Length")
     if content_length:
         try:
-            if int(content_length) > TEAMS_MAX_IMAGE_BYTES:
+            if int(content_length) > CONVERSATIONS_MAX_IMAGE_BYTES:
                 logger.warning("teams_image_too_large_header", url=url[:200], content_length=content_length)
                 return None
         except ValueError:
@@ -83,7 +82,7 @@ def _download_image(url: str, token: str) -> bytes | None:
     total = 0
     for chunk in resp.iter_content(chunk_size=64 * 1024):
         total += len(chunk)
-        if total > TEAMS_MAX_IMAGE_BYTES:
+        if total > CONVERSATIONS_MAX_IMAGE_BYTES:
             logger.warning("teams_image_too_large_body", url=url[:200], bytes_read=total)
             return None
         chunks.append(chunk)


### PR DESCRIPTION
## Problem

We have different file size limits in slack and teams (4 and 20)

## Changes

Let's have one const for both (20)

