### PR TITLE
fix(provisioning): refresh CIMD metadata on the agentic provisioning auth path

### DIFF
--- a/ee/api/agentic_provisioning/authentication.py
+++ b/ee/api/agentic_provisioning/authentication.py
@@ -16,6 +16,7 @@ from rest_framework.request import Request
 
 from posthog.api.oauth.cimd import (
     apply_provisioning_defaults,
+    enqueue_cimd_refresh_if_stale,
     get_application_by_client_id,
     is_cimd_client_id,
     is_cimd_registration_in_progress,
@@ -147,6 +148,21 @@ class ProvisioningAuthentication(BaseAuthentication):
 
             app = OAuthApplication.objects.filter(cimd_metadata_url=client_id).first()
             if app is not None:
+                # The raw lookup above bypasses get_or_create_cimd_application, so the
+                # CIMD document's TTL-based refresh never fires on this path. Enqueue it
+                # here so edits to live metadata (scope ceiling, redirect_uris, config)
+                # propagate instead of freezing at first registration. Refresh stays
+                # async; this request still serves the existing app.
+                try:
+                    enqueue_cimd_refresh_if_stale(client_id)
+                except Exception as e:
+                    logger.warning(
+                        "provisioning_cimd_refresh_enqueue_error",
+                        client_id=client_id,
+                        error=str(e),
+                        error_type=type(e).__name__,
+                    )
+
                 try:
                     if not app.is_provisioning_partner:
                         apply_provisioning_defaults(app)

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -735,6 +735,44 @@ class TestCimdProvisioningAutoRegistration(APIBaseTest):
         assert res.status_code == 200
         assert res.json()["type"] == "oauth"
 
+    @patch("posthog.api.oauth.cimd.requests.get")
+    def test_cimd_scope_ceiling_refreshes_on_agentic_auth_after_metadata_edit(self, mock_get, _url_mock):
+        from posthog.api.oauth.cimd import _cache_key, register_cimd_provisioning_application_task
+
+        initial = _make_cimd_metadata()
+        initial["com.posthog"] = {"scopes": ["insight:read"]}
+        mock_get.return_value = _cimd_mock_response(initial)
+        register_cimd_provisioning_application_task(CIMD_PROV_URL)
+
+        app = OAuthApplication.objects.get(cimd_metadata_url=CIMD_PROV_URL)
+        assert app.scopes == ["insight:read"]
+
+        # Partner edits the live metadata to widen the ceiling; the cached doc goes stale.
+        real_cache.delete(_cache_key(CIMD_PROV_URL))
+        widened = _make_cimd_metadata()
+        widened["com.posthog"] = {"scopes": ["insight:read", "dashboard:read"]}
+        mock_get.return_value = _cimd_mock_response(widened)
+
+        # A later agentic provisioning auth request must propagate the edit — the bug was that
+        # this raw-lookup path never refreshed, so the ceiling stayed frozen at registration.
+        _, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_cimd_refresh_e2e",
+                "email": "cimd-refresh-e2e@example.com",
+                "client_id": CIMD_PROV_URL,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+            },
+            content_type="application/json",
+            HTTP_API_VERSION="0.1d",
+        )
+        assert res.status_code == 200
+
+        app.refresh_from_db()
+        assert app.scopes == ["insight:read", "dashboard:read"]
+
     @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
     def test_existing_cimd_app_gets_provisioning_backfilled(self, mock_refresh, _url_mock):
         OAuthApplication.objects.create(

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -11,10 +11,13 @@ from unittest.mock import MagicMock, patch
 from django.core.cache import cache as real_cache
 from django.test import override_settings
 
+from parameterized import parameterized
 from rest_framework.test import APIClient
 
+from posthog.api.oauth.cimd import _cache_key
 from posthog.models.oauth import OAuthApplication
 
+from ee.api.agentic_provisioning.authentication import ProvisioningAuthentication
 from ee.api.agentic_provisioning.signature import compute_signature
 
 HMAC_SECRET = "test_hmac_secret"
@@ -576,6 +579,47 @@ class TestProvisioningAuthentication(APIBaseTest):
         assert res.status_code == 401
 
         cimd_app.delete()
+
+    @parameterized.expand(
+        [
+            ("stale_cache_fires_refresh", False, 1),
+            ("fresh_cache_skips_refresh", True, 0),
+        ]
+    )
+    @patch("posthog.api.oauth.cimd.refresh_cimd_metadata_task")
+    def test_cimd_provisioning_partner_refreshes_metadata_only_when_stale(
+        self, _name, cache_is_fresh, expected_delay_calls, mock_refresh
+    ):
+        cimd_url = "https://example.com/api/oauth/wizard/refresh-on-auth"
+        cimd_app = OAuthApplication.objects.create(
+            name="CIMD Wizard Refresh",
+            client_secret="",
+            client_type=OAuthApplication.CLIENT_PUBLIC,
+            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
+            redirect_uris="http://localhost:8239/callback",
+            algorithm="RS256",
+            is_cimd_client=True,
+            cimd_metadata_url=cimd_url,
+            provisioning_auth_method="pkce",
+            provisioning_partner_type="wizard",
+            provisioning_active=True,
+            provisioning_can_create_accounts=True,
+            provisioning_can_provision_resources=True,
+        )
+        self.addCleanup(cimd_app.delete)
+        self.addCleanup(real_cache.delete, _cache_key(cimd_url))
+
+        if cache_is_fresh:
+            real_cache.set(_cache_key(cimd_url), True, timeout=300)
+        else:
+            real_cache.delete(_cache_key(cimd_url))
+
+        partner = ProvisioningAuthentication()._identify_pkce_partner(cimd_url)
+
+        assert partner == cimd_app
+        assert mock_refresh.delay.call_count == expected_delay_calls
+        if expected_delay_calls:
+            mock_refresh.delay.assert_called_once_with(cimd_url)
 
     # --- PKCE code_challenge_method validation ---
 

--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -14,7 +14,7 @@ from django.test import override_settings
 from parameterized import parameterized
 from rest_framework.test import APIClient
 
-from posthog.api.oauth.cimd import _cache_key
+from posthog.api.oauth.cimd import _blocked_key, _cache_key
 from posthog.models.oauth import OAuthApplication
 
 from ee.api.agentic_provisioning.authentication import ProvisioningAuthentication
@@ -608,6 +608,8 @@ class TestProvisioningAuthentication(APIBaseTest):
         )
         self.addCleanup(cimd_app.delete)
         self.addCleanup(real_cache.delete, _cache_key(cimd_url))
+        # _identify_pkce_partner warms the blocklist cache with a 1-year TTL; clear it too.
+        self.addCleanup(real_cache.delete, _blocked_key(cimd_url))
 
         if cache_is_fresh:
             real_cache.set(_cache_key(cimd_url), True, timeout=300)

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -676,6 +676,18 @@ def get_or_create_cimd_application(url: str) -> OAuthApplication:
     raise CIMDFetchError(f"Another request is already registering this client ({url}). Please try again.")
 
 
+def enqueue_cimd_refresh_if_stale(url: str) -> None:
+    """Fire a background metadata refresh if the cached document has gone stale.
+
+    Mirrors the freshness check in get_or_create_cimd_application so callers that
+    resolve an existing CIMD app by a direct lookup (the agentic provisioning auth
+    path) still pick up document changes on the same TTL, instead of freezing the
+    app's scopes and config at first registration.
+    """
+    if not cache.get(_cache_key(url)):
+        refresh_cimd_metadata_task.delay(url)
+
+
 def get_application_by_client_id(client_id: str) -> OAuthApplication:
     """
     Look up an OAuthApplication by client_id, supporting CIMD URL-form client_ids.

--- a/posthog/api/oauth/cimd.py
+++ b/posthog/api/oauth/cimd.py
@@ -657,8 +657,7 @@ def get_or_create_cimd_application(url: str) -> OAuthApplication:
     """
     # Existing client: check cache freshness and if not fresh, fire refresh in the background, returning existing app immediately
     if app := OAuthApplication.objects.filter(cimd_metadata_url=url).first():
-        if not cache.get(_cache_key(url)):
-            refresh_cimd_metadata_task.delay(url)
+        enqueue_cimd_refresh_if_stale(url)
         return app
 
     # New client: synchronous fetch
@@ -679,10 +678,10 @@ def get_or_create_cimd_application(url: str) -> OAuthApplication:
 def enqueue_cimd_refresh_if_stale(url: str) -> None:
     """Fire a background metadata refresh if the cached document has gone stale.
 
-    Mirrors the freshness check in get_or_create_cimd_application so callers that
-    resolve an existing CIMD app by a direct lookup (the agentic provisioning auth
-    path) still pick up document changes on the same TTL, instead of freezing the
-    app's scopes and config at first registration.
+    Single source of the freshness check, used both by get_or_create_cimd_application
+    and by callers that resolve an existing CIMD app via a direct lookup (the agentic
+    provisioning auth path) so document changes are picked up on the same TTL, instead
+    of freezing the app's scopes and config at first registration.
     """
     if not cache.get(_cache_key(url)):
         refresh_cimd_metadata_task.delay(url)

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1695,6 +1695,10 @@ export const DashboardsUpdateWidgetsBatchBody = /* @__PURE__ */ zod
                                     .max(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string().min(1), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .optional()
                             .describe('New configuration for the recent events widget. Omit to leave unchanged.'),

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -1762,6 +1762,10 @@ export const DashboardsUpdateWidgetsBatchBody = /* @__PURE__ */ zod
                                     .max(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string().min(1), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .optional()
                             .describe('New configuration for the recent events widget. Omit to leave unchanged.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/dashboard-widgets-batch-update.json
@@ -47,6 +47,18 @@
                                             }
                                         ]
                                     },
+                                    "eventName": {
+                                        "anyOf": [
+                                            {
+                                                "minLength": 1,
+                                                "type": "string"
+                                            },
+                                            {
+                                                "type": "null"
+                                            }
+                                        ],
+                                        "description": "Limit the feed to a single event name. Omit or null for all events."
+                                    },
                                     "filterTestAccounts": {
                                         "anyOf": [
                                             {


### PR DESCRIPTION
## Problem

A CIMD-registered OAuth app used for agentic provisioning froze its scope ceiling (and `redirect_uris` / config) at first registration. Editing the live CIMD metadata document never updated an already-registered provisioning client.

PostHog *does* refresh CIMD documents on a TTL and overwrite the stored scopes, but that refresh is only enqueued by `get_or_create_cimd_application`, which fires the background task when the freshness cache key is stale. The agentic provisioning auth path resolves the partner with a raw lookup (`OAuthApplication.objects.filter(cimd_metadata_url=client_id).first()` in `_identify_pkce_partner`), so it never triggered the refresh. Only the standard `/authorize` browser flow refreshed. The standard OAuth path is unaffected.

## Changes

- Add a public `enqueue_cimd_refresh_if_stale(url)` helper in `posthog/api/oauth/cimd.py` that mirrors the freshness check in `get_or_create_cimd_application` (enqueues `refresh_cimd_metadata_task.delay` when the cache key is absent).
- Call it on the existing-app branch of `_identify_pkce_partner`, wrapped in its own try/except that only logs, so a broker/cache hiccup can never break authentication.

The new-app branch is untouched: it still kicks off background registration and returns a 202 (`cimd_registration_pending`), with no synchronous fetch.

### Safety

- Refresh stays async/non-blocking (`.delay`). The current request still serves the existing (stale) ceiling; the next request after the worker updates the row sees the new scopes. Same eventual-consistency contract `/authorize` already has.
- Already-issued access/refresh tokens are unaffected — they carry their own scope string and are re-capped on refresh. No auto-revoke on widening.
- Narrowing a ceiling still requires `revoke_application_sessions` to claw back live tokens; that is pre-existing and out of scope here, and this change doesn't touch it.
- No DB migration — control-flow change only.

## How did you test this code?

Authored by an agent (Claude Code, Opus 4.8); automated tests only, no manual testing.

`bin/hogli test ee/api/agentic_provisioning/test/test_provisioning_auth.py` → 32 passed (run with `SANDBOX_PROVIDER=local`). New tests:

- **`test_cimd_scope_ceiling_refreshes_on_agentic_auth_after_metadata_edit`** — end-to-end coverage of the actual bug. Registers a CIMD provisioning partner with one scope ceiling, edits the live metadata to widen it, then drives a real `POST /api/agentic/provisioning/account_requests` and asserts the stored ceiling actually updated. Because Celery runs eagerly in tests, the refresh task executes inline, so this exercises the full chain — auth path → enqueue → `refresh_cimd_metadata_task` → `fetch_and_upsert_cimd_application` → DB scope update — with only the HTTP fetch and the SSRF guard mocked (the standard boundaries the existing CIMD tests mock).
- **`test_cimd_provisioning_partner_refreshes_metadata_only_when_stale`** (parameterized) — unit-level gate: enqueues the refresh exactly once when the freshness cache key is absent, and not at all when present.

Verified both directions: with the `enqueue_cimd_refresh_if_stale` call removed, the e2e test fails (the ceiling stays frozen at registration) and the stale-cache unit case fails, while the fresh-cache case still passes. So the tests catch the regression rather than passing vacuously.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent: Claude Code (Opus 4.8, 1M context). Matt directed the work; the root-cause analysis was provided up front and the agent did the wiring, tests, and PR.
- Skills invoked: `/writing-tests` (gated the tests and kept them behavior-level), `/pr-ready` (self-review + draft PR), `/disk-cleanup` (local OrbStack recovery during testing — unrelated to the diff).
- Decisions: kept the refresh asynchronous and wrapped in a log-only try/except so auth can never break on a broker/cache failure; deliberately did not switch the call site to `get_or_create_cimd_provisioning_application`, which does a synchronous fetch for new apps and would change the non-blocking 202 behavior. A true live-stack e2e against a mutable external metadata URL was skipped because the `is_url_allowed` SSRF guard blocks localhost-style hosts; the eager-Celery test above covers the same propagation chain with the network boundary mocked.
