### PR TITLE
fix(web-analytics): let web analytics editors manage authorized URLs

### DIFF
--- a/frontend/src/scenes/settings/environment/TeamSettings.tsx
+++ b/frontend/src/scenes/settings/environment/TeamSettings.tsx
@@ -240,7 +240,7 @@ export function TeamAuthorizedURLs(): JSX.Element {
     const canEdit =
         inStorybook() || inStorybookTestRunner()
             ? true
-            : userHasAccess(AccessControlResourceType.WebAnalytics, AccessControlLevel.Manager)
+            : userHasAccess(AccessControlResourceType.WebAnalytics, AccessControlLevel.Editor)
 
     return (
         <AuthorizedUrlList

--- a/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
+++ b/frontend/src/scenes/toolbar-launch/ToolbarLaunch.tsx
@@ -7,6 +7,8 @@ import { AuthorizedUrlList } from 'lib/components/AuthorizedUrlList/AuthorizedUr
 import { AuthorizedUrlListType } from 'lib/components/AuthorizedUrlList/authorizedUrlListLogic'
 import { IconGroupedEvents, IconHeatmap } from 'lib/lemon-ui/icons'
 import { Link } from 'lib/lemon-ui/Link'
+import { userHasAccess } from 'lib/utils/accessControlUtils'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -14,6 +16,7 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneSection } from '~/layout/scenes/components/SceneSection'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
+import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
 export const scene: SceneExport = {
     component: ToolbarLaunch,
@@ -21,6 +24,14 @@ export const scene: SceneExport = {
 }
 
 export function ToolbarLaunch(): JSX.Element {
+    // Authorized URLs are a single shared team field; the backend gates edits on web analytics
+    // editor access, so only offer the add/edit/delete controls to users who can actually save.
+    // In Storybook there's no app context, so allow editing there.
+    const canEdit =
+        inStorybook() || inStorybookTestRunner()
+            ? true
+            : userHasAccess(AccessControlResourceType.WebAnalytics, AccessControlLevel.Editor)
+
     const features: FeatureHighlightProps[] = [
         {
             title: 'Heatmaps',
@@ -65,7 +76,13 @@ export function ToolbarLaunch(): JSX.Element {
             />
 
             <SceneSection title="Authorized URLs for Toolbar" description="Click on the URL to launch the toolbar.">
-                <AuthorizedUrlList type={AuthorizedUrlListType.TOOLBAR_URLS} addText="Add authorized URL" />
+                <AuthorizedUrlList
+                    type={AuthorizedUrlListType.TOOLBAR_URLS}
+                    addText="Add authorized URL"
+                    allowAdd={canEdit}
+                    allowDelete={canEdit}
+                    displaySuggestions={canEdit}
+                />
                 <LemonBanner type="info">
                     Make sure you're using the <Link to={`${urls.settings('project')}#snippet`}>HTML snippet</Link> or
                     the latest <code>posthog-js</code> version.

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -2362,6 +2362,12 @@ def validate_team_attrs(
 ) -> dict[str, Any]:
     if instance is not None:
         admin_fields_touched = TEAM_CONFIG_ADMIN_FIELDS_SET & attrs.keys()
+        # `app_urls` (the toolbar / web analytics authorized URLs) carries a `field_access_control`
+        # tying it to web analytics editor access. When access controls are enabled, defer to that
+        # field-level check instead of the blanket project-admin gate, so a web analytics editor can
+        # manage authorized URLs. Without access controls we keep the stricter admin-only behavior.
+        if view.user_access_control.access_controls_supported:
+            admin_fields_touched = admin_fields_touched - {"app_urls"}
         if admin_fields_touched:
             team_for_check = instance if isinstance(instance, Team) else instance.passthrough_team
             level = view.user_permissions.team(team_for_check).effective_membership_level

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3196,6 +3196,60 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(self.team.timezone, "UTC")
         self.assertEqual(self.team.session_recording_opt_in, False)
 
+    def test_web_analytics_editor_can_write_app_urls_with_access_control(self):
+        # A web analytics editor (org member, no project-admin) must be able to manage the toolbar /
+        # web analytics authorized URLs. `app_urls` carries a web-analytics-editor field access control,
+        # and web analytics defaults to editor, so a plain member passes without any explicit grant.
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ACCESS_CONTROL,
+                "name": AvailableFeature.ACCESS_CONTROL,
+            },
+        ]
+        self.organization.save()
+
+        response = self.client.patch(
+            "/api/environments/@current/",
+            {"app_urls": ["https://app.example.com"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.json())
+
+        self.team.refresh_from_db()
+        self.assertEqual(self.team.app_urls, ["https://app.example.com"])
+
+    def test_web_analytics_viewer_cannot_write_app_urls_with_access_control(self):
+        # Restricting web analytics below editor must block managing authorized URLs.
+        self.organization_membership.level = OrganizationMembership.Level.MEMBER
+        self.organization_membership.save()
+
+        self.organization.available_product_features = [
+            {
+                "key": AvailableFeature.ACCESS_CONTROL,
+                "name": AvailableFeature.ACCESS_CONTROL,
+            },
+        ]
+        self.organization.save()
+
+        # Default the whole team's web analytics access down to viewer.
+        AccessControl.objects.create(
+            team=self.team,
+            resource="web_analytics",
+            resource_id=None,
+            access_level="viewer",
+        )
+
+        response = self.client.patch(
+            "/api/environments/@current/",
+            {"app_urls": ["https://app.example.com"]},
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+        self.team.refresh_from_db()
+        self.assertNotIn("https://app.example.com", self.team.app_urls)
+
     def test_team_member_can_write_to_member_safe_team_patch_without_access_control(self):
         # See test_team_member_can_write_to_member_safe_team_config_without_access_control above:
         # member-safe fields stay writable; admin-only fields (timezone) are covered separately.
@@ -3539,10 +3593,12 @@ _MEMBER_SAFE_TEAM_CONFIG_FIELDS_FOR_PROJECTS: list[tuple[str, Any, str]] = [
     f for f in _MEMBER_SAFE_TEAM_CONFIG_FIELDS if f[0] != "onboarding_tasks"
 ]
 
-# Fields the frontend treats as admin-only that previously lacked a
-# `@field_access_control` annotation on the model. Captured as a regression so
-# anyone removing the decorator (or adding a new admin-UI-gated field without one)
-# gets a failing test pointing at the right place.
+# Sensitive fields the frontend treats as admin-only that aren't part of the regular
+# TEAM_CONFIG flow. Captured as a regression so a MEMBER stays blocked from them when the
+# org has no paid access control. `app_urls` additionally carries a web-analytics-editor
+# `@field_access_control`; with access controls enabled that governs it instead (see
+# test_web_analytics_editor_can_write_app_urls_with_access_control), but without it the
+# blanket project-admin gate still applies here.
 _UNANNOTATED_SENSITIVE_FIELDS: list[tuple[str, Any, str]] = [
     ("is_demo", True, "is_demo"),
     ("app_urls", ["https://evil.example.com"], "app_urls"),

--- a/posthog/models/team/team.py
+++ b/posthog/models/team/team.py
@@ -311,7 +311,7 @@ class Team(UUIDTClassicModel):
         validators=[MinLengthValidator(10, "Project's API token must be at least 10 characters long!")],
     )
     app_urls: ArrayField = field_access_control(
-        ArrayField(models.CharField(max_length=200, null=True), default=list, blank=True), "project", "admin"
+        ArrayField(models.CharField(max_length=200, null=True), default=list, blank=True), "web_analytics", "editor"
     )
     name = models.CharField(
         max_length=200,


### PR DESCRIPTION
## Problem

A user with "Web analytics: Editor" access control couldn't add an authorized URL on the Toolbar page — they hit a 403. Authorized URLs (`app_urls`) are a single shared team field that powers both the toolbar and web analytics, but editing them was gated on **org membership level** (project admin) inside `validate_team_attrs`. A web analytics editor is an org member, not a project admin, so the write was rejected. On top of that the Toolbar page showed the "Add authorized URL" button to everyone with no permission check, so the action looked available and then failed on save.

Closes GROW-43

## Changes

- `Team.app_urls` now carries a `field_access_control("web_analytics", "editor")` instead of `("project", "admin")`.
- `validate_team_attrs` defers `app_urls` to that field-level access control when access controls are enabled, and keeps the stricter project-admin gate for orgs **without** access controls (so the existing security behavior is preserved where RBAC isn't available).
- `ToolbarLaunch` gates the add/edit/delete controls on `userHasAccess(WebAnalytics, Editor)` so users who can't save don't see a button that 403s.
- Web analytics settings (`TeamAuthorizedURLs`) lowered from `Manager` to `Editor` to match the backend.

The enforcement chain is layered: the viewset `AccessControlPermission` allows the write (project object access defaults to admin unless an org explicitly restricts it), `validate_team_attrs` was the real blocker, and the `web_analytics`/`editor` field access control now governs who can actually write the field.

## How did you test this code?

I'm an agent. I ran the affected backend tests locally against a real Postgres (ClickHouse stubbed, since these tests don't touch it):

- New: `test_web_analytics_editor_can_write_app_urls_with_access_control`, `test_web_analytics_viewer_cannot_write_app_urls_with_access_control` — both pass. These catch the regression that a web-analytics editor is blocked from `app_urls` while a viewer is not.
- Existing regression suite `TestTeamAdminFieldAuthorization` plus all `app_urls`/`access_control`/`unannotated` cases in `test_team.py` (99 passed) — confirms a plain member is still blocked from `app_urls` in orgs without access controls.
- `posthog/rbac/test/test_field_access_control.py` (5 passed).

I did not run the frontend type-check (no `node_modules` in the sandbox); the frontend changes reuse the exact import/gating pattern already in `TeamSettings.tsx`.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (PostHog Code). Skills invoked: `/improving-drf-endpoints` (confirmed the change is permission/validation logic only — no serializer field, schema, or action changes, so no OpenAPI/type regeneration needed).

Decision worth flagging for the reviewer: this **widens** who can edit `app_urls` from project-admin to web-analytics-editor for RBAC orgs. Since `web_analytics` defaults to `editor`, in an RBAC org without explicit web-analytics restrictions this effectively means most members can manage authorized URLs — which matches the product intent (authorized URLs are integral to web analytics and the toolbar) and the reported request. Orgs that want it locked down can lower web analytics access. Non-RBAC orgs are unchanged (still project-admin-only).
