### PR TITLE
chore(ci): point geoip canary at moved test path

### DIFF
--- a/.github/workflows/ci-geoip-canary.yml
+++ b/.github/workflows/ci-geoip-canary.yml
@@ -48,7 +48,7 @@ jobs:
               id: canary
               env:
                   GEOIP_LIVE_TEST: '1'
-              run: cd nodejs && pnpm jest src/utils/geoip-live.test.ts --runInBand --forceExit
+              run: cd nodejs && pnpm jest src/common/utils/geoip-live.test.ts --runInBand --forceExit
 
             # Only the canary test itself failing means the live GeoLite2 build dropped
             # location data for the anchor IPs — i.e. a bad MaxMind release is already


### PR DESCRIPTION
## Problem

The infra consolidation moved `nodejs/src/utils/geoip-live.test.ts` to `nodejs/src/common/utils/`, but the geoip canary workflow still ran `jest src/utils/geoip-live.test.ts`. On master that now matches no tests and the job fails with "No tests found" (exit 1).

## Changes

Point the canary workflow at the moved `src/common/utils/geoip-live.test.ts` path so it runs the test again.

## How did you test this code?

I'm an agent (Claude, agent-assisted). This is a one-line path fix in a workflow; confirmed the new path matches the test's current location on master (`nodejs/src/common/utils/geoip-live.test.ts`). The workflow runs on a schedule, so the canary itself will exercise it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The consolidation and the router-test fix already landed on master via a separate PR; the workflow's hardcoded old path was the only straggler still breaking the job. This PR is scoped to just that one-line fix on top of current master.
