### PR TITLE
fix(surveys): guard survey response panel against missing $survey_id

### DIFF
--- a/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
+++ b/frontend/src/lib/components/EventPropertyTabs/EventPropertyTabs.tsx
@@ -10,7 +10,7 @@ import { LemonTab, LemonTabs, LemonTabsProps } from 'lib/lemon-ui/LemonTabs'
 import { isKeyOf } from 'lib/utils/guards'
 
 import { CORE_FILTER_DEFINITIONS_BY_GROUP, POSTHOG_EVENT_PROMOTED_PROPERTIES } from '~/taxonomy/taxonomy'
-import { EventType, RecordingEventType } from '~/types'
+import { EventType, RecordingEventType, SurveyEventProperties } from '~/types'
 
 import { AutocaptureImageTab, hasAutocaptureImage } from '../AutocapturePreviewImage/AutocapturePreviewImage'
 import { ErrorEventType } from '../Errors/types'
@@ -59,7 +59,7 @@ export const EventPropertyTabs = ({
     const isAITagEvent = event.event === '$ai_tag'
 
     const isErrorEvent = event.event === '$exception'
-    const isSurveyResponseEvent = event.event === 'survey sent'
+    const isSurveyResponseEvent = event.event === 'survey sent' && !!event.properties?.[SurveyEventProperties.SURVEY_ID]
     const isMcpEvent =
         typeof event.event === 'string' &&
         (event.event.startsWith('mcp_') || event.event.startsWith('$mcp_') || event.event.startsWith('mcp '))

--- a/frontend/src/lib/components/SurveyResponseDisplay/SurveyResponseDisplay.test.tsx
+++ b/frontend/src/lib/components/SurveyResponseDisplay/SurveyResponseDisplay.test.tsx
@@ -1,0 +1,27 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { initKeaTests } from '~/test/init'
+
+import { SurveyResponseDisplay } from './SurveyResponseDisplay'
+
+describe('SurveyResponseDisplay', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('renders without mounting surveyLogic when $survey_id is missing', () => {
+        render(
+            <SurveyResponseDisplay
+                eventProperties={{ $survey_name: 'Custom survey sent event', $survey_response: 'hello' }}
+            />
+        )
+
+        expect(screen.getByText('Custom survey sent event')).toBeInTheDocument()
+    })
+})

--- a/frontend/src/lib/components/SurveyResponseDisplay/SurveyResponseDisplay.tsx
+++ b/frontend/src/lib/components/SurveyResponseDisplay/SurveyResponseDisplay.tsx
@@ -9,12 +9,13 @@ import ViewRecordingButton, { ViewRecordingButtonVariant } from 'lib/components/
 import { IconLink } from 'lib/lemon-ui/icons'
 import { countryCodeToFlag } from 'lib/utils/country'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
+import { NewSurvey } from 'scenes/surveys/constants'
 import { getThumbIcon } from 'scenes/surveys/hooks/useSurveyResponseColumns'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 import { getSurveyResponseValue, isScaleTwoRating } from 'scenes/surveys/utils'
 import { urls } from 'scenes/urls'
 
-import { SurveyEventProperties as SurveyEventPropertyNames, SurveyQuestion } from '~/types'
+import { Survey, SurveyEventProperties as SurveyEventPropertyNames, SurveyQuestion } from '~/types'
 
 interface SurveyResponseDisplayProps {
     eventProperties: Record<string, any>
@@ -68,19 +69,39 @@ function MetaItem({ icon, children }: { icon?: JSX.Element; children: React.Reac
     )
 }
 
-export function SurveyResponseDisplay({
+export function SurveyResponseDisplay(props: SurveyResponseDisplayProps): JSX.Element {
+    const surveyId = props.eventProperties[SurveyEventPropertyNames.SURVEY_ID]
+    if (!surveyId) {
+        return <SurveyResponseContent {...props} />
+    }
+    return <SurveyResponseDisplayWithLogic {...props} surveyId={surveyId} />
+}
+
+function SurveyResponseDisplayWithLogic({
+    surveyId,
+    ...props
+}: SurveyResponseDisplayProps & { surveyId: string }): JSX.Element {
+    const { survey, archivedResponseUuids } = useValues(surveyLogic({ id: surveyId }))
+    return <SurveyResponseContent {...props} survey={survey} archivedResponseUuids={archivedResponseUuids} />
+}
+
+function SurveyResponseContent({
     eventProperties,
     eventUuid,
     distinctId,
     timestamp,
     personProperties,
-}: SurveyResponseDisplayProps): JSX.Element {
+    survey,
+    archivedResponseUuids,
+}: SurveyResponseDisplayProps & {
+    survey?: NewSurvey | Survey
+    archivedResponseUuids?: Set<string>
+}): JSX.Element {
     const surveyId = eventProperties[SurveyEventPropertyNames.SURVEY_ID]
 
     const { location } = useValues(router)
     const isOnSurveyPage = surveyId && location.pathname.includes(`/surveys/${surveyId}`)
 
-    const { survey, archivedResponseUuids } = useValues(surveyLogic({ id: surveyId }))
     const isArchived = eventUuid ? (archivedResponseUuids?.has(eventUuid) ?? false) : false
 
     const surveyName = survey?.name || eventProperties['$survey_name']


### PR DESCRIPTION
## Problem

Expanding an event named `survey sent` in Activity → Explore could crash the expanded panel with a handled exception:

```
[KEA] Undefined key for logic "kea.logic.<N>"
```

The "Survey response" tab was gated on the event name alone. When a `survey sent` event had no `$survey_id` (for example, an app firing its own `posthog.capture('survey sent', { $survey_response: ... })` that reuses the reserved event name), the empty id flowed into the keyed `surveyLogic`, whose `key` is `({ id }) => id`. Kea throws when a keyed logic is mounted with an undefined key, so the panel rendered broken.

## Changes

- **`EventPropertyTabs`**: the survey response tab now also requires `$survey_id` to be present, not just the event name. This is the point where we decide to treat an event as a survey response, so it's the right place to reject the bad shape.
- **`SurveyResponseDisplay`**: split into a thin chooser, a `WithLogic` wrapper, and a shared content component so `surveyLogic` is never mounted with an undefined key. A `survey sent` event without `$survey_id` now renders from its own properties (no logic mount) instead of throwing. No render markup was duplicated.

After the fix, such an event simply shows the **Properties** tab (where `$survey_response` is still visible) and no longer offers a broken "Survey response" tab. Events with a real `$survey_id` are unaffected.

## How did you test this code?

I'm an agent (Claude Code); a human directed and drove the verification.

- **Automated**: added `SurveyResponseDisplay.test.tsx`, which renders the component for an event missing `$survey_id` and asserts it renders instead of throwing. Catches the regression where the keyed `surveyLogic` is mounted with an undefined key (no existing test exercised an id-less event). Ran it locally with `hogli test` — passes. Invoked the `/writing-tests` skill to keep it to a single behavior-level case.
- **Manual (local stack, human-driven)**: captured a `survey sent` event with only `$survey_response` set and no `$survey_id`, mirroring the shape that triggers the bug. On `master` the same event reproduced the `[KEA] Undefined key` crash in the expanded Activity panel; on this branch it expands cleanly and falls back to the Properties tab. The before/after was done on one running stack via Vite hot-reload by swapping just these two files.

Touched files typecheck and lint clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @christiaan-ph (assignee/DRI). Skills invoked: `/writing-tests`.

Key decisions:
- Chose a guard at the tab-decision boundary as the primary fix rather than a `try/catch` or null-check at the crash site, since the crash site is not the earliest reasonable boundary.
- Added the component split as defense-in-depth because `SurveyResponseDisplay` is an exported shared component and shouldn't be a footgun for future callers.
- Factored the render body into one shared content component instead of duplicating JSX across the id / no-id paths.
