### PR TITLE
feat(signup): update signup page subtitle copy

### DIFF
--- a/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
+++ b/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
@@ -57,7 +57,7 @@ function SignupEmailPanel(): JSX.Element {
 
     return (
         <PaperDeskCard footer={footer}>
-            <CardTitle title="Get started" sub="No credit card. No sales call. Just hogs." />
+            <CardTitle title="Get started" sub="Make your product self-driving." />
             <Form logic={signupLogic} formKey="signupPanelEmail" enableFormOnSubmit className="flex flex-col gap-4">
                 <RegionField />
                 <LemonField


### PR DESCRIPTION
## Problem

The signup page subtitle copy ("No credit card. No sales call. Just hogs.") wasn't landing the value proposition we want new users to see.

Closes GROW-49

## Changes

Update the signup card subtitle from "No credit card. No sales call. Just hogs." to "Make your product self-driving." in the paper-desk signup variant.

## How did you test this code?

I'm an agent. This is a one-line copy change to a static `sub` prop on `CardTitle`; no automated tests were added or run.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Fernando directed this copy change from Linear issue GROW-49. Found the single occurrence of the old subtitle in `PaperDeskSignup.tsx` and swapped it. No skills were needed — pure static copy edit, no API/serializer/migration surface touched.
