### PR TITLE
fix(tasks): pad virtualized task logs and keep bottom pinned

### DIFF
--- a/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
+++ b/frontend/src/scenes/inbox/components/detail/ReportTasksSection.tsx
@@ -85,7 +85,10 @@ function TaskRow({
             {expanded ? (
                 <div className="mt-1.5 mb-1 ml-1.5">
                     {runId ? (
-                        <div className="h-[420px] overflow-y-auto rounded border border-primary bg-surface-primary">
+                        // The viewer's virtualized thread owns scroll, so this box only bounds the height and
+                        // clips — an `overflow-y-auto` here would nest a second scrollbar. Content is kept off
+                        // the border via `threadRowClassName`/`threadListClassName`, not padding on this box.
+                        <div className="h-[420px] overflow-hidden rounded border border-primary bg-surface-primary">
                             <RunViewer
                                 taskId={task.id}
                                 runId={runId}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/TaskTracker.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/TaskTracker.tsx
@@ -85,7 +85,7 @@ export function TaskTracker({ taskId }: TaskTrackerProps): JSX.Element {
                 <div className="w-72 shrink-0 pl-0 flex flex-col min-h-0 border-r border-primary">
                     <TasksListColumn selectedTaskId={selectedTaskId} />
                 </div>
-                <div className="flex-1 min-w-0 flex flex-col min-h-0 overflow-hidden">{rightPane}</div>
+                <div className="flex-1 min-w-0 flex flex-col min-h-0">{rightPane}</div>
             </div>
         </SceneContent>
     )

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskDetailPage.tsx
@@ -91,7 +91,7 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
         )
 
     return (
-        <SceneContent className="h-full min-h-0">
+        <SceneContent className="h-full min-h-0 gap-y-0">
             {sceneMenuBarEnabled && task && (
                 <SceneMenuBar>
                     <SceneMenuBarMenu label="File" dataAttr="task-menubar-file">
@@ -164,31 +164,33 @@ export function TaskDetailPage({ taskId, isMobile }: TaskDetailPageProps): JSX.E
                         />
                     )}
 
-                    <SceneTitleSection
-                        name={task?.title || 'Task'}
-                        description={null}
-                        resourceType={{ type: 'task' }}
-                        isLoading={isHeaderLoading}
-                        canEdit={false}
-                        forceBackTo={
-                            isMobile
-                                ? {
-                                      key: 'tasks',
-                                      name: 'Tasks',
-                                      path: urls.taskTracker(),
-                                  }
-                                : undefined
-                        }
-                        actions={titleActions}
-                    />
+                    <header className="flex flex-col gap-y-2">
+                        <SceneTitleSection
+                            name={task?.title || 'Task'}
+                            description={null}
+                            resourceType={{ type: 'task' }}
+                            isLoading={isHeaderLoading}
+                            canEdit={false}
+                            forceBackTo={
+                                isMobile
+                                    ? {
+                                          key: 'tasks',
+                                          name: 'Tasks',
+                                          path: urls.taskTracker(),
+                                      }
+                                    : undefined
+                            }
+                            actions={titleActions}
+                        />
 
-                    {isHeaderLoading ? (
-                        <TaskRunMetadataSkeleton />
-                    ) : (
-                        selectedRun && <TaskRunMetadata selectedRun={selectedRun} />
-                    )}
+                        {isHeaderLoading ? (
+                            <TaskRunMetadataSkeleton />
+                        ) : (
+                            selectedRun && <TaskRunMetadata selectedRun={selectedRun} />
+                        )}
 
-                    <LemonDivider className="mb-0" />
+                        <LemonDivider className="mb-0" />
+                    </header>
 
                     <TaskRunLog taskId={taskId} />
                 </>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskRunLog.tsx
@@ -54,8 +54,10 @@ export function TaskRunLog({ taskId }: { taskId: string }): JSX.Element | null {
         )
     }
     if (selectedRun) {
+        // The viewer owns scroll edge-to-edge; this box just bounds the height. No `overflow-hidden`/negative
+        // margins — content is kept off the scrollbar via the viewer's `threadRowClassName`, not by clipping here.
         return (
-            <div className="flex-1 min-h-0 overflow-hidden -mr-4 -mt-4 pr-4">
+            <div className="flex-1 min-h-0">
                 <TaskRunChat taskId={taskId} runId={selectedRun.id} />
             </div>
         )


### PR DESCRIPTION
## Problem

Task run logs are embedded in several places: Inbox run artefacts, Inbox report task rows, agent-run details, and the Tasks detail page. After the thread moved to react-window virtualization, those embeds could either lose their content inset, stack an outer scrollbar over the virtualized list, or stop following the bottom cleanly as streamed rows changed height.

## Changes

- Keeps virtualized sandbox threads edge-to-edge for scrollbars while applying row-level horizontal padding, so transcript content and tool cards no longer sit flush against bordered containers.
- Lets `SandboxRunViewer` pass wrapper/list classes through to `SandboxThreadView`, and uses a single virtualized thread layout for read-only and live task-run embeds.
- Removes the extra scroll wrapper from the Inbox report task row and tightens the Tasks detail page so the run log owns the available scroll area.
- Reasserts bottom pinning while streamed or newly measured rows grow, but unpins when the user scrolls up.

## How did you test this code?

I'm an agent. I ran:

- `pnpm exec oxlint ...` on the seven changed frontend files
- `pnpm exec oxfmt --check ...` on the seven changed frontend files
- `pnpm --filter=@posthog/frontend exec jest products/posthog_ai/frontend/sandbox/components/SandboxRunViewer.test.tsx --runInBand --forceExit`

No manual/browser testing was performed. `hogli` was not available in this shell, including through `flox activate`, so I ran the focused Jest test directly.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is a frontend layout fix for existing task-run surfaces.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The code changes were agent-assisted before this metadata pass. Codex reviewed the current branch, invoked `/submit-pr` for PR metadata, and verified no DRF, migration, API type, or test-writing skills were required for these frontend-only layout changes.

The title/body were updated because the branch now covers the shared virtualized thread and Tasks detail page in addition to the original Inbox padding fix.
