### PR TITLE
fix(kafka): honor disabled auto commits

### DIFF
--- a/rust/common/kafka/src/kafka_consumer.rs
+++ b/rust/common/kafka/src/kafka_consumer.rs
@@ -86,8 +86,12 @@ impl SingleTopicConsumer {
                 .set("enable.ssl.certificate.verification", "false");
         };
 
+        client_config.set(
+            "enable.auto.commit",
+            consumer_config.kafka_consumer_auto_commit.to_string(),
+        );
         if consumer_config.kafka_consumer_auto_commit {
-            client_config.set("enable.auto.commit", "true").set(
+            client_config.set(
                 "auto.commit.interval.ms",
                 consumer_config
                     .kafka_consumer_auto_commit_interval_ms


### PR DESCRIPTION
## Problem

Rust services can configure `ConsumerConfig` with `kafka_consumer_auto_commit=false`, but the shared Kafka consumer only wrote `enable.auto.commit=true` when the value was true. That left disabled auto-commit relying on librdkafka defaults instead of the config contract.

## Changes

- Always pass `enable.auto.commit` from `ConsumerConfig` into librdkafka.
- Keep `auto.commit.interval.ms` only for consumers that enable auto-commit.
- Checked the charts repo for `KAFKA_CONSUMER_AUTO_COMMIT` usage. Existing chart values do not set it directly; consumers that already request auto-commit continue to do so, while consumers that request manual commits now get explicit librdkafka config.

## How did you test this code?

Automated tests run by the agent:

```bash
flox activate -- bash -c 'cargo fmt && cargo check -p common-kafka'
```

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this aligns runtime behavior with the existing Rust consumer config contract.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the pi coding agent. Skills invoked: `/pr`.

The change was split out from the Cymbal notifications work after reviewing the shared Kafka consumer behavior and chart usage. The intent is to make `kafka_consumer_auto_commit=false` deterministic for existing manual-commit consumers without changing services that explicitly enable auto-commit.