### PR TITLE
fix(endpoints): link to v1 in created-endpoint activity entry

### DIFF
--- a/products/endpoints/frontend/activityDescriber.tsx
+++ b/products/endpoints/frontend/activityDescriber.tsx
@@ -38,7 +38,8 @@ export function endpointActivityDescriber(logItem: ActivityLogItem, asNotificati
             description: (
                 <>
                     <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> created endpoint{' '}
-                    <EndpointLink name={endpointName} /> (<VersionLink name={endpointName} version={1} />).
+                    <EndpointLink name={endpointName} /> (<VersionLink name={endpointName} version={1} />
+                    ).
                 </>
             ),
         }

--- a/products/endpoints/frontend/activityDescriber.tsx
+++ b/products/endpoints/frontend/activityDescriber.tsx
@@ -38,7 +38,7 @@ export function endpointActivityDescriber(logItem: ActivityLogItem, asNotificati
             description: (
                 <>
                     <strong className="ph-no-capture">{userNameForLogItem(logItem)}</strong> created endpoint{' '}
-                    <EndpointLink name={endpointName} />.
+                    <EndpointLink name={endpointName} /> (<VersionLink name={endpointName} version={1} />).
                 </>
             ),
         }


### PR DESCRIPTION
## Problem

In the Endpoints activity log, the "created endpoint" entry links to the endpoint's *current* version rather than the version it was at creation time (v1). A user reported that the history of an endpoint doesn't let them get back to v1 — clicking the created-endpoint link always opens the latest version.

## Changes

The `created` activity entry now reads `created endpoint <name> (v1)`, where `v1` is a link to version 1 of the endpoint (`/endpoints/<name>?version=1`). The endpoint's initial version is always 1, so the suffix is rendered with the existing `VersionLink` component used by the `version_created`/`version_updated` entries.

## How did you test this code?

I'm an agent. I made a frontend-only change reusing the already-tested `VersionLink` component and `urls.endpoint(name, version)` helper. No automated tests were added (the describer has no existing test file) and I did not run the app manually.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: add a `(v1)` link to the created-endpoint activity entry pointing at the endpoint's first version. Chose the frontend-only approach since an endpoint's initial version is invariably 1, so no backend `EndpointContext` change was needed — the existing `VersionLink` helper already produces the correct `?version=1` URL.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782384993997149?thread_ts=1782384993.997149&cid=C0ACRAMJUAG)*
