### PR TITLE
feat(data-warehouse): add activity history tabs to source and schema scenes

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2731,6 +2731,7 @@ const api = {
                     ActivityScope.TICKET,
                     ActivityScope.COHORT,
                     ActivityScope.OAUTH_APPLICATION,
+                    ActivityScope.EXTERNAL_DATA_SCHEMA,
                 ].includes(scopes[0]) ||
                 scopes.length > 1
             ) {

--- a/products/data_warehouse/backend/api/test/test_external_data_schema.py
+++ b/products/data_warehouse/backend/api/test/test_external_data_schema.py
@@ -19,6 +19,7 @@ from temporalio.service import RPCError
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
+from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.personal_api_key import PersonalAPIKey, hash_key_value
 from posthog.models.utils import generate_random_token_personal
 from posthog.temporal.common.schedule import describe_schedule
@@ -452,6 +453,48 @@ class TestExternalDataSchema(APIBaseTest):
             schema.refresh_from_db()
             assert schema.sync_type_config.get("reset_pipeline") is None
             assert schema.sync_type == ExternalDataSchema.SyncType.FULL_REFRESH
+
+    def test_update_schema_sync_type_is_logged_to_activity(self):
+        source = ExternalDataSource.objects.create(
+            team=self.team,
+            source_type=ExternalDataSourceType.STRIPE,
+            job_inputs={"auth_method": {"selection": "api_key", "stripe_secret_key": "123"}},
+        )
+        schema = ExternalDataSchema.objects.create(
+            name="BalanceTransaction",
+            team=self.team,
+            source=source,
+            should_sync=True,
+            status=ExternalDataSchema.Status.COMPLETED,
+            sync_type=ExternalDataSchema.SyncType.INCREMENTAL,
+        )
+
+        with (
+            mock.patch("products.data_warehouse.backend.api.external_data_schema.trigger_external_data_workflow"),
+            mock.patch(
+                "products.data_warehouse.backend.api.external_data_schema.external_data_workflow_exists",
+                return_value=False,
+            ),
+        ):
+            response = self.client.patch(
+                f"/api/environments/{self.team.pk}/external_data_schemas/{schema.id}",
+                data={"sync_type": "full_refresh"},
+            )
+            assert response.status_code == 200
+
+        logs = ActivityLog.objects.filter(scope="ExternalDataSchema", item_id=str(schema.id), activity="updated")
+        sync_type_changes = [
+            c for log in logs for c in (log.detail or {}).get("changes", []) if c["field"] == "sync_type"
+        ]
+        assert sync_type_changes == [
+            {
+                "type": "ExternalDataSchema",
+                "field": "sync_type",
+                "action": "changed",
+                "before": "incremental",
+                "after": "full_refresh",
+            }
+        ]
 
     def test_update_schema_sets_and_clears_incremental_field_lookback_seconds(self):
         source = ExternalDataSource.objects.create(

--- a/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/SchemaScene.tsx
@@ -4,6 +4,7 @@ import { useEffect } from 'react'
 
 import { LemonButton, LemonSkeleton } from '@posthog/lemon-ui'
 
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -14,6 +15,7 @@ import { urls } from 'scenes/urls'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
+import { ActivityScope } from '~/types'
 
 import { cleanSourceId } from 'products/data_warehouse/frontend/utils'
 
@@ -136,6 +138,12 @@ function SchemaSceneContent({ sourceId, schemaId }: SchemaSceneProps): JSX.Eleme
             content: <MetricsTab sourceId={cleanedSourceId} schemaId={schema.id} />,
         })
     }
+
+    tabs.push({
+        label: 'History',
+        key: 'history',
+        content: <ActivityLog id={schema.id} scope={ActivityScope.EXTERNAL_DATA_SCHEMA} />,
+    })
 
     const activeTab = !showMetrics && currentTab === 'metrics' ? 'configuration' : currentTab
 

--- a/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SchemaScene/schemaSceneLogic.ts
@@ -24,7 +24,7 @@ import { cleanSourceId } from 'products/data_warehouse/frontend/utils'
 
 import type { schemaSceneLogicType } from './schemaSceneLogicType'
 
-export const SCHEMA_SCENE_TABS = ['configuration', 'metrics'] as const
+export const SCHEMA_SCENE_TABS = ['configuration', 'metrics', 'history'] as const
 export type SchemaSceneTab = (typeof SCHEMA_SCENE_TABS)[number]
 
 export const SCHEMA_CONFIGURATION_SECTIONS = [

--- a/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
+++ b/products/data_warehouse/frontend/scenes/SourceScene/SourceScene.tsx
@@ -16,6 +16,7 @@ import { useEffect } from 'react'
 
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
+import { ActivityLog } from 'lib/components/ActivityLog/ActivityLog'
 import { NotFound } from 'lib/components/NotFound'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonTab, LemonTabs } from 'lib/lemon-ui/LemonTabs'
@@ -41,7 +42,7 @@ import { sourceSettingsLogic } from './tabs/sourceSettingsLogic'
 import { SyncsTab } from './tabs/SyncsTab'
 import { WebhookTab } from './tabs/WebhookTab'
 
-const SOURCE_SCENE_TABS = ['schemas', 'syncs', 'metrics', 'configuration', 'webhook'] as const
+const SOURCE_SCENE_TABS = ['schemas', 'syncs', 'metrics', 'configuration', 'webhook', 'history'] as const
 export type SourceSceneTab = (typeof SOURCE_SCENE_TABS)[number]
 
 export interface SourceSceneProps {
@@ -267,6 +268,12 @@ function ManagedSourceTabs({
             content: <WebhookTab id={sourceId} />,
         })
     }
+
+    tabs.push({
+        label: 'History',
+        key: 'history',
+        content: <ActivityLog id={sourceId} scope={ActivityScope.EXTERNAL_DATA_SOURCE} />,
+    })
 
     return <LemonTabs activeKey={currentTab} tabs={tabs} onChange={setCurrentTab} sceneInset />
 }


### PR DESCRIPTION
## Problem

When debugging a data warehouse source or schema, there's no quick way to see what changed and when — e.g. someone flipping a schema's sync type from `full_refresh` to `incremental`. The activity is logged, and the same info is reachable elsewhere, but having it readily available right on the source/schema scene might make debugging easier.

## Changes

- Add a **History** tab to both the source scene (`ExternalDataSource`) and the schema scene (`ExternalDataSchema`), rendering the existing activity log.
- Route single-scope `ExternalDataSchema` activity reads to the modern `/activity_log` endpoint. The schema scope wasn't on the opt-in allowlist, so a per-schema query previously short-circuited to an empty result without hitting the network — this is the same allowlist pattern already used for batch exports. The source scope already worked because it expands to two scopes.

No backend logging changes — those rows have been written all along; this just surfaces them.

Because of config masking, some of the activity logging is pretty limited in terms of what it tells you but at least gives a timeline of when things happened, and by who.

## How did you test this code?

I'm an agent (PostHog Code), human-driven by the PR assignee. Automated test only:

- Added `test_update_schema_sync_type_is_logged_to_activity` to `test_external_data_schema.py` — PATCHes a schema's sync type through the API and asserts the change lands in the activity log. Catches a regression no existing test did: if the update path stops firing the activity signal (e.g. `skip_activity_log`, a queryset `bulk_update`) or `sync_type` gets added to `field_exclusions`, the History tab silently goes empty. Passing locally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated two reported gaps: the masked `configuration` field on source history (working as designed — `job_inputs` holds credentials and is masked wholesale; left untouched), and no schema history at all. Traced the latter to frontend routing in `api.ts`, not the backend — confirmed by finding existing `ExternalDataSchema` rows in the local DB. Fix mirrors the existing `BATCH_EXPORT` allowlist entry rather than adding a new `SCOPE_EXPANSIONS` mapping, since a single-element expansion wouldn't satisfy the `scopes.length > 1` route.

Skills invoked: `/writing-tests` (gated the regression test and split it into its own focused test rather than folding it into an unrelated one).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
