### PR TITLE
fix(auth): make paper-desk auth scenes scrollable when taller than viewport

### DIFF
--- a/frontend/src/scenes/authentication/shared/paperDesk/PaperDesk.scss
+++ b/frontend/src/scenes/authentication/shared/paperDesk/PaperDesk.scss
@@ -2,7 +2,7 @@
 // Only rules that cannot be expressed in Tailwind utilities live here:
 // pseudo-elements, interactive pseudo-class combinators, child selectors, keyframes.
 
-// Dotted paper grid + faint accent glow — require pseudo-elements, not achievable via Tailwind
+// Dotted paper grid + faint accent glow — multi-layer background (per-layer size/repeat), not achievable via Tailwind
 .PaperDesk {
     --primary-3000-button-bg: var(--warning);
     --primary-3000-frame-bg: var(--primary-3000-button-border-light);
@@ -12,22 +12,15 @@
     // Links use the bright brand amber, not the darker text-contrast warning token.
     --color-text-warning: var(--warning);
 
-    &::before {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        content: '';
-        background-image: radial-gradient(rgb(17 17 17 / 5.5%) 1.4px, transparent 1.4px);
-        background-size: 16px 16px;
-    }
-
-    &::after {
-        position: absolute;
-        inset: 0;
-        pointer-events: none;
-        content: '';
-        background: radial-gradient(72% 72% at 50% 38%, rgb(247 165 1 / 5%), transparent 70%);
-    }
+    // Accent glow over the dotted grid. Layered onto the element itself rather than absolutely
+    // positioned pseudo-elements so the texture stays fixed to the viewport while the scene scrolls
+    // (a card taller than the viewport scrolls inside .PaperDesk; pseudo-elements would scroll away).
+    // background-color stays on the Tailwind `bg-[#eef0e7]` utility — only the image layers live here.
+    background-image:
+        radial-gradient(72% 72% at 50% 38%, rgb(247 165 1 / 5%), transparent 70%),
+        radial-gradient(rgb(17 17 17 / 5.5%) 1.4px, transparent 1.4px);
+    background-repeat: no-repeat, repeat;
+    background-size: auto, 16px 16px;
 }
 
 // Child SVG sizing — child selector, no Tailwind equivalent

--- a/frontend/src/scenes/authentication/shared/paperDesk/PaperDesk.scss
+++ b/frontend/src/scenes/authentication/shared/paperDesk/PaperDesk.scss
@@ -20,7 +20,9 @@
         radial-gradient(72% 72% at 50% 38%, rgb(247 165 1 / 5%), transparent 70%),
         radial-gradient(rgb(17 17 17 / 5.5%) 1.4px, transparent 1.4px);
     background-repeat: no-repeat, repeat;
-    background-size: auto, 16px 16px;
+    background-size:
+        auto,
+        16px 16px;
 }
 
 // Child SVG sizing — child selector, no Tailwind equivalent

--- a/frontend/src/scenes/authentication/shared/paperDesk/PaperDeskScene.tsx
+++ b/frontend/src/scenes/authentication/shared/paperDesk/PaperDeskScene.tsx
@@ -10,9 +10,9 @@ import { Typewriter } from './Typewriter'
 /** Full-viewport paper-desk stage: dotted parchment + accent glow + mono corner notes. */
 export function PaperDeskScene({ notes, children }: { notes: string[]; children: ReactNode }): JSX.Element {
     return (
-        <div className="PaperDesk relative min-h-screen overflow-hidden font-sans text-primary bg-[#eef0e7]">
+        <div className="PaperDesk relative h-screen overflow-x-hidden overflow-y-auto font-sans text-primary bg-[#eef0e7]">
             <Typewriter lines={notes} />
-            <div className="relative z-[3] flex flex-col items-center justify-center min-h-screen py-18 px-10">
+            <div className="relative z-[3] flex flex-col items-center justify-center min-h-full py-18 px-10">
                 <div className="PaperDesk__column flex flex-col items-center w-[27rem] max-w-full">{children}</div>
             </div>
             <DevLoginPanel />


### PR DESCRIPTION
## Problem

In the `paper-desk` auth flow variant, an invited user signing up on a short/wide window can't reach the bottom of the form — the page won't scroll, so the continue button is unreachable.

Root cause: the app sets `overflow: hidden` on `<body>` (the authenticated shell expects each pane to scroll itself). The legacy auth variant works because `BridgePage` is its own scroll container (`height: 100vh; overflow: auto`). The paper-desk stage instead used `min-h-screen overflow-hidden`, so it never establishes a scroll container — content taller than the viewport is simply clipped with no way to scroll.

Closes GROW-51

## Changes

Both changes live in the shared `PaperDeskScene`, so they fix all four paper-desk pages at once (login, signup, invite signup, verify email).

- **`PaperDeskScene.tsx`** — `.PaperDesk` becomes its own scroll container (`h-screen overflow-y-auto overflow-x-hidden`), mirroring the legacy `BridgePage` pattern. The centering wrapper switches from `min-h-screen` to `min-h-full` so it centers the card when short and grows with content when tall — which is what avoids the classic `justify-center` "top gets clipped when overflowing" trap (the wrapper grows instead of staying fixed, so there's no negative free space to mis-center).
- **`PaperDesk.scss`** — the dotted-grid + accent-glow decoration moves from absolutely-positioned `::before`/`::after` pseudo-elements into the element's own background layers. A scroll container's background doesn't scroll with its content, so the texture stays fixed to the viewport instead of scrolling away once you pass the first screen. `background-color` stays on the Tailwind `bg-[#eef0e7]` utility.

## How did you test this code?

I'm an agent (Claude Code). I did **not** run the full app manually. I reproduced the exact DOM/CSS chain (`body { overflow: hidden }` + the precise `.PaperDesk` class structure) in a headless Chromium and measured scroll reachability at a short, wide viewport (1440×700) with a tall form:

| Scenario | Can scroll? | Continue button reachable? |
|---|---|---|
| Before (tall form) | No — `maxScroll: 0` | No — button at y=1669, viewport is 700 |
| After (tall form) | Yes — `.PaperDesk` scrolls | Yes — top at y=72 on scroll-top, button at y=611 on scroll-bottom |
| After (short form) | n/a | Yes — centered, fully visible |

I also screenshotted the scrolled-to-bottom state to confirm the dotted texture and glow now stay fixed (instead of scrolling away) after moving them to background layers.

No automated test added: this is a CSS layout fix, and a className-string assertion would test implementation details rather than a realistic regression. A true regression test would need a browser-driven scroll check against the running scene.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Fernando (@fercgomes) directed this work from GROW-51; assigned as DRI.

- **Tool:** Claude Code (Opus 4.8).
- **Investigation:** Traced the DOM chain from `<body>` down for both unauthenticated and authenticated invite paths. Initially suspected `overflow-hidden` on `.PaperDesk` alone, but a standalone repro of just that structure scrolled fine — the real culprit was `useThemedHtml()` adding `overflow-hidden` to `<body>` combined with paper-desk never owning a scroll container (legacy `BridgePage` does, which is why only the new variant is affected).
- **Decision:** Chose to fix the shared `PaperDeskScene` (covers all four pages) over patching each page or special-casing `useThemedHtml`. Validated the chosen CSS against the `justify-center` top-clip trap in a headless browser before committing, and verified two candidate approaches (outer-scroll vs margin-auto centering) behave identically.
