### PR TITLE
chore: deflake virtual-property toolkit test

### DIFF
--- a/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/test/test_toolkit.py
@@ -221,7 +221,21 @@ class TestTaxonomyAgentToolkit(ClickhouseTestMixin, APIBaseTest):
             '"Paid Search", "Organic Video", "Direct" and many more distinct values.',
         )
 
-    def test_retrieve_entity_property_values_virtual_property_without_examples(self):
+    @patch("ee.hogai.chat_agent.query_planner.toolkit.ActorsPropertyTaxonomyQueryRunner")
+    def test_retrieve_entity_property_values_virtual_property_without_examples(self, mock_runner_class):
+        # The real runner reads ClickHouse actor data, which sibling tests on the same
+        # file-sharded run can pollute (ClickHouse writes are not rolled back per test),
+        # making it return a stray "0" instead of nothing. Mock an empty result so the
+        # virtual-property fallback is asserted deterministically.
+        now = datetime(2024, 1, 1, tzinfo=UTC)
+        mock_runner_class.return_value.run.return_value = CachedActorsPropertyTaxonomyQueryResponse(
+            cache_key="test",
+            is_cached=True,
+            last_refresh=now,
+            next_allowed_client_refresh=now,
+            results=[],
+            timezone="UTC",
+        )
         create_group_type_mapping_without_created_at(
             team=self.team, project_id=self.team.project_id, group_type_index=0, group_type="proj"
         )


### PR DESCRIPTION
## Problem

`test_retrieve_entity_property_values_virtual_property_without_examples` fails consistently in the Backend CI Core shard — it asserts the "no stored sample values" message for `$virt_mrr` but gets `'0'`.

`$virt_mrr` has no stored `PropertyDefinition`, so the toolkit runs the real `ActorsPropertyTaxonomyQueryRunner` against ClickHouse. Sibling tests leave actor rows behind (not rolled back per test), so the runner returns a stray `0` instead of empty. [File-granularity sharding](https://github.com/PostHog/posthog/pull/64783) added this mock to two sibling tests but missed this one.

## Changes

Mock the runner to return empty results — matching the two `*_with_empty_runner_results` siblings — so the fallback is asserted without touching ClickHouse.

## How did you test this code?

Agent-authored. Ran the full file 3× with order preserved (polluter runs first, the CI repro): 21/21 each. Pre-fix it failed deterministically on both source-PR runs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code (Opus 4.8), `/fixing-flaky-tests`. Root-caused from CI logs + git history; copied the mock pattern the same sharding PR applied to the two siblings this test was missed from.
