### PR TITLE
feat(signals): show scout description in inbox

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -58,6 +58,10 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
                 <>
                     <ScoutRowCard config={config} rollup={rollup} onUpdate={updateScoutConfig} asHeader />
 
+                    {config.description ? (
+                        <p className="text-sm text-secondary leading-snug mb-0 max-w-3xl">{config.description}</p>
+                    ) : null}
+
                     <div className="flex flex-col gap-1">
                         <span className="text-xs font-medium text-default uppercase tracking-wide">
                             Last {SCOUT_RUNS_WINDOW_SPAN}

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -56,7 +56,9 @@ export function ScoutRowCard({
                             <Tooltip
                                 title={
                                     <div className="flex flex-col gap-1 max-w-sm">
-                                        {config.description ? <span>{config.description}</span> : null}
+                                        {config.description ? (
+                                            <span className="line-clamp-6">{config.description}</span>
+                                        ) : null}
                                         <span className="text-muted">{config.skill_name} · view scout</span>
                                     </div>
                                 }

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRowCard.tsx
@@ -53,7 +53,14 @@ export function ScoutRowCard({
                             // trailing badges — truncate should clip to an ellipsis, never vanish.
                             <span className="truncate font-medium text-sm min-w-[6rem]">{displayName}</span>
                         ) : (
-                            <Tooltip title={`${config.skill_name} · view scout`}>
+                            <Tooltip
+                                title={
+                                    <div className="flex flex-col gap-1 max-w-sm">
+                                        {config.description ? <span>{config.description}</span> : null}
+                                        <span className="text-muted">{config.skill_name} · view scout</span>
+                                    </div>
+                                }
+                            >
                                 <Link
                                     to={urls.inboxScout(config.skill_name)}
                                     // The fleet list lives in the setup modal, which portals outside the

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -205,6 +205,8 @@ export interface SignalScoutConfig {
     id: string
     /** The `signals-scout-*` skill this config controls. Fixed at creation. */
     skill_name: string
+    /** What this scout investigates, sourced from the skill's `description` metadata. Empty if absent. */
+    description: string
     /** Whether this scout runs on its schedule. */
     enabled: boolean
     /** Whether the scout writes findings to the inbox. false = dry-run. */


### PR DESCRIPTION
## Problem

The inbox surfaces scouts by name, badge, cadence, and run history — but never says *what a scout actually watches for*. The skill's `description` metadata (e.g. *"Watches `$exception` bursts, stuck loops, multi-fingerprint clusters…"*) is already returned by `SignalScoutConfigSerializer`, but the frontend dropped it on the floor. You had to open the underlying skill to find out what a scout does.

## Changes

Wire the existing `description` field into the inbox UI in two places:

- **Scout detail page** — a muted paragraph under the header card, above the run rollup. Renders nothing when a scout has no description, so scouts without one don't show an empty gap.
- **Fleet list modal** — the description shows on hover as a tooltip on the scout name, with the existing `skill_name · view scout` affordance demoted to a muted line beneath it.

No backend or codegen changes: `description` is already on the serializer and flows straight through `api.signalScout.configs.list()`. The only data change is adding `description: string` to the handwritten `SignalScoutConfig` frontend type.

## How did you test this code?

I'm an agent (Claude Code). Automated checks only — no manual UI testing:

- `oxlint` on the three touched files: 0 warnings, 0 errors.
- `tsc` typecheck: no new errors from these changes (the touched files only show the repo-wide stale kea `*LogicType` artifacts that predate this PR).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this: we sketched a few ASCII layout options for where the description should live, and landed on a muted paragraph on the detail page plus a hover tooltip in the fleet list modal.

- Tool: Claude Code (Opus 4.8).
- Explored the inbox/scout frontend to confirm the field was already on the backend serializer but missing from the handwritten `SignalScoutConfig` type — so this is a pure frontend wire-up, no `hogli build:openapi` needed.
- Gated the tooltip change to the non-header (`asHeader === false`) render path so the detail-page header doesn't get a redundant tooltip stacked on top of the visible paragraph.
- Known follow-up: every scout's description shares a boilerplate tail (*"Emits findings only when they clear the confidence bar…"*). Shown verbatim here; trimming it in the fleet tooltip is a one-line change if it reads noisy.
