### PR TITLE
perf(hogql): gate access-control cache key on org entitlement

### DIFF
--- a/posthog/hogql_queries/query_runner.py
+++ b/posthog/hogql_queries/query_runner.py
@@ -95,6 +95,7 @@ from posthog.clickhouse.client.limit import (
     get_org_app_concurrency_limit,
 )
 from posthog.clickhouse.query_tagging import get_query_tag_value, is_api_key_access_method, tag_queries
+from posthog.constants import AvailableFeature
 from posthog.errors import QueryErrorCategory, classify_query_error, clickhouse_error_type
 from posthog.event_usage import AnalyticsProps, groups, report_user_or_team_action
 from posthog.exceptions_capture import capture_exception
@@ -2239,6 +2240,16 @@ class AnalyticsQueryRunner(QueryRunner, Generic[AR]):
 
     def get_cache_payload(self) -> dict:
         payload = super().get_cache_payload()
+
+        # Don't include restricted resources/objects in cache_payload if the ACCESS_CONTROL
+        # feature is unavailable and a user is provided (i.e. not a userless query or a project token)
+        user = cast("Optional[User | SyntheticUser]", self.user)
+        if (
+            user is not None
+            and not isinstance(user, SyntheticUser)
+            and not self.team.organization.is_feature_available(AvailableFeature.ACCESS_CONTROL)
+        ):
+            return payload
 
         # Partition only by the access-controlled tables this query reads that the user is restricted
         # from - so queries on events, persons and other non-access-controlled tables share one cache

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1552,3 +1552,20 @@ class TestQueryRunnerAccessControlFingerprint(BaseTest):
         assert "system.notebooks" in database._denied_tables
         ac_queries = [q["sql"] for q in ctx.captured_queries if "ee_accesscontrol" in q["sql"]]
         assert ac_queries == [], ac_queries
+
+    def test_unentitled_org_skips_access_control_fingerprint(self):
+        # Without the ACCESS_CONTROL entitlement no user can be restricted, so computing the cache key
+        # must not issue the access-control read
+        self.organization.available_product_features = []
+        self.organization.save()
+
+        runner = self._runner(self.user)
+        with CaptureQueriesContext(connection) as ctx:
+            runner.get_cache_key()
+
+        ac_queries = [q["sql"] for q in ctx.captured_queries if "ee_accesscontrol" in q["sql"]]
+        assert ac_queries == [], ac_queries
+
+        # Entitlement is read off the team's org, so the gate must short-circuit without building
+        # user_access_control (whose membership/preload reads are what we're avoiding per query).
+        assert runner._user_access_control is None

--- a/posthog/hogql_queries/test/test_query_runner.py
+++ b/posthog/hogql_queries/test/test_query_runner.py
@@ -1559,7 +1559,7 @@ class TestQueryRunnerAccessControlFingerprint(BaseTest):
         self.organization.available_product_features = []
         self.organization.save()
 
-        runner = self._runner(self.user)
+        runner = self._runner(self.user, base=AnalyticsQueryRunner)
         with CaptureQueriesContext(connection) as ctx:
             runner.get_cache_key()
 

--- a/products/dashboards/frontend/generated/api.zod.ts
+++ b/products/dashboards/frontend/generated/api.zod.ts
@@ -1695,6 +1695,10 @@ export const DashboardsUpdateWidgetsBatchBody = /* @__PURE__ */ zod
                                     .max(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string().min(1), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .optional()
                             .describe('New configuration for the recent events widget. Omit to leave unchanged.'),

--- a/services/mcp/src/generated/dashboards/api.ts
+++ b/services/mcp/src/generated/dashboards/api.ts
@@ -1762,6 +1762,10 @@ export const DashboardsUpdateWidgetsBatchBody = /* @__PURE__ */ zod
                                     .max(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitMax)
                                     .default(dashboardsUpdateWidgetsBatchBodyWidgetsItemOneConfigOneLimitDefault)
                                     .describe('Maximum number of events to return.'),
+                                eventName: zod
+                                    .union([zod.string().min(1), zod.null()])
+                                    .optional()
+                                    .describe('Limit the feed to a single event name. Omit or null for all events.'),
                             })
                             .optional()
                             .describe('New configuration for the recent events widget. Omit to leave unchanged.'),


### PR DESCRIPTION
## Problem

`AnalyticsQueryRunner.get_cache_payload` partitions the query cache key on access-control restrictions. For any HogQL query that references a non-system table (`events`, `persons`, a warehouse table…), that resolution issues two per-query Postgres reads — `DataWarehouseTable` + `DataWarehouseSavedQuery` — to figure out which access-controlled resources the query touches.

But access control is a Boost feature. For an org _without_ the `ACCESS_CONTROL`, no user can ever be restricted — `blocked_resource_ids_by_scope` (enforcement) already returns `{}` for them — so the resolution can't change the cache key. 

## Changes

- Gate the access-control fingerprint on org feature entitlement in `get_cache_payload`, return the base payload before running `queried_access_controlled_resources` (and its two warehouse reads).
- Entitlement is read off `self.team.organization` (already `select_related`'d on the request path in `posthog/api/routing.py`), not `self.user_access_control` — touching that property would build it + fire its `OrganizationMembership` query for every query, defeating its deliberate laziness.

## How did you test this code?

Test

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?