### PR TITLE
perf(dashboards): keep resized tile tracking the cursor

### DIFF
--- a/frontend/src/scenes/dashboard/DashboardItems.scss
+++ b/frontend/src/scenes/dashboard/DashboardItems.scss
@@ -31,6 +31,9 @@
 
 .react-grid-item.resizing {
     z-index: 1;
+
+    // Snap to the pointer — without this the cssTransforms transition eases the move and the tile trails the cursor.
+    transition: none;
     will-change: width, height;
 }
 

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -163,6 +163,11 @@ export function DashboardItems(): JSX.Element {
 
         const element = containerRef.current
         const observer = new ResizeObserver((entries) => {
+            // Skip per-frame height commits during a gesture — they re-render every tile just for GridBackground,
+            // lagging the cursor. flushPendingLayouts remeasures on stop.
+            if (interactionInProgress.current) {
+                return
+            }
             for (const entry of entries) {
                 if (entry.target === element) {
                     setContainerHeight(entry.contentRect.height)
@@ -295,7 +300,13 @@ export function DashboardItems(): JSX.Element {
             updateLayouts(pendingLayouts.current)
             pendingLayouts.current = null
         }
-    }, [updateLayouts])
+        // Remeasure once the gesture settles, since height updates were suppressed during it.
+        requestAnimationFrame(() => {
+            if (containerRef.current) {
+                setContainerHeight(containerRef.current.clientHeight)
+            }
+        })
+    }, [updateLayouts, containerRef])
 
     const handleWidthChange = useCallback(
         (containerWidth: number, _: unknown, newCols: number) => {

--- a/frontend/src/scenes/dashboard/DashboardItems.tsx
+++ b/frontend/src/scenes/dashboard/DashboardItems.tsx
@@ -306,7 +306,7 @@ export function DashboardItems(): JSX.Element {
                 setContainerHeight(containerRef.current.clientHeight)
             }
         })
-    }, [updateLayouts, containerRef])
+    }, [updateLayouts])
 
     const handleWidthChange = useCallback(
         (containerWidth: number, _: unknown, newCols: number) => {


### PR DESCRIPTION
## Problem

Resizing a dashboard tile lags behind the cursor instead of tracking it — worse when moving fast.

## Changes

Two causes:

1. Tiles are positioned via `transform`, which `.cssTransforms` eases over 100ms. Top/left/corner handles move the transform every frame, so the tile trailed the cursor. Drag already disabled this; resize didn't — added `transition: none` to `.resizing`.
2. The grid's `ResizeObserver` re-rendered every tile each frame (to feed the decorative `GridBackground`) as a tile grew. Now suppressed during a gesture, remeasured on stop.

## How did you test this code?

Agent-authored, not yet manually verified in-browser. No automated tests — this is render-timing behavior a unit test can't meaningfully assert. Verify by resizing a tile in dashboard edit mode (most visible on corner/top/bottom handles).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code, directed by @MattPua from a screen recording. Root causes confirmed against the installed `react-grid-layout@2.2.3` source. Open question: if residual lag is on width-only handles, fix #2 won't touch it — next lever is memoizing tile wrappers.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
