### PR TITLE
fix(data-warehouse): dedupe DuckLake JSON path placeholders

### DIFF
--- a/posthog/hogql/printer/duckdb.py
+++ b/posthog/hogql/printer/duckdb.py
@@ -41,6 +41,7 @@ class DuckDBPrinter(PostgresPrinter):
             for k, v in parent_handlers.items()
             if k not in DUCKDB_FUNCTION_RENAMES_LOWER
         }
+        self._jsonpath_placeholders: dict[str, str] = {}
 
     def _print_identifier(self, name: str) -> str:
         # DuckDB has no practical identifier length limit, so skip the Postgres
@@ -70,7 +71,13 @@ class DuckDBPrinter(PostgresPrinter):
             return f'."{escaped}"'
 
         path = "$" + "".join(member(k) for k in chain)
-        return [self.context.add_value(path)]
+        # DuckDB rejects `GROUP BY <expr>` when the SELECT and GROUP BY bind the same path to
+        # different placeholders, so reuse one placeholder per distinct path within a query.
+        placeholder = self._jsonpath_placeholders.get(path)
+        if placeholder is None:
+            placeholder = self.context.add_value(path)
+            self._jsonpath_placeholders[path] = placeholder
+        return [placeholder]
 
     def _unsafe_json_extract_trim_quotes(self, unsafe_field, unsafe_args):
         if not unsafe_args:

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -6883,6 +6883,20 @@ class TestDuckDBPrinter(BaseTest):
         self._expr("properties['a\"b']", context=context)
         self.assertEqual(list(context.values.values()), ['$."a\\"b"'])
 
+    def test_repeated_property_access_reuses_one_placeholder(self):
+        # DuckDB rejects `GROUP BY <expr>` when the same JSON path is bound to a different placeholder
+        # in the SELECT than in the GROUP BY — it can't prove the two parameterized expressions are
+        # equal. Repeated identical reads must collapse to a single bound value so the printed
+        # expressions match textually.
+        context = HogQLContext(team_id=self.team.pk, enable_select_queries=True)
+        printed = self._select(
+            "SELECT properties.$ai_session_id AS s, count() AS n FROM events GROUP BY properties.$ai_session_id",
+            context=context,
+        )
+        self.assertEqual(list(context.values.values()).count('$."$ai_session_id"'), 1)
+        # the SELECT and GROUP BY reference the very same placeholder token
+        self.assertEqual(printed.count("(events.properties) ->> %(hogql_val_0)s"), 2)
+
 
 class TestMySQLPrinter(BaseTest):
     maxDiff = None

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')


### PR DESCRIPTION
## Problem

Stacked on #66045. With the DuckDB-dialect fix in place, a query that reads the same property in both the SELECT and the GROUP BY — e.g. `SELECT properties.$ai_session_id … GROUP BY properties.$ai_session_id` — still fails on DuckDB with `column "properties" must appear in the GROUP BY clause`.

The HogQL→SQL printer mints a fresh bind placeholder per property read, so the same JSON path becomes two different parameterized expressions and DuckDB can't prove they're equal. This was masked before #66045 because the JSON-path bind error fired first.

## Changes

- `DuckDBPrinter` reuses one placeholder per distinct JSONPath within a query, so a property read prints identically in the SELECT and the GROUP BY. Safe because only the key-path placeholder is shared — the field expression (`events.properties` vs a joined table's) stays distinct.

## How did you test this code?

Agent-authored. Automated tests only:
- New `TestDuckDBPrinter` case asserting a property read in SELECT + GROUP BY collapses to one bound value and one placeholder.
- Full printer suite, `posthog/ducklake/test_client.py`, and the duckgres materialization activity suite pass.
- Confirmed the real grouping endpoint query now executes end-to-end on DuckDB 1.5.1, where it previously raised the GROUP BY error.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Surfaced while verifying #66045 against the real endpoint query: the unit test and a simple read both passed, but the actual grouped query exposed this second, orthogonal bug. Considered a global dedupe in `add_value` but scoped it to the DuckDB dialect to avoid changing other dialects' output. Built with Claude Code.
