### PR TITLE
fix(dashboards): fix display option save feedback loop and stale insight view

### DIFF
--- a/frontend/src/scenes/insights/insightDataLogic.test.ts
+++ b/frontend/src/scenes/insights/insightDataLogic.test.ts
@@ -235,6 +235,47 @@ describe('insightDataLogic', () => {
                 }).mount()
             }).toMatchValues({ query: updatedCachedQuery })
         })
+
+        // On a dashboard tile, `setQuery` is shared with insightVizDataLogic, whose listener calls
+        // props.setQuery (persistDisplayOptions). If a tile re-render re-syncs the incoming cached
+        // query via setQuery, it loops back into a PATCH of that (stale) query, reverting a display
+        // option the user just saved. propsChanged must use syncQueryFromProps on dashboard tiles.
+        it('syncs a changed cached query via syncQueryFromProps, not setQuery, on a dashboard tile', async () => {
+            const localUpdatedQuery = buildLocalUpdatedQuery()
+            const staleCachedQuery: InsightVizNode = {
+                ...baseQuery,
+                source: {
+                    ...baseQuery.source,
+                    dateRange: {
+                        ...baseQuery.source.dateRange,
+                        date_from: '-14d',
+                    },
+                },
+            }
+
+            const logic = insightDataLogic({
+                dashboardItemId: Insight123,
+                dashboardId: 99,
+                cachedInsight: { short_id: Insight123, query: baseQuery } as any,
+            })
+            logic.mount()
+
+            await expectLogic(logic, () => {
+                logic.actions.setQuery(localUpdatedQuery)
+            }).toMatchValues({ query: localUpdatedQuery })
+
+            await expectLogic(logic, () => {
+                insightDataLogic({
+                    dashboardItemId: Insight123,
+                    dashboardId: 99,
+                    cachedInsight: { short_id: Insight123, query: staleCachedQuery } as any,
+                    loadPriority: 1,
+                }).mount()
+            })
+                .toDispatchActions(['syncQueryFromProps'])
+                .toNotHaveDispatchedActions(['setQuery'])
+                .toMatchValues({ query: staleCachedQuery })
+        })
     })
 
     describe('reacts when the insight changes', () => {

--- a/frontend/src/scenes/insights/insightDataLogic.tsx
+++ b/frontend/src/scenes/insights/insightDataLogic.tsx
@@ -423,14 +423,20 @@ export const insightDataLogic = kea<insightDataLogicType>([
         if (!cachedQueryChanged) {
             return
         }
+        // On dashboard tiles props.setQuery persists edits, and `setQuery` is shared with
+        // insightVizDataLogic whose listener calls props.setQuery — so re-syncing a stale incoming
+        // cached query (e.g. from a tile results refresh) via setQuery loops back and PATCHes it,
+        // reverting a just-saved display option. syncQueryFromProps updates local state without the
+        // loop. The insight scene keeps setQuery for its URL/draft sync.
+        const syncCachedQuery = props.dashboardId != null ? actions.syncQueryFromProps : actions.setQuery
         try {
             if (!objectsEqual(props.cachedInsight.query, values.query)) {
-                actions.setQuery(props.cachedInsight.query)
+                syncCachedQuery(props.cachedInsight.query)
             }
         } catch {
             // values.query can throw if the logic's state isn't in the store yet
             // (e.g. when InsightCard rebuilds the logic during navigation)
-            actions.setQuery(props.cachedInsight.query)
+            syncCachedQuery(props.cachedInsight.query)
         }
     }),
     afterMount(({ actions, props }) => {

--- a/frontend/src/scenes/insights/insightLogic.tsx
+++ b/frontend/src/scenes/insights/insightLogic.tsx
@@ -328,7 +328,15 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
             },
             [insightsModel.actionTypes.renameInsightSuccess]: (state, { item }) => {
                 if (item.id === state.id) {
-                    return { ...state, name: item.name, description: item.description }
+                    // Include query so display-option saves (persistDisplayOptions) are reflected
+                    // immediately without a page refresh. Preserve existing result/last_refresh:
+                    // a bare PATCH doesn't recompute the chart so the response carries result: null.
+                    return {
+                        ...state,
+                        name: item.name,
+                        description: item.description,
+                        query: item.query ?? state.query,
+                    }
                 }
                 return state
             },
@@ -371,6 +379,10 @@ export const insightLogic: LogicWrapper<insightLogicType> = kea<insightLogicType
                     tags: insight.tags,
                     favorited: insight.favorited,
                 }),
+                [insightsModel.actionTypes.renameInsightSuccess]: (state, { item }) =>
+                    item.id === state.id && item.query
+                        ? { ...state, name: item.name, description: item.description, query: item.query }
+                        : state,
             },
         ],
         insightLoading: [


### PR DESCRIPTION
## Problem

Two bugs with the display options save flow introduced by #65857 and #65970:

1. A tile re-render after a save could loop back and revert it. `propsChanged` in `insightDataLogic` re-synced an incoming stale `cachedInsight.query` via `setQuery`, which (being a shared action with `insightVizDataLogic`) triggered `props.setQuery` → `persistDisplayOptions` → a PATCH with the old query.

2. After saving a display option on a dashboard tile, navigating to the insight's standalone page showed the old display options until a browser refresh. `insightLogic.insight` only updated `name` and `description` on `renameInsightSuccess` — not `query`. If the insight scene's `insightLogic` was already in memory from a previous visit, it kept the stale query and `insightDataLogic.query` derived from it.

## Changes

- In `insightDataLogic.propsChanged`, use `syncQueryFromProps` (not `setQuery`) to re-sync `cachedInsight.query` on dashboard tiles — `syncQueryFromProps` is not a shared action so it doesn't loop back through `insightVizDataLogic`'s persist path. The insight scene continues to use `setQuery` for URL/draft sync.
- In `insightLogic`, update `query` (in addition to `name`/`description`) when `renameInsightSuccess` fires, on both the `insight` and `savedInsight` reducers. `result` and `last_refresh` are preserved since a display-option PATCH doesn't recompute the chart. `savedInsight` is updated so `insightChanged` stays false and no spurious Save button appears.

## How did you test this code?

I'm an agent. The `insightDataLogic.test.ts` existing tests cover the `propsChanged` path. No new tests added for the `insightLogic` change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (claude-sonnet-4-6[1m]). @sampennington reported two remaining bugs after the initial display options race condition fixes (#65857, #65970). The `propsChanged` loop fix (commit 1) was authored by @sampennington. The `insightLogic` query sync fix (commit 2) was identified from tracing `renameInsightSuccess` through `insightLogic.insight` and `insightDataLogic.query` — the stale query persisted in any mounted `insightLogic` instance because the rename handler only forwarded name/description.