### PR TITLE
feat(customer-analytics): add Salesforce useful link to account details

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4765,9 +4765,9 @@ snapshots:
     scenes-app-customer-analytics-accounts--row-expanded-empty--light:
         hash: v1.k794b7964.904bd5b939f99d43408ae3a8a814a3c299bd57bf13a0fd1d98ff6033fd66e343.K1Z16ICEF6-O9kIej8kGnYyarloq2oZH5rdtmx-8Hu0
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--dark:
-        hash: v1.k794b7964.f2d43867c031f539641e4c8f6fcf30bfe6140cc9e3aa596b65d767dd10fa4921.F1vyV__TE7gcuA85X8fUmey9KXhssurg6Rk65ETYcIM
+        hash: v1.k794b7964.520e6455cfdd404a1af3d98f6c138a0b5ce57f94e66263f26b968418daebaa64.ACJbyDSyqXK4dZKV4TUemg4cKPIjpXZB008wOEI5D20
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--light:
-        hash: v1.k794b7964.7895f3c3ea4bd144f0fab73b065ed655f19e1726976d0fef0abfeb68d10743f6.1yXgRyhrdluQY4gaksbmnL5KmsTfBC51mFDrwuH-a8k
+        hash: v1.k794b7964.b6d4fa4f4fe7f87fe5fea5c702fc4db8558f8b9f0904cb9659ae9aece845b3ac.QfMAWNJmI8DCp90AGyh4Ena5eXJqEtCc3OFG2onVXnI
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--dark:
         hash: v1.k794b7964.53af994a2a4dfb2f883e27ed73be8d55e1177b97f5c8b622708dfcdbe5f33d2a.A7AJRK9hY-yytJMNPghuLYtOJIoj0VBJidseMubwZWs
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--light:

--- a/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
+++ b/products/customer_analytics/frontend/components/Accounts/AccountNotebooksExpansion.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 
-import { IconGraph, IconPencil, IconPeople, IconPiggyBank, IconReceipt } from '@posthog/icons'
+import { IconCloud, IconGraph, IconPencil, IconPeople, IconPiggyBank, IconReceipt } from '@posthog/icons'
 import {
     LemonButton,
     LemonInput,
@@ -46,6 +46,7 @@ const LINK_ICONS: Record<string, JSX.Element> = {
     'usage-dashboard': <IconGraph />,
     slack: <IconSlack />,
     'billing-admin': <IconReceipt />,
+    salesforce: <IconCloud />,
 }
 
 function UsefulLinks({ accountId }: { accountId: string }): JSX.Element {

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.test.ts
@@ -68,6 +68,7 @@ describe('accountLinksLogic', () => {
             billing_id: 'cus_1',
             slack_channel_id: 'C1',
             usage_dashboard_link: '',
+            sfdc_id: '',
         })
     })
 
@@ -87,6 +88,7 @@ describe('accountLinksLogic', () => {
             billing_id: 'new',
             slack_channel_id: 'C9',
             usage_dashboard_link: '',
+            sfdc_id: '001abc',
         })
         logic.actions.saveLinks()
         await expectLogic(logic).toFinishAllListeners()
@@ -98,6 +100,7 @@ describe('accountLinksLogic', () => {
                 billing_id: 'new',
                 slack_channel_id: 'C9',
                 usage_dashboard_link: null,
+                sfdc_id: '001abc',
             },
         })
         expect(logic.values.account).toEqual(updated)
@@ -113,13 +116,14 @@ describe('accountLinksLogic', () => {
             billing_id: '',
             slack_channel_id: '   ',
             usage_dashboard_link: '',
+            sfdc_id: '',
         })
         logic.actions.saveLinks()
         await expectLogic(logic).toFinishAllListeners()
 
         expect(mockAccountsPartialUpdate).toHaveBeenCalledWith(TEAM, 'acc-1', {
             external_id: null,
-            properties: { billing_id: null, slack_channel_id: null, usage_dashboard_link: null },
+            properties: { billing_id: null, slack_channel_id: null, usage_dashboard_link: null, sfdc_id: null },
         })
     })
 

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
@@ -20,6 +20,7 @@ const ORGANIZATION_GROUP_TYPE_INDEX = 0
 const REVENUE_DASHBOARD_ID = 259114
 const BILLING_ADMIN_ORIGIN = 'https://billing.posthog.com'
 const SLACK_ARCHIVES_ORIGIN = 'https://posthog.slack.com/archives'
+const SALESFORCE_ORIGIN = 'https://posthog.my.salesforce.com'
 
 export interface AccountLinksLogicProps {
     accountId: string
@@ -133,6 +134,7 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                 const billingId = account?.properties?.billing_id ?? null
                 const slackChannelId = account?.properties?.slack_channel_id ?? null
                 const usageDashboardLink = account?.properties?.usage_dashboard_link ?? null
+                const sfdcId = account?.properties?.sfdc_id ?? null
                 const backUrl =
                     removeProjectIdIfPresent(currentLocation.pathname) + currentLocation.search + currentLocation.hash
                 return [
@@ -175,6 +177,13 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                         to: billingId ? `${BILLING_ADMIN_ORIGIN}/admin/billing/customer/${billingId}/change/` : null,
                         targetBlank: true,
                         disabledReason: billingId ? null : 'No billing ID set',
+                    },
+                    {
+                        key: 'salesforce',
+                        label: 'Salesforce',
+                        to: sfdcId ? `${SALESFORCE_ORIGIN}/${sfdcId}` : null,
+                        targetBlank: true,
+                        disabledReason: sfdcId ? null : 'No Salesforce ID set',
                     },
                 ]
             },

--- a/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountLinksLogic.ts
@@ -26,7 +26,7 @@ export interface AccountLinksLogicProps {
     accountId: string
 }
 
-export type AccountLinkFieldKey = 'external_id' | 'billing_id' | 'slack_channel_id' | 'usage_dashboard_link'
+export type AccountLinkFieldKey = 'external_id' | 'billing_id' | 'slack_channel_id' | 'usage_dashboard_link' | 'sfdc_id'
 
 export interface AccountLinkFieldDef {
     key: AccountLinkFieldKey
@@ -41,6 +41,7 @@ export const ACCOUNT_LINK_FIELDS: AccountLinkFieldDef[] = [
     { key: 'billing_id', label: 'Billing ID', placeholder: 'e.g. cus_acme_123' },
     { key: 'slack_channel_id', label: 'Slack channel ID', placeholder: 'e.g. C0123456789' },
     { key: 'usage_dashboard_link', label: 'Usage dashboard link', placeholder: 'https://…' },
+    { key: 'sfdc_id', label: 'Salesforce ID', placeholder: 'e.g. 0011t00000AbCdEfGhI' },
 ]
 
 const EMPTY_FIELDS: AccountLinkFieldValues = {
@@ -48,6 +49,7 @@ const EMPTY_FIELDS: AccountLinkFieldValues = {
     billing_id: '',
     slack_channel_id: '',
     usage_dashboard_link: '',
+    sfdc_id: '',
 }
 
 export interface AccountLink {
@@ -125,6 +127,7 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                 billing_id: account?.properties?.billing_id ?? '',
                 slack_channel_id: account?.properties?.slack_channel_id ?? '',
                 usage_dashboard_link: account?.properties?.usage_dashboard_link ?? '',
+                sfdc_id: account?.properties?.sfdc_id ?? '',
             }),
         ],
         links: [
@@ -210,6 +213,7 @@ export const accountLinksLogic = kea<accountLinksLogicType>([
                         billing_id: orNull(form.billing_id),
                         slack_channel_id: orNull(form.slack_channel_id),
                         usage_dashboard_link: orNull(form.usage_dashboard_link),
+                        sfdc_id: orNull(form.sfdc_id),
                     } as PatchedAccountApiProperties,
                 })
                 actions.loadAccountSuccess(updated)


### PR DESCRIPTION
## Problem

There's no quick way to jump from an account to its Salesforce record, and the Salesforce ID can't be set manually.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

- Add a "Salesforce" useful link to the expanded account row, linking to `https://posthog.my.salesforce.com/<sfdc_id>`
- Disable the link when the account has no `sfdc_id` ("No Salesforce ID set")
- Make Salesforce ID editable in the "Edit links" popover, alongside the other external ids
- Reuse the existing `customer analytics account link clicked` event (`link_key: 'salesforce'`) — no new event

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Agent-authored. Ran the `accountLinksLogic` Jest suite (8 tests pass). No manual UI testing performed.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Authored by PostHog Code.

**Autonomy:** Human-driven (agent-assisted)

- `sfdc_id` was already a typed field on `AccountApiProperties`, so no backend/serializer change — frontend-only.
- The Salesforce origin is hardcoded as a sibling of the existing `BILLING_ADMIN_ORIGIN` / `SLACK_ARCHIVES_ORIGIN` constants in the same file. It's not sensitive — it's already the public default of `SF_INTERNAL_DOMAIN` in `ee/settings.py`, a My Domain subdomain grants no access by itself, and the whole "Useful links" feature points at internal CSM tooling. The custom-property alternative was rejected as friction for no security gain.
- The edit popover renders inputs from `ACCOUNT_LINK_FIELDS`, so the new field needed only logic plumbing. Existing tests were updated for the new field shape.
- Reviewer note: `sfdc_id` is also auto-populated by the Salesforce enrichment workflow, so a manual edit can be overwritten on the next run — same caveat as the other enriched ids in this popover.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
