### PR TITLE
chore(devenv): parametrize otel COMPOSE_PROJECT for worktrees

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -688,8 +688,10 @@ services:
             - ./otel-collector-config.dev.yaml:/etc/otel-collector-config.yaml
         environment:
             # Used by otel-collector-config.dev.yaml to scope container log
-            # collection to this compose project only.
-            COMPOSE_PROJECT: posthog
+            # collection to this compose project only. Reads the active compose
+            # project so per-worktree namespacing (COMPOSE_PROJECT_NAME) still
+            # matches; defaults to posthog for bare `docker compose` outside direnv.
+            COMPOSE_PROJECT: '${COMPOSE_PROJECT_NAME:-posthog}'
         extra_hosts:
             - 'host.docker.internal:host-gateway'
         depends_on:


### PR DESCRIPTION
## Problem

`docker-compose.dev.yml`'s `otel-collector` hardcodes `COMPOSE_PROJECT: posthog`. `otel-collector-config.dev.yaml` reads it to scope container-log collection (`labels["com.docker.compose.project"] == "${env:COMPOSE_PROJECT}"`). Under a worktree stack with a different `COMPOSE_PROJECT_NAME`, the collector keeps filtering for `posthog` and silently collects no logs. `docker-compose.sandbox.yml` already parametrizes this; `dev.yml` is the outlier.

## Changes

`COMPOSE_PROJECT: posthog` → `COMPOSE_PROJECT: '${COMPOSE_PROJECT_NAME:-posthog}'`, mirroring `docker-compose.sandbox.yml`.

No-op today (`.envrc` exports `COMPOSE_PROJECT_NAME=posthog`); the `:-posthog` default covers bare `docker compose` outside direnv. Only affects the local `observability` profile.

## How did you test this code?

I'm an agent. Verified the file parses as YAML and the interpolation resolves as expected; confirmed via grep that nothing references the literal container names by string. No automated test covers local compose config.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @rnegron; reviewed via `/code-review` and `/simplify` (no findings). Scoped to the single line — left the hardcoded `container_name`s alone as a separable change.
