### PR TITLE
fix(devenv): recognize proc-backed nodejs capability groups

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -74,7 +74,8 @@ procs:
             tech: Node
         # Node.js capabilities are controlled via NODEJS_CAPABILITY_GROUPS env var
         # Set by hogli dev:generate based on selected nodejs_* capabilities
-        # Valid groups: cdp_workflows, realtime_cohorts, session_replay, logs, traces, metrics, feature_flags
+        # Merged into this plugin-server: cdp, cdp_workflows, realtime_cohorts, feature_flags
+        # Run as dedicated ingestion-* procs: session_replay, logs, metrics, traces, error_tracking
         # Example: NODEJS_CAPABILITY_GROUPS=cdp_workflows,session_replay
 
     ingestion-errortracking:

--- a/nodejs/src/capabilities.ts
+++ b/nodejs/src/capabilities.ts
@@ -68,6 +68,14 @@ const CAPABILITY_GROUP_MAP: Record<string, PluginServerCapabilities> = {
     feature_flags: CAPABILITIES_FEATURE_FLAGS,
 }
 
+/**
+ * Capability groups that run as dedicated ingestion-* processes (see bin/mprocs.yaml),
+ * not inside this plugin-server. They are valid NODEJS_CAPABILITY_GROUPS values, so
+ * recognize them here to avoid a spurious "unknown group" warning; they contribute no
+ * capabilities to this process.
+ */
+const PROC_BACKED_GROUPS = new Set(['session_replay', 'logs', 'metrics', 'traces', 'error_tracking'])
+
 export function getPluginServerCapabilities(
     config: Pick<CommonConfig, 'PLUGIN_SERVER_MODE' | 'NODEJS_CAPABILITY_GROUPS'>
 ): PluginServerCapabilities {
@@ -87,7 +95,7 @@ export function getPluginServerCapabilities(
                     const groupCapabilities = CAPABILITY_GROUP_MAP[group]
                     if (groupCapabilities) {
                         capabilities.push(groupCapabilities)
-                    } else {
+                    } else if (!PROC_BACKED_GROUPS.has(group)) {
                         console.warn(`Unknown Node.js capability group: ${group}`)
                     }
                 }


### PR DESCRIPTION
## Problem

`hogli dev` derives `NODEJS_CAPABILITY_GROUPS` from the selected `nodejs_*` capabilities (generator strips the `nodejs_` prefix). The plugin-server's `CAPABILITY_GROUP_MAP` recognizes only 4 of the 9 groups (`cdp`, `cdp_workflows`, `realtime_cohorts`, `feature_flags`). The other 5 — `session_replay`, `logs`, `metrics`, `traces`, `error_tracking` — run as dedicated `ingestion-*` processes (`bin/mprocs.yaml`), so selecting any of them logs a spurious `Unknown Node.js capability group: ...` warning on boot. The `mprocs.yaml` comment listing valid groups was also wrong both ways.

## Changes

- Add a `PROC_BACKED_GROUPS` set in `nodejs/src/capabilities.ts` and skip the "unknown group" warning for those 5. They contribute no capabilities here either way — only the warning noise goes away.
- Fix the `bin/mprocs.yaml` comment to show which groups merge into the plugin-server vs. run as `ingestion-*` procs.

Kept the fix consumer-side on purpose: filtering proc-backed caps in the generator would empty `NODEJS_CAPABILITY_GROUPS` for a logs/metrics-only dev and fall through to the *default* capability set — a real behavior change.

## How did you test this code?

I'm an agent. Ran `tsc --noEmit`, Prettier, and ESLint on `nodejs/src/capabilities.ts` — all clean. No test added: the only behavioral delta is suppressing a dev-only `console.warn`; the returned capability set is unchanged (the 5 groups were never in `CAPABILITY_GROUP_MAP`), so a capabilities assertion would pass on master too, and a "did it warn" check is a weak side-effect test.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @rnegron. Invoked `/writing-tests` (concluded no test earns its place), `/code-review`, and `/simplify` (both found the diff already minimal and behavior-preserving). Chose the consumer-side fix over the generator-side one to avoid silently widening a single-capability dev's plugin-server scope. (Commit is unsigned — the local 1Password SSH-signing agent intermittently failed; happy to re-sign on request.)
