### PR TITLE
feat(warehouse): track source create and edit origin (mcp/ui/api)

### DIFF
--- a/products/data_warehouse/backend/api/external_data_source.py
+++ b/products/data_warehouse/backend/api/external_data_source.py
@@ -38,6 +38,7 @@ from posthog.hogql.database.database import Database
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.utils import action
+from posthog.event_usage import report_user_action
 from posthog.exceptions_capture import capture_exception
 from posthog.models.user import User
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
@@ -1396,6 +1397,24 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             direct_query_enabled=serializer.validated_data.get("direct_query_enabled", True),
         )
 
+    def perform_update(self, serializer: serializers.BaseSerializer) -> None:
+        # Runs for both PUT and PATCH (DRF's partial_update delegates to update -> perform_update).
+        # `created_via` is write-once and reflects original creation origin; the edit's own origin
+        # comes from the request-derived `source` that report_user_action attaches.
+        super().perform_update(serializer)
+        instance = cast(ExternalDataSource, serializer.instance)
+        report_user_action(
+            cast(User, self.request.user),
+            "data warehouse source updated",
+            {
+                "source_type": instance.source_type,
+                "created_via": instance.created_via,
+                "source_id": str(instance.pk),
+            },
+            team=self.team,
+            request=self.request,
+        )
+
     def _create_external_data_source(
         self,
         request: Request,
@@ -1907,6 +1926,24 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
             )
             managed_viewset.sync_views()
             ensure_person_join(self.team.pk, new_source_model.prefix)
+
+        # `source` (web/api/mcp) is derived from the request by report_user_action; `created_via`
+        # is the caller's explicit intent. They usually agree but are kept separate so a transport
+        # change (e.g. a new wrapper UA) doesn't silently rewrite historical attribution.
+        report_user_action(
+            cast(User, request.user),
+            "data warehouse source created",
+            {
+                "source_type": source_type,
+                "created_via": created_via,
+                "source_access_method": access_method,
+                "direct_query_enabled": direct_query_enabled,
+                "schema_count": len(active_schemas),
+                "source_id": str(new_source_model.pk),
+            },
+            team=self.team,
+            request=request,
+        )
 
         return Response(status=status.HTTP_201_CREATED, data={"id": new_source_model.pk})
 

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -420,6 +420,52 @@ class TestExternalDataSource(APIBaseTest):
         source = ExternalDataSource.objects.get(id=response.json()["id"])
         assert source.direct_query_enabled is expected
 
+    @patch("products.data_warehouse.backend.api.external_data_source.report_user_action")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
+        return_value=(True, None),
+    )
+    def test_create_external_data_source_reports_analytics_event(self, _mock_validate, mock_report):
+        response = self.client.post(
+            f"/api/environments/{self.team.pk}/external_data_sources/",
+            data={
+                "source_type": "Stripe",
+                "created_via": "mcp",
+                "payload": {
+                    "auth_method": {"selection": "api_key", "stripe_secret_key": "sk_test_123"},
+                    "schemas": [
+                        {"name": STRIPE_CUSTOMER_RESOURCE_NAME, "should_sync": True, "sync_type": "full_refresh"},
+                    ],
+                },
+            },
+        )
+
+        assert response.status_code == 201, response.json()
+        mock_report.assert_called_once()
+        _user, event, properties = mock_report.call_args.args
+        assert event == "data warehouse source created"
+        assert properties["created_via"] == "mcp"
+        assert properties["source_type"] == "Stripe"
+        # request must be forwarded so report_user_action can derive the web/api/mcp source
+        assert mock_report.call_args.kwargs["request"] is not None
+        assert mock_report.call_args.kwargs["team"] == self.team
+
+    @patch("products.data_warehouse.backend.api.external_data_source.report_user_action")
+    def test_patch_external_data_source_reports_analytics_event(self, mock_report):
+        source = self._create_external_data_source(created_via=ExternalDataSource.CreatedVia.WEB)
+
+        response = self.client.patch(
+            f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/",
+            data={"description": "edited"},
+        )
+
+        assert response.status_code == 200, response.json()
+        mock_report.assert_called_once()
+        _user, event, properties = mock_report.call_args.args
+        assert event == "data warehouse source updated"
+        assert properties["source_id"] == str(source.pk)
+        assert mock_report.call_args.kwargs["request"] is not None
+
     def test_patch_external_data_source_toggles_direct_query_enabled(self):
         source = self._create_external_data_source()
         assert source.direct_query_enabled is True

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -420,12 +420,15 @@ class TestExternalDataSource(APIBaseTest):
         source = ExternalDataSource.objects.get(id=response.json()["id"])
         assert source.direct_query_enabled is expected
 
-    @patch("products.data_warehouse.backend.api.external_data_source.report_user_action")
+    @patch("posthog.event_usage.posthoganalytics.capture")
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source.StripeSource.validate_credentials",
         return_value=(True, None),
     )
-    def test_create_external_data_source_reports_analytics_event(self, _mock_validate, mock_report):
+    def test_create_external_data_source_reports_analytics_event(self, _mock_validate, mock_capture):
+        # report_user_action runs for real (not mocked) and the request carries the MCP marker, so the
+        # test fails if the request stops being forwarded or `source` stops landing — the mcp/ui/api
+        # attribution this PR exists to deliver.
         response = self.client.post(
             f"/api/environments/{self.team.pk}/external_data_sources/",
             data={
@@ -438,36 +441,38 @@ class TestExternalDataSource(APIBaseTest):
                     ],
                 },
             },
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         assert response.status_code == 201, response.json()
-        mock_report.assert_called_once()
-        _user, event, properties = mock_report.call_args.args
-        assert event == "data warehouse source created"
-        assert properties["created_via"] == "mcp"
+        events = [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "data warehouse source created"]
+        assert len(events) == 1
+        properties = events[0].kwargs["properties"]
+        assert properties["source"] == "mcp"  # request-derived transport
+        assert properties["created_via"] == "mcp"  # caller's explicit intent
         assert properties["source_type"] == "Stripe"
-        # request must be forwarded so report_user_action can derive the web/api/mcp source
-        assert mock_report.call_args.kwargs["request"] is not None
-        assert mock_report.call_args.kwargs["team"] == self.team
+        assert properties["source_id"] == str(response.json()["id"])
 
-    @patch("products.data_warehouse.backend.api.external_data_source.report_user_action")
-    def test_patch_external_data_source_reports_analytics_event(self, mock_report):
+    @patch("posthog.event_usage.posthoganalytics.capture")
+    def test_patch_external_data_source_reports_analytics_event(self, mock_capture):
+        # Source originally created via the UI, then edited over MCP: the event must carry both the
+        # edit's transport (source=mcp) and the unchanged original origin (created_via=web).
         source = self._create_external_data_source(created_via=ExternalDataSource.CreatedVia.WEB)
 
         response = self.client.patch(
             f"/api/environments/{self.team.pk}/external_data_sources/{source.pk}/",
             data={"description": "edited"},
+            HTTP_X_POSTHOG_CLIENT="mcp",
         )
 
         assert response.status_code == 200, response.json()
-        mock_report.assert_called_once()
-        _user, event, properties = mock_report.call_args.args
-        assert event == "data warehouse source updated"
-        assert properties["source_id"] == str(source.pk)
+        events = [c for c in mock_capture.call_args_list if c.kwargs.get("event") == "data warehouse source updated"]
+        assert len(events) == 1
+        properties = events[0].kwargs["properties"]
+        assert properties["source"] == "mcp"  # who performed the edit
+        assert properties["created_via"] == ExternalDataSource.CreatedVia.WEB  # original origin, preserved
         assert properties["source_type"] == "Stripe"
-        # created_via reflects the original creation origin, not the edit's — it must survive the update event
-        assert properties["created_via"] == ExternalDataSource.CreatedVia.WEB
-        assert mock_report.call_args.kwargs["request"] is not None
+        assert properties["source_id"] == str(source.pk)
 
     def test_patch_external_data_source_toggles_direct_query_enabled(self):
         source = self._create_external_data_source()

--- a/products/data_warehouse/backend/api/test/test_external_data_source.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_source.py
@@ -464,6 +464,9 @@ class TestExternalDataSource(APIBaseTest):
         _user, event, properties = mock_report.call_args.args
         assert event == "data warehouse source updated"
         assert properties["source_id"] == str(source.pk)
+        assert properties["source_type"] == "Stripe"
+        # created_via reflects the original creation origin, not the edit's — it must survive the update event
+        assert properties["created_via"] == ExternalDataSource.CreatedVia.WEB
         assert mock_report.call_args.kwargs["request"] is not None
 
     def test_patch_external_data_source_toggles_direct_query_enabled(self):


### PR DESCRIPTION
## Problem

We can't currently compare how warehouse sources are set up and edited across MCP vs the in-app UI vs direct API.

Data querying already emits a `source`-tagged analytics event (`"query api response"`), so query traffic is breakdownable by origin. Warehouse-source flows were inconsistent:

- **Create** only recorded origin as the `created_via` column in Postgres (a snapshot of surviving rows, not in product analytics).
- **Edits** recorded nothing at all — MCP-vs-UI-vs-API edits were invisible.

## Changes

Adds two `report_user_action` events to the external data source viewset, mirroring how the query endpoint already attributes origin (passing `request=` lets `report_user_action` auto-attach `source` = `web`/`api`/`mcp`/`cli`, `access_method`, and `mcp_client_*`):

- **`"data warehouse source created"`** — emitted at the single 201 return inside `_create_external_data_source`, so it covers both the low-level `create()` flow and the one-shot `setup()` (MCP) flow. Props: `source_type`, `created_via`, `source_access_method`, `direct_query_enabled`, `schema_count`, `source_id`.
- **`"data warehouse source updated"`** — emitted from a new `perform_update` override, covering both PUT and PATCH. Props: `source_type`, `created_via` (original creation origin), `source_id`.

`created_via` (caller's explicit intent) and the request-derived `source` (transport) are kept as separate properties so a future transport/UA change doesn't silently rewrite historical attribution.

Net effect: create, edit, and query are now all answerable from one consistent place — a trend per event broken down by `source`. Events only start flowing after deploy; the `created_via` column stays the only lens on historical creation.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). Automated tests only — no manual testing claimed.

Added two tests to `test_external_data_source.py`:
- `test_create_external_data_source_reports_analytics_event` — asserts the create event fires with the right name/props and that `request` is forwarded (the bit that derives the origin).
- `test_patch_external_data_source_reports_analytics_event` — same for the edit path via `perform_update`.

These guard a real regression no existing test caught: the existing `created_via` tests only assert the Postgres column, not the emitted analytics event — so a refactor could drop the capture (or stop forwarding `request`) and silently kill the MCP-vs-UI-vs-API attribution.

Ran locally against ephemeral dev datastores: the 2 new event tests plus the existing create / `created_via` / patch / setup slice (10 tests) — all green. `ruff check`/`format` and the pre-commit `ty` typecheck pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8) at the request of @MarconLP, who was scoping how to measure MCP vs UI vs API usage of warehouse sources. We first mapped the three existing attribution layers — the `EventSource`/`get_event_source` framework in `posthog/event_usage.py`, the MCP server's own `$mcp_*` events, and the `created_via` column — then chose to mirror the query endpoint's `report_user_action(request=...)` pattern for consistency rather than inventing a new mechanism.

Skills invoked: `/improving-drf-endpoints` (before touching the viewset) and `/writing-tests` (to gate the new tests against the value bar).

Design decisions: instrument at the `_create_external_data_source` choke point so `create()` and `setup()` are covered once; use a `perform_update` override so PUT and PATCH are both covered without duplicating logic; name the warehouse access-method prop `source_access_method` to avoid colliding with the auth `access_method` that `report_user_action` injects from the request.
