### PR TITLE
chore(engineering-analytics): drop vestigial tabId from scene logics

### DIFF
--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.test.ts
@@ -215,18 +215,6 @@ describe('engineeringAnalyticsLogic', () => {
         expect(logic.values.activeCard).toBeNull()
     })
 
-    it('keeps filter state isolated per internal tab', () => {
-        const tabA = engineeringAnalyticsLogic({ tabId: 'tab-a' })
-        const tabB = engineeringAnalyticsLogic({ tabId: 'tab-b' })
-        tabA.mount()
-        tabB.mount()
-
-        tabA.actions.setStateFilter('merged')
-
-        expect(tabA.values.stateFilter).toBe('merged')
-        expect(tabB.values.stateFilter).toBe(DEFAULT_FILTERS.state)
-    })
-
     it('scene logic mounts without a tabId so /engineering-analytics resolves instead of 404ing', () => {
         // #62051 collapsed sceneLogic to single-scene state and stopped threading a tabId into
         // scene logics. A tab-aware scene logic then throws "must have a tabId prop" on mount,

--- a/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/engineeringAnalyticsLogic.ts
@@ -1,4 +1,4 @@
-import { LogicWrapper, actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { LogicWrapper, actions, afterMount, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { actionToUrl, router, urlToAction } from 'kea-router'
 
@@ -195,16 +195,9 @@ export function loaderStatusFromError(errorObject: unknown): LoaderStatus {
     return errorObject instanceof ApiError && errorObject.status === 400 ? 'notConnected' : 'error'
 }
 
-export interface EngineeringAnalyticsLogicProps {
-    tabId?: string
-}
-
 export const engineeringAnalyticsLogic: LogicWrapper<engineeringAnalyticsLogicType> =
     kea<engineeringAnalyticsLogicType>([
-        props({} as EngineeringAnalyticsLogicProps),
-        // One instance per internal tab so filters and loading state don't bleed across tabs.
-        key((props) => props.tabId ?? 'default'),
-        path((key) => ['products', 'engineering_analytics', 'frontend', 'scenes', 'engineeringAnalyticsLogic', key]),
+        path(['products', 'engineering_analytics', 'frontend', 'scenes', 'engineeringAnalyticsLogic']),
 
         actions({
             setStateFilter: (state: PRStateFilter) => ({ state }),

--- a/products/engineering_analytics/frontend/scenes/pullRequestDetailLogic.ts
+++ b/products/engineering_analytics/frontend/scenes/pullRequestDetailLogic.ts
@@ -19,7 +19,6 @@ export interface PullRequestDetailLogicProps {
     number: number
     // Which GitHub source the list was scoped to, threaded from `?source=` via paramsToProps.
     sourceId: string | null
-    tabId?: string
 }
 
 /** Failures first, then still-running, then passes — the order a reviewer triages in. */
@@ -33,10 +32,7 @@ export const pullRequestDetailLogic = kea<pullRequestDetailLogicType>([
     path(['products', 'engineering_analytics', 'frontend', 'scenes', 'pullRequestDetailLogic']),
     props({} as PullRequestDetailLogicProps),
     // sourceId is part of the identity: the same PR number can resolve to a different source.
-    key(
-        (props) =>
-            `${props.tabId ?? 'default'}/${props.repoOwner}/${props.repoName}#${props.number}@${props.sourceId ?? ''}`
-    ),
+    key((props) => `${props.repoOwner}/${props.repoName}#${props.number}@${props.sourceId ?? ''}`),
 
     loaders(({ props }) => ({
         lifecycle: [


### PR DESCRIPTION
## Problem

`engineeringAnalyticsLogic` and `pullRequestDetailLogic` both keyed on `props.tabId ?? 'default'` — a leftover from the now-removed in-app tab system. Tracing every builder: the only production caller of `engineeringAnalyticsLogic` passes no props, and `pullRequestDetailLogic` gets its props from `paramsToProps` (`repoOwner/repoName/number/sourceId` — never `tabId`). So the key was permanently `'default'`; the prop is dead weight.

## Changes

- Remove `tabId` from `EngineeringAnalyticsLogicProps` (drop the interface entirely — it had only that field), the `props`/`key` builders, and the now-meaningless "keeps filter state isolated per internal tab" test. The logic becomes a plain singleton (static `path`).
- Remove `tabId` from `PullRequestDetailLogicProps` and its key (`${repoOwner}/${repoName}#${number}@${sourceId}`).
- Kept the "scene logic mounts without a tabId so /engineering-analytics resolves instead of 404ing" regression test — that one guards the de-tab, not the removed keying.

No behaviour change: the key value is identical (`'default'` was always the prefix). Kea types regenerate with no drift (they already used generic `props`).

## How did you test this code?

I'm an agent (PostHog Code). `engineeringAnalyticsLogic.test.ts` passes (27 tests). `git grep tabId` across the product frontend returns only the kept regression test's name/comment. Frontend typecheck clean for these files.

## 🤖 Agent context

Authored with PostHog Code (Claude Opus). Split from the in-app-tab scaffolding-removal PR (#62052). Pure dead-prop removal — independent of the other split PRs (disjoint files).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
