### PR TITLE
feat(logs): user-configurable custom facets in the rail

### DIFF
--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -51,11 +51,19 @@ from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, Log
 from products.logs.backend.presentation.views.alerts_api import LogsAlertViewSet
 from products.logs.backend.presentation.views.explain import LogExplainViewSet
 from products.logs.backend.presentation.views.sampling_api import LogsSamplingRuleViewSet
+from products.logs.backend.presentation.views.user_config_api import LogsCustomFacetsViewSet
 from products.logs.backend.presentation.views.views_api import LogsViewViewSet
 from products.logs.backend.services_query_runner import ServicesQueryRunner
 from products.logs.backend.sparkline_query_runner import SparklineQueryRunner
 
-__all__ = ["LogsViewSet", "LogExplainViewSet", "LogsAlertViewSet", "LogsSamplingRuleViewSet", "LogsViewViewSet"]
+__all__ = [
+    "LogsViewSet",
+    "LogExplainViewSet",
+    "LogsAlertViewSet",
+    "LogsSamplingRuleViewSet",
+    "LogsCustomFacetsViewSet",
+    "LogsViewViewSet",
+]
 
 tracer = trace.get_tracer(__name__)
 LOGS_MAX_EXPORT_ROWS = 10_000

--- a/products/logs/backend/presentation/views/user_config_api.py
+++ b/products/logs/backend/presentation/views/user_config_api.py
@@ -1,0 +1,78 @@
+from drf_spectacular.utils import extend_schema
+from rest_framework import serializers, status, viewsets
+from rest_framework.request import Request
+from rest_framework.response import Response
+
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.event_usage import report_user_action
+
+from products.logs.backend.models import LogsUserConfig
+
+# Bound on how many facets a user can pin, so the rail config can't grow without limit.
+MAX_CUSTOM_FACETS = 50
+
+
+class CustomFacetListSerializer(serializers.ListSerializer):
+    def validate(self, attrs: list[dict]) -> list[dict]:
+        if len(attrs) > MAX_CUSTOM_FACETS:
+            raise serializers.ValidationError(f"At most {MAX_CUSTOM_FACETS} custom facets are allowed.")
+        seen: set[tuple[str, str]] = set()
+        deduped: list[dict] = []
+        for facet in attrs:
+            ident = (facet["key"], facet["attribute_type"])
+            if ident not in seen:
+                seen.add(ident)
+                deduped.append(facet)
+        return deduped
+
+
+class CustomFacetSerializer(serializers.Serializer):
+    key = serializers.CharField(
+        max_length=200,
+        help_text="Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.",
+    )
+    attribute_type = serializers.ChoiceField(
+        choices=["log", "resource"],
+        help_text='Where the key lives: "resource" for resource attributes, "log" for log attributes.',
+    )
+
+    class Meta:
+        list_serializer_class = CustomFacetListSerializer
+
+
+class LogsCustomFacetsViewSet(TeamAndOrgViewSetMixin, viewsets.ViewSet):
+    """The requesting user's custom facets for the current project — the facets they pinned into the
+    rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write."""
+
+    scope_object = "logs"
+    serializer_class = CustomFacetSerializer
+
+    @extend_schema(responses=CustomFacetSerializer(many=True))
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        # Auto-scoped to the canonical team by TeamScopedManager; only the user filter is ours to add.
+        config = LogsUserConfig.objects.filter(user=request.user).first()
+        facets = config.custom_facets if config else []
+        # Serialize on the way out so the response honors the declared schema and can't drift from
+        # create if CustomFacetSerializer ever grows a to_representation override or computed field.
+        return Response(CustomFacetSerializer(facets, many=True).data, status=status.HTTP_200_OK)
+
+    @extend_schema(request=CustomFacetSerializer(many=True), responses=CustomFacetSerializer(many=True))
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        serializer = CustomFacetSerializer(data=request.data, many=True)
+        serializer.is_valid(raise_exception=True)
+        custom_facets = serializer.validated_data
+        # team is passed explicitly: the manager's read scope doesn't propagate into row creation.
+        LogsUserConfig.objects.update_or_create(
+            user=request.user,
+            defaults={"custom_facets": custom_facets, "team": self.team},
+        )
+        report_user_action(
+            request.user,
+            "logs custom facets updated",
+            {"count": len(custom_facets)},
+            team=self.team,
+            request=request,
+        )
+        # serializer.data is to_representation(validated_data) — same serializer path as list, so the
+        # two endpoints return an identical shape (and reflect the dedup applied during validation).
+        return Response(serializer.data, status=status.HTTP_200_OK)

--- a/products/logs/backend/routes.py
+++ b/products/logs/backend/routes.py
@@ -13,3 +13,7 @@ def register_routes(routers: RouterRegistry) -> None:
     routers.register_legacy_dual_route(
         r"logs/explainLogWithAI", logs.LogExplainViewSet, "project_logs_explain_with_ai", ["team_id"]
     )
+    # New endpoint — projects-only (the dual-route helper is reserved for pre-rollback endpoints).
+    routers.projects.register(
+        r"logs/custom_facets", logs.LogsCustomFacetsViewSet, "project_logs_custom_facets", ["team_id"]
+    )

--- a/products/logs/backend/test/test_user_config_api.py
+++ b/products/logs/backend/test/test_user_config_api.py
@@ -1,0 +1,84 @@
+from posthog.test.base import APIBaseTest
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.models import Team, User
+
+
+class TestLogsCustomFacetsAPI(APIBaseTest):
+    base_url: str
+
+    def setUp(self):
+        super().setUp()
+        self.base_url = f"/api/projects/{self.team.pk}/logs/custom_facets/"
+
+    def _facets(self, *pairs: tuple[str, str]) -> list[dict]:
+        return [{"key": key, "attribute_type": attribute_type} for key, attribute_type in pairs]
+
+    def test_get_is_empty_when_unconfigured(self):
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_set_then_get_round_trips(self):
+        facets = self._facets(("k8s.namespace.name", "resource"), ("http.status_code", "log"))
+
+        post = self.client.post(self.base_url, facets, format="json")
+        assert post.status_code == status.HTTP_200_OK, post.json()
+        assert post.json() == facets
+
+        assert self.client.get(self.base_url).json() == facets
+
+    def test_set_replaces_the_whole_set(self):
+        self.client.post(self.base_url, self._facets(("a", "log")), format="json")
+        self.client.post(self.base_url, self._facets(("b", "resource")), format="json")
+
+        assert self.client.get(self.base_url).json() == self._facets(("b", "resource"))
+
+    def test_duplicates_are_collapsed_on_write(self):
+        payload = self._facets(("a", "log"), ("a", "log"), ("b", "resource"))
+
+        post = self.client.post(self.base_url, payload, format="json")
+        assert post.json() == self._facets(("a", "log"), ("b", "resource"))
+
+    @parameterized.expand(
+        [
+            ("invalid_attribute_type", [{"key": "a", "attribute_type": "bogus"}]),
+            ("blank_key", [{"key": "", "attribute_type": "log"}]),
+            ("missing_key", [{"attribute_type": "log"}]),
+            ("over_cap", [{"key": f"k{i}", "attribute_type": "log"} for i in range(51)]),
+        ]
+    )
+    def test_rejects_invalid_payload(self, _label, payload):
+        response = self.client.post(self.base_url, payload, format="json")
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
+
+    def test_config_is_isolated_per_user(self):
+        mine = self._facets(("mine", "log"))
+        self.client.post(self.base_url, mine, format="json")
+
+        other = User.objects.create_and_join(self.organization, "other@posthog.com", "secret")
+        self.client.force_login(other)
+        # The other user starts empty and can't see mine.
+        assert self.client.get(self.base_url).json() == []
+        theirs = self._facets(("theirs", "resource"))
+        self.client.post(self.base_url, theirs, format="json")
+        assert self.client.get(self.base_url).json() == theirs
+
+        # Mine is untouched by their write.
+        self.client.force_login(self.user)
+        assert self.client.get(self.base_url).json() == mine
+
+    def test_config_is_isolated_per_project(self):
+        team2 = Team.objects.create(organization=self.organization, name="Team 2")
+        self.client.post(self.base_url, self._facets(("team1", "log")), format="json")
+
+        response = self.client.get(f"/api/projects/{team2.pk}/logs/custom_facets/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == []
+
+    def test_requires_authentication(self):
+        self.client.logout()
+        response = self.client.get(self.base_url)
+        assert response.status_code == status.HTTP_401_UNAUTHORIZED

--- a/products/logs/frontend/components/LogsViewer/FacetRail/AddFacetCombobox.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/AddFacetCombobox.tsx
@@ -1,0 +1,43 @@
+import { Combobox, ComboboxContent, ComboboxEmpty, ComboboxInput, ComboboxItem, ComboboxList } from 'lib/ui/quill'
+
+interface AddFacetComboboxProps {
+    /** Resource-attribute keys the user can add (already excludes curated + already-added). */
+    availableKeys: string[]
+    onAdd: (key: string) => void
+    onClose: () => void
+}
+
+/** Search-and-pick a resource-attribute key to add as a custom facet. Picking one adds it and closes. */
+export function AddFacetCombobox({ availableKeys, onAdd, onClose }: AddFacetComboboxProps): JSX.Element {
+    return (
+        <Combobox
+            items={availableKeys}
+            autoHighlight
+            defaultOpen
+            value={null}
+            onValueChange={(key: string | null) => {
+                if (key) {
+                    onAdd(key)
+                }
+                onClose()
+            }}
+            onOpenChange={(open: boolean) => {
+                if (!open) {
+                    onClose()
+                }
+            }}
+        >
+            <ComboboxInput placeholder="Add facet…" autoFocus data-attr="logs-facet-rail-add-input" />
+            <ComboboxContent>
+                <ComboboxEmpty>No more attributes to add</ComboboxEmpty>
+                <ComboboxList>
+                    {(item: string) => (
+                        <ComboboxItem key={item} value={item} title={item}>
+                            {item}
+                        </ComboboxItem>
+                    )}
+                </ComboboxList>
+            </ComboboxContent>
+        </Combobox>
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
@@ -1,7 +1,7 @@
 import { CSSProperties, useMemo } from 'react'
 import { List } from 'react-window'
 
-import { IconChevronDown, IconChevronRight } from '@posthog/icons'
+import { IconChevronDown, IconChevronRight, IconX } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
@@ -31,6 +31,8 @@ interface FacetProps {
     searchPlaceholder?: string
     collapsed?: boolean
     onToggleCollapsed?: () => void
+    /** When provided, renders a trailing remove control in the header (custom/removable facets). */
+    onRemove?: () => void
     /** When set, values render in a fixed-height virtualized list capped at this many pixels. */
     maxHeight?: number
     /** For fixed facets: render zero-count values dimmed, and disabled unless already selected. */
@@ -50,6 +52,7 @@ export function Facet({
     searchPlaceholder = 'Search…',
     collapsed = false,
     onToggleCollapsed,
+    onRemove,
     maxHeight,
     dimZeroCounts = false,
 }: FacetProps): JSX.Element {
@@ -62,16 +65,27 @@ export function Facet({
 
     return (
         <div className="mb-3">
-            <button
-                type="button"
-                onClick={onToggleCollapsed}
-                disabled={!onToggleCollapsed}
-                className="flex items-center gap-1 w-full px-1 mb-1 text-[10px] font-semibold uppercase tracking-wide text-secondary hover:text-default"
-                data-attr={`logs-facet-${slug}-header`}
-            >
-                {collapsed ? <IconChevronRight /> : <IconChevronDown />}
-                <span>{title}</span>
-            </button>
+            <div className="flex items-center gap-1 px-1 mb-1">
+                <button
+                    type="button"
+                    onClick={onToggleCollapsed}
+                    disabled={!onToggleCollapsed}
+                    className="flex items-center gap-1 flex-1 min-w-0 text-[10px] font-semibold uppercase tracking-wide text-secondary hover:text-default"
+                    data-attr={`logs-facet-${slug}-header`}
+                >
+                    {collapsed ? <IconChevronRight /> : <IconChevronDown />}
+                    <span className="truncate">{title}</span>
+                </button>
+                {onRemove && (
+                    <LemonButton
+                        size="xsmall"
+                        icon={<IconX />}
+                        onClick={onRemove}
+                        tooltip="Remove facet"
+                        data-attr={`logs-facet-${slug}-remove`}
+                    />
+                )}
+            </div>
             {!collapsed && onSearchChange && (
                 <div className="px-1 pb-1">
                     <LemonInput

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -1,7 +1,8 @@
 import { useActions, useValues } from 'kea'
 import { useCallback, useMemo, useRef } from 'react'
 
-import { LemonInput } from '@posthog/lemon-ui'
+import { IconPlus } from '@posthog/icons'
+import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
 import { Resizer } from 'lib/components/Resizer/Resizer'
 import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerLogic'
@@ -9,10 +10,19 @@ import { ResizerLogicProps, resizerLogic } from 'lib/components/Resizer/resizerL
 import { logsViewerConfigLogic } from 'products/logs/frontend/components/LogsViewer/config/logsViewerConfigLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 
+import { AddFacetCombobox } from './AddFacetCombobox'
+import { customFacetsLogic } from './customFacetsLogic'
 import { Facet, FacetOption } from './Facet'
 import { facetCountsLogic } from './facetCountsLogic'
 import { facetRailLogic } from './facetRailLogic'
-import { FacetConfig, FacetFilterKey, facetsByGroup, filterFacetsByName, resourceAttributeValues } from './facets'
+import {
+    FacetConfig,
+    FacetFilterKey,
+    facetsByGroup,
+    filterFacetsByName,
+    resourceAttributeKey,
+    resourceAttributeValues,
+} from './facets'
 
 const DEFAULT_WIDTH_PX = 240
 const COLLAPSE_THRESHOLD_PX = 120
@@ -26,10 +36,15 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
     const railRef = useRef<HTMLDivElement>(null)
     const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
     const { severityLevels, serviceNames, filterGroup } = useValues(logsViewerFiltersLogic)
-    const { facetValues, loadingFacetKeys, facetSearch, visibleFacets } = useValues(facetCountsLogic({ id }))
+    const { facetValues, loadingFacetKeys, facetSearch, visibleFacets, addableResourceKeys } = useValues(
+        facetCountsLogic({ id })
+    )
     const { setFacetSearch } = useActions(facetCountsLogic({ id }))
-    const { collapsedFacets, facetNameSearch } = useValues(facetRailLogic({ id }))
-    const { toggleFacetValue, toggleFacetCollapsed, setFacetNameSearch } = useActions(facetRailLogic({ id }))
+    const { collapsedFacets, facetNameSearch, pickerOpen } = useValues(facetRailLogic({ id }))
+    const { toggleFacetValue, toggleFacetCollapsed, setFacetNameSearch, setPickerOpen } = useActions(
+        facetRailLogic({ id })
+    )
+    const { addCustomFacet, removeCustomFacet } = useActions(customFacetsLogic)
 
     const selectedByKey: Record<FacetFilterKey, string[]> = {
         severityLevels: severityLevels ?? [],
@@ -72,6 +87,8 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
         const onToggle = (value: string): void => toggleFacetValue(source, value)
         const onToggleCollapsed = (): void => toggleFacetCollapsed(facet.key)
         const collapsed = collapsedFacets.includes(facet.key)
+        const removeKey = facet.removable ? resourceAttributeKey(facet) : null
+        const onRemove = removeKey ? () => removeCustomFacet(removeKey) : undefined
 
         if (facet.kind === 'fixed') {
             // Fixed value set from config, counts overlaid. Missing values render as a dimmed 0.
@@ -110,6 +127,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                 searchPlaceholder={facet.searchPlaceholder}
                 collapsed={collapsed}
                 onToggleCollapsed={onToggleCollapsed}
+                onRemove={onRemove}
                 maxHeight={facet.maxHeight}
             />
         )
@@ -126,7 +144,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
             style={{ width: desiredSize ?? DEFAULT_WIDTH_PX, minWidth: 'min-content', maxWidth: '40%' }}
             data-attr="logs-facet-rail"
         >
-            <div className="px-2 py-1 border-b">
+            <div className="px-2 py-1 border-b flex items-center gap-1">
                 <LemonInput
                     type="search"
                     size="small"
@@ -136,7 +154,24 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
                     onChange={setFacetNameSearch}
                     data-attr="logs-facet-rail-search"
                 />
+                <LemonButton
+                    size="small"
+                    icon={<IconPlus />}
+                    onClick={() => setPickerOpen(!pickerOpen)}
+                    active={pickerOpen}
+                    tooltip="Add facet"
+                    data-attr="logs-facet-rail-add-button"
+                />
             </div>
+            {pickerOpen && (
+                <div className="px-2 py-1 border-b">
+                    <AddFacetCombobox
+                        availableKeys={addableResourceKeys}
+                        onAdd={(key) => addCustomFacet(key, 'resource')}
+                        onClose={() => setPickerOpen(false)}
+                    />
+                </div>
+            )}
             <div className="flex-1 min-h-0 overflow-y-auto p-2">
                 {displayedGroups.length === 0 && facetNameSearch.trim() ? (
                     <div className="px-1 text-xs text-muted">No matching facets</div>

--- a/products/logs/frontend/components/LogsViewer/FacetRail/customFacetsLogic.test.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/customFacetsLogic.test.ts
@@ -1,0 +1,106 @@
+import { expectLogic } from 'kea-test-utils'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+
+import { initKeaTests } from '~/test/init'
+
+import { logsCustomFacetsCreate, logsCustomFacetsList } from '../../../generated/api'
+import { customFacetsLogic } from './customFacetsLogic'
+
+jest.mock('../../../generated/api', () => ({
+    logsCustomFacetsList: jest.fn(),
+    logsCustomFacetsCreate: jest.fn(),
+}))
+
+jest.mock('lib/lemon-ui/LemonToast/LemonToast', () => ({
+    lemonToast: { error: jest.fn() },
+}))
+
+const listMock = logsCustomFacetsList as jest.Mock
+const createMock = logsCustomFacetsCreate as jest.Mock
+const errorToast = lemonToast.error as jest.Mock
+
+describe('customFacetsLogic', () => {
+    let logic: ReturnType<typeof customFacetsLogic.build>
+
+    beforeEach(async () => {
+        listMock.mockResolvedValue([{ key: 'cloud.provider', attribute_type: 'resource' }])
+        createMock.mockResolvedValue([])
+        initKeaTests()
+        logic = customFacetsLogic()
+        logic.mount()
+        await expectLogic(logic).toFinishAllListeners()
+    })
+
+    afterEach(() => {
+        logic.unmount()
+        jest.clearAllMocks()
+    })
+
+    it("loads the user's custom facets on mount", () => {
+        expect(logic.values.customFacetEntries).toEqual([{ key: 'cloud.provider', attribute_type: 'resource' }])
+    })
+
+    it('adds a facet optimistically and persists the new full set', async () => {
+        await expectLogic(logic, () => logic.actions.addCustomFacet('faas.id', 'resource')).toFinishAllListeners()
+
+        const expected = [
+            { key: 'cloud.provider', attribute_type: 'resource' },
+            { key: 'faas.id', attribute_type: 'resource' },
+        ]
+        expect(logic.values.customFacetEntries).toEqual(expected)
+        expect(createMock).toHaveBeenCalledWith(expect.any(String), expected)
+    })
+
+    it('ignores a duplicate key', async () => {
+        await expectLogic(logic, () =>
+            logic.actions.addCustomFacet('cloud.provider', 'resource')
+        ).toFinishAllListeners()
+        expect(logic.values.customFacetEntries).toEqual([{ key: 'cloud.provider', attribute_type: 'resource' }])
+    })
+
+    it('removes a facet and persists the remaining set', async () => {
+        await expectLogic(logic, () => logic.actions.removeCustomFacet('cloud.provider')).toFinishAllListeners()
+        expect(logic.values.customFacetEntries).toEqual([])
+        expect(createMock).toHaveBeenCalledWith(expect.any(String), [])
+    })
+
+    it('renders resource entries as Custom facets but skips log entries', async () => {
+        await expectLogic(logic, () => logic.actions.addCustomFacet('http.method', 'log')).toFinishAllListeners()
+
+        // The log entry is stored…
+        expect(logic.values.customFacetEntries).toHaveLength(2)
+        // …but only the resource one becomes a rail facet (log attrs need the facet_attribute path).
+        expect(logic.values.customFacets).toHaveLength(1)
+        expect(logic.values.customFacets[0]).toMatchObject({
+            group: 'Custom',
+            removable: true,
+            source: { type: 'resourceAttribute', key: 'cloud.provider' },
+        })
+    })
+
+    it('toasts and rolls back to the server set when a save fails', async () => {
+        createMock.mockRejectedValueOnce(new Error('save failed'))
+
+        // The optimistic add lands, the persist rejects, and the catch reloads from the server —
+        // which still only has the original facet, so the unsaved one is dropped from the rail.
+        await expectLogic(logic, () => logic.actions.addCustomFacet('faas.id', 'resource')).toDispatchActions([
+            'addCustomFacet',
+            'loadCustomFacets',
+            'setCustomFacets',
+        ])
+
+        expect(errorToast).toHaveBeenCalledTimes(1)
+        expect(logic.values.customFacetEntries).toEqual([{ key: 'cloud.provider', attribute_type: 'resource' }])
+    })
+
+    it('toasts and keeps the current set when a load fails', async () => {
+        listMock.mockRejectedValueOnce(new Error('load failed'))
+
+        await expectLogic(logic, () => logic.actions.loadCustomFacets()).toFinishAllListeners()
+
+        expect(errorToast).toHaveBeenCalledTimes(1)
+        // A failed reload must not wipe what was already loaded.
+        expect(logic.values.customFacetEntries).toEqual([{ key: 'cloud.provider', attribute_type: 'resource' }])
+    })
+})

--- a/products/logs/frontend/components/LogsViewer/FacetRail/customFacetsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/customFacetsLogic.ts
@@ -1,0 +1,87 @@
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { logsCustomFacetsCreate, logsCustomFacetsList } from '../../../generated/api'
+import { CustomFacetApi } from '../../../generated/api.schemas'
+import type { customFacetsLogicType } from './customFacetsLogicType'
+import { FacetConfig, entryToFacetConfig } from './facets'
+
+// Per-user, per-project custom facets — the rail's "Custom" group. A singleton: the set is the same
+// across every LogsViewer instance, persisted server-side via the logs/custom_facets endpoint.
+export const customFacetsLogic = kea<customFacetsLogicType>([
+    path(['products', 'logs', 'frontend', 'components', 'LogsViewer', 'FacetRail', 'customFacetsLogic']),
+
+    connect({
+        values: [teamLogic, ['currentTeamId']],
+    }),
+
+    actions({
+        loadCustomFacets: true,
+        setCustomFacets: (entries: CustomFacetApi[]) => ({ entries }),
+        addCustomFacet: (key: string, attributeType: CustomFacetApi['attribute_type']) => ({ key, attributeType }),
+        removeCustomFacet: (key: string) => ({ key }),
+    }),
+
+    reducers({
+        customFacetEntries: [
+            [] as CustomFacetApi[],
+            {
+                setCustomFacets: (_, { entries }) => entries,
+                // Optimistic: reflect the change in the rail immediately, then persist (listener below).
+                addCustomFacet: (state, { key, attributeType }) =>
+                    state.some((f) => f.key === key) ? state : [...state, { key, attribute_type: attributeType }],
+                removeCustomFacet: (state, { key }) => state.filter((f) => f.key !== key),
+            },
+        ],
+    }),
+
+    selectors({
+        customFacets: [
+            (s) => [s.customFacetEntries],
+            (entries: CustomFacetApi[]): FacetConfig[] =>
+                entries.map(entryToFacetConfig).filter((f): f is FacetConfig => f !== null),
+        ],
+    }),
+
+    listeners(({ values, actions }) => {
+        // Reducers run before listeners, so `customFacetEntries` already reflects the add/remove here —
+        // we just persist the new full set (the endpoint replaces it wholesale).
+        const persist = async (): Promise<void> => {
+            if (!values.currentTeamId) {
+                return
+            }
+            try {
+                await logsCustomFacetsCreate(String(values.currentTeamId), values.customFacetEntries)
+            } catch {
+                // The optimistic reducer update already landed; reload to fall back to the server's truth
+                // so the rail never keeps showing a facet that wasn't actually saved.
+                lemonToast.error('Failed to save custom facets')
+                actions.loadCustomFacets()
+            }
+        }
+        return {
+            loadCustomFacets: async (_, breakpoint) => {
+                if (!values.currentTeamId) {
+                    return
+                }
+                // Only the request is in the try — breakpoint() throws to cancel a superseded run and
+                // must propagate to kea, not be caught here as a load failure.
+                let entries: CustomFacetApi[]
+                try {
+                    entries = await logsCustomFacetsList(String(values.currentTeamId))
+                } catch {
+                    lemonToast.error('Failed to load custom facets')
+                    return
+                }
+                breakpoint()
+                actions.setCustomFacets(entries)
+            },
+            addCustomFacet: () => persist(),
+            removeCustomFacet: () => persist(),
+        }
+    }),
+
+    afterMount(({ actions }) => actions.loadCustomFacets()),
+])

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetCountsLogic.ts
@@ -10,8 +10,9 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 
 import { logsAttributesRetrieve, logsFacetValuesCreate } from '../../../generated/api'
 import { _LogFacetValueApi, _LogPropertyFilterApi, _LogsFacetValuesBodyApi } from '../../../generated/api.schemas'
+import { customFacetsLogic } from './customFacetsLogic'
 import type { facetCountsLogicType } from './facetCountsLogicType'
-import { FACETS, FacetConfig } from './facets'
+import { CURATED_RESOURCE_KEYS, FACETS, FacetConfig, resourceAttributeKey } from './facets'
 
 // Broad, filter-independent window for the "which resource attributes does this tenant emit" probe.
 // Cheap: keys-only group-by on the log_attributes aggregation table (no value scan).
@@ -39,6 +40,8 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
             ['filters', 'utcDateRange', 'queryFilterGroup'],
             teamLogic,
             ['currentTeamId'],
+            customFacetsLogic,
+            ['customFacets'],
         ],
     })),
 
@@ -143,7 +146,7 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                     // typing in one facet's search must not cancel a still-debouncing full reload.
                     loadFacetValuesForKey: async (facetKey: string, breakpoint) => {
                         await breakpoint(300)
-                        const facet = FACETS.find((f) => f.key === facetKey)
+                        const facet = values.visibleFacets.find((f) => f.key === facetKey)
                         const result = facet ? await mergeFetched([facet]) : values.facetValues
                         breakpoint()
                         return result
@@ -172,10 +175,24 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
 
     selectors({
         // Column facets always render; resource-attribute facets only when the tenant emits the key.
+        // The user's custom facets append after the curated set, forming the "Custom" group.
         visibleFacets: [
-            (s) => [s.presentResourceKeys],
-            (presentResourceKeys): FacetConfig[] =>
-                FACETS.filter((f) => f.source.type === 'column' || presentResourceKeys.includes(f.source.key)),
+            (s) => [s.presentResourceKeys, s.customFacets],
+            (presentResourceKeys, customFacets): FacetConfig[] => [
+                ...FACETS.filter((f) => f.source.type === 'column' || presentResourceKeys.includes(f.source.key)),
+                ...customFacets,
+            ],
+        ],
+        // Resource keys the tenant emits that aren't already a facet — the Add facet picker's options.
+        addableResourceKeys: [
+            (s) => [s.presentResourceKeys, s.customFacets],
+            (presentResourceKeys: string[], customFacets: FacetConfig[]): string[] => {
+                const taken = new Set<string>([
+                    ...CURATED_RESOURCE_KEYS,
+                    ...customFacets.map(resourceAttributeKey).filter((k): k is string => k !== null),
+                ])
+                return presentResourceKeys.filter((key) => !taken.has(key))
+            },
         ],
         // Per-facet loading state. A filter-change reload and a per-facet search have independent
         // breakpoints and can overlap, so union both sources — otherwise whichever settles first would
@@ -216,9 +233,23 @@ export const facetCountsLogic = kea<facetCountsLogicType>([
                 actions.loadFacetValues(null)
             }
         }
+        // Only newly-added custom facets need counts — removals fetch nothing, and the initial load is
+        // covered by the presence-probe reload. Refetching every facet on each change would re-run a CH
+        // scan per curated facet for no reason.
+        const fetchAddedCustomFacets = (customFacets: FacetConfig[], previous: FacetConfig[]): void => {
+            if (!values.presenceLoaded) {
+                return
+            }
+            const previousKeys = new Set((previous ?? []).map((f) => f.key))
+            const addedKeys = customFacets.filter((f) => !previousKeys.has(f.key)).map((f) => f.key)
+            if (addedKeys.length > 0) {
+                actions.loadFacetValues(addedKeys)
+            }
+        }
         return {
             filters: reloadAll,
             queryFilterGroup: reloadAll,
+            customFacets: fetchAddedCustomFacets,
         }
     }),
 ])

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facetRailLogic.ts
@@ -35,6 +35,8 @@ export const facetRailLogic = kea<facetRailLogicType>([
         // Free-text filter over the facet *fields* shown in the rail (not their values). URL-synced by
         // logsSceneLogic on the main scene, so deliberately not persisted here.
         setFacetNameSearch: (search: string) => ({ search }),
+        // Whether the "Add facet" picker is revealed below the search box.
+        setPickerOpen: (open: boolean) => ({ open }),
     }),
 
     reducers({
@@ -42,6 +44,12 @@ export const facetRailLogic = kea<facetRailLogicType>([
             '',
             {
                 setFacetNameSearch: (_, { search }) => search,
+            },
+        ],
+        pickerOpen: [
+            false,
+            {
+                setPickerOpen: (_, { open }) => open,
             },
         ],
         collapsedFacets: [

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.test.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.test.ts
@@ -1,4 +1,4 @@
-import { FacetConfig, filterFacetsByName } from './facets'
+import { CUSTOM_GROUP, FacetConfig, entryToFacetConfig, filterFacetsByName } from './facets'
 
 const facet = (key: string, title: string, group: string): FacetConfig => ({
     key,
@@ -16,17 +16,36 @@ const FACETS: FacetConfig[] = [
     facet('host', 'Host', 'Infrastructure'),
 ]
 
-describe('filterFacetsByName', () => {
-    it.each([
-        ['blank query returns all', '', ['level', 'service', 'namespace', 'pod', 'host']],
-        ['whitespace-only returns all', '   ', ['level', 'service', 'namespace', 'pod', 'host']],
-        ['matches a field title', 'namespace', ['namespace']],
-        ['title match is case-insensitive', 'NAMESPACE', ['namespace']],
-        ['partial title match', 'serv', ['service']],
-        ['matches a whole group by name', 'kubernetes', ['namespace', 'pod']],
-        ['group match is case-insensitive', 'INFRA', ['host']],
-        ['no match returns empty', 'zzz', []],
-    ])('%s', (_, query, expectedKeys) => {
-        expect(filterFacetsByName(FACETS, query).map((f) => f.key)).toEqual(expectedKeys)
+describe('facets', () => {
+    describe('filterFacetsByName', () => {
+        it.each([
+            ['blank query returns all', '', ['level', 'service', 'namespace', 'pod', 'host']],
+            ['whitespace-only returns all', '   ', ['level', 'service', 'namespace', 'pod', 'host']],
+            ['matches a field title', 'namespace', ['namespace']],
+            ['title match is case-insensitive', 'NAMESPACE', ['namespace']],
+            ['partial title match', 'serv', ['service']],
+            ['matches a whole group by name', 'kubernetes', ['namespace', 'pod']],
+            ['group match is case-insensitive', 'INFRA', ['host']],
+            ['no match returns empty', 'zzz', []],
+        ])('%s', (_, query, expectedKeys) => {
+            expect(filterFacetsByName(FACETS, query).map((f) => f.key)).toEqual(expectedKeys)
+        })
+    })
+
+    describe('entryToFacetConfig', () => {
+        it('maps a resource entry to a removable Custom facet', () => {
+            expect(entryToFacetConfig({ key: 'cloud.provider', attribute_type: 'resource' })).toMatchObject({
+                group: CUSTOM_GROUP,
+                title: 'cloud.provider',
+                kind: 'dynamic',
+                removable: true,
+                searchable: true,
+                source: { type: 'resourceAttribute', key: 'cloud.provider' },
+            })
+        })
+
+        it('returns null for a log entry (needs the facet_attribute backend path)', () => {
+            expect(entryToFacetConfig({ key: 'http.method', attribute_type: 'log' })).toBeNull()
+        })
     })
 })

--- a/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/facets.ts
@@ -8,7 +8,11 @@ import {
 
 import { SEVERITY_BAR_COLORS } from 'products/logs/frontend/components/VirtualizedLogsList/columnDefinitions'
 
+import type { CustomFacetApi } from '../../../generated/api.schemas'
 import { FacetOption } from './Facet'
+
+/** Group the user's own pinned facets render under, after the curated groups. */
+export const CUSTOM_GROUP = 'Custom'
 
 /**
  * Whether a facet's value set is known ahead of time or discovered from the data.
@@ -54,6 +58,8 @@ export interface FacetConfig {
     emptyLabel?: string
     /** Max pixel height before the value list virtualizes and scrolls. */
     maxHeight?: number
+    /** User-added facets (the "Custom" group) render a remove control; curated facets don't. */
+    removable?: boolean
 }
 
 interface LogResourceAttributeFilter {
@@ -181,6 +187,28 @@ export const FACETS: FacetConfig[] = [
     NODE_FACET,
     HOST_FACET,
 ]
+
+/** The resource-attribute key a facet targets, or null for column facets. */
+export function resourceAttributeKey(facet: FacetConfig): string | null {
+    return facet.source.type === 'resourceAttribute' ? facet.source.key : null
+}
+
+/** Resource-attribute keys already covered by a curated facet — excluded from the Add facet picker. */
+export const CURATED_RESOURCE_KEYS: string[] = FACETS.map(resourceAttributeKey).filter((k): k is string => k !== null)
+
+/**
+ * Turn a stored custom-facet entry into a rail facet. Resource attributes reuse the same builder as
+ * the curated ones (counts + selection already work for that source). Log attributes need the backend
+ * facet_attribute path and are added in a follow-up — null until then.
+ */
+export function entryToFacetConfig(entry: CustomFacetApi): FacetConfig | null {
+    if (entry.attribute_type === 'resource') {
+        // `custom:` namespaces the facet key so a user-added attribute can't collide with a curated
+        // facet's key (e.g. a raw `node` attribute vs the curated Node facet, which is keyed `node`).
+        return { ...resourceAttributeFacet(entry.key, `custom:${entry.key}`, entry.key, CUSTOM_GROUP), removable: true }
+    }
+    return null
+}
 
 /**
  * Filter facets by a free-text query matching the field name or its group (case-insensitive

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -980,6 +980,30 @@ export interface _LogsCountRangesResponseApi {
     interval: string
 }
 
+/**
+ * * `log` - log
+ * * `resource` - resource
+ */
+export type AttributeTypeEnumApi = (typeof AttributeTypeEnumApi)[keyof typeof AttributeTypeEnumApi]
+
+export const AttributeTypeEnumApi = {
+    Log: 'log',
+    Resource: 'resource',
+} as const
+
+export interface CustomFacetApi {
+    /**
+     * Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.
+     * @maxLength 200
+     */
+    key: string
+    /** Where the key lives: "resource" for resource attributes, "log" for log attributes.
+     *
+     * * `log` - log
+     * * `resource` - resource */
+    attribute_type: AttributeTypeEnumApi
+}
+
 export interface ExplainRequestApi {
     /** UUID of the log entry to explain */
     uuid: string

--- a/products/logs/frontend/generated/api.ts
+++ b/products/logs/frontend/generated/api.ts
@@ -9,6 +9,7 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
+    CustomFacetApi,
     ExplainRequestApi,
     LogsAlertConfigurationApi,
     LogsAlertCreateDestinationApi,
@@ -344,6 +345,42 @@ export const logsCountRangesCreate = async (
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
         body: JSON.stringify(_logsCountRangesRequestApi),
+    })
+}
+
+export const getLogsCustomFacetsListUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/custom_facets/`
+}
+
+/**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsList = async (projectId: string, options?: RequestInit): Promise<CustomFacetApi[]> => {
+    return apiMutator<CustomFacetApi[]>(getLogsCustomFacetsListUrl(projectId), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getLogsCustomFacetsCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/logs/custom_facets/`
+}
+
+/**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsCreate = async (
+    projectId: string,
+    customFacetApi: CustomFacetApi[],
+    options?: RequestInit
+): Promise<CustomFacetApi[]> => {
+    return apiMutator<CustomFacetApi[]>(getLogsCustomFacetsCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(customFacetApi),
     })
 }
 

--- a/products/logs/frontend/generated/api.zod.ts
+++ b/products/logs/frontend/generated/api.zod.ts
@@ -586,6 +586,26 @@ export const LogsCountRangesCreateBody = /* @__PURE__ */ zod.object({
 })
 
 /**
+ * The requesting user's custom facets for the current project — the facets they pinned into the
+ * rail's Custom group. Stored as a single (team, user) row; the whole set is replaced on write.
+ */
+export const logsCustomFacetsCreateBodyKeyMax = 200
+
+export const LogsCustomFacetsCreateBodyItem = /* @__PURE__ */ zod.object({
+    key: zod
+        .string()
+        .max(logsCustomFacetsCreateBodyKeyMax)
+        .describe("Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'."),
+    attribute_type: zod
+        .enum(['log', 'resource'])
+        .describe('\* `log` - log\n\* `resource` - resource')
+        .describe(
+            'Where the key lives: \"resource\" for resource attributes, \"log\" for log attributes.\n\n\* `log` - log\n\* `resource` - resource'
+        ),
+})
+export const LogsCustomFacetsCreateBody = /* @__PURE__ */ zod.array(LogsCustomFacetsCreateBodyItem)
+
+/**
  * Explain a log entry using AI.
  *
  * POST /api/environments/:id/logs/explainLogWithAI/

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -9228,6 +9228,18 @@ export namespace Schemas {
       value: string;
     }
 
+    /**
+     * * `log` - log
+     * * `resource` - resource
+     */
+    export type AttributeTypeEnum = typeof AttributeTypeEnum[keyof typeof AttributeTypeEnum];
+
+
+    export const AttributeTypeEnum = {
+      Log: 'log',
+      Resource: 'resource',
+    } as const;
+
     export interface UnmatchedUtmSample {
       /** A raw utm_source value that doesn't match the integration exactly */
       raw_value: string;
@@ -13996,6 +14008,19 @@ export namespace Schemas {
       target_display_name: string;
       /** canonical or team_custom */
       source: string;
+    }
+
+    export interface CustomFacet {
+      /**
+         * Attribute key to facet on, e.g. 'k8s.namespace.name' or 'http.status_code'.
+         * @maxLength 200
+         */
+      key: string;
+      /** Where the key lives: "resource" for resource attributes, "log" for log attributes.
+       *
+       * * `log` - log
+       * * `resource` - resource */
+      attribute_type: AttributeTypeEnum;
     }
 
     /**


### PR DESCRIPTION
## Problem

Users can only filter logs by the curated set of facets (severity, service, Kubernetes fields, etc.). If a tenant emits resource attributes that aren't in the curated list — e.g. `cloud.provider`, `faas.id` — there's no way to surface them as facets in the rail without a code change.

## Changes

**Custom facets — add & remove from the rail**

- Introduces `customFacetsLogic`, a singleton that loads, adds, and removes user-defined facets via the `logs/custom_facets` API endpoint. Changes are applied optimistically in the reducer and then persisted server-side (the endpoint replaces the full set).
- Adds `AddFacetCombobox`, a search-and-pick dropdown that lists resource-attribute keys the tenant emits but that aren't already covered by a curated or custom facet.
- A `+` button in the facet rail header reveals the combobox. Picking a key adds it as a facet under a new "Custom" group and closes the picker.
- Custom facets render a trailing `×` button in their header to remove them. Curated facets are unchanged.
- `facetCountsLogic` now includes custom facets in `visibleFacets` and exposes `addableResourceKeys` (present keys minus curated and already-added custom keys). When a new custom facet is added, only its counts are fetched — not the full curated set.
- Custom facet keys are namespaced with `custom:` internally to prevent collisions with curated facet keys.
- `log`-typed custom facet entries are stored but not yet rendered as rail facets (they need a different backend path); `entryToFacetConfig` returns `null` for them.

![facet rail with add button and custom group](placeholder)

## How did you test this code?

This is an agent-authored PR. No manual testing was performed. The following automated tests were added or extended:

- **`customFacetsLogic.test.ts`** — new test file covering: initial load, optimistic add, duplicate-key guard, remove + persist, and the `log`-type exclusion from rendered facets.
- **`facets.test.ts`** — extended with `entryToFacetConfig` cases: resource entry → removable Custom facet, log entry → null.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

The agent added the custom facets feature end-to-end: `customFacetsLogic` (kea logic with optimistic reducers + server persistence), `AddFacetCombobox` (Combobox-based picker), wiring into `facetCountsLogic` and `facetRailLogic`, and the remove control in `Facet`. The `custom:` key-namespacing approach was chosen to avoid silent collisions between user-added attributes and curated facets that share a short key name. Log-typed entries are stored but excluded from rendering pending a follow-up that implements the `facet_attribute` backend path.