### PR TITLE
fix(llma): truncate gateway capture payloads below kafka limit

### DIFF
--- a/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
+++ b/services/llm-gateway/src/llm_gateway/callbacks/posthog.py
@@ -50,7 +50,13 @@ def _replace_binary_content(data: Any) -> Any:
             return data
 
 
-_MAX_CAPTURE_SIZE = 15 * 1024 * 1024
+# Capture rejects events whose Kafka message exceeds message.max.bytes (~1 MB,
+# the librdkafka default) with a 413, and the posthoganalytics client drops
+# events over its own ~900 KB ceiling. $ai_generation events carry the full
+# prompt/completion via $ai_input / $ai_output_choices, so they routinely cross
+# that line. Truncate well below 1 MB to leave headroom for the event envelope
+# (distinct_id, event name, other properties) and JSON re-escaping on the wire.
+_MAX_CAPTURE_SIZE = 800 * 1024
 _MIN_FIELD_SIZE_TO_TRUNCATE = 10 * 1024
 _TRUNCATION_MARKER = "[truncated: content too large for capture]"
 _TRUNCATABLE_FIELDS = ("$ai_output_choices", "$ai_input")

--- a/services/llm-gateway/tests/callbacks/test_posthog.py
+++ b/services/llm-gateway/tests/callbacks/test_posthog.py
@@ -7,6 +7,7 @@ import pytest
 
 from llm_gateway.auth.models import AuthenticatedUser
 from llm_gateway.callbacks.posthog import (
+    _MAX_CAPTURE_SIZE,
     PostHogCallback,
     _normalize_trace_id,
     _replace_binary_content,
@@ -943,7 +944,7 @@ class TestReplaceBinaryContent:
         assert _replace_binary_content(input_data) == expected
 
 
-_MAX_SIZE = 15 * 1024 * 1024
+_MAX_SIZE = _MAX_CAPTURE_SIZE
 _TRUNCATION_MARKER = "[truncated: content too large for capture]"
 
 
@@ -973,6 +974,11 @@ class TestTruncateForCapture:
     def test_small_events_not_truncated(self, description: str, properties: dict) -> None:
         result = _truncate_for_capture(properties)
         assert result == properties
+
+    def test_threshold_below_kafka_message_limit(self) -> None:
+        # Capture rejects events over Kafka's message.max.bytes (~1 MB) with a 413,
+        # so the truncation threshold must stay under it with headroom for the envelope.
+        assert _MAX_CAPTURE_SIZE < 1_000_000
 
     def test_large_output_truncated(self) -> None:
         large_output = "x" * (_MAX_SIZE + 1)


### PR DESCRIPTION
## Problem

Large `$ai_generation` events emitted by the LLM gateway were being silently dropped at ingestion. The gateway only truncated `$ai_input` / `$ai_output_choices` when the serialized payload exceeded **15 MiB**, but capture rejects any Kafka message over **~1 MB** (`message.max.bytes`, the librdkafka default) with a `413 maximum event size exceeded`. Streaming completions with large prompts/contexts produce events comfortably above 1 MB but below 15 MiB, so they sailed past the gateway's truncation and were rejected — the LLM call itself succeeded, but its analytics event never reached LLM analytics.

(The `JSONDecodeError` seen alongside the 413 in logs is just the `posthoganalytics` client failing to parse the non-JSON 413 error body — a symptom, not a second bug.)

## Changes

Lower `_MAX_CAPTURE_SIZE` from 15 MiB to **800 KB**, sitting under both the ~1 MB Kafka limit and the `posthoganalytics` client's ~900 KB drop ceiling, with headroom for the event envelope and on-the-wire JSON re-escaping. The existing field-replacement truncation logic is unchanged — it now simply triggers before capture rejects the event instead of after.

Note: the gateway captures via the standard `posthoganalytics` batch endpoint, which has no S3 blob offloading (unlike the dedicated `/i/v0/ai` ingestion endpoint). Routing through that endpoint to preserve full prompt/completion content would be a larger follow-up; this change stops the drops.

## How did you test this code?

I'm an agent. I ran the existing truncation unit tests (`tests/callbacks/test_posthog.py`, `TestTruncateForCapture` + `_on_success` truncation test) — 8 passed. Added one regression test (`test_threshold_below_kafka_message_limit`) that pins the threshold under the 1 MB Kafka limit, since the root cause was the threshold being set above what capture accepts. The test suite imports the real constant rather than a duplicated literal so the two can't drift again.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from gateway logs showing repeated `413 maximum event size exceeded` on `$ai_generation` captures. Confirmed via the capture service (`rust/capture`) that AI events do **not** get a higher Kafka `message.max.bytes` — they share the same 1 MB producer as all other events; only the `/i/v0/ai` HTTP endpoint (with S3 blob offload) gets a larger body limit, and the gateway isn't using it. Chose to lower the truncation threshold (the user's explicit ask) over the larger AI-endpoint rerouting work. No skills were applicable to this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782395529373099)*
