### PR TITLE
feat(phai): show optimistic "spinning up sandbox" indicator on send

### DIFF
--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3534,6 +3534,20 @@ describe('maxThreadLogic', () => {
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
         })
 
+        it('lights the optimistic boot indicator before the open POST and clears it once the SSE opens', async () => {
+            jest.spyOn(api.conversations, 'open').mockResolvedValue(sandboxRunResponse)
+
+            await expectLogic(logic, () => {
+                logic.actions.streamConversation(
+                    { agent_mode: null, is_sandbox: true, content: 'hello', conversation: MOCK_CONVERSATION_ID },
+                    0
+                )
+            }).toDispatchActions(['setSandboxRunOpening', 'openSandboxSse'])
+
+            // openSandboxSse clears the optimistic flag via the reducer, so it never sticks on success.
+            expect(sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
+        })
+
         it('releases the lock immediately and surfaces an error when the send POST fails', async () => {
             jest.spyOn(api.conversations, 'open').mockRejectedValue(new Error('boom'))
 
@@ -3545,6 +3559,8 @@ describe('maxThreadLogic', () => {
             }).toDispatchActions(['pushSandboxError', 'decrActiveStreamingThreads'])
 
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
+            // The boot indicator must not stick once the failed send unwinds.
+            expect(sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
             expect(
                 runStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.threadItems.some(
                     (item) =>

--- a/frontend/src/scenes/max/maxThreadLogic.test.ts
+++ b/frontend/src/scenes/max/maxThreadLogic.test.ts
@@ -3545,7 +3545,7 @@ describe('maxThreadLogic', () => {
             }).toDispatchActions(['setSandboxRunOpening', 'openSandboxSse'])
 
             // openSandboxSse clears the optimistic flag via the reducer, so it never sticks on success.
-            expect(sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
+            expect(runStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
         })
 
         it('releases the lock immediately and surfaces an error when the send POST fails', async () => {
@@ -3560,7 +3560,7 @@ describe('maxThreadLogic', () => {
 
             expect(maxLogicInstance.values.activeStreamingThreads).toEqual(0)
             // The boot indicator must not stick once the failed send unwinds.
-            expect(sandboxStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
+            expect(runStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.runOpening).toEqual(false)
             expect(
                 runStreamLogic({ streamKey: MOCK_CONVERSATION_ID }).values.threadItems.some(
                     (item) =>

--- a/frontend/src/scenes/max/maxThreadLogic.tsx
+++ b/frontend/src/scenes/max/maxThreadLogic.tsx
@@ -212,6 +212,7 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                 'openSseForRun as openSandboxSse',
                 'pushHumanMessage as pushSandboxHumanMessage',
                 'pushErrorItem as pushSandboxError',
+                'setRunOpening as setSandboxRunOpening',
                 'bootstrapRun as bootstrapSandboxRun',
                 'reset as resetSandboxStream',
                 'cancelRun as cancelSandboxRun',
@@ -717,6 +718,10 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                                 value: `The user selected a mode: "${getModeDisplayName(values.agentMode)}". It was in the legacy implementation. Acknowledge the mode if the user refers to it.`,
                             })
                         }
+                        // Optimistic boot indicator: light the "spinning up sandbox" provisioning state
+                        // for the duration of the open POST, before any SSE state exists. `openSandboxSse`
+                        // (success) clears it via the reducer; the failure/no-handle paths clear it below.
+                        actions.setSandboxRunOpening(true)
                         // Single create-or-resume opener: it creates the conversation row on first use,
                         // starts/continues the Run, and returns the (task, run) handle. A message always
                         // provisions a run (a null handle only happens on a warm with a full pool).
@@ -763,7 +768,9 @@ export const maxThreadLogic = kea<maxThreadLogicType>([
                     posthog.captureException(e)
                     actions.pushSandboxError('Failed to send your message. Please try again.')
                 }
-                // The POST failed or no run was started — nothing will stream, release the lock now.
+                // The POST failed or no run was started — nothing will stream. Drop the optimistic boot
+                // indicator and release the lock now.
+                actions.setSandboxRunOpening(false)
                 actions.decrActiveStreamingThreads()
                 releaseStreamingLock()
                 return

--- a/products/posthog_ai/frontend/components/ThreadView.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.tsx
@@ -55,13 +55,16 @@ export function ThreadView({
         threadItems,
         toolInvocations,
         isThinking,
-        showThinkingIndicator,
+        streamPhase,
         runArtifacts,
         turnComplete,
         currentRunStatus,
         contextUsage,
     } = useValues(runStreamLogic)
     const turnCancelled = currentRunStatus === 'cancelled'
+    const hasActiveProgressItem = threadItems.some(
+        (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
+    )
 
     // Header/footer are kept as memoized leaf components with stable element identity so they don't rebuild
     // `VirtualizedThread`'s `renderRow` (and re-sweep visible rows) on every streamed frame. Each is wrapped
@@ -77,6 +80,10 @@ export function ThreadView({
         [branch, baseBranch, repo]
     )
 
+    // `provisioning` (conversations/open POST + cold boot before run_started) also shows the indicator,
+    // gated by !hasActiveProgressItem so real `_posthog/progress` boot steps take precedence.
+    const showThinking = (streamPhase === 'thinking' || streamPhase === 'provisioning') && !hasActiveProgressItem
+    const thinkingPhase = streamPhase === 'provisioning' ? 'provisioning' : 'thinking'
     // Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking.
     const pullRequestUrl = !isThinking ? runArtifacts.prUrl : undefined
     // Context usage rides the thread footer, but only between turns (idle) — never while the agent is
@@ -84,17 +91,18 @@ export function ThreadView({
     const showContextUsageFooter = showContextUsage && !isThinking && !!contextUsage
     const footer = useMemo(
         () =>
-            showThinkingIndicator || pullRequestUrl || showContextUsageFooter ? (
+            showThinking || pullRequestUrl || showContextUsageFooter ? (
                 <VirtualizedThread.Row className={rowClassName}>
                     <ThreadFooter
-                        showThinking={showThinkingIndicator}
+                        showThinking={showThinking}
+                        thinkingPhase={thinkingPhase}
                         pullRequestUrl={pullRequestUrl}
                         prBranch={branch}
                         showContextUsage={showContextUsageFooter}
                     />
                 </VirtualizedThread.Row>
             ) : undefined,
-        [showThinkingIndicator, pullRequestUrl, branch, showContextUsageFooter]
+        [showThinking, thinkingPhase, pullRequestUrl, branch, showContextUsageFooter]
     )
 
     const renderItem = useCallback(
@@ -150,11 +158,13 @@ const ThreadHeader = memo(function ThreadHeader({
  */
 const ThreadFooter = memo(function ThreadFooter({
     showThinking,
+    thinkingPhase,
     pullRequestUrl,
     prBranch,
     showContextUsage,
 }: {
     showThinking: boolean
+    thinkingPhase: 'thinking' | 'provisioning'
     pullRequestUrl?: string
     prBranch?: string
     showContextUsage?: boolean
@@ -164,7 +174,7 @@ const ThreadFooter = memo(function ThreadFooter({
     // items keep the same vertical rhythm as the thread.
     return (
         <div className="flex flex-col gap-1.5">
-            {showThinking && <ThinkingIndicator progress={currentProgress} />}
+            {showThinking && <ThinkingIndicator progress={currentProgress} phase={thinkingPhase} />}
             {pullRequestUrl && <PullRequestCard prUrl={pullRequestUrl} branch={prBranch} />}
             {showContextUsage && <ContextUsageBar />}
         </div>
@@ -173,12 +183,19 @@ const ThreadFooter = memo(function ThreadFooter({
 
 /**
  * Bottom-of-thread "what's it doing right now" line for sandbox conversations. Reflects the latest
- * `_posthog/progress` message when present, otherwise the canned thinking rotation.
+ * `_posthog/progress` message when present; during `provisioning` (the conversations/open POST / cold
+ * boot before `run_started`) it shows a fixed "spinning up" message, otherwise the canned thinking rotation.
  */
-function ThinkingIndicator({ progress }: { progress: string | null }): JSX.Element {
+function ThinkingIndicator({
+    progress,
+    phase,
+}: {
+    progress: string | null
+    phase: 'thinking' | 'provisioning'
+}): JSX.Element {
     // One roll per mount — re-rolling on every progress transition would visibly swap the verb.
     const fallbackMessage = useMemo(() => getRandomThinkingMessage(), [])
-    const message = progress?.trim() ? progress : fallbackMessage
+    const message = progress?.trim() ? progress : phase === 'provisioning' ? 'Spinning up sandbox…' : fallbackMessage
     // Match the LangGraph loader: a bubble-free reasoning line (muted brain icon + muted text),
     // static (no shimmer), via the shared Activity primitive — not a MessageTemplate bubble.
     return <ReasoningAnswer content={message} id="sandbox-thinking" completed={false} showCompletionIcon={false} />

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -1397,6 +1397,48 @@ describe('runStreamLogic', () => {
         })
     })
 
+    describe('streamPhase provisioning during open', () => {
+        it('is provisioning while the open POST is in flight, before any SSE state exists', () => {
+            expect(logic.values.streamPhase).toEqual('idle')
+
+            // The conversations/open POST has started — no SSE/run status yet.
+            logic.actions.setRunOpening(true)
+            expect(logic.values.sseStatus).toEqual('idle')
+            expect(logic.values.currentRunStatus).toEqual(null)
+            expect(logic.values.streamPhase).toEqual('provisioning')
+        })
+
+        it.each([
+            ['a stream error', (): void => logic.actions.handleStreamError({ errorTitle: 'x', retryable: true })],
+            ['an injected error item', (): void => logic.actions.pushErrorItem('boom')],
+        ])('clears the optimistic flag on %s', (_case, act) => {
+            logic.actions.setRunOpening(true)
+            expect(logic.values.runOpening).toEqual(true)
+
+            act()
+            expect(logic.values.runOpening).toEqual(false)
+        })
+
+        it('clears the optimistic flag once the SSE opens (openSseForRun)', async () => {
+            logic.actions.setRunOpening(true)
+            expect(logic.values.runOpening).toEqual(true)
+
+            // openSseForRun runs an async listener that opens a stream — await it so no work leaks.
+            await expectLogic(logic, () => {
+                logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })
+            }).toFinishAllListeners()
+            expect(logic.values.runOpening).toEqual(false)
+        })
+
+        it('lets run_started win over the optimistic flag (thinking, not provisioning)', () => {
+            logic.actions.setRunOpening(true)
+            expect(logic.values.streamPhase).toEqual('provisioning')
+
+            logic.actions.ingestAcpFrame(notification('_posthog/run_started', {}))
+            expect(logic.values.streamPhase).toEqual('thinking')
+        })
+    })
+
     describe('terminal-status handling', () => {
         it('closes the SSE and stops reconnects on a terminal task_run_state', async () => {
             logic.actions.openSseForRun({ taskId: 'task-1', runId: 'run-1' })

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1100,6 +1100,12 @@ export const runStreamLogic = kea<runStreamLogicType>([
         /** Internal: the live run history snapshot finished loading or was intentionally skipped. */
         bootstrapLogReady: true,
         closeSse: true,
+        /**
+         * The conversations/open POST is in flight — drives the optimistic "spinning up" indicator
+         * before any SSE state exists. The caller (maxThreadLogic) flips it on before the POST and off
+         * on the no-handle/failure paths; the success path lets `openSseForRun` clear it via the reducer.
+         */
+        setRunOpening: (opening: boolean) => ({ opening }),
         sseConnecting: true,
         sseOpened: true,
         sseReconnecting: (attempt: number) => ({ attempt }),
@@ -1205,6 +1211,21 @@ export const runStreamLogic = kea<runStreamLogicType>([
         reset: true,
     }),
     reducers({
+        // True while the conversations/open POST is in flight, before any SSE state exists. Folds into
+        // `streamPhase` as provisioning so the thread shows the optimistic "spinning up" indicator
+        // immediately on send. Cleared once a real stream lifecycle takes over (or ends/errors).
+        runOpening: [
+            false,
+            {
+                setRunOpening: (_, { opening }) => opening,
+                openSseForRun: () => false,
+                sseOpened: () => false,
+                handleStreamError: () => false,
+                handleTerminalStatus: () => false,
+                pushErrorItem: () => false,
+                reset: () => false,
+            },
+        ],
         sseStatus: [
             'idle' as RunSseStatus,
             {
@@ -1516,22 +1537,32 @@ export const runStreamLogic = kea<runStreamLogicType>([
         ],
         /**
          * Stream lifecycle phase gating the bottom-of-thread thinking indicator. `provisioning` = the
-         * cold-boot window — the stream is opening or open but the agent hasn't started yet (the
-         * workflow is still setting up the sandbox); it holds the gerund loader off until `run_started`
-         * so it can't show before a turn begins. Boot UX is surfaced by `_posthog/progress` items, not
-         * a dedicated indicator. `thinking` = the agent is working a turn (mirrors `isThinking`), and is
+         * cold-boot window — the conversations/open POST is in flight (`runOpening`), or the stream is
+         * opening/open but the agent hasn't started yet (the workflow is still setting up the sandbox).
+         * `ThreadView` shows a fixed "spinning up" indicator here until a real `_posthog/progress`
+         * boot step lands (which then takes over) or `run_started` flips the phase to `thinking`. The
+         * playful gerund loader is held off until `thinking` so it never shows before a turn begins.
+         * `thinking` = the agent is working a turn (mirrors `isThinking`), and is
          * what `ThreadView` gates the gerund loader on; `idle` otherwise (terminal, errored, or
          * not yet connecting). A read-only viewer is always `idle` — it never streams.
          */
         streamPhase: [
-            (s, p) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus, p.replayOnly!],
-            (runStarted, isThinking, currentRunStatus, sseStatus, replayOnly): 'provisioning' | 'thinking' | 'idle' => {
+            (s, p) => [s.runStarted, s.isThinking, s.currentRunStatus, s.sseStatus, s.runOpening, p.replayOnly!],
+            (
+                runStarted,
+                isThinking,
+                currentRunStatus,
+                sseStatus,
+                runOpening,
+                replayOnly
+            ): 'provisioning' | 'thinking' | 'idle' => {
                 // A read-only snapshot never provisions or thinks — there is no live stream behind it.
                 if (replayOnly) {
                     return 'idle'
                 }
                 const connecting = sseStatus === 'connecting' || sseStatus === 'open' || sseStatus === 'reconnecting'
-                if (connecting && !runStarted && !isTerminalRunStatus(currentRunStatus)) {
+                // `runOpening` covers the conversations/open POST window, before any SSE state exists.
+                if ((connecting || runOpening) && !runStarted && !isTerminalRunStatus(currentRunStatus)) {
                     return 'provisioning'
                 }
                 if (isThinking) {


### PR DESCRIPTION
## Problem

When a user sends a message in a **sandbox** PostHog AI conversation, the thread shows no agent-activity feedback between hitting send and the agent's first frame.

`maxThreadLogic.streamConversation` echoes the human bubble, then `await`s `api.conversations.open(...)` — the POST that creates the conversation row and provisions/starts the run, which can take several seconds. During that POST no stream state exists yet (`streamPhase === 'idle'`), and even once the SSE opens afterwards, `SandboxThreadView` only rendered its indicator for `streamPhase === 'thinking'`, never `'provisioning'`. Net result: the user sees their own message and then dead air.

## Changes

Show an optimistic **"Spinning up sandbox…"** indicator at the bottom of the thread from the instant the message is sent, carried seamlessly through the open POST and provisioning, until real boot progress or the agent's turn takes over.

- `sandboxStreamLogic`: new `setRunOpening` action + `runOpening` reducer (true while the open POST is in flight). It auto-clears the moment a real stream lifecycle begins or ends — `openSseForRun` / `sseOpened` / `handleStreamError` / `handleTerminalStatus` / `pushErrorItem` / `reset`. `streamPhase` now resolves to `provisioning` while `runOpening` is set, before any SSE state exists.
- `SandboxThreadView`: the bottom-of-thread indicator now renders during `provisioning` too, still gated by `!hasActiveProgressItem` so it yields to real `_posthog/progress` boot steps the moment they arrive. During provisioning it shows a fixed "Spinning up sandbox…" line; a normal turn keeps the playful gerund rotation.
- `maxThreadLogic`: flips `setSandboxRunOpening(true)` right before the open POST and clears it on the failure / no-handle (warm-pool-full) paths. The success path lets `openSandboxSse` clear it via the reducer. The silent `prewarmSandbox` path is untouched, so prewarming still shows nothing.

`isThinking` is deliberately left unchanged — only `streamPhase` (the indicator's gate) is touched, keeping the blast radius minimal.

> Stacked on top of #65770 (base branch `tasks-run-interaction-logic`); this PR's diff is just the optimistic-indicator change.

## How did you test this code?

I'm an agent (Claude, via Claude Code). I did **not** manually exercise the running app — that's worth a quick human check against a real cold sandbox to confirm the copy and timing feel right.

Automated tests I ran locally (all green):

- `sandboxStreamLogic.test.ts` (153 passed) — new `streamPhase provisioning during open` group covers: `provisioning` while the open POST is in flight with no SSE/run state; the flag clearing on stream error, injected error item, and `openSseForRun`; and `run_started` winning over the optimistic flag. These catch a regression where the indicator either never shows during the open window or sticks after the run starts/fails — no existing test exercised `runOpening`.
- `maxThreadLogic.test.ts` (128 passed) — extended the sandbox `streamConversation` tests to assert `setSandboxRunOpening` fires before the open POST and that `runOpening` never sticks on success or on a rejected POST.
- oxlint clean (0/0) on the changed source files; `tsgo` reports no errors in any touched file.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI assigned.

Authored with Claude Code (Opus 4.8). Planned in plan mode (Explore + Plan agents to trace the `conversations/open` → SSE → thread-render path), then implemented and tested. The "Spinning up sandbox…" copy was chosen by the human over a reused gerund or a generic "Starting…".

Key decisions:
- Put the new state in `sandboxStreamLogic` (not `maxThreadLogic`) because the indicator is bound to the stream logic; `maxThreadLogic` only flips the flag around the POST.
- Touched only `streamPhase`, not `isThinking`, to avoid side effects on `taskRunInteractionLogic.isBusy` and the thought/PR-card gating.
- Reused the existing `!hasActiveProgressItem` gate so the optimistic line cleanly hands off to real `_posthog/progress` boot steps.

No skills were required for this change (no migrations, DRF, or generated-API surface touched). Kea logic types were regenerated via kea-typegen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VbMb9xPrYNRgy7iuV7hHMh
