### PR TITLE
fix(data-warehouse): persist only changed fields in bulk schema edits

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5871,23 +5871,9 @@ const api = {
         },
         async bulkUpdateSchemas(
             sourceId: ExternalDataSource['id'],
-            // Only `id` is required; every other field is optional so callers can send a minimal
-            // diff. The backend writes only the fields present, leaving omitted ones untouched.
-            schemas: (Pick<ExternalDataSourceSchema, 'id'> &
-                Partial<
-                    Pick<
-                        ExternalDataSourceSchema,
-                        | 'should_sync'
-                        | 'sync_type'
-                        | 'incremental_field'
-                        | 'incremental_field_type'
-                        | 'incremental_field_lookback_seconds'
-                        | 'sync_frequency'
-                        | 'sync_time_of_day'
-                        | 'cdc_table_mode'
-                        | 'enabled_columns'
-                    >
-                >)[]
+            // Callers send a minimal diff — only `id` is required; the backend writes just the fields
+            // present and leaves the rest untouched. (Matches `externalDataSchemas.update`'s shape.)
+            schemas: (Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'>)[]
         ): Promise<ExternalDataSourceSchema[]> {
             return await new ApiRequest().externalDataSource(sourceId).withAction('bulk_update_schemas').update({
                 data: { schemas },

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -5871,18 +5871,23 @@ const api = {
         },
         async bulkUpdateSchemas(
             sourceId: ExternalDataSource['id'],
-            schemas: Pick<
-                ExternalDataSourceSchema,
-                | 'id'
-                | 'should_sync'
-                | 'sync_type'
-                | 'incremental_field'
-                | 'incremental_field_type'
-                | 'sync_frequency'
-                | 'sync_time_of_day'
-                | 'cdc_table_mode'
-                | 'enabled_columns'
-            >[]
+            // Only `id` is required; every other field is optional so callers can send a minimal
+            // diff. The backend writes only the fields present, leaving omitted ones untouched.
+            schemas: (Pick<ExternalDataSourceSchema, 'id'> &
+                Partial<
+                    Pick<
+                        ExternalDataSourceSchema,
+                        | 'should_sync'
+                        | 'sync_type'
+                        | 'incremental_field'
+                        | 'incremental_field_type'
+                        | 'incremental_field_lookback_seconds'
+                        | 'sync_frequency'
+                        | 'sync_time_of_day'
+                        | 'cdc_table_mode'
+                        | 'enabled_columns'
+                    >
+                >)[]
         ): Promise<ExternalDataSourceSchema[]> {
             return await new ApiRequest().externalDataSource(sourceId).withAction('bulk_update_schemas').update({
                 data: { schemas },

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -58,7 +58,8 @@ describe('sourceSettingsLogic', () => {
     it('debounces schema saves and only sends the latest queued change', async () => {
         const bulkUpdateSchemasSpy = jest
             .spyOn(api.externalDataSources, 'bulkUpdateSchemas')
-            .mockImplementation(async (_id, schemas) => schemas as ExternalDataSourceSchema[])
+            // Mirror the backend: merge the partial payload onto the stored row, return full schemas.
+            .mockImplementation(async (_id, schemas) => schemas.map((partial) => ({ ...makeSchema(), ...partial })))
 
         logic = sourceSettingsLogic({ id: 'source-1' })
         logic.mount()
@@ -90,7 +91,7 @@ describe('sourceSettingsLogic', () => {
                         return
                     }
 
-                    resolve(schemas as ExternalDataSourceSchema[])
+                    resolve(schemas.map((partial) => ({ ...makeSchema(), ...partial })))
                 })
         )
 
@@ -156,6 +157,50 @@ describe('sourceSettingsLogic', () => {
         ])
         expect(logic.values.source?.schemas[0].sync_frequency).toBe('24hour')
         expect(logic.values.source?.schemas[0].enabled_columns).toEqual(['id', 'name'])
+    })
+
+    it('re-sends a failed in-flight edit fields when a newer edit for the same schema is queued', async () => {
+        // Minimal-diff payloads must not lose data: if a flush fails while a newer edit for the same
+        // schema is queued, the retry has to re-send the failed edit's fields too — not just the new one.
+        let rejectFirst: (() => void) | null = null
+        let callCount = 0
+        const bulkUpdateSchemasSpy = jest
+            .spyOn(api.externalDataSources, 'bulkUpdateSchemas')
+            .mockImplementation((_id, schemas) => {
+                callCount++
+                if (callCount === 1) {
+                    return new Promise<ExternalDataSourceSchema[]>((_resolve, reject) => {
+                        rejectFirst = () => reject(new Error('boom'))
+                    })
+                }
+                return Promise.resolve(schemas.map((partial) => ({ ...makeSchema(), ...partial })))
+            })
+
+        logic = sourceSettingsLogic({ id: 'source-1' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        jest.useFakeTimers()
+
+        // Edit 1 (should_sync) flushes and goes in-flight.
+        logic.actions.updateSchema(makeSchema({ should_sync: true }))
+        await jest.advanceTimersByTimeAsync(500)
+        expect(bulkUpdateSchemasSpy).toHaveBeenCalledTimes(1)
+
+        // Edit 2 (a different field) is queued while edit 1 is still in-flight.
+        logic.actions.updateSchema(makeSchema({ should_sync: true, sync_frequency: '24hour' }))
+
+        // Edit 1 fails — the retry must carry both should_sync and sync_frequency.
+        const rejectFirstFn = rejectFirst as unknown as (() => void) | null
+        if (!rejectFirstFn) {
+            throw new Error('Expected first request to be pending')
+        }
+        rejectFirstFn()
+        await jest.advanceTimersByTimeAsync(500)
+
+        expect(bulkUpdateSchemasSpy).toHaveBeenCalledTimes(2)
+        expect(bulkUpdateSchemasSpy).toHaveBeenLastCalledWith('source-1', [
+            { id: 'schema-1', should_sync: true, sync_frequency: '24hour' },
+        ])
     })
 
     it('keys the logic by source id', () => {

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -128,6 +128,36 @@ describe('sourceSettingsLogic', () => {
         expect(logic.values.source?.schemas[0].should_sync).toBe(false)
     })
 
+    it('bulk frequency edit sends only the changed field and preserves untouched ones', async () => {
+        // The schema has a column selection the user never touched in this edit. The bulk PATCH must
+        // carry only { id, sync_frequency } — sending enabled_columns (even unchanged) makes the
+        // backend reproject and wipe the selection.
+        jest.spyOn(api.externalDataSources, 'get').mockResolvedValue(
+            makeSource([makeSchema({ sync_type: 'full_refresh', enabled_columns: ['id', 'name'] })])
+        )
+        const bulkUpdateSchemasSpy = jest
+            .spyOn(api.externalDataSources, 'bulkUpdateSchemas')
+            // Mirror the real backend: merge the partial payload onto the stored schema, return full rows.
+            .mockImplementation(async (_id, schemas) =>
+                schemas.map((partial) => ({ ...makeSchema({ enabled_columns: ['id', 'name'] }), ...partial }))
+            )
+
+        logic = sourceSettingsLogic({ id: 'source-1' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        jest.useFakeTimers()
+
+        logic.actions.bulkSetFrequency(logic.values.source!.schemas, '24hour')
+        await jest.advanceTimersByTimeAsync(500)
+
+        expect(bulkUpdateSchemasSpy).toHaveBeenCalledTimes(1)
+        expect(bulkUpdateSchemasSpy).toHaveBeenLastCalledWith('source-1', [
+            { id: 'schema-1', sync_frequency: '24hour' },
+        ])
+        expect(logic.values.source?.schemas[0].sync_frequency).toBe('24hour')
+        expect(logic.values.source?.schemas[0].enabled_columns).toEqual(['id', 'name'])
+    })
+
     it('keys the logic by source id', () => {
         expect(sourceSettingsLogic({ id: 'source-1' }).key).toEqual('source-1')
     })

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -130,9 +130,8 @@ describe('sourceSettingsLogic', () => {
     })
 
     it('bulk frequency edit sends only the changed field and preserves untouched ones', async () => {
-        // The schema has a column selection the user never touched in this edit. The bulk PATCH must
-        // carry only { id, sync_frequency } — sending enabled_columns (even unchanged) makes the
-        // backend reproject and wipe the selection.
+        // Sending enabled_columns (even unchanged) would make the backend wipe the selection, so the
+        // PATCH must carry only { id, sync_frequency }.
         jest.spyOn(api.externalDataSources, 'get').mockResolvedValue(
             makeSource([makeSchema({ sync_type: 'full_refresh', enabled_columns: ['id', 'name'] })])
         )
@@ -160,8 +159,7 @@ describe('sourceSettingsLogic', () => {
     })
 
     it('sends a changed writable field discovered by diff, not a fixed allowlist', async () => {
-        // The diff is dynamic: any writable field that changed is sent, even one no hardcoded list
-        // enumerates (here row_filters). Guards against regressing to an allowlist that silently drops it.
+        // row_filters isn't in any hardcoded list — guards against regressing to an allowlist that drops it.
         jest.spyOn(api.externalDataSources, 'get').mockResolvedValue(
             makeSource([makeSchema({ sync_type: 'incremental', incremental_field: 'updated_at' })])
         )
@@ -183,8 +181,7 @@ describe('sourceSettingsLogic', () => {
     })
 
     it('re-sends a failed in-flight edit fields when a newer edit for the same schema is queued', async () => {
-        // Minimal-diff payloads must not lose data: if a flush fails while a newer edit for the same
-        // schema is queued, the retry has to re-send the failed edit's fields too — not just the new one.
+        // A failed flush must not lose its fields: the retry re-sends them alongside the newer edit's.
         let rejectFirst: (() => void) | null = null
         let callCount = 0
         const bulkUpdateSchemasSpy = jest

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/dataWarehouseSourceSettingsLogic.test.ts
@@ -159,6 +159,29 @@ describe('sourceSettingsLogic', () => {
         expect(logic.values.source?.schemas[0].enabled_columns).toEqual(['id', 'name'])
     })
 
+    it('sends a changed writable field discovered by diff, not a fixed allowlist', async () => {
+        // The diff is dynamic: any writable field that changed is sent, even one no hardcoded list
+        // enumerates (here row_filters). Guards against regressing to an allowlist that silently drops it.
+        jest.spyOn(api.externalDataSources, 'get').mockResolvedValue(
+            makeSource([makeSchema({ sync_type: 'incremental', incremental_field: 'updated_at' })])
+        )
+        const bulkUpdateSchemasSpy = jest
+            .spyOn(api.externalDataSources, 'bulkUpdateSchemas')
+            .mockImplementation(async (_id, schemas) => schemas.map((partial) => ({ ...makeSchema(), ...partial })))
+
+        logic = sourceSettingsLogic({ id: 'source-1' })
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+        jest.useFakeTimers()
+
+        const schema = logic.values.source!.schemas[0]
+        const row_filters = [{ column: 'amount', operator: '>' as const, value: 100 }]
+        logic.actions.updateSchema({ ...schema, row_filters })
+        await jest.advanceTimersByTimeAsync(500)
+
+        expect(bulkUpdateSchemasSpy).toHaveBeenLastCalledWith('source-1', [{ id: 'schema-1', row_filters }])
+    })
+
     it('re-sends a failed in-flight edit fields when a newer edit for the same schema is queued', async () => {
         // Minimal-diff payloads must not lose data: if a flush fails while a newer edit for the same
         // schema is queued, the retry has to re-send the failed edit's fields too — not just the new one.

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -67,18 +67,9 @@ function nextJobsPollDelay(softFailureCount: number): number {
     return exponential * (0.5 + Math.random() * 0.5)
 }
 
-// The backend treats any field present in a bulk-update request as an intentional write, so we send
-// only the fields the user actually changed — re-sending an unchanged field (e.g. enabled_columns:
-// null) clobbers the persisted value. Which fields changed is discovered dynamically by diffing the
-// edit against the current schema (see diffSchemaPayloadFields), so new editable fields need no
-// wiring here.
-//
-// This set is the inverse: the schema fields that must never be written by that diff. It mirrors the
-// serializer's read-only/derived fields — the backend ignores them on write anyway, but listing them
-// keeps a server-mutated value (e.g. a status change landing mid-edit) out of the payload. Using a
-// denylist rather than an allowlist of writable fields is deliberate: a newly added editable field is
-// then sent automatically, and the worst case of forgetting to list a new read-only field here is a
-// harmless ignored field on the wire — never the silent data loss a stale allowlist would cause.
+// Read-only/derived fields to keep out of bulk-update payloads. A denylist (not an allowlist of
+// writable fields) so new editable fields are sent automatically — a stale allowlist silently
+// dropped edits like sync_frequency.
 const NON_WRITABLE_SCHEMA_FIELDS = new Set<keyof ExternalDataSourceSchema>([
     'id',
     'name',
@@ -98,8 +89,7 @@ type SchemaPayloadField = keyof ExternalDataSourceSchema
 interface PendingSchemaUpdate {
     revision: number
     schema: ExternalDataSourceSchema
-    // Which payload fields changed relative to the last server-confirmed state, accumulated
-    // across coalesced edits to the same schema before a flush.
+    // Fields changed vs. server state, accumulated across coalesced edits before a flush.
     changedFields: Set<SchemaPayloadField>
 }
 
@@ -154,15 +144,13 @@ function applySchemasToSource(
     )
 }
 
-// Build the PATCH body from only the fields that changed, always including `id`. A changed value is
-// normalized to `null` when nullish so an explicit clear is sent (JSON drops `undefined`), while a
-// field the user never touched is omitted entirely — the backend leaves it untouched.
+// PATCH body of only the changed fields (+ id). The backend writes every field it receives, so
+// sending an untouched field would clobber it. Nullish → null so a clear is sent (JSON drops undefined).
 function buildSchemaUpdatePayload(
     schema: ExternalDataSourceSchema,
     changedFields: Set<SchemaPayloadField>
 ): Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> {
     const payload: Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> = { id: schema.id }
-    // Indexing payload by a union-typed key isn't expressible to TS; assign through an indexable view.
     const assign = payload as Record<string, unknown>
 
     for (const field of changedFields) {
@@ -172,10 +160,8 @@ function buildSchemaUpdatePayload(
     return payload
 }
 
-// The writable fields that differ between the new schema and the last server-confirmed schema,
-// discovered by diffing every key rather than a fixed list so new editable fields are picked up for
-// free. Read-only/derived fields are skipped (see NON_WRITABLE_SCHEMA_FIELDS). With no known baseline
-// (source not loaded yet) every writable field counts as changed, so the edit still fully persists.
+// Writable fields whose value changed vs. the current schema. No baseline (source not loaded) =>
+// treat all as changed so the edit still persists.
 function diffSchemaPayloadFields(
     nextSchema: ExternalDataSourceSchema,
     baselineSchema: ExternalDataSourceSchema | undefined
@@ -198,10 +184,8 @@ function diffSchemaPayloadFields(
     return changed
 }
 
-// When a flush fails while a newer edit for the same schema is already queued, the pending update
-// only carries the fields that changed since the (optimistically applied) in-flight edit — so its
-// changedFields omit the fields the failed request was sending. Fold the failed update back in so
-// the retry re-sends everything the user intended; the pending (newer) edit wins on field overlap.
+// A failed flush merges its fields into the newer queued edit so the retry re-sends both; the newer
+// edit wins on overlap. Otherwise the retry would drop the failed edit's fields.
 function foldFailedUpdateIntoPending(failed: PendingSchemaUpdate, pending: PendingSchemaUpdate): PendingSchemaUpdate {
     const mergedSchema = { ...failed.schema }
     const assign = mergedSchema as Record<string, unknown>
@@ -831,9 +815,8 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
 
                 schemaUpdateCache.schemaUpdateRevisions[schema.id] = nextRevision
 
-                // Diff against the current source schema (already reflects any in-flight optimistic
-                // state) to find what this edit changed, then merge with fields a not-yet-flushed
-                // pending edit changed so coalesced edits send the union — not just the latest one.
+                // Union this edit's changed fields with any not-yet-flushed pending edit's, so
+                // coalesced edits send everything that changed — not just the latest field.
                 const baselineSchema = values.source?.schemas.find((item) => item.id === schema.id)
                 const changedFields = diffSchemaPayloadFields(schema, baselineSchema)
                 for (const field of schemaUpdateCache.pendingSchemaUpdates[schema.id]?.changedFields ?? []) {

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -67,9 +67,29 @@ function nextJobsPollDelay(softFailureCount: number): number {
     return exponential * (0.5 + Math.random() * 0.5)
 }
 
+// Fields the schema-update endpoint accepts. The backend treats any field present in the
+// request as an intentional write, so we only ever send the ones the user actually changed —
+// sending an unchanged field (e.g. enabled_columns: null) clobbers the persisted value.
+const SCHEMA_PAYLOAD_FIELDS = [
+    'should_sync',
+    'sync_type',
+    'incremental_field',
+    'incremental_field_type',
+    'incremental_field_lookback_seconds',
+    'sync_frequency',
+    'sync_time_of_day',
+    'cdc_table_mode',
+    'enabled_columns',
+] as const
+
+type SchemaPayloadField = (typeof SCHEMA_PAYLOAD_FIELDS)[number]
+
 interface PendingSchemaUpdate {
     revision: number
     schema: ExternalDataSourceSchema
+    // Which payload fields changed relative to the last server-confirmed state, accumulated
+    // across coalesced edits to the same schema before a flush.
+    changedFields: Set<SchemaPayloadField>
 }
 
 interface SchemaUpdateCache {
@@ -123,33 +143,41 @@ function applySchemasToSource(
     )
 }
 
+// Build the PATCH body from only the fields that changed, always including `id`. Nullable fields
+// are normalized to `null` so an explicit clear is sent, but a field the user never touched is
+// omitted entirely — the backend leaves it untouched.
 function buildSchemaUpdatePayload(
-    schema: ExternalDataSourceSchema
-): Pick<
-    ExternalDataSourceSchema,
-    | 'id'
-    | 'should_sync'
-    | 'sync_type'
-    | 'incremental_field'
-    | 'incremental_field_type'
-    | 'incremental_field_lookback_seconds'
-    | 'sync_frequency'
-    | 'sync_time_of_day'
-    | 'cdc_table_mode'
-    | 'enabled_columns'
-> {
-    return {
-        id: schema.id,
-        should_sync: schema.should_sync,
-        sync_type: schema.sync_type,
-        incremental_field: schema.incremental_field,
-        incremental_field_type: schema.incremental_field_type,
-        incremental_field_lookback_seconds: schema.incremental_field_lookback_seconds ?? null,
-        sync_frequency: schema.sync_frequency,
-        sync_time_of_day: schema.sync_time_of_day,
-        cdc_table_mode: schema.cdc_table_mode,
-        enabled_columns: schema.enabled_columns ?? null,
+    schema: ExternalDataSourceSchema,
+    changedFields: Set<SchemaPayloadField>
+): Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> {
+    const payload: Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> = { id: schema.id }
+    // Indexing payload by a union-typed key isn't expressible to TS; assign through an indexable view.
+    const assign = payload as Record<SchemaPayloadField, unknown>
+
+    for (const field of changedFields) {
+        assign[field] =
+            field === 'enabled_columns' || field === 'incremental_field_lookback_seconds'
+                ? (schema[field] ?? null)
+                : schema[field]
     }
+
+    return payload
+}
+
+// Fields that differ between the new schema and the last server-confirmed schema. With no known
+// baseline (source not loaded yet) every field counts as changed, matching the old full-payload
+// behavior so the edit still persists.
+function diffSchemaPayloadFields(
+    nextSchema: ExternalDataSourceSchema,
+    baselineSchema: ExternalDataSourceSchema | undefined
+): Set<SchemaPayloadField> {
+    const changed = new Set<SchemaPayloadField>()
+    for (const field of SCHEMA_PAYLOAD_FIELDS) {
+        if (!baselineSchema || !objectsEqual(nextSchema[field], baselineSchema[field])) {
+            changed.add(field)
+        }
+    }
+    return changed
 }
 
 function getSchemaUpdateCache(cache: SchemaUpdateCache): Required<SchemaUpdateCache> {
@@ -703,7 +731,9 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                     try {
                         const updatedSchemas = await api.externalDataSources.bulkUpdateSchemas(
                             values.sourceId,
-                            batchSchemaUpdates.map(({ schema }) => buildSchemaUpdatePayload(schema))
+                            batchSchemaUpdates.map(({ schema, changedFields }) =>
+                                buildSchemaUpdatePayload(schema, changedFields)
+                            )
                         )
 
                         for (const pendingUpdate of batchSchemaUpdates) {
@@ -756,7 +786,17 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                 const nextRevision = (schemaUpdateCache.schemaUpdateRevisions[schema.id] ?? 0) + 1
 
                 schemaUpdateCache.schemaUpdateRevisions[schema.id] = nextRevision
-                schemaUpdateCache.pendingSchemaUpdates[schema.id] = { schema, revision: nextRevision }
+
+                // Diff against the current source schema (already reflects any in-flight optimistic
+                // state) to find what this edit changed, then merge with fields a not-yet-flushed
+                // pending edit changed so coalesced edits send the union — not just the latest one.
+                const baselineSchema = values.source?.schemas.find((item) => item.id === schema.id)
+                const changedFields = diffSchemaPayloadFields(schema, baselineSchema)
+                for (const field of schemaUpdateCache.pendingSchemaUpdates[schema.id]?.changedFields ?? []) {
+                    changedFields.add(field)
+                }
+
+                schemaUpdateCache.pendingSchemaUpdates[schema.id] = { schema, revision: nextRevision, changedFields }
 
                 const optimisticSource = applyPendingSchemaUpdatesToSource(
                     values.source,

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -67,9 +67,10 @@ function nextJobsPollDelay(softFailureCount: number): number {
     return exponential * (0.5 + Math.random() * 0.5)
 }
 
-// Fields the schema-update endpoint accepts. The backend treats any field present in the
-// request as an intentional write, so we only ever send the ones the user actually changed —
-// sending an unchanged field (e.g. enabled_columns: null) clobbers the persisted value.
+// The schema fields the bulk-update endpoint accepts. The backend treats any field present in the
+// request as an intentional write, so we only send the ones the user actually changed — sending an
+// unchanged field (e.g. enabled_columns: null) clobbers the persisted value. This allowlist is the
+// single source of truth for which fields are sendable; everything else on the schema is read-only.
 const SCHEMA_PAYLOAD_FIELDS = [
     'should_sync',
     'sync_type',

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -180,6 +180,24 @@ function diffSchemaPayloadFields(
     return changed
 }
 
+// When a flush fails while a newer edit for the same schema is already queued, the pending update
+// only carries the fields that changed since the (optimistically applied) in-flight edit — so its
+// changedFields omit the fields the failed request was sending. Fold the failed update back in so
+// the retry re-sends everything the user intended; the pending (newer) edit wins on field overlap.
+function foldFailedUpdateIntoPending(failed: PendingSchemaUpdate, pending: PendingSchemaUpdate): PendingSchemaUpdate {
+    const mergedSchema = { ...failed.schema }
+    const assign = mergedSchema as Record<SchemaPayloadField, unknown>
+    for (const field of pending.changedFields) {
+        assign[field] = pending.schema[field]
+    }
+
+    return {
+        schema: mergedSchema,
+        revision: pending.revision,
+        changedFields: new Set([...failed.changedFields, ...pending.changedFields]),
+    }
+}
+
 function getSchemaUpdateCache(cache: SchemaUpdateCache): Required<SchemaUpdateCache> {
     cache.pendingSchemaUpdates ??= {}
     cache.inFlightSchemaUpdates ??= {}
@@ -764,8 +782,16 @@ export const sourceSettingsLogic = kea<sourceSettingsLogicType>([
                             scheduleSchemaUpdateFlush()
                         }
                     } catch (error: any) {
-                        for (const pendingUpdate of batchSchemaUpdates) {
-                            delete schemaUpdateCache.inFlightSchemaUpdates[pendingUpdate.schema.id]
+                        for (const failedUpdate of batchSchemaUpdates) {
+                            delete schemaUpdateCache.inFlightSchemaUpdates[failedUpdate.schema.id]
+
+                            // If a newer edit for this schema is queued, fold the failed fields into it
+                            // so the retry doesn't silently drop what this request was carrying.
+                            const pending = schemaUpdateCache.pendingSchemaUpdates[failedUpdate.schema.id]
+                            if (pending) {
+                                schemaUpdateCache.pendingSchemaUpdates[failedUpdate.schema.id] =
+                                    foldFailedUpdateIntoPending(failedUpdate, pending)
+                            }
                         }
 
                         if (Object.keys(schemaUpdateCache.pendingSchemaUpdates).length > 0) {

--- a/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
+++ b/products/data_warehouse/frontend/scenes/SourceScene/tabs/sourceSettingsLogic.ts
@@ -67,23 +67,33 @@ function nextJobsPollDelay(softFailureCount: number): number {
     return exponential * (0.5 + Math.random() * 0.5)
 }
 
-// The schema fields the bulk-update endpoint accepts. The backend treats any field present in the
-// request as an intentional write, so we only send the ones the user actually changed — sending an
-// unchanged field (e.g. enabled_columns: null) clobbers the persisted value. This allowlist is the
-// single source of truth for which fields are sendable; everything else on the schema is read-only.
-const SCHEMA_PAYLOAD_FIELDS = [
-    'should_sync',
-    'sync_type',
-    'incremental_field',
-    'incremental_field_type',
-    'incremental_field_lookback_seconds',
-    'sync_frequency',
-    'sync_time_of_day',
-    'cdc_table_mode',
-    'enabled_columns',
-] as const
+// The backend treats any field present in a bulk-update request as an intentional write, so we send
+// only the fields the user actually changed — re-sending an unchanged field (e.g. enabled_columns:
+// null) clobbers the persisted value. Which fields changed is discovered dynamically by diffing the
+// edit against the current schema (see diffSchemaPayloadFields), so new editable fields need no
+// wiring here.
+//
+// This set is the inverse: the schema fields that must never be written by that diff. It mirrors the
+// serializer's read-only/derived fields — the backend ignores them on write anyway, but listing them
+// keeps a server-mutated value (e.g. a status change landing mid-edit) out of the payload. Using a
+// denylist rather than an allowlist of writable fields is deliberate: a newly added editable field is
+// then sent automatically, and the worst case of forgetting to list a new read-only field here is a
+// harmless ignored field on the wire — never the silent data loss a stale allowlist would cause.
+const NON_WRITABLE_SCHEMA_FIELDS = new Set<keyof ExternalDataSourceSchema>([
+    'id',
+    'name',
+    'label',
+    'table',
+    'last_synced_at',
+    'latest_error',
+    'status',
+    'description',
+    'available_columns',
+    'incremental',
+    'should_sync_default',
+])
 
-type SchemaPayloadField = (typeof SCHEMA_PAYLOAD_FIELDS)[number]
+type SchemaPayloadField = keyof ExternalDataSourceSchema
 
 interface PendingSchemaUpdate {
     revision: number
@@ -144,40 +154,47 @@ function applySchemasToSource(
     )
 }
 
-// Build the PATCH body from only the fields that changed, always including `id`. Nullable fields
-// are normalized to `null` so an explicit clear is sent, but a field the user never touched is
-// omitted entirely — the backend leaves it untouched.
+// Build the PATCH body from only the fields that changed, always including `id`. A changed value is
+// normalized to `null` when nullish so an explicit clear is sent (JSON drops `undefined`), while a
+// field the user never touched is omitted entirely — the backend leaves it untouched.
 function buildSchemaUpdatePayload(
     schema: ExternalDataSourceSchema,
     changedFields: Set<SchemaPayloadField>
 ): Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> {
     const payload: Partial<ExternalDataSourceSchema> & Pick<ExternalDataSourceSchema, 'id'> = { id: schema.id }
     // Indexing payload by a union-typed key isn't expressible to TS; assign through an indexable view.
-    const assign = payload as Record<SchemaPayloadField, unknown>
+    const assign = payload as Record<string, unknown>
 
     for (const field of changedFields) {
-        assign[field] =
-            field === 'enabled_columns' || field === 'incremental_field_lookback_seconds'
-                ? (schema[field] ?? null)
-                : schema[field]
+        assign[field] = schema[field] ?? null
     }
 
     return payload
 }
 
-// Fields that differ between the new schema and the last server-confirmed schema. With no known
-// baseline (source not loaded yet) every field counts as changed, matching the old full-payload
-// behavior so the edit still persists.
+// The writable fields that differ between the new schema and the last server-confirmed schema,
+// discovered by diffing every key rather than a fixed list so new editable fields are picked up for
+// free. Read-only/derived fields are skipped (see NON_WRITABLE_SCHEMA_FIELDS). With no known baseline
+// (source not loaded yet) every writable field counts as changed, so the edit still fully persists.
 function diffSchemaPayloadFields(
     nextSchema: ExternalDataSourceSchema,
     baselineSchema: ExternalDataSourceSchema | undefined
 ): Set<SchemaPayloadField> {
     const changed = new Set<SchemaPayloadField>()
-    for (const field of SCHEMA_PAYLOAD_FIELDS) {
+    const fields = new Set<SchemaPayloadField>([
+        ...(Object.keys(nextSchema) as SchemaPayloadField[]),
+        ...((baselineSchema ? Object.keys(baselineSchema) : []) as SchemaPayloadField[]),
+    ])
+
+    for (const field of fields) {
+        if (NON_WRITABLE_SCHEMA_FIELDS.has(field)) {
+            continue
+        }
         if (!baselineSchema || !objectsEqual(nextSchema[field], baselineSchema[field])) {
             changed.add(field)
         }
     }
+
     return changed
 }
 
@@ -187,7 +204,7 @@ function diffSchemaPayloadFields(
 // the retry re-sends everything the user intended; the pending (newer) edit wins on field overlap.
 function foldFailedUpdateIntoPending(failed: PendingSchemaUpdate, pending: PendingSchemaUpdate): PendingSchemaUpdate {
     const mergedSchema = { ...failed.schema }
-    const assign = mergedSchema as Record<SchemaPayloadField, unknown>
+    const assign = mergedSchema as Record<string, unknown>
     for (const field of pending.changedFields) {
         assign[field] = pending.schema[field]
     }


### PR DESCRIPTION
## Problem

Bulk editing schemas on a data warehouse source's Schemas tab didn't persist correctly and clobbered untouched fields. A frequency-only bulk edit would silently wipe a schema's column selection.

The frontend always serialized the **full** schema field set on every edit, but the backend (`ExternalDataSchemaSerializer.update`, called with `partial=True`) treats **any field present in the request as an intentional write**. So a frequency-only edit also re-sent `enabled_columns` — and whenever the in-memory schema object didn't carry a column selection (the source-list payload often doesn't populate it), it sent `enabled_columns: null`, which the backend read as "sync all columns" and reprojected, wiping the existing selection. The request returned 200 throughout, so it looked like a silent data-clobber rather than an error.

## Changes

Send a **minimal diff** — only the fields the user actually changed:

- `sourceSettingsLogic.ts`: `updateSchema` now diffs the incoming schema against the current source schema and records the changed field keys on the pending update. Coalesced (debounced) edits to the same schema **union** their changed-field sets, so a multi-field edit still sends everything that changed — just nothing that didn't. `buildSchemaUpdatePayload` emits `{ id }` plus only the changed fields.
- `lib/api.ts`: widened `bulkUpdateSchemas`' parameter type so only `id` is required and the rest are optional (a pure widening; the sole caller still type-checks).

This matches the backend contract the existing backend tests already prove — a partial payload like `{ id, sync_frequency }` persists correctly and leaves omitted fields untouched.

## How did you test this code?

I'm an agent (agent-assisted). Automated tests only — no manual UI testing:

- Added `bulk frequency edit sends only the changed field and preserves untouched ones` to `dataWarehouseSourceSettingsLogic.test.ts`. It asserts the PATCH body is exactly `[{ id, sync_frequency }]` (no `enabled_columns`) and that the column selection survives — the precise regression that was occurring. No existing test caught this because the old mocks echoed the payload back, masking partial-payload behavior.
- Reworked the existing mocks to mirror the real backend (merge the partial payload onto the stored row, return full schemas), so the suite now exercises the realistic round-trip.
- All 11 logic tests pass. Ran the targeted `tsgo` type check over the changed code (clean; the unrelated repo-wide `tsgo` errors are missing kea-generated `*Type` files in a fresh checkout, not from this change).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code. Diagnosis flow: read both sides of the update path, confirmed via the backend's own tests that a partial payload persists correctly and that the bulk serializer marks every field `required=False`, and traced the clobber to `buildSchemaUpdatePayload` always emitting the full field set (notably `enabled_columns: schema.enabled_columns ?? null`). Source/schema logs on the affected source showed every bulk PATCH returning 200 with no errors, which pointed at silent data loss rather than a crash.

Considered making the backend ignore unchanged fields, but the backend contract (write what's present) is already correct and tested — the frontend was the side violating it, so the fix belongs there. Chose to track changed-field keys on the pending update (and union them across coalesced edits) rather than diffing at flush time, so the debounce/optimistic-merge machinery keeps working unchanged.

Invoked the `/writing-tests` skill before adding the test.
