### PR TITLE
fix(api): remove N+1 in user serializer membership_level

### DIFF
--- a/posthog/api/shared.py
+++ b/posthog/api/shared.py
@@ -3,7 +3,9 @@ This module contains serializers that are used across other serializers for nest
 """
 
 import copy
+from functools import cached_property
 from typing import Any, Optional
+from uuid import UUID
 
 from drf_spectacular.utils import extend_schema_field
 from opentelemetry import trace
@@ -282,10 +284,16 @@ class OrganizationBasicSerializer(serializers.ModelSerializer):
         ]
 
     def get_membership_level(self, organization: Organization) -> Optional[OrganizationMembership.Level]:
-        membership = OrganizationMembership.objects.filter(
-            organization=organization, user=self.context["request"].user
-        ).first()
-        return OrganizationMembership.Level(membership.level) if membership is not None else None
+        level = self._membership_levels_by_org.get(organization.id)
+        return OrganizationMembership.Level(level) if level is not None else None
+
+    @cached_property
+    def _membership_levels_by_org(self) -> dict[UUID, int]:
+        return dict(
+            OrganizationMembership.objects.filter(user=self.context["request"].user).values_list(
+                "organization_id", "level"
+            )
+        )
 
     @tracer.start_as_current_span("organization_basic_serializer.to_representation")
     def to_representation(self, instance):

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -12,6 +12,8 @@ from unittest.mock import ANY, patch
 from django.contrib.auth.tokens import default_token_generator
 from django.core import mail
 from django.core.cache import cache
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils import timezone
 from django.utils.text import slugify
 
@@ -130,6 +132,37 @@ class TestUserAPI(APIBaseTest):
                 },
             ],
         )
+
+    def test_me_membership_queries_do_not_scale_with_org_count(self):
+        def membership_query_count(user: User) -> int:
+            self.client.force_login(user)
+            with CaptureQueriesContext(connection) as ctx:
+                response = self.client.get("/api/users/@me/")
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            return sum(
+                1
+                for q in ctx.captured_queries
+                if "posthog_organizationmembership" in q["sql"] and q["sql"].lstrip()[:6].upper() == "SELECT"
+            )
+
+        user_in_one_org = create_user(
+            "one-org@example.com", self.CONFIG_PASSWORD, Organization.objects.create(name="Solo Org")
+        )
+
+        user_in_many_orgs = create_user(
+            "many-orgs@example.com", self.CONFIG_PASSWORD, Organization.objects.create(name="Org 0")
+        )
+        for i in range(1, 6):
+            OrganizationMembership.objects.create(
+                organization=Organization.objects.create(name=f"Org {i}"),
+                user=user_in_many_orgs,
+                level=OrganizationMembership.Level.MEMBER,
+            )
+
+        few = membership_query_count(user_in_one_org)
+        many = membership_query_count(user_in_many_orgs)
+
+        assert many == few, f"membership_level is N+1: {many} membership queries for 6 orgs vs {few} for 1 org"
 
     def test_current_user_includes_pending_invites(self):
         from posthog.models import OrganizationInvite

--- a/posthog/api/test/test_user.py
+++ b/posthog/api/test/test_user.py
@@ -134,35 +134,42 @@ class TestUserAPI(APIBaseTest):
         )
 
     def test_me_membership_queries_do_not_scale_with_org_count(self):
-        def membership_query_count(user: User) -> int:
+        def me_membership_queries(user: User) -> tuple[int, dict]:
             self.client.force_login(user)
             with CaptureQueriesContext(connection) as ctx:
                 response = self.client.get("/api/users/@me/")
             self.assertEqual(response.status_code, status.HTTP_200_OK)
-            return sum(
+            count = sum(
                 1
                 for q in ctx.captured_queries
                 if "posthog_organizationmembership" in q["sql"] and q["sql"].lstrip()[:6].upper() == "SELECT"
             )
+            return count, response.json()
 
         user_in_one_org = create_user(
             "one-org@example.com", self.CONFIG_PASSWORD, Organization.objects.create(name="Solo Org")
         )
 
-        user_in_many_orgs = create_user(
-            "many-orgs@example.com", self.CONFIG_PASSWORD, Organization.objects.create(name="Org 0")
+        owner_org = Organization.objects.create(name="Owner Org")
+        user_in_many_orgs = create_user("many-orgs@example.com", self.CONFIG_PASSWORD, owner_org)
+        OrganizationMembership.objects.filter(organization=owner_org, user=user_in_many_orgs).update(
+            level=OrganizationMembership.Level.OWNER
         )
-        for i in range(1, 6):
+        member_orgs = [Organization.objects.create(name=f"Member Org {i}") for i in range(5)]
+        for org in member_orgs:
             OrganizationMembership.objects.create(
-                organization=Organization.objects.create(name=f"Org {i}"),
-                user=user_in_many_orgs,
-                level=OrganizationMembership.Level.MEMBER,
+                organization=org, user=user_in_many_orgs, level=OrganizationMembership.Level.MEMBER
             )
 
-        few = membership_query_count(user_in_one_org)
-        many = membership_query_count(user_in_many_orgs)
+        few, _ = me_membership_queries(user_in_one_org)
+        many, many_body = me_membership_queries(user_in_many_orgs)
 
+        assert few > 0, "membership query predicate matched nothing; the table/SELECT filter is wrong"
         assert many == few, f"membership_level is N+1: {many} membership queries for 6 orgs vs {few} for 1 org"
+
+        levels_by_org = {org["id"]: org["membership_level"] for org in many_body["organizations"]}
+        assert levels_by_org[str(owner_org.id)] == OrganizationMembership.Level.OWNER
+        assert levels_by_org[str(member_orgs[0].id)] == OrganizationMembership.Level.MEMBER
 
     def test_current_user_includes_pending_invites(self):
         from posthog.models import OrganizationInvite


### PR DESCRIPTION
## Problem

`/api/users/@me/` is served by `UserSerializer`, which embeds `organizations` as `OrganizationBasicSerializer(many=True)`. Each org's `membership_level` field ran its own `OrganizationMembership` query, so serializing a user in N organizations issued N membership queries. That endpoint fires on every page navigation, so under load this multiplied per-request DB connection checkouts and contributed to write-path connection-pool pressure.

## Changes

Batch the requesting user's membership levels into a single query, exposed as a `cached_property` keyed by organization id. `get_membership_level` reads from that map instead of querying per org.

The serialized output is unchanged — `membership_level` values are identical, only the query strategy changes. The `cached_property` lives for exactly one request (DRF instantiates the serializer, and deep-copies its declared fields, per request), so there's no cross-request or cross-user state.

## How did you test this code?

I'm an agent (PostHog Code) — no manual testing, only the automated tests below.

- Added `test_me_membership_queries_do_not_scale_with_org_count` (`posthog/api/test/test_user.py`): asserts the `OrganizationMembership` query count for `/api/users/@me/` is identical for a 1-org user and a 6-org user. It fails on the N+1 (19 vs 14 membership queries before the fix) and passes after. No existing test covered query-count scaling on this path.
- `test_retrieve_current_user` (asserts actual `membership_level` values) still passes — output is unchanged.
- Full `posthog/api/test/test_user.py`: 150 passed. One unrelated, pre-existing failure (`test_redirect_to_preflight_when_no_users`) fails locally with `TemplateDoesNotExist: index.html` because the frontend isn't built in this environment.
- `ruff check` + `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude). Skills invoked: `/improving-drf-endpoints` (serializer change) and `/writing-tests` (test gate).
- The N+1 surfaced while diagnosing write-path connection-pool saturation in Grafana; the APM trace pointed at the user serializer's field serialization, which led to `OrganizationBasicSerializer.get_membership_level`.
- First implemented as manual per-request memoization on `self.context`, then switched to `functools.cached_property` — cleaner, and the per-request serializer-instance guarantee (plus DRF's `Field.__deepcopy__` re-instantiating from init args rather than copying instance state) makes it safe.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
