### PR TITLE
chore(cdp): remove CDP_EMAIL_QUEUE_ROUTING flag after full rollout

### DIFF
--- a/nodejs/src/cdp/cdp-api.test.ts
+++ b/nodejs/src/cdp/cdp-api.test.ts
@@ -1006,7 +1006,6 @@ describe('CDP API', () => {
     // email branch always goes through EmailService directly on this path.
     describe('hog_flows/:id/invocations — email actions are sent inline despite queue routing', () => {
         let emailSpy: jest.SpyInstance
-        let originalMatcher: (teamId: number) => boolean
         let hogFlowId: string
 
         beforeEach(async () => {
@@ -1085,12 +1084,6 @@ describe('CDP API', () => {
             const inserted = await insertHogFlow(hogFlow)
             hogFlowId = inserted.id
 
-            // Simulate CDP_EMAIL_QUEUE_ROUTING='*' (prod-us) without rebuilding the executor — the
-            // matcher is set in the constructor closure, so reaching in is the only way to flip it.
-            const hogExecutor = api['hogExecutor'] as any
-            originalMatcher = hogExecutor.emailQueueMatcher
-            hogExecutor.emailQueueMatcher = () => true
-
             // Stub EmailService so the test doesn't depend on a running maildev SMTP. The spy
             // captures whether the inline path was taken — that's the assertion that proves the fix.
             emailSpy = jest
@@ -1117,7 +1110,6 @@ describe('CDP API', () => {
         })
 
         afterEach(() => {
-            ;(api['hogExecutor'] as any).emailQueueMatcher = originalMatcher
             emailSpy.mockRestore()
         })
 

--- a/nodejs/src/cdp/cdp-services.ts
+++ b/nodejs/src/cdp/cdp-services.ts
@@ -146,7 +146,6 @@ export type CdpCoreServicesConfig = Pick<
         | 'CDP_FETCH_BACKOFF_BASE_MS'
         | 'CDP_FETCH_BACKOFF_MAX_MS'
         | 'CDP_SELF_LOOP_GUARD_MODE'
-        | 'CDP_EMAIL_QUEUE_ROUTING'
         | 'CDP_EMAIL_TRACKING_URL'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_TOPIC'
         | 'HOG_FUNCTION_MONITORING_APP_METRICS_PRODUCER'
@@ -405,7 +404,6 @@ export function createCdpCoreServices(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-            emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
             selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },

--- a/nodejs/src/cdp/config.ts
+++ b/nodejs/src/cdp/config.ts
@@ -50,11 +50,6 @@ export type CdpConfig = ClickhouseConfig & {
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: CyclotronJobQueueKind
     CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: CyclotronJobQueueSource
     CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: string
-    // Controls which teams route email sends to the dedicated email queue.
-    // Supports team IDs, percentage rollout, or both.
-    // Examples: '' (disabled), '123,456' (specific teams), '*:0.1' (10% of traffic),
-    //           '123,*:0.05' (team 123 + 5% of rest), '*' (all traffic)
-    CDP_EMAIL_QUEUE_ROUTING: string
 
     CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: string
     CDP_LEGACY_EVENT_CONSUMER_TOPIC: string
@@ -185,7 +180,6 @@ export function getDefaultCdpConfig(): CdpConfig {
         CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_KIND: 'hog',
         CDP_CYCLOTRON_JOB_QUEUE_CONSUMER_MODE: 'kafka',
         CDP_CYCLOTRON_STRIP_PERSON_FROM_STATE_TEAMS: '',
-        CDP_EMAIL_QUEUE_ROUTING: '',
 
         CDP_LEGACY_EVENT_CONSUMER_GROUP_ID: 'clickhouse-plugin-server-async-onevent',
         CDP_LEGACY_EVENT_CONSUMER_TOPIC: KAFKA_EVENTS_JSON,

--- a/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
+++ b/nodejs/src/cdp/hog-transformations/hog-transformer.service.ts
@@ -507,7 +507,6 @@ export function createHogTransformerService(
             fetchRetries: config.CDP_FETCH_RETRIES,
             fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
             fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-            emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
             selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
         },
         { teamManager: deps.teamManager, siteUrl: config.SITE_URL },

--- a/nodejs/src/cdp/services/hog-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.test.ts
@@ -75,7 +75,6 @@ describe('Hog Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
                 selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
@@ -2255,7 +2254,7 @@ describe('Hog Executor', () => {
         })
     })
 
-    describe('email queue routing config', () => {
+    describe('email queue routing', () => {
         const createEmailInvocation = (): CyclotronJobInvocationHogFunction => {
             const hogFunction = createHogFunction({ name: 'Email function', team_id: 123 })
             const invocation: CyclotronJobInvocationHogFunction = {
@@ -2274,103 +2273,23 @@ describe('Hog Executor', () => {
             return invocation
         }
 
-        const createExecutorWithRouting = (emailQueueRouting: string): HogExecutorService => {
-            const hogInputsService = new HogInputsService(
-                hub.integrationManager,
-                hub.ENCRYPTION_SALT_KEYS,
-                hub.SITE_URL
-            )
-            const emailService = new EmailService(
-                {
-                    sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                    sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                    sesRegion: hub.SES_REGION,
-                    sesEndpoint: hub.SES_ENDPOINT,
-                },
-                hub.integrationManager,
-                new TeamWorkflowsConfigService(hub.postgres),
-                hub.ENCRYPTION_SALT_KEYS,
-                hub.SITE_URL,
-                new EmailTrackingCodeSigner(hub.ENCRYPTION_SALT_KEYS, hub.CDP_EMAIL_TRACKING_URL)
-            )
-            const recipientTokensService = new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-            return new HogExecutorService(
-                {
-                    hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                    googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                    fetchRetries: hub.CDP_FETCH_RETRIES,
-                    fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                    fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                    emailQueueRouting,
-                    selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
-                },
-                { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                hogInputsService,
-                emailService,
-                recipientTokensService
-            )
-        }
-
-        it('should send inline when routing is empty', async () => {
-            const exec = createExecutorWithRouting('')
+        it('should route email sends to the dedicated email queue', async () => {
             const invocation = createEmailInvocation()
 
-            const result = await exec.executeWithAsyncFunctions(invocation)
-
-            expect(result.invocation.queue).not.toBe('email')
-            expect(result.finished).toBe(true)
-        })
-
-        it('should route to email queue when team matches', async () => {
-            const exec = createExecutorWithRouting('123')
-            const invocation = createEmailInvocation()
-
-            const result = await exec.executeWithAsyncFunctions(invocation)
-
-            expect(result.invocation.queue).toBe('email')
-            expect(result.finished).toBe(false)
-        })
-
-        it('should send inline when team does not match', async () => {
-            const exec = createExecutorWithRouting('456')
-            const invocation = createEmailInvocation()
-
-            const result = await exec.executeWithAsyncFunctions(invocation)
-
-            expect(result.invocation.queue).not.toBe('email')
-            expect(result.finished).toBe(true)
-        })
-
-        it('should route based on percentage when under threshold', async () => {
-            const exec = createExecutorWithRouting('*:0.5')
-            const invocation = createEmailInvocation()
-
-            jest.spyOn(Math, 'random').mockReturnValue(0.3)
-            const result = await exec.executeWithAsyncFunctions(invocation)
-
-            expect(result.invocation.queue).toBe('email')
-            expect(result.finished).toBe(false)
-        })
-
-        it('should send inline when percentage roll is above threshold', async () => {
-            const exec = createExecutorWithRouting('*:0.5')
-            const invocation = createEmailInvocation()
-
-            jest.spyOn(Math, 'random').mockReturnValue(0.7)
-            const result = await exec.executeWithAsyncFunctions(invocation)
-
-            expect(result.invocation.queue).not.toBe('email')
-        })
-
-        it('should route all teams when config is *', async () => {
-            const exec = createExecutorWithRouting('*')
-            const invocation = createEmailInvocation()
-
-            const result = await exec.executeWithAsyncFunctions(invocation)
+            const result = await executor.executeWithAsyncFunctions(invocation)
 
             expect(result.invocation.queue).toBe('email')
             expect(result.invocation.queueMetadata?.originQueue).toBeDefined()
             expect(result.finished).toBe(false)
+        })
+
+        it('should send inline when sendEmailsInline is set', async () => {
+            const invocation = createEmailInvocation()
+
+            const result = await executor.executeWithAsyncFunctions(invocation, { sendEmailsInline: true })
+
+            expect(result.invocation.queue).not.toBe('email')
+            expect(result.finished).toBe(true)
         })
     })
 })

--- a/nodejs/src/cdp/services/hog-executor.service.ts
+++ b/nodejs/src/cdp/services/hog-executor.service.ts
@@ -8,8 +8,7 @@ import { ACCESS_TOKEN_PLACEHOLDER } from '~/config/constants'
 import { FetchOptions, FetchResponse, InvalidRequestError, SecureRequestError, fetch } from '~/utils/request'
 import { tryCatch } from '~/utils/try-catch'
 
-import { buildIntegerMatcherWithPercentage } from '../../config/config'
-import { PluginsServerConfig, ValueMatcher } from '../../types'
+import { PluginsServerConfig } from '../../types'
 import { parseJSON } from '../../utils/json-parse'
 import { logger } from '../../utils/logger'
 import { TeamManager } from '../../utils/team-manager'
@@ -59,7 +58,6 @@ export interface HogExecutorConfig {
     fetchBackoffBaseMs: number
     fetchBackoffMaxMs: number
     selfLoopGuardMode: SelfLoopGuardMode
-    emailQueueRouting: string
 }
 
 export interface HogExecutorAsyncContext {
@@ -203,17 +201,13 @@ export type HogExecutorExecuteAsyncOptions = HogExecutorExecuteOptions & {
 }
 
 export class HogExecutorService {
-    private emailQueueMatcher: ValueMatcher<number>
-
     constructor(
         private config: HogExecutorConfig,
         private asyncContext: HogExecutorAsyncContext,
         private hogInputsService: HogInputsService,
         private emailService: EmailService,
         private recipientTokensService: RecipientTokensService
-    ) {
-        this.emailQueueMatcher = buildIntegerMatcherWithPercentage(config.emailQueueRouting)
-    }
+    ) {}
 
     async buildInputsWithGlobals(
         hogFunction: HogFunctionType,
@@ -369,8 +363,7 @@ export class HogExecutorService {
                 // Queue-aware routing: each worker can execute some actions inline
                 // and routes others to a specialized queue. The email worker sends
                 // emails inline but routes fetches back to hogflow. The hogflow
-                // worker does fetches inline but routes emails to the email queue
-                // (when the team is configured for it via CDP_EMAIL_QUEUE_ROUTING).
+                // worker does fetches inline but routes emails to the email queue.
                 //
                 // Future: once we add an execution time budget, the email worker
                 // will also handle fetches inline. The only reason to reschedule
@@ -386,13 +379,9 @@ export class HogExecutorService {
                         result = await this.executeFetch(nextInvocation, options)
                     }
                 } else if (queueParamsType === 'email') {
-                    // Route to the email queue only if we're not already there,
-                    // the team is configured for it, and the caller hasn't asked
-                    // for inline-only execution (e.g. the test panel).
-                    const routeToEmailQueue =
-                        invocation.queue !== 'email' &&
-                        this.emailQueueMatcher(nextInvocation.teamId) &&
-                        !options?.sendEmailsInline
+                    // Route to the email queue only if we're not already there and the
+                    // caller hasn't asked for inline-only execution (e.g. the test panel).
+                    const routeToEmailQueue = invocation.queue !== 'email' && !options?.sendEmailsInline
                     if (routeToEmailQueue) {
                         result = this.routeEmailToQueue(nextInvocation)
                     } else {

--- a/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
+++ b/nodejs/src/cdp/services/hogflows/actions/hog_function.test.ts
@@ -64,7 +64,6 @@ describe('HogFunctionHandler', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
                 selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -1871,21 +1871,25 @@ describe('Hogflow Executor', () => {
                 },
             })
 
-            // There are 4 async actions, so we need to execute multiple times until finished
+            // Each execute call returns the metrics for one queue segment, and email
+            // actions route through the dedicated email queue — so we accumulate metrics
+            // across every segment to assert the total billing over the whole run.
             let result = await executor.execute(invocation)
+            const metrics = [...result.metrics]
             while (!result.finished) {
                 result = await executor.execute(result.invocation)
+                metrics.push(...result.metrics)
             }
 
             expect(result.finished).toBe(true)
             expect(result.error).toBeUndefined()
 
             // Verify we have billing metrics for both hog functions and email actions
-            const fetchBilling = result.metrics.filter(
+            const fetchBilling = metrics.filter(
                 (m) => m.metric_kind === 'fetch' && m.metric_name === 'billable_invocation'
             )
             expect(fetchBilling).toHaveLength(2)
-            const emailBilling = result.metrics.filter(
+            const emailBilling = metrics.filter(
                 (m) => m.metric_kind === 'email' && m.metric_name === 'billable_invocation'
             )
             expect(emailBilling).toHaveLength(2)

--- a/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
+++ b/nodejs/src/cdp/services/hogflows/hogflow-executor.service.test.ts
@@ -84,7 +84,6 @@ describe('Hogflow Executor', () => {
                 fetchRetries: hub.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                emailQueueRouting: hub.CDP_EMAIL_QUEUE_ROUTING,
                 selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
@@ -1894,7 +1893,7 @@ describe('Hogflow Executor', () => {
     })
 
     describe('email queue routing', () => {
-        it('should route email actions to the email queue when routing is configured', async () => {
+        it('should route email actions to the email queue', async () => {
             const team = await getFirstTeam(hub.postgres)
 
             await insertIntegration(hub.postgres, team.id, {
@@ -1934,42 +1933,6 @@ describe('Hogflow Executor', () => {
                 ],
             })
 
-            // Create executor with email queue routing enabled for all teams
-            const routingExecutor = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                            emailQueueRouting: '*',
-                            selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            new TeamWorkflowsConfigService(hub.postgres),
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL,
-                            new EmailTrackingCodeSigner(hub.ENCRYPTION_SALT_KEYS, hub.CDP_EMAIL_TRACKING_URL)
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
-            )
-
             const hogFlow = new FixtureHogFlowBuilder()
                 .withTeamId(team.id)
                 .withExitCondition('exit_only_at_end')
@@ -2014,7 +1977,7 @@ describe('Hogflow Executor', () => {
                 },
             })
 
-            const result = await routingExecutor.execute(invocation)
+            const result = await executor.execute(invocation)
 
             // Should be routed to email queue, not finished
             expect(result.finished).toBe(false)
@@ -2022,76 +1985,6 @@ describe('Hogflow Executor', () => {
             expect(result.invocation.queueMetadata?.originQueue).toBeDefined()
             expect(result.invocation.queueParameters).toBeDefined()
             expect(result.invocation.queueParameters?.type).toBe('email')
-        })
-
-        it('should send email inline when routing is not configured', async () => {
-            const team = await getFirstTeam(hub.postgres)
-
-            await insertIntegration(hub.postgres, team.id, {
-                id: 1,
-                kind: 'email',
-                config: {
-                    email: 'test@posthog.com',
-                    name: 'Test User',
-                    domain: 'posthog.com',
-                    verified: true,
-                    provider: 'maildev',
-                },
-            })
-
-            const hogFlow = new FixtureHogFlowBuilder()
-                .withTeamId(team.id)
-                .withExitCondition('exit_only_at_end')
-                .withWorkflow({
-                    actions: {
-                        trigger: {
-                            type: 'trigger',
-                            config: {
-                                type: 'event',
-                                filters: HOG_FILTERS_EXAMPLES.no_filters.filters ?? {},
-                            },
-                        },
-                        email_1: {
-                            type: 'function_email',
-                            config: {
-                                template_id: 'template-email-routing-test',
-                                inputs: {
-                                    email: {
-                                        value: {
-                                            to: { email: 'recipient@example.com', name: 'Recipient' },
-                                            from: { integrationId: 1, email: 'test@posthog.com' },
-                                            subject: 'Test Email',
-                                            text: 'Test',
-                                            html: '<p>Test</p>',
-                                        },
-                                    },
-                                },
-                            },
-                        },
-                    },
-                    edges: [
-                        { from: 'trigger', to: 'email_1', type: 'continue' },
-                        { from: 'email_1', to: 'exit', type: 'continue' },
-                    ],
-                })
-                .build()
-
-            const invocation = createExampleHogFlowInvocation(hogFlow, {
-                event: {
-                    ...createHogExecutionGlobals().event,
-                    event: '$pageview',
-                },
-            })
-
-            // Default executor has emailQueueRouting = '' (inline)
-            let result = await executor.execute(invocation)
-            while (!result.finished) {
-                result = await executor.execute(result.invocation)
-            }
-
-            // Should send inline and complete
-            expect(result.finished).toBe(true)
-            expect(result.invocation.queue).not.toBe('email')
         })
 
         it('should complete the full round-trip: hogflow → email queue → email sent → workflow continues', async () => {
@@ -2133,78 +2026,6 @@ describe('Hogflow Executor', () => {
                     },
                 ],
             })
-
-            // Executor with routing enabled (simulates hogflow worker)
-            const hogflowExecutor = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                            emailQueueRouting: '*',
-                            selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            new TeamWorkflowsConfigService(hub.postgres),
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL,
-                            new EmailTrackingCodeSigner(hub.ENCRYPTION_SALT_KEYS, hub.CDP_EMAIL_TRACKING_URL)
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
-            )
-
-            // Executor with no routing (simulates email worker — emails are inline)
-            const emailExecutor = new HogFlowExecutorService(
-                new HogFlowFunctionsService(
-                    hub.SITE_URL,
-                    new HogFunctionTemplateManagerService(hub.postgres),
-                    new HogExecutorService(
-                        {
-                            hogCostTimingUpperMs: hub.CDP_WATCHER_HOG_COST_TIMING_UPPER_MS,
-                            googleAdwordsDeveloperToken: hub.CDP_GOOGLE_ADWORDS_DEVELOPER_TOKEN,
-                            fetchRetries: hub.CDP_FETCH_RETRIES,
-                            fetchBackoffBaseMs: hub.CDP_FETCH_BACKOFF_BASE_MS,
-                            fetchBackoffMaxMs: hub.CDP_FETCH_BACKOFF_MAX_MS,
-                            emailQueueRouting: '',
-                            selfLoopGuardMode: hub.CDP_SELF_LOOP_GUARD_MODE,
-                        },
-                        { teamManager: hub.teamManager, siteUrl: hub.SITE_URL },
-                        new HogInputsService(hub.integrationManager, hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL),
-                        new EmailService(
-                            {
-                                sesAccessKeyId: hub.SES_ACCESS_KEY_ID,
-                                sesSecretAccessKey: hub.SES_SECRET_ACCESS_KEY,
-                                sesRegion: hub.SES_REGION,
-                                sesEndpoint: hub.SES_ENDPOINT,
-                            },
-                            hub.integrationManager,
-                            new TeamWorkflowsConfigService(hub.postgres),
-                            hub.ENCRYPTION_SALT_KEYS,
-                            hub.SITE_URL,
-                            new EmailTrackingCodeSigner(hub.ENCRYPTION_SALT_KEYS, hub.CDP_EMAIL_TRACKING_URL)
-                        ),
-                        new RecipientTokensService(hub.ENCRYPTION_SALT_KEYS, hub.SITE_URL)
-                    )
-                ),
-                new RecipientPreferencesService(new RecipientsManagerService(hub.postgres))
-            )
 
             const hogFlow = new FixtureHogFlowBuilder()
                 .withTeamId(team.id)
@@ -2254,16 +2075,16 @@ describe('Hogflow Executor', () => {
                 },
             })
 
-            // Step 1: Hogflow worker executes — should route to email queue
-            const hogflowResult = await hogflowExecutor.execute(invocation)
+            // Step 1: Hogflow worker executes (queue !== 'email') — should route to email queue
+            const hogflowResult = await executor.execute(invocation)
             expect(hogflowResult.finished).toBe(false)
             expect(hogflowResult.invocation.queue).toBe('email')
             expect(hogflowResult.invocation.queueParameters?.type).toBe('email')
 
-            // Step 2: Email worker picks up the job — should send the email and continue
-            let emailResult = await emailExecutor.execute(hogflowResult.invocation)
+            // Step 2: Email worker picks up the job (queue === 'email') — should send inline and continue
+            let emailResult = await executor.execute(hogflowResult.invocation)
             while (!emailResult.finished) {
-                emailResult = await emailExecutor.execute(emailResult.invocation)
+                emailResult = await executor.execute(emailResult.invocation)
             }
 
             // Workflow should complete

--- a/nodejs/src/cdp/templates/test/test-helpers.ts
+++ b/nodejs/src/cdp/templates/test/test-helpers.ts
@@ -211,7 +211,6 @@ export class TemplateTester {
                 fetchRetries: config.CDP_FETCH_RETRIES,
                 fetchBackoffBaseMs: config.CDP_FETCH_BACKOFF_BASE_MS,
                 fetchBackoffMaxMs: config.CDP_FETCH_BACKOFF_MAX_MS,
-                emailQueueRouting: config.CDP_EMAIL_QUEUE_ROUTING,
                 selfLoopGuardMode: config.CDP_SELF_LOOP_GUARD_MODE,
             },
             { teamManager: undefined as any, siteUrl: config.SITE_URL },

--- a/nodejs/src/cdp/workflows-e2e.test.ts
+++ b/nodejs/src/cdp/workflows-e2e.test.ts
@@ -1538,8 +1538,6 @@ describe('Workflows E2E (email queue)', () => {
         await cyclotronPool.query('DELETE FROM cyclotron_jobs')
 
         hub = await createHub()
-        // Route all teams' emails through the dedicated queue
-        hub.CDP_EMAIL_QUEUE_ROUTING = '*'
         hub.CDP_CYCLOTRON_BATCH_DELAY_MS = 50
 
         kafkaProducer = await ActualKafkaProducerWrapper.create(hub.KAFKA_CLIENT_RACK)


### PR DESCRIPTION
## Problem

Email queue routing was gated behind the `CDP_EMAIL_QUEUE_ROUTING` server config — a per-team / percentage matcher used to gradually roll out routing email sends through the dedicated email queue. That rollout is now complete (all teams, `*`), so the matcher always evaluates to `true` and the per-team gating is dead code.

## Changes

Remove the now-vestigial flag and everything that fed it:

- Drop the `CDP_EMAIL_QUEUE_ROUTING` config key (type, default, and the `CdpCoreServicesConfig` union member).
- Remove the `emailQueueMatcher` field and its `buildIntegerMatcherWithPercentage(...)` construction from `HogExecutorService`, plus the `emailQueueRouting` field on `HogExecutorConfig` and the three factory wire-ups (core services, hog transformer, test helpers).
- Simplify the routing condition in `executeWithAsyncFunctions` to `invocation.queue !== 'email' && !options?.sendEmailsInline`.

Behavior is unchanged from the fully-rolled-out state: email sends always route to the dedicated queue unless the invocation is already on the email queue (the email worker sending inline) or the caller asks for inline delivery (`sendEmailsInline`, used by the test panel). The shared `buildIntegerMatcherWithPercentage` helper stays — it's used elsewhere.

Tests were updated to match: the per-team/percentage matching tests are gone (that behavior no longer exists), replaced with coverage of the two remaining paths (default routing + inline bypass). The round-trip e2e tests now drive both the hogflow-worker and email-worker steps through a single executor, since the inline-on-email-worker behavior now comes from `invocation.queue === 'email'` rather than a separate routing config.

## How did you test this code?

I'm an agent (PostHog Code). I ran the affected suites locally against the dev infra (Postgres + Kafka up):

- `hog-executor.service.test.ts` — "email queue routing" — 2 passed
- `hogflow-executor.service.test.ts` — "email queue routing" — 2 passed
- `cdp-api.test.ts` — test-panel inline bypass — 1 passed
- `workflows-e2e.test.ts` — full suite — 55 passed, 11 skipped

`tsc --noEmit` is clean for all touched files (the only remaining errors are a pre-existing unbuilt `@posthog/cyclotron` native module in a file this PR doesn't touch). ESLint clean on all touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). The human driver asked to verify whether removing the fully-rolled-out `CDP_EMAIL_QUEUE_ROUTING` flag left dead code in the workflows/CDP path, then to clean it up.

Approach: traced every reference (it turned out to be a Node.js server config, not a PostHog feature flag, and lives entirely under `nodejs/src/cdp/`), confirmed the matcher term was the only thing the flag gated, and verified the surrounding `else` branch is still live (it serves the email-worker and test-panel paths). Removed the flag and its plumbing, simplified the conditional, and rewrote the tests that existed only to exercise per-team/percentage matching. No skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
