### PR TITLE
feat(logs): add custom-facets read/write API

### DIFF
--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -51,11 +51,19 @@ from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, Log
 from products.logs.backend.presentation.views.alerts_api import LogsAlertViewSet
 from products.logs.backend.presentation.views.explain import LogExplainViewSet
 from products.logs.backend.presentation.views.sampling_api import LogsSamplingRuleViewSet
+from products.logs.backend.presentation.views.user_config_api import LogsCustomFacetsViewSet
 from products.logs.backend.presentation.views.views_api import LogsViewViewSet
 from products.logs.backend.services_query_runner import ServicesQueryRunner
 from products.logs.backend.sparkline_query_runner import SparklineQueryRunner
 
-__all__ = ["LogsViewSet", "LogExplainViewSet", "LogsAlertViewSet", "LogsSamplingRuleViewSet", "LogsViewViewSet"]
+__all__ = [
+    "LogsViewSet",
+    "LogExplainViewSet",
+    "LogsAlertViewSet",
+    "LogsSamplingRuleViewSet",
+    "LogsCustomFacetsViewSet",
+    "LogsViewViewSet",
+]
 
 tracer = trace.get_tracer(__name__)
 LOGS_MAX_EXPORT_ROWS = 10_000

--- a/products/logs/backend/presentation/views/user_config_api.py
+++ b/products/logs/backend/presentation/views/user_config_api.py
@@ -1,0 +1,78 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+
+from products.logs.backend.models import LogsUserConfig
+
+# Bound on how many facets a user can pin, so the rail config can't grow without limit.
+MAX_CUSTOM_FACETS = 50
+
+
+class CustomFacetListSerializer(serializers.ListSerializer):
+    def validate(self, attrs: list[dict]) -> list[dict]:
+        if len(attrs) > MAX_CUSTOM_FACETS:
+            raise serializers.ValidationError(f"At most {MAX_CUSTOM_FACETS} custom facets are allowed.")
+        seen: set[tuple[str, str]] = set()
+        deduped: list[dict] = []
+        for facet in attrs:
+            ident = (facet["key"], facet["attribute_type"])
+            if ident not in seen:
+                seen.add(ident)
+                deduped.append(facet)
+        return deduped
+
+
+class CustomFacetSerializer(serializers.Serializer):
+    key = serializers.CharField(
+        max_length=200,
+        help_text="Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.",
+    )
+    attribute_type = serializers.ChoiceField(
+        choices=["log", "resource"],
+        help_text='Where the key lives: "resource" for resource attributes, "log" for log attributes.',
+    )
+
+    class Meta:
+        list_serializer_class = CustomFacetListSerializer
+
+
+class LogsCustomFacetsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    """The requesting user's custom facets for the current project — the facets they pinned into the
+    rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write."""
+
+    scope_object = "logs"
+    serializer_class = CustomFacetSerializer
+
+    @extend_schema(responses=CustomFacetSerializer(many=True))
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        # Auto-scoped to the canonical team by TeamScopedManager; only the user filter is ours to add.
+        config = LogsUserConfig.objects.filter(user=request.user).first()
+        facets = config.custom_facets if config else []
+        # Serialize on the way out so the response honors the declared schema and can't drift from
+        # create if CustomFacetSerializer ever grows a to_representation override or computed field.
+        return Response(CustomFacetSerializer(facets, many=True).data, status=status.HTTP_200_OK)
+
+    @extend_schema(request=CustomFacetSerializer(many=True), responses=CustomFacetSerializer(many=True))
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        serializer = CustomFacetSerializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+        custom_facets = serializer.validated_data
+        # team is passed explicitly: the manager's read scope doesn't propagate into row creation.
+        LogsUserConfig.objects.update_or_create(
+            user=request.user,
+            defaults={"custom_facets": custom_facets, "team": self.team},
+        )
+        report_user_action(
+            request.user,
+            "logs custom facets updated",
+            {"count": len(custom_facets)},
+            team=self.team,
+            request=request,
+        )
+        # serializer.data is to_representation(validated_data) — same serializer path as list, so the
+        # two endpoints return an identical shape (and reflect the dedup applied during validation).
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/products/logs/backend/routes.py
+++ b/products/logs/backend/routes.py
@@ -13,3 +13,7 @@ def register_routes(routers: RouterRegistry) -> None:
     routers.register_legacy_dual_route(
         r"logs/explainLogWithAI", logs.LogExplainViewSet, "project_logs_explain_with_ai", ["team_id"]
     )
+    # New endpoint — projects-only (the dual-route helper is reserved for pre-rollback endpoints).
+    routers.projects.register(
+        r"logs/custom_facets", logs.LogsCustomFacetsViewSet, "project_logs_custom_facets", ["team_id"]
+    )

--- a/products/logs/backend/test/test_user_config_api.py
+++ b/products/logs/backend/test/test_user_config_api.py
@@ -1,0 +1,84 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Team, User
+
+
+class TestLogsCustomFacetsAPI(APIBaseTest):
+    base_url: str
+
+    def setUp(self):
+        super().setUp()
+        self.base_url = f"/api/projects/{self.team.pk}/logs/custom_facets/"
+
+    def _facets(self, *pairs: tuple[str, str]) -> list[dict]:
+        return [{"key": key, "attribute_type": attribute_type} for key, attribute_type in pairs]
+
+    def test_get_is_empty_when_unconfigured(self):
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_set_then_get_round_trips(self):
+        facets = self._facets(("k8s.namespace.name", "resource"), ("http.status_code", "log"))
+
+        post = self.client.post(self.base_url, facets, format="json")
+        assert post.status_code == status.HTTP_200_OK, post.json()
+        assert post.json() == facets
+
+        assert self.client.get(self.base_url).json() == facets
+
+    def test_set_replaces_the_whole_set(self):
+        self.client.post(self.base_url, self._facets(("a", "log")), format="json")
+        self.client.post(self.base_url, self._facets(("b", "resource")), format="json")
+
+        assert self.client.get(self.base_url).json() == self._facets(("b", "resource"))
+
+    def test_duplicates_are_collapsed_on_write(self):
+        payload = self._facets(("a", "log"), ("a", "log"), ("b", "resource"))
+
+        post = self.client.post(self.base_url, payload, format="json")
+        assert post.json() == self._facets(("a", "log"), ("b", "resource"))
+
+    @parameterized.expand(
+        [
+            ("invalid_attribute_type", [{"key": "a", "attribute_type": "bogus"}]),
+            ("blank_key", [{"key": "", "attribute_type": "log"}]),
+            ("missing_key", [{"attribute_type": "log"}]),
+            ("over_cap", [{"key": f"k{i}", "attribute_type": "log"} for i in range(51)]),
+        ]
+    )
+    def test_rejects_invalid_payload(self, _label, payload):
+        response = self.client.post(self.base_url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+
+    def test_config_is_isolated_per_user(self):
+        mine = self._facets(("mine", "log"))
+        self.client.post(self.base_url, mine, format="json")
+
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "secret")
+        self.client.force_login(other)
+        # The other user starts empty and can't see mine.
+        assert self.client.get(self.base_url).json() == []
+        theirs = self._facets(("theirs", "resource"))
+        self.client.post(self.base_url, theirs, format="json")
+        assert self.client.get(self.base_url).json() == theirs
+
+        # Mine is untouched by their write.
+        self.client.force_login(self.user)
+        assert self.client.get(self.base_url).json() == mine
+
+    def test_config_is_isolated_per_project(self):
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+        self.client.post(self.base_url, self._facets(("team1", "log")), format="json")
+
+        response = self.client.get(f"/api/projects/{team2.pk}/logs/custom_facets/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_requires_authentication(self):
+        self.client.logout()
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -980,6 +980,30 @@ export interface _LogsCountRangesResponseApi {
     interval: string
 }
 
+/**
+ * * `log` - log
+ * * `resource` - resource
+ */
+export type AttributeTypeEnumApi = (typeof AttributeTypeEnumApi)[keyof typeof AttributeTypeEnumApi]
+
+export const AttributeTypeEnumApi = {
+    Log: 'log',
+    Resource: 'resource',
+} as const
+
+export interface CustomFacetApi {
+    /**
+     * Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.
+     * @maxLength 200
+     */
+    key: string
+    /** Where the key lives: "resource" for resource attributes, "log" for log attributes.
+     *
+     * * `log` - log
+     * * `resource` - resource */
+    attribute_type: AttributeTypeEnumApi
+}
+
 export interface ExplainRequestApi {
     /** UUID of the log entry to explain */
     uuid: string

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -9,6 +9,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    CustomFacetApi,
     ExplainRequestApi,
     LogsAlertConfigurationApi,
     LogsAlertCreateDestinationApi,
@@ -344,6 +345,42 @@ export const logsCountRangesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(_logsCountRangesRequestApi),
+    })
+}
+
+export const getLogsCustomFacetsListUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/custom_facets/`
+}
+
+/**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsList = async (projectId: string, options?: RequestInit): Promise<CustomFacetApi[]> => {
+    return apiMutator<CustomFacetApi[]>(getLogsCustomFacetsListUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getLogsCustomFacetsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/custom_facets/`
+}
+
+/**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsCreate = async (
+    projectId: string,
+    customFacetApi: CustomFacetApi[],
+    options?: RequestInit
+): Promise<CustomFacetApi[]> => {
+    return apiMutator<CustomFacetApi[]>(getLogsCustomFacetsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(customFacetApi),
     })
 }
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -586,6 +586,26 @@ export const LogsCountRangesCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsCreateBodyKeyMax = 200
+
+export const LogsCustomFacetsCreateBodyItem = /* @__PURE__ */ zod.object({
+    key: zod
+        .string()
+        .max(logsCustomFacetsCreateBodyKeyMax)
+        .describe("Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'."),
+    attribute_type: zod
+        .enum(['log', 'resource'])
+        .describe('\* `log` - log\n\* `resource` - resource')
+        .describe(
+            'Where the key lives: \"resource\" for resource attributes, \"log\" for log attributes.\n\n\* `log` - log\n\* `resource` - resource'
+        ),
+})
+export const LogsCustomFacetsCreateBody = /* @__PURE__ */ zod.array(LogsCustomFacetsCreateBodyItem)
+
+/**
  * Explain a log entry using AI.
  *
  * POST /api/environments/:id/logs/explainLogWithAI/

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9617,6 +9617,18 @@ export namespace Schemas {
       value: string;
     }
 
+    /**
+     * * `log` - log
+     * * `resource` - resource
+     */
+    export type AttributeTypeEnum = typeof AttributeTypeEnum[keyof typeof AttributeTypeEnum];
+
+
+    export const AttributeTypeEnum = {
+      Log: 'log',
+      Resource: 'resource',
+    } as const;
+
     export interface UnmatchedUtmSample {
       /** A raw utm_source value that doesn't match the integration exactly */
       raw_value: string;
@@ -14375,6 +14387,19 @@ export namespace Schemas {
       target_display_name: string;
       /** canonical or team_custom */
       source: string;
+    }
+
+    export interface CustomFacet {
+      /**
+         * Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.
+         * @maxLength 200
+         */
+      key: string;
+      /** Where the key lives: "resource" for resource attributes, "log" for log attributes.
+       *
+       * * `log` - log
+       * * `resource` - resource */
+      attribute_type: AttributeTypeEnum;
     }
 
     /**


### PR DESCRIPTION
## Problem

Users can pin custom facets into the logs explorer rail, but there was no backend storage or API to persist those preferences per user and project. Without this, pinned facets are lost on page reload.

## Changes

Adds a `GET`/`POST` endpoint at `/api/projects/:id/logs/custom_facets/` that stores and retrieves a user's pinned facets for a given project. The full set is replaced on each write (no partial updates).

Key constraints enforced server-side:
- Max 50 facets per user/project
- `attribute_type` must be `"log"` or `"resource"`
- Duplicate `(key, attribute_type)` pairs are silently collapsed on write
- Keys are capped at 200 characters

Frontend generated types (`CustomFacetApi`, `AttributeTypeEnumApi`) and Zod schemas are updated to match the new endpoint.

## How did you test this code?

New test suite in `test_user_config_api.py` covers:

| Test | Regression caught |
|---|---|
| Empty response when unconfigured | Ensures no 500 on missing row |
| Round-trip set/get | Validates basic persistence |
| Write replaces the whole set | Guards against accidental merge/append behaviour |
| Duplicates collapsed on write | Ensures dedup logic in `CustomFacetListSerializer` fires |
| Invalid payloads rejected (parameterized) | Covers bad `attribute_type`, blank key, missing key, over-cap list |
| Config isolated per user | Prevents cross-user data leakage |
| Config isolated per project | Prevents cross-team data leakage |
| Unauthenticated request rejected | Ensures auth guard is in place |

---

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented the backend API layer for logs custom facets persistence. Chose a full-replace write model (rather than patch) to keep the API surface minimal and avoid merge-conflict edge cases on the client. The 50-facet cap and dedup logic live in a dedicated `ListSerializer` subclass to keep validation co-located with the schema. Route registered under `routers.projects` only (not the legacy dual-route) since this is a new endpoint with no rollback concern.