### PR TITLE
chore(cohorts): add cohort services to rust image build and deploy

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -57,6 +57,14 @@
   dockerfile: ./rust/Dockerfile
   project: vglf58qgzw
 
+- image: cohort-event-shuffler
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+
+- image: cohort-stream-processor
+  dockerfile: ./rust/Dockerfile
+  project: vglf58qgzw
+
 - image: batch-import-worker
   dockerfile: ./rust/Dockerfile
   project: 4ppc15q4bv

--- a/.github/workflows/rust-docker-build.yml
+++ b/.github/workflows/rust-docker-build.yml
@@ -135,6 +135,12 @@ jobs:
                     - release: flags-consumer
                       digest_key: flags-consumer
                       values_key: image
+                    - release: cohort-event-shuffler
+                      digest_key: cohort-event-shuffler
+                      values_key: image
+                    - release: cohort-stream-processor
+                      digest_key: cohort-stream-processor
+                      values_key: image
                     - release: batch-import-worker
                       digest_key: batch-import-worker
                       values_key: image

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -477,8 +477,7 @@ procs:
 
     # Behavioral Cohorts stream rebuild (Rust). The shuffler keys clickhouse_events_json into
     # cohort_stream_events; the processor consumes that and emits membership changes. Opt-in
-    # (autostart: false) until the shadow-mode pipeline is rolled out — like flags-consumer, they
-    # stay out of every dev's default stack and are started manually when working on them.
+    # (autostart: false).
     cohort-event-shuffler:
         shell: |-
             bin/wait-for-docker && \

--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -476,14 +476,14 @@ procs:
         ready_pattern: 'Metrics server listening on *'
 
     # Behavioral Cohorts stream rebuild (Rust). The shuffler keys clickhouse_events_json into
-    # cohort_stream_events; the processor consumes that and emits membership changes. Both are gated
-    # behind the `behavioral_cohorts` capability (wired into the `cohorts` intent) so they only run
-    # when a dev opts in — the default no-intent manifest is unchanged.
+    # cohort_stream_events; the processor consumes that and emits membership changes. Opt-in
+    # (autostart: false) until the shadow-mode pipeline is rolled out — like flags-consumer, they
+    # stay out of every dev's default stack and are started manually when working on them.
     cohort-event-shuffler:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service cohort-event-shuffler
-        capability: behavioral_cohorts
+        autostart: false
         ready_pattern: 'observability server starting'
         groups:
             layer: Product services
@@ -493,7 +493,7 @@ procs:
         shell: |-
             bin/wait-for-docker && \
             bin/start-rust-service cohort-stream-processor
-        capability: behavioral_cohorts
+        autostart: false
         ready_pattern: 'observability server starting'
         groups:
             layer: Product services

--- a/devenv/intent-map.yaml
+++ b/devenv/intent-map.yaml
@@ -152,11 +152,6 @@ capabilities:
         requires: [event_ingestion]
         docker_profiles: []
 
-    behavioral_cohorts:
-        description: 'Behavioral Cohorts stream rebuild (Rust cohort-event-shuffler + cohort-stream-processor)'
-        requires: [event_ingestion]
-        docker_profiles: []
-
     nodejs_session_replay:
         description: 'Node.js Session Replay - recording ingestion'
         requires: [event_ingestion]
@@ -340,7 +335,6 @@ intents:
                 celery_workers,
                 celery_scheduler,
                 nodejs_realtime_cohorts,
-                behavioral_cohorts,
             ]
 
     pipelines:

--- a/rust/affected-services/tests/integration.rs
+++ b/rust/affected-services/tests/integration.rs
@@ -111,9 +111,6 @@ fn every_deployable_binary_has_an_image_entry() {
         "stl_dump",
         "run", // hogvm dev/diff CLI, not a service
         "hermes",
-        // Not yet in .github/rust-images.yml — no production Depot/chart image build.
-        "cohort-event-shuffler",
-        "cohort-stream-processor",
     ]
     .into();
 


### PR DESCRIPTION
## Problem

The behavioral cohorts rebuild ships two new rust services, `cohort-event-shuffler` and `cohort-stream-processor`, meant to run in production shadow mode.
Their crates already live on master, but CI never built or deployed their images, and the local dev stack auto started them under the `cohorts` intent before they are ready.

Part of https://github.com/PostHog/posthog/issues/65898.

## Changes

* `.github/rust-images.yml`: build entries for both images, reusing the feature flags Depot project.
* `.github/workflows/rust-docker-build.yml`: both added to the deploy matrix with `values_key: image`. The deploy job is already gated by `CD_DEPLOY_ENABLED` on master, so the new rows inherit that gate.
* `rust/affected-services/tests/integration.rs`: removed both binaries from the `non_deployable` allowlist now that they have image entries, keeping the completeness test accurate.
* `bin/mprocs.yaml` and `devenv/intent-map.yaml`: both services move to the `flags-consumer` pattern (`autostart: false`, no capability) so they stay out of every dev's default stack and start manually. The now dead `behavioral_cohorts` capability and its `cohorts` intent reference are removed.

## How did you test this code?

* `actionlint` on the workflow.
* `cargo test -p affected-services` (22 tests, including the completeness test).
* hogli devenv suite (69 tests).
* A resolver and generator check confirming the `cohorts` intent still resolves and both services emit as `autostart: false` in both the cohorts intent and the no intent default.
* `bin/hogli format:yaml` and `cargo fmt`, both clean.

No manual or production testing was done.

## Docs update

No.