### PR TITLE
chore(logs): add logs node to clickhouse multinode smoke test

### DIFF
--- a/.github/workflows/ci-clickhouse-multinode-migrations.yml
+++ b/.github/workflows/ci-clickhouse-multinode-migrations.yml
@@ -72,7 +72,7 @@ jobs:
 
             - name: Add multinode hostnames to /etc/hosts
               run: |
-                  echo "127.0.0.1 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions kafka zookeeper" | sudo tee -a /etc/hosts
+                  echo "127.0.0.1 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs kafka zookeeper" | sudo tee -a /etc/hosts
 
             - name: Set up Python
               uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0

--- a/docker-compose.multinode-clickhouse.yml
+++ b/docker-compose.multinode-clickhouse.yml
@@ -1,7 +1,7 @@
 #
 # Multi-node ClickHouse smoke-test stack.
 #
-# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions)
+# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions + logs)
 # so migration runs can be verified against a topology that resembles production.
 # Opt-in only: not used by `bin/start` or any of the default dev/CI flows.
 # Driven by `tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke`
@@ -135,6 +135,22 @@ services:
         ports:
             - '8127:8123'
             - '9400:9000'
+
+    clickhouse-logs:
+        <<: *clickhouse-multinode
+        hostname: clickhouse-logs
+        volumes:
+            - ./posthog/idl:/idl
+            - ./docker/clickhouse/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+            - ./docker/clickhouse/config.xml:/etc/clickhouse-server/config.xml
+            - ./docker/clickhouse/config.d/multinode/logs_node.xml:/etc/clickhouse-server/config.d/default.xml
+            - ./docker/clickhouse/config.d/dev-memory.xml:/etc/clickhouse-server/config.d/dev-memory.xml
+            - ./docker/clickhouse/users-dev.xml:/etc/clickhouse-server/users.xml
+            - ./docker/clickhouse/user_defined_function.xml:/etc/clickhouse-server/user_defined_function.xml
+            - ./posthog/user_scripts:/var/lib/clickhouse/user_scripts
+        ports:
+            - '8128:8123'
+            - '9500:9000'
 
 volumes:
     redpanda-data:

--- a/docker/clickhouse/config.d/multinode/ai_events_node.xml
+++ b/docker/clickhouse/config.d/multinode/ai_events_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/data_node.xml
+++ b/docker/clickhouse/config.d/multinode/data_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/logs_node.xml
+++ b/docker/clickhouse/config.d/multinode/logs_node.xml
@@ -142,8 +142,8 @@
 
     <macros>
         <shard>01</shard>
-        <replica>aux</replica>
+        <replica>logs</replica>
         <hostClusterType>online</hostClusterType>
-        <hostClusterRole>aux</hostClusterRole>
+        <hostClusterRole>logs</hostClusterRole>
     </macros>
 </clickhouse>

--- a/docker/clickhouse/config.d/multinode/ops_node.xml
+++ b/docker/clickhouse/config.d/multinode/ops_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/docker/clickhouse/config.d/multinode/sessions_node.xml
+++ b/docker/clickhouse/config.d/multinode/sessions_node.xml
@@ -66,6 +66,12 @@
                     <port>9000</port>
                 </replica>
             </shard>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
         </posthog_migrations>
 
         <ai_events>
@@ -100,6 +106,14 @@
                 </replica>
             </shard>
         </sessions>
+        <logs>
+            <shard>
+                <replica>
+                    <host>clickhouse-logs</host>
+                    <port>9000</port>
+                </replica>
+            </shard>
+        </logs>
     </remote_servers>
 
     <named_collections>
@@ -121,6 +135,9 @@
         <warpstream_cyclotron>
             <kafka_broker_list from_env="KAFKA_HOSTS"/>
         </warpstream_cyclotron>
+        <warpstream_logs>
+            <kafka_broker_list from_env="KAFKA_HOSTS"/>
+        </warpstream_logs>
     </named_collections>
 
     <macros>

--- a/posthog/clickhouse/cluster.py
+++ b/posthog/clickhouse/cluster.py
@@ -62,6 +62,7 @@ _MULTINODE_HOST_PORT_OVERRIDES: dict[str, tuple[str, int]] = {
     "clickhouse-aux": ("localhost", 9200),
     "clickhouse-ops": ("localhost", 9300),
     "clickhouse-sessions": ("localhost", 9400),
+    "clickhouse-logs": ("localhost", 9500),
 }
 
 

--- a/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
+++ b/tools/infra-scripts/clickhouse-multinode/multinode-migration-smoke
@@ -2,7 +2,7 @@
 #
 # End-to-end smoke test for ClickHouse migrations against a multi-node topology.
 #
-# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions),
+# Boots one ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions + logs),
 # runs `manage.py migrate_clickhouse` with MULTINODE_CLICKHOUSE=1 (so migrations respect
 # their declared NodeRole instead of being collapsed to NodeRole.ALL), then runs the
 # verification script to assert each node ended up with the tables it should have.
@@ -24,7 +24,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR/../../.."
 
 COMPOSE_FILE="docker-compose.multinode-clickhouse.yml"
-CH_SERVICES=(clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions)
+CH_SERVICES=(clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs)
 INFRA_SERVICES=(zookeeper kafka db redis7)
 ALL_SERVICES=("${INFRA_SERVICES[@]}" "${CH_SERVICES[@]}")
 HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-180}"

--- a/tools/infra-scripts/clickhouse-multinode/start-multinode-clickhouse
+++ b/tools/infra-scripts/clickhouse-multinode/start-multinode-clickhouse
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # Boot the multinode ClickHouse smoke-test stack in the background.
-# One ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions).
+# One ClickHouse server per logical cluster (data + ai_events + aux + ops + sessions + logs).
 # This is opt-in tooling for verifying migration routing — `bin/start` is unaffected.
 #
 
@@ -12,7 +12,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR/../../.."
 
 COMPOSE_FILE="docker-compose.multinode-clickhouse.yml"
-SERVICES=(zookeeper kafka db redis7 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions)
+SERVICES=(zookeeper kafka db redis7 clickhouse-data clickhouse-ai-events clickhouse-aux clickhouse-ops clickhouse-sessions clickhouse-logs)
 
 case "${1:-up}" in
     up)
@@ -24,6 +24,7 @@ case "${1:-up}" in
         echo "  clickhouse-aux        localhost:9200 (HTTP 8125)"
         echo "  clickhouse-ops        localhost:9300 (HTTP 8126)"
         echo "  clickhouse-sessions   localhost:9400 (HTTP 8127)"
+        echo "  clickhouse-logs       localhost:9500 (HTTP 8128)"
         echo
         echo "To run migrations against this stack, set:"
         echo "  export MULTINODE_CLICKHOUSE=1"

--- a/tools/infra-scripts/clickhouse-multinode/verify-multinode-clickhouse.py
+++ b/tools/infra-scripts/clickhouse-multinode/verify-multinode-clickhouse.py
@@ -42,6 +42,7 @@ NODES: list[Node] = [
     Node("clickhouse-aux", "localhost", 9200, "aux"),
     Node("clickhouse-ops", "localhost", 9300, "ops"),
     Node("clickhouse-sessions", "localhost", 9400, "sessions"),
+    Node("clickhouse-logs", "localhost", 9500, "logs"),
 ]
 
 # Logical cluster -> expected member hosts (sorted). Each multinode XML file
@@ -55,6 +56,7 @@ EXPECTED_CLUSTERS: dict[str, list[str]] = {
         "clickhouse-ai-events",
         "clickhouse-aux",
         "clickhouse-data",
+        "clickhouse-logs",
         "clickhouse-ops",
         "clickhouse-sessions",
     ],
@@ -62,6 +64,7 @@ EXPECTED_CLUSTERS: dict[str, list[str]] = {
     "aux": ["clickhouse-aux"],
     "ops": ["clickhouse-ops"],
     "sessions": ["clickhouse-sessions"],
+    "logs": ["clickhouse-logs"],
 }
 
 
@@ -86,6 +89,10 @@ SATELLITE_TABLE_MANIFEST: dict[str, SatelliteTables] = {
     "aux": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
     "ops": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
     "sessions": SatelliteTables(on_satellite=[], forbidden_on_data=[]),
+    "logs": SatelliteTables(
+        on_satellite=["logs34"],
+        forbidden_on_data=["logs34"],
+    ),
 }
 
 DATABASE = "posthog"


### PR DESCRIPTION
## Problem

The multinode ClickHouse smoke test boots one server per logical cluster (data + ai_events + aux + ops + sessions) and verifies migrations route to the right node. But it had no `logs` node, even though `NodeRole.LOGS` is a satellite-style role and every logs CH migration declares `node_roles=[NodeRole.LOGS]`.

With no `logs`-role host in the stack, those migrations matched no node and were silently skipped during the smoke run — so the test gave us zero coverage of logs migration routing. A logs migration that forgot its `node_roles` (and thus leaked tables onto the data node) would have sailed through.

## Changes

Adds a `clickhouse-logs` node to the smoke stack and asserts logs tables land only on it:

- **New `logs_node.xml`** per-role config (`hostClusterRole=logs`).
- **All six node configs** now carry the `clickhouse-logs` shard in `posthog_migrations` (so migration host-discovery finds it), a `<logs>` remote cluster, and the `warpstream_logs` named collection. The per-role files mount over the standard `default.xml`, which defines `warpstream_logs`; without it the logs Kafka table fails to create. The configs stay identical except for their `<macros>`, matching the existing convention.
- **`docker-compose.multinode-clickhouse.yml`** — new `clickhouse-logs` service on ports `8128:8123` / `9500:9000`.
- **`cluster.py`** — host/port override so host-side role-routed connections reach `localhost:9500`.
- **`verify-multinode-clickhouse.py`** — new node, the `logs` cluster + `posthog_migrations` membership, and a manifest entry asserting `logs34` exists on the logs node and is **forbidden on the data node**.
- **Scripts + CI** — service lists, the port banner, and the CI `/etc/hosts` line all include `clickhouse-logs`.

## How did you test this code?

I'm an agent. I did not run the full Docker-based smoke (it needs a running Docker daemon + the multinode stack). Automated/static checks I actually ran:

- All six multinode XML configs parse via `xml.dom.minidom`.
- `verify-multinode-clickhouse.py` compiles (`py_compile`).
- Both bash scripts pass `bash -n`.
- `docker compose -f docker-compose.multinode-clickhouse.yml config --services` lists `clickhouse-logs`.
- lint-staged (ruff, ty, yaml format) ran clean on commit.

The CI workflow `ClickHouse Multinode Migration Smoke` exercises this end to end on push.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). No repo skills were invoked — the change is infra/config tooling, not a Django/ClickHouse migration or DRF endpoint.

Key decision: `logs` routing only needs the node in `posthog_migrations` + the `hostClusterRole=logs` macro. The `<logs>` cluster and the `warpstream_logs` named collection were added to keep the per-role configs consistent and to let the logs Kafka table actually create on the node — discovered by tracing `kafka_logs_avro` → `KAFKA_NAMED_COLLECTION = "warpstream_logs"`, which the multinode `default.xml` override was missing. Picked `logs34` for the placement assertion since it's the current canonical logs data table.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
