### PR TITLE
chore(renovate): add release-age cooldown for all ecosystems

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -23,6 +23,12 @@
   vulnerabilityAlerts: {
     enabled: false,
   },
+  // Supply-chain cooldown: hold a new release for 3 days before updating, for every
+  // manager. config:best-practices only cools npm (via security:minimumReleaseAgeNpm),
+  // leaving pep621/cargo/gomod/github-actions with no delay. Security/OSV updates
+  // bypass minimumReleaseAge, so vulnerability fixes are never held back.
+  minimumReleaseAge: '3 days',
+  internalChecksFilter: 'strict',
   ignorePaths: [
     'common/hogql_parser/**',
   ],


### PR DESCRIPTION
## Problem

`config:best-practices` cools only the **npm** datasource (via `security:minimumReleaseAgeNpm`). Our other managers — `pep621`, `cargo`, `gomod`, `github-actions` — get zero delay, so a freshly published version can open a Renovate PR the moment it lands.

## Changes

Two top-level keys in `.github/renovate.json5` close the gap:

- `minimumReleaseAge: '3 days'` — hold every manager's updates for 3 days. Same window as npm, so all ecosystems cool uniformly. Security/OSV updates bypass it, so fixes are never delayed.
- `internalChecksFilter: 'strict'` — don't raise a branch/PR until the release has aged. Renovate's default, set explicitly per the docs' recommendation when using `minimumReleaseAge`.

npm is unchanged (its preset window is already 3 days). The `chrome-headless-shell` datasource has no release timestamp, so the cooldown is a no-op there.

## How did you test this code?

I'm an agent. Ran `renovate-config-validator` against the file ("Config validated successfully"); confirmed the JSON5 parses. There's no repo CI step for this config — Renovate validates it server-side. Semantics (age bypass for security updates, `strict` as default) cross-checked against the [Renovate docs](https://docs.renovatebot.com/key-concepts/minimum-release-age/).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @rnegron. Reviewed and simplified via `/code-review` and `/simplify` — no changes needed. Chose `3 days` (matches npm) over `7` to avoid an npm-vs-rest split.
