### PR TITLE
refactor(mcp-analytics): extract shared query-runner wiring

### DIFF
--- a/products/mcp_analytics/backend/hogql_queries/base.py
+++ b/products/mcp_analytics/backend/hogql_queries/base.py
@@ -1,0 +1,48 @@
+"""Shared wiring for the MCP analytics HogQL query runners.
+
+The access gate and date-range construction are identical across every MCP
+analytics runner; keeping them here means a runner is just its query shape plus
+its harness-label SQL.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import posthoganalytics
+
+from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.rbac.user_access_control import UserAccessControlError
+
+if TYPE_CHECKING:
+    from posthog.schema import DateRange
+
+    from posthog.models.team import Team
+    from posthog.models.user import User
+
+# Gates these runners behind the same flag the product's DRF endpoints require, so the
+# generic /query/ endpoint can't bypass it (see PostHogFeatureFlagPermission).
+MCP_ANALYTICS_FEATURE_FLAG = "mcp-analytics"
+
+
+def validate_mcp_analytics_access(team: "Team", user: "User") -> bool:
+    org_id = str(team.organization_id)
+    enabled = posthoganalytics.feature_enabled(
+        MCP_ANALYTICS_FEATURE_FLAG,
+        str(user.distinct_id),
+        groups={"organization": org_id, "project": str(team.id)},
+        group_properties={"organization": {"id": org_id}, "project": {"id": str(team.id)}},
+        only_evaluate_locally=False,
+        send_feature_flag_events=False,
+    )
+    if not enabled:
+        raise UserAccessControlError("mcp_analytics", "viewer")
+    return True
+
+
+def mcp_query_date_range(team: "Team", date_range: "DateRange | None") -> QueryDateRange:
+    return QueryDateRange(
+        date_range=date_range,
+        team=team,
+        interval=None,
+        now=datetime.now(team.timezone_info),
+    )

--- a/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
+++ b/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
@@ -1,8 +1,5 @@
-from datetime import datetime
 from functools import cached_property
 from typing import TYPE_CHECKING
-
-import posthoganalytics
 
 from posthog.schema import (
     CachedMCPHarnessBreakdownQueryResponse,
@@ -19,17 +16,13 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.query_tagging import Feature, Product, tags_context
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
-from posthog.rbac.user_access_control import UserAccessControlError
 
 from products.mcp_analytics.backend import mcp_harness
 from products.mcp_analytics.backend.constants import MCP_TOOL_CALL_EVENT
+from products.mcp_analytics.backend.hogql_queries.base import mcp_query_date_range, validate_mcp_analytics_access
 
 if TYPE_CHECKING:
     from posthog.models.user import User
-
-# Gates this runner behind the same flag the product's DRF endpoints require, so the
-# generic /query/ endpoint can't bypass it (see PostHogFeatureFlagPermission).
-MCP_ANALYTICS_FEATURE_FLAG = "mcp-analytics"
 
 
 class MCPHarnessBreakdownQueryRunner(AnalyticsQueryRunner[MCPHarnessBreakdownQueryResponse]):
@@ -46,27 +39,11 @@ class MCPHarnessBreakdownQueryRunner(AnalyticsQueryRunner[MCPHarnessBreakdownQue
     cached_response: CachedMCPHarnessBreakdownQueryResponse
 
     def validate_query_runner_access(self, user: "User") -> bool:
-        org_id = str(self.team.organization_id)
-        enabled = posthoganalytics.feature_enabled(
-            MCP_ANALYTICS_FEATURE_FLAG,
-            str(user.distinct_id),
-            groups={"organization": org_id, "project": str(self.team.id)},
-            group_properties={"organization": {"id": org_id}, "project": {"id": str(self.team.id)}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-        if not enabled:
-            raise UserAccessControlError("mcp_analytics", "viewer")
-        return True
+        return validate_mcp_analytics_access(self.team, user)
 
     @cached_property
     def query_date_range(self) -> QueryDateRange:
-        return QueryDateRange(
-            date_range=self.query.dateRange,
-            team=self.team,
-            interval=None,
-            now=datetime.now(self.team.timezone_info),
-        )
+        return mcp_query_date_range(self.team, self.query.dateRange)
 
     def _where(self) -> ast.Expr:
         exprs: list[ast.Expr] = [


### PR DESCRIPTION
## Problem

The feature-flag access gate and `QueryDateRange` construction were copy-pasted across the MCP analytics query runners, so adding a new runner meant repeating both.

## Changes

Extract `validate_mcp_analytics_access` and `mcp_query_date_range` into `backend/hogql_queries/base.py` and point `MCPHarnessBreakdownQueryRunner` at them. Pure internal refactor — no behavior change. Prep for the new runners stacked above.

Part 2/7 of the stack replacing #66046. Stacked on #66084.

## How did you test this code?

I'm an agent (PostHog Code). Automated only: the existing `test_harness_breakdown.py` suite (unchanged behavior) plus `tach check --dependencies --interfaces`. All pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @pauldambra.

Built with PostHog Code (Claude). Kept as its own PR so the "no observable change" claim is reviewable at a glance. No repo skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
