### PR TITLE
fix(mcp-analytics): classify SDK $mcp_client_name harness

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -915,6 +915,12 @@
                 },
                 {
                     "$ref": "#/definitions/MCPHarnessBreakdownQuery"
+                },
+                {
+                    "$ref": "#/definitions/MCPToolTopUsersQuery"
+                },
+                {
+                    "$ref": "#/definitions/MCPToolFailuresQuery"
                 }
             ]
         },
@@ -7838,6 +7844,178 @@
                 "results": {
                     "items": {
                         "$ref": "#/definitions/MCPHarnessBreakdownItem"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedMCPToolFailuresQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/MCPToolFailureItem"
+                    },
+                    "type": "array"
+                },
+                "timezone": {
+                    "type": "string"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": [
+                "cache_key",
+                "is_cached",
+                "last_refresh",
+                "next_allowed_client_refresh",
+                "results",
+                "timezone"
+            ],
+            "type": "object"
+        },
+        "CachedMCPToolTopUsersQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "cache_key": {
+                    "type": "string"
+                },
+                "cache_target_age": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "calculation_trigger": {
+                    "description": "What triggered the calculation of the query, leave empty if user/immediate",
+                    "type": "string"
+                },
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "is_cached": {
+                    "type": "boolean"
+                },
+                "last_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "next_allowed_client_refresh": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "query_metadata": {
+                    "type": "object"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/MCPToolTopUserItem"
                     },
                     "type": "array"
                 },
@@ -26697,6 +26875,240 @@
             "required": ["results"],
             "type": "object"
         },
+        "MCPToolFailureItem": {
+            "additionalProperties": false,
+            "description": "One row of the per-tool \"Failures\" table: an exception message paired with a tool.",
+            "properties": {
+                "harnesses": {
+                    "description": "Resolved harness labels seen for this exception, deduped and sorted.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "last_seen": {
+                    "type": "string"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "occurrences": {
+                    "$ref": "#/definitions/integer"
+                }
+            },
+            "required": ["message", "occurrences", "last_seen", "harnesses"],
+            "type": "object"
+        },
+        "MCPToolFailuresQuery": {
+            "additionalProperties": false,
+            "description": "Top exception messages paired with a single MCP tool, with server-resolved harness labels.",
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "MCPToolFailuresQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/MCPToolFailuresQueryResponse"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "toolName": {
+                    "description": "The raw $mcp_tool_name to scope $exception events to.",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["kind", "toolName"],
+            "type": "object"
+        },
+        "MCPToolFailuresQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/MCPToolFailureItem"
+                    },
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
+        "MCPToolTopUserItem": {
+            "additionalProperties": false,
+            "description": "One row of the per-tool \"Top users\" table: a user and their activity on a tool.",
+            "properties": {
+                "calls": {
+                    "$ref": "#/definitions/integer"
+                },
+                "distinct_id": {
+                    "type": "string"
+                },
+                "error_rate_pct": {
+                    "type": "number"
+                },
+                "errors": {
+                    "$ref": "#/definitions/integer"
+                },
+                "harnesses": {
+                    "description": "Resolved harness labels seen for this user, deduped and sorted.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "last_seen": {
+                    "type": "string"
+                },
+                "person_properties": {
+                    "description": "JSON-encoded person.properties for the most recent call, for display.",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "distinct_id",
+                "person_properties",
+                "calls",
+                "errors",
+                "error_rate_pct",
+                "harnesses",
+                "last_seen"
+            ],
+            "type": "object"
+        },
+        "MCPToolTopUsersQuery": {
+            "additionalProperties": false,
+            "description": "Top users of a single MCP tool over the last 7 days, with server-resolved harness labels.",
+            "properties": {
+                "dateRange": {
+                    "$ref": "#/definitions/DateRange"
+                },
+                "kind": {
+                    "const": "MCPToolTopUsersQuery",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "response": {
+                    "$ref": "#/definitions/MCPToolTopUsersQueryResponse"
+                },
+                "tags": {
+                    "$ref": "#/definitions/QueryLogTags"
+                },
+                "toolName": {
+                    "description": "The effective tool name to scope to (matched against the single-exec-resolved tool name).",
+                    "type": "string"
+                },
+                "version": {
+                    "description": "version of the node, used for schema migrations",
+                    "type": "number"
+                }
+            },
+            "required": ["kind", "toolName"],
+            "type": "object"
+        },
+        "MCPToolTopUsersQueryResponse": {
+            "additionalProperties": false,
+            "properties": {
+                "error": {
+                    "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                    "type": "string"
+                },
+                "hogql": {
+                    "description": "Generated HogQL query.",
+                    "type": "string"
+                },
+                "modifiers": {
+                    "$ref": "#/definitions/HogQLQueryModifiers",
+                    "description": "Modifiers used when performing the query"
+                },
+                "query_status": {
+                    "$ref": "#/definitions/QueryStatus",
+                    "description": "Query status indicates whether next to the provided data, a query is still running."
+                },
+                "resolved_compare_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The resolved previous/comparison period date range, when comparing against another period"
+                },
+                "resolved_date_range": {
+                    "$ref": "#/definitions/ResolvedDateRangeResponse",
+                    "description": "The date range used for the query"
+                },
+                "results": {
+                    "items": {
+                        "$ref": "#/definitions/MCPToolTopUserItem"
+                    },
+                    "type": "array"
+                },
+                "timings": {
+                    "description": "Measured timings for different parts of the query generation process",
+                    "items": {
+                        "$ref": "#/definitions/QueryTiming"
+                    },
+                    "type": "array"
+                },
+                "warnings": {
+                    "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                    "items": {
+                        "$ref": "#/definitions/DataWarehouseSyncWarning"
+                    },
+                    "type": "array"
+                }
+            },
+            "required": ["results"],
+            "type": "object"
+        },
         "MarkdownBlock": {
             "additionalProperties": false,
             "properties": {
@@ -29693,6 +30105,8 @@
                 "EndpointsUsageTableQuery",
                 "EndpointsUsageTrendsQuery",
                 "MCPHarnessBreakdownQuery",
+                "MCPToolTopUsersQuery",
+                "MCPToolFailuresQuery",
                 "PropertyValuesQuery"
             ],
             "type": "string"
@@ -37130,6 +37544,108 @@
                         },
                         "results": {
                             "items": {
+                                "$ref": "#/definitions/MCPToolTopUserItem"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_compare_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The resolved previous/comparison period date range, when comparing against another period"
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {
+                                "$ref": "#/definitions/MCPToolFailureItem"
+                            },
+                            "type": "array"
+                        },
+                        "timings": {
+                            "description": "Measured timings for different parts of the query generation process",
+                            "items": {
+                                "$ref": "#/definitions/QueryTiming"
+                            },
+                            "type": "array"
+                        },
+                        "warnings": {
+                            "description": "Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries.",
+                            "items": {
+                                "$ref": "#/definitions/DataWarehouseSyncWarning"
+                            },
+                            "type": "array"
+                        }
+                    },
+                    "required": ["results"],
+                    "type": "object"
+                },
+                {
+                    "additionalProperties": false,
+                    "properties": {
+                        "error": {
+                            "description": "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise.",
+                            "type": "string"
+                        },
+                        "hogql": {
+                            "description": "Generated HogQL query.",
+                            "type": "string"
+                        },
+                        "modifiers": {
+                            "$ref": "#/definitions/HogQLQueryModifiers",
+                            "description": "Modifiers used when performing the query"
+                        },
+                        "query_status": {
+                            "$ref": "#/definitions/QueryStatus",
+                            "description": "Query status indicates whether next to the provided data, a query is still running."
+                        },
+                        "resolved_compare_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The resolved previous/comparison period date range, when comparing against another period"
+                        },
+                        "resolved_date_range": {
+                            "$ref": "#/definitions/ResolvedDateRangeResponse",
+                            "description": "The date range used for the query"
+                        },
+                        "results": {
+                            "items": {
                                 "$ref": "#/definitions/PropertyValueItem"
                             },
                             "type": "array"
@@ -37398,6 +37914,12 @@
                 },
                 {
                     "$ref": "#/definitions/MCPHarnessBreakdownQuery"
+                },
+                {
+                    "$ref": "#/definitions/MCPToolTopUsersQuery"
+                },
+                {
+                    "$ref": "#/definitions/MCPToolFailuresQuery"
                 },
                 {
                     "$ref": "#/definitions/PropertyValuesQuery"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -194,6 +194,8 @@ export enum NodeKind {
 
     // MCP analytics
     MCPHarnessBreakdownQuery = 'MCPHarnessBreakdownQuery',
+    MCPToolTopUsersQuery = 'MCPToolTopUsersQuery',
+    MCPToolFailuresQuery = 'MCPToolFailuresQuery',
 
     // Property values
     PropertyValuesQuery = 'PropertyValuesQuery',
@@ -259,6 +261,8 @@ export type AnyDataNode =
     | EndpointsUsageTableQuery
     | EndpointsUsageTrendsQuery
     | MCPHarnessBreakdownQuery
+    | MCPToolTopUsersQuery
+    | MCPToolFailuresQuery
 
 /**
  * @discriminator kind
@@ -371,6 +375,8 @@ export type QuerySchema =
 
     // MCP analytics
     | MCPHarnessBreakdownQuery
+    | MCPToolTopUsersQuery
+    | MCPToolFailuresQuery
 
     // Property values
     | PropertyValuesQuery
@@ -2536,6 +2542,56 @@ export interface MCPHarnessBreakdownQuery extends DataNode<MCPHarnessBreakdownQu
 }
 
 export type CachedMCPHarnessBreakdownQueryResponse = CachedQueryResponse<MCPHarnessBreakdownQueryResponse>
+
+/** One row of the per-tool "Top users" table: a user and their activity on a tool. */
+export interface MCPToolTopUserItem {
+    distinct_id: string
+    /** JSON-encoded person.properties for the most recent call, for display. */
+    person_properties: string
+    calls: integer
+    errors: integer
+    error_rate_pct: number
+    /** Resolved harness labels seen for this user, deduped and sorted. */
+    harnesses: string[]
+    last_seen: string
+}
+
+export interface MCPToolTopUsersQueryResponse extends AnalyticsQueryResponseBase {
+    results: MCPToolTopUserItem[]
+}
+
+/** Top users of a single MCP tool over the last 7 days, with server-resolved harness labels. */
+export interface MCPToolTopUsersQuery extends DataNode<MCPToolTopUsersQueryResponse> {
+    kind: NodeKind.MCPToolTopUsersQuery
+    /** The effective tool name to scope to (matched against the single-exec-resolved tool name). */
+    toolName: string
+    dateRange?: DateRange
+}
+
+export type CachedMCPToolTopUsersQueryResponse = CachedQueryResponse<MCPToolTopUsersQueryResponse>
+
+/** One row of the per-tool "Failures" table: an exception message paired with a tool. */
+export interface MCPToolFailureItem {
+    message: string
+    occurrences: integer
+    last_seen: string
+    /** Resolved harness labels seen for this exception, deduped and sorted. */
+    harnesses: string[]
+}
+
+export interface MCPToolFailuresQueryResponse extends AnalyticsQueryResponseBase {
+    results: MCPToolFailureItem[]
+}
+
+/** Top exception messages paired with a single MCP tool, with server-resolved harness labels. */
+export interface MCPToolFailuresQuery extends DataNode<MCPToolFailuresQueryResponse> {
+    kind: NodeKind.MCPToolFailuresQuery
+    /** The raw $mcp_tool_name to scope $exception events to. */
+    toolName: string
+    dateRange?: DateRange
+}
+
+export type CachedMCPToolFailuresQueryResponse = CachedQueryResponse<MCPToolFailuresQueryResponse>
 
 export enum WebStatsBreakdown {
     Page = 'Page',

--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -44,6 +44,8 @@ from posthog.schema import (
     MarketingAnalyticsAggregatedQuery,
     MarketingAnalyticsTableQuery,
     MCPHarnessBreakdownQuery,
+    MCPToolFailuresQuery,
+    MCPToolTopUsersQuery,
     NodeKind,
     PathsQuery,
     PropertyGroupFilter,
@@ -310,6 +312,8 @@ RunnableQueryNode = Union[
     EndpointsUsageTableQuery,
     EndpointsUsageTrendsQuery,
     MCPHarnessBreakdownQuery,
+    MCPToolTopUsersQuery,
+    MCPToolFailuresQuery,
 ]
 
 
@@ -944,6 +948,28 @@ def get_query_runner(
 
         return MCPHarnessBreakdownQueryRunner(
             query=cast(MCPHarnessBreakdownQuery | dict[str, Any], query),
+            team=team,
+            timings=timings,
+            limit_context=limit_context,
+            modifiers=modifiers,
+            user=user,
+        )
+    if kind == "MCPToolTopUsersQuery":
+        from products.mcp_analytics.backend.facade.queries import MCPToolTopUsersQueryRunner
+
+        return MCPToolTopUsersQueryRunner(
+            query=cast(MCPToolTopUsersQuery | dict[str, Any], query),
+            team=team,
+            timings=timings,
+            limit_context=limit_context,
+            modifiers=modifiers,
+            user=user,
+        )
+    if kind == "MCPToolFailuresQuery":
+        from products.mcp_analytics.backend.facade.queries import MCPToolFailuresQueryRunner
+
+        return MCPToolFailuresQueryRunner(
+            query=cast(MCPToolFailuresQuery | dict[str, Any], query),
             team=team,
             timings=timings,
             limit_context=limit_context,

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5678,6 +5678,38 @@ class MCPHarnessBreakdownItem(BaseModel):
     total_calls: int
 
 
+class MCPToolFailureItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    harnesses: list[str] = Field(
+        ...,
+        description=("Resolved harness labels seen for this exception, deduped and sorted."),
+    )
+    last_seen: str
+    message: str
+    occurrences: int
+
+
+class MCPToolTopUserItem(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    calls: int
+    distinct_id: str
+    error_rate_pct: float
+    errors: int
+    harnesses: list[str] = Field(
+        ...,
+        description="Resolved harness labels seen for this user, deduped and sorted.",
+    )
+    last_seen: str
+    person_properties: str = Field(
+        ...,
+        description=("JSON-encoded person.properties for the most recent call, for display."),
+    )
+
+
 class MarketingAnalyticsItem(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -10786,6 +10818,110 @@ class CachedMCPHarnessBreakdownQueryResponse(BaseModel):
         default=None, description="The date range used for the query"
     )
     results: list[MCPHarnessBreakdownItem]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class CachedMCPToolFailuresQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None,
+        description=("What triggered the calculation of the query, leave empty if user/immediate"),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolFailureItem]
+    timezone: str
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class CachedMCPToolTopUsersQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    cache_key: str
+    cache_target_age: AwareDatetime | None = None
+    calculation_trigger: str | None = Field(
+        default=None,
+        description=("What triggered the calculation of the query, leave empty if user/immediate"),
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    is_cached: bool
+    last_refresh: AwareDatetime
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    next_allowed_client_refresh: AwareDatetime
+    query_metadata: dict[str, Any] | None = None
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolTopUserItem]
     timezone: str
     timings: list[QueryTiming] | None = Field(
         default=None,
@@ -16277,6 +16413,88 @@ class MCPHarnessBreakdownQueryResponse(BaseModel):
     )
 
 
+class MCPToolFailuresQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolFailureItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class MCPToolTopUsersQueryResponse(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolTopUserItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
 class MarketingAnalyticsAggregatedQueryResponse(BaseModel):
     model_config = ConfigDict(
         extra="forbid",
@@ -20082,6 +20300,88 @@ class QueryResponseAlternative97(BaseModel):
     resolved_date_range: ResolvedDateRangeResponse | None = Field(
         default=None, description="The date range used for the query"
     )
+    results: list[MCPToolTopUserItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class QueryResponseAlternative98(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
+    results: list[MCPToolFailureItem]
+    timings: list[QueryTiming] | None = Field(
+        default=None,
+        description=("Measured timings for different parts of the query generation process"),
+    )
+    warnings: list[DataWarehouseSyncWarning] | None = Field(
+        default=None,
+        description=(
+            "Warnings about data warehouse sources referenced by the query whose latest"
+            " sync failed, is paused, hit a billing limit, or is otherwise stale."
+            " Results may not reflect current source data. Accumulated across every"
+            " HogQL execution that contributes to this response — so insights backed by"
+            " warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw"
+            " HogQL queries."
+        ),
+    )
+
+
+class QueryResponseAlternative99(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    error: str | None = Field(
+        default=None,
+        description=(
+            "Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise."
+        ),
+    )
+    hogql: str | None = Field(default=None, description="Generated HogQL query.")
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    query_status: QueryStatus | None = Field(
+        default=None,
+        description=("Query status indicates whether next to the provided data, a query is still running."),
+    )
+    resolved_compare_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None,
+        description=("The resolved previous/comparison period date range, when comparing against another period"),
+    )
+    resolved_date_range: ResolvedDateRangeResponse | None = Field(
+        default=None, description="The date range used for the query"
+    )
     results: list[PropertyValueItem]
     timings: list[QueryTiming] | None = Field(
         default=None,
@@ -22411,6 +22711,35 @@ class MCPHarnessBreakdownQuery(BaseModel):
     ) = None
     response: MCPHarnessBreakdownQueryResponse | None = None
     tags: QueryLogTags | None = None
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class MCPToolFailuresQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    kind: Literal["MCPToolFailuresQuery"] = "MCPToolFailuresQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: MCPToolFailuresQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    toolName: str = Field(..., description="The raw $mcp_tool_name to scope $exception events to.")
+    version: float | None = Field(default=None, description="version of the node, used for schema migrations")
+
+
+class MCPToolTopUsersQuery(BaseModel):
+    model_config = ConfigDict(
+        extra="forbid",
+    )
+    dateRange: DateRange | None = None
+    kind: Literal["MCPToolTopUsersQuery"] = "MCPToolTopUsersQuery"
+    modifiers: HogQLQueryModifiers | None = Field(default=None, description="Modifiers used when performing the query")
+    response: MCPToolTopUsersQueryResponse | None = None
+    tags: QueryLogTags | None = None
+    toolName: str = Field(
+        ...,
+        description=("The effective tool name to scope to (matched against the single-exec-resolved tool name)."),
+    )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 
@@ -25054,6 +25383,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative95
         | QueryResponseAlternative96
         | QueryResponseAlternative97
+        | QueryResponseAlternative98
+        | QueryResponseAlternative99
     ]
 ):
     root: (
@@ -25150,6 +25481,8 @@ class QueryResponseAlternative(
         | QueryResponseAlternative95
         | QueryResponseAlternative96
         | QueryResponseAlternative97
+        | QueryResponseAlternative98
+        | QueryResponseAlternative99
     )
 
 
@@ -26195,6 +26528,8 @@ class HogQLAutocomplete(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | None
     ) = Field(default=None, description="Query in whose context to validate.")
     startPosition: int = Field(..., description="Start position of the editor word")
@@ -26285,6 +26620,8 @@ class HogQLMetadata(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | None
     ) = Field(
         default=None,
@@ -26410,6 +26747,8 @@ class MaxInsightContext(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ) = Field(..., discriminator="kind")
     type: Literal["insight"] = "insight"
@@ -26532,6 +26871,8 @@ class QueryRequest(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ) = Field(
         ...,
@@ -26646,6 +26987,8 @@ class QuerySchemaRoot(
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ]
 ):
@@ -26730,6 +27073,8 @@ class QuerySchemaRoot(
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ) = Field(..., discriminator="kind")
 
@@ -26819,6 +27164,8 @@ class QueryUpgradeRequest(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ) = Field(..., discriminator="kind")
 
@@ -26908,6 +27255,8 @@ class QueryUpgradeResponse(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     ) = Field(..., discriminator="kind")
 
@@ -27174,6 +27523,8 @@ class VisualizationArtifactContent(BaseModel):
         | EndpointsUsageTableQuery
         | EndpointsUsageTrendsQuery
         | MCPHarnessBreakdownQuery
+        | MCPToolTopUsersQuery
+        | MCPToolFailuresQuery
         | PropertyValuesQuery
     )
 

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2557,6 +2557,8 @@ class NodeKind(StrEnum):
     ENDPOINTS_USAGE_TABLE_QUERY = "EndpointsUsageTableQuery"
     ENDPOINTS_USAGE_TRENDS_QUERY = "EndpointsUsageTrendsQuery"
     MCP_HARNESS_BREAKDOWN_QUERY = "MCPHarnessBreakdownQuery"
+    MCP_TOOL_TOP_USERS_QUERY = "MCPToolTopUsersQuery"
+    MCP_TOOL_FAILURES_QUERY = "MCPToolFailuresQuery"
     PROPERTY_VALUES_QUERY = "PropertyValuesQuery"
 
 

--- a/products/mcp_analytics/backend/facade/queries.py
+++ b/products/mcp_analytics/backend/facade/queries.py
@@ -6,5 +6,13 @@ mcp_analytics is tach-isolated to expose only `backend.facade.*`, so core's
 """
 
 from products.mcp_analytics.backend.hogql_queries.harness_breakdown import MCPHarnessBreakdownQueryRunner
+from products.mcp_analytics.backend.hogql_queries.tool_tables import (
+    MCPToolFailuresQueryRunner,
+    MCPToolTopUsersQueryRunner,
+)
 
-__all__ = ["MCPHarnessBreakdownQueryRunner"]
+__all__ = [
+    "MCPHarnessBreakdownQueryRunner",
+    "MCPToolFailuresQueryRunner",
+    "MCPToolTopUsersQueryRunner",
+]

--- a/products/mcp_analytics/backend/hogql_queries/base.py
+++ b/products/mcp_analytics/backend/hogql_queries/base.py
@@ -1,0 +1,48 @@
+"""Shared wiring for the MCP analytics HogQL query runners.
+
+The access gate and date-range construction are identical across every MCP
+analytics runner; keeping them here means a runner is just its query shape plus
+its harness-label SQL.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import posthoganalytics
+
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.rbac.user_access_control import UserAccessControlError
+
+if TYPE_CHECKING:
+    from posthog.schema import DateRange
+
+    from posthog.models.team import Team
+    from posthog.models.user import User
+
+# Gates these runners behind the same flag the product's DRF endpoints require, so the
+# generic /query/ endpoint can't bypass it (see PostHogFeatureFlagPermission).
+MCP_ANALYTICS_FEATURE_FLAG = "mcp-analytics"
+
+
+def validate_mcp_analytics_access(team: "Team", user: "User") -> bool:
+    org_id = str(team.organization_id)
+    enabled = posthoganalytics.feature_enabled(
+        MCP_ANALYTICS_FEATURE_FLAG,
+        str(user.distinct_id),
+        groups={"organization": org_id, "project": str(team.id)},
+        group_properties={"organization": {"id": org_id}, "project": {"id": str(team.id)}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+    if not enabled:
+        raise UserAccessControlError("mcp_analytics", "viewer")
+    return True
+
+
+def mcp_query_date_range(team: "Team", date_range: "DateRange | None") -> QueryDateRange:
+    return QueryDateRange(
+        date_range=date_range,
+        team=team,
+        interval=None,
+        now=datetime.now(team.timezone_info),
+    )

--- a/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
+++ b/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
@@ -1,8 +1,5 @@
-from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING
-
-import posthoganalytics
 
 from posthog.schema import (
     CachedMCPHarnessBreakdownQueryResponse,
@@ -19,17 +16,13 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.rbac.user_access_control import UserAccessControlError
 
 from products.mcp_analytics.backend import mcp_harness
 from products.mcp_analytics.backend.constants import MCP_TOOL_CALL_EVENT
+from products.mcp_analytics.backend.hogql_queries.base import mcp_query_date_range, validate_mcp_analytics_access
 
 if TYPE_CHECKING:
     from posthog.models.user import User
-
-# Gates this runner behind the same flag the product's DRF endpoints require, so the
-# generic /query/ endpoint can't bypass it (see PostHogFeatureFlagPermission).
-MCP_ANALYTICS_FEATURE_FLAG = "mcp-analytics"
 
 
 class MCPHarnessBreakdownQueryRunner(AnalyticsQueryRunner[MCPHarnessBreakdownQueryResponse]):
@@ -46,27 +39,11 @@ class MCPHarnessBreakdownQueryRunner(AnalyticsQueryRunner[MCPHarnessBreakdownQue
     cached_response: CachedMCPHarnessBreakdownQueryResponse
 
     def validate_query_runner_access(self, user: "User") -> bool:
-        org_id = str(self.team.organization_id)
-        enabled = posthoganalytics.feature_enabled(
-            MCP_ANALYTICS_FEATURE_FLAG,
-            str(user.distinct_id),
-            groups={"organization": org_id, "project": str(self.team.id)},
-            group_properties={"organization": {"id": org_id}, "project": {"id": str(self.team.id)}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-        if not enabled:
-            raise UserAccessControlError("mcp_analytics", "viewer")
-        return True
+        return validate_mcp_analytics_access(self.team, user)
 
     @cached_property
     def query_date_range(self) -> QueryDateRange:
-        return QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=None,
-            now=datetime.now(self.team.timezone_info),
-        )
+        return mcp_query_date_range(self.team, self.query.dateRange)
 
     def _where(self) -> ast.Expr:
         exprs: list[ast.Expr] = [

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -1,0 +1,235 @@
+"""Per-tool "Top users" and "Failures" tables for the MCP analytics tool detail page.
+
+Both resolve the client harness to a customer label server-side via `mcp_harness`
+(the single source of truth) so the tool-detail surface shows the same labelling as
+the dashboard donut — the frontend only maps a resolved label to its logo.
+"""
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from posthog.schema import (
+    CachedMCPToolFailuresQueryResponse,
+    CachedMCPToolTopUsersQueryResponse,
+    MCPToolFailureItem,
+    MCPToolFailuresQuery,
+    MCPToolFailuresQueryResponse,
+    MCPToolTopUserItem,
+    MCPToolTopUsersQuery,
+    MCPToolTopUsersQueryResponse,
+)
+
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.query_tagging import Feature, Product, tags_context
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+
+from products.mcp_analytics.backend import mcp_harness
+from products.mcp_analytics.backend.constants import MCP_TOOL_CALL_EVENT
+from products.mcp_analytics.backend.hogql_queries.base import mcp_query_date_range, validate_mcp_analytics_access
+
+if TYPE_CHECKING:
+    from posthog.models.user import User
+
+# The new SDK source marker, and the *effective* tool name (the inner tool when the
+# call went through the single-exec wrapper, else the directly-registered tool name).
+# Mirrors EFFECTIVE_TOOL_HOGQL / NEW_SDK_FILTER in the tool-detail frontend logic.
+_NEW_SDK_SOURCE = "posthog_mcp_analytics"
+_EFFECTIVE_TOOL = (
+    "coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))"
+)
+
+# A per-row distinct-and-sorted list of resolved harness labels, collected from the
+# token computed in the inner subquery. groupArray evaluates the label per row, so the
+# token only has to be materialized once as `h`.
+_HARNESS_LABELS_AGG = f"arraySort(arrayDistinct(groupArray({mcp_harness.harness_label_sql('h')})))"
+
+
+class MCPToolTopUsersQueryRunner(AnalyticsQueryRunner[MCPToolTopUsersQueryResponse]):
+    query: MCPToolTopUsersQuery
+    cached_response: CachedMCPToolTopUsersQueryResponse
+
+    def validate_query_runner_access(self, user: "User") -> bool:
+        return validate_mcp_analytics_access(self.team, user)
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        return mcp_query_date_range(self.team, self.query.dateRange)
+
+    def _where(self) -> ast.Expr:
+        return ast.And(
+            exprs=[
+                parse_expr("event = {event}", placeholders={"event": ast.Constant(value=MCP_TOOL_CALL_EVENT)}),
+                parse_expr(
+                    "timestamp >= {date_from}", placeholders={"date_from": self.query_date_range.date_from_as_hogql()}
+                ),
+                parse_expr(
+                    "timestamp <= {date_to}", placeholders={"date_to": self.query_date_range.date_to_as_hogql()}
+                ),
+                parse_expr(
+                    f"{_EFFECTIVE_TOOL} = {{tool}}", placeholders={"tool": ast.Constant(value=self.query.toolName)}
+                ),
+                parse_expr(
+                    f"properties.$mcp_source = {{source}}", placeholders={"source": ast.Constant(value=_NEW_SDK_SOURCE)}
+                ),
+            ]
+        )
+
+    def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        return parse_select(
+            f"""
+            SELECT
+                distinct_id,
+                argMax(person_properties, timestamp) AS person_properties,
+                count() AS calls,
+                countIf(is_error) AS errors,
+                round(countIf(is_error) * 100.0 / count(), 1) AS error_rate_pct,
+                {_HARNESS_LABELS_AGG} AS harnesses,
+                max(timestamp) AS last_seen
+            FROM (
+                SELECT
+                    distinct_id,
+                    timestamp,
+                    toBool(properties.$mcp_is_error) AS is_error,
+                    toString(person.properties) AS person_properties,
+                    {{token}} AS h
+                FROM events
+                WHERE {{where}}
+            )
+            GROUP BY distinct_id
+            ORDER BY calls DESC
+            LIMIT 5
+            """,
+            placeholders={
+                "token": parse_expr(mcp_harness.HARNESS_TOKEN_SQL),
+                "where": self._where(),
+            },
+        )
+
+    def _calculate(self) -> MCPToolTopUsersQueryResponse:
+        with tags_context(
+            product=Product.MCP_ANALYTICS,
+            feature=Feature.QUERY,
+            team_id=self.team.id,
+            name="mcp_tool_top_users_query",
+        ):
+            response = execute_hogql_query(
+                query=self.to_query(),
+                team=self.team,
+                query_type="mcp_tool_top_users_query",
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+        results = [
+            MCPToolTopUserItem(
+                distinct_id=str(row[0]),
+                person_properties=str(row[1] or ""),
+                calls=int(row[2] or 0),
+                errors=int(row[3] or 0),
+                error_rate_pct=float(row[4] or 0),
+                harnesses=[str(h) for h in (row[5] or [])],
+                last_seen=str(row[6] or ""),
+            )
+            for row in (response.results or [])
+        ]
+        return MCPToolTopUsersQueryResponse(
+            results=results,
+            timings=response.timings,
+            hogql=response.hogql,
+            modifiers=self.modifiers,
+        )
+
+
+class MCPToolFailuresQueryRunner(AnalyticsQueryRunner[MCPToolFailuresQueryResponse]):
+    query: MCPToolFailuresQuery
+    cached_response: CachedMCPToolFailuresQueryResponse
+
+    def validate_query_runner_access(self, user: "User") -> bool:
+        return validate_mcp_analytics_access(self.team, user)
+
+    @cached_property
+    def query_date_range(self) -> QueryDateRange:
+        return mcp_query_date_range(self.team, self.query.dateRange)
+
+    def _where(self) -> ast.Expr:
+        # $exception events don't carry the new-SDK markers ($mcp_source / $mcp_exec_tool_call_name),
+        # so this matches the raw $mcp_tool_name rather than the effective tool name.
+        return ast.And(
+            exprs=[
+                parse_expr("event = {event}", placeholders={"event": ast.Constant(value="$exception")}),
+                parse_expr(
+                    "timestamp >= {date_from}", placeholders={"date_from": self.query_date_range.date_from_as_hogql()}
+                ),
+                parse_expr(
+                    "timestamp <= {date_to}", placeholders={"date_to": self.query_date_range.date_to_as_hogql()}
+                ),
+                parse_expr(
+                    "toString(properties.$mcp_tool_name) = {tool}",
+                    placeholders={"tool": ast.Constant(value=self.query.toolName)},
+                ),
+                parse_expr("notEmpty(toString(properties.$exception_message))"),
+            ]
+        )
+
+    def to_query(self) -> ast.SelectQuery | ast.SelectSetQuery:
+        return parse_select(
+            f"""
+            SELECT
+                message,
+                count() AS occurrences,
+                max(timestamp) AS last_seen,
+                {_HARNESS_LABELS_AGG} AS harnesses
+            FROM (
+                SELECT
+                    substring(toString(properties.$exception_message), 1, 200) AS message,
+                    timestamp,
+                    {{token}} AS h
+                FROM events
+                WHERE {{where}}
+            )
+            GROUP BY message
+            ORDER BY occurrences DESC
+            LIMIT 20
+            """,
+            placeholders={
+                "token": parse_expr(mcp_harness.HARNESS_TOKEN_SQL),
+                "where": self._where(),
+            },
+        )
+
+    def _calculate(self) -> MCPToolFailuresQueryResponse:
+        with tags_context(
+            product=Product.MCP_ANALYTICS,
+            feature=Feature.QUERY,
+            team_id=self.team.id,
+            name="mcp_tool_failures_query",
+        ):
+            response = execute_hogql_query(
+                query=self.to_query(),
+                team=self.team,
+                query_type="mcp_tool_failures_query",
+                timings=self.timings,
+                modifiers=self.modifiers,
+                limit_context=self.limit_context,
+            )
+
+        results = [
+            MCPToolFailureItem(
+                message=str(row[0] or ""),
+                occurrences=int(row[1] or 0),
+                last_seen=str(row[2] or ""),
+                harnesses=[str(h) for h in (row[3] or [])],
+            )
+            for row in (response.results or [])
+        ]
+        return MCPToolFailuresQueryResponse(
+            results=results,
+            timings=response.timings,
+            hogql=response.hogql,
+            modifiers=self.modifiers,
+        )

--- a/products/mcp_analytics/backend/mcp_harness.py
+++ b/products/mcp_analytics/backend/mcp_harness.py
@@ -7,8 +7,10 @@ query-time computation:
 
   1. Resolve a normalized token from the strongest available signal (the
      x-anthropic-client vendor header, then Claude Code's User-Agent surface,
-     then the session-pinned clientInfo.name, then the User-Agent product token,
-     then the OAuth client name) — `HARNESS_TOKEN_SQL`.
+     then the clientInfo.name — `$mcp_client_name` as reported by the posthog-node
+     MCP analytics SDK, or `mcp_session_client_name` as reported by PostHog's hosted
+     MCP server — then the User-Agent product token, then the OAuth client name) —
+     `HARNESS_TOKEN_SQL`.
   2. Bucket that token into a customer label — `harness_label_sql`.
 
 This module is being established as the single source of truth. Today the same
@@ -45,6 +47,7 @@ _RAW_TOKEN = f"""coalesce(
         NULL
     ),
     if(lower({_UA_PRODUCT}) = 'claude-code', {_UA_TOKEN}, NULL),
+    nullIf(nullIf(toString(properties.$mcp_client_name), ''), 'mcp'),
     nullIf(nullIf(toString(properties.mcp_session_client_name), ''), 'mcp'),
     nullIf({_UA_TOKEN}, ''),
     nullIf(toString(properties.$mcp_oauth_client_name), ''),

--- a/products/mcp_analytics/backend/tests/test_harness_breakdown.py
+++ b/products/mcp_analytics/backend/tests/test_harness_breakdown.py
@@ -66,6 +66,14 @@ class TestMCPHarnessBreakdownQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Click
             ("vendor_claudecode", {"mcp_vendor_client": "ClaudeCode"}, "Claude Code"),
             ("session_codex", {"mcp_session_client_name": "codex-mcp-client"}, "OpenAI Codex"),
             ("session_cursor", {"mcp_session_client_name": "cursor-vscode"}, "Cursor"),
+            # The posthog-node MCP analytics SDK reports clientInfo.name as $mcp_client_name,
+            # not the hosted server's mcp_session_client_name. Both must classify.
+            ("sdk_client_name_claudeai", {"$mcp_client_name": "claude-ai"}, "Claude.ai"),
+            (
+                "sdk_client_name_mcp_remote_stripped",
+                {"$mcp_client_name": "claude-ai (via mcp-remote 0.1.37)"},
+                "Claude.ai",
+            ),
             ("ua_claude_cli", {"$mcp_client_user_agent": "claude-code/2.1.0 (cli)"}, "Claude Code"),
             (
                 "ua_claude_sdk",

--- a/products/mcp_analytics/backend/tests/test_tool_tables.py
+++ b/products/mcp_analytics/backend/tests/test_tool_tables.py
@@ -1,0 +1,187 @@
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin, _create_event, _create_person, flush_persons_and_events
+
+from parameterized import parameterized
+
+from posthog.schema import DateRange, MCPToolFailuresQuery, MCPToolTopUsersQuery
+
+from products.mcp_analytics.backend.hogql_queries.tool_tables import (
+    MCPToolFailuresQueryRunner,
+    MCPToolTopUsersQueryRunner,
+)
+from products.mcp_analytics.backend.tests import _MCPAnalyticsTeamScopedTestMixin
+
+NEW_SDK_SOURCE = "posthog_mcp_analytics"
+
+
+class TestMCPToolTopUsersQueryRunner(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, APIBaseTest):
+    def _emit(
+        self,
+        *,
+        tool_name: str = "query_run",
+        distinct_id: str = "d1",
+        client_name: str | None = None,
+        source: str | None = NEW_SDK_SOURCE,
+        is_error: bool = False,
+        exec_tool: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        properties: dict[str, Any] = {
+            "$mcp_tool_name": tool_name,
+            "$mcp_is_error": is_error,
+        }
+        if source is not None:
+            properties["$mcp_source"] = source
+        if client_name is not None:
+            properties["$mcp_client_name"] = client_name
+        if exec_tool is not None:
+            properties["$mcp_exec_tool_call_name"] = exec_tool
+        _create_event(
+            team=self.team,
+            event="$mcp_tool_call",
+            distinct_id=distinct_id,
+            timestamp=timestamp or datetime.now(tz=UTC),
+            properties=properties,
+        )
+
+    def _run(self, tool_name: str = "query_run") -> list[Any]:
+        runner = MCPToolTopUsersQueryRunner(
+            query=MCPToolTopUsersQuery(toolName=tool_name, dateRange=DateRange(date_from="-7d")),
+            team=self.team,
+        )
+        return runner.calculate().results
+
+    @parameterized.expand(
+        [
+            ("sdk_claudeai", "claude-ai", ["Claude.ai"]),
+            ("sdk_mcp_remote_stripped", "claude-ai (via mcp-remote 0.1.37)", ["Claude.ai"]),
+            ("sdk_cursor", "cursor-vscode", ["Cursor"]),
+            ("sdk_unknown_to_other", "totally-unknown-thing", ["Other"]),
+        ]
+    )
+    def test_resolves_harness_labels(self, _name: str, client_name: str, expected: list[str]) -> None:
+        self._emit(client_name=client_name)
+        flush_persons_and_events()
+
+        rows = self._run()
+
+        assert len(rows) == 1
+        assert rows[0].harnesses == expected
+
+    def test_aggregates_per_user_and_dedupes_harnesses(self) -> None:
+        self._emit(distinct_id="d1", client_name="claude-ai", is_error=False)
+        self._emit(distinct_id="d1", client_name="claude-ai (via mcp-remote 0.1.37)", is_error=True)
+        self._emit(distinct_id="d1", client_name="cursor-vscode", is_error=False)
+        flush_persons_and_events()
+
+        rows = self._run()
+
+        assert len(rows) == 1
+        row = rows[0]
+        assert row.distinct_id == "d1"
+        assert row.calls == 3
+        assert row.errors == 1
+        assert row.error_rate_pct == 33.3
+        # Claude.ai once despite two raw spellings; sorted distinct labels.
+        assert row.harnesses == ["Claude.ai", "Cursor"]
+
+    def test_excludes_other_tools_and_resolves_effective_tool_name(self) -> None:
+        self._emit(distinct_id="d1", tool_name="other_tool", client_name="claude-ai")
+        # Single-exec wrapper: outer tool name is the wrapper, the effective tool is in $mcp_exec_tool_call_name.
+        self._emit(distinct_id="d2", tool_name="exec", exec_tool="query_run", client_name="cursor-vscode")
+        flush_persons_and_events()
+
+        rows = self._run(tool_name="query_run")
+
+        assert {r.distinct_id for r in rows} == {"d2"}
+
+    def test_excludes_events_without_new_sdk_source(self) -> None:
+        self._emit(distinct_id="d1", client_name="claude-ai", source=None)
+        flush_persons_and_events()
+
+        assert self._run() == []
+
+    def test_carries_person_properties(self) -> None:
+        _create_person(team=self.team, distinct_ids=["d1"], properties={"email": "a@b.com"})
+        self._emit(distinct_id="d1", client_name="claude-ai")
+        flush_persons_and_events()
+
+        rows = self._run()
+
+        assert '"email":"a@b.com"' in rows[0].person_properties.replace(" ", "")
+        assert not rows[0].person_properties.startswith('"')  # raw JSON object, not a double-encoded string
+
+
+class TestMCPToolFailuresQueryRunner(_MCPAnalyticsTeamScopedTestMixin, ClickhouseTestMixin, APIBaseTest):
+    def _emit_exception(
+        self,
+        *,
+        tool_name: str = "query_run",
+        message: str = "boom",
+        client_name: str | None = None,
+        timestamp: datetime | None = None,
+    ) -> None:
+        properties: dict[str, Any] = {"$mcp_tool_name": tool_name, "$exception_message": message}
+        if client_name is not None:
+            properties["$mcp_client_name"] = client_name
+        _create_event(
+            team=self.team,
+            event="$exception",
+            distinct_id="d1",
+            timestamp=timestamp or datetime.now(tz=UTC),
+            properties=properties,
+        )
+
+    def _run(self, tool_name: str = "query_run") -> list[Any]:
+        runner = MCPToolFailuresQueryRunner(
+            query=MCPToolFailuresQuery(toolName=tool_name, dateRange=DateRange(date_from="-7d")),
+            team=self.team,
+        )
+        return runner.calculate().results
+
+    @parameterized.expand(
+        [
+            ("sdk_claudeai", "claude-ai", ["Claude.ai"]),
+            ("sdk_mcp_remote_stripped", "claude-ai (via mcp-remote 0.1.37)", ["Claude.ai"]),
+            ("sdk_unknown_to_other", "weird-client", ["Other"]),
+        ]
+    )
+    def test_resolves_harness_labels(self, _name: str, client_name: str, expected: list[str]) -> None:
+        self._emit_exception(client_name=client_name)
+        flush_persons_and_events()
+
+        rows = self._run()
+
+        assert len(rows) == 1
+        assert rows[0].harnesses == expected
+
+    def test_groups_by_message_and_counts_occurrences(self) -> None:
+        self._emit_exception(message="boom", client_name="claude-ai")
+        self._emit_exception(message="boom", client_name="cursor-vscode")
+        self._emit_exception(message="other", client_name="claude-ai")
+        flush_persons_and_events()
+
+        rows = self._run()
+        by_message = {r.message: r for r in rows}
+
+        assert by_message["boom"].occurrences == 2
+        assert by_message["boom"].harnesses == ["Claude.ai", "Cursor"]
+        assert by_message["other"].occurrences == 1
+
+    def test_excludes_other_tools(self) -> None:
+        self._emit_exception(tool_name="other_tool", message="boom", client_name="claude-ai")
+        flush_persons_and_events()
+
+        assert self._run(tool_name="query_run") == []
+
+    def test_date_range_excludes_older_events(self) -> None:
+        now = datetime.now(tz=UTC)
+        self._emit_exception(message="old", client_name="claude-ai", timestamp=now - timedelta(days=30))
+        self._emit_exception(message="recent", client_name="claude-ai", timestamp=now)
+        flush_persons_and_events()
+
+        rows = self._run()
+
+        assert {r.message for r in rows} == {"recent"}

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -49,7 +49,6 @@ import {
     ToolSummary,
     mcpAnalyticsToolDetailLogic,
 } from './mcpAnalyticsToolDetailLogic'
-import { categorizeHarness } from './mcpDashboardOverviewLogic'
 
 export const scene: SceneExport<MCPAnalyticsToolDetailLogicProps> = {
     component: MCPAnalyticsToolDetail,
@@ -128,22 +127,15 @@ function renderPersonCell(value: unknown): JSX.Element {
     )
 }
 
-// Deduped harness logos so the column stays one line instead of wrapping.
-function HarnessLogos({ value }: { value: string }): JSX.Element {
-    const categories = Array.from(
-        new Set(
-            value
-                .split(',')
-                .map((raw) => categorizeHarness(raw.trim()))
-                .filter(Boolean)
-        )
-    )
-    if (categories.length === 0) {
+// Harness logos for a row. Labels are resolved (deduped + sorted) server-side; the column
+// just maps each label to its logo and stays on one line.
+function HarnessLogos({ labels }: { labels: string[] }): JSX.Element {
+    if (labels.length === 0) {
         return <span className="text-muted">—</span>
     }
     return (
         <div className="flex items-center gap-1">
-            {categories.map((category) => (
+            {labels.map((category) => (
                 <HarnessLogo key={category} category={category} />
             ))}
         </div>
@@ -659,7 +651,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                             { header: 'Error rate', align: 'right', render: (r) => `${Number(r[3] ?? 0)}%` },
                             {
                                 header: 'Harnesses',
-                                render: (r) => <HarnessLogos value={String(r[4] ?? '')} />,
+                                render: (r) => <HarnessLogos labels={(r[4] as string[]) ?? []} />,
                             },
                             { header: 'Last seen', render: (r) => <TZLabel time={String(r[5])} /> },
                         ]}
@@ -690,7 +682,7 @@ export function MCPAnalyticsToolDetail({ toolName }: { toolName: string }): JSX.
                         { header: 'Last seen', render: (r) => <TZLabel time={String(r[2])} /> },
                         {
                             header: 'Harnesses',
-                            render: (r) => <HarnessLogos value={String(r[3] ?? '')} />,
+                            render: (r) => <HarnessLogos labels={(r[3] as string[]) ?? []} />,
                         },
                     ]}
                 />

--- a/products/mcp_analytics/frontend/dashboard/harnessRegistry.ts
+++ b/products/mcp_analytics/frontend/dashboard/harnessRegistry.ts
@@ -32,7 +32,8 @@ interface HarnessDescriptor {
 // produced server-side by the backend classifier (products/mcp_analytics/backend/mcp_harness.py,
 // the single source of truth); this map owns only the frontend-specific concerns the backend
 // has no opinion on. Keys must match HARNESS_LABELS / harness_label_sql in mcp_harness.py.
-const HARNESS_BY_LABEL: Record<string, HarnessDescriptor> = {
+// Exported so tests can assert coverage against the backend HARNESS_LABELS tuple.
+export const HARNESS_BY_LABEL: Record<string, HarnessDescriptor> = {
     'Claude Desktop': { logo: { src: claudeLogo, alt: 'Claude Desktop logo' }, colorIndex: 5 },
     'Claude Code (VS Code)': { logo: { src: claudeLogo, alt: 'Claude Code logo' }, colorIndex: 6 },
     'Claude Agent SDK': { logo: { src: claudeLogo, alt: 'Claude Agent SDK logo' }, colorIndex: 7 },

--- a/products/mcp_analytics/frontend/dashboard/harnessRegistry.ts
+++ b/products/mcp_analytics/frontend/dashboard/harnessRegistry.ts
@@ -22,154 +22,53 @@ export interface HarnessLogo {
 }
 
 interface HarnessDescriptor {
-    category: string
-    // Matches against the normalized client token: lowercased, with the
-    // "(via mcp-remote …)" suffix stripped (see categorizeHarness).
-    match: (normalized: string) => boolean
     logo?: HarnessLogo
     // Index into the data-viz palette, chosen so the logo drawn on top keeps
     // enough contrast against its slice.
     colorIndex?: number
 }
 
-// Single source of truth for harness identity — how a normalized client token maps
-// to a display category, its logo, and its slice colour. Adding a new harness is one
-// entry here. Categories were derived from sampling the top distinct client
-// identifiers seen in production (clientInfo.name, the x-anthropic-client vendor
-// header, and User-Agent product tokens) over the past 30 days. The bucket list
-// mirrors the HogQL in products/posthog_ai/skills/querying-posthog-data/references/models-mcp.md
-// — keep the two in sync until a materialized $mcp_harness property exists.
-//
-// The normalized token can carry a surface suffix the query lifts out of the
-// User-Agent's parenthetical, e.g. "claude-code cli", "claude-code claude-desktop",
-// "openai-mcp chatgpt". List surface-specific entries before the generic prefix
-// match so they win; clients whose parenthetical is platform/arch noise (e.g.
-// "cursor darwin arm64") still fold to one bucket via the generic startsWith.
-const HARNESS_REGISTRY: HarnessDescriptor[] = [
-    {
-        category: 'Claude Desktop',
-        match: (n) => n === 'claude-code claude-desktop',
-        logo: { src: claudeLogo, alt: 'Claude Desktop logo' },
-        colorIndex: 5,
-    },
-    {
-        category: 'Claude Code (VS Code)',
-        match: (n) => n === 'claude-code claude-vscode',
-        logo: { src: claudeLogo, alt: 'Claude Code logo' },
-        colorIndex: 6,
-    },
-    {
-        category: 'Claude Agent SDK',
-        match: (n) => n.startsWith('claude-code sdk'),
-        logo: { src: claudeLogo, alt: 'Claude Agent SDK logo' },
-        colorIndex: 7,
-    },
-    {
-        category: 'Claude Code',
-        match: (n) => n.startsWith('claude-code'),
-        logo: { src: claudeLogo, alt: 'Claude Code logo' },
-        colorIndex: 0,
-    },
-    {
-        category: 'Claude.ai',
-        match: (n) => n === 'claude-ai' || n === 'anthropic/claudeai' || n === 'claude-user',
-        logo: { src: claudeLogo, alt: 'Claude.ai logo' },
-        colorIndex: 2,
-    },
-    { category: 'Anthropic API', match: (n) => n === 'anthropic/api' },
-    { category: 'Cowork', match: (n) => n === 'cowork', logo: { src: claudeLogo, alt: 'Cowork logo' }, colorIndex: 3 },
-    {
-        category: 'Claude Design',
-        match: (n) => n === 'claude-design',
-        logo: { src: claudeLogo, alt: 'Claude Design logo' },
-        colorIndex: 4,
-    },
-    {
-        category: 'ChatGPT',
-        match: (n) => n === 'openai-mcp chatgpt',
-        logo: { src: openaiLogo, alt: 'ChatGPT logo' },
-        colorIndex: 8,
-    },
-    {
-        category: 'OpenAI Agent Builder',
-        match: (n) => n === 'openai-mcp agent builder',
-        logo: { src: openaiLogo, alt: 'OpenAI Agent Builder logo' },
-        colorIndex: 9,
-    },
-    {
-        category: 'OpenAI Responses API',
-        match: (n) => n === 'openai-mcp responses api',
-        logo: { src: openaiLogo, alt: 'OpenAI Responses API logo' },
-        colorIndex: 10,
-    },
-    {
-        category: 'OpenAI',
-        match: (n) => n.startsWith('openai-mcp'),
-        logo: { src: openaiLogo, alt: 'OpenAI logo' },
-        colorIndex: 1,
-    },
-    {
-        category: 'OpenAI Codex',
-        match: (n) => n.startsWith('codex'),
-        logo: { src: openaiLogo, alt: 'OpenAI Codex logo' },
-        colorIndex: 13,
-    },
-    {
-        category: 'Cursor',
-        match: (n) => n.startsWith('cursor'),
-        logo: { src: cursorLogo, alt: 'Cursor logo' },
-        colorIndex: 12,
-    },
-    {
-        category: 'VS Code',
-        match: (n) => n.startsWith('visual studio code'),
-        logo: { src: vscodeLogo, alt: 'VS Code logo' },
-        colorIndex: 11,
-    },
-    { category: 'Windsurf', match: (n) => n === 'windsurf', logo: { src: windsurfLogo, alt: 'Windsurf logo' } },
-    { category: 'Replit', match: (n) => n.startsWith('replit'), logo: { src: replitLogo, alt: 'Replit logo' } },
-    { category: 'Lovable', match: (n) => n.startsWith('lovable'), logo: { src: lovableLogo, alt: 'Lovable logo' } },
-    { category: 'Manus', match: (n) => n === 'manus', logo: { src: manusLogo, alt: 'Manus logo' } },
-    { category: 'CodeRabbit', match: (n) => n === 'coderabbit', logo: { src: coderabbitLogo, alt: 'CodeRabbit logo' } },
-    { category: 'Notion', match: (n) => n.startsWith('notion'), logo: { src: notionLogo, alt: 'Notion logo' } },
-    { category: 'Linear', match: (n) => n.startsWith('linear'), logo: { src: linearLogo, alt: 'Linear logo' } },
-    {
-        category: 'LibreChat',
-        match: (n) => n.includes('librechat'),
-        logo: { src: librechatLogo, alt: 'LibreChat logo' },
-    },
-    { category: 'Pi', match: (n) => n.startsWith('pi-client'), logo: { src: piLogo, alt: 'Pi logo' } },
-    {
-        category: 'Antigravity',
-        match: (n) => n.startsWith('antigravity'),
-        logo: { src: antigravityLogo, alt: 'Antigravity logo' },
-    },
-    { category: 'Poke', match: (n) => n === 'poke' },
-    { category: 'opencode', match: (n) => n === 'opencode', logo: { src: opencodeLogo, alt: 'opencode logo' } },
-    { category: 'Kiro', match: (n) => n.startsWith('kiro') },
-    { category: 'Desktop Commander', match: (n) => n.startsWith('desktop-commander') },
-]
-
-const HARNESS_BY_CATEGORY: Record<string, HarnessDescriptor> = Object.fromEntries(
-    HARNESS_REGISTRY.map((entry) => [entry.category, entry])
-)
-
-export function categorizeHarness(raw: string): string {
-    const stripped = raw
-        .replace(/\s*\(via mcp-remote[^)]*\)\s*/i, '')
-        .trim()
-        .toLowerCase()
-    if (!stripped) {
-        return 'Other'
-    }
-    return HARNESS_REGISTRY.find((entry) => entry.match(stripped))?.category ?? 'Other'
+// Maps a *resolved* harness label to its logo and slice colour. The label itself is
+// produced server-side by the backend classifier (products/mcp_analytics/backend/mcp_harness.py,
+// the single source of truth); this map owns only the frontend-specific concerns the backend
+// has no opinion on. Keys must match HARNESS_LABELS / harness_label_sql in mcp_harness.py.
+const HARNESS_BY_LABEL: Record<string, HarnessDescriptor> = {
+    'Claude Desktop': { logo: { src: claudeLogo, alt: 'Claude Desktop logo' }, colorIndex: 5 },
+    'Claude Code (VS Code)': { logo: { src: claudeLogo, alt: 'Claude Code logo' }, colorIndex: 6 },
+    'Claude Agent SDK': { logo: { src: claudeLogo, alt: 'Claude Agent SDK logo' }, colorIndex: 7 },
+    'Claude Code': { logo: { src: claudeLogo, alt: 'Claude Code logo' }, colorIndex: 0 },
+    'Claude.ai': { logo: { src: claudeLogo, alt: 'Claude.ai logo' }, colorIndex: 2 },
+    'Anthropic API': {},
+    Cowork: { logo: { src: claudeLogo, alt: 'Cowork logo' }, colorIndex: 3 },
+    'Claude Design': { logo: { src: claudeLogo, alt: 'Claude Design logo' }, colorIndex: 4 },
+    ChatGPT: { logo: { src: openaiLogo, alt: 'ChatGPT logo' }, colorIndex: 8 },
+    'OpenAI Agent Builder': { logo: { src: openaiLogo, alt: 'OpenAI Agent Builder logo' }, colorIndex: 9 },
+    'OpenAI Responses API': { logo: { src: openaiLogo, alt: 'OpenAI Responses API logo' }, colorIndex: 10 },
+    OpenAI: { logo: { src: openaiLogo, alt: 'OpenAI logo' }, colorIndex: 1 },
+    'OpenAI Codex': { logo: { src: openaiLogo, alt: 'OpenAI Codex logo' }, colorIndex: 13 },
+    Cursor: { logo: { src: cursorLogo, alt: 'Cursor logo' }, colorIndex: 12 },
+    'VS Code': { logo: { src: vscodeLogo, alt: 'VS Code logo' }, colorIndex: 11 },
+    Windsurf: { logo: { src: windsurfLogo, alt: 'Windsurf logo' } },
+    Replit: { logo: { src: replitLogo, alt: 'Replit logo' } },
+    Lovable: { logo: { src: lovableLogo, alt: 'Lovable logo' } },
+    Manus: { logo: { src: manusLogo, alt: 'Manus logo' } },
+    CodeRabbit: { logo: { src: coderabbitLogo, alt: 'CodeRabbit logo' } },
+    Notion: { logo: { src: notionLogo, alt: 'Notion logo' } },
+    Linear: { logo: { src: linearLogo, alt: 'Linear logo' } },
+    LibreChat: { logo: { src: librechatLogo, alt: 'LibreChat logo' } },
+    Pi: { logo: { src: piLogo, alt: 'Pi logo' } },
+    Antigravity: { logo: { src: antigravityLogo, alt: 'Antigravity logo' } },
+    Poke: {},
+    opencode: { logo: { src: opencodeLogo, alt: 'opencode logo' } },
+    Kiro: {},
+    'Desktop Commander': {},
 }
 
-export function harnessLogo(category: string): HarnessLogo | undefined {
-    return HARNESS_BY_CATEGORY[category]?.logo
+export function harnessLogo(label: string): HarnessLogo | undefined {
+    return HARNESS_BY_LABEL[label]?.logo
 }
 
-export function harnessSliceColor(theme: ChartTheme, category: string, fallbackIndex: number): string {
-    const index = HARNESS_BY_CATEGORY[category]?.colorIndex ?? fallbackIndex
+export function harnessSliceColor(theme: ChartTheme, label: string, fallbackIndex: number): string {
+    const index = HARNESS_BY_LABEL[label]?.colorIndex ?? fallbackIndex
     return theme.colors[index % theme.colors.length]
 }

--- a/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsToolDetailLogic.ts
@@ -4,7 +4,13 @@ import { loaders } from 'kea-loaders'
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
-import { HogQLQueryResponse, MCPHarnessBreakdownItem, NodeKind } from '~/queries/schema/schema-general'
+import {
+    HogQLQueryResponse,
+    MCPHarnessBreakdownItem,
+    MCPToolFailureItem,
+    MCPToolTopUserItem,
+    NodeKind,
+} from '~/queries/schema/schema-general'
 import { PropertyFilterType } from '~/types'
 
 import type { mcpAnalyticsToolDetailLogicType } from './mcpAnalyticsToolDetailLogicType'
@@ -275,24 +281,19 @@ ORDER BY day
         failureRows: [
             [] as ResultRows,
             {
-                loadFailureRows: async (): Promise<ResultRows> =>
-                    queryRows(`
-SELECT
-    substring(toString(properties.$exception_message), 1, 200) AS message,
-    count() AS occurrences,
-    max(timestamp) AS last_seen,
-    arrayStringConcat(arraySort(arrayDistinct(groupArray(toString(properties.$mcp_client_name)))), ', ') AS harnesses
-FROM events
--- $exception events don't carry the new-SDK markers ($mcp_source / $mcp_exec_tool_call_name), so
--- unlike the $mcp_tool_call queries this matches the raw $mcp_tool_name without EFFECTIVE_TOOL_HOGQL/NEW_SDK_FILTER.
-WHERE event = '$exception'
-    AND timestamp >= now() - INTERVAL 7 DAY
-    AND toString(properties.$mcp_tool_name) = '${escapeHogQLString(props.toolName)}'
-    AND notEmpty(toString(properties.$exception_message))
-GROUP BY message
-ORDER BY occurrences DESC
-LIMIT 20
-`),
+                // Harness labels are resolved server-side by MCPToolFailuresQuery (same source of
+                // truth as the dashboard), so the frontend only maps a label to its logo.
+                loadFailureRows: async (): Promise<ResultRows> => {
+                    const response = (await api.query({
+                        kind: NodeKind.MCPToolFailuresQuery,
+                        toolName: props.toolName,
+                        dateRange: {
+                            date_from: dayjs().subtract(7, 'day').toISOString(),
+                            date_to: dayjs().toISOString(),
+                        },
+                    })) as { results?: MCPToolFailureItem[] }
+                    return (response?.results ?? []).map((r) => [r.message, r.occurrences, r.last_seen, r.harnesses])
+                },
             },
         ],
         sampleIntentRows: [
@@ -362,23 +363,27 @@ LIMIT 5
         topUserRows: [
             [] as ResultRows,
             {
-                loadTopUserRows: async (): Promise<ResultRows> =>
-                    queryRows(`
-SELECT
-    argMax(tuple(distinct_id, person.created_at, person.properties), timestamp) AS person,
-    count() AS calls,
-    countIf(toBool(properties.$mcp_is_error)) AS errors,
-    round(countIf(toBool(properties.$mcp_is_error)) * 100.0 / count(), 1) AS error_rate_pct,
-    arrayStringConcat(arraySort(arrayDistinct(groupArray(toString(properties.$mcp_client_name)))), ', ') AS harnesses,
-    max(timestamp) AS last_seen
-FROM events
-WHERE event = '$mcp_tool_call'
-    AND timestamp >= now() - INTERVAL 7 DAY
-    AND ${buildToolFilter(props.toolName)}
-GROUP BY distinct_id
-ORDER BY calls DESC
-LIMIT 5
-`),
+                // Harness labels are resolved server-side by MCPToolTopUsersQuery (same source of
+                // truth as the dashboard), so the frontend only maps a label to its logo. The
+                // person tuple is rebuilt into the [distinct_id, _, properties] shape renderPersonCell expects.
+                loadTopUserRows: async (): Promise<ResultRows> => {
+                    const response = (await api.query({
+                        kind: NodeKind.MCPToolTopUsersQuery,
+                        toolName: props.toolName,
+                        dateRange: {
+                            date_from: dayjs().subtract(7, 'day').toISOString(),
+                            date_to: dayjs().toISOString(),
+                        },
+                    })) as { results?: MCPToolTopUserItem[] }
+                    return (response?.results ?? []).map((r) => [
+                        [r.distinct_id, '', r.person_properties],
+                        r.calls,
+                        r.errors,
+                        r.error_rate_pct,
+                        r.harnesses,
+                        r.last_seen,
+                    ])
+                },
             },
         ],
     })),

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -10,7 +10,7 @@ import { urls } from 'scenes/urls'
 import { initKeaTests } from '~/test/init'
 import { AnyPropertyFilter, PropertyFilterType, PropertyOperator } from '~/types'
 
-import { harnessLogo } from './dashboard/harnessRegistry'
+import { HARNESS_BY_LABEL, harnessLogo } from './dashboard/harnessRegistry'
 import {
     type ActivityRow,
     type BucketRow,
@@ -49,6 +49,45 @@ function session(overrides: Partial<SessionRow> & { session_id: string }): Sessi
 
 describe('mcpDashboardOverviewLogic', () => {
     describe('harnessLogo', () => {
+        // The expected labels mirror HARNESS_LABELS in mcp_harness.py, minus "Other".
+        // If the backend renames or adds a label, update this list to keep it in sync
+        // and add the corresponding entry to HARNESS_BY_LABEL in harnessRegistry.ts.
+        const EXPECTED_HARNESS_LABELS = [
+            'Claude Desktop',
+            'Claude Code (VS Code)',
+            'Claude Agent SDK',
+            'Claude Code',
+            'Claude.ai',
+            'Anthropic API',
+            'Cowork',
+            'Claude Design',
+            'ChatGPT',
+            'OpenAI Agent Builder',
+            'OpenAI Responses API',
+            'OpenAI',
+            'OpenAI Codex',
+            'Cursor',
+            'VS Code',
+            'Windsurf',
+            'Replit',
+            'Lovable',
+            'Manus',
+            'CodeRabbit',
+            'Notion',
+            'Linear',
+            'LibreChat',
+            'Pi',
+            'Antigravity',
+            'Poke',
+            'opencode',
+            'Kiro',
+            'Desktop Commander',
+        ]
+
+        it.each(EXPECTED_HARNESS_LABELS)('HARNESS_BY_LABEL has an entry for backend label %s', (label) => {
+            expect(Object.prototype.hasOwnProperty.call(HARNESS_BY_LABEL, label)).toBe(true)
+        })
+
         it.each([
             'Claude Code',
             'OpenAI',

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -19,7 +19,6 @@ import {
     buildKPIs,
     buildKpiWindow,
     buildToolDailySeries,
-    categorizeHarness,
     deltaPct,
     mcpDashboardOverviewLogic,
     normalizeBucket,
@@ -49,52 +48,7 @@ function session(overrides: Partial<SessionRow> & { session_id: string }): Sessi
 }
 
 describe('mcpDashboardOverviewLogic', () => {
-    describe('categorizeHarness', () => {
-        it.each([
-            ['claude-code/1.0.0', 'Claude Code'],
-            ['claude-code cli', 'Claude Code'],
-            ['claude-code claude-desktop', 'Claude Desktop'],
-            ['claude-code claude-vscode', 'Claude Code (VS Code)'],
-            ['claude-code sdk-ts', 'Claude Agent SDK'],
-            ['claude-ai', 'Claude.ai'],
-            ['anthropic/claudeai', 'Claude.ai'],
-            ['cowork', 'Cowork'],
-            ['claude-design', 'Claude Design'],
-            ['claude-user', 'Claude.ai'],
-            ['openai-mcp', 'OpenAI'],
-            ['openai-mcp chatgpt', 'ChatGPT'],
-            ['openai-mcp agent builder', 'OpenAI Agent Builder'],
-            ['openai-mcp responses api', 'OpenAI Responses API'],
-            ['cursor/0.42', 'Cursor'],
-            ['cursor darwin arm64', 'Cursor'],
-            ['codex-cli', 'OpenAI Codex'],
-            // Raw clientInfo.name tokens the harness coalesce now surfaces from
-            // mcp_session_client_name (these clients send no useful User-Agent).
-            ['codex-mcp-client', 'OpenAI Codex'],
-            ['cursor-vscode', 'Cursor'],
-            ['opencode', 'opencode'],
-            ['Lovable MCP Client', 'Lovable'],
-            ['linear-agent', 'Linear'],
-            ['@librechat/api-client', 'LibreChat'],
-            ['pi-client', 'Pi'],
-            ['antigravity-client', 'Antigravity'],
-            ['coderabbit', 'CodeRabbit'],
-            ['notion-mcp-client', 'Notion'],
-            ['replit-agent-mcp-client', 'Replit'],
-            ['windsurf', 'Windsurf'],
-            ['claude-code sdk-cli', 'Claude Agent SDK'],
-            ['claude-code sdk-py', 'Claude Agent SDK'],
-            ['visual studio code', 'VS Code'],
-            ['something-nobody-knows', 'Other'],
-            ['', 'Other'],
-        ])('maps %s -> %s', (raw, expected) => {
-            expect(categorizeHarness(raw)).toBe(expected)
-        })
-
-        it('strips the "(via mcp-remote …)" suffix before matching', () => {
-            expect(categorizeHarness('claude-code (via mcp-remote 1.2.3)')).toBe('Claude Code')
-        })
-
+    describe('harnessLogo', () => {
         it.each([
             'Claude Code',
             'OpenAI',

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -13,11 +13,8 @@ import { HogQLFilters, HogQLQueryResponse, MCPHarnessBreakdownItem, NodeKind } f
 import { AnyPropertyFilter, IntervalType, TeamType } from '~/types'
 
 import { mcpClusteringLogic } from './clustering/mcpClusteringLogic'
-import { categorizeHarness } from './dashboard/harnessRegistry'
 import type { MCPIntentClusterApi } from './generated/api.schemas'
 import type { mcpDashboardOverviewLogicType } from './mcpDashboardOverviewLogicType'
-
-export { categorizeHarness }
 
 export interface DateFilter {
     dateFrom: string | null

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26271,6 +26271,92 @@ export namespace Schemas {
       version?: number | null;
     }
 
+    export interface MCPToolTopUserItem {
+      calls: number;
+      distinct_id: string;
+      error_rate_pct: number;
+      errors: number;
+      /** Resolved harness labels seen for this user, deduped and sorted. */
+      harnesses: string[];
+      last_seen: string;
+      /** JSON-encoded person.properties for the most recent call, for display. */
+      person_properties: string;
+    }
+
+    export interface MCPToolTopUsersQueryResponse {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MCPToolTopUserItem[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface MCPToolTopUsersQuery {
+      dateRange?: DateRange | null;
+      kind?: 'MCPToolTopUsersQuery';
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      response?: MCPToolTopUsersQueryResponse | null;
+      tags?: QueryLogTags | null;
+      /** The effective tool name to scope to (matched against the single-exec-resolved tool name). */
+      toolName: string;
+      /** version of the node, used for schema migrations */
+      version?: number | null;
+    }
+
+    export interface MCPToolFailureItem {
+      /** Resolved harness labels seen for this exception, deduped and sorted. */
+      harnesses: string[];
+      last_seen: string;
+      message: string;
+      occurrences: number;
+    }
+
+    export interface MCPToolFailuresQueryResponse {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MCPToolFailureItem[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface MCPToolFailuresQuery {
+      dateRange?: DateRange | null;
+      kind?: 'MCPToolFailuresQuery';
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      response?: MCPToolFailuresQueryResponse | null;
+      tags?: QueryLogTags | null;
+      /** The raw $mcp_tool_name to scope $exception events to. */
+      toolName: string;
+      /** version of the node, used for schema migrations */
+      version?: number | null;
+    }
+
     /**
      * Extra globals for the query
      */
@@ -26299,7 +26385,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLMetadataResponse | null;
       /** Query within which "expr" and "template" are validated. Defaults to "select * from events" */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | null;
       tags?: QueryLogTags | null;
       /** Variables to be subsituted into the query */
       variables?: HogQLMetadataVariables;
@@ -26325,7 +26411,7 @@ export namespace Schemas {
       query: string;
       response?: HogQLAutocompleteResponse | null;
       /** Query in whose context to validate. */
-      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | null;
+      sourceQuery?: EventsNode | ActionsNode | PersonsNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | CalendarHeatmapQuery | RecordingsQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | null;
       /** Start position of the editor word */
       startPosition: number;
       tags?: QueryLogTags | null;
@@ -43626,7 +43712,7 @@ export namespace Schemas {
        * ```
        *
        * For more details on HogQL queries, see the [PostHog HogQL documentation](/docs/hogql#api-access). */
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | PropertyValuesQuery;
       /** Whether results should be calculated sync or async, and how much to rely on the cache:
        * - `'blocking'` - calculate synchronously (returning only when the query is done), UNLESS there are very fresh results in the cache
        * - `'async'` - kick off background calculation (returning immediately with a query status), UNLESS there are very fresh results in the cache
@@ -45663,6 +45749,46 @@ export namespace Schemas {
       resolved_compare_date_range?: ResolvedDateRangeResponse | null;
       /** The date range used for the query */
       resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MCPToolTopUserItem[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative98 {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
+      results: MCPToolFailureItem[];
+      /** Measured timings for different parts of the query generation process */
+      timings?: QueryTiming[] | null;
+      /** Warnings about data warehouse sources referenced by the query whose latest sync failed, is paused, hit a billing limit, or is otherwise stale. Results may not reflect current source data. Accumulated across every HogQL execution that contributes to this response — so insights backed by warehouse tables (Trends, Funnels, etc.) receive the same warnings as raw HogQL queries. */
+      warnings?: DataWarehouseSyncWarning[] | null;
+    }
+
+    export interface QueryResponseAlternative99 {
+      /** Query error. Returned only if 'explain' or `modifiers.debug` is true. Throws an error otherwise. */
+      error?: string | null;
+      /** Generated HogQL query. */
+      hogql?: string | null;
+      /** Modifiers used when performing the query */
+      modifiers?: HogQLQueryModifiers | null;
+      /** Query status indicates whether next to the provided data, a query is still running. */
+      query_status?: QueryStatus | null;
+      /** The resolved previous/comparison period date range, when comparing against another period */
+      resolved_compare_date_range?: ResolvedDateRangeResponse | null;
+      /** The date range used for the query */
+      resolved_date_range?: ResolvedDateRangeResponse | null;
       results: PropertyValueItem[];
       /** Measured timings for different parts of the query generation process */
       timings?: QueryTiming[] | null;
@@ -45670,18 +45796,18 @@ export namespace Schemas {
       warnings?: DataWarehouseSyncWarning[] | null;
     }
 
-    export type QueryResponseAlternative = { [key: string]: unknown } | QueryResponseAlternative1 | QueryResponseAlternative2 | QueryResponseAlternative3 | QueryResponseAlternative4 | QueryResponseAlternative5 | QueryResponseAlternative6 | QueryResponseAlternative7 | QueryResponseAlternative8 | QueryResponseAlternative9 | QueryResponseAlternative10 | QueryResponseAlternative11 | QueryResponseAlternative14 | QueryResponseAlternative15 | QueryResponseAlternative16 | QueryResponseAlternative17 | QueryResponseAlternative18 | QueryResponseAlternative19 | QueryResponseAlternative20 | QueryResponseAlternative21 | QueryResponseAlternative22 | QueryResponseAlternative23 | QueryResponseAlternative24 | QueryResponseAlternative25 | QueryResponseAlternative26 | QueryResponseAlternative27 | QueryResponseAlternative28 | QueryResponseAlternative29 | QueryResponseAlternative30 | QueryResponseAlternative31 | QueryResponseAlternative32 | QueryResponseAlternative33 | QueryResponseAlternative34 | QueryResponseAlternative35 | QueryResponseAlternative36 | QueryResponseAlternative37 | QueryResponseAlternative38 | unknown | QueryResponseAlternative39 | QueryResponseAlternative40 | QueryResponseAlternative41 | QueryResponseAlternative42 | QueryResponseAlternative43 | QueryResponseAlternative44 | QueryResponseAlternative45 | QueryResponseAlternative46 | QueryResponseAlternative47 | QueryResponseAlternative48 | QueryResponseAlternative49 | QueryResponseAlternative50 | QueryResponseAlternative51 | QueryResponseAlternative52 | QueryResponseAlternative53 | QueryResponseAlternative54 | QueryResponseAlternative55 | QueryResponseAlternative57 | QueryResponseAlternative58 | QueryResponseAlternative59 | QueryResponseAlternative60 | QueryResponseAlternative62 | QueryResponseAlternative63 | QueryResponseAlternative64 | QueryResponseAlternative65 | QueryResponseAlternative66 | QueryResponseAlternative67 | QueryResponseAlternative68 | QueryResponseAlternative69 | QueryResponseAlternative70 | QueryResponseAlternative71 | QueryResponseAlternative73 | QueryResponseAlternative74 | QueryResponseAlternative75 | QueryResponseAlternative76 | QueryResponseAlternative77 | QueryResponseAlternative78 | QueryResponseAlternative79 | QueryResponseAlternative80 | QueryResponseAlternative81 | QueryResponseAlternative82 | QueryResponseAlternative83 | QueryResponseAlternative84 | QueryResponseAlternative85 | QueryResponseAlternative86 | QueryResponseAlternative87 | QueryResponseAlternative89 | QueryResponseAlternative90 | QueryResponseAlternative91 | QueryResponseAlternative92 | QueryResponseAlternative93 | QueryResponseAlternative94 | QueryResponseAlternative95 | QueryResponseAlternative96 | QueryResponseAlternative97;
+    export type QueryResponseAlternative = { [key: string]: unknown } | QueryResponseAlternative1 | QueryResponseAlternative2 | QueryResponseAlternative3 | QueryResponseAlternative4 | QueryResponseAlternative5 | QueryResponseAlternative6 | QueryResponseAlternative7 | QueryResponseAlternative8 | QueryResponseAlternative9 | QueryResponseAlternative10 | QueryResponseAlternative11 | QueryResponseAlternative14 | QueryResponseAlternative15 | QueryResponseAlternative16 | QueryResponseAlternative17 | QueryResponseAlternative18 | QueryResponseAlternative19 | QueryResponseAlternative20 | QueryResponseAlternative21 | QueryResponseAlternative22 | QueryResponseAlternative23 | QueryResponseAlternative24 | QueryResponseAlternative25 | QueryResponseAlternative26 | QueryResponseAlternative27 | QueryResponseAlternative28 | QueryResponseAlternative29 | QueryResponseAlternative30 | QueryResponseAlternative31 | QueryResponseAlternative32 | QueryResponseAlternative33 | QueryResponseAlternative34 | QueryResponseAlternative35 | QueryResponseAlternative36 | QueryResponseAlternative37 | QueryResponseAlternative38 | unknown | QueryResponseAlternative39 | QueryResponseAlternative40 | QueryResponseAlternative41 | QueryResponseAlternative42 | QueryResponseAlternative43 | QueryResponseAlternative44 | QueryResponseAlternative45 | QueryResponseAlternative46 | QueryResponseAlternative47 | QueryResponseAlternative48 | QueryResponseAlternative49 | QueryResponseAlternative50 | QueryResponseAlternative51 | QueryResponseAlternative52 | QueryResponseAlternative53 | QueryResponseAlternative54 | QueryResponseAlternative55 | QueryResponseAlternative57 | QueryResponseAlternative58 | QueryResponseAlternative59 | QueryResponseAlternative60 | QueryResponseAlternative62 | QueryResponseAlternative63 | QueryResponseAlternative64 | QueryResponseAlternative65 | QueryResponseAlternative66 | QueryResponseAlternative67 | QueryResponseAlternative68 | QueryResponseAlternative69 | QueryResponseAlternative70 | QueryResponseAlternative71 | QueryResponseAlternative73 | QueryResponseAlternative74 | QueryResponseAlternative75 | QueryResponseAlternative76 | QueryResponseAlternative77 | QueryResponseAlternative78 | QueryResponseAlternative79 | QueryResponseAlternative80 | QueryResponseAlternative81 | QueryResponseAlternative82 | QueryResponseAlternative83 | QueryResponseAlternative84 | QueryResponseAlternative85 | QueryResponseAlternative86 | QueryResponseAlternative87 | QueryResponseAlternative89 | QueryResponseAlternative90 | QueryResponseAlternative91 | QueryResponseAlternative92 | QueryResponseAlternative93 | QueryResponseAlternative94 | QueryResponseAlternative95 | QueryResponseAlternative96 | QueryResponseAlternative97 | QueryResponseAlternative98 | QueryResponseAlternative99;
 
     export interface QueryStatusResponse {
       query_status: QueryStatus;
     }
 
     export interface QueryUpgradeRequest {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | PropertyValuesQuery;
     }
 
     export interface QueryUpgradeResponse {
-      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | PropertyValuesQuery;
+      query: EventsNode | ActionsNode | PersonsNode | DataWarehouseNode | FunnelsDataWarehouseNode | LifecycleDataWarehouseNode | EventsQuery | SessionsQuery | ActorsQuery | GroupsQuery | InsightActorsQuery | InsightActorsQueryOptions | SessionsTimelineQuery | HogQuery | HogQLQuery | HogQLMetadata | HogQLAutocomplete | SessionAttributionExplorerQuery | RevenueExampleEventsQuery | RevenueExampleDataWarehouseTablesQuery | ErrorTrackingQuery | ErrorTrackingSimilarIssuesQuery | ErrorTrackingBreakdownsQuery | ErrorTrackingIssueCorrelationQuery | ExperimentFunnelsQuery | ExperimentTrendsQuery | ExperimentQuery | ExperimentExposureQuery | DocumentSimilarityQuery | WebOverviewQuery | WebStatsTableQuery | WebExternalClicksTableQuery | WebGoalsQuery | WebVitalsQuery | WebVitalsPathBreakdownQuery | WebPageURLSearchQuery | WebAnalyticsExternalSummaryQuery | WebNotableChangesQuery | RevenueAnalyticsGrossRevenueQuery | RevenueAnalyticsMetricsQuery | RevenueAnalyticsMRRQuery | RevenueAnalyticsOverviewQuery | RevenueAnalyticsTopCustomersQuery | MarketingAnalyticsTableQuery | MarketingAnalyticsAggregatedQuery | NonIntegratedConversionsTableQuery | DataVisualizationNode | DataTableNode | SavedInsightNode | InsightVizNode | TrendsQuery | FunnelsQuery | RetentionQuery | PathsQuery | StickinessQuery | LifecycleQuery | FunnelCorrelationQuery | DatabaseSchemaQuery | RecordingsQuery | LogsQuery | LogAttributesQuery | LogValuesQuery | TraceSpansQuery | TraceSpansAggregationQuery | TraceSpansTreeQuery | TraceSpansAttributeBreakdownQuery | SuggestedQuestionsQuery | TeamTaxonomyQuery | EventTaxonomyQuery | ActorsPropertyTaxonomyQuery | TracesQuery | TraceQuery | TraceNeighborsQuery | VectorSearchQuery | UsageMetricsQuery | AccountsQuery | EndpointsUsageOverviewQuery | EndpointsUsageTableQuery | EndpointsUsageTrendsQuery | MCPHarnessBreakdownQuery | MCPToolTopUsersQuery | MCPToolFailuresQuery | PropertyValuesQuery;
     }
 
     export interface QuotaResourceLimit {


### PR DESCRIPTION
## Problem

The MCP analytics "share by harness" breakdown showed every harness as **Other** for projects instrumented with the posthog-node MCP analytics SDK (for example project 263599 — all calls bucketed to Other).

Root cause: the harness classifier in `mcp_harness.py` only read the identity properties emitted by PostHog's *hosted* MCP server (`mcp_vendor_client`, `$mcp_client_user_agent`, `mcp_session_client_name`, `$mcp_oauth_client_name`). Events from the SDK (`$mcp_source = posthog_mcp_analytics`) report the client under `$mcp_client_name` instead — a property the classifier never consulted — so the token resolved to empty and fell through to "Other". The data needed to classify was present the whole time; it just wasn't being read.

## Changes

**Fix:** add `$mcp_client_name` to the token coalesce in `mcp_harness.py`, at the same tier as `mcp_session_client_name` (both are the MCP `clientInfo.name`, one per instrumentation path; an event only carries one). The existing `(via mcp-remote ...)` proxy-suffix strip handles those values for free, so `claude-ai` and `claude-ai (via mcp-remote 0.1.37)` both resolve to **Claude.ai**.

**Refactor (frontend now defers to the backend):** the dashboard donut already resolved labels server-side via `MCPHarnessBreakdownQuery`, but the tool-detail "Top users" and "Failures" tables still classified raw `$mcp_client_name` client-side using a duplicate `categorizeHarness` + match registry. That second copy is now gone:

- New `MCPToolTopUsersQueryRunner` and `MCPToolFailuresQueryRunner`, both resolving harness labels server-side via `mcp_harness` (the single source of truth).
- Shared access gate + date-range construction extracted to `hogql_queries/base.py`; `harness_breakdown` refactored onto it.
- `harnessRegistry.ts` now maps a *resolved label* to its logo/colour only — `categorizeHarness` and the match predicates are removed.
- Tool-detail loaders call the new query kinds; `HarnessLogos` renders the server-resolved label lists.

## How did you test this code?

I'm an agent (PostHog Code). I did not do manual UI testing. Automated tests I actually ran (all green against a local Postgres + ClickHouse):

- `test_harness_breakdown.py` (22 tests) — extended with `$mcp_client_name` → label cases, including the `mcp-remote` proxy strip. Catches the regression where SDK-reported clients silently become "Other".
- `test_tool_tables.py` (14 tests, new) — harness label resolution (incl. `$mcp_client_name` + proxy strip), per-user/per-message aggregation, effective-tool-name + new-SDK filtering, date-range scoping, and person-properties passthrough for the two new runners.
- `mcpDashboardOverviewLogic.test.ts` (52 tests) — pass after removing the `categorizeHarness` suite and keeping the `harnessLogo` registry tests.

I also verified the fix against real production data via Metabase (the project that triggered this), and smoke-tested `get_query_runner` dispatch for both new query kinds.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed the work; assigned as DRI.

Built with PostHog Code (Claude Opus). Started from a bug report ("share by harness shows all Other for project 263599"), diagnosed via the `query-clickhouse-via-metabase` skill against prod-us ClickHouse — that's how the `$mcp_client_name` vs hosted-server property mismatch surfaced. Paul then asked to remove the duplicated frontend classification so the backend is the sole source of truth.

Key decisions:
- Placed `$mcp_client_name` at the `mcp_session_client_name` tier rather than first, since they're the same signal from disjoint instrumentation paths — precedence between them never matters in practice.
- For the frontend cleanup, chose dedicated backend query runners (consistent with the existing `MCPHarnessBreakdownQuery` the donut already uses) over materializing a `$mcp_harness` property at ingestion — smaller blast radius, no ingestion changes.
- Split into two commits (bug fix, then refactor) so the one-line fix is reviewable on its own.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
