### PR TITLE
fix: add hasrecording to view recording button on event

### DIFF
--- a/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
+++ b/frontend/src/lib/components/ViewRecordingButton/ViewRecordingButton.tsx
@@ -263,8 +263,13 @@ export const recordingDisabledReason = (
 const recordingWarningReason = (
     recordingDuration: number | undefined,
     minimumDuration: number | undefined,
-    recordingStatus: string | undefined
+    recordingStatus: string | undefined,
+    hasRecording: boolean | undefined
 ): string | undefined => {
+    // These warnings only caveat that a recording might not exist. Once we know one does, they're just confusing.
+    if (hasRecording === true) {
+        return undefined
+    }
     if (recordingDuration && minimumDuration && recordingDuration < minimumDuration) {
         const minimumDurationInSeconds = minimumDuration / 1000
         return `There is a chance this recording was not captured because the event happened earlier than the ${minimumDurationInSeconds}s minimum session duration.`
@@ -309,7 +314,7 @@ export function useRecordingButton({
     }
 
     const disabledReason = recordingDisabledReason(sessionId, recordingStatus, hasRecording)
-    const warningReason = recordingWarningReason(recordingDuration, minimumDuration, recordingStatus)
+    const warningReason = recordingWarningReason(recordingDuration, minimumDuration, recordingStatus, hasRecording)
 
     return { onClick, disabledReason, warningReason }
 }


### PR DESCRIPTION
## Problem

https://us.posthog.com/project/2/support/tickets/2008

individual events can be buffering and a replay can still be recorded. The view recording button on an event can be greyed out in this case making it less obvious that an event has a recording

## Changes

We have a ton of debug information we can pull from these days for a more concrete answer.

## How did you test this code?

very small change

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

