### PR TITLE
chore(devenv): remove orphan hypercache capability + guard test

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -341,7 +341,7 @@ procs:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service hypercache-server
-        capability: hypercache
+        # no capability: always_required via intent-map.yaml
         ready_pattern: 'listening on *'
         groups:
             layer: Product services

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -512,6 +512,17 @@ class TestMprocsRegistry:
         assert "shell" in config
         assert "start-backend" in config["shell"]
 
+    def test_all_declared_capabilities_are_defined(self) -> None:
+        # Every capability a proc declares must be defined in intent-map.yaml.
+        # An orphan capability is benign only while its proc is always_required;
+        # routing it through resolution raises ValueError (resolver.py).
+        registry = create_mprocs_registry()
+        intent_map = load_intent_map()
+
+        orphans = registry.get_all_capabilities() - set(intent_map.capabilities)
+
+        assert not orphans, f"procs declare capabilities not defined in intent-map.yaml: {orphans}"
+
 
 class TestDevenvConfig:
     """Test DevenvConfig data class."""

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -513,9 +513,7 @@ class TestMprocsRegistry:
         assert "start-backend" in config["shell"]
 
     def test_all_declared_capabilities_are_defined(self) -> None:
-        # Every capability a proc declares must be defined in intent-map.yaml.
-        # An orphan capability is benign only while its proc is always_required;
-        # routing it through resolution raises ValueError (resolver.py).
+        """Every proc-declared capability must exist in intent-map.yaml; orphans raise ValueError on resolution."""
         registry = create_mprocs_registry()
         intent_map = load_intent_map()
 


### PR DESCRIPTION
## Problem

`hypercache-server` in `bin/mprocs.yaml` declares `capability: hypercache`, but `intent-map.yaml` never defines that capability — the sole orphan. Harmless today only because the proc is `always_required` (started by name, never routed through capability resolution); the moment anything resolves it, `IntentResolver` raises `ValueError("Unknown capability ...")`. Nothing guards this drift.

## Changes

- Drop the orphan `capability: hypercache` line — `hypercache-server` already starts via `always_required`.
- Add `test_all_declared_capabilities_are_defined` to `TestMprocsRegistry`: asserts every proc-declared capability is defined in `intent-map.yaml`, via the real `create_mprocs_registry()` / `load_intent_map()` loaders.

## How did you test this code?

I'm an agent. Ran the new test and the surrounding `TestMprocsRegistry` / `TestIntentMapLoading` / `TestIntentResolver` classes — 19 passed. Confirmed the guard fails on the pre-fix tree (flags `{'hypercache'}`) and passes after the removal.

**Test justification:** catches a re-introduced orphan capability (a proc declaring a capability the intent map doesn't define). No existing test covered this — `test_registry_get_all_capabilities` only checks specific names are present, never the declared⊆defined invariant.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @rnegron. The durable value is the guard test, not the one-line removal — it stops the next orphan from sitting latent until something routes it through resolution.
