### PR TITLE
fix(insights): remove max-height cap on bar-value chart container

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2576,6 +2576,14 @@ snapshots:
         hash: v1.k794b7964.d8d3e3ecade64da3301879f5c9a72a9e0a4f879fd23adc9c22940150ced641c4._P8QZDgkeQ4Z5Ii0RfD5kHotcs8VMJdg7y7F9UhxXyE
     insights-trendsbarchart--aggregated-compare-breakdown--light:
         hash: v1.k794b7964.71df39ed07e55a63f5769f6771aa97fafb3b45f83bb3316e820b1d5c62eacc17.fqe0WSxWna4P6aIUpMidVoxtseV69UR9iFJyEX0uXv8
+    insights-trendsbarchart--bar-value-50-breakdowns--dark:
+        hash: v1.k794b7964.0aa74828d652bcc08c7edf6e846f25079cd634404524a2f46ecfab9ca58b3253.RC1OqPi8ALE8mT4L0qBcaNeMFwNYDmyvdY32qCX8Lao
+    insights-trendsbarchart--bar-value-50-breakdowns--light:
+        hash: v1.k794b7964.da48bff1f9643e5f27c0371f29bee5b1478389736d9e9baf4d159effe918f7f9.DTLbuDHBCHUpqdykg69Lzh-lasHbn-AzA9k50D9Eig8
+    insights-trendsbarchart--bar-value-single-breakdown--dark:
+        hash: v1.k794b7964.e2b8f5afe06a39c4cf3ae1beb282fed9a64117a91ac92ffa91a8f9fa0a09a69d.QWoL7QbuoCoXDv6xoLFepkGX5DRp5NfndCYdz1TZjE4
+    insights-trendsbarchart--bar-value-single-breakdown--light:
+        hash: v1.k794b7964.13733d2478cb0d86b2fbed8cae08efb73555fbd2798dc199118ccde0bf192b6b.ujkbY4JXzzAH9hNg6G5F5z4q6Lt4CkeCQMYu_H0cAoc
     insights-trendsbarchart--compare--dark:
         hash: v1.k794b7964.471bac2dc88d109f8b59fb9824be9b97aa91a0e92e71053ccfa7483c5d1a33a7.lBVLXYRSp4frYlGbUwXnYMibF-b5l_ZyGDNqL8q3rLI
     insights-trendsbarchart--compare--light:

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -230,8 +230,11 @@
     }
 
     &--ActionsBarValue {
+        // Keep the standard height as a floor so a few-row chart still fills it (a single bar
+        // shouldn't shrink), but drop the height/max-height cap so many breakdown rows grow the
+        // container instead of being clipped.
         height: auto;
-        min-height: auto;
+        min-height: var(--insight-viz-min-height);
         max-height: none;
     }
 

--- a/frontend/src/queries/nodes/InsightViz/InsightViz.scss
+++ b/frontend/src/queries/nodes/InsightViz/InsightViz.scss
@@ -229,6 +229,12 @@
         margin: 0;
     }
 
+    &--ActionsBarValue {
+        height: auto;
+        min-height: auto;
+        max-height: none;
+    }
+
     &--BoldNumber {
         display: flex;
         align-items: center;

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -538,3 +538,18 @@ const BAR_VALUE_50_BREAKDOWNS_INSIGHT = {
 export const BarValue50Breakdowns: Story = {
     render: () => renderTrendInsight(BAR_VALUE_50_BREAKDOWNS_INSIGHT),
 }
+
+// A single breakdown row should still fill the standard chart height — the lone bar must not
+// shrink. Guards the min-height floor on TrendsInsight--ActionsBarValue: drop it back to `auto`
+// and this snapshot collapses to a thin one-row bar instead of filling the container.
+const BAR_VALUE_SINGLE_BREAKDOWN_INSIGHT = {
+    ...BAR_VALUE_50_BREAKDOWNS_INSIGHT,
+    id: 204,
+    short_id: 'barValueSingle',
+    name: 'Page views by URL (single breakdown)',
+    result: BAR_VALUE_50_BREAKDOWNS.slice(0, 1),
+}
+
+export const BarValueSingleBreakdown: Story = {
+    render: () => renderTrendInsight(BAR_VALUE_SINGLE_BREAKDOWN_INSIGHT),
+}

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
-import { useState } from 'react'
+import { ComponentType, useState } from 'react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 
@@ -90,7 +90,21 @@ function Stage({ children }: { children: React.ReactNode }): JSX.Element {
     )
 }
 
-function renderTrendsBarChart(insightFixture: any): JSX.Element {
+// Uses the real TrendsInsight CSS classes so the snapshot exercises the max-height removal
+// on ActionsBarValue. Reverting that CSS would clip bars and diff the snapshot.
+function BarValueStage({ children }: { children: React.ReactNode }): JSX.Element {
+    return (
+        // eslint-disable-next-line react/forbid-dom-props
+        <div style={{ width: 720 }}>
+            <div className="TrendsInsight TrendsInsight--ActionsBarValue">{children}</div>
+        </div>
+    )
+}
+
+function renderTrendsBarChart(
+    insightFixture: any,
+    StageComponent: ComponentType<{ children: React.ReactNode }> = Stage
+): JSX.Element {
     const [dashboardItemId] = useState(() => `TrendsBarChartStory.${uniqueNode++}` as InsightShortId)
     const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
 
@@ -105,9 +119,9 @@ function renderTrendsBarChart(insightFixture: any): JSX.Element {
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-                <Stage>
+                <StageComponent>
                     <TrendsBarChart />
-                </Stage>
+                </StageComponent>
             </BindLogic>
         </BindLogic>
     )
@@ -452,4 +466,63 @@ const PERCENT_STACK_BREAKDOWN_INSIGHT = {
 
 export const PercentStackBreakdown: Story = {
     render: () => renderTrendsBarChart(PERCENT_STACK_BREAKDOWN_INSIGHT),
+}
+
+// 50 breakdown rows — verifies all bars are visible and the container grows rather than clipping.
+// If TrendsInsight--ActionsBarValue loses its max-height:none override, only ~20 rows show up.
+const BAR_VALUE_50_BREAKDOWNS = Array.from({ length: 50 }, (_, i) => ({
+    action: ACTION,
+    label: `/blog/post-${String(i + 1).padStart(2, '0')}`,
+    count: 0,
+    aggregated_value: Math.max(5, Math.round(9000 / (i + 1))),
+    data: [],
+    labels: [],
+    days: [],
+    breakdown_value: `/blog/post-${String(i + 1).padStart(2, '0')}`,
+    filter: {
+        date_from: '2023-07-04T00:00:00Z',
+        date_to: '2023-07-10T23:59:59Z',
+        display: 'ActionsBarValue',
+        insight: 'TRENDS',
+        interval: 'day',
+    },
+}))
+
+const BAR_VALUE_50_BREAKDOWNS_INSIGHT = {
+    id: 203,
+    short_id: 'barValue50',
+    name: 'Page views by URL (50 breakdowns)',
+    derived_name: 'Pageview count',
+    filters: {},
+    last_refresh: '2023-07-11T12:00:00Z',
+    refreshing: false,
+    saved: true,
+    is_sample: false,
+    description: '',
+    tags: [],
+    favorited: false,
+    created_at: '2023-07-11T12:00:00Z',
+    updated_at: '2023-07-11T12:00:00Z',
+    last_modified_at: '2023-07-11T12:00:00Z',
+    dashboards: [],
+    dashboard_tiles: [],
+    result: BAR_VALUE_50_BREAKDOWNS,
+    query: {
+        kind: 'InsightVizNode',
+        source: {
+            dateRange: { date_from: '2023-07-04', date_to: '2023-07-10' },
+            filterTestAccounts: false,
+            interval: 'day',
+            kind: 'TrendsQuery',
+            series: [{ event: '$pageview', kind: 'EventsNode', math: 'total', name: '$pageview' }],
+            trendsFilter: { display: 'ActionsBarValue' },
+            breakdownFilter: { breakdown: '$current_url', breakdown_type: 'event' },
+            version: 2,
+        },
+        full: true,
+    },
+}
+
+export const BarValue50Breakdowns: Story = {
+    render: () => renderTrendsBarChart(BAR_VALUE_50_BREAKDOWNS_INSIGHT, BarValueStage),
 }

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -1,6 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
-import { useState } from 'react'
+import { type CSSProperties, useState } from 'react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { TrendInsight } from 'scenes/trends/Trends'
@@ -130,8 +130,11 @@ function renderTrendInsight(insightFixture: any): JSX.Element {
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                {/* TrendInsight renders `.TrendsInsight` but not the `.InsightVizDisplay` ancestor that
+                    defines `--insight-viz-min-height`. Define it here so the chart's height behaves like the
+                    real insight page — without it the standard-height floor no-ops and a single bar collapses. */}
                 {/* eslint-disable-next-line react/forbid-dom-props */}
-                <div style={{ width: 720 }}>
+                <div style={{ width: 720, '--insight-viz-min-height': '32rem' } as CSSProperties}>
                     <TrendInsight view={InsightType.TRENDS} />
                 </div>
             </BindLogic>

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.stories.tsx
@@ -1,8 +1,9 @@
 import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
-import { ComponentType, useState } from 'react'
+import { useState } from 'react'
 
 import { insightLogic } from 'scenes/insights/insightLogic'
+import { TrendInsight } from 'scenes/trends/Trends'
 
 import { mswDecorator } from '~/mocks/browser'
 import { dataNodeLogic } from '~/queries/nodes/DataNode/dataNodeLogic'
@@ -10,6 +11,7 @@ import type { DataNodeLogicProps } from '~/queries/nodes/DataNode/dataNodeLogic'
 import { insightVizDataNodeKey } from '~/queries/nodes/InsightViz/InsightViz'
 import { getCachedResults } from '~/queries/nodes/InsightViz/utils'
 import type { InsightLogicProps, InsightShortId } from '~/types'
+import { InsightType } from '~/types'
 
 import { TrendsBarChart } from './TrendsBarChart'
 
@@ -90,21 +92,7 @@ function Stage({ children }: { children: React.ReactNode }): JSX.Element {
     )
 }
 
-// Uses the real TrendsInsight CSS classes so the snapshot exercises the max-height removal
-// on ActionsBarValue. Reverting that CSS would clip bars and diff the snapshot.
-function BarValueStage({ children }: { children: React.ReactNode }): JSX.Element {
-    return (
-        // eslint-disable-next-line react/forbid-dom-props
-        <div style={{ width: 720 }}>
-            <div className="TrendsInsight TrendsInsight--ActionsBarValue">{children}</div>
-        </div>
-    )
-}
-
-function renderTrendsBarChart(
-    insightFixture: any,
-    StageComponent: ComponentType<{ children: React.ReactNode }> = Stage
-): JSX.Element {
+function renderTrendsBarChart(insightFixture: any): JSX.Element {
     const [dashboardItemId] = useState(() => `TrendsBarChartStory.${uniqueNode++}` as InsightShortId)
     const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
 
@@ -119,9 +107,33 @@ function renderTrendsBarChart(
     return (
         <BindLogic logic={insightLogic} props={insightProps}>
             <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
-                <StageComponent>
+                <Stage>
                     <TrendsBarChart />
-                </StageComponent>
+                </Stage>
+            </BindLogic>
+        </BindLogic>
+    )
+}
+
+function renderTrendInsight(insightFixture: any): JSX.Element {
+    const [dashboardItemId] = useState(() => `TrendsBarChartStory.${uniqueNode++}` as InsightShortId)
+    const cachedInsight = { ...insightFixture, short_id: dashboardItemId }
+
+    const insightProps: InsightLogicProps = { dashboardItemId, doNotLoad: true, cachedInsight }
+    const dataNodeLogicProps: DataNodeLogicProps = {
+        query: cachedInsight.query.source,
+        key: insightVizDataNodeKey(insightProps),
+        cachedResults: getCachedResults(cachedInsight, cachedInsight.query.source),
+        doNotLoad: true,
+    }
+
+    return (
+        <BindLogic logic={insightLogic} props={insightProps}>
+            <BindLogic logic={dataNodeLogic} props={dataNodeLogicProps}>
+                {/* eslint-disable-next-line react/forbid-dom-props */}
+                <div style={{ width: 720 }}>
+                    <TrendInsight view={InsightType.TRENDS} />
+                </div>
             </BindLogic>
         </BindLogic>
     )
@@ -524,5 +536,5 @@ const BAR_VALUE_50_BREAKDOWNS_INSIGHT = {
 }
 
 export const BarValue50Breakdowns: Story = {
-    render: () => renderTrendsBarChart(BAR_VALUE_50_BREAKDOWNS_INSIGHT, BarValueStage),
+    render: () => renderTrendInsight(BAR_VALUE_50_BREAKDOWNS_INSIGHT),
 }


### PR DESCRIPTION
## Problem

The `.TrendsInsight` CSS block applies `max-height: var(--insight-viz-min-height)` (~512px) to give in-chart legends a real height to resolve their `max-height: 40%` cap against. `ActionsBarValue` (horizontal bar chart) wasn't in the existing exceptions list, so charts with many breakdown rows were clipped instead of growing to show all bars.

With 25 breakdown rows at 24px each plus margins the chart needs ~640px, which exceeds the ~512px cap.

## Changes
<img width="1512" height="861" alt="Screenshot 2026-06-25 at 17 09 14" src="https://github.com/user-attachments/assets/53c2b661-1069-48fb-b2d6-a39404206bc2" />

- Add `TrendsInsight--ActionsBarValue` to the exceptions block in `InsightViz.scss` that clears `height`/`min-height`/`max-height`, consistent with how `ActionsTable` and `WorldMap` are handled
- The margin is preserved (unlike those other exceptions) since the bar-value chart needs it

## How did you test this code?

I'm an agent. No automated tests cover this CSS layout path. The fix was verified by reading the relevant CSS and chart component code.

## Publish to changelog?