### PR TITLE
fix(error-tracking): don't crash issues list when aggregations are missing

### DIFF
--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -26,7 +26,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
     date_from: datetime.datetime
     date_to: datetime.datetime
 
-    CACHE_VERSION = 3
+    CACHE_VERSION = 2
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
+++ b/products/error_tracking/backend/hogql_queries/error_tracking_query_runner.py
@@ -26,7 +26,7 @@ class ErrorTrackingQueryRunner(AnalyticsQueryRunner[ErrorTrackingQueryResponse])
     date_from: datetime.datetime
     date_to: datetime.datetime
 
-    CACHE_VERSION = 2
+    CACHE_VERSION = 3
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
+++ b/products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/issues/IssuesList.tsx
@@ -36,9 +36,6 @@ import { ERROR_TRACKING_LISTING_RESOLUTION } from 'products/error_tracking/front
 
 const VolumeColumn: QueryContextColumnComponent = (props) => {
     const record = props.record as ErrorTrackingIssue
-    if (!record.aggregations) {
-        throw new Error('No aggregations found')
-    }
     const sparklineKey = record.id ?? 'issue-unknown'
     const baseData = useSparklineData(record.aggregations, ERROR_TRACKING_LISTING_RESOLUTION)
     const { spikeEventsByIssueId } = useValues(batchSpikeEventsLogic)


### PR DESCRIPTION
## Problem

`VolumeColumn` threw `Error('No aggregations found')` during render whenever an issue row arrived without an `aggregations` object. Thrown mid-render, it unwound the whole React subtree, so one bad row took down the entire issues list — most visibly the **Issues panel on the person profile tab** (the `ph-issues` notebook node), which reuses this exact column. This is a recurring production crash that re-throws many times per affected page view.

## Changes

Remove the throw and pass the optional `record.aggregations` straight into `useSparklineData`, which already handles `undefined` by rendering a flat fallback sparkline. This makes `VolumeColumn` degrade gracefully — matching its sibling `CountColumn` in the same file, which already falls back to `0`.

`aggregations` is legitimately optional in the schema (it's `null` for the issue-detail query that sets `withAggregations: false`), so the renderer must tolerate its absence rather than assume it.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). Automated checks run:
- `pnpm --filter=@posthog/frontend typescript:check` — no errors in the edited file (`useSparklineData` already accepts `undefined`).
- oxlint/oxfmt on the file — clean.

No new test added: nothing pinned the throw, and the graceful path is already exercised by the issue-detail scene that passes optional aggregations through.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with PostHog Code. Confirmed via session-replay + `$exception` analysis that the crash fires on the person profile Issues panel and recurs across many users. The backend reliably populates `aggregations` whenever `withAggregations` is set (always true on this path), so there's no clean query-side defect to target — the bug is the render layer treating an optional field as guaranteed. A defensive render-side fix also covers all upstream causes (stale cache, optimistic update, backend edge) rather than one hypothesized one. Considered bumping the runner's `CACHE_VERSION` (last bumped before the v2 response-shape change) as belt-and-suspenders, but the month-long recurrence shows stale cache isn't the driver, so it's out of scope here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
