### PR TITLE
fix(actions): show correct operator in action tooltip for legacy steps

### DIFF
--- a/frontend/src/lib/components/DefinitionPopover/utils.test.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.test.ts
@@ -2,42 +2,48 @@ import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types
 
 import { allOperatorsToHumanName, genericOperatorToHumanName } from './utils'
 
-describe('genericOperatorToHumanName', () => {
-    it.each([
-        [PropertyOperator.Exact, 'equals'],
-        [PropertyOperator.GreaterThanOrEqual, 'greater than or equal'],
-        [PropertyOperator.LessThanOrEqual, 'less than or equal'],
-        [PropertyOperator.GreaterThan, 'greater than'],
-        [PropertyOperator.IContains, 'contains'],
-    ])('maps a typed property with operator %s to "%s"', (operator, expected) => {
-        const property = { type: PropertyFilterType.Event, key: 'amount', value: 5, operator } as AnyPropertyFilter
-        expect(genericOperatorToHumanName(property)).toBe(expected)
+describe('DefinitionPopover operator helpers', () => {
+    describe('genericOperatorToHumanName', () => {
+        it.each([
+            [PropertyOperator.Exact, 'equals'],
+            [PropertyOperator.GreaterThanOrEqual, 'greater than or equal'],
+            [PropertyOperator.LessThanOrEqual, 'less than or equal'],
+            [PropertyOperator.GreaterThan, 'greater than'],
+            [PropertyOperator.IContains, 'contains'],
+        ])('maps a typed property with operator %s to "%s"', (operator, expected) => {
+            const property = { type: PropertyFilterType.Event, key: 'amount', value: 5, operator } as AnyPropertyFilter
+            expect(genericOperatorToHumanName(property)).toBe(expected)
+        })
+
+        it('reads the operator from a legacy action step property that has no type', () => {
+            // Legacy action step properties are stored without a `type` field
+            const property = {
+                key: 'amount',
+                value: 5,
+                operator: PropertyOperator.GreaterThanOrEqual,
+            } as AnyPropertyFilter
+            expect(genericOperatorToHumanName(property)).toBe('greater than or equal')
+        })
+
+        it.each([null, undefined, {} as AnyPropertyFilter])('falls back to "equals" for %s', (property) => {
+            expect(genericOperatorToHumanName(property)).toBe('equals')
+        })
     })
 
-    it('reads the operator from a legacy action step property that has no type', () => {
-        // Legacy action step properties are stored without a `type` field
-        const property = { key: 'amount', value: 5, operator: PropertyOperator.GreaterThanOrEqual } as AnyPropertyFilter
-        expect(genericOperatorToHumanName(property)).toBe('greater than or equal')
-    })
-
-    it.each([null, undefined, {} as AnyPropertyFilter])('falls back to "equals" for %s', (property) => {
-        expect(genericOperatorToHumanName(property)).toBe('equals')
-    })
-})
-
-describe('allOperatorsToHumanName', () => {
-    it.each([
-        // Cohort operators have no symbol prefix and must not be sliced
-        [PropertyOperator.In, 'in'],
-        [PropertyOperator.NotIn, 'not in'],
-        // Regular operators drop their 2-char symbol prefix
-        [PropertyOperator.Exact, 'equals'],
-        [PropertyOperator.IsNot, "doesn't equal"],
-        [PropertyOperator.GreaterThan, 'greater than'],
-        // Unknown / missing operator falls back to 'equals'
-        [undefined, 'equals'],
-        [null, 'equals'],
-    ])('maps %s to "%s"', (operator, expected) => {
-        expect(allOperatorsToHumanName(operator)).toBe(expected)
+    describe('allOperatorsToHumanName', () => {
+        it.each([
+            // Cohort operators have no symbol prefix and must not be sliced
+            [PropertyOperator.In, 'in'],
+            [PropertyOperator.NotIn, 'not in'],
+            // Regular operators drop their 2-char symbol prefix
+            [PropertyOperator.Exact, 'equals'],
+            [PropertyOperator.IsNot, "doesn't equal"],
+            [PropertyOperator.GreaterThan, 'greater than'],
+            // Unknown / missing operator falls back to 'equals'
+            [undefined, 'equals'],
+            [null, 'equals'],
+        ])('maps %s to "%s"', (operator, expected) => {
+            expect(allOperatorsToHumanName(operator)).toBe(expected)
+        })
     })
 })

--- a/frontend/src/lib/components/DefinitionPopover/utils.test.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.test.ts
@@ -1,6 +1,29 @@
-import { PropertyOperator } from '~/types'
+import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { allOperatorsToHumanName } from './utils'
+import { allOperatorsToHumanName, genericOperatorToHumanName } from './utils'
+
+describe('genericOperatorToHumanName', () => {
+    it.each([
+        [PropertyOperator.Exact, 'equals'],
+        [PropertyOperator.GreaterThanOrEqual, 'greater than or equal'],
+        [PropertyOperator.LessThanOrEqual, 'less than or equal'],
+        [PropertyOperator.GreaterThan, 'greater than'],
+        [PropertyOperator.IContains, 'contains'],
+    ])('maps a typed property with operator %s to "%s"', (operator, expected) => {
+        const property = { type: PropertyFilterType.Event, key: 'amount', value: 5, operator } as AnyPropertyFilter
+        expect(genericOperatorToHumanName(property)).toBe(expected)
+    })
+
+    it('reads the operator from a legacy action step property that has no type', () => {
+        // Legacy action step properties are stored without a `type` field
+        const property = { key: 'amount', value: 5, operator: PropertyOperator.GreaterThanOrEqual } as AnyPropertyFilter
+        expect(genericOperatorToHumanName(property)).toBe('greater than or equal')
+    })
+
+    it.each([null, undefined, {} as AnyPropertyFilter])('falls back to "equals" for %s', (property) => {
+        expect(genericOperatorToHumanName(property)).toBe('equals')
+    })
+})
 
 describe('allOperatorsToHumanName', () => {
     it.each([

--- a/frontend/src/lib/components/DefinitionPopover/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.ts
@@ -1,4 +1,3 @@
-import { isPropertyFilterWithOperator } from 'lib/components/PropertyFilters/utils'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { allOperatorsMapping, genericOperatorMap } from 'lib/utils/operators'
 
@@ -15,8 +14,12 @@ export function operatorToHumanName(operator?: string): string {
 }
 
 export function genericOperatorToHumanName(property?: AnyPropertyFilter | null): string {
-    if (isPropertyFilterWithOperator(property) && property.operator && genericOperatorMap[property.operator]) {
-        return genericOperatorMap[property.operator].slice(2)
+    // Read the operator directly rather than gating on isPropertyFilterWithOperator: legacy action
+    // step properties are stored as bare `{ key, value, operator }` without a `type`, so the type
+    // guard rejects them and every operator (>=, <, etc.) would collapse to the "equals" fallback.
+    const operator = property && 'operator' in property ? property.operator : undefined
+    if (operator && genericOperatorMap[operator]) {
+        return genericOperatorMap[operator].slice(2)
     }
     return 'equals'
 }

--- a/frontend/src/lib/components/DefinitionPopover/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.ts
@@ -14,9 +14,8 @@ export function operatorToHumanName(operator?: string): string {
 }
 
 export function genericOperatorToHumanName(property?: AnyPropertyFilter | null): string {
-    // Read the operator directly rather than gating on isPropertyFilterWithOperator: legacy action
-    // step properties are stored as bare `{ key, value, operator }` without a `type`, so the type
-    // guard rejects them and every operator (>=, <, etc.) would collapse to the "equals" fallback.
+    // Legacy action step properties have no `type`, so isPropertyFilterWithOperator would reject them
+    // and collapse every operator to "equals" — read the operator directly instead.
     const operator = property && 'operator' in property ? property.operator : undefined
     if (operator && genericOperatorMap[operator]) {
         return genericOperatorMap[operator].slice(2)


### PR DESCRIPTION
## Problem

The inline action tooltip (e.g. in an experiment exposure event dropdown) showed `>=` (and other comparison) operators as "equals". A customer flagged it on an action whose step uses a `>=` property filter, where the tooltip read "equals" instead.

Root cause: `genericOperatorToHumanName` gated its operator lookup behind `isPropertyFilterWithOperator`, which only returns true for property filters with a recognized `type`. Legacy action step properties are stored as bare `{ key, value, operator }` with no `type`, so the guard rejected them and every operator fell through to the hardcoded `"equals"` default — regardless of the real operator.

## Changes

Read the operator directly off the property in `genericOperatorToHumanName` instead of requiring a recognized `type`. The `genericOperatorMap` already maps `gte`/`lte`/`gt`/`lt` correctly, so once the lookup runs the right label shows. This fixes both surfaces that call the helper: the new Quill-styled `ActionMatchGroups` preview pane and the legacy `ActionPopoverInfo`.

Before / after, rendered from the real `ActionMatchGroups` component with a legacy (no-`type`) `>=` step property — "before" uses master's code, "after" uses this branch:

| Before | After |
| --- | --- |
| ![Before: operator shown as equals](https://raw.githubusercontent.com/PostHog/posthog/f59728fc69f10ff705d76f0ce5907f8c05c88a61/.github/pr-screenshots/action-tooltip-operator-before.png) | ![After: operator shown as greater than or equal](https://raw.githubusercontent.com/PostHog/posthog/f59728fc69f10ff705d76f0ce5907f8c05c88a61/.github/pr-screenshots/action-tooltip-operator-after.png) |

## How did you test this code?

I'm an agent (PostHog Slack app). I added unit tests to `utils.test.ts` covering typed properties (`gte` → "greater than or equal", `lte`, `gt`, `icontains`), the legacy no-`type` action step case (the regression — previously returned "equals"), and the null/undefined/empty fallback. Ran the suite with jest (16/16 pass) and ran the frontend typecheck (clean for the changed files). The before/after screenshots above were produced by server-rendering the real `ActionMatchGroups` component against both code versions. No manual click-through in the running app.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triggered from a support thread where a customer reported the action tooltip mislabeling `>=` filters as "equals". Investigated with the PostHog Slack app agent (Explore subagent to locate the rendering path), traced it to the `type`-guard gate in `genericOperatorToHumanName` rather than the operator map (which is correct). Considered routing through the already-correct `allOperatorsToHumanName`, but the minimal, behavior-preserving fix was to drop the over-strict guard and read the operator directly. Ran `/simplify` and a high-effort `/code-review` over the diff: no correctness issues surfaced (every other path is pre-existing or behaviorally identical), and the cleanup pass consolidated the test file under a single top-level describe and trimmed the code comment.

The before/after images are hosted outside this PR's diff (no screenshot files are committed to the branch).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782280765547529?thread_ts=1782280765.547529&cid=C0ACRAMJUAG)*
