### PR TITLE
chore(posthog_ai): add checking-deploy-timing skill

### DIFF
--- a/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
+++ b/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
@@ -26,14 +26,14 @@ They're returned newest-first; paginate with `offset` if you need to go further 
 ## Workflow
 
 1. **Find the change's merge commit.** Identify the PR (e.g. `gh search prs --repo PostHog/posthog --author <user> "<keywords>"`), then `gh pr view <n> --repo PostHog/posthog --json number,title,mergedAt,mergeCommit,state`. Note the merge commit SHA and `mergedAt`.
-2. **Find the first deploy to the target environment after the merge.** Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU"). The annotations come back **newest-first**, so don't just take the first `... to <env>` match on page 1 — that's the _most recent_ deploy, not the first one after the merge. Walk newest→oldest (paginating with `offset`) through that environment's markers until a `date_marker` falls _before_ `mergedAt`; the last matching marker you saw before crossing that boundary is the first deploy after the merge.
-3. **Confirm the deployed commit actually contains the merge commit.** A later `date_marker` is necessary but not sufficient — the deploy might predate the merge in git history. Verify ancestry:
+2. **List the target environment's deploys around the merge, oldest-first.** Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU"). The annotations come back **newest-first**, so don't just take the first `... to <env>` match on page 1 — that's the _most recent_ deploy. Paginate (with `offset`) until you reach markers around `mergedAt`, then consider that environment's deploys in chronological order, starting with the first whose `date_marker` is _after_ `mergedAt`. Check them earliest-first in step 3.
+3. **Confirm the deployed commit actually contains the merge commit.** A later `date_marker` is necessary but not sufficient — a deploy can fire just after the merge yet build a slightly older commit. Verify ancestry:
 
    ```sh
    gh api repos/PostHog/posthog/compare/<merge_sha>...<deployed_sha> --jq '{status,ahead_by,behind_by}'
    ```
 
-   `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge. If `behind_by > 0`, that deploy is _before_ the change — keep scanning forward to the next deploy of that environment.
+   `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge — that's your answer. If `behind_by > 0`, this deploy predates the change; move to the **next newer** deploy of that environment (the next one chronologically) and re-check. The first deploy that passes is the one that shipped the change.
 
 4. **Report** the deploy time (and PR/commit) for the region asked about. Mention other regions if relevant — `prod-us` and `prod-eu` usually deploy minutes apart but not simultaneously.
 

--- a/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
+++ b/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
@@ -26,12 +26,12 @@ They're returned newest-first; paginate with `offset` if you need to go further 
 ## Workflow
 
 1. **Find the change's merge commit.** Identify the PR (e.g. `gh search prs --repo PostHog/posthog --author <user> "<keywords>"`), then `gh pr view <n> --repo PostHog/posthog --json number,title,mergedAt,mergeCommit,state`. Note the merge commit SHA and `mergedAt`.
-2. **Find the first deploy to the target environment after the merge.** Scan the `deploy` annotations for the earliest `... to <env>` marker with `date_marker` after `mergedAt`. Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU").
+2. **Find the first deploy to the target environment after the merge.** Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU"). The annotations come back **newest-first**, so don't just take the first `... to <env>` match on page 1 — that's the _most recent_ deploy, not the first one after the merge. Walk newest→oldest (paginating with `offset`) through that environment's markers until a `date_marker` falls _before_ `mergedAt`; the last matching marker you saw before crossing that boundary is the first deploy after the merge.
 3. **Confirm the deployed commit actually contains the merge commit.** A later `date_marker` is necessary but not sufficient — the deploy might predate the merge in git history. Verify ancestry:
    ```sh
    gh api repos/PostHog/posthog/compare/<merge_sha>...<deployed_sha> --jq '{status,ahead_by,behind_by}'
    ```
-   `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge. If `behind_by > 0`, that deploy is *before* the change — keep scanning forward to the next deploy of that environment.
+   `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge. If `behind_by > 0`, that deploy is _before_ the change — keep scanning forward to the next deploy of that environment.
 4. **Report** the deploy time (and PR/commit) for the region asked about. Mention other regions if relevant — `prod-us` and `prod-eu` usually deploy minutes apart but not simultaneously.
 
 ## Notes

--- a/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
+++ b/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: checking-deploy-timing
+description: 'Determine when a PostHog code change reached a given environment by reading the hidden GIT deploy annotations in the project and correlating them with the merge commit on GitHub. Use when PostHog staff ask "when was X deployed", "is my change live in the US/EU yet", "has my PR shipped", "did the fix roll out to prod-us", or otherwise want to know whether/when a commit, PR, or feature went out to a region. Do not answer deploy-timing questions from event/data volume alone — that only shows when data changed, not when code shipped.'
+---
+
+# Checking when something was deployed
+
+PostHog's CI writes a deploy marker into the project as an **annotation** every time a commit
+ships to an environment. These annotations are `hidden_in_user_interface: true`, so they don't
+show in the UI and are easy to forget — but they are the source of truth for "when did this go
+out". Always check them when staff ask about deploy timing, rather than inferring from when a
+metric or event volume changed (that conflates a capture change with a query/code change).
+
+## The deploy annotations
+
+List them with `posthog:annotations-list` using `{"search": "deploy"}`. Each deploy marker looks like:
+
+- `content`: `Deployed PostHog/posthog@<sha> to <env>` — env is `prod-us`, `prod-eu`, or `dev`
+- `creation_type`: `GIT`
+- `scope`: `organization`
+- `hidden_in_user_interface`: `true`
+- `date_marker`: the deploy time (UTC)
+
+They're returned newest-first; paginate with `offset` if you need to go further back.
+
+## Workflow
+
+1. **Find the change's merge commit.** Identify the PR (e.g. `gh search prs --repo PostHog/posthog --author <user> "<keywords>"`), then `gh pr view <n> --repo PostHog/posthog --json number,title,mergedAt,mergeCommit,state`. Note the merge commit SHA and `mergedAt`.
+2. **Find the first deploy to the target environment after the merge.** Scan the `deploy` annotations for the earliest `... to <env>` marker with `date_marker` after `mergedAt`. Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU").
+3. **Confirm the deployed commit actually contains the merge commit.** A later `date_marker` is necessary but not sufficient — the deploy might predate the merge in git history. Verify ancestry:
+   ```sh
+   gh api repos/PostHog/posthog/compare/<merge_sha>...<deployed_sha> --jq '{status,ahead_by,behind_by}'
+   ```
+   `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge. If `behind_by > 0`, that deploy is *before* the change — keep scanning forward to the next deploy of that environment.
+4. **Report** the deploy time (and PR/commit) for the region asked about. Mention other regions if relevant — `prod-us` and `prod-eu` usually deploy minutes apart but not simultaneously.
+
+## Notes
+
+- "Live in the US" = `prod-us`; "the EU" = `prod-eu`. `dev` is the internal staging environment, not customer-facing.
+- For a **query-runner / read-path** change, the new behaviour applies retroactively to all data once deployed — so you can't time it from event volume, only from the deploy annotation. For a **capture** change, event volume for the new property is a secondary cross-check, but the annotation is still the authoritative deploy time.

--- a/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
+++ b/products/posthog_ai/skills/checking-deploy-timing/SKILL.md
@@ -28,10 +28,13 @@ They're returned newest-first; paginate with `offset` if you need to go further 
 1. **Find the change's merge commit.** Identify the PR (e.g. `gh search prs --repo PostHog/posthog --author <user> "<keywords>"`), then `gh pr view <n> --repo PostHog/posthog --json number,title,mergedAt,mergeCommit,state`. Note the merge commit SHA and `mergedAt`.
 2. **Find the first deploy to the target environment after the merge.** Match the region the user asked about (`prod-us` for "the US", `prod-eu` for "the EU"). The annotations come back **newest-first**, so don't just take the first `... to <env>` match on page 1 — that's the _most recent_ deploy, not the first one after the merge. Walk newest→oldest (paginating with `offset`) through that environment's markers until a `date_marker` falls _before_ `mergedAt`; the last matching marker you saw before crossing that boundary is the first deploy after the merge.
 3. **Confirm the deployed commit actually contains the merge commit.** A later `date_marker` is necessary but not sufficient — the deploy might predate the merge in git history. Verify ancestry:
+
    ```sh
    gh api repos/PostHog/posthog/compare/<merge_sha>...<deployed_sha> --jq '{status,ahead_by,behind_by}'
    ```
+
    `behind_by: 0` with `status` `ahead` or `identical` means the deployed commit includes the merge. If `behind_by > 0`, that deploy is _before_ the change — keep scanning forward to the next deploy of that environment.
+
 4. **Report** the deploy time (and PR/commit) for the region asked about. Mention other regions if relevant — `prod-us` and `prod-eu` usually deploy minutes apart but not simultaneously.
 
 ## Notes


### PR DESCRIPTION
## Problem

When PostHog staff ask an agent "when was X deployed" / "is my change live in the US yet", the agent tends to infer timing from when an event or metric changed. That conflates a capture change with a query/read-path change, and misses the authoritative source: the hidden `GIT` deploy annotations CI writes into the project on every deploy.

## Changes

Adds a small `checking-deploy-timing` skill under `products/posthog_ai/skills/`. It tells the agent to:
- list the `Deployed PostHog/posthog@<sha> to <env>` annotations (`hidden_in_user_interface: true`) via `posthog:annotations-list`,
- find the first `prod-us`/`prod-eu` deploy after the PR's merge commit, and
- confirm the deployed commit actually contains the merge via `gh api .../compare/<merge>...<deployed>` (`behind_by: 0`).

**Why:** this came out of a Slack thread where the deploy-timing answer was initially inferred from `$mcp_client_name` event volume; the deploy annotations are the source of truth, so the next agent should reach for them first.

## How did you test this code?

I'm an agent. I did not run `hogli lint:skills`/`build:skills` (no Python env in this session). I manually verified the frontmatter: `name` + `description` present, description 535/1024 chars, file 41/500 lines.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1782406618235879?thread_ts=1782406618.235879&cid=C0B3E1Y576X)*