### PR TITLE
fix(nav): flatten + Create button in nav experiment test arm

### DIFF
--- a/frontend/src/layout/panel-layout/ai-first/Nav.tsx
+++ b/frontend/src/layout/panel-layout/ai-first/Nav.tsx
@@ -242,7 +242,7 @@ export function Nav(): JSX.Element {
                         >
                             <DropdownMenuTrigger asChild>
                                 <LemonButton
-                                    type="primary"
+                                    type="secondary"
                                     size="small"
                                     icon={<IconPlusSmall />}
                                     fullWidth={!isLayoutNavCollapsed}


### PR DESCRIPTION
## Problem

The `create-button-nav-experiment` test arm shipped a Create button in the left nav that felt too big and too 3D — it used a primary `LemonButton`, whose raised "chrome" depth/shadow makes it pop off the surface. This refines the appearance of that test arm.

## Changes

- Switch the nav Create button (experiment `test` arm) from `type="primary"` to `type="secondary"` — a flat, transparent button instead of the raised 3D primary style.
- One-line change in `Nav.tsx`. The icon (`IconPlusSmall`), placement (its own row below the header), full-width behavior, the Create dropdown menu, and the `nav create button clicked` capture are all unchanged.
- The experiment itself is untouched — still `control` / `test`, no new variant.

Screenshots: I'm an agent and can't attach screenshots. Reviewers can see it locally by resolving `create-button-nav-experiment` to the `test` variant.

## How did you test this code?

I'm an agent — I did not perform manual/visual testing. This is a one-line visual prop change (`type="primary"` → `type="secondary"`) with no logic change, so no automated tests were added. I ran the frontend formatter (oxfmt / lint-staged `format:js`) and it passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — internal experiment styling, no docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @mjwarren3 (assignee/DRI).

Tooling: Claude Code (Opus 4.8). No repo-provided skills were needed — this is a pure frontend styling change.

Decisions along the way: we iterated on the button's look based on feedback that it was "too big and 3D". Options tried and rejected: a flat full-width `tertiary` button, and an icon-only `ButtonPrimitive` placed inline next to the search button. We briefly prototyped a three-variant setup (`control` / `simple` / `test`) but **rejected adding a variant** because the experiment is already running — adding an arm mid-flight would compromise its results. Landed on the minimal change: flip the existing `test`-arm button from `primary` to `secondary`, keeping the original `IconPlusSmall` and placement.
