### PR TITLE
feat(clickhouse): add logs node to the multinode migration smoke

### DIFF
--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -72,7 +72,7 @@ jobs:
 
             - name: Add multinode hostnames to /etc/hosts
               run: |
-                  echo "127.0.0.1 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions kafka zookeeper" | sudo tee -a /etc/hosts
+                  echo "127.0.0.1 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs kafka zookeeper" | sudo tee -a /etc/hosts
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docker-compose.multinode-clickhouse.yml
+++ b/docker-compose.multinode-clickhouse.yml
@@ -1,7 +1,7 @@
 #
 # Multi-node ClickHouse smoke-test stack.
 #
-# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions)
+# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions + logs)
 # so migration runs can be verified against a topology that resembles production.
 # Opt-in only: not used by `bin/start` or any of the default dev/CI flows.
 # Driven by `tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke`
@@ -135,6 +135,22 @@ services:
         ports:
             - '8127:8123'
             - '9400:9000'
+
+    clickhouse-logs:
+        <<: *clickhouse-multinode
+        hostname: clickhouse-logs
+        volumes:
+            - ./posthog/idl:/idl
+            - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+            - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+            - ./docker/clickhouse/config.d/multinode/logs_node.xml:/etc/clickhouse-server/config.d/default.xml
+            - ./docker/clickhouse/config.d/dev-memory.xml:/etc/clickhouse-server/config.d/dev-memory.xml
+            - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+            - ./docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
+            - ./posthog/user_scripts:/var/lib/clickhouse/user_scripts
+        ports:
+            - '8128:8123'
+            - '9500:9000'
 
 volumes:
     redpanda-data:

--- a/docker/clickhouse/config.d/multinode/ai_events_node.xml
+++ b/docker/clickhouse/config.d/multinode/ai_events_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/data_node.xml
+++ b/docker/clickhouse/config.d/multinode/data_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/logs_node.xml
+++ b/docker/clickhouse/config.d/multinode/logs_node.xml
@@ -142,8 +142,8 @@
 
     <macros>
         <shard>01</shard>
-        <replica>aux</replica>
+        <replica>logs</replica>
         <hostClusterType>online</hostClusterType>
-        <hostClusterRole>aux</hostClusterRole>
+        <hostClusterRole>logs</hostClusterRole>
     </macros>
 </clickhouse>

--- a/docker/clickhouse/config.d/multinode/ops_node.xml
+++ b/docker/clickhouse/config.d/multinode/ops_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/sessions_node.xml
+++ b/docker/clickhouse/config.d/multinode/sessions_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -62,6 +62,7 @@ _MULTINODE_HOST_PORT_OVERRIDES: dict[str, tuple[str, int]] = {
     "clickhouse-aux": ("localhost", 9200),
     "clickhouse-ops": ("localhost", 9300),
     "clickhouse-sessions": ("localhost", 9400),
+    "clickhouse-logs": ("localhost", 9500),
 }
 
 

--- a/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
+++ b/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
@@ -24,7 +24,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR/../../.."
 
 COMPOSE_FILE="docker-compose.multinode-clickhouse.yml"
-CH_SERVICES=(clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions)
+CH_SERVICES=(clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs)
 INFRA_SERVICES=(zookeeper kafka db redis7)
 ALL_SERVICES=("${INFRA_SERVICES[@]}" "${CH_SERVICES[@]}")
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"
@@ -147,7 +147,7 @@ export CLICKHOUSE_HOST="${CLICKHOUSE_HOST:-localhost}"
 export CLICKHOUSE_MIGRATIONS_HOST="${CLICKHOUSE_MIGRATIONS_HOST:-localhost}"
 export CLICKHOUSE_CLUSTER="${CLICKHOUSE_CLUSTER:-posthog}"
 export CLICKHOUSE_MIGRATIONS_CLUSTER="${CLICKHOUSE_MIGRATIONS_CLUSTER:-posthog_migrations}"
-export CLICKHOUSE_SATELLITE_CLUSTERS="${CLICKHOUSE_SATELLITE_CLUSTERS:-ai_events,aux,ops,sessions}"
+export CLICKHOUSE_SATELLITE_CLUSTERS="${CLICKHOUSE_SATELLITE_CLUSTERS:-ai_events,aux,ops,sessions,logs}"
 export CLICKHOUSE_DATABASE="${CLICKHOUSE_DATABASE:-posthog}"
 export CLICKHOUSE_USER="${CLICKHOUSE_USER:-default}"
 export CLICKHOUSE_PASSWORD="${CLICKHOUSE_PASSWORD:-}"

--- a/tools/infra-scripts/clickhouse-multinode/start-multinode-clickhouse
+++ b/tools/infra-scripts/clickhouse-multinode/start-multinode-clickhouse
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Boot the multinode ClickHouse smoke-test stack in the background.
-# One ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions).
+# One ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions + logs).
 # This is opt-in tooling for verifying migration routing — `bin/start` is unaffected.
 #
 
@@ -12,7 +12,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR/../../.."
 
 COMPOSE_FILE="docker-compose.multinode-clickhouse.yml"
-SERVICES=(zookeeper kafka db redis7 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions)
+SERVICES=(zookeeper kafka db redis7 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs)
 
 case "${1:-up}" in
     up)
@@ -24,6 +24,7 @@ case "${1:-up}" in
         echo "  clickhouse-aux        localhost:9200 (HTTP 8125)"
         echo "  clickhouse-ops        localhost:9300 (HTTP 8126)"
         echo "  clickhouse-sessions   localhost:9400 (HTTP 8127)"
+        echo "  clickhouse-logs       localhost:9500 (HTTP 8128)"
         echo
         echo "To run migrations against this stack, set:"
         echo "  export MULTINODE_CLICKHOUSE=1"

--- a/tools/infra-scripts/clickhouse-multinode/verify-multinode-clickhouse.py
+++ b/tools/infra-scripts/clickhouse-multinode/verify-multinode-clickhouse.py
@@ -12,9 +12,9 @@ Connects to each ClickHouse node directly (via its published port) and asserts:
    clusters with the expected member hosts — confirms `<remote_servers>` is
    wired correctly.
 3. Tables that production routes to a satellite cluster (ai_events / aux / ops
-   / sessions) live on the matching node and **not** on the data node. Catches
-   migrations that forgot `node_roles=[NodeRole.X]` and accidentally created a
-   table everywhere.
+   / sessions / logs) live on the matching node and **not** on the data node.
+   Catches migrations that forgot `node_roles=[NodeRole.X]` and accidentally
+   created a table everywhere.
 
 Exits 0 on success, non-zero on the first failed assertion (with context).
 """
@@ -42,6 +42,7 @@ NODES: list[Node] = [
     Node("clickhouse-aux", "localhost", 9200, "aux"),
     Node("clickhouse-ops", "localhost", 9300, "ops"),
     Node("clickhouse-sessions", "localhost", 9400, "sessions"),
+    Node("clickhouse-logs", "localhost", 9500, "logs"),
 ]
 
 # Logical cluster -> expected member hosts (sorted). Each multinode XML file
@@ -55,6 +56,7 @@ EXPECTED_CLUSTERS: dict[str, list[str]] = {
         "clickhouse-ai-events",
         "clickhouse-aux",
         "clickhouse-data",
+        "clickhouse-logs",
         "clickhouse-ops",
         "clickhouse-sessions",
     ],
@@ -62,6 +64,7 @@ EXPECTED_CLUSTERS: dict[str, list[str]] = {
     "aux": ["clickhouse-aux"],
     "ops": ["clickhouse-ops"],
     "sessions": ["clickhouse-sessions"],
+    "logs": ["clickhouse-logs"],
 }
 
 
@@ -86,6 +89,12 @@ SATELLITE_TABLE_MANIFEST: dict[str, SatelliteTables] = {
     "aux": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
     "ops": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
     "sessions": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
+    "logs": SatelliteTables(
+        on_satellite=["logs34", "log_attributes2", "logs_billing_metrics", "logs_kafka_metrics"],
+        # Base logs tables run with node_roles=[NodeRole.LOGS], so they must not
+        # land on the data node. Distributed wrappers may, so they're not listed.
+        forbidden_on_data=["logs34", "log_attributes2"],
+    ),
 }
 
 DATABASE = "posthog"


### PR DESCRIPTION
> Stacked on #66102. Base will retarget to `master` once that merges (or rebase if it's closed).

## Problem

The "ClickHouse Multinode Migration Smoke" boots `data` / `ai_events` / `aux` / `ops` / `sessions` nodes but **no `logs` node**. So every `NodeRole.LOGS` migration op matches zero hosts and silently no-ops — meaning **logs migrations have never actually been exercised by the smoke**. It also means a logs replicated-table ALTER (which routes through `any_host_by_roles`) crashes the run instead of being verified.

#66102 makes that crash degrade gracefully. This PR is the thorough fix: give the smoke a real `logs` node so logs migrations run and are checked like every other cluster's.

## Changes

- New `logs_node.xml` (`hostClusterRole=logs`) and a `clickhouse-logs` compose service (ports `8128`/`9500`).
- Wire `clickhouse-logs` into the `posthog_migrations` cluster and a new `logs` satellite cluster across every node config; add it to the smoke's `CH_SERVICES`, `CLICKHOUSE_SATELLITE_CLUSTERS`, and the CI `/etc/hosts` line.
- Declare the `warpstream_logs` named collection on every node. `0280_logs34` creates `kafka_logs_avro` against that collection unconditionally; it only worked before because the op was skipped (no logs node). Without this, adding the node would fail the migration — this is the main gotcha.
- Add `clickhouse-logs -> localhost:9500` to `_MULTINODE_HOST_PORT_OVERRIDES` in `cluster.py`, so role-routed connections reach the logs node's published port instead of falling back to the data node on `:9000`.
- `verify-multinode-clickhouse.py` now asserts the logs node's role, cluster membership, and that the base logs tables (`logs34`, `log_attributes2`, `logs_billing_metrics`, `logs_kafka_metrics`) land on it and not on the data node.
- Add `clickhouse-logs` to the `start-multinode-clickhouse` local-dev helper so manual boots include it too.

## How did you test this code?

I'm an agent (PostHog Code), human-directed. **Booted the full 6-node stack locally and ran it end to end:**

- `manage.py migrate_clickhouse` against the stack (with `MULTINODE_CLICKHOUSE=1`) → **✅ Migration successful** — all migrations, including the existing logs migrations (`0200`/`0211`/`0214`/`0223`/`0280`), applied against the new logs node. This is the first time they've actually run there.
- `verify-multinode-clickhouse.py` → **OK**: `clickhouse-logs` reports `hostClusterRole=logs`, all 10 logical clusters are consistent across every node, and the base logs tables are present on the logs node (22 tables) and **not** leaked onto the data node.
- This confirmed two things that would otherwise have only surfaced in CI: the missing `warpstream_logs` named collection (without it `0280` fails creating `kafka_logs_avro`) and the missing `clickhouse-logs` port override (without it logs connections hit the data node).

The smoke job also runs on this PR (it touches the multinode config + workflow paths) for the canonical CI signal.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal CI/migration-tooling change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus).
- Companion to #66102. That PR makes the `any_host_by_roles` migration path skip-on-empty (cheap unblock + safety net for any role-without-a-node); this PR removes the underlying gap by actually giving the smoke a logs node so logs migrations get real coverage. They're complementary — either can land independently.
- Key decision: declare `warpstream_logs` on the nodes rather than guard the kafka ops in the migration. The smoke already declares the other `warpstream_*` collections for exactly this reason, so this matches the existing pattern and keeps the prod migration untouched.
- Open question for the ClickHouse/logs team: confirm prod's *migrations* cluster actually includes a `logs`-role host (vs logs schema applied out-of-band). This PR models it that way for the smoke; worth confirming it matches prod.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

