### PR TITLE
fix(signals): let scout descriptions fill full width

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -59,7 +59,7 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
                     <ScoutRowCard config={config} rollup={rollup} onUpdate={updateScoutConfig} asHeader />
 
                     {config.description ? (
-                        <p className="text-sm text-secondary leading-snug mb-0 max-w-3xl">{config.description}</p>
+                        <p className="text-sm text-secondary leading-snug mb-0">{config.description}</p>
                     ) : null}
 
                     <div className="flex flex-col gap-1">

--- a/frontend/src/scenes/inbox/components/scratchpad/ScratchpadPanel.tsx
+++ b/frontend/src/scenes/inbox/components/scratchpad/ScratchpadPanel.tsx
@@ -123,7 +123,7 @@ function ScratchpadHeader({
                 <IconNotebook className="size-5 text-primary-3000" />
                 <span className="text-base font-semibold text-default">Scout scratchpad</span>
             </div>
-            <p className="mb-0 max-w-2xl text-sm text-secondary">
+            <p className="mb-0 text-sm text-secondary">
                 Where your scouts jot down useful context as they scan your project — things they've classified, ruled
                 out, or the vocabulary they've settled on. Browse it to see what they're picking up about your setup.
             </p>


### PR DESCRIPTION
## Problem

In the Signals scout views, the description text was capped well short of its container width, leaving it looking cramped and un-polished. This showed up in two places:

- The scout detail view (`/inbox/scouts/<scout>`)
- The scratchpad page (`/inbox/scouts/scratchpad`)

## Changes

Removed the explicit Tailwind `max-w-*` caps on the description `<p>` elements:

- `ScoutDetailView.tsx` — dropped `max-w-3xl` (was capping at 768px)
- `ScratchpadPanel.tsx` — dropped `max-w-2xl` (was capping at 672px)

Both paragraphs live in flex-column containers that already stretch full width, so the block-level `<p>` now fills the available width like the surrounding content. No `w-full` needed.

## How did you test this code?

I'm an agent. This is a CSS-class-only change (removing two `max-w-*` utilities); no automated tests were added or run. Visual change verified by reasoning about the layout — the descriptions now inherit their full-width flex containers.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy reported the descriptions in the scout view and scratchpad page weren't expanding to fill the full width and felt un-polished. Traced both to explicit `max-w-*` caps on the description paragraphs and removed them. Authored with Claude Code.
