### PR TITLE
fix(dashboards): stop stale tile re-render from reverting display option saves

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -235,6 +235,47 @@ describe('insightDataLogic', () => {
                 }).mount()
             }).toMatchValues({ query: updatedCachedQuery })
         })
+
+        // On a dashboard tile, `setQuery` is shared with insightVizDataLogic, whose listener calls
+        // props.setQuery (persistDisplayOptions). If a tile re-render re-syncs the incoming cached
+        // query via setQuery, it loops back into a PATCH of that (stale) query, reverting a display
+        // option the user just saved. propsChanged must use syncQueryFromProps on dashboard tiles.
+        it('syncs a changed cached query via syncQueryFromProps, not setQuery, on a dashboard tile', async () => {
+            const localUpdatedQuery = buildLocalUpdatedQuery()
+            const staleCachedQuery: InsightVizNode = {
+                ...baseQuery,
+                source: {
+                    ...baseQuery.source,
+                    dateRange: {
+                        ...baseQuery.source.dateRange,
+                        date_from: '-14d',
+                    },
+                },
+            }
+
+            const logic = insightDataLogic({
+                dashboardItemId: Insight123,
+                dashboardId: 99,
+                cachedInsight: { short_id: Insight123, query: baseQuery } as any,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setQuery(localUpdatedQuery)
+            }).toMatchValues({ query: localUpdatedQuery })
+
+            await expectLogic(logic, () => {
+                insightDataLogic({
+                    dashboardItemId: Insight123,
+                    dashboardId: 99,
+                    cachedInsight: { short_id: Insight123, query: staleCachedQuery } as any,
+                    loadPriority: 1,
+                }).mount()
+            })
+                .toDispatchActions(['syncQueryFromProps'])
+                .toNotHaveDispatchedActions(['setQuery'])
+                .toMatchValues({ query: staleCachedQuery })
+        })
     })
 
     describe('reacts when the insight changes', () => {

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -423,14 +423,20 @@ export const insightDataLogic = kea<insightDataLogicType>([
         if (!cachedQueryChanged) {
             return
         }
+        // On dashboard tiles props.setQuery persists edits, and `setQuery` is shared with
+        // insightVizDataLogic whose listener calls props.setQuery — so re-syncing a stale incoming
+        // cached query (e.g. from a tile results refresh) via setQuery loops back and PATCHes it,
+        // reverting a just-saved display option. syncQueryFromProps updates local state without the
+        // loop. The insight scene keeps setQuery for its URL/draft sync.
+        const syncCachedQuery = props.dashboardId != null ? actions.syncQueryFromProps : actions.setQuery
         try {
             if (!objectsEqual(props.cachedInsight.query, values.query)) {
-                actions.setQuery(props.cachedInsight.query)
+                syncCachedQuery(props.cachedInsight.query)
             }
         } catch {
             // values.query can throw if the logic's state isn't in the store yet
             // (e.g. when InsightCard rebuilds the logic during navigation)
-            actions.setQuery(props.cachedInsight.query)
+            syncCachedQuery(props.cachedInsight.query)
         }
     }),
     afterMount(({ actions, props }) => {


### PR DESCRIPTION
## Problem

Changing a display option (chart type, trend lines, legend, etc.) from a dashboard tile's ⋯ menu didn't persist. The card updated optimistically and showed an "Insight updated" toast, but opening the insight or refreshing showed the old value — the change never made it to the database.

Root cause is a save-then-revert race. The real PATCH saves the new query (the response even echoes it back), but a second PATCH carrying the **pre-edit** query lands right after and overwrites it. That stale write comes from `insightDataLogic.propsChanged`: when a dashboard tile re-renders (e.g. a results refresh) and pushes an incoming cached query, propsChanged re-synced it via `setQuery`. Because `setQuery` is a **shared connected action** with `insightVizDataLogic` — whose listener calls `props.setQuery` — that sync looped back into `persistDisplayOptions`, PATCHing the stale query.

This loop was dormant until recently: dashboard tiles had no `setQuery` wired, so `props.setQuery` was a no-op. The dashboard-card display-options feature wired `setQuery: persistDisplayOptions` into tiles, which armed it. (`query` isn't a material field, so `last_modified_at` never moved — which is why this looked like nothing was saving at all.)

## Changes

In `propsChanged`, the dashboard-tile branch now syncs an incoming cached query via `syncQueryFromProps` instead of `setQuery`. `syncQueryFromProps` updates local state through the reducer and is **not** a shared action, so it can't loop back into `props.setQuery` / a persist. The ad-hoc branch directly above already does exactly this for the same reason. The insight scene (no `dashboardId`) keeps `setQuery` so its URL/draft sync is untouched.

## How did you test this code?

I'm an agent (PostHog Code, Claude Opus 4.8), human-directed. Automated tests only — I did not perform manual UI testing.

Added a regression test in `insightDataLogic.test.ts` (`cached insight query sync` block): it simulates a local display-option edit on a dashboard tile, then a stale tile re-render, and asserts `propsChanged` dispatches `syncQueryFromProps` and **not** `setQuery`. No existing test caught this because the existing cached-query-sync coverage runs without a `dashboardId`, so it never exercised the path where `setQuery` loops back into a persist.

Verified the test fails with the fix reverted and passes with it; the full `insightDataLogic.test.ts` suite (18 tests) is green. Diagnosis was also confirmed against production: the PATCH response echoed `showTrendLines: true` while the stored insight held `showTrendLines: false`, proving a later write reverted it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus 4.8), directed by @sampennington.
- Diagnosis path: traced a "Failed to update insight" report to client-side read-only mode (separate, not in this PR), then a "changes don't persist" report to this stale-resync loop. Confirmed empirically via the insight's PATCH request body, PATCH response, persisted DB state, and activity log (bursts of writes per single toggle).
- Decision: gated on `props.dashboardId != null` rather than `props.setQuery` so all dashboard-tile syncs avoid the loop while the insight scene's `setQuery` side effects (URL/draft) stay intact. Considered guarding inside `persistDisplayOptions` instead, but the correct invariant is "a props-in sync must never trigger a persist", which belongs in `propsChanged`.
- No repo skills were invoked for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
