### PR TITLE
feat(mcp-analytics): scope harness breakdown to one tool via toolName

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -27340,6 +27340,10 @@
                 "tags": {
                     "$ref": "#/definitions/QueryLogTags"
                 },
+                "toolName": {
+                    "description": "When set, scope to a single effective tool's new-SDK calls (the per-tool \"By harness\" table).",
+                    "type": "string"
+                },
                 "version": {
                     "description": "version of the node, used for schema migrations",
                     "type": "number"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -2567,6 +2567,8 @@ export interface MCPHarnessBreakdownQuery extends DataNode<MCPHarnessBreakdownQu
     dateRange?: DateRange
     properties?: AnyPropertyFilter[]
     filterTestAccounts?: boolean
+    /** When set, scope to a single effective tool's new-SDK calls (the per-tool "By harness" table). */
+    toolName?: string
 }
 
 export type CachedMCPHarnessBreakdownQueryResponse = CachedQueryResponse<MCPHarnessBreakdownQueryResponse>

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -23552,6 +23552,10 @@ class MCPHarnessBreakdownQuery(BaseModel):
     ) = None
     response: MCPHarnessBreakdownQueryResponse | None = None
     tags: QueryLogTags | None = None
+    toolName: str | None = Field(
+        default=None,
+        description=('When set, scope to a single effective tool\'s new-SDK calls (the per-tool "By harness" table).'),
+    )
     version: float | None = Field(default=None, description="version of the node, used for schema migrations")
 
 

--- a/products/mcp_analytics/backend/hogql_queries/base.py
+++ b/products/mcp_analytics/backend/hogql_queries/base.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING
 
 import posthoganalytics
 
+from posthog.hogql import ast
+from posthog.hogql.parser import parse_expr
+
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 from posthog.rbac.user_access_control import UserAccessControlError
 
@@ -22,6 +25,29 @@ if TYPE_CHECKING:
 # Gates these runners behind the same flag the product's DRF endpoints require, so the
 # generic /query/ endpoint can't bypass it (see PostHogFeatureFlagPermission).
 MCP_ANALYTICS_FEATURE_FLAG = "mcp-analytics"
+
+# The effective tool name for new-SDK events: the inner tool when the call went through the
+# single-exec wrapper, else the directly-registered tool name. Shared by every runner that
+# scopes to one tool, so the expression lives OnceAndOnlyOnce.
+EFFECTIVE_TOOL_SQL = (
+    "coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))"
+)
+# Marker the posthog-node MCP analytics SDK stamps on the events it sends.
+NEW_SDK_SOURCE = "posthog_mcp_analytics"
+
+
+def tool_scope_exprs(tool: str) -> list[ast.Expr]:
+    """Predicates scoping new-SDK $mcp_tool_call events to one effective tool.
+
+    `tool` is bound as an ast.Constant, never string-interpolated.
+    """
+    return [
+        parse_expr(
+            "{EFFECTIVE_TOOL_SQL} = {tool}",
+            placeholders={"EFFECTIVE_TOOL_SQL": parse_expr(EFFECTIVE_TOOL_SQL), "tool": ast.Constant(value=tool)},
+        ),
+        parse_expr("properties.$mcp_source = {source}", placeholders={"source": ast.Constant(value=NEW_SDK_SOURCE)}),
+    ]
 
 
 def validate_mcp_analytics_access(team: "Team", user: "User") -> bool:

--- a/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
+++ b/products/mcp_analytics/backend/hogql_queries/harness_breakdown.py
@@ -19,7 +19,11 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.mcp_analytics.backend import mcp_harness
 from products.mcp_analytics.backend.constants import MCP_TOOL_CALL_EVENT
-from products.mcp_analytics.backend.hogql_queries.base import mcp_query_date_range, validate_mcp_analytics_access
+from products.mcp_analytics.backend.hogql_queries.base import (
+    mcp_query_date_range,
+    tool_scope_exprs,
+    validate_mcp_analytics_access,
+)
 
 if TYPE_CHECKING:
     from posthog.models.user import User
@@ -53,6 +57,8 @@ class MCPHarnessBreakdownQueryRunner(AnalyticsQueryRunner[MCPHarnessBreakdownQue
             ),
             parse_expr("timestamp <= {date_to}", placeholders={"date_to": self.query_date_range.date_to_as_hogql()}),
         ]
+        if self.query.toolName:
+            exprs.extend(tool_scope_exprs(self.query.toolName))
         properties = list(self.query.properties or [])
         if self.query.filterTestAccounts:
             properties += self.team.test_account_filters or []

--- a/products/mcp_analytics/backend/hogql_queries/tool_tables.py
+++ b/products/mcp_analytics/backend/hogql_queries/tool_tables.py
@@ -51,18 +51,17 @@ from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
 from products.mcp_analytics.backend import mcp_harness
 from products.mcp_analytics.backend.constants import MCP_TOOL_CALL_EVENT
-from products.mcp_analytics.backend.hogql_queries.base import mcp_query_date_range, validate_mcp_analytics_access
+from products.mcp_analytics.backend.hogql_queries.base import (
+    EFFECTIVE_TOOL_SQL,
+    NEW_SDK_SOURCE,
+    mcp_query_date_range,
+    tool_scope_exprs,
+    validate_mcp_analytics_access,
+)
 
 if TYPE_CHECKING:
     from posthog.models.user import User
 
-# The new SDK source marker, and the *effective* tool name (the inner tool when the
-# call went through the single-exec wrapper, else the directly-registered tool name).
-# Mirrors EFFECTIVE_TOOL_HOGQL / NEW_SDK_FILTER in the tool-detail frontend logic.
-_NEW_SDK_SOURCE = "posthog_mcp_analytics"
-_EFFECTIVE_TOOL = (
-    "coalesce(nullIf(toString(properties.$mcp_exec_tool_call_name), ''), toString(properties.$mcp_tool_name))"
-)
 # The description of the *effective* tool: for single-exec calls the inner tool's
 # $mcp_exec_tool_call_description, else the directly-registered $mcp_tool_description.
 # Without this, an inner tool's Descriptions table would show the exec wrapper's text
@@ -93,11 +92,7 @@ def _tool_call_where(tool: str, date_range: QueryDateRange, *, extra: list[ast.E
         parse_expr("event = {event}", placeholders={"event": ast.Constant(value=MCP_TOOL_CALL_EVENT)}),
         parse_expr("timestamp >= {date_from}", placeholders={"date_from": date_range.date_from_as_hogql()}),
         parse_expr("timestamp <= {date_to}", placeholders={"date_to": date_range.date_to_as_hogql()}),
-        parse_expr(
-            "{_EFFECTIVE_TOOL} = {tool}",
-            placeholders={"_EFFECTIVE_TOOL": parse_expr(_EFFECTIVE_TOOL), "tool": ast.Constant(value=tool)},
-        ),
-        parse_expr("properties.$mcp_source = {source}", placeholders={"source": ast.Constant(value=_NEW_SDK_SOURCE)}),
+        *tool_scope_exprs(tool),
     ]
     if extra:
         exprs.extend(extra)
@@ -612,7 +607,7 @@ class MCPToolNeighborsQueryRunner(AnalyticsQueryRunner[MCPToolNeighborsQueryResp
                     "timestamp <= {date_to}", placeholders={"date_to": self.query_date_range.date_to_as_hogql()}
                 ),
                 parse_expr(
-                    "properties.$mcp_source = {source}", placeholders={"source": ast.Constant(value=_NEW_SDK_SOURCE)}
+                    "properties.$mcp_source = {source}", placeholders={"source": ast.Constant(value=NEW_SDK_SOURCE)}
                 ),
                 parse_expr("notEmpty({conv_id})", placeholders={"conv_id": parse_expr(_CONVERSATION_ID)}),
             ]
@@ -623,7 +618,7 @@ class MCPToolNeighborsQueryRunner(AnalyticsQueryRunner[MCPToolNeighborsQueryResp
                 SELECT
                     {_CONVERSATION_ID} AS conv_id,
                     timestamp,
-                    {_EFFECTIVE_TOOL} AS tool
+                    {effective_tool} AS tool
                 FROM events
                 WHERE {cte_where}
             )
@@ -641,7 +636,7 @@ class MCPToolNeighborsQueryRunner(AnalyticsQueryRunner[MCPToolNeighborsQueryResp
             """,
             placeholders={
                 "_CONVERSATION_ID": parse_expr(_CONVERSATION_ID),
-                "_EFFECTIVE_TOOL": parse_expr(_EFFECTIVE_TOOL),
+                "effective_tool": parse_expr(EFFECTIVE_TOOL_SQL),
                 "neighbor_expr": parse_expr(neighbor_expr),
                 "cte_where": cte_where,
                 "tool": ast.Constant(value=self.query.toolName),

--- a/products/mcp_analytics/backend/tests/test_harness_breakdown.py
+++ b/products/mcp_analytics/backend/tests/test_harness_breakdown.py
@@ -60,6 +60,35 @@ class TestMCPHarnessBreakdownQueryRunner(_MCPAnalyticsTeamScopedTestMixin, Click
         )
         return {row.harness: row for row in runner.calculate().results}
 
+    def test_tool_name_scopes_to_effective_tool_and_new_sdk(self) -> None:
+        new_sdk = {"$mcp_source": "posthog_mcp_analytics"}
+        self._emit(distinct_id="d1", properties={"$mcp_client_name": "claude-ai", **new_sdk})
+        self._emit(
+            distinct_id="d2",
+            properties={"$mcp_tool_name": "other_tool", "$mcp_client_name": "cursor-vscode", **new_sdk},
+        )
+        # Single-exec wrapper: the effective tool is in $mcp_exec_tool_call_name.
+        self._emit(
+            distinct_id="d3",
+            properties={
+                "$mcp_tool_name": "exec",
+                "$mcp_exec_tool_call_name": "query_run",
+                "$mcp_client_name": "windsurf",
+                **new_sdk,
+            },
+        )
+        # Same tool but missing the new-SDK source marker -> excluded.
+        self._emit(distinct_id="d4", properties={"$mcp_client_name": "claude-ai"})
+        flush_persons_and_events()
+
+        runner = MCPHarnessBreakdownQueryRunner(
+            query=MCPHarnessBreakdownQuery(dateRange=DateRange(date_from="-90d"), toolName="query_run"),
+            team=self.team,
+        )
+        rows = {row.harness: row for row in runner.calculate().results}
+
+        assert set(rows) == {"Claude.ai", "Windsurf"}
+
     @parameterized.expand(
         [
             ("vendor_cowork", {"mcp_vendor_client": "Cowork"}, "Cowork"),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -26500,6 +26500,8 @@ export namespace Schemas {
       properties?: (EventPropertyFilter | PersonPropertyFilter | ElementPropertyFilter | EventMetadataPropertyFilter | SessionPropertyFilter | CohortPropertyFilter | RecordingPropertyFilter | LogEntryPropertyFilter | GroupPropertyFilter | FeaturePropertyFilter | FlagPropertyFilter | HogQLPropertyFilter | EmptyPropertyFilter | DataWarehousePropertyFilter | DataWarehousePersonPropertyFilter | ErrorTrackingIssueFilter | LogPropertyFilter | SpanPropertyFilter | RevenueAnalyticsPropertyFilter | WorkflowVariablePropertyFilter)[] | null;
       response?: MCPHarnessBreakdownQueryResponse | null;
       tags?: QueryLogTags | null;
+      /** When set, scope to a single effective tool's new-SDK calls (the per-tool "By harness" table). */
+      toolName?: string | null;
       /** version of the node, used for schema migrations */
       version?: number | null;
     }

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -408,6 +408,10 @@ const MCPHarnessBreakdownQuery = z.object({
     filterTestAccounts: z.coerce.boolean().optional(),
     kind: z.literal('MCPHarnessBreakdownQuery').default('MCPHarnessBreakdownQuery'),
     properties: z.array(AnyPropertyFilter).optional(),
+    toolName: z
+        .string()
+        .describe('When set, scope to a single effective tool\'s new-SDK calls (the per-tool "By harness" table).')
+        .optional(),
 })
 
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {


### PR DESCRIPTION
## Problem

The per-tool "By harness" table scopes the shared dashboard runner to one tool by passing a hand-written HogQL filter string from the frontend. That's the last thing tying the frontend to the duplicated effective-tool / new-SDK-source expressions, so the frontend HogQL builders can't be deleted while it stands.

## Changes

Add an optional `toolName` to `MCPHarnessBreakdownQuery`; when set, the runner appends the effective-tool + new-SDK-source filter server-side. The effective-tool and source expressions move to `base.py` so the dashboard runner and the tool-detail runners share them once. `toolName` is optional, so the dashboard donut and the `query-mcp-harness-breakdown` MCP tool are unaffected.

Part 6/7 of the stack replacing #66046. Stacked on #66088.

## How did you test this code?

I'm an agent (PostHog Code). Automated only: a new `test_harness_breakdown.py` case asserting `toolName` scopes to the effective tool (including the single-exec wrapper) and excludes events missing the new-SDK source; plus the full existing suite (no behavior change without `toolName`). All pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @pauldambra.

Built with PostHog Code (Claude). Centralizing the expressions in `base.py` is the Python-side of killing the cross-language duplication this stack targets. No repo skills invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
