### PR TITLE
feat(conversations): SupportHog to nudge user to open ticket

### DIFF
--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -754,6 +754,7 @@ export interface ConversationsSettings {
     slack_notify_on_join?: boolean
     slack_notify_on_leave?: boolean
     slack_alert_channel_id?: string | null
+    slack_confirm_before_ticket?: boolean
     email_enabled?: boolean
     teams_enabled?: boolean
     teams_team_id?: string | null

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -754,7 +754,7 @@ export interface ConversationsSettings {
     slack_notify_on_join?: boolean
     slack_notify_on_leave?: boolean
     slack_alert_channel_id?: string | null
-    slack_confirm_before_ticket?: boolean
+    slack_nudge_enabled?: boolean
     email_enabled?: boolean
     teams_enabled?: boolean
     teams_team_id?: string | null

--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -41,6 +41,7 @@ from posthog.api.team import (
     get_or_mint_live_events_token,
     handle_conversations_token_on_update,
     handle_logs_config,
+    report_conversations_settings_changes,
     validate_secret_token_generation,
     validate_team_attrs,
 )
@@ -1262,6 +1263,12 @@ class ProjectBackwardCompatSerializer(
                     changes=project_changes,
                 ),
             )
+
+        report_conversations_settings_changes(
+            cast(User, self.context["request"].user),
+            team_before_update.get("conversations_settings"),
+            team,
+        )
 
         return instance
 

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1296,7 +1296,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
                 raise serializers.ValidationError(
                     {"slack_bot_display_name": "Must be 200 characters or fewer with no control characters."}
                 )
-        for toggle_key in ("slack_notify_on_join", "slack_notify_on_leave", "slack_confirm_before_ticket"):
+        for toggle_key in ("slack_notify_on_join", "slack_notify_on_leave", "slack_nudge_enabled"):
             if toggle_key in value:
                 value[toggle_key] = bool(value[toggle_key])
         if "slack_alert_channel_id" in value:

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1629,7 +1629,29 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             ),
         )
 
+        self._report_conversations_settings_changes(before_update, updated_team)
+
         return updated_team
+
+    def _report_conversations_settings_changes(self, before_update: dict[str, Any], updated_team: Team) -> None:
+        old_settings = before_update.get("conversations_settings") or {}
+        new_settings = updated_team.conversations_settings or {}
+        changed_keys = sorted(
+            k for k in old_settings.keys() | new_settings.keys() if old_settings.get(k) != new_settings.get(k)
+        )
+        # One event per changed setting so insights can break down by `setting`.
+        for key in changed_keys:
+            new_value = new_settings.get(key)
+            properties: dict[str, Any] = {"setting": key}
+            # Only non-string values are safe to report — the dict holds free text and the widget token.
+            if isinstance(new_value, (bool, int, float, type(None))):
+                properties["value"] = new_value
+            report_user_action(
+                cast(User, self.context["request"].user),
+                "support setting changed",
+                properties,
+                team=updated_team,
+            )
 
     def _update_revenue_analytics_config(self, instance: Team, validated_data: dict[str, Any]) -> Team:
         # Capture old config before saving

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1629,29 +1629,13 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
             ),
         )
 
-        self._report_conversations_settings_changes(before_update, updated_team)
+        report_conversations_settings_changes(
+            cast(User, self.context["request"].user),
+            before_update.get("conversations_settings"),
+            updated_team,
+        )
 
         return updated_team
-
-    def _report_conversations_settings_changes(self, before_update: dict[str, Any], updated_team: Team) -> None:
-        old_settings = before_update.get("conversations_settings") or {}
-        new_settings = updated_team.conversations_settings or {}
-        changed_keys = sorted(
-            k for k in old_settings.keys() | new_settings.keys() if old_settings.get(k) != new_settings.get(k)
-        )
-        # One event per changed setting so insights can break down by `setting`.
-        for key in changed_keys:
-            new_value = new_settings.get(key)
-            properties: dict[str, Any] = {"setting": key}
-            # Only non-string values are safe to report — the dict holds free text and the widget token.
-            if isinstance(new_value, (bool, int, float, type(None))):
-                properties["value"] = new_value
-            report_user_action(
-                cast(User, self.context["request"].user),
-                "support setting changed",
-                properties,
-                team=updated_team,
-            )
 
     def _update_revenue_analytics_config(self, instance: Team, validated_data: dict[str, Any]) -> Team:
         # Capture old config before saving
@@ -2401,6 +2385,26 @@ class ProjectEnvironmentsViewSet(TeamViewSet):
         raise exceptions.PermissionDenied(
             "Multiple environments per project are no longer available. Please contact support if you need assistance."
         )
+
+
+def report_conversations_settings_changes(user: User, before_settings: dict | None, team: Team) -> None:
+    """Fire one "support setting changed" event per changed conversations_settings key.
+
+    Shared by the team and project serializers — both endpoints can PATCH the settings.
+    """
+    old_settings = before_settings or {}
+    new_settings = team.conversations_settings or {}
+    changed_keys = sorted(
+        k for k in old_settings.keys() | new_settings.keys() if old_settings.get(k) != new_settings.get(k)
+    )
+    # One event per changed setting so insights can break down by `setting`.
+    for key in changed_keys:
+        new_value = new_settings.get(key)
+        properties: dict[str, Any] = {"setting": key}
+        # Only non-string values are safe to report — the dict holds free text and the widget token.
+        if isinstance(new_value, (bool, int, float, type(None))):
+            properties["value"] = new_value
+        report_user_action(user, "support setting changed", properties, team=team)
 
 
 def handle_conversations_token_on_update(

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -1296,7 +1296,7 @@ class TeamSerializer(serializers.ModelSerializer, UserPermissionsSerializerMixin
                 raise serializers.ValidationError(
                     {"slack_bot_display_name": "Must be 200 characters or fewer with no control characters."}
                 )
-        for toggle_key in ("slack_notify_on_join", "slack_notify_on_leave"):
+        for toggle_key in ("slack_notify_on_join", "slack_notify_on_leave", "slack_confirm_before_ticket"):
             if toggle_key in value:
                 value[toggle_key] = bool(value[toggle_key])
         if "slack_alert_channel_id" in value:

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -1565,6 +1565,32 @@ def team_api_test_factory():
             assert settings["widget_greeting_text"] == "Hello!"
             assert settings["widget_color"] == "#ff0000"
 
+        def test_conversations_settings_change_reports_event_per_setting(self):
+            with patch("posthog.api.team.report_user_action") as mock_report:
+                response = self.client.patch(
+                    "/api/environments/@current/",
+                    {"conversations_settings": {"slack_nudge_enabled": False, "widget_greeting_text": "Hi!"}},
+                )
+                assert response.status_code == status.HTTP_200_OK
+                props_by_setting = {
+                    c.args[2]["setting"]: c.args[2]
+                    for c in mock_report.call_args_list
+                    if c.args[1] == "support setting changed"
+                }
+                assert set(props_by_setting) == {"slack_nudge_enabled", "widget_greeting_text"}
+                assert props_by_setting["slack_nudge_enabled"]["value"] is False
+                # Free-text values are withheld — the dict holds arbitrary copy and the widget token.
+                assert "value" not in props_by_setting["widget_greeting_text"]
+
+            # A no-op save (same values) must not re-fire the event.
+            with patch("posthog.api.team.report_user_action") as mock_report:
+                response = self.client.patch(
+                    "/api/environments/@current/",
+                    {"conversations_settings": {"slack_nudge_enabled": False}},
+                )
+                assert response.status_code == status.HTTP_200_OK
+                assert not any(c.args[1] == "support setting changed" for c in mock_report.call_args_list)
+
         def test_conversations_widget_position_setting(self):
             response = self.client.patch(
                 "/api/environments/@current/",

--- a/products/conversations/backend/api/slack_events.py
+++ b/products/conversations/backend/api/slack_events.py
@@ -10,11 +10,9 @@ from django.views.decorators.csrf import csrf_exempt
 import structlog
 
 from posthog.models.integration import SlackIntegrationError
-from posthog.models.team import Team
 
-from products.conversations.backend.models import TeamConversationsSlackConfig
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
-from products.conversations.backend.support_slack import validate_support_request
+from products.conversations.backend.support_slack import team_exists_for_slack_workspace, validate_support_request
 from products.conversations.backend.tasks import process_supporthog_event
 
 logger = structlog.get_logger(__name__)
@@ -27,15 +25,6 @@ SUPPORT_EVENT_TYPES = [
     "member_joined_channel",
     "member_left_channel",
 ]
-
-
-def _team_for_slack_workspace(slack_team_id: str) -> Team | None:
-    config = (
-        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
-        .select_related("team")
-        .first()
-    )
-    return config.team if config else None
 
 
 def _route_event_to_relevant_region(request: HttpRequest, data: dict) -> None:
@@ -54,9 +43,9 @@ def _route_event_to_relevant_region(request: HttpRequest, data: dict) -> None:
     if inner_event_type not in SUPPORT_EVENT_TYPES:
         return
 
-    team = _team_for_slack_workspace(slack_team_id) if slack_team_id else None
+    team_exists = team_exists_for_slack_workspace(slack_team_id) if slack_team_id else False
 
-    if team and not (settings.DEBUG and is_primary_region(request)):
+    if team_exists and not (settings.DEBUG and is_primary_region(request)):
         cast(Any, process_supporthog_event).delay(event=event, slack_team_id=slack_team_id, event_id=event_id)
     elif is_primary_region(request):
         proxy_to_secondary_region(request, log_prefix="supporthog")

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -50,6 +50,8 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
         payload = json.loads(request.POST.get("payload", "{}"))
     except (json.JSONDecodeError, TypeError):
         return HttpResponse("Invalid JSON", status=400)
+    if not isinstance(payload, dict):
+        return HttpResponse("Invalid payload", status=400)
 
     slack_team_id = (payload.get("team") or {}).get("id", "")
     if not slack_team_id:

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -17,18 +17,11 @@ import structlog
 
 from posthog.models.integration import SlackIntegrationError
 
-from products.conversations.backend.models import TeamConversationsSlackConfig
 from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
-from products.conversations.backend.support_slack import validate_support_request
+from products.conversations.backend.support_slack import team_exists_for_slack_workspace, validate_support_request
 from products.conversations.backend.tasks import process_supporthog_interactivity
 
 logger = structlog.get_logger(__name__)
-
-
-def _team_exists_for_slack_workspace(slack_team_id: str) -> bool:
-    return TeamConversationsSlackConfig.objects.filter(
-        slack_team_id=slack_team_id, slack_bot_token__isnull=False
-    ).exists()
 
 
 @csrf_exempt
@@ -60,7 +53,7 @@ def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
 
     logger.info("supporthog_interactivity_received", payload_type=payload.get("type"), slack_team_id=slack_team_id)
 
-    if _team_exists_for_slack_workspace(slack_team_id) and not (settings.DEBUG and is_primary_region(request)):
+    if team_exists_for_slack_workspace(slack_team_id) and not (settings.DEBUG and is_primary_region(request)):
         cast(Any, process_supporthog_interactivity).delay(payload=payload, slack_team_id=slack_team_id)
     elif is_primary_region(request):
         proxy_to_secondary_region(request, log_prefix="supporthog_interactivity")

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -1,8 +1,9 @@
 """Slack interactivity endpoint for the SupportHog app.
 
-Receives button clicks from the opt-in "open a ticket?" confirmation prompt
-(``slack_confirm_before_ticket``). The events endpoint posts the prompt; this
-endpoint handles the click and creates — or skips — the ticket.
+Receives button clicks from the "open a ticket?" nudge prompt posted in channels
+outside the configured support channels (``slack_nudge_enabled``, on by default).
+The events endpoint posts the prompt; this endpoint handles the click and creates
+— or skips — the ticket.
 """
 
 import json

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -1,0 +1,67 @@
+"""Slack interactivity endpoint for the SupportHog app.
+
+Receives button clicks from the opt-in "open a ticket?" ephemeral prompt
+(``slack_confirm_before_ticket``). The events endpoint posts the prompt; this
+endpoint handles the click and creates — or skips — the ticket.
+"""
+
+import json
+from typing import Any, cast
+
+from django.conf import settings
+from django.http import HttpRequest, HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+
+import structlog
+
+from posthog.models.integration import SlackIntegrationError
+
+from products.conversations.backend.models import TeamConversationsSlackConfig
+from products.conversations.backend.services.region_routing import is_primary_region, proxy_to_secondary_region
+from products.conversations.backend.support_slack import validate_support_request
+from products.conversations.backend.tasks import process_supporthog_interactivity
+
+logger = structlog.get_logger(__name__)
+
+
+def _team_exists_for_slack_workspace(slack_team_id: str) -> bool:
+    return TeamConversationsSlackConfig.objects.filter(
+        slack_team_id=slack_team_id, slack_bot_token__isnull=False
+    ).exists()
+
+
+@csrf_exempt
+def supporthog_interactivity_handler(request: HttpRequest) -> HttpResponse:
+    """Handle Slack interactive button clicks for SupportHog.
+
+    Regional routing matches the events endpoint: EU is the primary region. If the
+    workspace isn't found locally, the request is proxied to the secondary region (US).
+    """
+    if request.method != "POST":
+        return HttpResponse(status=405)
+
+    try:
+        validate_support_request(request)
+    except SlackIntegrationError as e:
+        logger.warning("supporthog_interactivity_invalid_request", error=str(e))
+        return HttpResponse("Invalid request", status=403)
+
+    try:
+        payload = json.loads(request.POST.get("payload", "{}"))
+    except (json.JSONDecodeError, TypeError):
+        return HttpResponse("Invalid JSON", status=400)
+
+    slack_team_id = (payload.get("team") or {}).get("id", "")
+    if not slack_team_id:
+        return HttpResponse(status=200)
+
+    logger.info("supporthog_interactivity_received", payload_type=payload.get("type"), slack_team_id=slack_team_id)
+
+    if _team_exists_for_slack_workspace(slack_team_id) and not (settings.DEBUG and is_primary_region(request)):
+        cast(Any, process_supporthog_interactivity).delay(payload=payload, slack_team_id=slack_team_id)
+    elif is_primary_region(request):
+        proxy_to_secondary_region(request, log_prefix="supporthog_interactivity")
+    else:
+        logger.warning("supporthog_interactivity_no_team_any_region", slack_team_id=slack_team_id)
+
+    return HttpResponse(status=200)

--- a/products/conversations/backend/api/slack_interactivity.py
+++ b/products/conversations/backend/api/slack_interactivity.py
@@ -1,6 +1,6 @@
 """Slack interactivity endpoint for the SupportHog app.
 
-Receives button clicks from the opt-in "open a ticket?" ephemeral prompt
+Receives button clicks from the opt-in "open a ticket?" confirmation prompt
 (``slack_confirm_before_ticket``). The events endpoint posts the prompt; this
 endpoint handles the click and creates — or skips — the ticket.
 """

--- a/products/conversations/backend/api/tests/test_slack_endpoints.py
+++ b/products/conversations/backend/api/tests/test_slack_endpoints.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any
+from urllib.parse import urlencode
 
 from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import MagicMock, patch
@@ -159,6 +160,109 @@ class TestSupportSlackEventsAPI(BaseTest):
             )
 
         assert response.status_code == 202
+        mock_process.delay.assert_not_called()
+        mock_proxy.assert_not_called()
+
+
+class TestSupportSlackInteractivityAPI(BaseTest):
+    client: APIClient
+
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_enabled = True
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+        TeamConversationsSlackConfig.objects.update_or_create(
+            team=self.team,
+            defaults={"slack_team_id": "T123", "slack_bot_token": "xoxb-test"},
+        )
+        self.client = APIClient()
+        cache.clear()
+
+    def _post_raw(self, payload_field: str, **kwargs):
+        # Slack sends interactivity payloads form-encoded, as a `payload` field.
+        return self.client.post(
+            "/api/conversations/v1/slack/interactivity",
+            data=urlencode({"payload": payload_field}),
+            content_type="application/x-www-form-urlencoded",
+            **kwargs,
+        )
+
+    def _post(self, payload: Any, **kwargs):
+        return self._post_raw(json.dumps(payload), **kwargs)
+
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_invalid_signature_returns_403(self, mock_validate: MagicMock):
+        mock_validate.side_effect = SlackIntegrationError("Invalid")
+
+        response = self._post({"type": "block_actions"})
+
+        assert response.status_code == 403
+
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_invalid_json_returns_400(self, mock_validate: MagicMock):
+        mock_validate.return_value = None
+
+        response = self._post_raw("{")
+
+        assert response.status_code == 400
+
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_non_object_payload_returns_400(self, mock_validate: MagicMock):
+        mock_validate.return_value = None
+
+        response = self._post(None)
+
+        assert response.status_code == 400
+
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_missing_team_id_returns_200_without_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
+        mock_validate.return_value = None
+
+        response = self._post({"type": "block_actions"})
+
+        assert response.status_code == 200
+        mock_process.delay.assert_not_called()
+
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_block_actions_enqueues_processing(self, mock_validate: MagicMock, mock_process: MagicMock):
+        mock_validate.return_value = None
+        payload = {"type": "block_actions", "team": {"id": "T123"}, "actions": []}
+
+        response = self._post(payload)
+
+        assert response.status_code == 200
+        mock_process.delay.assert_called_once_with(payload=payload, slack_team_id="T123")
+
+    @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_proxies_to_secondary_when_team_not_found_on_primary(
+        self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
+    ):
+        mock_validate.return_value = None
+
+        with patch("products.conversations.backend.api.slack_interactivity.is_primary_region", return_value=True):
+            response = self._post({"type": "block_actions", "team": {"id": "T_UNKNOWN"}})
+
+        assert response.status_code == 200
+        mock_process.delay.assert_not_called()
+        mock_proxy.assert_called_once()
+
+    @patch("products.conversations.backend.api.slack_interactivity.proxy_to_secondary_region")
+    @patch("products.conversations.backend.api.slack_interactivity.process_supporthog_interactivity")
+    @patch("products.conversations.backend.api.slack_interactivity.validate_support_request")
+    def test_drops_click_when_team_not_found_on_secondary(
+        self, mock_validate: MagicMock, mock_process: MagicMock, mock_proxy: MagicMock
+    ):
+        mock_validate.return_value = None
+
+        with patch("products.conversations.backend.api.slack_interactivity.is_primary_region", return_value=False):
+            response = self._post({"type": "block_actions", "team": {"id": "T_UNKNOWN"}})
+
+        assert response.status_code == 200
         mock_process.delay.assert_not_called()
         mock_proxy.assert_not_called()
 

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -1,11 +1,16 @@
+import json
+
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from django.core.cache import cache
 
 from parameterized import parameterized
 
-from products.conversations.backend.models import Ticket
+from posthog.models.team.extensions import get_or_create_team_extension
+
+from products.conversations.backend.cache import is_nudge_suppressed
+from products.conversations.backend.models import TeamConversationsSlackConfig, Ticket
 from products.conversations.backend.models.constants import Channel, ChannelDetail
 from products.conversations.backend.slack import (
     TICKET_CONFIRM_ACTION_DISMISS,
@@ -17,8 +22,10 @@ from products.conversations.backend.slack import (
     handle_support_message,
     handle_support_reaction,
 )
+from products.conversations.backend.tasks import process_supporthog_interactivity
 
 MODULE = "products.conversations.backend.slack"
+TASKS_MODULE = "products.conversations.backend.tasks"
 
 
 class TestSlackMessageRouting(BaseTest):
@@ -611,7 +618,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
     def test_create_ticket_from_confirmation_is_idempotent(self, mock_create_or_update, mock_get_client):
-        Ticket.objects.create_with_number(
+        existing = Ticket.objects.create_with_number(
             team=self.team,
             channel_source=Channel.SLACK,
             widget_session_id="",
@@ -620,7 +627,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
             slack_thread_ts="1700000000.000100",
         )
 
-        create_ticket_from_confirmation(
+        result = create_ticket_from_confirmation(
             team=self.team,
             slack_team_id="T123",
             slack_channel_id="C_CONFIG",
@@ -629,6 +636,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
 
         mock_get_client.assert_not_called()
         mock_create_or_update.assert_not_called()
+        assert result == existing
 
 
 class TestSlackMemberAlerts(BaseTest):
@@ -764,3 +772,84 @@ class TestSlackMemberAlerts(BaseTest):
         handle_member_joined_channel({"user": "U123", "channel": "C_SUPPORT"}, self.team, "T123")
 
         mock_report.assert_not_called()
+
+
+class TestSupporthogInteractivity(BaseTest):
+    def setUp(self):
+        super().setUp()
+        cache.clear()
+        self.team.conversations_settings = {"slack_enabled": True}
+        self.team.save()
+        config = get_or_create_team_extension(self.team, TeamConversationsSlackConfig)
+        config.slack_team_id = "T123"
+        config.slack_bot_token = "xoxb-test"
+        config.save(update_fields=["slack_team_id", "slack_bot_token"])
+
+    def _payload(self, action_id: str, value: dict) -> dict:
+        return {
+            "type": "block_actions",
+            "team": {"id": "T123"},
+            "user": {"id": "U_CLICKER"},
+            "channel": {"id": "C_CONFIG"},
+            "message": {"ts": "1700000000.000999"},
+            "actions": [{"action_id": action_id, "value": json.dumps(value)}],
+        }
+
+    @patch(f"{TASKS_MODULE}.get_slack_client")
+    def test_disabled_team_is_noop(self, mock_get_client):
+        self.team.conversations_settings = {"slack_enabled": False}
+        self.team.save()
+
+        process_supporthog_interactivity(
+            self._payload(TICKET_CONFIRM_ACTION_OPEN, {"channel": "C_CONFIG", "message_ts": "1700000000.000100"}),
+            "T123",
+        )
+
+        mock_get_client.assert_not_called()
+
+    @patch(f"{TASKS_MODULE}.get_slack_client")
+    def test_dismiss_deletes_prompt_acks_and_suppresses(self, mock_get_client):
+        mock_get_client.return_value.auth_test.return_value = {"user_id": "U_BOT"}
+
+        process_supporthog_interactivity(
+            self._payload(TICKET_CONFIRM_ACTION_DISMISS, {"channel": "C_CONFIG", "message_ts": "1700000000.000100"}),
+            "T123",
+        )
+
+        client = mock_get_client.return_value
+        client.chat_delete.assert_called_once()
+        client.chat_postEphemeral.assert_called_once()
+        assert is_nudge_suppressed(self.team.pk, "C_CONFIG", "U_CLICKER")
+
+    @parameterized.expand(
+        [
+            (
+                "created",
+                {"channel": "C_CONFIG", "message_ts": "1700000000.000100"},
+                Mock(ticket_number=42),
+                True,
+                "ticket #42",
+            ),
+            (
+                "genuine_failure",
+                {"channel": "C_CONFIG", "message_ts": "1700000000.000100"},
+                None,
+                True,
+                "couldn't",
+            ),
+            ("malformed_value", {}, None, False, "couldn't"),
+        ]
+    )
+    @patch(f"{TASKS_MODULE}.get_slack_client")
+    @patch(f"{TASKS_MODULE}.create_ticket_from_confirmation")
+    def test_open_replaces_prompt_with_confirmation_or_error(
+        self, _name, value, create_return, expect_create_called, expected_text, mock_create, mock_get_client
+    ):
+        mock_create.return_value = create_return
+
+        process_supporthog_interactivity(self._payload(TICKET_CONFIRM_ACTION_OPEN, value), "T123")
+
+        assert mock_create.call_count == (1 if expect_create_called else 0)
+        client = mock_get_client.return_value
+        client.chat_update.assert_called_once()
+        assert expected_text in client.chat_update.call_args.kwargs["text"].lower()

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -82,8 +82,9 @@ class TestSlackMessageRouting(BaseTest):
 
         mock_create_or_update.assert_not_called()
 
+    @patch("products.conversations.backend.slack.get_slack_client")
     @patch("products.conversations.backend.slack.create_or_update_slack_ticket")
-    def test_top_level_message_passes_channel_detail(self, mock_create_or_update):
+    def test_top_level_message_passes_channel_detail(self, mock_create_or_update, mock_get_client):
         handle_support_message(
             {
                 "type": "message",
@@ -99,6 +100,9 @@ class TestSlackMessageRouting(BaseTest):
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_CHANNEL_MESSAGE
         assert mock_create_or_update.call_args.kwargs["is_thread_reply"] is False
+        # Confirm-before-ticket is off by default: the ticket is created directly,
+        # never a nudge prompt.
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
 
     @patch("products.conversations.backend.slack.create_or_update_slack_ticket")
     def test_bot_mention_passes_channel_detail(self, mock_create_or_update):

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch
 
 from django.core.cache import cache
 
+from celery.exceptions import MaxRetriesExceededError
 from parameterized import parameterized
 
 from posthog.models.team.extensions import get_or_create_team_extension
@@ -872,3 +873,20 @@ class TestSupporthogInteractivity(BaseTest):
         client = mock_get_client.return_value
         client.chat_update.assert_called_once()
         assert expected_text in client.chat_update.call_args.kwargs["text"].lower()
+
+    @patch(f"{TASKS_MODULE}.get_slack_client")
+    @patch(f"{TASKS_MODULE}.create_ticket_from_confirmation")
+    def test_open_shows_error_when_retries_exhausted(self, mock_create, mock_get_client):
+        # A persistent failure retries and eventually exhausts — the prompt must still be
+        # replaced with the error state, not left with live buttons forever.
+        mock_create.side_effect = RuntimeError("boom")
+
+        with patch.object(process_supporthog_interactivity, "retry", side_effect=MaxRetriesExceededError()):
+            process_supporthog_interactivity(
+                self._payload(TICKET_CONFIRM_ACTION_OPEN, {"channel": "C_CONFIG", "message_ts": "1700000000.000100"}),
+                "T123",
+            )
+
+        client = mock_get_client.return_value
+        client.chat_update.assert_called_once()
+        assert "couldn't" in client.chat_update.call_args.kwargs["text"].lower()

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -484,6 +484,11 @@ class TestSlackConfirmBeforeTicket(BaseTest):
             for element in block["elements"]
         }
         assert action_ids == {TICKET_CONFIRM_ACTION_OPEN, TICKET_CONFIRM_ACTION_DISMISS}
+        # The prompt also points at the other ways to open a ticket.
+        context_texts = [
+            element["text"] for block in kwargs["blocks"] if block["type"] == "context" for element in block["elements"]
+        ]
+        assert any("react to your original message" in text for text in context_texts)
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -8,6 +8,9 @@ from parameterized import parameterized
 from products.conversations.backend.models import Ticket
 from products.conversations.backend.models.constants import Channel, ChannelDetail
 from products.conversations.backend.slack import (
+    TICKET_CONFIRM_ACTION_DISMISS,
+    TICKET_CONFIRM_ACTION_OPEN,
+    create_ticket_from_confirmation,
     handle_member_joined_channel,
     handle_member_left_channel,
     handle_support_mention,
@@ -388,6 +391,124 @@ class TestSlackMessageRouting(BaseTest):
             "T123",
         )
 
+        mock_create_or_update.assert_not_called()
+
+
+class TestSlackConfirmBeforeTicket(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.team.conversations_settings = {
+            "slack_enabled": True,
+            "slack_channel_id": "C_CONFIG",
+            "slack_confirm_before_ticket": True,
+        }
+        self.team.save()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_top_level_message_posts_prompt_instead_of_creating(self, mock_create_or_update, mock_get_client):
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "New support request",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_not_called()
+        mock_get_client.return_value.chat_postEphemeral.assert_called_once()
+        kwargs = mock_get_client.return_value.chat_postEphemeral.call_args.kwargs
+        assert kwargs["channel"] == "C_CONFIG"
+        assert kwargs["user"] == "U123"
+        assert kwargs["thread_ts"] == "1700000000.000100"
+        action_ids = {
+            element["action_id"]
+            for block in kwargs["blocks"]
+            if block["type"] == "actions"
+            for element in block["elements"]
+        }
+        assert action_ids == {TICKET_CONFIRM_ACTION_OPEN, TICKET_CONFIRM_ACTION_DISMISS}
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_thread_reply_still_syncs_when_confirm_enabled(self, mock_create_or_update, mock_get_client):
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id="C_CONFIG",
+            slack_thread_ts="1700000000.000100",
+        )
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "thread_ts": "1700000000.000100",
+                "ts": "1700000000.000200",
+                "user": "U123",
+                "text": "Reply in thread",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.chat_postEphemeral.assert_not_called()
+        mock_create_or_update.assert_called_once()
+        assert mock_create_or_update.call_args.kwargs["is_thread_reply"] is True
+
+    @patch(f"{MODULE}._backfill_thread_replies")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_create_ticket_from_confirmation_seeds_from_message(
+        self, mock_create_or_update, mock_get_client, mock_backfill
+    ):
+        mock_get_client.return_value.conversations_history.return_value = {
+            "messages": [{"user": "U_OP", "text": "Original message"}]
+        }
+        mock_create_or_update.return_value = object()
+
+        create_ticket_from_confirmation(
+            team=self.team,
+            slack_team_id="T123",
+            slack_channel_id="C_CONFIG",
+            message_ts="1700000000.000100",
+        )
+
+        mock_create_or_update.assert_called_once()
+        kwargs = mock_create_or_update.call_args.kwargs
+        assert kwargs["slack_user_id"] == "U_OP"
+        assert kwargs["text"] == "Original message"
+        assert kwargs["thread_ts"] == "1700000000.000100"
+        assert kwargs["is_thread_reply"] is False
+        assert kwargs["channel_detail"] == ChannelDetail.SLACK_CHANNEL_MESSAGE
+        mock_backfill.assert_called_once()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_create_ticket_from_confirmation_is_idempotent(self, mock_create_or_update, mock_get_client):
+        Ticket.objects.create_with_number(
+            team=self.team,
+            channel_source=Channel.SLACK,
+            widget_session_id="",
+            distinct_id="",
+            slack_channel_id="C_CONFIG",
+            slack_thread_ts="1700000000.000100",
+        )
+
+        create_ticket_from_confirmation(
+            team=self.team,
+            slack_team_id="T123",
+            slack_channel_id="C_CONFIG",
+            message_ts="1700000000.000100",
+        )
+
+        mock_get_client.assert_not_called()
         mock_create_or_update.assert_not_called()
 
 

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -495,6 +495,34 @@ class TestSlackNudge(BaseTest):
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_malicious_ticket_emoji_falls_back_in_prompt(self, _mock_create_or_update, mock_get_client):
+        # The emoji setting is team-editable and interpolated into mrkdwn — a value
+        # carrying mentions must not reach Slack.
+        self.team.conversations_settings = {
+            **self.team.conversations_settings,
+            "slack_ticket_emoji": "ticket: <!channel> :ticket",
+        }
+        self.team.save()
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_OTHER",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "my data export keeps failing",
+            },
+            self.team,
+            "T123",
+        )
+
+        kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
+        rendered = json.dumps(kwargs["blocks"])
+        assert "<!channel>" not in rendered
+        assert ":ticket:" in rendered
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
     def test_no_prompt_when_nudge_disabled(self, mock_create_or_update, mock_get_client):
         self.team.conversations_settings = {**self.team.conversations_settings, "slack_nudge_enabled": False}
         self.team.save()

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -448,24 +448,23 @@ class TestSlackMessageRouting(BaseTest):
         mock_create_or_update.assert_not_called()
 
 
-class TestSlackConfirmBeforeTicket(BaseTest):
+class TestSlackNudge(BaseTest):
     def setUp(self):
         super().setUp()
         cache.clear()  # nudge suppression + bot user id are cached per team
         self.team.conversations_settings = {
             "slack_enabled": True,
             "slack_channel_id": "C_CONFIG",
-            "slack_confirm_before_ticket": True,
         }
         self.team.save()
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
-    def test_top_level_message_posts_prompt_instead_of_creating(self, mock_create_or_update, mock_get_client):
+    def test_message_in_other_channel_posts_prompt_by_default(self, mock_create_or_update, mock_get_client):
         handle_support_message(
             {
                 "type": "message",
-                "channel": "C_CONFIG",
+                "channel": "C_OTHER",
                 "ts": "1700000000.000100",
                 "user": "U123",
                 "text": "my data export keeps failing",
@@ -477,7 +476,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         mock_create_or_update.assert_not_called()
         mock_get_client.return_value.chat_postMessage.assert_called_once()
         kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
-        assert kwargs["channel"] == "C_CONFIG"
+        assert kwargs["channel"] == "C_OTHER"
         assert kwargs["thread_ts"] == "1700000000.000100"
         # Mentions the author so they actually get notified (a plain ephemeral is silent).
         assert "<@U123>" in kwargs["text"]
@@ -496,20 +495,41 @@ class TestSlackConfirmBeforeTicket(BaseTest):
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")
-    def test_thread_reply_still_syncs_when_confirm_enabled(self, mock_create_or_update, mock_get_client):
+    def test_no_prompt_when_nudge_disabled(self, mock_create_or_update, mock_get_client):
+        self.team.conversations_settings = {**self.team.conversations_settings, "slack_nudge_enabled": False}
+        self.team.save()
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_OTHER",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "my data export keeps failing",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_thread_reply_in_other_channel_still_syncs_without_prompt(self, mock_create_or_update, mock_get_client):
         Ticket.objects.create_with_number(
             team=self.team,
             channel_source=Channel.SLACK,
             widget_session_id="",
             distinct_id="",
-            slack_channel_id="C_CONFIG",
+            slack_channel_id="C_OTHER",
             slack_thread_ts="1700000000.000100",
         )
 
         handle_support_message(
             {
                 "type": "message",
-                "channel": "C_CONFIG",
+                "channel": "C_OTHER",
                 "thread_ts": "1700000000.000100",
                 "ts": "1700000000.000200",
                 "user": "U123",
@@ -531,7 +551,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         handle_support_message(
             {
                 "type": "message",
-                "channel": "C_CONFIG",
+                "channel": "C_OTHER",
                 "ts": "1700000000.000100",
                 "user": "U123",
                 "text": "<@UBOT123> can you please take a look",
@@ -550,7 +570,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         handle_support_message(
             {
                 "type": "message",
-                "channel": "C_CONFIG",
+                "channel": "C_OTHER",
                 "ts": "1700000000.000100",
                 "user": "U123",
                 "text": "thanks :+1:",
@@ -571,7 +591,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         handle_support_message(
             {
                 "type": "message",
-                "channel": "C_CONFIG",
+                "channel": "C_OTHER",
                 "ts": "1700000000.000100",
                 "user": "U123",
                 "text": "my data export keeps failing",
@@ -588,7 +608,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
     def test_does_not_renudge_same_user_within_cooldown(self, mock_create_or_update, mock_get_client):
         event = {
             "type": "message",
-            "channel": "C_CONFIG",
+            "channel": "C_OTHER",
             "user": "U123",
             "text": "my data export keeps failing",
         }
@@ -612,7 +632,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         create_ticket_from_confirmation(
             team=self.team,
             slack_team_id="T123",
-            slack_channel_id="C_CONFIG",
+            slack_channel_id="C_OTHER",
             message_ts="1700000000.000100",
         )
 
@@ -637,7 +657,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         result = create_ticket_from_confirmation(
             team=self.team,
             slack_team_id="T123",
-            slack_channel_id="C_CONFIG",
+            slack_channel_id="C_OTHER",
             message_ts="1700000000.000100",
         )
 
@@ -652,14 +672,14 @@ class TestSlackConfirmBeforeTicket(BaseTest):
             channel_source=Channel.SLACK,
             widget_session_id="",
             distinct_id="",
-            slack_channel_id="C_CONFIG",
+            slack_channel_id="C_OTHER",
             slack_thread_ts="1700000000.000100",
         )
 
         result = create_ticket_from_confirmation(
             team=self.team,
             slack_team_id="T123",
-            slack_channel_id="C_CONFIG",
+            slack_channel_id="C_OTHER",
             message_ts="1700000000.000100",
         )
 

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -245,6 +245,48 @@ class TestSlackMessageRouting(BaseTest):
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_EMOJI_REACTION
 
+    @patch(f"{MODULE}.resolve_posthog_user_for_slack")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_internal_user_can_open_ticket_via_mention(self, mock_create_or_update, mock_resolve_user):
+        mock_resolve_user.return_value = self.user
+
+        handle_support_mention(
+            {
+                "type": "app_mention",
+                "channel": "C_ANY",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "<@U_BOT> help me",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_called_once()
+        assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_BOT_MENTION
+
+    @patch(f"{MODULE}.resolve_posthog_user_for_slack")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_internal_user_can_open_ticket_via_emoji(self, mock_create_or_update, mock_get_client, mock_resolve_user):
+        mock_resolve_user.return_value = self.user
+        mock_get_client.return_value.conversations_history.return_value = {
+            "messages": [{"user": "U123", "text": "Original message"}]
+        }
+
+        handle_support_reaction(
+            {
+                "type": "reaction_added",
+                "reaction": "ticket",
+                "item": {"channel": "C_CONFIG", "ts": "1700000000.000100"},
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_create_or_update.assert_called_once()
+        assert mock_create_or_update.call_args.kwargs["channel_detail"] == ChannelDetail.SLACK_EMOJI_REACTION
+
     @patch(f"{MODULE}.create_or_update_slack_ticket")
     def test_top_level_bot_message_does_not_create_ticket(self, mock_create_or_update):
         handle_support_message(
@@ -397,6 +439,7 @@ class TestSlackMessageRouting(BaseTest):
 class TestSlackConfirmBeforeTicket(BaseTest):
     def setUp(self):
         super().setUp()
+        cache.clear()  # nudge suppression + bot user id are cached per team
         self.team.conversations_settings = {
             "slack_enabled": True,
             "slack_channel_id": "C_CONFIG",
@@ -413,18 +456,19 @@ class TestSlackConfirmBeforeTicket(BaseTest):
                 "channel": "C_CONFIG",
                 "ts": "1700000000.000100",
                 "user": "U123",
-                "text": "New support request",
+                "text": "my data export keeps failing",
             },
             self.team,
             "T123",
         )
 
         mock_create_or_update.assert_not_called()
-        mock_get_client.return_value.chat_postEphemeral.assert_called_once()
-        kwargs = mock_get_client.return_value.chat_postEphemeral.call_args.kwargs
+        mock_get_client.return_value.chat_postMessage.assert_called_once()
+        kwargs = mock_get_client.return_value.chat_postMessage.call_args.kwargs
         assert kwargs["channel"] == "C_CONFIG"
-        assert kwargs["user"] == "U123"
         assert kwargs["thread_ts"] == "1700000000.000100"
+        # Mentions the author so they actually get notified (a plain ephemeral is silent).
+        assert "<@U123>" in kwargs["text"]
         action_ids = {
             element["action_id"]
             for block in kwargs["blocks"]
@@ -458,9 +502,84 @@ class TestSlackConfirmBeforeTicket(BaseTest):
             "T123",
         )
 
-        mock_get_client.return_value.chat_postEphemeral.assert_not_called()
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
         mock_create_or_update.assert_called_once()
         assert mock_create_or_update.call_args.kwargs["is_thread_reply"] is True
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_bot_mention_in_top_level_message_skips_prompt(self, mock_create_or_update, mock_get_client):
+        mock_get_client.return_value.auth_test.return_value = {"user_id": "UBOT123"}
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "<@UBOT123> can you please take a look",
+            },
+            self.team,
+            "T123",
+        )
+
+        # The app_mention event opens the ticket; no nudge prompt and no auto-create here.
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_trivial_message_skips_prompt(self, mock_create_or_update, mock_get_client):
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "thanks :+1:",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.resolve_posthog_user_for_slack")
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_internal_user_skips_prompt(self, mock_create_or_update, mock_get_client, mock_resolve_user):
+        mock_resolve_user.return_value = self.user  # author resolves to an org member
+
+        handle_support_message(
+            {
+                "type": "message",
+                "channel": "C_CONFIG",
+                "ts": "1700000000.000100",
+                "user": "U123",
+                "text": "my data export keeps failing",
+            },
+            self.team,
+            "T123",
+        )
+
+        mock_get_client.return_value.chat_postMessage.assert_not_called()
+        mock_create_or_update.assert_not_called()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_does_not_renudge_same_user_within_cooldown(self, mock_create_or_update, mock_get_client):
+        event = {
+            "type": "message",
+            "channel": "C_CONFIG",
+            "user": "U123",
+            "text": "my data export keeps failing",
+        }
+        handle_support_message({**event, "ts": "1700000000.000100"}, self.team, "T123")
+        handle_support_message({**event, "ts": "1700000000.000200"}, self.team, "T123")
+
+        # First message nudges and sets a cooldown; the second is suppressed.
+        mock_get_client.return_value.chat_postMessage.assert_called_once()
 
     @patch(f"{MODULE}._backfill_thread_replies")
     @patch(f"{MODULE}.get_slack_client")

--- a/products/conversations/backend/api/tests/test_slack_message_routing.py
+++ b/products/conversations/backend/api/tests/test_slack_message_routing.py
@@ -595,7 +595,7 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         self, mock_create_or_update, mock_get_client, mock_backfill
     ):
         mock_get_client.return_value.conversations_history.return_value = {
-            "messages": [{"user": "U_OP", "text": "Original message"}]
+            "messages": [{"user": "U_OP", "text": "Original message", "ts": "1700000000.000100"}]
         }
         mock_create_or_update.return_value = object()
 
@@ -614,6 +614,25 @@ class TestSlackConfirmBeforeTicket(BaseTest):
         assert kwargs["is_thread_reply"] is False
         assert kwargs["channel_detail"] == ChannelDetail.SLACK_CHANNEL_MESSAGE
         mock_backfill.assert_called_once()
+
+    @patch(f"{MODULE}.get_slack_client")
+    @patch(f"{MODULE}.create_or_update_slack_ticket")
+    def test_create_ticket_from_confirmation_rejects_wrong_message(self, mock_create_or_update, mock_get_client):
+        # `latest` is an upper bound: if the source message was deleted, Slack returns the
+        # previous channel message instead. That must not seed a ticket.
+        mock_get_client.return_value.conversations_history.return_value = {
+            "messages": [{"user": "U_SOMEONE_ELSE", "text": "Unrelated earlier message", "ts": "1699999999.000001"}]
+        }
+
+        result = create_ticket_from_confirmation(
+            team=self.team,
+            slack_team_id="T123",
+            slack_channel_id="C_CONFIG",
+            message_ts="1700000000.000100",
+        )
+
+        assert result is None
+        mock_create_or_update.assert_not_called()
 
     @patch(f"{MODULE}.get_slack_client")
     @patch(f"{MODULE}.create_or_update_slack_ticket")

--- a/products/conversations/backend/api/urls.py
+++ b/products/conversations/backend/api/urls.py
@@ -22,6 +22,7 @@ from .github_setup import (
 from .restore import WidgetRestoreRedeemView, WidgetRestoreRequestView
 from .slack_channels import SlackChannelsView
 from .slack_events import supporthog_event_handler
+from .slack_interactivity import supporthog_interactivity_handler
 from .slack_oauth import SupportSlackAuthorizeView, SupportSlackDisconnectView, support_slack_oauth_callback
 from .teams_channels import TeamsChannelsView, TeamsInstallAppView, TeamsSelectChannelView, TeamsTeamsView
 from .teams_events import teams_event_handler
@@ -37,6 +38,7 @@ urlpatterns = [
     path("v1/widget/restore", WidgetRestoreRedeemView.as_view(), name="widget-restore-v1"),
     # SupportHog Slack app
     re_path(r"^v1/slack/events/?$", supporthog_event_handler, name="supporthog-slack-events"),
+    re_path(r"^v1/slack/interactivity/?$", supporthog_interactivity_handler, name="supporthog-slack-interactivity"),
     re_path(r"^v1/slack/authorize/?$", SupportSlackAuthorizeView.as_view(), name="supporthog-slack-authorize"),
     re_path(r"^v1/slack/callback/?$", support_slack_oauth_callback, name="supporthog-slack-callback"),
     re_path(r"^v1/slack/disconnect/?$", SupportSlackDisconnectView.as_view(), name="supporthog-slack-disconnect"),

--- a/products/conversations/backend/cache.py
+++ b/products/conversations/backend/cache.py
@@ -261,6 +261,38 @@ def set_cached_bot_user_id(team_id: int, bot_user_id: str) -> None:
         logger.warning("conversations_cache_set_error", key=key)
 
 
+# Slack Nudge Suppression
+# Suppresses the opt-in "open a ticket?" nudge so we don't pester a user on every
+# message in a channel. Set after sending a nudge (short cooldown) or after the user
+# clicks "No thanks" (longer). Keyed by team:channel:user — presence means suppressed.
+
+NUDGE_COOLDOWN_TTL = 5 * 60  # after nudging the same user in a channel
+NUDGE_DISMISS_TTL = 3 * 60 * 60  # after the user clicks "No thanks"
+
+
+def _nudge_suppress_key(team_id: int, channel: str, slack_user_id: str) -> str:
+    return _make_cache_key("slack_nudge_suppressed", str(team_id), channel, slack_user_id)
+
+
+def is_nudge_suppressed(team_id: int, channel: str, slack_user_id: str) -> bool:
+    """Whether the confirm-ticket nudge is currently suppressed for this user in this channel."""
+    key = _nudge_suppress_key(team_id, channel, slack_user_id)
+    try:
+        return cache.get(key) is not None
+    except Exception:
+        logger.warning("conversations_cache_get_error", key=key)
+        return False
+
+
+def suppress_nudge(team_id: int, channel: str, slack_user_id: str, ttl_seconds: int) -> None:
+    """Suppress the nudge for this user in this channel for ttl_seconds."""
+    key = _nudge_suppress_key(team_id, channel, slack_user_id)
+    try:
+        cache.set(key, True, timeout=ttl_seconds)
+    except Exception:
+        logger.warning("conversations_cache_set_error", key=key)
+
+
 # Teams User Cache
 # Caches Teams user profile lookups (displayName, email) resolved via Graph API.
 # Keyed by tenant_id:teams_user_id. Short TTL keeps profiles fresh.

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -765,6 +765,11 @@ def post_ticket_confirmation_prompt(
     client = get_slack_client(team)
     action_value = json.dumps({"channel": slack_channel_id, "message_ts": message_ts})
     prompt_text = f"👋 <@{slack_user_id}> - did you want to open a support ticket?"
+    settings_dict = team.conversations_settings or {}
+    emoji = settings_dict.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+    bot_id = get_bot_user_id_cached(team, client)
+    mention = f"<@{bot_id}>" if bot_id else "the SupportHog bot"
+    hint_text = f"You can also react to your original message with :{emoji}: or tag {mention} to open a ticket."
     try:
         client.chat_postMessage(
             channel=slack_channel_id,
@@ -795,6 +800,10 @@ def post_ticket_confirmation_prompt(
                             "value": action_value,
                         },
                     ],
+                },
+                {
+                    "type": "context",
+                    "elements": [{"type": "mrkdwn", "text": hint_text}],
                 },
             ],
         )

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -878,6 +878,11 @@ def create_ticket_from_confirmation(
         return None
 
     original_msg = messages[0]
+    # `latest` is an upper bound, so a deleted source message silently falls back to
+    # the previous message in the channel — refuse to seed a ticket from that.
+    if original_msg.get("ts") != message_ts:
+        logger.warning("slack_support_confirmation_message_mismatch", channel=slack_channel_id, message_ts=message_ts)
+        return None
     original_text = original_msg.get("text", "")
 
     # Require an author and either text or files

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -86,7 +86,7 @@ NUDGE_TRIVIAL_MAX_WORDS = 3
 _SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]+$")
 _SLACK_CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9_]+$")
 
-# Action IDs for the opt-in "open a ticket?" confirmation prompt (slack_confirm_before_ticket).
+# Action IDs for the "open a ticket?" nudge prompt (slack_nudge_enabled, on by default).
 # The buttons are posted by post_ticket_confirmation_prompt and routed by the interactivity endpoint.
 TICKET_CONFIRM_ACTION_OPEN = "supporthog_open_ticket_confirm"
 TICKET_CONFIRM_ACTION_DISMISS = "supporthog_open_ticket_dismiss"
@@ -665,13 +665,14 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
         return
 
     if channel not in configured_channels:
-        return
-
-    # Opt-in: ask the author first instead of auto-creating. The ticket is created
-    # only when they click "Open ticket" on the prompt (handled by the interactivity
-    # endpoint), so we stop here. Heuristics keep us from pestering the whole channel.
-    if settings_dict.get("slack_confirm_before_ticket"):
-        if _should_send_nudge(team, channel, slack_user_id, text, blocks, files):
+        # Outside the support channels (where tickets auto-create), nudge the author
+        # with an "open a ticket?" prompt so they don't have to remember the emoji
+        # reaction or @mention. On by default; the ticket is created only when they
+        # click "Open ticket" (handled by the interactivity endpoint). Heuristics
+        # keep us from pestering the whole channel.
+        if settings_dict.get("slack_nudge_enabled", True) and _should_send_nudge(
+            team, channel, slack_user_id, text, blocks, files
+        ):
             post_ticket_confirmation_prompt(
                 team=team,
                 slack_channel_id=channel,
@@ -681,7 +682,7 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
             suppress_nudge(_get_team_id(team), channel, slack_user_id, NUDGE_COOLDOWN_TTL)
         return
 
-    # Top-level message -> create new ticket, use message ts as thread_ts
+    # Top-level message in a support channel -> create new ticket, use message ts as thread_ts
     create_or_update_slack_ticket(
         team=team,
         slack_channel_id=channel,
@@ -754,10 +755,10 @@ def post_ticket_confirmation_prompt(
 ) -> None:
     """Ask the message author whether to open a ticket, via a threaded reply.
 
-    Posted instead of auto-creating when ``slack_confirm_before_ticket`` is enabled.
-    The prompt @mentions the author so they get a notification, and is deleted when they
-    click either button (routed through the interactivity endpoint to
-    ``create_ticket_from_confirmation``).
+    Posted for top-level messages outside the configured support channels (where tickets
+    auto-create) when ``slack_nudge_enabled`` is on. The prompt @mentions the author so
+    they get a notification, and is deleted when they click either button (routed through
+    the interactivity endpoint to ``create_ticket_from_confirmation``).
     """
     if not message_ts or not slack_user_id:
         return

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -28,13 +28,16 @@ from posthog.models.team.team import Team
 from posthog.models.user import User
 
 from .cache import (
+    NUDGE_COOLDOWN_TTL,
     get_cached_bot_user_id,
     get_cached_slack_avatar,
     get_cached_slack_user,
+    is_nudge_suppressed,
     set_cached_bot_user_id,
     set_cached_slack_avatar,
     set_cached_slack_user,
     slack_ticket_create_lock,
+    suppress_nudge,
 )
 from .formatting import extract_slack_user_ids, slack_to_content_and_rich_content, strip_slack_user_mentions
 from .models import Ticket
@@ -72,12 +75,17 @@ def _is_ticketable_message(event: dict, *, is_bot: bool) -> bool:
     return not subtype or subtype in TICKETABLE_MESSAGE_SUBTYPES or is_bot
 
 
+# Default emoji that triggers a ticket via reaction, when the team hasn't customized it.
+DEFAULT_TICKET_EMOJI = "ticket"
+# A top-level message with this many meaningful words or fewer is too trivial to nudge.
+NUDGE_TRIVIAL_MAX_WORDS = 3
+
 # Slack ID shapes — guard against malformed payloads before interpolating into mrkdwn.
 # Permissive on charset (underscores allowed) but blocks angle brackets, @, #, and spaces.
 _SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]+$")
 _SLACK_CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9_]+$")
 
-# Action IDs for the opt-in "open a ticket?" ephemeral prompt (slack_confirm_before_ticket).
+# Action IDs for the opt-in "open a ticket?" confirmation prompt (slack_confirm_before_ticket).
 # The buttons are posted by post_ticket_confirmation_prompt and routed by the interactivity endpoint.
 TICKET_CONFIRM_ACTION_OPEN = "supporthog_open_ticket_confirm"
 TICKET_CONFIRM_ACTION_DISMISS = "supporthog_open_ticket_dismiss"
@@ -88,6 +96,11 @@ def _get_team_id(team: Team) -> int:
     if not isinstance(team_id, int):
         raise ValueError("Invalid team id")
     return team_id
+
+
+def ticket_created_text(ticket: "Ticket | None") -> str:
+    """Copy for message to confirm creation of ticket."""
+    return f":ticket: Ticket #{ticket.ticket_number} created" if ticket else ":ticket: Ticket created"
 
 
 class _NoRedirectHandler(HTTPRedirectHandler):
@@ -359,6 +372,7 @@ def create_or_update_slack_ticket(
     is_thread_reply: bool = False,
     slack_team_id: str | None = None,
     channel_detail: ChannelDetail | None = None,
+    post_confirmation: bool = True,
 ) -> Ticket | None:
     """
     Core function: create a new ticket or add a message to an existing one.
@@ -537,43 +551,34 @@ def create_or_update_slack_ticket(
         },
     )
 
-    # Post a confirmation reply in the Slack thread
-    # ticket_url = f"{settings.SITE_URL}/project/{team_id}/support/tickets/{ticket.id}"
-    support_settings = team.conversations_settings or {}
-    confirmation_kwargs: dict = {
-        "channel": slack_channel_id,
-        "thread_ts": thread_ts,
-        "text": f"Ticket #{ticket.ticket_number} created.",
-        "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f":ticket: Ticket #{ticket.ticket_number} created",
+    # Post a confirmation reply in the Slack thread. Skipped when the caller will surface
+    # the confirmation itself (e.g. the confirm-prompt flow updates its prompt in place).
+    if post_confirmation:
+        support_settings = team.conversations_settings or {}
+        confirmation_kwargs: dict = {
+            "channel": slack_channel_id,
+            "thread_ts": thread_ts,
+            "text": f"Ticket #{ticket.ticket_number} created.",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": ticket_created_text(ticket),
+                    },
                 },
-            },
-            # {
-            #     "type": "actions",
-            #     "elements": [
-            #         {
-            #             "type": "button",
-            #             "text": {"type": "plain_text", "text": "View in PostHog", "emoji": True},
-            #             "url": ticket_url,
-            #         }
-            #     ],
-            # },
-        ],
-    }
-    bot_display_name = support_settings.get("slack_bot_display_name")
-    bot_icon_url = support_settings.get("slack_bot_icon_url")
-    if bot_display_name:
-        confirmation_kwargs["username"] = bot_display_name
-    if bot_icon_url:
-        confirmation_kwargs["icon_url"] = bot_icon_url
-    try:
-        client.chat_postMessage(**confirmation_kwargs)
-    except Exception:
-        logger.warning("slack_support_confirmation_failed", ticket_id=str(ticket.id))
+            ],
+        }
+        bot_display_name = support_settings.get("slack_bot_display_name")
+        bot_icon_url = support_settings.get("slack_bot_icon_url")
+        if bot_display_name:
+            confirmation_kwargs["username"] = bot_display_name
+        if bot_icon_url:
+            confirmation_kwargs["icon_url"] = bot_icon_url
+        try:
+            client.chat_postMessage(**confirmation_kwargs)
+        except Exception:
+            logger.warning("slack_support_confirmation_failed", ticket_id=str(ticket.id))
 
     return ticket
 
@@ -662,15 +667,17 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
         return
 
     # Opt-in: ask the author first instead of auto-creating. The ticket is created
-    # only when they click "Open ticket" on the ephemeral prompt (handled by the
-    # interactivity endpoint), so we stop here.
+    # only when they click "Open ticket" on the prompt (handled by the interactivity
+    # endpoint), so we stop here. Heuristics keep us from pestering the whole channel.
     if settings_dict.get("slack_confirm_before_ticket"):
-        post_ticket_confirmation_prompt(
-            team=team,
-            slack_channel_id=channel,
-            message_ts=message_ts or "",
-            slack_user_id=slack_user_id,
-        )
+        if _should_send_nudge(team, channel, slack_user_id, text, blocks, files):
+            post_ticket_confirmation_prompt(
+                team=team,
+                slack_channel_id=channel,
+                message_ts=message_ts or "",
+                slack_user_id=slack_user_id,
+            )
+            suppress_nudge(_get_team_id(team), channel, slack_user_id, NUDGE_COOLDOWN_TTL)
         return
 
     # Top-level message -> create new ticket, use message ts as thread_ts
@@ -688,6 +695,53 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
     )
 
 
+_EMOJI_SHORTCODE_RE = re.compile(r":[a-z0-9_'+-]+:")
+
+
+def _is_trivial_message(text: str, files: list[dict] | None) -> bool:
+    """Too trivial to nudge: emoji-only or 3 words or fewer. Messages with files
+    (e.g. screenshots) are never trivial."""
+    if files:
+        return False
+    stripped = _EMOJI_SHORTCODE_RE.sub(" ", text or "")
+    words = [w for w in stripped.split() if re.search(r"[A-Za-z0-9]", w)]
+    return len(words) <= NUDGE_TRIVIAL_MAX_WORDS
+
+
+def _should_send_nudge(
+    team: Team,
+    channel: str,
+    slack_user_id: str,
+    text: str,
+    blocks: list[dict] | None,
+    files: list[dict] | None,
+) -> bool:
+    """Heuristics to avoid pestering the channel: nudge only external users on substantive
+    messages, skipping anyone recently nudged/dismissed or who @mentioned the bot (which
+    opens a ticket directly)."""
+    team_id = _get_team_id(team)
+
+    # Cheapest checks first — no Slack API.
+    if _is_trivial_message(text, files):
+        return False
+    if is_nudge_suppressed(team_id, channel, slack_user_id):
+        return False
+
+    client = get_slack_client(team)
+
+    # If the author @mentioned the bot, the app_mention event opens a ticket directly.
+    bot_id = get_bot_user_id_cached(team, client)
+    if bot_id and bot_id in extract_slack_user_ids(text, blocks):
+        return False
+
+    # External users only — internal teammates don't need nudging.
+    user_info = resolve_slack_user(client, slack_user_id)
+    if resolve_posthog_user_for_slack(user_info.get("email"), team):
+        return False
+
+    return True
+
+
 def post_ticket_confirmation_prompt(
     *,
     team: Team,
@@ -695,27 +749,31 @@ def post_ticket_confirmation_prompt(
     message_ts: str,
     slack_user_id: str,
 ) -> None:
-    """Ask the message author whether to open a ticket, via an ephemeral message.
+    """Ask the message author whether to open a ticket, via a threaded reply.
 
     Posted instead of auto-creating when ``slack_confirm_before_ticket`` is enabled.
-    Only the author sees the prompt; the ticket is created when they click "Open ticket"
-    (routed through the interactivity endpoint to ``create_ticket_from_confirmation``).
+    The prompt @mentions the author so they get a notification, and is deleted when they
+    click either button (routed through the interactivity endpoint to
+    ``create_ticket_from_confirmation``).
     """
     if not message_ts or not slack_user_id:
         return
 
     client = get_slack_client(team)
     action_value = json.dumps({"channel": slack_channel_id, "message_ts": message_ts})
+    prompt_text = f"👋 <@{slack_user_id}> - did you want to open a support ticket?"
     try:
-        client.chat_postEphemeral(
+        client.chat_postMessage(
             channel=slack_channel_id,
-            user=slack_user_id,
             thread_ts=message_ts,
-            text="Open a support ticket for this message?",
+            text=prompt_text,
             blocks=[
                 {
                     "type": "section",
-                    "text": {"type": "mrkdwn", "text": ":ticket: Open a support ticket for this message?"},
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": prompt_text,
+                    },
                 },
                 {
                     "type": "actions",
@@ -743,6 +801,43 @@ def post_ticket_confirmation_prompt(
             team_id=_get_team_id(team),
             slack_channel_id=slack_channel_id,
         )
+
+
+def _create_ticket_and_backfill(
+    *,
+    client: WebClient,
+    team: Team,
+    slack_channel_id: str,
+    thread_ts: str,
+    source_message: dict,
+    slack_team_id: str | None,
+    channel_detail: ChannelDetail,
+    after_ts: str | None = None,
+    post_confirmation: bool = True,
+) -> Ticket | None:
+    """Create a ticket from an already-validated seed message, then backfill its thread replies.
+
+    Shared tail of the emoji-reaction, bot-mention-parent, and confirm-prompt paths — each
+    fetches and validates its own seed message, then hands it here. ``after_ts`` bounds the
+    backfill (reaction path); ``post_confirmation=False`` suppresses the threaded confirmation
+    when the caller surfaces it itself (confirm-prompt path).
+    """
+    ticket = create_or_update_slack_ticket(
+        team=team,
+        slack_channel_id=slack_channel_id,
+        thread_ts=thread_ts,
+        slack_user_id=source_message.get("user", ""),
+        text=source_message.get("text", ""),
+        blocks=source_message.get("blocks"),
+        files=source_message.get("files"),
+        is_thread_reply=False,
+        slack_team_id=slack_team_id,
+        channel_detail=channel_detail,
+        post_confirmation=post_confirmation,
+    )
+    if ticket:
+        _backfill_thread_replies(client, team, ticket, slack_channel_id, thread_ts, after_ts=after_ts)
+    return ticket
 
 
 def create_ticket_from_confirmation(
@@ -781,32 +876,23 @@ def create_ticket_from_confirmation(
         return None
 
     original_msg = messages[0]
-    original_user = original_msg.get("user", "")
     original_text = original_msg.get("text", "")
-    original_blocks = original_msg.get("blocks")
-    original_files = original_msg.get("files")
 
-    # Require either text or files
-    if not original_user or (not original_text.strip() and not original_files):
+    # Require an author and either text or files
+    if not original_msg.get("user") or (not original_text.strip() and not original_msg.get("files")):
         return None
 
-    ticket = create_or_update_slack_ticket(
+    return _create_ticket_and_backfill(
+        client=client,
         team=team,
         slack_channel_id=slack_channel_id,
         thread_ts=message_ts,
-        slack_user_id=original_user,
-        text=original_text,
-        blocks=original_blocks,
-        files=original_files,
-        is_thread_reply=False,
+        source_message=original_msg,
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_CHANNEL_MESSAGE,
+        # The interactivity handler updates the prompt in place into the confirmation.
+        post_confirmation=False,
     )
-
-    if ticket:
-        _backfill_thread_replies(client, team, ticket, slack_channel_id, message_ts)
-
-    return ticket
 
 
 def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
@@ -867,26 +953,17 @@ def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:
 
         if messages:
             parent_msg = messages[0]
-            parent_user = parent_msg.get("user", "")
             parent_text = parent_msg.get("text", "")
-            parent_blocks = parent_msg.get("blocks")
-            parent_files = parent_msg.get("files")
-
-            if parent_user and (parent_text.strip() or parent_files):
-                ticket = create_or_update_slack_ticket(
+            if parent_msg.get("user") and (parent_text.strip() or parent_msg.get("files")):
+                _create_ticket_and_backfill(
+                    client=client,
                     team=team,
                     slack_channel_id=channel,
                     thread_ts=thread_ts,
-                    slack_user_id=parent_user,
-                    text=parent_text,
-                    blocks=parent_blocks,
-                    files=parent_files,
-                    is_thread_reply=False,
+                    source_message=parent_msg,
                     slack_team_id=slack_team_id,
                     channel_detail=ChannelDetail.SLACK_BOT_MENTION,
                 )
-                if ticket:
-                    _backfill_thread_replies(client, team, ticket, channel, thread_ts)
                 return
 
     # A bare "@supporthog" (mention only, no message or files) must not create an empty
@@ -1071,7 +1148,7 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
         return
 
     settings_dict = team.conversations_settings or {}
-    configured_emoji = settings_dict.get("slack_ticket_emoji", "ticket")
+    configured_emoji = settings_dict.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
 
     if reaction != configured_emoji:
         return
@@ -1149,23 +1226,18 @@ def handle_support_reaction(event: dict, team: Team, slack_team_id: str) -> None
     if not reacted_text.strip() and not reacted_files:
         return
 
-    ticket = create_or_update_slack_ticket(
+    # Only backfill replies posted after the reacted message; earlier thread history is
+    # intentionally excluded since the ticket starts from the reacted message.
+    _create_ticket_and_backfill(
+        client=client,
         team=team,
         slack_channel_id=channel,
         thread_ts=root_ts,
-        slack_user_id=reacted_msg.get("user", ""),
-        text=reacted_text,
-        blocks=reacted_msg.get("blocks"),
-        files=reacted_files,
-        is_thread_reply=False,
+        source_message=reacted_msg,
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_EMOJI_REACTION,
+        after_ts=message_ts,
     )
-
-    if ticket:
-        # Only backfill replies posted after the reacted message; earlier thread history is
-        # intentionally excluded since the ticket starts from the reacted message.
-        _backfill_thread_replies(client, team, ticket, channel, root_ts, after_ts=message_ts)
 
 
 def _track_bot_joined_channel(event: dict, team: Team, slack_team_id: str, *, own_bot_user_id: str | None) -> None:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -851,13 +851,15 @@ def create_ticket_from_confirmation(
 
     Mirrors the emoji-reaction path: re-fetch the source message, create the ticket, then
     backfill any replies posted while the prompt was pending. Idempotent — a duplicate
-    click is a no-op because a ticket already exists for the thread.
+    click returns the already-open ticket so the caller can confirm rather than error.
+    Returns None only on genuine failure (source message gone, fetch error, empty content).
     """
-    if Ticket.objects.filter(team=team, slack_channel_id=slack_channel_id, slack_thread_ts=message_ts).exists():
+    existing = Ticket.objects.filter(team=team, slack_channel_id=slack_channel_id, slack_thread_ts=message_ts).first()
+    if existing:
         logger.debug(
             "slack_support_confirmation_ticket_exists", slack_channel_id=slack_channel_id, message_ts=message_ts
         )
-        return None
+        return existing
 
     client = get_slack_client(team)
     try:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -16,6 +16,7 @@ from typing import Any
 from urllib.parse import urljoin, urlparse
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
+from django.conf import settings
 from django.db.models import F
 
 import structlog
@@ -734,10 +735,12 @@ def _should_send_nudge(
     if bot_id and bot_id in extract_slack_user_ids(text, blocks):
         return False
 
-    # External users only — internal teammates don't need nudging.
-    user_info = resolve_slack_user(client, slack_user_id)
-    if resolve_posthog_user_for_slack(user_info.get("email"), team):
-        return False
+    # External users only — internal teammates don't need nudging. Skipped in local
+    # dev, where the tester's own account is the only org member and would never nudge.
+    if not settings.DEBUG:
+        user_info = resolve_slack_user(client, slack_user_id)
+        if resolve_posthog_user_for_slack(user_info.get("email"), team):
+            return False
 
     return True
 

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -10,6 +10,7 @@ All three converge to create_or_update_slack_ticket().
 """
 
 import re
+import json
 from types import MappingProxyType
 from typing import Any
 from urllib.parse import urljoin, urlparse
@@ -75,6 +76,11 @@ def _is_ticketable_message(event: dict, *, is_bot: bool) -> bool:
 # Permissive on charset (underscores allowed) but blocks angle brackets, @, #, and spaces.
 _SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]+$")
 _SLACK_CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9_]+$")
+
+# Action IDs for the opt-in "open a ticket?" ephemeral prompt (slack_confirm_before_ticket).
+# The buttons are posted by post_ticket_confirmation_prompt and routed by the interactivity endpoint.
+TICKET_CONFIRM_ACTION_OPEN = "supporthog_open_ticket_confirm"
+TICKET_CONFIRM_ACTION_DISMISS = "supporthog_open_ticket_dismiss"
 
 
 def _get_team_id(team: Team) -> int:
@@ -655,6 +661,18 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
     if channel not in configured_channels:
         return
 
+    # Opt-in: ask the author first instead of auto-creating. The ticket is created
+    # only when they click "Open ticket" on the ephemeral prompt (handled by the
+    # interactivity endpoint), so we stop here.
+    if settings_dict.get("slack_confirm_before_ticket"):
+        post_ticket_confirmation_prompt(
+            team=team,
+            slack_channel_id=channel,
+            message_ts=message_ts or "",
+            slack_user_id=slack_user_id,
+        )
+        return
+
     # Top-level message -> create new ticket, use message ts as thread_ts
     create_or_update_slack_ticket(
         team=team,
@@ -668,6 +686,127 @@ def handle_support_message(event: dict, team: Team, slack_team_id: str) -> None:
         slack_team_id=slack_team_id,
         channel_detail=ChannelDetail.SLACK_CHANNEL_MESSAGE,
     )
+
+
+def post_ticket_confirmation_prompt(
+    *,
+    team: Team,
+    slack_channel_id: str,
+    message_ts: str,
+    slack_user_id: str,
+) -> None:
+    """Ask the message author whether to open a ticket, via an ephemeral message.
+
+    Posted instead of auto-creating when ``slack_confirm_before_ticket`` is enabled.
+    Only the author sees the prompt; the ticket is created when they click "Open ticket"
+    (routed through the interactivity endpoint to ``create_ticket_from_confirmation``).
+    """
+    if not message_ts or not slack_user_id:
+        return
+
+    client = get_slack_client(team)
+    action_value = json.dumps({"channel": slack_channel_id, "message_ts": message_ts})
+    try:
+        client.chat_postEphemeral(
+            channel=slack_channel_id,
+            user=slack_user_id,
+            thread_ts=message_ts,
+            text="Open a support ticket for this message?",
+            blocks=[
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": ":ticket: Open a support ticket for this message?"},
+                },
+                {
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "action_id": TICKET_CONFIRM_ACTION_OPEN,
+                            "style": "primary",
+                            "text": {"type": "plain_text", "text": "Open ticket", "emoji": True},
+                            "value": action_value,
+                        },
+                        {
+                            "type": "button",
+                            "action_id": TICKET_CONFIRM_ACTION_DISMISS,
+                            "text": {"type": "plain_text", "text": "No thanks", "emoji": True},
+                            "value": action_value,
+                        },
+                    ],
+                },
+            ],
+        )
+    except Exception:
+        logger.warning(
+            "slack_support_confirmation_prompt_failed",
+            team_id=_get_team_id(team),
+            slack_channel_id=slack_channel_id,
+        )
+
+
+def create_ticket_from_confirmation(
+    *,
+    team: Team,
+    slack_team_id: str,
+    slack_channel_id: str,
+    message_ts: str,
+) -> Ticket | None:
+    """Create a ticket from a channel message after the author confirms via the prompt.
+
+    Mirrors the emoji-reaction path: re-fetch the source message, create the ticket, then
+    backfill any replies posted while the prompt was pending. Idempotent — a duplicate
+    click is a no-op because a ticket already exists for the thread.
+    """
+    if Ticket.objects.filter(team=team, slack_channel_id=slack_channel_id, slack_thread_ts=message_ts).exists():
+        logger.debug(
+            "slack_support_confirmation_ticket_exists", slack_channel_id=slack_channel_id, message_ts=message_ts
+        )
+        return None
+
+    client = get_slack_client(team)
+    try:
+        result = client.conversations_history(
+            channel=slack_channel_id,
+            latest=message_ts,
+            inclusive=True,
+            limit=1,
+        )
+        messages: list[dict] = result.get("messages", [])
+    except Exception:
+        logger.warning("slack_support_confirmation_fetch_failed", channel=slack_channel_id, message_ts=message_ts)
+        return None
+
+    if not messages:
+        return None
+
+    original_msg = messages[0]
+    original_user = original_msg.get("user", "")
+    original_text = original_msg.get("text", "")
+    original_blocks = original_msg.get("blocks")
+    original_files = original_msg.get("files")
+
+    # Require either text or files
+    if not original_user or (not original_text.strip() and not original_files):
+        return None
+
+    ticket = create_or_update_slack_ticket(
+        team=team,
+        slack_channel_id=slack_channel_id,
+        thread_ts=message_ts,
+        slack_user_id=original_user,
+        text=original_text,
+        blocks=original_blocks,
+        files=original_files,
+        is_thread_reply=False,
+        slack_team_id=slack_team_id,
+        channel_detail=ChannelDetail.SLACK_CHANNEL_MESSAGE,
+    )
+
+    if ticket:
+        _backfill_thread_replies(client, team, ticket, slack_channel_id, message_ts)
+
+    return ticket
 
 
 def handle_support_mention(event: dict, team: Team, slack_team_id: str) -> None:

--- a/products/conversations/backend/slack.py
+++ b/products/conversations/backend/slack.py
@@ -85,6 +85,22 @@ NUDGE_TRIVIAL_MAX_WORDS = 3
 # Permissive on charset (underscores allowed) but blocks angle brackets, @, #, and spaces.
 _SLACK_USER_ID_RE = re.compile(r"^[UW][A-Z0-9_]+$")
 _SLACK_CHANNEL_ID_RE = re.compile(r"^[CGD][A-Z0-9_]+$")
+# Slack emoji-name shape (e.g. "ticket", "+1", "o'clock") — no spaces, colons, or mrkdwn.
+_SLACK_EMOJI_NAME_RE = re.compile(r"^[a-z0-9_'+-]+$")
+
+
+def get_safe_ticket_emoji(settings_dict: dict) -> str:
+    """The configured ticket emoji, only when it's a plain emoji name.
+
+    The value is team-editable and gets interpolated into mrkdwn (`:{emoji}:`), so
+    anything that doesn't look like an emoji name — e.g. `ticket: <!channel> :ticket` —
+    falls back to the default instead of injecting mentions into the bot's messages.
+    """
+    emoji = settings_dict.get("slack_ticket_emoji") or DEFAULT_TICKET_EMOJI
+    if isinstance(emoji, str) and _SLACK_EMOJI_NAME_RE.match(emoji):
+        return emoji
+    return DEFAULT_TICKET_EMOJI
+
 
 # Action IDs for the "open a ticket?" nudge prompt (slack_nudge_enabled, on by default).
 # The buttons are posted by post_ticket_confirmation_prompt and routed by the interactivity endpoint.
@@ -766,8 +782,7 @@ def post_ticket_confirmation_prompt(
     client = get_slack_client(team)
     action_value = json.dumps({"channel": slack_channel_id, "message_ts": message_ts})
     prompt_text = f"👋 <@{slack_user_id}> - did you want to open a support ticket?"
-    settings_dict = team.conversations_settings or {}
-    emoji = settings_dict.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+    emoji = get_safe_ticket_emoji(team.conversations_settings or {})
     bot_id = get_bot_user_id_cached(team, client)
     mention = f"<@{bot_id}>" if bot_id else "the SupportHog bot"
     hint_text = f"You can also react to your original message with :{emoji}: or tag {mention} to open a ticket."

--- a/products/conversations/backend/support_slack.py
+++ b/products/conversations/backend/support_slack.py
@@ -36,6 +36,17 @@ def get_support_slack_bot_token(team: "Team") -> str:
     return str(config.slack_bot_token or "")
 
 
+def team_exists_for_slack_workspace(slack_team_id: str) -> bool:
+    """Whether any team has SupportHog connected to this Slack workspace.
+
+    Used by the webhook endpoints for region routing — the Celery task re-resolves
+    the full config, so only existence matters here.
+    """
+    return TeamConversationsSlackConfig.objects.filter(
+        slack_team_id=slack_team_id, slack_bot_token__isnull=False
+    ).exists()
+
+
 def validate_support_request(request: HttpRequest | Request) -> None:
     """
     Validate Support Slack bot requests.

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -19,6 +19,7 @@ from django.utils import timezone
 import requests
 import structlog
 from celery import shared_task
+from celery.exceptions import MaxRetriesExceededError
 
 from posthog.egress.github.transport import GitHubRateLimitError
 from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
@@ -277,7 +278,14 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                     )
                 except Exception as e:
                     logger.exception("supporthog_interactivity_create_failed", error=str(e))
-                    raise cast(Any, process_supporthog_interactivity).retry(exc=e)
+                    # Retry transient failures — the retried run redoes the whole handler,
+                    # so the prompt still resolves on eventual success. Once retries are
+                    # exhausted, fall through to the error update below rather than leaving
+                    # the user staring at live buttons forever.
+                    try:
+                        raise cast(Any, process_supporthog_interactivity).retry(exc=e)
+                    except MaxRetriesExceededError:
+                        pass
             # Replace the prompt in place: a confirmation when we have a ticket (created or
             # already open), or an explicit error so a failed open never reads as success.
             # post_confirmation=False above means no separate confirmation was posted.

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -29,6 +29,7 @@ from posthog.models.uploaded_media import UploadedMedia
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.storage import object_storage
 
+from products.conversations.backend.cache import NUDGE_DISMISS_TTL, suppress_nudge
 from products.conversations.backend.events import capture_ticket_status_changed
 from products.conversations.backend.formatting import (
     extract_images_from_rich_content,
@@ -55,9 +56,11 @@ from products.conversations.backend.models.constants import Channel, ChannelDeta
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.slack import (
+    DEFAULT_TICKET_EMOJI,
     TICKET_CONFIRM_ACTION_DISMISS,
     TICKET_CONFIRM_ACTION_OPEN,
     create_ticket_from_confirmation,
+    get_bot_user_id,
     get_slack_client,
     handle_member_joined_channel,
     handle_member_left_channel,
@@ -65,6 +68,7 @@ from products.conversations.backend.slack import (
     handle_support_message,
     handle_support_reaction,
     resolve_slack_avatar_by_email,
+    ticket_created_text,
 )
 from products.conversations.backend.support_teams import (
     get_bot_framework_token,
@@ -163,23 +167,65 @@ def process_supporthog_event(event: dict[str, Any], slack_team_id: str, event_id
         raise cast(Any, process_supporthog_event).retry(exc=e)
 
 
-def _delete_supporthog_ephemeral(response_url: str) -> None:
-    """Remove the ephemeral "open a ticket?" prompt once the author has clicked.
+def _delete_supporthog_prompt(team: Team, channel: str, message_ts: str) -> None:
+    """Delete the "open a ticket?" prompt message after a "No thanks" click.
+
+    Best-effort: a failure here never blocks anything else.
+    """
+    if not channel or not message_ts:
+        return
+    try:
+        get_slack_client(team).chat_delete(channel=channel, ts=message_ts)
+    except Exception:
+        logger.warning("supporthog_interactivity_prompt_delete_failed", exc_info=True)
+
+
+def _update_supporthog_prompt_to_confirmation(team: Team, channel: str, message_ts: str, ticket: Ticket | None) -> None:
+    """Replace the "open a ticket?" prompt in place with the ticket confirmation.
 
     Best-effort: a failure here never blocks the ticket creation that already ran.
     """
-    if not response_url:
+    if not channel or not message_ts:
         return
+    text = ticket_created_text(ticket)
     try:
-        requests.post(response_url, json={"delete_original": True}, timeout=3)
+        get_slack_client(team).chat_update(
+            channel=channel,
+            ts=message_ts,
+            text=text,
+            blocks=[{"type": "section", "text": {"type": "mrkdwn", "text": text}}],
+        )
     except Exception:
-        logger.warning("supporthog_interactivity_response_url_failed", exc_info=True)
+        logger.warning("supporthog_interactivity_prompt_update_failed", exc_info=True)
+
+
+def _post_dismiss_acknowledgment(team: Team, channel: str, user: str, thread_ts: str) -> None:
+    """Privately acknowledge a "No thanks" click, pointing the author at the other ways in.
+
+    Ephemeral so only the person who clicked sees it; best-effort.
+    """
+    if not channel or not user:
+        return
+    settings_dict = team.conversations_settings or {}
+    emoji = settings_dict.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+    try:
+        client = get_slack_client(team)
+        bot_id = get_bot_user_id(client)
+        mention = f"<@{bot_id}>" if bot_id else "the SupportHog bot"
+        client.chat_postEphemeral(
+            channel=channel,
+            user=user,
+            thread_ts=thread_ts or None,
+            text=f"Got it — if you change your mind, react with :{emoji}: or tag {mention}.",
+        )
+    except Exception:
+        logger.warning("supporthog_interactivity_dismiss_ack_failed", exc_info=True)
 
 
 @shared_task(ignore_result=True, max_retries=3, default_retry_delay=5)
 @skip_team_scope_audit
 def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str) -> None:
-    """Handle a button click from the opt-in "open a ticket?" ephemeral prompt."""
+    """Handle a button click from the opt-in "open a ticket?" confirmation prompt."""
     config = (
         TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
         .select_related("team")
@@ -197,31 +243,45 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
     if payload.get("type") != "block_actions":
         return
 
-    response_url = payload.get("response_url", "")
+    # The prompt message to delete: where the button was clicked.
+    container = payload.get("container") or {}
+    prompt_channel = (payload.get("channel") or {}).get("id") or container.get("channel_id") or ""
+    prompt_ts = (payload.get("message") or {}).get("ts") or container.get("message_ts") or ""
+
+    clicker = (payload.get("user") or {}).get("id", "")
+
     for action in payload.get("actions") or []:
         action_id = action.get("action_id")
+        try:
+            value = json.loads(action.get("value") or "{}")
+        except (json.JSONDecodeError, TypeError):
+            value = {}
+        source_channel = value.get("channel", "")
+        source_message_ts = value.get("message_ts", "")
+
         if action_id == TICKET_CONFIRM_ACTION_DISMISS:
-            _delete_supporthog_ephemeral(response_url)
+            _delete_supporthog_prompt(team, prompt_channel, prompt_ts)
+            _post_dismiss_acknowledgment(team, prompt_channel, clicker, source_message_ts)
+            # Don't pester them again in this channel for a while.
+            if clicker:
+                suppress_nudge(team.pk, prompt_channel, clicker, NUDGE_DISMISS_TTL)
             return
         if action_id == TICKET_CONFIRM_ACTION_OPEN:
-            try:
-                value = json.loads(action.get("value") or "{}")
-            except (json.JSONDecodeError, TypeError):
-                value = {}
-            channel = value.get("channel", "")
-            message_ts = value.get("message_ts", "")
-            if channel and message_ts:
+            ticket = None
+            if source_channel and source_message_ts:
                 try:
-                    create_ticket_from_confirmation(
+                    ticket = create_ticket_from_confirmation(
                         team=team,
                         slack_team_id=slack_team_id,
-                        slack_channel_id=channel,
-                        message_ts=message_ts,
+                        slack_channel_id=source_channel,
+                        message_ts=source_message_ts,
                     )
                 except Exception as e:
                     logger.exception("supporthog_interactivity_create_failed", error=str(e))
                     raise cast(Any, process_supporthog_interactivity).retry(exc=e)
-            _delete_supporthog_ephemeral(response_url)
+            # Replace the prompt in place with the confirmation (post_confirmation=False above
+            # means create_ticket_from_confirmation didn't post a separate one).
+            _update_supporthog_prompt_to_confirmation(team, prompt_channel, prompt_ts, ticket)
             return
 
 

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -57,11 +57,11 @@ from products.conversations.backend.models.constants import Channel, ChannelDeta
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.slack import (
-    DEFAULT_TICKET_EMOJI,
     TICKET_CONFIRM_ACTION_DISMISS,
     TICKET_CONFIRM_ACTION_OPEN,
     create_ticket_from_confirmation,
     get_bot_user_id,
+    get_safe_ticket_emoji,
     get_slack_client,
     handle_member_joined_channel,
     handle_member_left_channel,
@@ -206,8 +206,7 @@ def _post_dismiss_acknowledgment(team: Team, channel: str, user: str, thread_ts:
     """
     if not channel or not user:
         return
-    settings_dict = team.conversations_settings or {}
-    emoji = settings_dict.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+    emoji = get_safe_ticket_emoji(team.conversations_settings or {})
     try:
         client = get_slack_client(team)
         bot_id = get_bot_user_id(client)
@@ -292,7 +291,7 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
             if ticket:
                 text = ticket_created_text(ticket)
             else:
-                emoji = support_settings.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+                emoji = get_safe_ticket_emoji(support_settings)
                 text = f":warning: Couldn't open a ticket — react with :{emoji}: or @mention us to try again."
             _update_supporthog_prompt(team, prompt_channel, prompt_ts, text)
             return

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -1,6 +1,7 @@
 """Celery tasks for the conversations product."""
 
 import html as html_mod
+import json
 from datetime import datetime, timedelta
 from email.utils import formataddr
 from typing import Any, cast
@@ -54,6 +55,9 @@ from products.conversations.backend.models.constants import Channel, ChannelDeta
 from products.conversations.backend.models.ticket import Ticket
 from products.conversations.backend.services.attachments import CONVERSATIONS_MAX_IMAGE_BYTES
 from products.conversations.backend.slack import (
+    TICKET_CONFIRM_ACTION_DISMISS,
+    TICKET_CONFIRM_ACTION_OPEN,
+    create_ticket_from_confirmation,
     get_slack_client,
     handle_member_joined_channel,
     handle_member_left_channel,
@@ -157,6 +161,68 @@ def process_supporthog_event(event: dict[str, Any], slack_team_id: str, event_id
             error=str(e),
         )
         raise cast(Any, process_supporthog_event).retry(exc=e)
+
+
+def _delete_supporthog_ephemeral(response_url: str) -> None:
+    """Remove the ephemeral "open a ticket?" prompt once the author has clicked.
+
+    Best-effort: a failure here never blocks the ticket creation that already ran.
+    """
+    if not response_url:
+        return
+    try:
+        requests.post(response_url, json={"delete_original": True}, timeout=3)
+    except Exception:
+        logger.warning("supporthog_interactivity_response_url_failed", exc_info=True)
+
+
+@shared_task(ignore_result=True, max_retries=3, default_retry_delay=5)
+@skip_team_scope_audit
+def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str) -> None:
+    """Handle a button click from the opt-in "open a ticket?" ephemeral prompt."""
+    config = (
+        TeamConversationsSlackConfig.objects.filter(slack_team_id=slack_team_id, slack_bot_token__isnull=False)
+        .select_related("team")
+        .first()
+    )
+    if not config:
+        logger.warning("supporthog_interactivity_no_team", slack_team_id=slack_team_id)
+        return
+
+    team = config.team
+    support_settings = team.conversations_settings or {}
+    if not support_settings.get("slack_enabled"):
+        return
+
+    if payload.get("type") != "block_actions":
+        return
+
+    response_url = payload.get("response_url", "")
+    for action in payload.get("actions") or []:
+        action_id = action.get("action_id")
+        if action_id == TICKET_CONFIRM_ACTION_DISMISS:
+            _delete_supporthog_ephemeral(response_url)
+            return
+        if action_id == TICKET_CONFIRM_ACTION_OPEN:
+            try:
+                value = json.loads(action.get("value") or "{}")
+            except (json.JSONDecodeError, TypeError):
+                value = {}
+            channel = value.get("channel", "")
+            message_ts = value.get("message_ts", "")
+            if channel and message_ts:
+                try:
+                    create_ticket_from_confirmation(
+                        team=team,
+                        slack_team_id=slack_team_id,
+                        slack_channel_id=channel,
+                        message_ts=message_ts,
+                    )
+                except Exception as e:
+                    logger.exception("supporthog_interactivity_create_failed", error=str(e))
+                    raise cast(Any, process_supporthog_interactivity).retry(exc=e)
+            _delete_supporthog_ephemeral(response_url)
+            return
 
 
 @shared_task(ignore_result=True, max_retries=3, default_retry_delay=5)

--- a/products/conversations/backend/tasks.py
+++ b/products/conversations/backend/tasks.py
@@ -180,14 +180,13 @@ def _delete_supporthog_prompt(team: Team, channel: str, message_ts: str) -> None
         logger.warning("supporthog_interactivity_prompt_delete_failed", exc_info=True)
 
 
-def _update_supporthog_prompt_to_confirmation(team: Team, channel: str, message_ts: str, ticket: Ticket | None) -> None:
-    """Replace the "open a ticket?" prompt in place with the ticket confirmation.
+def _update_supporthog_prompt(team: Team, channel: str, message_ts: str, text: str) -> None:
+    """Replace the "open a ticket?" prompt in place with a final status line (buttons removed).
 
     Best-effort: a failure here never blocks the ticket creation that already ran.
     """
     if not channel or not message_ts:
         return
-    text = ticket_created_text(ticket)
     try:
         get_slack_client(team).chat_update(
             channel=channel,
@@ -279,9 +278,15 @@ def process_supporthog_interactivity(payload: dict[str, Any], slack_team_id: str
                 except Exception as e:
                     logger.exception("supporthog_interactivity_create_failed", error=str(e))
                     raise cast(Any, process_supporthog_interactivity).retry(exc=e)
-            # Replace the prompt in place with the confirmation (post_confirmation=False above
-            # means create_ticket_from_confirmation didn't post a separate one).
-            _update_supporthog_prompt_to_confirmation(team, prompt_channel, prompt_ts, ticket)
+            # Replace the prompt in place: a confirmation when we have a ticket (created or
+            # already open), or an explicit error so a failed open never reads as success.
+            # post_confirmation=False above means no separate confirmation was posted.
+            if ticket:
+                text = ticket_created_text(ticket)
+            else:
+                emoji = support_settings.get("slack_ticket_emoji", DEFAULT_TICKET_EMOJI)
+                text = f":warning: Couldn't open a ticket — react with :{emoji}: or @mention us to try again."
+            _update_supporthog_prompt(team, prompt_channel, prompt_ts, text)
             return
 
 

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -48,7 +48,7 @@ function SlackChannelSection(): JSX.Element {
         slackNotifyOnJoin,
         slackNotifyOnLeave,
         slackAlertChannelId,
-        slackConfirmBeforeTicket,
+        slackNudgeEnabled,
         currentTeamLoading,
     } = useValues(supportSettingsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -65,7 +65,7 @@ function SlackChannelSection(): JSX.Element {
         setSlackNotifyOnJoin,
         setSlackNotifyOnLeave,
         setSlackAlertChannel,
-        setSlackConfirmBeforeTicket,
+        setSlackNudgeEnabled,
         disconnectSlack,
     } = useActions(supportSettingsLogic)
     const adminRestrictionReason = useRestrictedArea({
@@ -128,16 +128,17 @@ function SlackChannelSection(): JSX.Element {
                         </div>
                         <LemonCheckbox
                             className="mt-2"
-                            checked={slackConfirmBeforeTicket}
-                            onChange={setSlackConfirmBeforeTicket}
+                            checked={slackNudgeEnabled}
+                            onChange={setSlackNudgeEnabled}
                             disabled={currentTeamLoading}
-                            label="Ask before creating a ticket"
+                            label="Nudge users to open tickets in other channels"
                             bordered
                         />
                         <p className="text-xs text-muted-alt mt-1">
-                            When enabled, the SupportHog bot replies in-thread mentioning the author to ask whether to
-                            open a ticket, instead of creating one automatically. Only affects channel messages —
-                            @mentions and emoji reactions still create tickets immediately.
+                            When someone posts in a channel the bot is in that isn't a support channel, SupportHog
+                            replies in-thread asking whether to open a ticket — so they don't need to remember the emoji
+                            reaction or @mention. Support channels are unaffected: messages there always create tickets
+                            automatically.
                         </p>
                     </div>
                     {memberAlertsEnabled && (

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -126,20 +126,24 @@ function SlackChannelSection(): JSX.Element {
                                 Refresh
                             </LemonButton>
                         </div>
+                    </div>
+                    <LemonDivider />
+                    <div className="flex flex-col gap-2">
+                        <div>
+                            <label className="font-medium">Ticket nudges</label>
+                            <p className="text-xs text-muted-alt">
+                                When someone posts in any other channel the bot is in, SupportHog replies in-thread
+                                asking whether to open a ticket — so they don't need to remember the emoji reaction or
+                                @mention. Support channels are unaffected: messages there always create tickets
+                                automatically.
+                            </p>
+                        </div>
                         <LemonCheckbox
-                            className="mt-2"
                             checked={slackNudgeEnabled}
                             onChange={setSlackNudgeEnabled}
                             disabled={currentTeamLoading}
-                            label="Nudge users to open tickets in other channels"
-                            bordered
+                            label="Nudge users to open tickets"
                         />
-                        <p className="text-xs text-muted-alt mt-1">
-                            When someone posts in a channel the bot is in that isn't a support channel, SupportHog
-                            replies in-thread asking whether to open a ticket — so they don't need to remember the emoji
-                            reaction or @mention. Support channels are unaffected: messages there always create tickets
-                            automatically.
-                        </p>
                     </div>
                     {memberAlertsEnabled && (
                         <>

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -132,10 +132,10 @@ function SlackChannelSection(): JSX.Element {
                         <div>
                             <label className="font-medium">Ticket nudges</label>
                             <p className="text-xs text-muted-alt">
-                                When someone posts in any other channel the bot is in, SupportHog replies in-thread
-                                asking whether to open a ticket — so they don't need to remember the emoji reaction or
-                                @mention. Support channels are unaffected: messages there always create tickets
-                                automatically.
+                                When enabled, SupportHog replies in-thread asking whether the customer wants to open a
+                                ticket. This means customers don't have to remember the emoji reaction or @mention.
+                                'Support channels' will still have tickets created for every thread, and no nudge is
+                                sent.
                             </p>
                         </div>
                         <LemonCheckbox

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -48,6 +48,7 @@ function SlackChannelSection(): JSX.Element {
         slackNotifyOnJoin,
         slackNotifyOnLeave,
         slackAlertChannelId,
+        slackConfirmBeforeTicket,
         currentTeamLoading,
     } = useValues(supportSettingsLogic)
     const { featureFlags } = useValues(featureFlagLogic)
@@ -64,6 +65,7 @@ function SlackChannelSection(): JSX.Element {
         setSlackNotifyOnJoin,
         setSlackNotifyOnLeave,
         setSlackAlertChannel,
+        setSlackConfirmBeforeTicket,
         disconnectSlack,
     } = useActions(supportSettingsLogic)
     const adminRestrictionReason = useRestrictedArea({
@@ -124,6 +126,19 @@ function SlackChannelSection(): JSX.Element {
                                 Refresh
                             </LemonButton>
                         </div>
+                        <LemonCheckbox
+                            className="mt-2"
+                            checked={slackConfirmBeforeTicket}
+                            onChange={setSlackConfirmBeforeTicket}
+                            disabled={currentTeamLoading}
+                            label="Ask before creating a ticket"
+                            bordered
+                        />
+                        <p className="text-xs text-muted-alt mt-1">
+                            When enabled, the SupportHog bot sends the author an ephemeral message asking whether to
+                            open a ticket, instead of creating one automatically. Only affects channel messages —
+                            @mentions and emoji reactions still create tickets immediately.
+                        </p>
                     </div>
                     {memberAlertsEnabled && (
                         <>

--- a/products/conversations/frontend/scenes/settings/SlackSection.tsx
+++ b/products/conversations/frontend/scenes/settings/SlackSection.tsx
@@ -135,7 +135,7 @@ function SlackChannelSection(): JSX.Element {
                             bordered
                         />
                         <p className="text-xs text-muted-alt mt-1">
-                            When enabled, the SupportHog bot sends the author an ephemeral message asking whether to
+                            When enabled, the SupportHog bot replies in-thread mentioning the author to ask whether to
                             open a ticket, instead of creating one automatically. Only affects channel messages —
                             @mentions and emoji reactions still create tickets immediately.
                         </p>

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -62,6 +62,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         saveSlackBotSettings: true,
         setSlackNotifyOnJoin: (enabled: boolean) => ({ enabled }),
         setSlackNotifyOnLeave: (enabled: boolean) => ({ enabled }),
+        setSlackConfirmBeforeTicket: (enabled: boolean) => ({ enabled }),
         setSlackAlertChannel: (channelId: string | null) => ({ channelId }),
         disconnectSlack: true,
         // Teams channel settings
@@ -443,6 +444,10 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             (s) => [s.currentTeam],
             (currentTeam): boolean => !!currentTeam?.conversations_settings?.slack_notify_on_leave,
         ],
+        slackConfirmBeforeTicket: [
+            (s) => [s.currentTeam],
+            (currentTeam): boolean => !!currentTeam?.conversations_settings?.slack_confirm_before_ticket,
+        ],
         slackAlertChannelId: [
             (s) => [s.currentTeam],
             (currentTeam): string | null => currentTeam?.conversations_settings?.slack_alert_channel_id ?? null,
@@ -679,6 +684,14 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
                     slack_notify_on_leave: enabled,
+                },
+            })
+        },
+        setSlackConfirmBeforeTicket: ({ enabled }) => {
+            actions.updateCurrentTeam({
+                conversations_settings: {
+                    ...values.currentTeam?.conversations_settings,
+                    slack_confirm_before_ticket: enabled,
                 },
             })
         },

--- a/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
+++ b/products/conversations/frontend/scenes/settings/supportSettingsLogic.ts
@@ -62,7 +62,7 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
         saveSlackBotSettings: true,
         setSlackNotifyOnJoin: (enabled: boolean) => ({ enabled }),
         setSlackNotifyOnLeave: (enabled: boolean) => ({ enabled }),
-        setSlackConfirmBeforeTicket: (enabled: boolean) => ({ enabled }),
+        setSlackNudgeEnabled: (enabled: boolean) => ({ enabled }),
         setSlackAlertChannel: (channelId: string | null) => ({ channelId }),
         disconnectSlack: true,
         // Teams channel settings
@@ -444,9 +444,9 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
             (s) => [s.currentTeam],
             (currentTeam): boolean => !!currentTeam?.conversations_settings?.slack_notify_on_leave,
         ],
-        slackConfirmBeforeTicket: [
+        slackNudgeEnabled: [
             (s) => [s.currentTeam],
-            (currentTeam): boolean => !!currentTeam?.conversations_settings?.slack_confirm_before_ticket,
+            (currentTeam): boolean => currentTeam?.conversations_settings?.slack_nudge_enabled ?? true,
         ],
         slackAlertChannelId: [
             (s) => [s.currentTeam],
@@ -687,11 +687,11 @@ export const supportSettingsLogic = kea<supportSettingsLogicType>([
                 },
             })
         },
-        setSlackConfirmBeforeTicket: ({ enabled }) => {
+        setSlackNudgeEnabled: ({ enabled }) => {
             actions.updateCurrentTeam({
                 conversations_settings: {
                     ...values.currentTeam?.conversations_settings,
-                    slack_confirm_before_ticket: enabled,
+                    slack_nudge_enabled: enabled,
                 },
             })
         },


### PR DESCRIPTION
## Problem

SupportHog only creates tickets when a message lands in a configured support channel, or when someone remembers to react with the ticket emoji or @mention the bot. In every other channel the bot is in, a support-worthy message from a user silently goes nowhere unless they know those tricks.

## Changes

Adds a nudge: when someone posts a top-level message in a channel the bot is in that **isn't** one of the configured support channels, SupportHog replies in-thread, @mentioning the author, asking whether to open a support ticket — with **Open ticket** / **No thanks** buttons and a hint about the emoji-reaction and @mention paths:

- **Open ticket** — creates the ticket (re-fetching the source message and backfilling any replies posted while the prompt was pending), then edits the prompt in place into the usual `Ticket #N created` confirmation. Idempotent: a double-click resolves to the existing ticket.
- **No thanks** — deletes the prompt, sends the author an ephemeral pointing at the other ways in, and suppresses further nudges for that user in that channel for 3 hours.

**Support channels are completely unchanged**: messages there always auto-create tickets, and are never nudged. So are the @mention and emoji-reaction paths (still instant, any channel) and thread-reply syncing.

Controlled by a new per-team setting, `slack_nudge_enabled`, **on by default**, with a checkbox in Conversations → Slack settings.

Heuristics keep the bot from pestering channels — no nudge for trivial messages (≤3 meaningful words, emoji-only), messages from internal teammates (skipped in local dev, where the tester is the only org member), messages that @mention the bot (the `app_mention` event opens the ticket directly), or anyone nudged in the last 5 minutes.

Plumbing:

- New `v1/slack/interactivity` endpoint for the button clicks (SupportHog previously had no interactivity endpoint). Same signing-secret validation and EU→US region proxying as the events endpoint; dispatches to a Celery task and returns 200 immediately. Rejects non-object payloads, verifies the fetched message's `ts` before seeding (a deleted message must not seed a ticket from the previous channel message), and resolves the prompt with an explicit error once retries exhaust.
- Refactors the shared create-then-backfill tail of the emoji-reaction, bot-mention, and confirm-prompt paths into `_create_ticket_and_backfill`.

> [!IMPORTANT]
> Requires a one-off Slack app config change: set the SupportHog app's Interactivity Request URL to `https://eu.posthog.com/api/conversations/v1/slack/interactivity`. Until that's set, the prompt buttons do nothing.

## How did you test this code?

Automated tests (local manual testing against a test Slack workspace via ngrok is in progress — note the interactivity URL prerequisite above):

- `test_slack_message_routing.py` — `TestSlackNudge` and `TestSupporthogInteractivity`: prompt posted in non-support channels (default on); disabled setting → no prompt; support channels auto-create with no prompt; trivial/internal/bot-mention messages skip the prompt; re-nudge cooldown; confirm-click creates and seeds the ticket from the original message (rejecting a wrong/deleted source message); idempotency on double-click; dismiss deletes the prompt and suppresses; error states surface instead of silent success, including after retry exhaustion.
- `test_slack_endpoints.py` — `TestSupportSlackInteractivityAPI`: view-level coverage mirroring the events endpoint (signature 403, malformed/non-object payload 400, enqueueing, region proxy/drop).

Open ticket:

https://github.com/user-attachments/assets/367ba8a8-dbac-454d-8057-233d1e8bf242

Dismiss:

https://github.com/user-attachments/assets/b2c4779d-25e7-4d82-ab8a-528d16ed706d



## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Built with PostHog Code (Claude Code harness). Skills invoked along the way: `/writing-tests`, `/debugging-ci-failures`, `/review`.
- Notable course-correction: the first implementation had the scope inverted (prompting *inside* support channels instead of auto-creating there, and doing nothing elsewhere); reworked after review to the intended behavior — support channels always auto-create, other channels get the nudge, default on.
- Other decisions: threaded @mention prompt instead of a bare ephemeral so the author actually gets notified; suppression cache keyed by team/channel/user so a "No thanks" is respected without a DB write; the internal-teammate nudge filter is skipped under DEBUG so the flow is testable in local dev.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
