### PR TITLE
feat(funnels): support compare in detailed results tables

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelTimeToConvertTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelTimeToConvertTable.tsx
@@ -1,47 +1,75 @@
 import { useValues } from 'kea'
 
-import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
+import { LemonTable, LemonTableColumn, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-import { HistogramGraphDatum } from '~/types'
+import { buildTimeToConvertCompareRows, TimeToConvertCompareRow } from './funnelTimeToConvertTableUtils'
+
+type TimeToConvertColumn = LemonTableColumn<TimeToConvertCompareRow, keyof TimeToConvertCompareRow | undefined>
+
+const timeRangeColumn: TimeToConvertColumn = {
+    title: 'Time to convert',
+    key: 'time_range',
+    render: (_, row) =>
+        `${humanFriendlyDuration(row.bin0, { maxUnits: 2 })} – ${humanFriendlyDuration(row.bin1, { maxUnits: 2 })}`,
+}
+
+const conversionsColumn: TimeToConvertColumn = {
+    title: 'Conversions',
+    key: 'count',
+    align: 'right',
+    render: (_, row) => humanFriendlyNumber(row.count),
+}
+
+const percentColumn: TimeToConvertColumn = {
+    title: '% of total',
+    key: 'percent',
+    align: 'right',
+    render: (_, row) => row.label || '0%',
+}
+
+const previousConversionsColumn: TimeToConvertColumn = {
+    title: 'Conversions',
+    key: 'previous_count',
+    align: 'right',
+    render: (_, row) => (row.previous ? humanFriendlyNumber(row.previous.count) : '–'),
+}
+
+const previousPercentColumn: TimeToConvertColumn = {
+    title: '% of total',
+    key: 'previous_percent',
+    align: 'right',
+    render: (_, row) => row.previous?.label || '–',
+}
 
 export function FunnelTimeToConvertTable(): JSX.Element | null {
     const { insightProps, insightLoading } = useValues(insightLogic)
-    const { histogramGraphData, conversionMetrics } = useValues(funnelDataLogic(insightProps))
+    const { histogramGraphData, histogramGraphDataPrevious, timeConversionResultsPrevious, conversionMetrics } =
+        useValues(funnelDataLogic(insightProps))
 
     if (!histogramGraphData || histogramGraphData.length === 0) {
         return null
     }
 
-    const columns: LemonTableColumns<HistogramGraphDatum> = [
-        {
-            title: 'Time to convert',
-            key: 'time_range',
-            render: (_, datum) =>
-                `${humanFriendlyDuration(datum.bin0, { maxUnits: 2 })} – ${humanFriendlyDuration(datum.bin1, {
-                    maxUnits: 2,
-                })}`,
-        },
-        {
-            title: 'Conversions',
-            key: 'count',
-            align: 'right',
-            render: (_, datum) => humanFriendlyNumber(datum.count),
-        },
-        {
-            title: '% of total',
-            key: 'percent',
-            align: 'right',
-            render: (_, datum) => datum.label || '0%',
-        },
-    ]
+    const isComparing = !!histogramGraphDataPrevious && histogramGraphDataPrevious.length > 0
+    const rows = buildTimeToConvertCompareRows(histogramGraphData, histogramGraphDataPrevious)
+
+    const columns: LemonTableColumns<TimeToConvertCompareRow> = isComparing
+        ? [
+              { children: [timeRangeColumn] },
+              { title: 'Current', children: [conversionsColumn, percentColumn] },
+              { title: 'Previous', children: [previousConversionsColumn, previousPercentColumn] },
+          ]
+        : [timeRangeColumn, conversionsColumn, percentColumn]
+
+    const previousAverageTime = timeConversionResultsPrevious?.average_conversion_time
 
     return (
         <LemonTable
-            dataSource={histogramGraphData}
+            dataSource={rows}
             columns={columns}
             loading={insightLoading}
             rowKey="id"
@@ -50,7 +78,18 @@ export function FunnelTimeToConvertTable(): JSX.Element | null {
                 conversionMetrics.averageTime ? (
                     <div className="flex items-center justify-between px-2 py-1">
                         <span className="font-medium">Average time to convert</span>
-                        <span>{humanFriendlyDuration(conversionMetrics.averageTime, { maxUnits: 3 })}</span>
+                        <span>
+                            {humanFriendlyDuration(conversionMetrics.averageTime, { maxUnits: 3 })}
+                            {isComparing && (
+                                <span className="text-secondary">
+                                    {' '}
+                                    (current) ·{' '}
+                                    {previousAverageTime
+                                        ? `${humanFriendlyDuration(previousAverageTime, { maxUnits: 3 })} (previous)`
+                                        : '– (previous)'}
+                                </span>
+                            )}
+                        </span>
                     </div>
                 ) : undefined
             }

--- a/frontend/src/scenes/insights/views/Funnels/FunnelTrendsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelTrendsTable.tsx
@@ -17,8 +17,9 @@ import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
 import { cohortsModel } from '~/models/cohortsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
-import { FunnelsActorsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { BreakdownKeyType, FunnelStepWithConversionMetrics } from '~/types'
+
+import { buildFunnelTrendsActorsQuery } from './funnelTrendsTableUtils'
 
 /** Runtime shape of a `funnelDataLogic.indexedSteps` row when the funnel is in trends mode. */
 type FunnelTrendSeries = {
@@ -94,14 +95,12 @@ export function FunnelTrendsTable(): JSX.Element | null {
                 {breakdownLabel ? <> • {breakdownLabel}</> : null}
             </>
         )
-        const query: FunnelsActorsQuery = {
-            kind: NodeKind.FunnelsActorsQuery,
+        const query = buildFunnelTrendsActorsQuery({
             source: querySource!,
-            funnelTrendsDropOff: false,
-            includeRecordings: true,
-            funnelTrendsEntrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
-            ...(hasBreakdown(breakdownValue) ? { funnelStepBreakdown: breakdownValue } : {}),
-        }
+            entrancePeriodStart: dayjs(day).format('YYYY-MM-DD HH:mm:ss'),
+            breakdownValue,
+            compare: row.compare_label,
+        })
         openPersonsModal({ title, query })
     }
 

--- a/frontend/src/scenes/insights/views/Funnels/funnelTimeToConvertTableUtils.test.ts
+++ b/frontend/src/scenes/insights/views/Funnels/funnelTimeToConvertTableUtils.test.ts
@@ -1,0 +1,45 @@
+import { HistogramGraphDatum } from '~/types'
+
+import { buildTimeToConvertCompareRows } from './funnelTimeToConvertTableUtils'
+
+const datum = (id: number, count: number): HistogramGraphDatum => ({
+    id,
+    bin0: id * 60,
+    bin1: (id + 1) * 60,
+    count,
+    label: `${count}%`,
+})
+
+describe('buildTimeToConvertCompareRows', () => {
+    it('returns rows with null previous when not comparing', () => {
+        const current = [datum(0, 40), datum(1, 30)]
+
+        const rows = buildTimeToConvertCompareRows(current, null)
+
+        expect(rows).toEqual([
+            { ...current[0], previous: null },
+            { ...current[1], previous: null },
+        ])
+    })
+
+    it('aligns previous bins positionally against shared boundaries', () => {
+        const current = [datum(0, 40), datum(1, 30)]
+        const previous = [datum(0, 38), datum(1, 31)]
+
+        const rows = buildTimeToConvertCompareRows(current, previous)
+
+        expect(rows[0].previous).toEqual(previous[0])
+        expect(rows[1].previous).toEqual(previous[1])
+    })
+
+    it('leaves previous null where the previous series is shorter', () => {
+        const current = [datum(0, 40), datum(1, 30), datum(2, 20)]
+        const previous = [datum(0, 38)]
+
+        const rows = buildTimeToConvertCompareRows(current, previous)
+
+        expect(rows[0].previous).toEqual(previous[0])
+        expect(rows[1].previous).toBeNull()
+        expect(rows[2].previous).toBeNull()
+    })
+})

--- a/frontend/src/scenes/insights/views/Funnels/funnelTimeToConvertTableUtils.ts
+++ b/frontend/src/scenes/insights/views/Funnels/funnelTimeToConvertTableUtils.ts
@@ -1,0 +1,21 @@
+import { HistogramGraphDatum } from '~/types'
+
+export interface TimeToConvertCompareRow extends HistogramGraphDatum {
+    /** The matching bin from the previous period, or null outside compare mode / when absent. */
+    previous: HistogramGraphDatum | null
+}
+
+/** Zips the current and previous time-to-convert bins into one row per bin.
+ *
+ * Compare-to-previous for time-to-convert is computed on shared bin boundaries, so the two periods
+ * align positionally — `previous[i]` is the same duration bucket as `current[i]`. A shorter or
+ * missing previous series leaves `previous: null` rather than misaligning the columns. */
+export function buildTimeToConvertCompareRows(
+    current: HistogramGraphDatum[],
+    previous: HistogramGraphDatum[] | null
+): TimeToConvertCompareRow[] {
+    return current.map((datum, index) => ({
+        ...datum,
+        previous: previous?.[index] ?? null,
+    }))
+}

--- a/frontend/src/scenes/insights/views/Funnels/funnelTrendsTableUtils.test.ts
+++ b/frontend/src/scenes/insights/views/Funnels/funnelTrendsTableUtils.test.ts
@@ -1,0 +1,57 @@
+import { FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
+
+import { buildFunnelTrendsActorsQuery } from './funnelTrendsTableUtils'
+
+const source: FunnelsQuery = {
+    kind: NodeKind.FunnelsQuery,
+    series: [],
+}
+
+describe('buildFunnelTrendsActorsQuery', () => {
+    it('scopes a previous-period click to the previous window', () => {
+        const query = buildFunnelTrendsActorsQuery({
+            source,
+            entrancePeriodStart: '2026-06-08 00:00:00',
+            compare: 'previous',
+        })
+
+        expect(query.compare).toEqual('previous')
+        expect(query.funnelTrendsEntrancePeriodStart).toEqual('2026-06-08 00:00:00')
+        expect(query.funnelTrendsDropOff).toBe(false)
+        expect(query.includeRecordings).toBe(true)
+    })
+
+    it('passes current explicitly when clicking a current-period row', () => {
+        const query = buildFunnelTrendsActorsQuery({
+            source,
+            entrancePeriodStart: '2026-06-15 00:00:00',
+            compare: 'current',
+        })
+
+        expect(query.compare).toEqual('current')
+    })
+
+    it('omits compare outside compare mode', () => {
+        const query = buildFunnelTrendsActorsQuery({
+            source,
+            entrancePeriodStart: '2026-06-15 00:00:00',
+        })
+
+        expect(query.compare).toBeUndefined()
+    })
+
+    it('threads a breakdown value through and omits it when absent', () => {
+        const withBreakdown = buildFunnelTrendsActorsQuery({
+            source,
+            entrancePeriodStart: '2026-06-15 00:00:00',
+            breakdownValue: 'Chrome',
+        })
+        const withoutBreakdown = buildFunnelTrendsActorsQuery({
+            source,
+            entrancePeriodStart: '2026-06-15 00:00:00',
+        })
+
+        expect(withBreakdown.funnelStepBreakdown).toEqual('Chrome')
+        expect(withoutBreakdown.funnelStepBreakdown).toBeUndefined()
+    })
+})

--- a/frontend/src/scenes/insights/views/Funnels/funnelTrendsTableUtils.ts
+++ b/frontend/src/scenes/insights/views/Funnels/funnelTrendsTableUtils.ts
@@ -1,0 +1,35 @@
+import { hasBreakdown } from 'scenes/funnels/funnelUtils'
+
+import { FunnelsActorsQuery, FunnelsQuery, NodeKind } from '~/queries/schema/schema-general'
+import { BreakdownKeyType } from '~/types'
+
+export interface FunnelTrendsActorsQueryParams {
+    source: FunnelsQuery
+    /** Already-formatted entrance period start (the clicked period's own date, shifted for previous). */
+    entrancePeriodStart: string
+    breakdownValue?: BreakdownKeyType
+    /** The clicked row's period. `'previous'` makes the runner scope actors to the shifted window. */
+    compare?: 'current' | 'previous'
+}
+
+/** Builds the actors query for a clicked trends-table cell.
+ *
+ * In compare mode each row belongs to one period, so we thread `compare` through: the runner
+ * resolves `'previous'` to the shifted date range, mirroring `openPersonsModalForSeries`. Without
+ * it, a previous-period click would resolve against the current window and return no actors. */
+export function buildFunnelTrendsActorsQuery({
+    source,
+    entrancePeriodStart,
+    breakdownValue,
+    compare,
+}: FunnelTrendsActorsQueryParams): FunnelsActorsQuery {
+    return {
+        kind: NodeKind.FunnelsActorsQuery,
+        source,
+        funnelTrendsDropOff: false,
+        includeRecordings: true,
+        funnelTrendsEntrancePeriodStart: entrancePeriodStart,
+        ...(hasBreakdown(breakdownValue) ? { funnelStepBreakdown: breakdownValue } : {}),
+        ...(compare ? { compare } : {}),
+    }
+}


### PR DESCRIPTION
## Problem

Funnel compare-to-previous is rolling out behind `product-analytics-funnels-compare`, and the charts already render both periods. But the detailed results tables added in #64339 don't reflect compare:

- **Time-to-convert table** rendered the current period only — `histogramGraphDataPrevious` was already computed but unused, so there was no indication compare was even on.
- **Trends table** rendered both periods' rows, but a cell click built an actors query without saying *which* period was clicked, so a previous-period click resolved against the current window.

## Changes

Both changes are frontend-only — the backend already returns both periods, and the `FunnelsActorsQuery.compare` field + runner handling this relies on landed in master via #65291.

**Time-to-convert table** (`FunnelTimeToConvertTable`)
- When comparing, splits into **Current** / **Previous** column groups (conversions + % of total each); the footer shows both periods' average time to convert.
- Bins are shared between periods, so rows stay 1:1 and previous bins align positionally (`buildTimeToConvertCompareRows`). Outside compare mode the table is unchanged.
- No explicit delta column — matches the grouped-bar histogram above it and every other funnel compare surface.

**Trends table** (`FunnelTrendsTable`)
- `openModalForCell` now threads the row's `compare_label` onto the `FunnelsActorsQuery` (`buildFunnelTrendsActorsQuery`), so the runner's `_previous_period_context()` scopes a previous-period click to the shifted window — mirroring `openPersonsModalForSeries`.

## How did you test this code?

I'm an agent; I did **not** manually exercise the UI. This branch is a clean extraction of the results-table commits from #65305 (which was stacked on the now-merged #65291) onto master — the code is unchanged. Automated checks run on the original work:

- Jest unit tests: `funnelTimeToConvertTableUtils.test.ts` (previous-bin alignment, shorter/missing previous series) and `funnelTrendsTableUtils.test.ts` (current/previous/no-compare scoping, breakdown threading).
- `oxlint` + `oxfmt` clean on all six changed files.

Worth a human eyeballing the rendered tables in compare mode before un-drafting.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal funnel results table, gated behind the existing compare flag.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Created with Claude Code (Opus 4.8). This PR re-homes the "detailed results tables" feature off the now-merged stacked dependency #65291. The two results-table commits from #65305 were cherry-picked onto current master and dropped the persons-modal commit (`b8041817`), which is already in master via #65291. The diff is identical to the corresponding commits on #65305; no logic changed during extraction. The two commits were regrouped by surface (trends table, time-to-convert table); the inline greptile fix from #65305 is folded into the time-to-convert commit.

Supersedes the stacked #65305.
