### PR TITLE
feat(logs): add facet search bar

### DIFF
--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -1,6 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useCallback, useMemo, useRef } from 'react'
 
+import { LemonInput } from '@posthog/lemon-ui'
+
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
 
@@ -10,7 +12,7 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 import { Facet, FacetOption } from './Facet'
 import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
-import { FacetConfig, FacetFilterKey, facetsByGroup, resourceAttributeValues } from './facets'
+import { FacetConfig, FacetFilterKey, facetsByGroup, filterFacetsByName, resourceAttributeValues } from './facets'
 
 const DEFAULT_WIDTH_PX = 240
 const COLLAPSE_THRESHOLD_PX = 120
@@ -26,8 +28,8 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const { severityLevels, serviceNames, filterGroup } = useValues(logsViewerFiltersLogic)
     const { facetValues, loadingFacetKeys, facetSearch, visibleFacets } = useValues(facetCountsLogic({ id }))
     const { setFacetSearch } = useActions(facetCountsLogic({ id }))
-    const { collapsedFacets } = useValues(facetRailLogic({ id }))
-    const { toggleFacetValue, toggleFacetCollapsed } = useActions(facetRailLogic({ id }))
+    const { collapsedFacets, facetNameSearch } = useValues(facetRailLogic({ id }))
+    const { toggleFacetValue, toggleFacetCollapsed, setFacetNameSearch } = useActions(facetRailLogic({ id }))
 
     const selectedByKey: Record<FacetFilterKey, string[]> = {
         severityLevels: severityLevels ?? [],
@@ -113,6 +115,9 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
         )
     }
 
+    // Filter the rail by the field-name search, then group — empty groups fall away in facetsByGroup.
+    const displayedGroups = facetsByGroup(filterFacetsByName(visibleFacets, facetNameSearch))
+
     return (
         <div
             ref={railRef}
@@ -122,17 +127,29 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
             data-attr="logs-facet-rail"
         >
             <div className="px-2 py-1 border-b">
-                <span className="text-xs font-semibold text-secondary uppercase tracking-wide">Filters</span>
+                <LemonInput
+                    type="search"
+                    size="small"
+                    fullWidth
+                    placeholder="Search facets…"
+                    value={facetNameSearch}
+                    onChange={setFacetNameSearch}
+                    data-attr="logs-facet-rail-search"
+                />
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto p-2">
-                {facetsByGroup(visibleFacets).map(([group, facets]) => (
-                    <div key={group}>
-                        <div className="px-1 pb-1 mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted border-b border-primary">
-                            {group}
+                {displayedGroups.length === 0 ? (
+                    <div className="px-1 text-xs text-muted">No matching facets</div>
+                ) : (
+                    displayedGroups.map(([group, facets]) => (
+                        <div key={group}>
+                            <div className="px-1 pb-1 mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted border-b border-primary">
+                                {group}
+                            </div>
+                            {facets.map(renderFacet)}
                         </div>
-                        {facets.map(renderFacet)}
-                    </div>
-                ))}
+                    ))
+                )}
             </div>
             <Resizer {...resizerLogicProps} visible={false} offset="0.25rem" handleClassName="rounded my-1" />
         </div>

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -138,7 +138,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 />
             </div>
             <div className="flex-1 min-h-0 overflow-y-auto p-2">
-                {displayedGroups.length === 0 ? (
+                {displayedGroups.length === 0 && facetNameSearch.trim() ? (
                     <div className="px-1 text-xs text-muted">No matching facets</div>
                 ) : (
                     displayedGroups.map(([group, facets]) => (

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
@@ -32,9 +32,18 @@ export const facetRailLogic = kea<facetRailLogicType>([
         // filter field/group the facet's source maps to (see FacetConfig.source).
         toggleFacetValue: (source: FacetSource, value: string) => ({ source, value }),
         toggleFacetCollapsed: (facetKey: string) => ({ facetKey }),
+        // Free-text filter over the facet *fields* shown in the rail (not their values). URL-synced by
+        // logsSceneLogic on the main scene, so deliberately not persisted here.
+        setFacetNameSearch: (search: string) => ({ search }),
     }),
 
     reducers({
+        facetNameSearch: [
+            '',
+            {
+                setFacetNameSearch: (_, { search }) => search,
+            },
+        ],
         collapsedFacets: [
             [] as string[],
             { persist: true },

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.test.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.test.ts
@@ -1,0 +1,32 @@
+import { FacetConfig, filterFacetsByName } from './facets'
+
+const facet = (key: string, title: string, group: string): FacetConfig => ({
+    key,
+    title,
+    group,
+    kind: 'dynamic',
+    source: { type: 'resourceAttribute', key },
+})
+
+const FACETS: FacetConfig[] = [
+    facet('level', 'Level', 'Standard'),
+    facet('service', 'Service', 'Standard'),
+    facet('namespace', 'Namespace', 'Kubernetes'),
+    facet('pod', 'Pod', 'Kubernetes'),
+    facet('host', 'Host', 'Infrastructure'),
+]
+
+describe('filterFacetsByName', () => {
+    it.each([
+        ['blank query returns all', '', ['level', 'service', 'namespace', 'pod', 'host']],
+        ['whitespace-only returns all', '   ', ['level', 'service', 'namespace', 'pod', 'host']],
+        ['matches a field title', 'namespace', ['namespace']],
+        ['title match is case-insensitive', 'NAMESPACE', ['namespace']],
+        ['partial title match', 'serv', ['service']],
+        ['matches a whole group by name', 'kubernetes', ['namespace', 'pod']],
+        ['group match is case-insensitive', 'INFRA', ['host']],
+        ['no match returns empty', 'zzz', []],
+    ])('%s', (_, query, expectedKeys) => {
+        expect(filterFacetsByName(FACETS, query).map((f) => f.key)).toEqual(expectedKeys)
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
@@ -182,6 +182,21 @@ export const FACETS: FacetConfig[] = [
     HOST_FACET,
 ]
 
+/**
+ * Filter facets by a free-text query matching the field name or its group (case-insensitive
+ * substring) — powers the rail's "search facets" box. A blank query returns everything, so
+ * `facetsByGroup` then drops any group left with no matching facets for free.
+ */
+export function filterFacetsByName(facets: FacetConfig[], query: string): FacetConfig[] {
+    const needle = query.trim().toLowerCase()
+    if (!needle) {
+        return facets
+    }
+    return facets.filter(
+        (facet) => facet.title.toLowerCase().includes(needle) || facet.group.toLowerCase().includes(needle)
+    )
+}
+
 /** Group facets by `group`, preserving first-appearance order of both groups and facets. */
 export function facetsByGroup(facets: FacetConfig[]): [string, FacetConfig[]][] {
     const groups: [string, FacetConfig[]][] = []

--- a/products/logs/frontend/logsSceneLogic.test.ts
+++ b/products/logs/frontend/logsSceneLogic.test.ts
@@ -144,4 +144,36 @@ describe('logsSceneLogic', () => {
             expect(router.values.searchParams).not.toHaveProperty('activeTab')
         })
     })
+
+    describe('facetNameSearch URL sync', () => {
+        it('parses facetNameSearch from URL', async () => {
+            await expectLogic(logic, () => {
+                router.actions.push('/logs', { facetNameSearch: 'namespace' })
+            }).toFinishAllListeners()
+
+            expect(logic.values.facetNameSearch).toEqual('namespace')
+        })
+
+        it('syncs facetNameSearch to URL on setFacetNameSearch', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFacetNameSearch('kube')
+            }).toFinishAllListeners()
+
+            expect(logic.values.facetNameSearch).toEqual('kube')
+            expect(router.values.searchParams).toHaveProperty('facetNameSearch', 'kube')
+        })
+
+        it('removes facetNameSearch from URL when cleared', async () => {
+            await expectLogic(logic, () => {
+                logic.actions.setFacetNameSearch('kube')
+            }).toFinishAllListeners()
+
+            await expectLogic(logic, () => {
+                logic.actions.setFacetNameSearch('')
+            }).toFinishAllListeners()
+
+            expect(logic.values.facetNameSearch).toEqual('')
+            expect(router.values.searchParams).not.toHaveProperty('facetNameSearch')
+        })
+    })
 })

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -20,6 +20,7 @@ import {
     DEFAULT_INITIAL_LOGS_LIMIT,
     logsViewerDataLogic,
 } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
+import { facetRailLogic } from 'products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic'
 import { logsFilterHistoryLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsFilterHistoryLogic'
 import {
     DEFAULT_DATE_RANGE,
@@ -69,6 +70,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             ['setLinkToLogId', 'clearLinkToLogId'],
             logDetailsModalLogic({ id: LOGS_SCENE_VIEWER_ID }),
             ['closeLogDetails'],
+            facetRailLogic({ id: LOGS_SCENE_VIEWER_ID }),
+            ['setFacetNameSearch'],
         ],
         values: [
             logsViewerFiltersLogic({ id: LOGS_SCENE_VIEWER_ID }),
@@ -79,6 +82,8 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             ['initialLogsLimit'],
             logsViewerLogic({ id: LOGS_SCENE_VIEWER_ID }),
             ['linkToLogId'],
+            facetRailLogic({ id: LOGS_SCENE_VIEWER_ID }),
+            ['facetNameSearch'],
         ],
     })),
     urlToAction(({ actions, values, cache }) => {
@@ -164,6 +169,12 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             if (linkToLogId && linkToLogId !== values.linkToLogId) {
                 actions.setLinkToLogId(linkToLogId)
             }
+
+            // Facet-name search: a plain string param. Absent param resets the field to empty.
+            const facetNameSearch = typeof params.facetNameSearch === 'string' ? params.facetNameSearch : ''
+            if (facetNameSearch !== values.facetNameSearch) {
+                actions.setFacetNameSearch(facetNameSearch)
+            }
         }
         return {
             '*': urlToAction,
@@ -205,6 +216,7 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
                     updateSearchParams(params, 'severityLevels', values.filters.severityLevels, DEFAULT_SEVERITY_LEVELS)
                     updateSearchParams(params, 'serviceNames', values.filters.serviceNames, DEFAULT_SERVICE_NAMES)
                     updateSearchParams(params, 'orderBy', values.orderBy, DEFAULT_ORDER_BY)
+                    updateSearchParams(params, 'facetNameSearch', values.facetNameSearch, '')
                     return params
                 })
             )
@@ -291,6 +303,9 @@ export const logsSceneLogic = kea<logsSceneLogicType>([
             actions.syncUrl()
         },
         setOrderBy: () => {
+            actions.syncUrl()
+        },
+        setFacetNameSearch: () => {
             actions.syncUrl()
         },
         keepSqlEditorMounted: ({ editorTabId }) => {


### PR DESCRIPTION
## Problem

When the facet rail contains many fields, finding a specific facet requires scrolling through all groups. There's no way to quickly narrow down to the facet you care about.

## Changes  
![image.png](https://app.graphite.com/user-attachments/assets/b69f5269-495b-4bf0-8c28-454503b5ecfd.png)



Adds a search input at the top of the facet rail that filters visible facets by field title or group name (case-insensitive substring match). Empty groups are automatically hidden when no facets within them match. A "No matching facets" message is shown when nothing matches.

The search value is synced to the URL via `logsSceneLogic` so it survives page refreshes and can be shared via link. Clearing the search removes the param from the URL.

The old "Filters" label at the top of the rail is replaced by the search input.

## How did you test this code?

This is an agent-authored PR. The following automated tests were added and cover the new behaviour:

- **`facets.test.ts`** — unit tests for `filterFacetsByName`, covering blank queries, whitespace-only queries, case-insensitive title matches, partial matches, group-name matches, and no-match cases. These catch regressions where the filter incorrectly excludes or includes facets.
- **`logsSceneLogic.test.ts`** — tests that `facetNameSearch` is parsed from the URL on load, synced to the URL on `setFacetNameSearch`, and removed from the URL when cleared. These catch regressions in the URL sync wiring.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Used Claude with code editing tools.
- Added `filterFacetsByName` as a pure utility in `facets.ts` so it's independently testable without any logic dependencies.
- URL sync was deliberately placed in `logsSceneLogic` (rather than persisted in `facetRailLogic`) to keep it consistent with how other filter params are handled in the scene, and to avoid the search term surviving across sessions unexpectedly.
- The `facetsByGroup` call was moved to happen after `filterFacetsByName` so empty groups naturally fall away without any extra filtering step.