### PR TITLE
fix(experiments): disable reload and retry buttons while recalculating

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx
@@ -134,7 +134,7 @@ export const ExperimentReloadAction = ({
     }))
 
     const loadingText =
-        progress && progress.total > 0 ? `Loading ${progress.completed} of ${progress.total}` : 'Loading…'
+        progress && progress.total > 0 ? `Loaded ${progress.completed} of ${progress.total} metrics` : 'Loading…'
 
     return (
         <div className="flex flex-col">

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx
@@ -19,10 +19,18 @@ type MetricErrorStateProps = {
     metric: ExperimentMetric
     query?: Record<string, any>
     onRetry?: () => void
+    /** Disables the "Try again" button (with a tooltip) while a recalculation is already in flight. */
+    retryDisabledReason?: string
     height?: number
 }
 
-export const MetricErrorState = ({ error, query, onRetry, height = 200 }: MetricErrorStateProps): JSX.Element => {
+export const MetricErrorState = ({
+    error,
+    query,
+    onRetry,
+    retryDisabledReason,
+    height = 200,
+}: MetricErrorStateProps): JSX.Element => {
     const { openSupportForm } = useActions(supportLogic)
 
     const errorMessage = parseErrorMessage(error.detail)
@@ -51,6 +59,7 @@ export const MetricErrorState = ({ error, query, onRetry, height = 200 }: Metric
                         type="primary"
                         size="xsmall"
                         onClick={onRetry}
+                        disabledReason={retryDisabledReason}
                         sideAction={
                             query
                                 ? {

--- a/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx
@@ -246,6 +246,11 @@ function CollapsibleBreakdownSection({
                                                                             metric={metric}
                                                                             query={query}
                                                                             onRetry={onRetry}
+                                                                            retryDisabledReason={
+                                                                                isRecalculating
+                                                                                    ? 'Recalculation in progress'
+                                                                                    : undefined
+                                                                            }
                                                                         />
                                                                     )}
                                                                 </td>
@@ -835,6 +840,7 @@ export function MetricRowGroup({
                             error={error}
                             query={debugQuery}
                             onRetry={handleRetry}
+                            retryDisabledReason={isRecalculating ? 'Recalculation in progress' : undefined}
                         />
                     </td>
                 </tr>

--- a/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
+++ b/frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx
@@ -15,6 +15,8 @@ interface ChartEmptyStateProps {
     error?: any
     query?: Record<string, any>
     onRetry?: () => void
+    /** Disables the "Try again" button (with a tooltip) while a recalculation is already in flight. */
+    retryDisabledReason?: string
 }
 
 export function ChartEmptyState({
@@ -24,6 +26,7 @@ export function ChartEmptyState({
     metric,
     query,
     onRetry,
+    retryDisabledReason,
 }: ChartEmptyStateProps): JSX.Element | null {
     /**
      * early return if experiment has not started
@@ -69,7 +72,14 @@ export function ChartEmptyState({
                 <ErrorChecklist error={error} metric={metric} />
             ) : (
                 // Use rich error state for all other errors
-                <MetricErrorState error={error} metric={metric} query={query} onRetry={onRetry} height={height} />
+                <MetricErrorState
+                    error={error}
+                    metric={metric}
+                    query={query}
+                    onRetry={onRetry}
+                    retryDisabledReason={retryDisabledReason}
+                    height={height}
+                />
             )}
         </div>
     )

--- a/frontend/src/scenes/experiments/experimentMetricsLogic.ts
+++ b/frontend/src/scenes/experiments/experimentMetricsLogic.ts
@@ -483,10 +483,20 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                 if (!resolvedIds) {
                     return
                 }
+
+                /**
+                 * Mark loading up front so the reload button disables on click, not only once the create POST
+                 * returns. Without this there's a window (the POST round-trip) where the button stays clickable.
+                 * Cleared by setCurrentRecalculation on success, or in the catch below on failure.
+                 */
+                actions.setRecalculationLoading(true)
                 try {
                     const { projectId, experimentId } = resolvedIds
-                    // 201 with a new pending run, or 200 with the already-active one. No results yet.
-                    // Create a recalculation workflow. 201: a new run. 200: one is already running, poll it.
+
+                    /**
+                     * 201 with a new pending run, or 200 with the already-active one. No results yet.
+                     * Create a recalculation workflow. 201: a new run. 200: one is already running, poll it.
+                     */
                     const recalculation = await experimentsMetricsRecalculationCreate(String(projectId), experimentId, {
                         trigger,
                     })
@@ -526,6 +536,10 @@ export const experimentMetricsLogic = kea<experimentMetricsLogicType>([
                         actions.pollRecalculation(recalculation.id)
                     }
                 } catch (error: any) {
+                    /**
+                     * Re-enable the reload button: the run never started, so nothing else will clear loading.
+                     */
+                    actions.setRecalculationLoading(false)
                     lemonToast.error(error?.detail || 'Failed to trigger metrics recalculation')
                 }
             },


### PR DESCRIPTION
## Problem

Two ways a user could fire a redundant recalculation while one was already running:

- The reload button only disabled once the create POST returned, not on click. `triggerRecalculation` awaited the POST before any loading state was set, so for the round-trip (a couple of seconds) the button stayed clickable and a second click started another run.
- The "Try again" button on an errored metric stayed enabled during a recalculation, so a user could trigger more runs from a stale error row while results were already loading.

## Changes

This PR closes both windows so the reload and retry affordances reflect that a recalculation is in flight.

### Disable the reload button on click

`triggerRecalculation` now sets `recalculationLoading` true right after its guards, before awaiting the create POST, so `isRecalculating` (and the button's disabled state) flips immediately on click instead of after the round-trip. The success path already clears it via `setCurrentRecalculation`; the catch path now clears it too, so a failed trigger re-enables the button rather than leaving it stuck.

- `frontend/src/scenes/experiments/experimentMetricsLogic.ts`

### Disable "Try again" while recalculating

Threaded a `retryDisabledReason` prop from `MetricRowGroup` through `ChartEmptyState` to `MetricErrorState`, set to "Recalculation in progress" when `isRecalculating`. The button shows the reason as a tooltip and is unclickable while a run is in flight, covering both the main error row and the breakdown sub-table.

- `frontend/src/scenes/experiments/MetricsView/new/MetricRowGroup.tsx`
- `frontend/src/scenes/experiments/MetricsView/shared/ChartEmptyState.tsx`
- `frontend/src/scenes/experiments/MetricsView/new/MetricErrorState.tsx`

### Reload progress copy

Reworded the reload button's progress label from "Loading N of M" to "Loaded N of M metrics" so it reads as a count of completed metrics rather than an indefinite in-progress state.

- `frontend/src/scenes/experiments/ExperimentView/ExperimentReloadAction.tsx`

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

```bash
pnpm --filter=@posthog/frontend jest src/scenes/experiments/experimentMetricsLogic.test.ts
```

![cat-type-small](https://github.com/user-attachments/assets/84dd69e7-d726-4d05-b2fc-9f2112a94068)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **yes**

Skills used:

- /systematic-debugging (superpowers)
- /writing-kea-logics (local)

Relevant decisions:

- Set `recalculationLoading` after the early-return guards but before the create POST, so the bail paths (`!flagEnabled`, draft, missing ids) don't leave the button stuck disabled, and added the clear in the catch since nothing downstream would.
- Disabled "Try again" via a `retryDisabledReason` prop threaded through the component chain rather than reading `isRecalculating` in the leaf, keeping `MetricErrorState`/`ChartEmptyState` presentational and the recalc state owned by `MetricRowGroup`.