### PR TITLE
feat(inbox): restore staff-only Runs tab in the tab bar

### DIFF
--- a/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
@@ -48,9 +48,9 @@ type InboxTabBarKey = InboxTabKey | typeof WELCOME_TAB_KEY
 
 /**
  * Tab bar: Pull requests / Reports (everyone) + Not actionable and Runs (staff-only, each with a
- * "Staff-only" tag). Each report tab shows its own server-computed count. The Configuration tab is
- * only shown when `showConfigTab` is set – i.e. when the scene is too narrow for the setup rail; on
- * wide viewports the rail replaces it.
+ * "Staff" tag). Each report tab shows its own server-computed count. The Configuration tab is only
+ * shown when `showConfigTab` is set – i.e. when the scene is too narrow for the setup rail; on wide
+ * viewports the rail replaces it.
  *
  * In `onboarding` mode (self-driving not set up, empty inbox) a locked "Welcome" tab is shown and
  * selected, while the real tabs stay visible but disabled – the user can see what's coming, but the
@@ -77,7 +77,7 @@ export function InboxTabBar({
                 {isFlatListTabKey(key) && <FlatTabCount tabKey={key} />}
                 {isStaffOnlyTabKey(key) && (
                     <LemonTag type="completion" size="small">
-                        Staff-only
+                        Staff
                     </LemonTag>
                 )}
             </span>

--- a/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
+++ b/frontend/src/scenes/inbox/components/shell/InboxTabBar.tsx
@@ -10,7 +10,6 @@ import { INBOX_FLAT_TAB_LIST_PARAMS, reportListLogic } from '../../logics/report
 import {
     INBOX_FLAT_LIST_TAB_KEYS,
     INBOX_STAFF_ONLY_TAB_KEYS,
-    INBOX_TAB_BAR_HIDDEN_KEYS,
     INBOX_TAB_KEYS,
     INBOX_TAB_LABEL,
     InboxFlatListTabKey,
@@ -23,10 +22,6 @@ function isFlatListTabKey(tab: InboxTabKey): tab is InboxFlatListTabKey {
 
 function isStaffOnlyTabKey(tab: InboxTabKey): boolean {
     return (INBOX_STAFF_ONLY_TAB_KEYS as string[]).includes(tab)
-}
-
-function isTabBarHiddenKey(tab: InboxTabKey): boolean {
-    return (INBOX_TAB_BAR_HIDDEN_KEYS as string[]).includes(tab)
 }
 
 /**
@@ -52,11 +47,10 @@ const WELCOME_TAB_KEY = 'welcome'
 type InboxTabBarKey = InboxTabKey | typeof WELCOME_TAB_KEY
 
 /**
- * Tab bar: Pull requests / Reports (everyone) + Not actionable (staff-only, with a "Staff" tag).
- * Each report tab shows its own server-computed count. The Runs tab is deprecated from the bar
- * (its run logs now expand inline in the report detail); its route stays for deep links. The
- * Configuration tab is only shown when `showConfigTab` is set – i.e. when the scene is too narrow
- * for the setup rail; on wide viewports the rail replaces it.
+ * Tab bar: Pull requests / Reports (everyone) + Not actionable and Runs (staff-only, each with a
+ * "Staff-only" tag). Each report tab shows its own server-computed count. The Configuration tab is
+ * only shown when `showConfigTab` is set – i.e. when the scene is too narrow for the setup rail; on
+ * wide viewports the rail replaces it.
  *
  * In `onboarding` mode (self-driving not set up, empty inbox) a locked "Welcome" tab is shown and
  * selected, while the real tabs stay visible but disabled – the user can see what's coming, but the
@@ -72,7 +66,7 @@ export function InboxTabBar({
     const { activeTab, isStaff } = useValues(inboxSceneLogic)
 
     const visibleTabKeys = INBOX_TAB_KEYS.filter(
-        (key) => !isTabBarHiddenKey(key) && (key !== 'config' || showConfigTab) && (!isStaffOnlyTabKey(key) || isStaff)
+        (key) => (key !== 'config' || showConfigTab) && (!isStaffOnlyTabKey(key) || isStaff)
     )
 
     const realTabs = visibleTabKeys.map((key) => ({
@@ -83,7 +77,7 @@ export function InboxTabBar({
                 {isFlatListTabKey(key) && <FlatTabCount tabKey={key} />}
                 {isStaffOnlyTabKey(key) && (
                     <LemonTag type="completion" size="small">
-                        Staff
+                        Staff-only
                     </LemonTag>
                 )}
             </span>

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -141,14 +141,6 @@ export const INBOX_REPORT_TAB_KEYS: InboxTabKey[] = ['pulls', 'reports', 'not-ac
  */
 export const INBOX_STAFF_ONLY_TAB_KEYS: InboxTabKey[] = ['not-actionable', 'runs']
 
-/**
- * Tabs deprecated from the tab bar entirely (route preserved for back-compat / deep links). The
- * per-report run logs now expand inline within the report detail's Runs section, so the standalone
- * project-wide Runs view no longer earns a tab. `urls.inboxReport('runs', …)` and `urls.inbox('runs')`
- * still resolve to `AgentRunDetail` / `RunsTab` for anything that deep-links to them.
- */
-export const INBOX_TAB_BAR_HIDDEN_KEYS: InboxTabKey[] = ['runs']
-
 /** The flat report-list tabs that share the keyed reportListLogic + InboxReportList primitive. */
 export const INBOX_FLAT_LIST_TAB_KEYS = ['pulls', 'reports', 'not-actionable', 'archived'] as const
 export type InboxFlatListTabKey = (typeof INBOX_FLAT_LIST_TAB_KEYS)[number]


### PR DESCRIPTION
## Problem

The inbox Runs tab — an internal, staff-only view of project-wide agent runs — had been hidden from the tab bar. A staff user noticed completed runs that seemed actionable but couldn't reach the Runs view to cross-check them against the Reports / Not actionable tabs. We want this plumbing visible again to staff (it remains hidden from regular users).

## Changes

- Removed the `INBOX_TAB_BAR_HIDDEN_KEYS` mechanism (it only ever held `'runs'`) so the Runs tab renders in the bar again. It stays gated to staff via the existing `INBOX_STAFF_ONLY_TAB_KEYS` filter, appearing between *Not actionable* and *Archive*. The tab's component, route, and logic were already intact — only the bar entry was suppressed.
- Renamed the staff-only tag from "Staff" to "Staff-only" so its meaning is clear. The single tag covers both *Not actionable* and *Runs*.

## How did you test this code?

I'm an agent (PostHog Code). I did not run manual testing or the automated suite — `node_modules` wasn't installed in my environment, so the TypeScript check couldn't run. I verified statically that there are no remaining references to the removed `INBOX_TAB_BAR_HIDDEN_KEYS` / `isTabBarHiddenKey` symbols. The change is small and confined to the inbox tab-bar rendering.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code from a Slack thread, directed by Josh Snyder, with the "Staff-only" label wording requested by Michael Matloka. No repo skills were invoked — the change is a frontend-only tab-bar adjustment.

The Runs tab had been deprecated from the bar by adding `'runs'` to a hidden-keys list, on the rationale that per-report run logs now expand inline in the report detail. Rather than re-introducing a separate visibility flag, I removed the now-single-purpose hidden-keys mechanism entirely, since staff-only gating already exists and is the intended audience for this internal view.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782382063038469?thread_ts=1782382063.038469&cid=C09SK2PAGKF)*
