### PR TITLE
fix(llma): preserve signals scout stale-run catch-up

### DIFF
--- a/products/signals/ARCHITECTURE.md
+++ b/products/signals/ARCHITECTURE.md
@@ -300,8 +300,8 @@ Defined in `backend/temporal/agentic/scout_coordinator.py`.
 **Flow:**
 
 1. Activity `fetch_enabled_signals_scout_runs_activity` bounds candidates to the teams enrolled via the `signals-scout` feature flag's JSON payload allowlist — `guaranteed_team_ids` minus `skip_team_ids`, with a hardcoded fail-safe default (`_participating_teams` → `_enrolled_team_ids`, modeled on `posthog/temporal/ai_observability/team_discovery.py`). Enrollment is flag-driven: editing the payload in the flag UI enrolls or drains a team next tick with no manual seed. For each enrolled team it calls `sync_canonical_skills(team, prune=True)` to mirror the on-disk `signals-scout-*` skills onto the team's `LLMSkill` rows, then auto-registers a `SignalScoutConfig` for any scout skill missing one (`scout_harness/config_registry.register_missing_configs`; the `signals-scout-config-create` endpoint is the explicit upsert counterpart, so a freshly authored scout is configurable without waiting for a tick). Failures here are logged and the tick continues — a stale skill is preferable to a dead tick.
-2. For each enabled config, the coordinator computes how overdue the scout is: due when `last_run_at is None`, or `now - last_run_at >= run_interval_minutes`. There is no sampling — every due scout is planned.
-3. Due runs are sorted most-overdue-first and truncated at `MAX_RUNS_PER_TICK` (50 per tick; the cost bound — overflow catches up next tick). `last_run_at` is advanced via `.update()` for everything dispatched (bypasses `save()`, so the per-tick write never hits the activity log). Planned runs are re-sorted by `(team_id, skill_name)` for stable child IDs.
+2. For each participating team's live scout skills, the coordinator calls `scout_harness.run_guard.reap_stale_runs_and_find_blocked_skills()` before due/budget allocation. Stale `QUEUED` / `IN_PROGRESS` runs older than `STALE_RUN_CUTOFF_S` are failed and emit `signals_scout_run_reaped`; skills still blocked by a live active run are skipped entirely, so they are not dispatched or stamped. A skill reaped during this planning pass becomes eligible for catch-up even if `last_run_at` would normally suppress it: the coordinator moves `last_run_at` back to the due grace boundary so the lane stays due until a child is dispatched, while ordering it behind genuinely overdue scouts for the current tick.
+3. Due runs are allocated under the per-team, daily, and global tick caps, with each team's candidates ordered most-overdue-first. Overflow stays unstamped and catches up next tick. `last_run_at` is advanced via `.update()` only after child dispatch (bypasses `save()`, so the per-tick write never hits the activity log). Planned runs are re-sorted by `(team_id, skill_name)` for stable child IDs.
 4. Each `PlannedRun` becomes a child `RunSignalsScoutWorkflow` started with `ParentClosePolicy.ABANDON` and a deterministic workflow ID per `(team_id, skill_name, tick_id)` so retried coordinators can't double-launch within a tick.
 
 The coordinator's lifetime is seconds regardless of fan-out width; throttling happens at the Temporal task queue + worker concurrency layer. Pausing a scout is `enabled=False` on its config; slowing it is a larger `run_interval_minutes` — both tunable via the `signals-scout-config-update` MCP tool.
@@ -319,12 +319,14 @@ bridge row at the start of the run; status, timing, and chat log live on the lin
 job is to spawn the activity with `start_to_close_timeout=WORKFLOW_HARD_CEILING_S`,
 a 2-minute heartbeat, and `RetryPolicy(maximum_attempts=1)` — the spec calls for "fail
 safe and silent": a bad run does not retry blindly; the next scheduled tick will try
-again. Single-flight is a best-effort app-layer guard: `_has_running_run` skips
-dispatch when a prior run for the same `(team, skill_name)` has
-`task_run.status = IN_PROGRESS`. An earlier partial unique constraint on
-`(team, skill_name) WHERE status='running'` was dropped together with the bridge
-model's own status column; active recovery of stranded `IN_PROGRESS` task runs
-(`_self_heal_stale_runs` is a no-op today) is a tracked follow-up.
+again. Single-flight is a best-effort app-layer guard shared through
+`scout_harness.run_guard`: the coordinator uses it before planning, and the runner
+uses it again before spawning as a race backstop. It treats `QUEUED` and
+`IN_PROGRESS` `TaskRun`s as active, reaps stale rows older than `STALE_RUN_CUTOFF_S`,
+and skips only skills still blocked after that recovery. An earlier partial unique
+constraint on `(team, skill_name) WHERE status='running'` was dropped together with
+the bridge model's own status column; a `task_run.status`-based DB constraint is still
+a possible follow-up for stronger single-flight guarantees.
 
 Findings emitted during the run go through the harness's `emit_signal_*` tools,
 which call `emit_signal()` with `source_product="signals_scout"` and
@@ -508,16 +510,16 @@ Per-team configuration for which signal sources are enabled.
 
 Per-scout binding for the headless **Signals agent**: one row per `(team, skill_name)`. The coordinator auto-creates a row when it discovers a `signals-scout-*` skill on a participating team. Changes are activity-logged (they drive spend); team-level participation is gated by the `signals-scout` flag at the coordinator, not here. See `backend/scout_harness/AGENTS.md` for the harness internals.
 
-| Field                  | Type                 | Description                                                                                                                                                                                                                                     |
-| ---------------------- | -------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `team`                 | FK → Team            | Owning team (`related_name="signal_scout_configs"`). `unique_together(team, skill_name)`.                                                                                                                                                       |
-| `skill_name`           | CharField            | The `signals-scout-*` skill this row controls. Auto-registered by the coordinator when it finds the skill on a participating team.                                                                                                              |
-| `enabled`              | Boolean              | Per-scout switch; defaults `True`. `False` pauses just this scout.                                                                                                                                                                              |
-| `emit`                 | Boolean              | Dry-run vs emit. Defaults `True`: a freshly authored scout is live from its first tick. Flip to `False` for dry-run — the scout runs and logs but `emit_finding` writes nothing — to validate it on a team before its findings reach the inbox. |
-| `run_interval_minutes` | PositiveSmallInt     | Minutes between runs. The coordinator dispatches when `last_run_at is None or now - last_run_at >= run_interval_minutes`. Default `1440` (daily). Validated `30 <= N <= 43200`.                                                                 |
-| `last_run_at`          | DateTime (nullable)  | Stamped after each dispatch; drives the due-check. Excluded from activity logging (written every run).                                                                                                                                          |
-| `created_by`           | FK → User (nullable) | Audit pointer                                                                                                                                                                                                                                   |
-| `enabled_by`           | FK → User (nullable) | Who last flipped `enabled` — tracked because enablement drives spend.                                                                                                                                                                           |
+| Field                  | Type                 | Description                                                                                                                                                                                                                                                                          |
+| ---------------------- | -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `team`                 | FK → Team            | Owning team (`related_name="signal_scout_configs"`). `unique_together(team, skill_name)`.                                                                                                                                                                                            |
+| `skill_name`           | CharField            | The `signals-scout-*` skill this row controls. Auto-registered by the coordinator when it finds the skill on a participating team.                                                                                                                                                   |
+| `enabled`              | Boolean              | Per-scout switch; defaults `True`. `False` pauses just this scout.                                                                                                                                                                                                                   |
+| `emit`                 | Boolean              | Dry-run vs emit. Defaults `True`: a freshly authored scout is live from its first tick. Flip to `False` for dry-run — the scout runs and logs but `emit_finding` writes nothing — to validate it on a team before its findings reach the inbox.                                      |
+| `run_interval_minutes` | PositiveIntegerField | Minutes between runs. The coordinator dispatches when `last_run_at is None or now - last_run_at >= run_interval_minutes`. Default `1440` (daily). Validated `30 <= N <= 43200`.                                                                                                      |
+| `last_run_at`          | DateTime (nullable)  | Stamped after each dispatch; drives the due-check. When a stale active run is reaped before dispatch, the coordinator can move it back to the due grace boundary so the missed run remains eligible until a child is dispatched. Excluded from activity logging (written every run). |
+| `created_by`           | FK → User (nullable) | Audit pointer                                                                                                                                                                                                                                                                        |
+| `enabled_by`           | FK → User (nullable) | Who last flipped `enabled` — tracked because enablement drives spend.                                                                                                                                                                                                                |
 
 ### `SignalScoutRun`
 
@@ -539,7 +541,7 @@ Thin bridge from a Tasks `TaskRun` to the scout skill that ran inside it: one sc
 
 **Indexes:** `(team, skill_name)`.
 
-**Constraints:** None at the DB level today. Single-flight is a best-effort app-layer guard (`_has_running_run` against `task_run.status = IN_PROGRESS`). An earlier partial unique constraint on `(team, skill_name) WHERE status='running'` was dropped together with the bridge model's own status column; a `task_run.status`-based constraint plus active recovery of stranded `IN_PROGRESS` task runs (`_self_heal_stale_runs` is a no-op today) is a tracked follow-up.
+**Constraints:** None at the DB level today. Single-flight is a best-effort app-layer guard in `scout_harness.run_guard` against active `QUEUED` / `IN_PROGRESS` `TaskRun`s for the same `(team, skill_name)`. The guard fails stale active runs older than `STALE_RUN_CUTOFF_S` before reporting blocked skills, so crashed workers do not wedge a lane permanently. An earlier partial unique constraint on `(team, skill_name) WHERE status='running'` was dropped together with the bridge model's own status column; a `task_run.status`-based constraint is still a possible follow-up for stronger single-flight guarantees.
 
 ### `SignalScratchpad`
 
@@ -1124,6 +1126,7 @@ products/signals/
 │   │   ├── AGENTS.md
 │   │   ├── __init__.py              # Public re-exports (LoadedSkill, sync helpers, …)
 │   │   ├── runner.py                # Per-run entrypoint; owns SignalScoutRun lifecycle + sandbox loop
+│   │   ├── run_guard.py             # Shared stale-run reaper + active-run guard
 │   │   ├── prompt.py                # System prompt assembly (skill + scratchpad + profile + run history)
 │   │   ├── skill_loader.py          # Resolves signals-scout-* LLMSkill rows for a run
 │   │   ├── lazy_seed.py             # Canonical SKILL.md → LLMSkill sync (sync_canonical_skills)

--- a/products/signals/backend/models.py
+++ b/products/signals/backend/models.py
@@ -1043,8 +1043,10 @@ class SignalScoutConfig(ModelActivityMixin, TeamScopedRootMixin, UUIDModel):
         db_default=1440,
         validators=[MinValueValidator(30), MaxValueValidator(43200)],
     )
-    # Stamped by the coordinator after each dispatch; drives the due-check. Written every
-    # run, so it is excluded from activity logging (see field_exclusions below).
+    # Stamped by the coordinator after dispatch; drives the due-check. Planning can move it
+    # backward to the due boundary after reaping a stale active run, so that a cap-deferred
+    # catch-up stays eligible until a child is actually dispatched. Written every run, so it is
+    # excluded from activity logging (see field_exclusions below).
     last_run_at = models.DateTimeField(null=True, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/products/signals/backend/scout_harness/AGENTS.md
+++ b/products/signals/backend/scout_harness/AGENTS.md
@@ -86,6 +86,11 @@ it is exercised via the `run_signals_scout` management command (see `../manageme
   `ACTIVITY_SLACK_S`, and `WORKFLOW_HARD_CEILING_S` (`= DEFAULT_MAX_RUNTIME_S +
 ACTIVITY_SLACK_S`, the activity-level ceiling that gates the workflow's
   `start_to_close_timeout`).
+- `run_guard.py`
+  Shared stale-run recovery + active-run guard used by both the coordinator and runner.
+  It batch-scans `QUEUED` / `IN_PROGRESS` `SignalScoutRun` rows for a team, fails any
+  row older than `STALE_RUN_CUTOFF_S`, emits `signals_scout_run_reaped`, and returns
+  the skills still blocked by active runs.
 - `team_limits.py`
   Single source of truth for a team's effective scout caps + metadata, resolved from the
   `signals-scout` flag payload in one read. The same three-layer cap resolution
@@ -123,13 +128,15 @@ one sandbox session → zero or more emitted signals.
 
 - The harness inserts the bridge row at the start of a run (inside `_spawn_and_run`).
   `SignalScoutRun` is now a thin bridge to a Tasks `TaskRun` — run status / timing / error
-  live on `task_run`, not on the bridge row. Single-flight is a best-effort app-layer guard:
-  `_has_running_run` skips dispatch when a prior run for the same `(team, skill_name)` has
-  `task_run.status = IN_PROGRESS`. The old `WHERE status='running'` partial unique index was
-  dropped in the bridge simplification; `_self_heal_stale_runs` now reaps the orphan case at
-  the app layer (failing any `QUEUED`/`IN_PROGRESS` run older than `STALE_RUN_CUTOFF_S` before
-  the guard), so a worker crash no longer wedges a lane permanently. A `task_run.status`-based
-  DB constraint is still a possible follow-up for stronger single-flight guarantees.
+  live on `task_run`, not on the bridge row. Single-flight is a best-effort app-layer guard
+  shared through `run_guard.reap_stale_runs_and_find_blocked_skills()`: the coordinator calls
+  it before planning so stale lanes can catch up, moving `last_run_at` back to the due grace
+  boundary when the lane would otherwise be suppressed, and the runner calls it again as a race
+  backstop before spawning. The old `WHERE status='running'`
+  partial unique index was dropped in the bridge simplification; the guard now fails any
+  `QUEUED` / `IN_PROGRESS` run older than `STALE_RUN_CUTOFF_S` before reporting which skills
+  remain blocked. A `task_run.status`-based DB constraint is still a possible follow-up for
+  stronger single-flight guarantees.
 - The sandbox is opened with the team's MCP token plus the harness-internal tools.
   The skill body is loaded into the system prompt; each scout has its own
   `SignalScoutConfig` row (keyed on `(team, skill_name)`) whose `enabled` flag and
@@ -145,7 +152,7 @@ one sandbox session → zero or more emitted signals.
   `signals_scout_run_started` (the run cleared the guards and a TaskRun exists),
   `signals_scout_run_finished` (terminal: `completed`/`failed`/`cancelled` + runtime + emit
   count), and `signals_scout_run_reaped` (a stranded orphan was reaped by
-  `_self_heal_stale_runs`). They join on `run_id`/`task_run_id` and are the event-derived
+  `run_guard`). They join on `run_id`/`task_run_id` and are the event-derived
   (no-warehouse-lag) basis for throughput, stall, and worker-death alerting — a `started`
   with no `finished` is a run that died before finalize; a reaped run emits no `finished`.
 - Emit happens via the harness's `emit_signal_*` tools, which call `emit_signal()`
@@ -177,7 +184,10 @@ one sandbox session → zero or more emitted signals.
   Polls every `COORDINATOR_INTERVAL_MINUTES = 30`; dispatches each scout whose
   per-scout schedule (`run_interval_minutes`, default every 24 hours) is due, most-overdue
   first, hard cap `MAX_RUNS_PER_TICK = 50` per tick, `ScheduleOverlapPolicy.SKIP` to
-  drop ticks rather than queue them.
+  drop ticks rather than queue them. Before due/budget allocation it uses `run_guard` to
+  reap stale active runs and skip skills still blocked by live `QUEUED` / `IN_PROGRESS`
+  task runs; reaped lanes become low-priority catch-up candidates and stay due if caps
+  defer them.
 - **Models** — `SignalScoutConfig`, `SignalScoutRun`, `SignalScratchpad`,
   `SignalProjectProfile` in `../models.py`.
 - **Source variant** — `SignalSourceConfig.SourceProduct.SIGNALS_SCOUT` paired with
@@ -203,10 +213,10 @@ one sandbox session → zero or more emitted signals.
   every team.
 - Run lifecycle lives on the linked `TaskRun` (`task_run.status`), managed by
   `MultiTurnSession` — the `SignalScoutRun` bridge row carries no status of its own. A
-  `TaskRun` stranded in `IN_PROGRESS` (worker SIGKILL before finalize) would block new runs
-  for that `(team, skill)` via `_has_running_run` — so `_self_heal_stale_runs` fails any such
-  run older than `STALE_RUN_CUTOFF_S` before the guard, letting the lane recover within a tick
-  or two instead of wedging until manual intervention.
+  `TaskRun` stranded in `QUEUED` / `IN_PROGRESS` (worker SIGKILL before finalize) would block
+  new runs for that `(team, skill)` — so `run_guard` fails any such run older than
+  `STALE_RUN_CUTOFF_S` before planning or spawning, letting the lane recover within a tick or
+  two instead of wedging until manual intervention.
 - Emit path goes through `emit_signal()` and only `emit_signal()` — **with one sanctioned
   carve-out**: a scout that opts into the report-authoring channel (`emit_report` / `edit_report`
   in its skill's `allowed_tools`) writes a full `SignalReport` directly. That write does NOT go

--- a/products/signals/backend/scout_harness/limits.py
+++ b/products/signals/backend/scout_harness/limits.py
@@ -17,11 +17,11 @@ ACTIVITY_SLACK_S = 60
 # Hard ceiling on how long a single agent activity can actually be running. The
 # workflow always sets `start_to_close_timeout = DEFAULT_MAX_RUNTIME_S + ACTIVITY_SLACK_S`,
 # providing a heartbeat window before Temporal's own timeout fires. The stale-RUNNING
-# self-heal in `runner.py` uses this as the staleness base.
+# self-heal in `run_guard.py` uses this as the staleness base.
 WORKFLOW_HARD_CEILING_S = DEFAULT_MAX_RUNTIME_S + ACTIVITY_SLACK_S
 
 # Age past which an in-flight scout run is treated as orphaned and reaped by the
-# stale-run self-heal in `runner.py`. A run older than the activity's hard ceiling cannot
+# stale-run self-heal in `run_guard.py`. A run older than the activity's hard ceiling cannot
 # still be legitimately executing — Temporal kills the activity at `WORKFLOW_HARD_CEILING_S`
 # — so a `QUEUED`/`IN_PROGRESS` TaskRun past this cutoff is an orphan left behind by a
 # crashed worker/sandbox that never wrote a terminal status. Set to a generous multiple of

--- a/products/signals/backend/scout_harness/run_guard.py
+++ b/products/signals/backend/scout_harness/run_guard.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+from django.utils import timezone
+
+import posthoganalytics
+
+from posthog.event_usage import groups
+from posthog.models import Team
+
+from products.signals.backend.models import SignalScoutRun
+from products.signals.backend.scout_harness.limits import STALE_RUN_CUTOFF_S
+from products.tasks.backend.facade import api as tasks_facade
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class ScoutRunGuardResult:
+    blocked_skill_names: set[str]
+    reaped_skill_names: set[str]
+
+
+def reap_stale_runs_and_find_blocked_skills(
+    team: Team,
+    skill_names: Collection[str],
+    now: datetime | None = None,
+) -> ScoutRunGuardResult:
+    """Reap stale active scout runs and return lanes still blocked by active runs."""
+    candidate_skill_names = {name for name in skill_names if name}
+    if not candidate_skill_names:
+        return ScoutRunGuardResult(blocked_skill_names=set(), reaped_skill_names=set())
+
+    effective_now = now or timezone.now()
+    cutoff = effective_now - timedelta(seconds=STALE_RUN_CUTOFF_S)
+    team_id = team.parent_team_id or team.id
+    active_statuses = (tasks_facade.TaskRunStatus.QUEUED, tasks_facade.TaskRunStatus.IN_PROGRESS)
+    stale_runs = list(
+        SignalScoutRun.objects.unscoped()
+        .filter(
+            team_id=team_id,
+            skill_name__in=candidate_skill_names,
+            task_run__status__in=active_statuses,
+            task_run__created_at__lt=cutoff,
+        )
+        .select_related("task_run")
+    )
+
+    reaped_skill_names: set[str] = set()
+    event_team: Team | None = None
+    for run in stale_runs:
+        task_run = run.task_run
+        try:
+            status_before = task_run.status
+            age_seconds = (effective_now - task_run.created_at).total_seconds()
+            claimed = tasks_facade.claim_and_fail_stale_run(
+                task_run.id,
+                "Scout run abandoned: no terminal status past the runtime ceiling "
+                "(worker/sandbox lost before finalize).",
+            )
+            if not claimed:
+                continue
+            reaped_skill_names.add(run.skill_name)
+            if event_team is None:
+                event_team = _event_team(team_id)
+            logger.warning(
+                "signals_scout: reaped stale active run before dispatch",
+                extra={
+                    "team_id": team_id,
+                    "skill_name": run.skill_name,
+                    "run_id": str(run.id),
+                    "task_run_id": str(run.task_run_id),
+                },
+            )
+            _capture_run_reaped(
+                team=event_team,
+                skill_name=run.skill_name,
+                run_id=run.id,
+                task_run_id=str(run.task_run_id),
+                status_before=status_before,
+                age_seconds=age_seconds,
+            )
+        except Exception:
+            logger.exception(
+                "signals_scout: failed to reap stale active run; continuing",
+                extra={"team_id": team_id, "skill_name": run.skill_name, "run_id": str(run.id)},
+            )
+
+    blocked_skill_names = set(
+        SignalScoutRun.objects.unscoped()
+        .filter(
+            team_id=team_id,
+            skill_name__in=candidate_skill_names,
+            task_run__status__in=active_statuses,
+        )
+        .values_list("skill_name", flat=True)
+        .distinct()
+    )
+    return ScoutRunGuardResult(blocked_skill_names=blocked_skill_names, reaped_skill_names=reaped_skill_names)
+
+
+def _event_team(team_id: int) -> Team:
+    return Team.objects.select_related("organization").get(id=team_id)
+
+
+def _capture_run_reaped(
+    *,
+    team: Team,
+    skill_name: str,
+    run_id: Any,
+    task_run_id: str,
+    status_before: str,
+    age_seconds: float,
+) -> None:
+    """Emit a scout-owned event when a stranded run is reaped."""
+    try:
+        posthoganalytics.capture(
+            event="signals_scout_run_reaped",
+            distinct_id=str(team.uuid),
+            properties={
+                "skill_name": skill_name,
+                "run_id": str(run_id),
+                "task_run_id": task_run_id,
+                "status_before": status_before,
+                "age_seconds": round(age_seconds, 1),
+                "stale_cutoff_seconds": STALE_RUN_CUTOFF_S,
+            },
+            groups=groups(team.organization, team),
+        )
+    except Exception:
+        logger.warning(
+            "signals_scout: failed to capture run-reaped analytics event",
+            extra={"team_id": team.id, "run_id": str(run_id), "skill_name": skill_name},
+        )

--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -4,7 +4,6 @@ import time
 import asyncio
 import logging
 from dataclasses import dataclass
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from django.utils import timezone
@@ -18,9 +17,10 @@ from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalScoutConfig, SignalScoutRun
 from products.signals.backend.scout_harness.lazy_seed import sync_canonical_skills
-from products.signals.backend.scout_harness.limits import DEFAULT_MAX_RUNTIME_S, STALE_RUN_CUTOFF_S
+from products.signals.backend.scout_harness.limits import DEFAULT_MAX_RUNTIME_S
 from products.signals.backend.scout_harness.model_selection import resolve_scout_model
 from products.signals.backend.scout_harness.prompt import SignalScoutRunSummary, build_run_prompt
+from products.signals.backend.scout_harness.run_guard import reap_stale_runs_and_find_blocked_skills
 from products.signals.backend.scout_harness.skill_loader import (
     LoadedSkill,
     load_skill_for_run,
@@ -148,24 +148,13 @@ async def arun_signals_scout(
     )
     config = await database_sync_to_async(_resolve_config, thread_sensitive=False)(team, skill.name)
 
-    # Stale-run recovery, before the skip-if-running guard below. A scout run writes its own
-    # terminal `task_run.status` from inside the activity; if the worker/sandbox dies hard
-    # mid-run that write never lands, leaving the TaskRun stuck `IN_PROGRESS` — which would
-    # otherwise block every future dispatch for this `(team, skill)` forever via
-    # `_has_running_run`. Reap such orphans here so the lane self-heals. Keyed on the same
-    # canonical `(team, skill_name)` the guard uses so it reaps exactly the rows the guard sees.
-    await database_sync_to_async(_self_heal_stale_runs, thread_sensitive=False)(
-        team.parent_team_id or team.id, skill.name
+    # Shared stale-run recovery + active-run guard. The coordinator calls the same helper before
+    # planning; this runner-side check remains as a race backstop for runs that start between
+    # planning and child execution.
+    guard_result = await database_sync_to_async(reap_stale_runs_and_find_blocked_skills, thread_sensitive=False)(
+        team, [skill.name]
     )
-
-    # Skip-if-running guard, keyed on (team, skill_name). Different skills for the same
-    # team are allowed to run concurrently — the coordinator can dispatch several due
-    # scouts for one team in a single tick. Best-effort — there is a race window between
-    # this check and the bridge-row insert inside _spawn_and_run (a second trigger could
-    # land in between), which we accept until a claim/lease primitive lands.
-    if await database_sync_to_async(_has_running_run, thread_sensitive=False)(
-        team_id=team.parent_team_id or team.id, skill_name=skill.name
-    ):
+    if skill.name in guard_result.blocked_skill_names:
         logger.info(
             "signals_scout: skipping trigger, prior run still in progress",
             extra={"team_id": team_id, "skill_name": skill.name},
@@ -313,9 +302,8 @@ async def arun_signals_scout(
         # activity as failed. Post-collapse the bridge row's status flows from its
         # linked TaskRun (managed by MultiTurnSession), so we don't update anything
         # here directly. A TaskRun stranded in IN_PROGRESS (e.g. SIGKILL before
-        # MultiTurnSession finalizes) blocks new runs for this (team, skill) via
-        # `_has_running_run` until it transitions out — active recovery is a deferred
-        # follow-up (see `_self_heal_stale_runs`).
+        # MultiTurnSession finalizes) blocks new runs for this (team, skill) until the
+        # shared run guard reaps it after the stale cutoff.
         runtime_s = time.monotonic() - started
         logger.warning(
             "signals_scout: run cancelled mid-flight",
@@ -497,108 +485,6 @@ def _resolve_config(team: Team, skill_name: str) -> SignalScoutConfig:
     return config
 
 
-def _has_running_run(*, team_id: int, skill_name: str) -> bool:
-    # Locked on (canonical team, skill_name) — different skills for the same team are
-    # allowed to fan out (the coordinator can dispatch several due scouts per tick). Status flows
-    # from the linked TaskRun now that SignalScoutRun is just a bridge; treat both QUEUED
-    # and IN_PROGRESS as active, since a TaskRun sits in QUEUED before transitioning and a
-    # second trigger landing in that window would otherwise slip past the guard. Not keyed
-    # on `scout_config_id`: configs are `on_delete=SET_NULL`, so a config delete/recreate
-    # mid-run would orphan the FK and silently defeat the dedupe in exactly the
-    # config-churn case it should still cover.
-    return (
-        SignalScoutRun.objects.unscoped()
-        .filter(
-            team_id=team_id,
-            skill_name=skill_name,
-            task_run__status__in=(tasks_facade.TaskRunStatus.QUEUED, tasks_facade.TaskRunStatus.IN_PROGRESS),
-        )
-        .exists()
-    )
-
-
-def _self_heal_stale_runs(team_id: int, skill_name: str) -> None:
-    """Reap orphaned in-flight runs so a dead run can't block the lane forever.
-
-    A scout run writes its own terminal `task_run.status` from inside the activity. If the
-    worker / sandbox dies hard mid-run (SIGKILL, pod eviction, sandbox loss), that write
-    never lands and the TaskRun is frozen at `QUEUED`/`IN_PROGRESS`. `_has_running_run`
-    then single-flights against that frozen row and skips every future dispatch for this
-    `(team, skill)` indefinitely — there is no other release. Nothing else reconciles it:
-    Temporal has already torn the workflow down (the activity is killed at
-    `WORKFLOW_HARD_CEILING_S` with `maximum_attempts=1`), and the Tasks cleanup path does
-    not cover a crashed worker.
-
-    A run older than `STALE_RUN_CUTOFF_S` (a generous multiple of that ceiling) cannot
-    still be legitimately executing, so it is an orphan and we mark it failed. The cutoff's
-    slack means a run merely at the wall — about to fail or finish on its own — is never
-    reaped out from under itself. Best-effort and silent: a failure to reap one row must
-    never block the new run, so each is guarded independently.
-    """
-    cutoff = timezone.now() - timedelta(seconds=STALE_RUN_CUTOFF_S)
-    stale_runs = list(
-        SignalScoutRun.objects.unscoped()
-        .filter(
-            team_id=team_id,
-            skill_name=skill_name,
-            task_run__status__in=(tasks_facade.TaskRunStatus.QUEUED, tasks_facade.TaskRunStatus.IN_PROGRESS),
-            task_run__created_at__lt=cutoff,
-        )
-        .select_related("task_run")
-    )
-    if not stale_runs:
-        return
-    # Resolve the team once, only when there is actually something to reap, so the reaped
-    # event carries the same team / groups shape as the other scout lifecycle events.
-    team = _get_team(team_id)
-    now = timezone.now()
-    for run in stale_runs:
-        try:
-            task_run = run.task_run
-            # Read the pre-reap status / age off the loaded bridge instance before the claim:
-            # the conditional update below doesn't refresh it, so these stay the original values.
-            status_before = task_run.status
-            age_seconds = (now - task_run.created_at).total_seconds()
-            # Compare-and-set claim on the status transition. Two triggers for the same
-            # `(team, skill)` can reach this self-heal concurrently and load the same stale
-            # row; the conditional UPDATE lets exactly one win — the other matches zero rows
-            # once the first commits `FAILED`. Only the winner falls through to emit, so a
-            # single stranded run can't double-count in the worker-death / mass-stall signal.
-            claimed = tasks_facade.claim_and_fail_stale_run(
-                task_run.id,
-                "Scout run abandoned: no terminal status past the runtime ceiling "
-                "(worker/sandbox lost before finalize).",
-            )
-            if not claimed:
-                continue
-            logger.warning(
-                "signals_scout: reaped stale in-progress run before dispatch",
-                extra={
-                    "team_id": team_id,
-                    "skill_name": skill_name,
-                    "run_id": str(run.id),
-                    "task_run_id": str(run.task_run_id),
-                },
-            )
-            # A reaped run never reaches the finalize path, so it emits no
-            # `signals_scout_run_finished`. This event makes the strand observable with no
-            # warehouse lag — a spike is the worker-death / mass-stall shape, caught within a
-            # tick of the cutoff rather than days late.
-            _capture_run_reaped(
-                team=team,
-                skill_name=skill_name,
-                run_id=run.id,
-                task_run_id=str(run.task_run_id),
-                status_before=status_before,
-                age_seconds=age_seconds,
-            )
-        except Exception:
-            logger.exception(
-                "signals_scout: failed to reap stale in-progress run; continuing",
-                extra={"team_id": team_id, "skill_name": skill_name, "run_id": str(run.id)},
-            )
-
-
 def _create_run_row(
     *,
     run_id: Any,
@@ -673,45 +559,6 @@ def _capture_run_started(
         logger.warning(
             "signals_scout: failed to capture run-started analytics event",
             extra={"team_id": team.id, "run_id": str(run_id), "skill_name": skill.name},
-        )
-
-
-def _capture_run_reaped(
-    *,
-    team: Team,
-    skill_name: str,
-    run_id: Any,
-    task_run_id: str,
-    status_before: str,
-    age_seconds: float,
-) -> None:
-    """Emit a scout-owned event when a stranded run is reaped (see `_self_heal_stale_runs`).
-
-    A run orphaned by a hard worker death never reaches the finalize path, so it emits no
-    `signals_scout_run_finished` — the reap is otherwise visible only in the logs. This event
-    surfaces the strand directly: a rising count is the worker-death / mass-stall shape, and
-    `status_before` + `age_seconds` distinguish a routine one-off from a fleet event. Keyed on
-    the team to match the other scout lifecycle events. Best-effort: a capture failure must
-    never block the reap or the new run.
-    """
-    try:
-        posthoganalytics.capture(
-            event="signals_scout_run_reaped",
-            distinct_id=str(team.uuid),
-            properties={
-                "skill_name": skill_name,
-                "run_id": str(run_id),
-                "task_run_id": task_run_id,
-                "status_before": status_before,
-                "age_seconds": round(age_seconds, 1),
-                "stale_cutoff_seconds": STALE_RUN_CUTOFF_S,
-            },
-            groups=groups(team.organization, team),
-        )
-    except Exception:
-        logger.warning(
-            "signals_scout: failed to capture run-reaped analytics event",
-            extra={"team_id": team.id, "run_id": str(run_id), "skill_name": skill_name},
         )
 
 

--- a/products/signals/backend/temporal/agentic/scout_coordinator.py
+++ b/products/signals/backend/temporal/agentic/scout_coordinator.py
@@ -20,6 +20,7 @@ from posthog.temporal.common.heartbeat import Heartbeater
 from products.signals.backend.models import SignalScoutConfig
 from products.signals.backend.scout_harness.config_registry import live_scout_skill_names, register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import sync_canonical_skills
+from products.signals.backend.scout_harness.run_guard import reap_stale_runs_and_find_blocked_skills
 
 # Per-team cap resolution + the flag-payload read live in the temporalio-free `team_limits` module
 # so the HTTP metadata surface can share them. Imported by name so the planning code below calls
@@ -55,6 +56,10 @@ COORDINATOR_INTERVAL_MINUTES = 30
 # Slack on the due-check so a scout that's a few seconds short at a tick still counts as due —
 # else stamp jitter makes it skip every other tick (a 60-min scout runs every 2h).
 DUE_GRACE_SECONDS = 60
+
+# A stale lane reaped during planning should catch up this tick if budget allows, but it should
+# never jump ahead of work that is genuinely due by schedule.
+REAPED_CATCH_UP_OVERDUE_S = float("-inf")
 
 
 @dataclass
@@ -220,13 +225,20 @@ def _collect_planned_runs(
             # brand-new canonical scouts as rows — both rare, and both catch up on the team's next
             # `sync` (follow-up if needed: a slow fleet-wide prune/seed sweep off the dispatch path).
             live_skills = live_scout_skill_names(team.id, withheld_skill_names=withheld_for_team)
+        guard_result = reap_stale_runs_and_find_blocked_skills(team, live_skills, now=now)
+
         # Skip enabled configs whose `signals-scout-*` skill was deleted or is no longer the
         # latest version: dispatching them would spawn a child workflow that fails fast in
         # load_skill_for_run on every tick.
         for config in SignalScoutConfig.all_teams.filter(team_id=team.id, enabled=True, skill_name__in=live_skills):
+            if config.skill_name in guard_result.blocked_skill_names:
+                continue
             overdue_s = _overdue_seconds(config, now)
             if overdue_s is None:
-                continue
+                if config.skill_name not in guard_result.reaped_skill_names:
+                    continue
+                overdue_s = REAPED_CATCH_UP_OVERDUE_S
+                _mark_reaped_catch_up_due(config, now)
             due.append(_DueRun(overdue_s, str(config.pk), team.id, config.skill_name))
 
     if not due:
@@ -243,6 +255,28 @@ def _collect_planned_runs(
     # Stable order for predictable child-workflow ids within the tick.
     planned.sort(key=lambda p: (p.team_id, p.skill_name))
     return planned
+
+
+def _mark_reaped_catch_up_due(config: SignalScoutConfig, now: datetime) -> None:
+    """Keep a reaped, otherwise-not-due lane eligible until a child is dispatched.
+
+    `last_run_at` stays the scheduler's only durable due marker, so move it back to the
+    grace boundary instead of stamping it to now. If this catch-up is selected and dispatched,
+    `stamp_dispatched_signals_scout_runs_activity` overwrites this with the real dispatch time.
+    """
+    catch_up_last_run_at = now - timedelta(minutes=config.run_interval_minutes) + timedelta(seconds=DUE_GRACE_SECONDS)
+    updated_count = SignalScoutConfig.all_teams.filter(pk=config.pk, last_run_at=config.last_run_at).update(
+        last_run_at=catch_up_last_run_at
+    )
+    if updated_count == 0:
+        logger.warning(
+            "signals_scout coordinator: failed to persist reaped catch-up due marker",
+            team_id=config.team_id,
+            skill_name=config.skill_name,
+            scout_config_id=str(config.pk),
+            expected_last_run_at=config.last_run_at.isoformat() if config.last_run_at else None,
+            catch_up_last_run_at=catch_up_last_run_at.isoformat(),
+        )
 
 
 def _allocate_tick_budget(

--- a/products/signals/backend/test/test_scout_coordinator.py
+++ b/products/signals/backend/test/test_scout_coordinator.py
@@ -2,11 +2,12 @@ from __future__ import annotations
 
 import random
 from datetime import timedelta
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import pytest
 from unittest.mock import AsyncMock, patch
 
+from django.apps import apps
 from django.test import override_settings
 from django.utils import timezone
 
@@ -19,9 +20,10 @@ from posthog.models import Organization, Team
 from posthog.models.scoping import team_scope
 from posthog.sync import database_sync_to_async
 
-from products.signals.backend.models import SignalScoutConfig
+from products.signals.backend.models import SignalScoutConfig, SignalScoutRun
 from products.signals.backend.scout_harness.config_registry import register_missing_configs
 from products.signals.backend.scout_harness.lazy_seed import HARNESS_SEEDED_BY, sync_canonical_skills
+from products.signals.backend.scout_harness.limits import STALE_RUN_CUTOFF_S
 
 # The flag-payload read + per-team cap resolution live in `scout_harness/team_limits.py`; helpers
 # defined there are imported and patched there (see `_PAYLOAD_PATH` / `_IS_CLOUD_PATH`).
@@ -53,6 +55,9 @@ from products.signals.backend.temporal.agentic.scout_coordinator import (
     stamp_dispatched_signals_scout_runs_activity,
 )
 from products.skills.backend.models.skills import LLMSkill
+
+if TYPE_CHECKING:
+    from products.tasks.backend.models import TaskRun
 
 _PAYLOAD_PATH = "products.signals.backend.scout_harness.team_limits.posthoganalytics.get_feature_flag_payload"
 _IS_CLOUD_PATH = "products.signals.backend.scout_harness.team_limits.is_cloud"
@@ -116,6 +121,18 @@ def _create_skill(team: Team, name: str, *, seeded: bool = True) -> LLMSkill:
 
 def _create_config(team: Team, skill_name: str, **kwargs: Any) -> SignalScoutConfig:
     return SignalScoutConfig.objects.create(team=team, skill_name=skill_name, **kwargs)
+
+
+def _make_task_run(team: Team) -> TaskRun:
+    Task = apps.get_model("tasks", "Task")
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    task = Task.objects.create(
+        team=team,
+        title="scout run",
+        description="scout run",
+        origin_product=Task.OriginProduct.SIGNALS_SCOUT,
+    )
+    return TaskRun.objects.create(task=task, team=team)
 
 
 @pytest.fixture(autouse=True)
@@ -480,6 +497,137 @@ async def test_config_within_interval_is_not_due(ateam):
     )
 
     assert await _run_activity() == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+async def test_stale_active_run_is_reaped_and_planned_as_catch_up(ateam):
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    last_run = timezone.now()
+    config = await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=1440, last_run_at=last_run
+    )
+    task_run = await database_sync_to_async(_make_task_run)(ateam)
+    await database_sync_to_async(TaskRun.objects.filter(id=task_run.id).update)(
+        status=TaskRun.Status.IN_PROGRESS,
+        created_at=timezone.now() - timedelta(seconds=STALE_RUN_CUTOFF_S + 60),
+    )
+    await database_sync_to_async(SignalScoutRun.objects.create)(
+        task_run=task_run,
+        team=ateam,
+        scout_config=config,
+        skill_name="signals-scout-foo",
+        skill_version=1,
+    )
+
+    planned = await _run_activity()
+
+    assert [(p.team_id, p.skill_name) for p in planned if p.team_id == ateam.id] == [(ateam.id, "signals-scout-foo")]
+    reaped = await database_sync_to_async(TaskRun.objects.get)(id=task_run.id)
+    assert reaped.status == TaskRun.Status.FAILED
+    refreshed = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=config.pk)
+    assert refreshed.last_run_at is not None
+    assert refreshed.last_run_at < last_run
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize("active_status", ["queued", "in_progress"])
+async def test_recent_active_run_blocks_planning_without_stamping(ateam, active_status):
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-foo")
+    last_run = timezone.now() - timedelta(minutes=2000)
+    config = await database_sync_to_async(_create_config)(
+        ateam, "signals-scout-foo", enabled=True, run_interval_minutes=1440, last_run_at=last_run
+    )
+    task_run = await database_sync_to_async(_make_task_run)(ateam)
+    await database_sync_to_async(TaskRun.objects.filter(id=task_run.id).update)(
+        status=active_status,
+        created_at=timezone.now() - timedelta(seconds=30),
+    )
+    await database_sync_to_async(SignalScoutRun.objects.create)(
+        task_run=task_run,
+        team=ateam,
+        scout_config=config,
+        skill_name="signals-scout-foo",
+        skill_version=1,
+    )
+
+    planned = await _run_activity()
+
+    assert all((p.team_id, p.skill_name) != (ateam.id, "signals-scout-foo") for p in planned)
+    still_active = await database_sync_to_async(TaskRun.objects.get)(id=task_run.id)
+    assert still_active.status == active_status
+    refreshed = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=config.pk)
+    assert refreshed.last_run_at == last_run
+
+
+@pytest.mark.asyncio
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "cap_patch_path",
+    [
+        "products.signals.backend.scout_harness.team_limits.MAX_RUNS_PER_TEAM_PER_TICK",
+        "products.signals.backend.temporal.agentic.scout_coordinator.MAX_RUNS_PER_TICK",
+    ],
+)
+async def test_reaped_catch_up_persists_when_deferred_by_cap(ateam, cap_patch_path):
+    TaskRun = apps.get_model("tasks", "TaskRun")
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-overdue")
+    await database_sync_to_async(_create_skill)(ateam, "signals-scout-reaped")
+    await database_sync_to_async(_create_config)(
+        ateam,
+        "signals-scout-overdue",
+        enabled=True,
+        run_interval_minutes=60,
+        last_run_at=timezone.now() - timedelta(hours=4),
+    )
+    reaped_config = await database_sync_to_async(_create_config)(
+        ateam,
+        "signals-scout-reaped",
+        enabled=True,
+        run_interval_minutes=1440,
+        last_run_at=timezone.now(),
+    )
+    task_run = await database_sync_to_async(_make_task_run)(ateam)
+    await database_sync_to_async(TaskRun.objects.filter(id=task_run.id).update)(
+        status=TaskRun.Status.IN_PROGRESS,
+        created_at=timezone.now() - timedelta(seconds=STALE_RUN_CUTOFF_S + 60),
+    )
+    await database_sync_to_async(SignalScoutRun.objects.create)(
+        task_run=task_run,
+        team=ateam,
+        scout_config=reaped_config,
+        skill_name="signals-scout-reaped",
+        skill_version=1,
+    )
+
+    with patch(cap_patch_path, 1):
+        planned = await _run_activity()
+
+        assert [(p.team_id, p.skill_name) for p in planned if p.team_id == ateam.id] == [
+            (ateam.id, "signals-scout-overdue")
+        ]
+        reaped = await database_sync_to_async(TaskRun.objects.get)(id=task_run.id)
+        assert reaped.status == TaskRun.Status.FAILED
+        refreshed_reaped = await database_sync_to_async(SignalScoutConfig.all_teams.get)(pk=reaped_config.pk)
+        assert refreshed_reaped.last_run_at is not None
+        assert refreshed_reaped.last_run_at < reaped_config.last_run_at
+
+        env = ActivityEnvironment()
+        await env.run(
+            stamp_dispatched_signals_scout_runs_activity,
+            StampDispatchedRunsInput(
+                dispatched_runs=[PlannedRun(team_id=ateam.id, skill_name="signals-scout-overdue")]
+            ),
+        )
+
+        planned_after_dispatch = await _run_activity()
+
+    assert [(p.team_id, p.skill_name) for p in planned_after_dispatch if p.team_id == ateam.id] == [
+        (ateam.id, "signals-scout-reaped")
+    ]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

A signals scout lane could get stuck after a worker or sandbox died mid-run. The linked `TaskRun` stayed `QUEUED` or `IN_PROGRESS`, so the single-flight guard treated the scout as still active and skipped future runs. In some cases the coordinator also stamped or suppressed scheduling incorrectly, causing that scout to miss its next daily run instead of recovering once the stale run was reaped.

Closes #65033

## Changes

- Added a shared scout run guard that detects active `QUEUED` / `IN_PROGRESS` runs, reaps stale ones, and reports which scout lanes are still blocked.
- Updated the coordinator to use that guard before planning new scout runs, so stale lanes can recover before dispatch decisions are made.
- Prevented recently active scout runs from being planned or stamped, so live work is not duplicated and the schedule stays due for the next tick.
- Preserved catch-up scheduling when a stale run is reaped but budget caps defer it, so the missed run remains eligible until a child workflow is actually dispatched.
- Updated the scout architecture/docs comments to describe the new coordinator-side stale-run recovery behavior.

## How did you test this code?

- Added tests for stale recovery, recent-run blocking, cap-deferred catch-up, runner fallback behavior, and the reaped analytics event.
- Ran tests: `hogli test products/signals/backend/test/test_scout_coordinator.py products/signals/backend/test/test_scout_harness.py`
- Smoke-tested the local scout config API against `localhost:8010`: health/setup, config list, sync, and patch all returned 200

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update
- `ARCHITECTURE.md`: Documented that the coordinator reaps stale scout runs before planning and keeps reaped catch-ups due until dispatch.
- `AGENTS.md`: Updated agent guidance to explain the shared run guard and coordinator/runner stale-run recovery flow.