### PR TITLE
docs(ty): note ty runs as a pre-commit check, not CI-only

### DIFF
--- a/docs/internal/ty.md
+++ b/docs/internal/ty.md
@@ -19,7 +19,7 @@ uv run ty check posthog ee         # Check directories
 
 - Extremely fast (~10-100x faster than mypy)
 - Alpha software — expect edge cases
-- Runs in CI only (non-blocking) to gather feedback
+- Runs in CI (informational, non-blocking) and as a lint-staged pre-commit check to gather feedback
 - Uses GitHub problem matcher to show warnings inline
 
 **mypy** remains the **authoritative type checker**:


### PR DESCRIPTION
## Problem

`docs/internal/ty.md` said ty "Runs in CI only (non-blocking)". Wrong — lint-staged also runs `uv run ty check` as a pre-commit hook (`package.json`), so the doc misleads anyone debugging a ty-rejected commit.

## Changes

One line in `docs/internal/ty.md`, now describing both surfaces:

> - Runs in CI (informational, non-blocking) and as a lint-staged pre-commit check to gather feedback

Docs-only — does not touch ty's behavior.

## How did you test this code?

I'm an agent; no code changed. Verified the wording matches the `uv run ty check` entry in `package.json`'s lint-staged config. Prettier-clean via the markdown pre-commit hook.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent-authored with Claude Code, directed by @rnegron. Corrects a stale line; deliberately kept docs-only (no `continue-on-error`, no removing ty from pre-commit). Review and simplify passes found nothing to change.
