### PR TITLE
fix(data-warehouse): cut Stripe per-customer API call volume

### DIFF
--- a/posthog/temporal/tests/data_imports/conftest.py
+++ b/posthog/temporal/tests/data_imports/conftest.py
@@ -408,7 +408,7 @@ def stripe_customer():
                     "id": "cus_NffrFeUfNV2Hib",
                     "object": "customer",
                     "address": null,
-                    "balance": 0,
+                    "balance": -1000,
                     "created": 1680893993,
                     "currency": null,
                     "default_source": null,

--- a/posthog/temporal/tests/data_imports/test_end_to_end.py
+++ b/posthog/temporal/tests/data_imports/test_end_to_end.py
@@ -3584,7 +3584,7 @@ async def test_cdp_producer_push_to_kafka(team, stripe_customer, mock_stripe_cli
         "tax_exempt": "none",
         "address": None,
         "invoice_prefix": "0759376C",
-        "balance": 0,
+        "balance": -1000,
         "currency": None,
         "livemode": False,
         "invoice_settings": '{"custom_fields":null,"default_payment_method":null,"footer":null,"rendering_options":null}',

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/constants.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/constants.py
@@ -51,7 +51,12 @@ RESOURCE_TO_STRIPE_WEBHOOK_EVENT: dict[str, str] = {
     REFUND_RESOURCE_NAME: "refund",
     SUBSCRIPTION_RESOURCE_NAME: "customer.subscription",
     CREDIT_NOTE_RESOURCE_NAME: "credit_note",
-    CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME: "billing",
+    # CustomerBalanceTransaction (the legacy customer credit-balance ledger returned by
+    # `customers.balance_transactions.list`) has no Stripe webhook event — no event ever carries a
+    # `customer_balance_transaction` object. The previous "billing" prefix only subscribed the source
+    # webhook to unrelated `billing.*` events (credit grants, meters, alerts, and the distinct
+    # `billing.credit_balance_transaction` object), none of which can populate this table. So it's
+    # intentionally absent here and stays API-sweep-only.
     CUSTOMER_PAYMENT_METHOD_RESOURCE_NAME: "payment_method",
     COUPON_RESOURCE_NAME: "coupon",
     DISCOUNT_RESOURCE_NAME: "customer.discount",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -148,6 +148,27 @@ class StripeNestedResource:
     parent: StripeResource
     parent_name: str = ""
     params: dict[str, Any] = dataclasses.field(default_factory=dict)
+    # Optional predicate over a parent object. When set and it returns False, we skip the nested
+    # API call for that parent entirely. Stripe has no top-level list for these nested resources, so
+    # the default behaviour fans out one call per parent — most of which return nothing. A cheap
+    # signal already present on the parent object lets us avoid the calls that can't yield data.
+    parent_has_nested: Optional[Callable[[dict[str, Any]], bool]] = None
+
+
+def _customer_might_have_balance_transactions(customer: dict[str, Any]) -> bool:
+    """Skip the per-customer balance-transactions call when the customer's credit balance is exactly 0.
+
+    A customer balance transaction is a credit/debit against the customer's stored balance, so any
+    customer that has ever had one and not netted it back to zero carries a non-zero ``balance``. The
+    vast majority of customers never touch their balance, so this turns the full per-customer sweep
+    (one call each, almost all empty) into a handful of calls.
+
+    Tradeoff: a customer whose balance was credited and then fully consumed back to 0 has ledger
+    entries but a 0 balance, so we won't fetch their history. This is rare and an accepted cost of
+    avoiding the per-customer fan-out. A missing ``balance`` (unexpected payload shape) is treated as
+    "might have" so we never silently drop data."""
+    balance = customer.get("balance")
+    return balance is None or balance != 0
 
 
 @dataclasses.dataclass
@@ -205,6 +226,7 @@ def _build_resources(
             parent_id="id",
             parent=StripeResource(method=client.customers.list),
             parent_name=CUSTOMER_RESOURCE_NAME,
+            parent_has_nested=_customer_might_have_balance_transactions,
         ),
         CUSTOMER_PAYMENT_METHOD_RESOURCE_NAME: StripeNestedResource(
             method=client.customers.payment_methods.list,
@@ -276,8 +298,14 @@ def get_rows(
                 resource.parent.method,
                 params={**default_params, **resource.parent.params, **resume_params},
             )
+            skipped_parents = 0
             for obj in stripe_parent_objects.auto_paging_iter():
                 parent_obj_id = obj[resource.parent_id]
+                # Skip parents that a cheap signal on the parent object rules out — avoids one empty
+                # nested call per parent (the bulk of Stripe API volume for these resources).
+                if resource.parent_has_nested is not None and not resource.parent_has_nested(obj):
+                    skipped_parents += 1
+                    continue
                 try:
                     stripe_nested_objects = _call_stripe(
                         resource.method,
@@ -305,6 +333,10 @@ def get_rows(
                     if not _is_stripe_resource_missing_error(e):
                         raise
                     logger.debug(f"Stripe: skipping {resource.nested_parent_param}={parent_obj_id}, no longer exists")
+            if skipped_parents:
+                logger.debug(
+                    f"Stripe: skipped {skipped_parents} {resource.nested_parent_param}(s) with no nested data, saving that many API calls"
+                )
         else:
             stripe_objects = _call_stripe(
                 resource.method, params={**default_params, **resource.params, **resume_params}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -11,13 +11,16 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.generated_
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe import stripe as stripe_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.constants import (
     CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME,
+    CUSTOMER_PAYMENT_METHOD_RESOURCE_NAME,
     CUSTOMER_RESOURCE_NAME,
+    RESOURCE_TO_STRIPE_WEBHOOK_EVENT,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source import StripeSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.stripe import (
     StripeAuthenticationError,
     StripeNestedResource,
     StripeResource,
+    _all_known_webhook_events,
     get_rows,
 )
 
@@ -109,16 +112,17 @@ class TestStripeSource:
         assert message.startswith("Stripe rejected the API key.")
 
 
-def _run_nested_get_rows(nested_method):
-    parent = StripeResource(
-        method=lambda **kwargs: _list_object([{"id": "cus_ok1"}, {"id": "cus_gone"}, {"id": "cus_ok2"}])
-    )
+def _run_nested_get_rows(nested_method, parent_objects=None, parent_has_nested=None):
+    if parent_objects is None:
+        parent_objects = [{"id": "cus_ok1"}, {"id": "cus_gone"}, {"id": "cus_ok2"}]
+    parent = StripeResource(method=lambda **kwargs: _list_object(parent_objects))
     resource = StripeNestedResource(
         method=nested_method,
         nested_parent_param="customer",
         parent_id="id",
         parent=parent,
         parent_name=CUSTOMER_RESOURCE_NAME,
+        parent_has_nested=parent_has_nested,
     )
 
     resumable_source_manager = MagicMock()
@@ -165,3 +169,58 @@ class TestStripeNestedResourceGetRows:
 
         with pytest.raises(stripe_lib.InvalidRequestError):
             _run_nested_get_rows(nested_method)
+
+    def test_parent_has_nested_skips_filtered_parents_without_calling(self):
+        called_for: list[str] = []
+
+        def nested_method(customer=None, params=None):
+            called_for.append(customer)
+            return _list_object([{"id": f"cbt_{customer}", "amount": 100}])
+
+        # Only customers with a non-zero balance should trigger the nested call.
+        rows = _run_nested_get_rows(
+            nested_method,
+            parent_objects=[
+                {"id": "cus_zero", "balance": 0},
+                {"id": "cus_credit", "balance": -500},
+                {"id": "cus_owed", "balance": 1500},
+            ],
+            parent_has_nested=stripe_module._customer_might_have_balance_transactions,
+        )
+
+        # cus_zero is skipped entirely — no API call, no rows.
+        assert called_for == ["cus_credit", "cus_owed"]
+        assert {row["customer"] for row in rows} == {"cus_credit", "cus_owed"}
+
+
+class TestCustomerMightHaveBalanceTransactions:
+    @pytest.mark.parametrize(
+        "customer,expected",
+        [
+            ({"balance": 0}, False),
+            ({"balance": -500}, True),
+            ({"balance": 1500}, True),
+            # Missing balance is an unexpected payload shape — fetch rather than silently drop data.
+            ({}, True),
+            ({"balance": None}, True),
+        ],
+    )
+    def test_predicate(self, customer, expected):
+        assert stripe_module._customer_might_have_balance_transactions(customer) is expected
+
+
+class TestWebhookEventMapping:
+    def test_customer_balance_transaction_has_no_webhook_event(self):
+        # Customer balance transactions have no Stripe webhook event, so the resource must not be in
+        # the event map — otherwise we'd subscribe the source webhook to unrelated events.
+        assert CUSTOMER_BALANCE_TRANSACTION_RESOURCE_NAME not in RESOURCE_TO_STRIPE_WEBHOOK_EVENT
+
+    def test_no_billing_events_subscribed(self):
+        # The removed "billing" mapping was the only thing pulling in billing.* events (credit
+        # grants, meters, alerts) — none of which can populate any table we sync.
+        assert not any(e.startswith("billing.") or e.startswith("billing_") for e in _all_known_webhook_events())
+
+    def test_payment_method_events_still_subscribed(self):
+        # CustomerPaymentMethod keeps its mapping, so payment_method.* events stay subscribed.
+        assert RESOURCE_TO_STRIPE_WEBHOOK_EVENT[CUSTOMER_PAYMENT_METHOD_RESOURCE_NAME] == "payment_method"
+        assert any(e.startswith("payment_method.") for e in _all_known_webhook_events())


### PR DESCRIPTION
## Problem

Stripe flagged that we make a very high rate of `GET /v1/customers/:id/balance_transactions` calls — in one observed window, thousands of calls of which only a handful returned any data. Because we use restricted API keys, this risks merchants hitting 429s.

The cause is two of our synced Stripe tables, `CustomerBalanceTransaction` and `CustomerPaymentMethod`. Neither has a top-level Stripe list endpoint — the data is only reachable per-customer — so the sync fans out one nested `GET` per customer. The vast majority of customers have never touched their credit balance, so almost every call comes back empty. This also repeats on every sync (nested resources are full-refresh, not incremental), so it's an ongoing cost, not a one-time backfill.

## Changes

**Skip customers that can't have balance transactions.** A customer balance transaction is a credit/debit against the customer's stored `balance`, which is already present on the customer objects we paginate. Any customer carrying ledger entries (that haven't netted back to zero) has a non-zero `balance`, so we skip the nested call entirely for `balance == 0`. For a typical account that collapses thousands of empty calls into a handful — and it takes effect automatically on the next sync, with no action needed from the merchant.

The skip is implemented as a generic optional `parent_has_nested` predicate on `StripeNestedResource`, so other nested resources can opt in later. A missing `balance` (unexpected payload shape) is treated as "might have" so we never silently drop data, and we log how many calls were saved.

**Drop a bogus webhook event mapping.** `CustomerBalanceTransaction` was mapped to the `billing` event prefix, which subscribed the source webhook to all `billing.*` events (credit grants, meters, alerts, and the unrelated `billing.credit_balance_transaction` object). I confirmed against the Stripe SDK event catalog that **no** Stripe event carries a `customer_balance_transaction` object, so that subscription could never populate the table — it was pure noise. Removed it; this resource is inherently API-sweep-only.

### Known tradeoff

A customer whose balance was credited and then fully consumed back to exactly 0 has ledger entries but a 0 balance, so we won't fetch their history. This is rare and is the accepted cost of avoiding the per-customer fan-out. It's documented in the code.

### Not in this PR

The payment-method calls (`GET /v1/customers/:id/payment_methods`) have the same fan-out shape but no cheap customer-object signal to filter on. The right structural fix there is making `CustomerPaymentMethod` webhook-driven (the `payment_method.*` events exist and already map correctly), so after initial sync we stop sweeping. That touches webhook→schema routing and warrants its own focused PR.

## How did you test this code?

I'm an agent (Claude, agent-assisted). I added and ran automated unit tests — no manual testing against live Stripe.

- `_customer_might_have_balance_transactions` predicate: parametrized over zero / negative / positive / missing / null balance.
- Sweep behavior: asserts the nested call is **not made** for `balance == 0` customers and that their rows are absent — the regression this guards is the per-customer fan-out silently coming back.
- Webhook mapping: asserts `CustomerBalanceTransaction` is absent from the event map, no `billing.*` events are subscribed, and `payment_method.*` events are still subscribed.

24 tests pass in `tests/test_stripe_source.py`; `ruff check` / `ruff format` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a Stripe partner report about high call volume to the customer balance-transactions endpoint. Traced it to the nested-resource fan-out in the Stripe warehouse source, confirmed there's no top-level list endpoint for these resources, and confirmed (by enumerating the Stripe SDK's event catalog) that customer balance transactions have no webhook event — which is why the existing `billing` mapping was both wrong and the reason webhooks can't replace the sweep here.

Chose the `balance == 0` filter as the low-risk, no-merchant-action win the human explicitly endorsed, over heavier alternatives (incremental parent listing, webhook enablement) that carry more correctness surface. Payment-method webhook enablement was deliberately deferred to a separate PR for the same reason.

No repo skills were invoked.
