### PR TITLE
fix(mcp): attribute single-exec tool calls to the real inner tool

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -18,10 +18,8 @@ import {
 } from '@/lib/errors'
 import { estimateTokens } from '@/lib/estimate-tokens'
 import { getPostHogClient } from '@/lib/posthog'
-import { AnalyticsEvent } from '@/lib/posthog/analytics'
 import { createExecTool, formatInputValidationError, type ExecInnerCallTracker } from '@/tools/exec'
 import { createRenderUiTool } from '@/tools/render-ui'
-import { getToolCategory } from '@/tools/toolDefinitions'
 import type { Context, ZodObjectAny } from '@/tools/types'
 
 import { trackToolCall, trackToolsList, type ToolCallIntentMeta } from './analytics'
@@ -257,6 +255,16 @@ export class ToolExecutor {
 
         const startMs = Date.now()
 
+        // In single-exec mode every transport-level call is `exec`, so `$mcp_tool_name`
+        // would always read `exec` and hide which tool the agent actually invoked.
+        // Attribute the canonical event to the inner tool that dispatched (captured by
+        // `trackInnerCall` above) — keeping the same standard `$mcp_tool_name` the SDK
+        // emits for direct calls, so exec-routed and direct calls share one vocabulary.
+        // `$mcp_mode` already distinguishes single-exec from direct for anyone who needs
+        // it. Non-`call` verbs (tools/info/search/schema) resolve no inner tool and stay
+        // attributed to `exec`.
+        const execToolName = (): string => execMetrics.innerToolName ?? 'exec'
+
         try {
             const handlerResult = await resolved.handler(state.context, validation.data)
             const duration = Date.now() - startMs
@@ -273,7 +281,7 @@ export class ToolExecutor {
                   })
 
             void trackToolCall(
-                'exec',
+                execToolName(),
                 duration,
                 false,
                 state,
@@ -286,13 +294,13 @@ export class ToolExecutor {
 
             return response
         } catch (error: unknown) {
-            const metricTool = execMetrics.innerToolName ?? 'exec'
+            const metricTool = execToolName()
             if (!execMetrics.innerToolName) {
                 toolCallsTotal.inc({ tool: 'exec', status: 'error' })
             }
             classifyToolError(error, metricTool)
 
-            void trackToolCall('exec', Date.now() - startMs, true, state, undefined, intentMeta)
+            void trackToolCall(metricTool, Date.now() - startMs, true, state, undefined, intentMeta)
 
             const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(state.requestContext)
             // Attribute the failure to the inner tool that actually ran (e.g. `query-logs`),
@@ -307,6 +315,11 @@ export class ToolExecutor {
         const commandReference = this.instructionsBuilder.buildExecCommandReference(state)
 
         const trackInnerCall: ExecInnerCallTracker = (toolName, properties) => {
+            // Record which inner tool actually dispatched so `callExecTool` can attribute
+            // the canonical `$mcp_tool_call` event to the real tool instead of the `exec`
+            // dispatcher. The PostHog event is intentionally NOT emitted here: the wrapper
+            // event (now relabelled to the inner tool name, with the inner tool's category
+            // derived from it) already carries this call, so a second emit would double-count.
             execMetrics.innerToolName = toolName
             const status = properties.success ? 'success' : properties.validation_error ? 'validation_error' : 'error'
             toolCallsTotal.inc({ tool: toolName, status })
@@ -316,25 +329,6 @@ export class ToolExecutor {
             if (!properties.validation_error) {
                 toolCallDurationSeconds.observe({ tool: toolName, status }, properties.duration_ms / 1000)
             }
-
-            // Mirror the native path: stamp the inner tool's category so exec-routed
-            // calls share the dashboard's `$mcp_tool_category` grouping dimension.
-            const toolCategory = getToolCategory(toolName)
-
-            void (async () => {
-                const freshContext = await state.reqCtx.safelyGetAnalyticsContext(state.context)
-                await state.reqCtx.trackEvent(
-                    AnalyticsEvent.MCP_TOOL_CALL,
-                    {
-                        tool_name: toolName,
-                        ...(toolCategory ? { $mcp_tool_category: toolCategory } : {}),
-                        ...properties,
-                    },
-                    freshContext,
-                    undefined,
-                    state.distinctId
-                )
-            })().catch(() => {})
         }
         const clientContext = getEffectiveMCPClientContext(state.requestContext, state.sessionContext)
 

--- a/services/mcp/tests/hono/tool-executor-tokens.test.ts
+++ b/services/mcp/tests/hono/tool-executor-tokens.test.ts
@@ -186,5 +186,40 @@ describe('ToolExecutor token estimates', () => {
             expect(execCall[4].output_tokens).toBe(estimateTokens(joinedText(response)))
             expect(execCall[4].output_tokens).not.toBe(estimateTokens(response))
         })
+
+        it('attributes the canonical event to the inner tool via the standard $mcp_tool_name', async () => {
+            // Full catalog tools (real names, so the instructions builder resolves them),
+            // with the target handler stubbed to keep dispatch offline + deterministic.
+            const tools = catalog.getPreBuiltEntries().map((entry) => {
+                const preBuilt = catalog.getToolByName(entry.name)!
+                return {
+                    ...preBuilt.base,
+                    title: entry.title,
+                    description: entry.description ?? '',
+                    annotations: entry.annotations,
+                    scopes: [],
+                }
+            })
+            const target = tools.find((t) => t.name === 'docs-search')! as any
+            target.handler = vi.fn(async () => 'inner-ok')
+            const state = makeState(tools as any, { useSingleExec: true })
+
+            await executor.handleToolCall(
+                { name: 'exec', arguments: { command: 'call docs-search {"query":"hi"}' } },
+                state
+            )
+
+            // The canonical event is attributed to the real inner tool — the same standard
+            // property the SDK emits for direct calls — never the `exec` dispatcher.
+            const innerCall = mockTrackToolCall.mock.calls.find((call) => call[0] === 'docs-search')!
+            expect(innerCall).toBeTruthy()
+            expect(innerCall[2]).toBe(false)
+            expect(mockTrackToolCall.mock.calls.some((call) => call[0] === 'exec')).toBe(false)
+
+            // Regression: the inner dispatch must not ALSO emit its own `mcp_tool_call`
+            // event — that would double-count the inner tool on the legacy event.
+            const trackEvent = state.reqCtx.trackEvent as ReturnType<typeof vi.fn>
+            expect(trackEvent.mock.calls.some((call) => call[0] === 'mcp_tool_call')).toBe(false)
+        })
     })
 })


### PR DESCRIPTION
## Problem

PostHog's MCP server runs most clients in **single-exec mode**, where the agent only ever calls one transport-level tool — `exec` — with the real tool encoded in a `call <tool> ...` command string. As a result `$mcp_tool_name` on the canonical `$mcp_tool_call` event was **always `"exec"`**, which is ~85% of all captured tool calls. You couldn't tell whether the agent ran `execute-sql`, `query-trends`, or `feature-flag-get-all` — they all collapsed into one opaque `exec` bucket on every dashboard, breakdown, and funnel keyed on `$mcp_tool_name`.

The real inner tool name *was* captured, but only as a side effect on the legacy `mcp_tool_call` event in the `tool_name` property, with `$mcp_tool_name` left null — invisible to anything reading the canonical event vocabulary.

## Changes

In `services/mcp/src/hono/tool-executor.ts`, `callExecTool` now attributes the canonical event to the inner tool that actually dispatched:

- **Relabel** `$mcp_tool_name` to the real inner tool (the name `trackInnerCall` already resolves), on both the success and error paths — using the **same standard property the SDK emits for direct calls**. Exec-routed and direct calls now share one vocabulary, so every existing chart keyed on `$mcp_tool_name` self-heals with no query changes. `$mcp_tool_category` now derives from the real tool too.
- **Remove** the now-redundant inner emit in `trackInnerCall`. Once the wrapper event carries the real name, leaving the inner emit would double-count every inner tool on the legacy `mcp_tool_call` event. Prometheus metrics are untouched.
- Non-`call` verbs (`tools`/`info`/`search`/`schema`) target no inner tool and stay attributed to `exec`.

**No PostHog-specific properties.** An earlier draft restored the old `$mcp_exec_tool_call_name` / `_description` properties (lost in the hono refactor). We dropped that: the name is redundant with `$mcp_tool_name` after the relabel, "was this exec-routed?" is already answerable via `$mcp_mode` (stamped on every event), and a per-event static description is pure bloat. Keeping the vocabulary identical to what the `@posthog/mcp` SDK emits avoids a two-tier world where our dogfood has richer data than customers can get — and a server-only side property is exactly the pattern that silently broke here in the first place.

## How did you test this code?

I'm an agent (PostHog Code). I did not manually exercise the running server. Automated tests only:

- Added a test in `tool-executor-tokens.test.ts` asserting an exec `call <tool>` attributes the canonical event to the inner tool name via the standard `$mcp_tool_name`, and **does not** also emit a separate `mcp_tool_call` (the double-count regression).
- Full hono suite + `exec` unit suite pass; lint clean on touched files. The two changed files typecheck — the only `tsc` errors in the package are pre-existing and in unrelated chart files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude) via the `mcp-analytics` skill. The work started as an investigation — validated against live dogfood data in project 2 (confirming `exec` dominated `$mcp_tool_name`), then traced the emission paths and git history to find that the old `$mcp_exec_tool_call_name` property was real and lost in the hono standalone refactor (`#59368`).

Two designs were weighed: restore the old `$mcp_exec_tool_call_name` side property, or relabel `$mcp_tool_name` itself. We landed on the relabel **alone** — making the standard property correct fixes existing consumers for free and keeps exec-routed calls indistinguishable from direct ones in the vocabulary (which is the point; `exec` is our server's plumbing, not something the analytics layer should encode). The exec-vs-direct distinction is preserved via the existing `$mcp_mode` property. Removing the inner emit was a required consequence of relabeling, to avoid double-counting on the legacy event.

A leftover dead `createExecInnerToolCallResolver` (orphaned by the same refactor) is now unused beyond a test mock fallback — left in place as an optional future cleanup.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
