### PR TITLE
feat(support): add Inbox target area to support form

### DIFF
--- a/frontend/src/lib/components/Support/supportLogic.ts
+++ b/frontend/src/lib/components/Support/supportLogic.ts
@@ -288,7 +288,7 @@ const TARGET_AREA_TO_NAME_PRODUCTS = [
     {
         value: 'signals',
         'data-attr': `support-form-target-area-signals`,
-        label: 'Signals',
+        label: 'Inbox',
     },
     {
         value: 'slack',
@@ -388,6 +388,7 @@ export const URL_PATH_TO_TARGET_AREA: Record<string, SupportTicketTargetArea> = 
     workflows: 'workflows',
     billing: 'billing',
     logs: 'logs',
+    inbox: 'signals',
 }
 
 export const SUPPORT_TICKET_TEMPLATES = {


### PR DESCRIPTION
## Problem

We just shipped the Inbox (the self-driving inbox) to customers, but there was no obvious way for them to file support tickets about it. The in-app support form had a `signals` target area, but it was labeled "Signals" — the underlying engine name, not the product customers actually see. Someone looking for help with the Inbox wouldn't recognize it, and opening support from the Inbox page didn't pre-select anything.

## Changes

- Relabel the `signals` support target area to **Inbox**. The underlying `value` (`signals`) and routing are unchanged, so existing tickets and team routing keep working — only the customer-facing label changes.
- Map the `/inbox` URL path to the `signals` target area so the support form auto-selects **Inbox** when a customer opens it from the Inbox page.

Both changes are in `frontend/src/lib/components/Support/supportLogic.ts`.

## How did you test this code?

I'm an agent (PostHog Slack app). I made the edits but did not run the frontend lint/typecheck or manually exercise the support form — the change is a label string plus one entry in the existing `URL_PATH_TO_TARGET_AREA` map, matching the surrounding patterns. No automated tests were added; reviewer may want to confirm the form renders the new label and auto-selects on `/inbox`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Josh Snyder via the PostHog Slack app, who asked for a way for customers to submit support tickets about the newly released Inbox. Investigation found the `signals` target area already existed and routed correctly, so the chosen fix was minimal: relabel it to "Inbox" (keeping the `signals` value/routing) and wire `/inbox` into the URL auto-detection map rather than adding a new target area and routing path. No repo skills applied to this change. Left unassigned since the directing human's GitHub handle wasn't verified in-session — owning team should assign on triage.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AUPF8DC7P/p1782406044865399)*
