### PR TITLE
feat(charts): clean, lightly-curved styling for SQL line/area charts

### DIFF
--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -1,5 +1,5 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
+import { type DependencyList, useMemo } from 'react'
 
 import type { ChartTheme } from '@posthog/quill-charts'
 
@@ -47,13 +47,18 @@ export function useChartTheme(overrides?: Partial<ChartTheme>): ChartTheme {
     )
 }
 
-/** Merges the refreshed rendering defaults (monotone curve, axis lines, tick marks, crosshair)
- *  under a chart's config when `QUILL_CHART_STYLE_REFRESH` is enabled. Keys the config sets
- *  explicitly (non-undefined) always win. Pass a stable (memoized) config object. */
-export function useRefreshedChartConfig<T extends object>(config: T): T {
+/** Drop-in replacement for the `useMemo` that builds a chart's config object. On top of memoizing,
+ *  it applies app-level rendering defaults — currently the refreshed style (monotone curve, axis
+ *  lines, tick marks, crosshair) behind `QUILL_CHART_STYLE_REFRESH`. Keys the config sets
+ *  explicitly (non-undefined) always win over the defaults. */
+export function useChartConfig<T extends object>(factory: () => T, deps: DependencyList): T
+export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined
+export function useChartConfig<T extends object>(factory: () => T | undefined, deps: DependencyList): T | undefined {
     const refreshEnabled = useChartStyleRefreshEnabled()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    const config = useMemo(factory, deps)
     return useMemo(() => {
-        if (!refreshEnabled) {
+        if (!refreshEnabled || !config) {
             return config
         }
         const defined = Object.fromEntries(Object.entries(config).filter(([, value]) => value !== undefined))

--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -3,15 +3,60 @@ import { useMemo } from 'react'
 
 import type { ChartTheme } from '@posthog/quill-charts'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { buildTheme } from './utils/theme'
 
+/** Rendering options the refreshed style turns on. Applied as config *defaults* — a chart's own
+ *  config always wins. All four are stable quill-charts config keys, so removing the flag later
+ *  means inlining these at the call sites (or flipping the library defaults), not deleting an API. */
+const REFRESHED_CONFIG_DEFAULTS = {
+    curve: 'monotone',
+    showAxisLines: true,
+    showTickMarks: true,
+    showCrosshair: true,
+} as const
+
+function refreshedThemeOverrides(isDarkModeOn: boolean): Partial<ChartTheme> {
+    return {
+        gridColor: isDarkModeOn ? 'rgba(255,255,255,0.06)' : 'rgba(0,0,0,0.06)',
+        gridDashPattern: [3, 3],
+        axisLineColor: isDarkModeOn ? 'rgba(255,255,255,0.35)' : 'rgba(0,0,0,0.35)',
+    }
+}
+
+export function useChartStyleRefreshEnabled(): boolean {
+    const { featureFlags } = useValues(featureFlagLogic)
+    return !!featureFlags[FEATURE_FLAGS.QUILL_CHART_STYLE_REFRESH]
+}
+
 /** Theme for app quill charts. `buildTheme()` reads CSS variables from the DOM, so the memo keys on
- *  `isDarkModeOn` to re-read them when the app theme flips. Pass a stable (memoized or module-level)
- *  `overrides` object — a fresh object every render defeats the memo. */
+ *  `isDarkModeOn` to re-read them when the app theme flips. Behind `QUILL_CHART_STYLE_REFRESH` it
+ *  also applies the refreshed chart colors (faint dashed grid, muted axis lines); caller `overrides`
+ *  win over both. Pass a stable (memoized or module-level) `overrides` object — a fresh object every
+ *  render defeats the memo. */
 export function useChartTheme(overrides?: Partial<ChartTheme>): ChartTheme {
     const { isDarkModeOn } = useValues(themeLogic)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    return useMemo(() => buildTheme(overrides), [isDarkModeOn, overrides])
+    const refreshEnabled = useChartStyleRefreshEnabled()
+    return useMemo(
+        () => buildTheme({ ...(refreshEnabled ? refreshedThemeOverrides(isDarkModeOn) : {}), ...overrides }),
+        [isDarkModeOn, refreshEnabled, overrides]
+    )
+}
+
+/** Merges the refreshed rendering defaults (monotone curve, axis lines, tick marks, crosshair)
+ *  under a chart's config when `QUILL_CHART_STYLE_REFRESH` is enabled. Keys the config sets
+ *  explicitly (non-undefined) always win. Pass a stable (memoized) config object. */
+export function useRefreshedChartConfig<T extends object>(config: T): T {
+    const refreshEnabled = useChartStyleRefreshEnabled()
+    return useMemo(() => {
+        if (!refreshEnabled) {
+            return config
+        }
+        const defined = Object.fromEntries(Object.entries(config).filter(([, value]) => value !== undefined))
+        return { ...REFRESHED_CONFIG_DEFAULTS, ...defined } as T
+    }, [refreshEnabled, config])
 }

--- a/frontend/src/lib/charts/hooks.ts
+++ b/frontend/src/lib/charts/hooks.ts
@@ -1,0 +1,17 @@
+import { useValues } from 'kea'
+import { useMemo } from 'react'
+
+import type { ChartTheme } from '@posthog/quill-charts'
+
+import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+
+import { buildTheme } from './utils/theme'
+
+/** Theme for app quill charts. `buildTheme()` reads CSS variables from the DOM, so the memo keys on
+ *  `isDarkModeOn` to re-read them when the app theme flips. Pass a stable (memoized or module-level)
+ *  `overrides` object — a fresh object every render defeats the memo. */
+export function useChartTheme(overrides?: Partial<ChartTheme>): ChartTheme {
+    const { isDarkModeOn } = useValues(themeLogic)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    return useMemo(() => buildTheme(overrides), [isDarkModeOn, overrides])
+}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -421,6 +421,7 @@ export const FEATURE_FLAGS = {
     PRODUCT_ANALYTICS_PATHS_V2: 'paths-v2', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_ANALYTICS_QUILL_LEGEND: 'product-analytics-quill-legend', // owner: #team-product-analytics, gates the in-chart quill legend replacing the legacy side InsightLegend
     PRODUCT_ANALYTICS_QUILL_SQL_CHARTS: 'product-analytics-quill-sql-charts', // owner: #team-data-tools, gates rendering DataVisualization line/area charts via @posthog/quill-charts
+    QUILL_CHART_STYLE_REFRESH: 'quill-chart-style-refresh', // owner: #team-product-analytics, gates refreshed quill chart styling (monotone curves, axis lines + tick marks, faint dashed grid, crosshair)
     PRODUCT_ANALYTICS_RETENTION_AGGREGATION: 'retention-aggregation', // owner: @anirudhpillai #team-product-analytics
     PRODUCT_ANALYTICS_RETENTION_DWH: 'retention-dwh', // owner: @thmsobrmlr #team-product-analytics
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-self-driving

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/SqlPieGraph.tsx
@@ -1,14 +1,11 @@
 import clsx from 'clsx'
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { LemonColorGlyph } from '@posthog/lemon-ui'
 import { PieChart, TooltipSurface, TooltipSwatch } from '@posthog/quill-charts'
 import type { PieChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
+import { useChartTheme } from 'lib/charts/hooks'
 
 import { makeChartErrorHandler } from 'products/product_analytics/frontend/insights/trends/shared/chartErrorHandler'
 
@@ -30,10 +27,7 @@ export const SqlPieGraph = ({
     presetChartHeight,
     className,
 }: LineGraphProps): JSX.Element => {
-    const { isDarkModeOn } = useValues(themeLogic)
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const slices = useMemo(() => buildPieSlices(xData, yData), [xData, yData])
     const formattingSettings = yData[0]?.settings

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -564,9 +564,17 @@ describe('sqlLineGraphAdapter', () => {
             expect(config.yAxis).toMatchObject({ label: 'Count', scale: 'log', showGrid: false, hide: true })
         })
 
-        it('defaults to a linear scale with grid shown', () => {
+        it('defaults to a linear scale with the grid off and clean axis lines drawn', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC' })
-            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: true })
+            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: false })
+            expect(config.showAxisLines).toBe(true)
+            expect(config.showTickMarks).toBe(true)
+        })
+
+        it('shows the grid when the user explicitly enables grid lines', () => {
+            const chartSettings: ChartSettings = { leftYAxisSettings: { showGridLines: true } }
+            const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC' })
+            expect(config.yAxis).toMatchObject({ showGrid: true })
         })
 
         it('keeps a single-object yAxis when no series targets the right axis', () => {
@@ -584,7 +592,8 @@ describe('sqlLineGraphAdapter', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC', ySeriesData })
             expect(config.yAxis).toEqual([
                 // Left is logarithmic, so startAtZero is omitted (no zero baseline on a log scale).
-                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: true, hide: false },
+                // Grid defaults off on the line path (no explicit showGridLines on the left axis).
+                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: false, hide: false },
                 {
                     id: 'right',
                     position: 'right',

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.test.ts
@@ -564,17 +564,9 @@ describe('sqlLineGraphAdapter', () => {
             expect(config.yAxis).toMatchObject({ label: 'Count', scale: 'log', showGrid: false, hide: true })
         })
 
-        it('defaults to a linear scale with the grid off and clean axis lines drawn', () => {
+        it('defaults to a linear scale with grid shown', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings: {}, timezone: 'UTC' })
-            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: false })
-            expect(config.showAxisLines).toBe(true)
-            expect(config.showTickMarks).toBe(true)
-        })
-
-        it('shows the grid when the user explicitly enables grid lines', () => {
-            const chartSettings: ChartSettings = { leftYAxisSettings: { showGridLines: true } }
-            const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC' })
-            expect(config.yAxis).toMatchObject({ showGrid: true })
+            expect(config.yAxis).toMatchObject({ scale: 'linear', showGrid: true })
         })
 
         it('keeps a single-object yAxis when no series targets the right axis', () => {
@@ -592,8 +584,7 @@ describe('sqlLineGraphAdapter', () => {
             const config = buildLineChartConfig({ xData: dateXData, chartSettings, timezone: 'UTC', ySeriesData })
             expect(config.yAxis).toEqual([
                 // Left is logarithmic, so startAtZero is omitted (no zero baseline on a log scale).
-                // Grid defaults off on the line path (no explicit showGridLines on the left axis).
-                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: false, hide: false },
+                { id: 'left', position: 'left', label: 'Left', scale: 'log', showGrid: true, hide: false },
                 {
                     id: 'right',
                     position: 'right',

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -339,7 +339,12 @@ function buildYAxisConfig(
     yAxis: YAxisSettings | undefined,
     axisSeries: SqlLineYSeries[],
     yAxisAtZero: boolean | undefined,
-    { forceLinear = false, id, position }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right' } = {}
+    {
+        forceLinear = false,
+        id,
+        position,
+        gridDefault = true,
+    }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right'; gridDefault?: boolean } = {}
 ): YAxisConfig {
     const isLog = !forceLinear && yAxis?.scale === 'logarithmic'
     const tickSettings = axisSeries[0]?.settings
@@ -353,7 +358,7 @@ function buildYAxisConfig(
         ...(position ? { position } : {}),
         label: yAxis?.label,
         scale: isLog ? 'log' : 'linear',
-        showGrid: yAxis?.showGridLines ?? true,
+        showGrid: yAxis?.showGridLines ?? gridDefault,
         hide: yAxis?.showTicks === false,
         tickFormatter,
         // Quill ignores startAtZero on a log scale; floatBaseline (the false case) is line-only, so
@@ -408,13 +413,23 @@ export function buildLineChartConfig({
                       buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
                           id: 'left',
                           position: 'left',
+                          gridDefault: false,
                       }),
                       buildYAxisConfig(chartSettings.rightYAxisSettings, rightSeries, chartSettings.yAxisAtZero, {
                           id: 'right',
                           position: 'right',
+                          gridDefault: false,
                       }),
                   ]
-                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero),
+                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
+                      gridDefault: false,
+                  }),
+        // Grid off by default for a cleaner plot; draw a crisp L-shaped axis with tick marks instead
+        // of the full frame. An explicit `showGridLines` still wins (drawGrid takes over when on).
+        showAxisLines: true,
+        showTickMarks: true,
+        // Soften the line with a monotone-cubic curve (no overshoot — peaks stay accurate).
+        curve: 'monotone',
         goalLines: schemaGoalLinesToConfigs(goalLines),
         trendLines: buildTrendLineConfigs(ySeriesData),
         legend: buildLegendConfig(chartSettings),
@@ -514,5 +529,7 @@ export function buildComboChartConfig({
             ...buildSqlTooltipConfig(chartSettings, ySeriesData),
             ...(labelFormatter ? { labelFormatter } : {}),
         },
+        // Smooth the line/area series (bars are unaffected) to match the line chart.
+        curve: 'monotone',
     }
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -339,12 +339,7 @@ function buildYAxisConfig(
     yAxis: YAxisSettings | undefined,
     axisSeries: SqlLineYSeries[],
     yAxisAtZero: boolean | undefined,
-    {
-        forceLinear = false,
-        id,
-        position,
-        gridDefault = true,
-    }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right'; gridDefault?: boolean } = {}
+    { forceLinear = false, id, position }: { forceLinear?: boolean; id?: string; position?: 'left' | 'right' } = {}
 ): YAxisConfig {
     const isLog = !forceLinear && yAxis?.scale === 'logarithmic'
     const tickSettings = axisSeries[0]?.settings
@@ -358,7 +353,7 @@ function buildYAxisConfig(
         ...(position ? { position } : {}),
         label: yAxis?.label,
         scale: isLog ? 'log' : 'linear',
-        showGrid: yAxis?.showGridLines ?? gridDefault,
+        showGrid: yAxis?.showGridLines ?? true,
         hide: yAxis?.showTicks === false,
         tickFormatter,
         // Quill ignores startAtZero on a log scale; floatBaseline (the false case) is line-only, so
@@ -420,11 +415,6 @@ export function buildLineChartConfig({
                       }),
                   ]
                 : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero),
-        showCrosshair: true,
-        showAxisLines: true,
-        showTickMarks: true,
-        // Soften the line with a monotone-cubic curve (no overshoot — peaks stay accurate).
-        curve: 'monotone',
         goalLines: schemaGoalLinesToConfigs(goalLines),
         trendLines: buildTrendLineConfigs(ySeriesData),
         legend: buildLegendConfig(chartSettings),
@@ -524,7 +514,5 @@ export function buildComboChartConfig({
             ...buildSqlTooltipConfig(chartSettings, ySeriesData),
             ...(labelFormatter ? { labelFormatter } : {}),
         },
-        // Smooth the line/area series (bars are unaffected) to match the line chart.
-        curve: 'monotone',
     }
 }

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -413,19 +413,14 @@ export function buildLineChartConfig({
                       buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
                           id: 'left',
                           position: 'left',
-                          gridDefault: false,
                       }),
                       buildYAxisConfig(chartSettings.rightYAxisSettings, rightSeries, chartSettings.yAxisAtZero, {
                           id: 'right',
                           position: 'right',
-                          gridDefault: false,
                       }),
                   ]
-                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero, {
-                      gridDefault: false,
-                  }),
-        // Grid off by default for a cleaner plot; draw a crisp L-shaped axis with tick marks instead
-        // of the full frame. An explicit `showGridLines` still wins (drawGrid takes over when on).
+                : buildYAxisConfig(chartSettings.leftYAxisSettings, leftSeries, chartSettings.yAxisAtZero),
+        showCrosshair: true,
         showAxisLines: true,
         showTickMarks: true,
         // Soften the line with a monotone-cubic curve (no overshoot — peaks stay accurate).

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -3,7 +3,7 @@ import { useEffect, useMemo } from 'react'
 
 import { type ChartTheme, type Series } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { LineGraphProps } from './LineGraph'
@@ -23,7 +23,7 @@ export interface SqlChartModel<TConfig> {
     config: TConfig
 }
 
-export function useSqlChartModel<TConfig>(
+export function useSqlChartModel<TConfig extends object>(
     { xData, yData, visualizationType, chartSettings, dashboardId, goalLines }: LineGraphProps,
     buildConfig: (args: BuildBarConfigArgs) => TConfig
 ): SqlChartModel<TConfig> | null {
@@ -44,7 +44,7 @@ export function useSqlChartModel<TConfig>(
 
     const theme = useChartTheme()
 
-    const config = useMemo(
+    const config = useChartConfig(
         () =>
             xData
                 ? buildConfig({

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/useSqlChartModel.ts
@@ -3,10 +3,8 @@ import { useEffect, useMemo } from 'react'
 
 import { type ChartTheme, type Series } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { LineGraphProps } from './LineGraph'
 import {
@@ -30,7 +28,6 @@ export function useSqlChartModel<TConfig>(
     buildConfig: (args: BuildBarConfigArgs) => TConfig
 ): SqlChartModel<TConfig> | null {
     const { timezone } = useValues(teamLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
 
     useEffect(() => {
         if (exceedsMaxSeries(yData, dashboardId)) {
@@ -45,8 +42,7 @@ export function useSqlChartModel<TConfig>(
         [ySeriesData, visualizationType]
     )
 
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const config = useMemo(
         () =>

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -5,7 +5,7 @@ import { BoxPlot } from '@posthog/quill-charts'
 import type { BoxPlotClickData, BoxPlotConfig, BoxPlotSeries, BoxPlotTooltipContext } from '@posthog/quill-charts'
 
 import 'scenes/insights/InsightTooltip/InsightTooltip.scss'
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getSeriesColor } from 'lib/colors'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -92,7 +92,7 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
 
     const formatValue = useCallback((value: number) => formatAggregationAxisValue(trendsFilter, value), [trendsFilter])
 
-    const config = useMemo<BoxPlotConfig>(
+    const config = useChartConfig<BoxPlotConfig>(
         () => ({
             yScaleType: yAxisScaleType === 'log10' ? 'log' : 'linear',
             yTickFormatter: formatValue,

--- a/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
+++ b/frontend/src/scenes/insights/views/BoxPlot/BoxPlotChart.tsx
@@ -5,7 +5,7 @@ import { BoxPlot } from '@posthog/quill-charts'
 import type { BoxPlotClickData, BoxPlotConfig, BoxPlotSeries, BoxPlotTooltipContext } from '@posthog/quill-charts'
 
 import 'scenes/insights/InsightTooltip/InsightTooltip.scss'
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { getSeriesColor } from 'lib/colors'
 import { DateDisplay } from 'lib/components/DateDisplay'
 import { SeriesLetter } from 'lib/components/SeriesGlyph'
@@ -18,7 +18,6 @@ import { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { BoxPlotDatum, InsightActorsQuery, NodeKind } from '~/queries/schema/schema-general'
 import { ChartParams } from '~/types'
 
@@ -64,12 +63,10 @@ export function BoxPlotChart({ showPersonsModal = true }: ChartParams): JSX.Elem
     const { boxplotData, seriesGroups, dateLabels, yAxisScaleType, querySource, interval, insightData, trendsFilter } =
         useValues(boxPlotChartLogic(insightProps))
     const { timezone, weekStartDay } = useValues(teamLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
 
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const series = useMemo<BoxPlotSeries[]>(
         () =>

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import {
     ChoiceTooltip,
     ChoiceTooltipContextData,
@@ -58,7 +58,7 @@ export function MultipleChoiceBarChart({
     // rendered through the category-axis formatter instead.
     const labels = useMemo(() => chartData.map((_, i) => String(i)), [chartData])
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => ({
             axisOrientation: 'horizontal',
             barLayout: 'grouped',

--- a/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/MultipleChoiceBarChart.tsx
@@ -1,17 +1,15 @@
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import {
     ChoiceTooltip,
     ChoiceTooltipContextData,
 } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ChoiceQuestionResponseData } from '~/types'
 
 const CATEGORY_LABEL_WIDTH = 280
@@ -38,8 +36,7 @@ export function MultipleChoiceBarChart({
     tooltipContextByIndex,
     onBarClick,
 }: Props): JSX.Element {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     // Bars encode the share of respondents who picked each choice against a fixed 0–100% domain;
     // counts surface in the labels and tooltip. Per-bar overrides carry the colors — the series

--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { NpsBucketMeta, RatingTooltip } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
@@ -48,7 +48,7 @@ export function RatingBarChart({
         [chartLabels, data, barColors]
     )
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => ({
             hideYAxis: true,
             bars: { bandPadding: 0.2, valuePadding: VALUE_LABEL_PADDING },

--- a/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
+++ b/frontend/src/scenes/surveys/components/question-visualizations/RatingBarChart.tsx
@@ -1,14 +1,12 @@
-import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { NpsBucketMeta, RatingTooltip } from 'scenes/surveys/components/question-visualizations/questionVizTooltips'
 import { formatCountWithPercentage } from 'scenes/surveys/components/question-visualizations/questionVizTransforms'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { ChoiceQuestionResponseData } from '~/types'
 
 // Room above each bar tip for the value label's height, so it floats rather than overlapping the bar.
@@ -35,8 +33,7 @@ export function RatingBarChart({
     npsBucketByIndex,
     onBarClick,
 }: Props): JSX.Element {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const series = useMemo<Series[]>(
         () => [

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -118,14 +118,14 @@ export function drawBarChartStatic(
         labels: drawLabels,
     }
 
+    // Grid sits behind the bars; the L-axis is drawn after them (below) so a bar doesn't paint over
+    // the baseline where it meets the axis.
     if (showGrid) {
         drawGrid(baseDrawCtx, {
             gridColor: theme.gridColor,
             orientation: isHorizontal ? 'horizontal' : 'vertical',
             categoryTicks: computeGridTicks(d3Scales, drawLabels, isHorizontal, xTickFormatter),
         })
-    } else if (showAxisLines) {
-        drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
     }
 
     const seriesBars = buildBarLayers({
@@ -174,6 +174,10 @@ export function drawBarChartStatic(
             ctx.restore()
         }
     })
+
+    if (!showGrid && showAxisLines) {
+        drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+    }
 }
 
 export interface DrawBarHoverArgs {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -123,6 +123,7 @@ export function drawBarChartStatic(
     if (showGrid) {
         drawGrid(baseDrawCtx, {
             gridColor: theme.gridColor,
+            gridDash: theme.gridDashPattern,
             orientation: isHorizontal ? 'horizontal' : 'vertical',
             categoryTicks: computeGridTicks(d3Scales, drawLabels, isHorizontal, xTickFormatter),
         })
@@ -176,7 +177,7 @@ export function drawBarChartStatic(
     })
 
     if (!showGrid && showAxisLines) {
-        drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+        drawAxes(baseDrawCtx, { axisColor: theme.axisLineColor ?? theme.axisColor ?? theme.gridColor })
     }
 }
 

--- a/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.tsx
+++ b/packages/quill/packages/charts/src/charts/BoxPlot/BoxPlot.tsx
@@ -238,7 +238,11 @@ function BoxPlotInner<Meta = unknown>({
             }
 
             if (showGrid) {
-                drawGrid(baseDrawCtx, { gridColor: theme.gridColor, orientation: 'vertical' })
+                drawGrid(baseDrawCtx, {
+                    gridColor: theme.gridColor,
+                    gridDash: theme.gridDashPattern,
+                    orientation: 'vertical',
+                })
             }
 
             for (const s of coloredSeries) {

--- a/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
@@ -191,7 +191,7 @@ function ComboChartInner<Meta = unknown>({
                     (label) => bandCenter(comboScales, label),
                     xTickFormatter
                 ).map((entry) => entry.x)
-                drawGrid(baseDrawCtx, { gridColor: theme.gridColor, categoryTicks })
+                drawGrid(baseDrawCtx, { gridColor: theme.gridColor, gridDash: theme.gridDashPattern, categoryTicks })
             }
 
             // ── 1. Bars ──────────────────────────────────────────────────────────────────────
@@ -227,7 +227,7 @@ function ComboChartInner<Meta = unknown>({
             })
 
             if (!showGrid && showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+                drawAxes(baseDrawCtx, { axisColor: theme.axisLineColor ?? theme.axisColor ?? theme.gridColor })
             }
         },
         [

--- a/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/ComboChart/ComboChart.tsx
@@ -89,7 +89,9 @@ function ComboChartInner<Meta = unknown>({
         defaultSeriesType = DEFAULT_SERIES_TYPE,
         xTickFormatter,
         valueDomain,
+        curve,
     } = config ?? {}
+    const smooth = curve === 'monotone'
 
     const seriesTypeOf = useCallback(
         (s: Pick<Series, 'type'>): SeriesType => resolveSeriesType(s, defaultSeriesType),
@@ -181,6 +183,8 @@ function ComboChartInner<Meta = unknown>({
                 labels: drawLabels,
             }
 
+            // Grid sits behind the data; the L-axis is drawn after the series (below) so neither bars
+            // nor lines paint over the baseline where they meet the axis.
             if (showGrid) {
                 const categoryTicks = computeVisibleXLabels(
                     drawLabels,
@@ -188,8 +192,6 @@ function ComboChartInner<Meta = unknown>({
                     xTickFormatter
                 ).map((entry) => entry.x)
                 drawGrid(baseDrawCtx, { gridColor: theme.gridColor, categoryTicks })
-            } else if (showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
             }
 
             // ── 1. Bars ──────────────────────────────────────────────────────────────────────
@@ -221,7 +223,12 @@ function ComboChartInner<Meta = unknown>({
                 shouldFill: (s) => seriesTypeOf(s) === 'area' || !!s.fill,
                 bottomFor: (s) => s.fill?.lowerData,
                 zOrder: 'areas-first',
+                smooth,
             })
+
+            if (!showGrid && showAxisLines) {
+                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+            }
         },
         [
             seriesTypeOf,
@@ -232,6 +239,7 @@ function ComboChartInner<Meta = unknown>({
             barStackedData,
             topStackedKeyByAxis,
             barCornerRadius,
+            smooth,
         ]
     )
 

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -201,7 +201,7 @@ function LineChartInner<Meta = unknown>({
                 smooth,
             })
 
-            if (!showGrid && showAxisLines) {
+            if (showAxisLines) {
                 drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
             }
         },

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -182,7 +182,7 @@ function LineChartInner<Meta = unknown>({
             // Grid sits behind the data; the L-axis is drawn after the series (below) so the line
             // doesn't paint over the baseline where it meets the axis.
             if (showGrid) {
-                drawGrid(baseDrawCtx, { gridColor: theme.gridColor })
+                drawGrid(baseDrawCtx, { gridColor: theme.gridColor, gridDash: theme.gridDashPattern })
             }
 
             // Area then line+points per series, clipped vertically (shared with ComboChart). Areas use
@@ -202,7 +202,7 @@ function LineChartInner<Meta = unknown>({
             })
 
             if (showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+                drawAxes(baseDrawCtx, { axisColor: theme.axisLineColor ?? theme.axisColor ?? theme.gridColor })
             }
         },
         [showGrid, showAxisLines, stackedData, smooth]

--- a/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/LineChart/LineChart.tsx
@@ -82,7 +82,9 @@ function LineChartInner<Meta = unknown>({
         valueDomain,
         floatBaseline = false,
         yAxes,
+        curve,
     } = config ?? {}
+    const smooth = curve === 'monotone'
 
     const { visibleSeries, legendProps } = useChartLegend(series, theme, config?.legend)
 
@@ -177,10 +179,10 @@ function LineChartInner<Meta = unknown>({
                 labels: drawLabels,
             }
 
+            // Grid sits behind the data; the L-axis is drawn after the series (below) so the line
+            // doesn't paint over the baseline where it meets the axis.
             if (showGrid) {
                 drawGrid(baseDrawCtx, { gridColor: theme.gridColor })
-            } else if (showAxisLines) {
-                drawAxes(baseDrawCtx, { axisColor: theme.gridColor })
             }
 
             // Area then line+points per series, clipped vertically (shared with ComboChart). Areas use
@@ -196,9 +198,14 @@ function LineChartInner<Meta = unknown>({
                 bottomFor: (s) => s.fill?.lowerData ?? stackedData?.get(s.key)?.bottom,
                 shouldFill: (s) => !!s.fill,
                 zOrder: 'per-series',
+                smooth,
             })
+
+            if (!showGrid && showAxisLines) {
+                drawAxes(baseDrawCtx, { axisColor: theme.axisColor ?? theme.gridColor })
+            }
         },
-        [showGrid, showAxisLines, stackedData]
+        [showGrid, showAxisLines, stackedData, smooth]
     )
 
     const drawHover = useCallback(

--- a/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesBarChart/TimeSeriesBarChart.tsx
@@ -37,6 +37,8 @@ export interface TimeSeriesBarChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Draw short tick marks next to each visible axis label. Pairs with `showAxisLines`. */
+    showTickMarks?: boolean
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
     /** Stacked layout only — stack negatives below the zero baseline (d3.stackOffsetDiverging). */
@@ -86,6 +88,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
         barCornerRadius,
         showCrosshair,
         showAxisLines,
+        showTickMarks,
         tooltip: tooltipConfig,
         divergingStack,
         fillStyle,
@@ -121,6 +124,7 @@ export function TimeSeriesBarChart<Meta = unknown>({
         yAxisLabel: primaryYAxis?.label,
         showGrid: primaryYAxis?.showGrid,
         showAxisLines,
+        showTickMarks,
         barLayout,
         axisOrientation,
         showCrosshair,

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -38,6 +38,8 @@ export interface TimeSeriesComboChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Draw short tick marks next to each visible axis label. Pairs with `showAxisLines`. */
+    showTickMarks?: boolean
     /** Line interpolation for line/area series: `linear` (default) or `monotone` (smooth curve). */
     curve?: 'linear' | 'monotone'
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
@@ -86,6 +88,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         barCornerRadius,
         showCrosshair,
         showAxisLines,
+        showTickMarks,
         curve,
         tooltip: tooltipConfig,
         legend,
@@ -117,6 +120,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         yAxisLabel: primaryYAxis?.label,
         showGrid: primaryYAxis?.showGrid,
         showAxisLines,
+        showTickMarks,
         curve,
         showCrosshair,
         defaultSeriesType,

--- a/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesComboChart/TimeSeriesComboChart.tsx
@@ -38,6 +38,8 @@ export interface TimeSeriesComboChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Line interpolation for line/area series: `linear` (default) or `monotone` (smooth curve). */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
     /** Built-in legend with click-to-toggle series visibility. Hidden by default. */
@@ -84,6 +86,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         barCornerRadius,
         showCrosshair,
         showAxisLines,
+        curve,
         tooltip: tooltipConfig,
         legend,
         trendLines,
@@ -114,6 +117,7 @@ export function TimeSeriesComboChart<Meta = unknown>({
         yAxisLabel: primaryYAxis?.label,
         showGrid: primaryYAxis?.showGrid,
         showAxisLines,
+        curve,
         showCrosshair,
         defaultSeriesType,
         barLayout,

--- a/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
+++ b/packages/quill/packages/charts/src/charts/TimeSeriesLineChart/TimeSeriesLineChart.tsx
@@ -47,6 +47,10 @@ export interface TimeSeriesLineChartConfig {
     showCrosshair?: boolean
     /** Draw L-shaped axis baselines without grid lines (ignored when `yAxis.showGrid` is true). */
     showAxisLines?: boolean
+    /** Draw short tick marks next to each visible axis label. Pairs with `showAxisLines`. */
+    showTickMarks?: boolean
+    /** Line interpolation: `linear` (default) or `monotone` (smooth curve through every point). */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour (pinning, placement). Tooltip *content* is the `tooltip` render prop. */
     tooltip?: TooltipConfig
     /** Built-in legend with click-to-toggle series visibility. Hidden by default. */
@@ -92,6 +96,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
         percentStackView,
         showCrosshair,
         showAxisLines,
+        showTickMarks,
+        curve,
         tooltip: tooltipConfig,
         legend,
     } = config ?? {}
@@ -130,6 +136,8 @@ export function TimeSeriesLineChart<Meta = unknown>({
         yAxisLabel: primaryYAxis?.label,
         showGrid: primaryYAxis?.showGrid,
         showAxisLines,
+        showTickMarks,
+        curve,
         percentStackView,
         showCrosshair,
         tooltip: tooltipConfig,

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -1,11 +1,21 @@
 import React, { useMemo } from 'react'
 
-import { AxisLabels } from '../overlays/AxisLabels'
+import {
+    AxisLabels,
+    computeVisibleValueTicks,
+    computeVisibleXLabels,
+    computeVisibleYTicks,
+} from '../overlays/AxisLabels'
 import { AxisTitles } from '../overlays/AxisTitles'
 import { DefaultTooltip } from '../overlays/DefaultTooltip'
 import { Tooltip } from '../overlays/Tooltip'
 import { normalizeAxisLabel } from '../utils/axis-labels'
-import { composeDrawHoverWithCrosshair, composeDrawHoverWithSelection } from './canvas-renderer'
+import {
+    composeDrawHoverWithCrosshair,
+    composeDrawHoverWithSelection,
+    drawTickMarks,
+    type TickMarkCoords,
+} from './canvas-renderer'
 import { ChartHoverContext, ChartLayoutContext } from './chart-context'
 import type { ChartHoverContextValue, ChartLayoutContextValue } from './chart-context'
 import { ChartShell, countVisibleSeries, useCanvasBounds, useColoredSeries } from './chart-shell'
@@ -209,6 +219,79 @@ export function Chart<Meta = unknown>({
 
     const resolvedYFormatter = useResolvedYFormatter(scales, yTickFormatter)
 
+    // Computed once and shared with AxisLabels and AxisTitles via context so they can't drift.
+    const yGutters = useMemo<Gutter[]>(
+        () =>
+            !scales || hideYAxis || axisOrientation === 'horizontal'
+                ? []
+                : computeYAxisGutters(scales, {
+                      yTicks: scales.yTicks(),
+                      yTickFormatter: resolvedYFormatter,
+                      userYTickFormatter: yTickFormatter,
+                      yAxisFormatters,
+                      titles: yAxisTitles,
+                  }),
+        [scales, hideYAxis, axisOrientation, resolvedYFormatter, yTickFormatter, yAxisFormatters, yAxisTitles]
+    )
+
+    // Mirrors AxisLabels' visible-label computation (same pure helpers, same inputs) so every tick
+    // mark sits next to a rendered label. Drawn on canvas rather than as DOM overlays so ticks share
+    // the axis/grid stroke snapping and can't drift a pixel against those lines.
+    const tickMarkCoords = useMemo<TickMarkCoords | null>(() => {
+        if (!showTickMarks || !scales || !dimensions) {
+            return null
+        }
+        if (axisOrientation === 'horizontal') {
+            const labelToY = labelToCoord ?? scales.x
+            const ys = hideYAxis
+                ? []
+                : labels
+                      .filter((label, i) => !xTickFormatter || xTickFormatter(label, i) !== null)
+                      .map((label) => labelToY(label))
+                      .filter((y): y is number => y != null && isFinite(y))
+                      .map((y) => ({ y, side: 'left' as const, offset: 0 }))
+            const xs = hideXAxis
+                ? []
+                : computeVisibleValueTicks(scales.yTicks(), scales.y, resolvedYFormatter).map((t) => t.x)
+            return { xs, ys }
+        }
+        const xs = hideXAxis
+            ? []
+            : computeVisibleXLabels(labels, scales.x, xTickFormatter, maxCategoryLabelWidth).map((l) => l.x)
+        const ys = yGutters.flatMap((gutter) =>
+            computeVisibleYTicks(gutter.ticks, gutter.scale)
+                .map((tick) => gutter.scale(tick))
+                .filter((y) => isFinite(y))
+                .map((y) => ({ y, side: gutter.side, offset: gutter.offset }))
+        )
+        return { xs, ys }
+    }, [
+        showTickMarks,
+        scales,
+        dimensions,
+        axisOrientation,
+        labels,
+        xTickFormatter,
+        maxCategoryLabelWidth,
+        yGutters,
+        hideXAxis,
+        hideYAxis,
+        resolvedYFormatter,
+        labelToCoord,
+    ])
+
+    const drawStaticWithTicks = useMemo(() => {
+        if (!tickMarkCoords) {
+            return drawStatic
+        }
+        // Same color expression the chart types pass to drawAxes, so ticks match their axis line.
+        const tickColor = theme.axisLineColor ?? theme.axisColor ?? theme.gridColor
+        return (args: ChartDrawArgs): void => {
+            drawStatic(args)
+            drawTickMarks(args.ctx, args.dimensions, tickMarkCoords, tickColor)
+        }
+    }, [drawStatic, tickMarkCoords, theme.axisColor, theme.gridColor])
+
     const { hoverIndex, hoverPosition, tooltipCtx, dragRect, handlers } = useChartInteraction<Meta>({
         scales,
         dimensions,
@@ -252,7 +335,7 @@ export function Chart<Meta = unknown>({
         hoverPosition,
         theme,
         dragRect,
-        drawStatic,
+        drawStatic: drawStaticWithTicks,
         drawHover: composedDrawHover,
         hoverAnimationMs,
     })
@@ -281,21 +364,6 @@ export function Chart<Meta = unknown>({
         [axisOrientation, xTickFormatter, isPercent]
     )
     const axisColor = theme.axisColor ?? DEFAULT_AXIS_COLOR
-
-    // Computed once and shared with AxisLabels and AxisTitles via context so they can't drift.
-    const yGutters = useMemo<Gutter[]>(
-        () =>
-            !scales || hideYAxis || axisOrientation === 'horizontal'
-                ? []
-                : computeYAxisGutters(scales, {
-                      yTicks: scales.yTicks(),
-                      yTickFormatter: resolvedYFormatter,
-                      userYTickFormatter: yTickFormatter,
-                      yAxisFormatters,
-                      titles: yAxisTitles,
-                  }),
-        [scales, hideYAxis, axisOrientation, resolvedYFormatter, yTickFormatter, yAxisFormatters, yAxisTitles]
-    )
 
     const layoutValue = useMemo<ChartLayoutContextValue | null>(() => {
         if (!scales || !dimensions) {
@@ -340,7 +408,6 @@ export function Chart<Meta = unknown>({
                         orientation={axisOrientation}
                         labelToCoord={labelToCoord}
                         maxCategoryLabelWidth={maxCategoryLabelWidth}
-                        showTickMarks={showTickMarks}
                     />
                     <AxisTitles
                         xAxisLabel={xAxisLabel}

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -124,6 +124,7 @@ export function Chart<Meta = unknown>({
         yAxisLabel,
         tooltip: tooltipConfig,
         showCrosshair = false,
+        showTickMarks = false,
         axisOrientation = 'vertical',
         isPercent = false,
         animateHover,
@@ -339,6 +340,7 @@ export function Chart<Meta = unknown>({
                         orientation={axisOrientation}
                         labelToCoord={labelToCoord}
                         maxCategoryLabelWidth={maxCategoryLabelWidth}
+                        showTickMarks={showTickMarks}
                     />
                     <AxisTitles
                         xAxisLabel={xAxisLabel}

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -10,6 +10,8 @@ export interface DrawContext {
     xScale: (label: string) => number | undefined
     yScale: ScaleLinear<number, number> | ScaleLogarithmic<number, number>
     labels: string[]
+    /** Smooth the line/area with monotone-cubic interpolation instead of straight segments. */
+    smooth?: boolean
 }
 
 export function drawLine(drawCtx: DrawContext, series: ResolvedSeries, yValues?: number[]): void {
@@ -122,25 +124,118 @@ function planLineStrokes(series: ResolvedSeries, length: number): Stroke[] {
     return strokes
 }
 
-/** Walks data from [start, end] inclusive, emitting moveTo/lineTo. Caller owns beginPath/stroke. */
+/** Walks data from [start, end] inclusive. Emits straight segments, or monotone-cubic curves when
+ *  `drawCtx.smooth` is set. NaN/out-of-domain points break the line into separate subpaths. Caller
+ *  owns beginPath/stroke. */
 function tracePath(drawCtx: DrawContext, data: number[], start: number, end: number): void {
-    const { ctx, xScale, yScale, labels } = drawCtx
-    let started = false
+    const { ctx, xScale, yScale, labels, smooth } = drawCtx
+    let xs: number[] = []
+    let ys: number[] = []
+    const flush = (): void => {
+        if (xs.length === 0) {
+            return
+        }
+        ctx.moveTo(xs[0], ys[0])
+        if (smooth && xs.length > 1) {
+            curveForward(ctx, xs, ys)
+        } else {
+            for (let k = 1; k < xs.length; k++) {
+                ctx.lineTo(xs[k], ys[k])
+            }
+        }
+        xs = []
+        ys = []
+    }
     for (let i = start; i <= end; i++) {
         const x = xScale(labels[i])
         const y = yScale(data[i])
         if (x == null || !isFinite(y)) {
-            // Reset so the next valid point starts a fresh subpath rather than
+            // A gap ends the current subpath so the next valid point starts fresh rather than
             // connecting straight across the NaN gap.
-            started = false
+            flush()
             continue
         }
-        if (!started) {
-            ctx.moveTo(x, y)
-            started = true
+        xs.push(x)
+        ys.push(y)
+    }
+    flush()
+}
+
+/** Monotone-cubic (Fritsch–Carlson) tangents for points with strictly increasing x. Matches d3's
+ *  `curveMonotoneX`: preserves monotonicity between points, so the curve never overshoots the data
+ *  (no spurious wiggles or dips past a peak/trough). */
+function monotoneTangents(xs: number[], ys: number[]): number[] {
+    const n = xs.length
+    const h: number[] = new Array(n - 1)
+    const s: number[] = new Array(n - 1)
+    for (let i = 0; i < n - 1; i++) {
+        h[i] = xs[i + 1] - xs[i]
+        s[i] = h[i] !== 0 ? (ys[i + 1] - ys[i]) / h[i] : 0
+    }
+    const m: number[] = new Array(n)
+    if (n === 2) {
+        m[0] = s[0]
+        m[1] = s[0]
+        return m
+    }
+    for (let i = 1; i < n - 1; i++) {
+        const s0 = s[i - 1]
+        const s1 = s[i]
+        if (s0 * s1 <= 0) {
+            m[i] = 0
         } else {
-            ctx.lineTo(x, y)
+            const p = (s0 * h[i] + s1 * h[i - 1]) / (h[i - 1] + h[i])
+            m[i] = (Math.sign(s0) + Math.sign(s1)) * Math.min(Math.abs(s0), Math.abs(s1), 0.5 * Math.abs(p))
         }
+    }
+    m[0] = (3 * s[0] - m[1]) / 2
+    m[n - 1] = (3 * s[n - 2] - m[n - 2]) / 2
+    return m
+}
+
+interface CurveSegment {
+    cp1x: number
+    cp1y: number
+    cp2x: number
+    cp2y: number
+}
+
+// Control-arm length as a fraction of the segment width. 1/3 is the standard monotone-cubic arm
+// (full curve); shortening it pulls the curve closer to the straight chord between points for a
+// gentler bend. Crucially this keeps the *same* tangent direction at each point, so adjacent
+// segments still meet smoothly there — the data points stay rounded, only the mid-segment bow shrinks.
+const SMOOTH_ARM = 1 / 6
+
+function monotoneSegments(xs: number[], ys: number[]): CurveSegment[] {
+    const m = monotoneTangents(xs, ys)
+    const segs: CurveSegment[] = []
+    for (let i = 0; i < xs.length - 1; i++) {
+        const arm = (xs[i + 1] - xs[i]) * SMOOTH_ARM
+        segs.push({
+            cp1x: xs[i] + arm,
+            cp1y: ys[i] + m[i] * arm,
+            cp2x: xs[i + 1] - arm,
+            cp2y: ys[i + 1] - m[i + 1] * arm,
+        })
+    }
+    return segs
+}
+
+/** Emit monotone bezier segments from the first point forward. Assumes the current path point is
+ *  already at (xs[0], ys[0]). */
+function curveForward(ctx: CanvasRenderingContext2D, xs: number[], ys: number[]): void {
+    const segs = monotoneSegments(xs, ys)
+    for (let i = 0; i < segs.length; i++) {
+        ctx.bezierCurveTo(segs[i].cp1x, segs[i].cp1y, segs[i].cp2x, segs[i].cp2y, xs[i + 1], ys[i + 1])
+    }
+}
+
+/** Emit the same monotone curve traversed last→first (control points swapped). Assumes the current
+ *  path point is already at (xs[n-1], ys[n-1]). Used for an area's bottom edge. */
+function curveReverse(ctx: CanvasRenderingContext2D, xs: number[], ys: number[]): void {
+    const segs = monotoneSegments(xs, ys)
+    for (let i = segs.length - 1; i >= 0; i--) {
+        ctx.bezierCurveTo(segs[i].cp2x, segs[i].cp2y, segs[i].cp1x, segs[i].cp1y, xs[i], ys[i])
     }
 }
 
@@ -202,7 +297,7 @@ export function drawArea(
     yValues?: number[],
     bottomValues?: number[]
 ): void {
-    const { ctx, xScale, yScale, labels, dimensions } = drawCtx
+    const { ctx, xScale, yScale, labels, dimensions, smooth } = drawCtx
     const data = yValues ?? series.data
     const opacity = series.fill?.opacity ?? 0.5
     const baseline = dimensions.plotTop + dimensions.plotHeight
@@ -262,7 +357,7 @@ export function drawArea(
 
         if (useGradient || (dashedFrom === null && dashedTo === null)) {
             ctx.fillStyle = gradient ?? series.color
-            fillAreaPath(ctx, top, bottom)
+            fillAreaPath(ctx, top, bottom, smooth)
             continue
         }
 
@@ -276,14 +371,14 @@ export function drawArea(
 
         if (wholeSegmentLeading || wholeSegmentTrailing) {
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top, bottom)
+            fillAreaPath(ctx, top, bottom, smooth)
             continue
         }
 
         if (dashedTo !== null && toSplit > 0) {
             const leadingEnd = Math.min(top.length, toSplit + 1)
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top.slice(0, leadingEnd), bottom.slice(0, leadingEnd))
+            fillAreaPath(ctx, top.slice(0, leadingEnd), bottom.slice(0, leadingEnd), smooth)
         }
 
         const solidStart = toSplit === -1 ? 0 : toSplit
@@ -294,13 +389,13 @@ export function drawArea(
         // segment and the shaded region stops a step past where the line turns dashed.
         if (solidEnd - solidStart >= 2) {
             ctx.fillStyle = series.color
-            fillAreaPath(ctx, top.slice(solidStart, solidEnd), bottom.slice(solidStart, solidEnd))
+            fillAreaPath(ctx, top.slice(solidStart, solidEnd), bottom.slice(solidStart, solidEnd), smooth)
         }
 
         if (dashedFrom !== null && fromSplit > 0) {
             const hatchStart = Math.max(0, fromSplit - 1)
             ctx.fillStyle = hatch
-            fillAreaPath(ctx, top.slice(hatchStart), bottom.slice(hatchStart))
+            fillAreaPath(ctx, top.slice(hatchStart), bottom.slice(hatchStart), smooth)
         }
     }
 
@@ -310,15 +405,26 @@ export function drawArea(
 function fillAreaPath(
     ctx: CanvasRenderingContext2D,
     top: { x: number; y: number }[],
-    bottom: { x: number; y: number }[]
+    bottom: { x: number; y: number }[],
+    smooth?: boolean
 ): void {
     ctx.beginPath()
     ctx.moveTo(top[0].x, top[0].y)
-    for (let i = 1; i < top.length; i++) {
-        ctx.lineTo(top[i].x, top[i].y)
+    if (smooth && top.length > 1) {
+        curveForward(ctx, top.map((p) => p.x), top.map((p) => p.y))
+    } else {
+        for (let i = 1; i < top.length; i++) {
+            ctx.lineTo(top[i].x, top[i].y)
+        }
     }
-    for (let i = bottom.length - 1; i >= 0; i--) {
-        ctx.lineTo(bottom[i].x, bottom[i].y)
+    // Down the right edge, then back along the bottom to close the band.
+    ctx.lineTo(bottom[bottom.length - 1].x, bottom[bottom.length - 1].y)
+    if (smooth && bottom.length > 1) {
+        curveReverse(ctx, bottom.map((p) => p.x), bottom.map((p) => p.y))
+    } else {
+        for (let i = bottom.length - 2; i >= 0; i--) {
+            ctx.lineTo(bottom[i].x, bottom[i].y)
+        }
     }
     ctx.closePath()
     ctx.fill()
@@ -358,9 +464,10 @@ export function drawAxes(drawCtx: DrawContext, options: DrawAxesOptions = {}): v
     ctx.strokeStyle = options.axisColor ?? 'rgba(0, 0, 0, 0.15)'
     ctx.lineWidth = 1
     ctx.setLineDash([])
-    // +0.5 / -0.5 pixel snapping keeps the 1px strokes crisp and inside the plot rect (see drawGrid).
-    const axisX = Math.round(dimensions.plotLeft) + 0.5
-    const axisY = Math.round(dimensions.plotTop + dimensions.plotHeight) - 0.5
+    // Snap the corner to the rounded plot edge so the L lines up with the zero baseline and the first
+    // tick mark (which anchor to the plot edge) rather than sitting a pixel inside it.
+    const axisX = Math.round(dimensions.plotLeft)
+    const axisY = Math.round(dimensions.plotTop + dimensions.plotHeight)
     // Route both strokes through the shared, snapped corner (axisX, axisY) so the L meets cleanly
     // even when plotLeft/plotHeight are fractional.
     ctx.beginPath()
@@ -593,13 +700,15 @@ export interface LineSeriesLayerOptions {
     /** `per-series`: area then line+points per series (LineChart). `areas-first`: every area, then
      *  every line+points (ComboChart) so a later area can't paint over an earlier line. */
     zOrder?: 'per-series' | 'areas-first'
+    /** Smooth lines/areas with monotone-cubic interpolation instead of straight segments. */
+    smooth?: boolean
 }
 
 /** Draw a line/area layer (clipped vertically) — the per-series area/line/points orchestration shared
  *  by LineChart and ComboChart. Callers supply the y-value source (raw vs stacked tops), the fill
  *  predicate, and the z-order; the loop, clip, and primitive calls live here. */
 export function drawLineSeriesLayer(options: LineSeriesLayerOptions): void {
-    const { ctx, dimensions, labels, series, xScale, resolveYScale } = options
+    const { ctx, dimensions, labels, series, xScale, resolveYScale, smooth } = options
     const yValuesFor = options.yValuesFor ?? (() => undefined)
     const bottomFor = options.bottomFor ?? ((s: ResolvedSeries) => s.fill?.lowerData)
     const shouldFill = options.shouldFill ?? ((s: ResolvedSeries) => !!s.fill)
@@ -610,13 +719,13 @@ export function drawLineSeriesLayer(options: LineSeriesLayerOptions): void {
         if (!shouldFill(s)) {
             return
         }
-        drawArea({ ctx, dimensions, labels, xScale, yScale: resolveYScale(s) }, s, yValuesFor(s), bottomFor(s))
+        drawArea({ ctx, dimensions, labels, xScale, yScale: resolveYScale(s), smooth }, s, yValuesFor(s), bottomFor(s))
     }
     const paintLine = (s: ResolvedSeries): void => {
         if (s.fill?.lowerData) {
             return
         }
-        const drawCtx: DrawContext = { ctx, dimensions, labels, xScale, yScale: resolveYScale(s) }
+        const drawCtx: DrawContext = { ctx, dimensions, labels, xScale, yScale: resolveYScale(s), smooth }
         drawLine(drawCtx, s, yValuesFor(s))
         drawPoints(drawCtx, s, yValuesFor(s))
     }

--- a/packages/quill/packages/charts/src/core/canvas-renderer.ts
+++ b/packages/quill/packages/charts/src/core/canvas-renderer.ts
@@ -453,6 +453,13 @@ export function drawPoints(drawCtx: DrawContext, series: ResolvedSeries, yValues
     }
 }
 
+/** Snap a coordinate to the nearest half-pixel so a 1px stroke fills exactly one pixel row/column.
+ *  Every axis-adjacent stroke — grid lines, axis baselines, tick marks — must share this rule, or
+ *  they land one pixel apart and visibly misalign. */
+function snapToPixel(coord: number): number {
+    return Math.round(coord) + 0.5
+}
+
 export interface DrawAxesOptions {
     axisColor?: string
 }
@@ -464,10 +471,10 @@ export function drawAxes(drawCtx: DrawContext, options: DrawAxesOptions = {}): v
     ctx.strokeStyle = options.axisColor ?? 'rgba(0, 0, 0, 0.15)'
     ctx.lineWidth = 1
     ctx.setLineDash([])
-    // Snap the corner to the rounded plot edge so the L lines up with the zero baseline and the first
-    // tick mark (which anchor to the plot edge) rather than sitting a pixel inside it.
-    const axisX = Math.round(dimensions.plotLeft)
-    const axisY = Math.round(dimensions.plotTop + dimensions.plotHeight)
+    // snapToPixel matches drawGrid's tick snapping, so the bottom baseline coincides exactly with a
+    // zero-value grid line and with drawTickMarks' ticks.
+    const axisX = snapToPixel(dimensions.plotLeft)
+    const axisY = snapToPixel(dimensions.plotTop + dimensions.plotHeight)
     // Route both strokes through the shared, snapped corner (axisX, axisY) so the L meets cleanly
     // even when plotLeft/plotHeight are fractional.
     ctx.beginPath()
@@ -480,8 +487,55 @@ export function drawAxes(drawCtx: DrawContext, options: DrawAxesOptions = {}): v
     ctx.stroke()
 }
 
+/** Length (px) of an axis tick mark, measured outward from the plot edge. */
+export const TICK_MARK_LENGTH = 4
+
+/** Pixel positions for canvas tick marks: `xs` tick below the plot's bottom edge, `ys` tick outside
+ *  the left or right plot edge (`offset` pushes stacked multi-axis gutters further outward). */
+export interface TickMarkCoords {
+    xs: number[]
+    ys: { y: number; side: 'left' | 'right'; offset: number }[]
+}
+
+/** Draws short tick marks extending outward from the plot edges, one per visible axis label.
+ *  Canvas-drawn with the same snapping as `drawAxes`/`drawGrid` so each tick continues its
+ *  axis/grid line exactly — a DOM overlay can't guarantee that across subpixel rounding. */
+export function drawTickMarks(
+    ctx: CanvasRenderingContext2D,
+    dimensions: ChartDimensions,
+    coords: TickMarkCoords,
+    color?: string
+): void {
+    ctx.strokeStyle = color ?? 'rgba(0, 0, 0, 0.15)'
+    ctx.lineWidth = 1
+    ctx.setLineDash([])
+    const axisY = snapToPixel(dimensions.plotTop + dimensions.plotHeight)
+    ctx.beginPath()
+    for (const x of coords.xs) {
+        const tickX = snapToPixel(x)
+        ctx.moveTo(tickX, axisY)
+        ctx.lineTo(tickX, axisY + TICK_MARK_LENGTH)
+    }
+    for (const { y, side, offset } of coords.ys) {
+        const tickY = snapToPixel(y)
+        if (side === 'left') {
+            const edge = snapToPixel(dimensions.plotLeft - offset)
+            ctx.moveTo(edge - TICK_MARK_LENGTH, tickY)
+            ctx.lineTo(edge, tickY)
+        } else {
+            const edge = snapToPixel(dimensions.plotLeft + dimensions.plotWidth + offset)
+            ctx.moveTo(edge, tickY)
+            ctx.lineTo(edge + TICK_MARK_LENGTH, tickY)
+        }
+    }
+    ctx.stroke()
+}
+
 export interface DrawGridOptions {
     gridColor?: string
+    /** Canvas dash pattern (e.g. `[3, 3]`) for the interior grid lines. Solid when omitted.
+     *  The plot-edge baseline strokes stay solid either way — only the interior lines dash. */
+    gridDash?: number[]
     orientation?: 'vertical' | 'horizontal'
     /** Cross-axis grid line positions (x-pixels in vertical mode, y-pixels in horizontal). */
     categoryTicks?: number[]
@@ -507,7 +561,7 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
 
     ctx.strokeStyle = gridColor
     ctx.lineWidth = 1
-    ctx.setLineDash([])
+    ctx.setLineDash(options.gridDash ?? [])
 
     // Skip the first category tick when it falls right next to the axis baseline
     // (left edge in vertical mode, top edge in horizontal) — otherwise it renders
@@ -532,6 +586,7 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
             ctx.lineTo(dimensions.plotLeft + dimensions.plotWidth, y)
             ctx.stroke()
         }
+        ctx.setLineDash([])
         const axisY = Math.round(dimensions.plotTop) + 0.5
         ctx.beginPath()
         ctx.moveTo(dimensions.plotLeft, axisY)
@@ -566,6 +621,7 @@ export function drawGrid(drawCtx: DrawContext, options: DrawGridOptions = {}): v
         ctx.stroke()
     }
 
+    ctx.setLineDash([])
     const axisX = Math.round(dimensions.plotLeft) + 0.5
     ctx.beginPath()
     ctx.moveTo(axisX, dimensions.plotTop)

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -222,6 +222,12 @@ export interface ChartConfig {
     /** Draw only the L-shaped axis baselines (left + bottom) without interior grid lines. Ignored
      *  when `showGrid` is true, since the grid already frames the plot. */
     showAxisLines?: boolean
+    /** Draw short tick marks on the axes next to each visible tick label. Pairs with
+     *  `showAxisLines` for a clean, grid-free axis that still reads precisely. */
+    showTickMarks?: boolean
+    /** Line/area interpolation. `linear` (default) draws straight segments; `monotone` smooths the
+     *  line with monotone-cubic curves that pass through every point without overshooting. */
+    curve?: 'linear' | 'monotone'
     /** Tooltip behaviour. Defaults to enabled with no pinning and `follow-data` placement. */
     tooltip?: TooltipConfig
     /** Show a vertical crosshair line that follows the cursor. */

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -7,7 +7,12 @@ export interface ChartTheme {
     colors: string[]
     backgroundColor?: string
     axisColor?: string
+    /** Stroke color for the L-shaped axis baselines and tick marks. Falls back to `axisColor`,
+     *  then `gridColor` — set it to mute the lines without muting the tick label text. */
+    axisLineColor?: string
     gridColor?: string
+    /** Canvas dash pattern (e.g. `[3, 3]`) for interior grid lines. Solid when omitted. */
+    gridDashPattern?: number[]
     crosshairColor?: string
     tooltipBackground?: string
     tooltipColor?: string

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -227,7 +227,7 @@ function YTickLabel({
         <div
             data-attr={dataAttr}
             title={title}
-            style={{ ...TICK_STYLE_BASE, ...titleStyle(title), ...edge, top: y, transform: 'translateY(-50%)', color }}
+            style={{ ...TICK_STYLE_BASE, ...titleStyle(title), ...edge, top: y, transform: 'translateY(calc(-50% + 3px))', color }}
         >
             {text}
         </div>

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -17,8 +17,6 @@ interface AxisLabelsProps {
     /** When set, truncate category tick labels wider than this (px) with an ellipsis and reveal
      *  the full value on hover. Omitted (default) renders labels untruncated. */
     maxCategoryLabelWidth?: number
-    /** Draw a short tick mark on the axis next to each visible label. */
-    showTickMarks?: boolean
 }
 
 // Minimum gap (px) required between adjacent kept labels. Category labels are often words and get
@@ -227,7 +225,7 @@ function YTickLabel({
         <div
             data-attr={dataAttr}
             title={title}
-            style={{ ...TICK_STYLE_BASE, ...titleStyle(title), ...edge, top: y, transform: 'translateY(calc(-50% + 3px))', color }}
+            style={{ ...TICK_STYLE_BASE, ...titleStyle(title), ...edge, top: y, transform: 'translateY(-50%)', color }}
         >
             {text}
         </div>
@@ -267,70 +265,6 @@ function XTickLabel({
     )
 }
 
-// Length (px) of a tick mark measured outward from the plot edge.
-const TICK_MARK_LENGTH = 4
-// The axis line is canvas-drawn while ticks are DOM overlays, so subpixel rounding can leave a hairline
-// gap between them. The axis line is 1px wide, so extending each tick this far past the plot edge makes
-// it reach the line's far side — closing the gap — without poking visibly into the plot.
-const TICK_MARK_AXIS_OVERLAP = 1
-
-const TICK_MARK_STYLE_BASE: React.CSSProperties = { position: 'absolute', pointerEvents: 'none' }
-
-/** Short mark crossing a value/category axis line, aligned to a label, so the two stay visually joined. */
-function YTickMark({
-    y,
-    side,
-    box,
-    color,
-    offset = 0,
-}: {
-    y: number
-    side: 'left' | 'right'
-    box: ChartBox
-    color: string
-    offset?: number
-}): React.ReactElement {
-    // Pull the inner edge `TICK_MARK_AXIS_OVERLAP` px past the plot edge so the tick crosses the axis line.
-    const edge =
-        side === 'left'
-            ? { right: box.width - box.plotLeft + offset - TICK_MARK_AXIS_OVERLAP }
-            : { left: box.plotLeft + box.plotWidth + offset - TICK_MARK_AXIS_OVERLAP }
-    return (
-        <div
-            aria-hidden
-            data-attr={side === 'left' ? 'hog-chart-axis-tickmark-y' : 'hog-chart-axis-tickmark-yr'}
-            style={{
-                ...TICK_MARK_STYLE_BASE,
-                ...edge,
-                top: y,
-                width: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
-                height: 1,
-                transform: 'translateY(-50%)',
-                background: color,
-            }}
-        />
-    )
-}
-
-function XTickMark({ x, box, color }: { x: number; box: ChartBox; color: string }): React.ReactElement {
-    return (
-        <div
-            aria-hidden
-            data-attr="hog-chart-axis-tickmark-x"
-            style={{
-                ...TICK_MARK_STYLE_BASE,
-                left: x,
-                // Start `TICK_MARK_AXIS_OVERLAP` px above the plot's bottom edge so the tick crosses the axis line.
-                top: box.plotTop + box.plotHeight - TICK_MARK_AXIS_OVERLAP,
-                width: 1,
-                height: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
-                transform: 'translateX(-50%)',
-                background: color,
-            }}
-        />
-    )
-}
-
 export const AxisLabels = React.memo(function AxisLabels({
     xTickFormatter,
     yTickFormatter,
@@ -340,7 +274,6 @@ export const AxisLabels = React.memo(function AxisLabels({
     orientation = 'vertical',
     labelToCoord,
     maxCategoryLabelWidth = 0,
-    showTickMarks = false,
 }: AxisLabelsProps): React.ReactElement | null {
     const { scales, dimensions, labels, yGutters } = useChartLayout()
     const yTicks = scales.yTicks()
@@ -379,25 +312,27 @@ export const AxisLabels = React.memo(function AxisLabels({
                         }
                         const { text, title } = truncateWithTitle(fullText, maxCategoryLabelWidth)
                         return (
-                            <React.Fragment key={`y-cat-${i}`}>
-                                <YTickLabel
-                                    y={y}
-                                    side="left"
-                                    box={dimensions}
-                                    text={text}
-                                    title={title}
-                                    color={axisColor}
-                                    dataAttr="hog-chart-axis-tick-y"
-                                />
-                                {showTickMarks && <YTickMark y={y} side="left" box={dimensions} color={axisColor} />}
-                            </React.Fragment>
+                            <YTickLabel
+                                key={`y-cat-${i}`}
+                                y={y}
+                                side="left"
+                                box={dimensions}
+                                text={text}
+                                title={title}
+                                color={axisColor}
+                                dataAttr="hog-chart-axis-tick-y"
+                            />
                         )
                     })}
                 {visibleValueTicks.map(({ tick, text, x }) => (
-                    <React.Fragment key={`x-val-${tick}`}>
-                        <XTickLabel x={x} box={dimensions} text={text} color={axisColor} dataAttr="hog-chart-axis-tick-x" />
-                        {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
-                    </React.Fragment>
+                    <XTickLabel
+                        key={`x-val-${tick}`}
+                        x={x}
+                        box={dimensions}
+                        text={text}
+                        color={axisColor}
+                        dataAttr="hog-chart-axis-tick-x"
+                    />
                 ))}
             </>
         )
@@ -412,42 +347,30 @@ export const AxisLabels = React.memo(function AxisLabels({
                         return null
                     }
                     return (
-                        <React.Fragment key={`${gutter.key}-${tick}`}>
-                            <YTickLabel
-                                y={y}
-                                side={gutter.side}
-                                offset={gutter.offset}
-                                box={dimensions}
-                                text={gutter.formatter(tick)}
-                                color={axisColor}
-                                dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
-                            />
-                            {showTickMarks && (
-                                <YTickMark
-                                    y={y}
-                                    side={gutter.side}
-                                    offset={gutter.offset}
-                                    box={dimensions}
-                                    color={axisColor}
-                                />
-                            )}
-                        </React.Fragment>
+                        <YTickLabel
+                            key={`${gutter.key}-${tick}`}
+                            y={y}
+                            side={gutter.side}
+                            offset={gutter.offset}
+                            box={dimensions}
+                            text={gutter.formatter(tick)}
+                            color={axisColor}
+                            dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
+                        />
                     )
                 })
             )}
 
             {visibleXLabels.map(({ index, text, title, x }) => (
-                <React.Fragment key={`x-${index}`}>
-                    <XTickLabel
-                        x={x}
-                        box={dimensions}
-                        text={text}
-                        title={title}
-                        color={axisColor}
-                        dataAttr="hog-chart-axis-tick-x"
-                    />
-                    {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
-                </React.Fragment>
+                <XTickLabel
+                    key={`x-${index}`}
+                    x={x}
+                    box={dimensions}
+                    text={text}
+                    title={title}
+                    color={axisColor}
+                    dataAttr="hog-chart-axis-tick-x"
+                />
             ))}
         </>
     )

--- a/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
+++ b/packages/quill/packages/charts/src/overlays/AxisLabels.tsx
@@ -17,6 +17,8 @@ interface AxisLabelsProps {
     /** When set, truncate category tick labels wider than this (px) with an ellipsis and reveal
      *  the full value on hover. Omitted (default) renders labels untruncated. */
     maxCategoryLabelWidth?: number
+    /** Draw a short tick mark on the axis next to each visible label. */
+    showTickMarks?: boolean
 }
 
 // Minimum gap (px) required between adjacent kept labels. Category labels are often words and get
@@ -265,6 +267,70 @@ function XTickLabel({
     )
 }
 
+// Length (px) of a tick mark measured outward from the plot edge.
+const TICK_MARK_LENGTH = 4
+// The axis line is canvas-drawn while ticks are DOM overlays, so subpixel rounding can leave a hairline
+// gap between them. The axis line is 1px wide, so extending each tick this far past the plot edge makes
+// it reach the line's far side — closing the gap — without poking visibly into the plot.
+const TICK_MARK_AXIS_OVERLAP = 1
+
+const TICK_MARK_STYLE_BASE: React.CSSProperties = { position: 'absolute', pointerEvents: 'none' }
+
+/** Short mark crossing a value/category axis line, aligned to a label, so the two stay visually joined. */
+function YTickMark({
+    y,
+    side,
+    box,
+    color,
+    offset = 0,
+}: {
+    y: number
+    side: 'left' | 'right'
+    box: ChartBox
+    color: string
+    offset?: number
+}): React.ReactElement {
+    // Pull the inner edge `TICK_MARK_AXIS_OVERLAP` px past the plot edge so the tick crosses the axis line.
+    const edge =
+        side === 'left'
+            ? { right: box.width - box.plotLeft + offset - TICK_MARK_AXIS_OVERLAP }
+            : { left: box.plotLeft + box.plotWidth + offset - TICK_MARK_AXIS_OVERLAP }
+    return (
+        <div
+            aria-hidden
+            data-attr={side === 'left' ? 'hog-chart-axis-tickmark-y' : 'hog-chart-axis-tickmark-yr'}
+            style={{
+                ...TICK_MARK_STYLE_BASE,
+                ...edge,
+                top: y,
+                width: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
+                height: 1,
+                transform: 'translateY(-50%)',
+                background: color,
+            }}
+        />
+    )
+}
+
+function XTickMark({ x, box, color }: { x: number; box: ChartBox; color: string }): React.ReactElement {
+    return (
+        <div
+            aria-hidden
+            data-attr="hog-chart-axis-tickmark-x"
+            style={{
+                ...TICK_MARK_STYLE_BASE,
+                left: x,
+                // Start `TICK_MARK_AXIS_OVERLAP` px above the plot's bottom edge so the tick crosses the axis line.
+                top: box.plotTop + box.plotHeight - TICK_MARK_AXIS_OVERLAP,
+                width: 1,
+                height: TICK_MARK_LENGTH + TICK_MARK_AXIS_OVERLAP,
+                transform: 'translateX(-50%)',
+                background: color,
+            }}
+        />
+    )
+}
+
 export const AxisLabels = React.memo(function AxisLabels({
     xTickFormatter,
     yTickFormatter,
@@ -274,6 +340,7 @@ export const AxisLabels = React.memo(function AxisLabels({
     orientation = 'vertical',
     labelToCoord,
     maxCategoryLabelWidth = 0,
+    showTickMarks = false,
 }: AxisLabelsProps): React.ReactElement | null {
     const { scales, dimensions, labels, yGutters } = useChartLayout()
     const yTicks = scales.yTicks()
@@ -312,27 +379,25 @@ export const AxisLabels = React.memo(function AxisLabels({
                         }
                         const { text, title } = truncateWithTitle(fullText, maxCategoryLabelWidth)
                         return (
-                            <YTickLabel
-                                key={`y-cat-${i}`}
-                                y={y}
-                                side="left"
-                                box={dimensions}
-                                text={text}
-                                title={title}
-                                color={axisColor}
-                                dataAttr="hog-chart-axis-tick-y"
-                            />
+                            <React.Fragment key={`y-cat-${i}`}>
+                                <YTickLabel
+                                    y={y}
+                                    side="left"
+                                    box={dimensions}
+                                    text={text}
+                                    title={title}
+                                    color={axisColor}
+                                    dataAttr="hog-chart-axis-tick-y"
+                                />
+                                {showTickMarks && <YTickMark y={y} side="left" box={dimensions} color={axisColor} />}
+                            </React.Fragment>
                         )
                     })}
                 {visibleValueTicks.map(({ tick, text, x }) => (
-                    <XTickLabel
-                        key={`x-val-${tick}`}
-                        x={x}
-                        box={dimensions}
-                        text={text}
-                        color={axisColor}
-                        dataAttr="hog-chart-axis-tick-x"
-                    />
+                    <React.Fragment key={`x-val-${tick}`}>
+                        <XTickLabel x={x} box={dimensions} text={text} color={axisColor} dataAttr="hog-chart-axis-tick-x" />
+                        {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
+                    </React.Fragment>
                 ))}
             </>
         )
@@ -347,30 +412,42 @@ export const AxisLabels = React.memo(function AxisLabels({
                         return null
                     }
                     return (
-                        <YTickLabel
-                            key={`${gutter.key}-${tick}`}
-                            y={y}
-                            side={gutter.side}
-                            offset={gutter.offset}
-                            box={dimensions}
-                            text={gutter.formatter(tick)}
-                            color={axisColor}
-                            dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
-                        />
+                        <React.Fragment key={`${gutter.key}-${tick}`}>
+                            <YTickLabel
+                                y={y}
+                                side={gutter.side}
+                                offset={gutter.offset}
+                                box={dimensions}
+                                text={gutter.formatter(tick)}
+                                color={axisColor}
+                                dataAttr={gutter.side === 'left' ? 'hog-chart-axis-tick-y' : 'hog-chart-axis-tick-yr'}
+                            />
+                            {showTickMarks && (
+                                <YTickMark
+                                    y={y}
+                                    side={gutter.side}
+                                    offset={gutter.offset}
+                                    box={dimensions}
+                                    color={axisColor}
+                                />
+                            )}
+                        </React.Fragment>
                     )
                 })
             )}
 
             {visibleXLabels.map(({ index, text, title, x }) => (
-                <XTickLabel
-                    key={`x-${index}`}
-                    x={x}
-                    box={dimensions}
-                    text={text}
-                    title={title}
-                    color={axisColor}
-                    dataAttr="hog-chart-axis-tick-x"
-                />
+                <React.Fragment key={`x-${index}`}>
+                    <XTickLabel
+                        x={x}
+                        box={dimensions}
+                        text={text}
+                        title={title}
+                        color={axisColor}
+                        dataAttr="hog-chart-axis-tick-x"
+                    />
+                    {showTickMarks && <XTickMark x={x} box={dimensions} color={axisColor} />}
+                </React.Fragment>
             ))}
         </>
     )

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -1,15 +1,10 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
 
-import { type ChartTheme } from '@posthog/quill-charts'
-
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { PropertyFilters } from 'lib/components/PropertyFilters/PropertyFilters'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
 import { TestAccountFilterSwitch } from 'lib/components/TestAccountFiltersSwitch'
 import { teamLogic } from 'scenes/teamLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { McpDateFilter } from './components/McpDateFilter'
 import { ActivityChart } from './dashboard/ActivityChart'
@@ -42,12 +37,9 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         propertyFilters,
     } = useValues(mcpDashboardOverviewLogic)
     const { setDateFilter, setFilterTestAccounts, setPropertyFilters } = useActions(mcpDashboardOverviewLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn is the dep that forces a recompute when
-    // the theme flips (it isn't passed as an argument).
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     return (
         <div className="flex flex-col gap-4">

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolDetail.tsx
@@ -26,7 +26,7 @@ import {
     TableRow,
 } from '@posthog/quill-primitives'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { TZLabel } from 'lib/components/TZLabel'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
@@ -34,7 +34,6 @@ import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { FeaturePreviewSceneGate } from '~/layout/scenes/components/FeaturePreviewSceneGate'
 import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
@@ -495,11 +494,9 @@ function MCPAnalyticsToolDetailContent({ toolName }: { toolName: string }): JSX.
         topUserRows,
         topUserRowsLoading,
     } = useValues(mcpAnalyticsToolDetailLogic({ toolName }))
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn forces a recompute on theme flip.
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const callsSeries = useMemo<Series[]>(
         () => seriesFor(dailyChartData, theme, ['calls', 'errors']),
         [dailyChartData, theme]

--- a/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsToolQuality.tsx
@@ -1,18 +1,14 @@
 import { useActions, useValues } from 'kea'
-import { useMemo } from 'react'
 
 import { IconX } from '@posthog/icons'
-import { type ChartTheme } from '@posthog/quill-charts'
 import { Button } from '@posthog/quill-primitives'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { TagsCombobox } from 'lib/components/Scenes/TagsCombobox'
 import { LinkPrimitive } from 'lib/lemon-ui/Link/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { McpDateFilter } from './components/McpDateFilter'
 import { mcpAnalyticsToolQualityLogic } from './mcpAnalyticsToolQualityLogic'
@@ -98,12 +94,9 @@ function ChartsScopeHeader(): JSX.Element {
 
 export function MCPAnalyticsToolQuality(): JSX.Element {
     const { dailyChartData, dailyStatsLoading } = useValues(mcpAnalyticsToolQualityLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { timezone } = useValues(teamLogic)
 
-    // buildTheme() reads CSS vars from the DOM; isDarkModeOn is the dep that forces a recompute when
-    // the theme flips (it isn't passed as an argument).
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     return (
         <div className="flex flex-col gap-4" data-quill>

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -2,9 +2,9 @@ import { useActions, useValues } from 'kea'
 import posthog from 'posthog-js'
 import { type ErrorInfo, useMemo } from 'react'
 
-import { type ChartTheme, type TooltipContext } from '@posthog/quill-charts'
+import { type TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -43,7 +43,7 @@ export function FunnelBarHorizontalChart({
     inCardView,
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo<ChartTheme>(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const fillerColor = useMemo(() => getFillerColor(), [isDarkModeOn])
 
     const { insightProps } = useValues(insightLogic)

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -5,7 +5,7 @@ import { useMemo, type ErrorInfo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { hexToRGBA } from 'lib/utils/colors'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -55,7 +55,7 @@ export function FunnelHistogramChart(): JSX.Element | null {
         [histogramGraphData, histogramGraphDataPrevious, currentColor]
     )
 
-    const config = useMemo<BarChartConfig>(
+    const config = useChartConfig<BarChartConfig>(
         () => (isComparing ? { ...CHART_CONFIG, barLayout: 'grouped' } : CHART_CONFIG),
         [isComparing]
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelHistogramChart/FunnelHistogramChart.tsx
@@ -5,14 +5,12 @@ import { useMemo, type ErrorInfo } from 'react'
 import { BarChart, ValueLabels } from '@posthog/quill-charts'
 import type { BarChartConfig } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { hexToRGBA } from 'lib/utils/colors'
 import { humanFriendlyNumber } from 'lib/utils/numbers'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import { insightVizDataLogic } from 'scenes/insights/insightVizDataLogic'
-
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 
 import { buildFunnelHistogramData } from './funnelHistogramTransforms'
 
@@ -35,8 +33,7 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 }
 
 export function FunnelHistogramChart(): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { histogramGraphData, histogramGraphDataPrevious } = useValues(funnelDataLogic(insightProps))
     const { theme: dataColorTheme } = useValues(insightVizDataLogic(insightProps))

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -10,7 +10,7 @@ import type {
     TooltipContext,
 } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -137,7 +137,7 @@ export function FunnelLineChart({
         [showLegend, series.length, legendPosition, canEditInsight, inSharedMode]
     )
 
-    const chartConfig: TimeSeriesLineChartConfig = useMemo(
+    const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildFunnelLineTimeSeriesConfig({
                 indexedSteps: steps,

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -10,7 +10,7 @@ import type {
     TooltipContext,
 } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
@@ -22,7 +22,6 @@ import { formatBreakdownLabel } from 'scenes/insights/utils'
 import { teamLogic } from 'scenes/teamLogic'
 import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import type { Noun } from '~/models/groupsModel'
 import { groupsModel } from '~/models/groupsModel'
@@ -65,8 +64,7 @@ export function FunnelLineChart({
     inSharedMode,
     showPersonsModal: showPersonsModalProp = true,
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { BarChart, DEFAULT_MARGINS } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -83,7 +83,7 @@ export function FunnelStepsBarChart({
     const isBreakdownCompare = steps[0]?.nested_breakdown?.some(
         (variant) => variant.compare_label != null && hasBreakdown(variant.breakdown_value)
     )
-    const config = useMemo(
+    const config = useChartConfig(
         () => withFunnelStepsBarInteraction(chartConfig, { isBreakdownCompare, quillTooltipEnabled }),
         [isBreakdownCompare, quillTooltipEnabled]
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { BarChart, DEFAULT_MARGINS } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -15,7 +15,6 @@ import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { hasBreakdown } from 'scenes/funnels/funnelUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import { ChartParams } from '~/types'
 
@@ -49,12 +48,9 @@ export function FunnelStepsBarChart({
     showPersonsModal: showPersonsModalProp = true,
     inCardView,
 }: ChartParams): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-    // buildTheme() reads CSS vars; we re-memo on isDarkModeOn so the theme refreshes
-    // when the user toggles dark mode even though the function takes no arguments.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { visibleStepsWithConversionMetrics, getFunnelsColor, breakdownFilter, querySource, insightData } = useValues(
         funnelDataLogic(insightProps)

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -170,7 +170,7 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
 
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
-    const barConfig = useMemo(
+    const barConfig = useChartConfig(
         () => buildRetentionBarChartConfig({ isPercentage, goalLines, series, tooltip: TOOLTIP_CONFIG }),
         [isPercentage, goalLines, series, TOOLTIP_CONFIG]
     )

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -14,7 +14,6 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
 import { retentionModalLogic } from 'scenes/retention/retentionModalLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
@@ -56,11 +55,10 @@ function resolveGroupTypeLabel(
 
 export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const {
         hasValidBreakdown,

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -173,7 +173,7 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
 
     const goalLines = retentionFilter?.goalLines ?? EMPTY_GOAL_LINES
 
-    const lineConfig = useMemo(
+    const lineConfig = useChartConfig(
         () =>
             buildRetentionLineChartConfig({ isPercentage, goalLines, showTrendLines, series, tooltip: TOOLTIP_CONFIG }),
         [isPercentage, goalLines, showTrendLines, series, TOOLTIP_CONFIG]

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { roundToDecimal } from 'lib/utils/numbers'
@@ -14,7 +14,6 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
 import { retentionModalLogic } from 'scenes/retention/retentionModalLogic'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
@@ -56,11 +55,10 @@ function resolveGroupTypeLabel(
 
 export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const {
         hasValidBreakdown,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -113,7 +113,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
         [indexedResults, getTrendsColor, getTrendsHidden, getLabel, quillLegendEnabled]
     )
 
-    const chartConfig: TimeSeriesBarChartConfig = useMemo(
+    const chartConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildStickinessBarTimeSeriesConfig({
                 yAxisScaleType,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -49,7 +49,7 @@ interface StickinessBarChartProps {
 const handleChartError = makeChartErrorHandler('stickiness-bar-chart')
 
 export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -115,7 +115,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
         [indexedResults, display, getTrendsColor, getTrendsHidden, getLabel, showMultipleYAxes, quillLegendEnabled]
     )
 
-    const chartConfig: TimeSeriesLineChartConfig = useMemo(
+    const chartConfig: TimeSeriesLineChartConfig = useChartConfig(
         () => ({
             ...buildStickinessLineTimeSeriesConfig({
                 yAxisScaleType,

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -49,7 +49,7 @@ interface StickinessLineChartProps {
 const handleChartError = makeChartErrorHandler('stickiness-line-chart')
 
 export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@posthog/quill-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { percentage } from 'lib/utils/numbers'
@@ -216,7 +216,7 @@ export function TrendsBarChart({
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const timeSeriesConfig: TimeSeriesBarChartConfig = useMemo(
+    const timeSeriesConfig: TimeSeriesBarChartConfig = useChartConfig(
         () => ({
             ...buildTrendsBarTimeSeriesConfig({
                 trendsFilter,
@@ -261,7 +261,7 @@ export function TrendsBarChart({
         [trendsFilter, isPercentStackView, baseCurrency]
     )
 
-    const aggregatedConfig: BarChartConfig = useMemo(() => {
+    const aggregatedConfig: BarChartConfig = useChartConfig(() => {
         // Band keys are synthetic per-series; render the human label via the categorical-axis
         // formatter and skip repeats so band-shared breakdown rows don't double-paint.
         let xTickFormatter: BarChartConfig['xTickFormatter']

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@posthog/quill-charts'
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { percentage } from 'lib/utils/numbers'
@@ -89,7 +89,7 @@ export function TrendsBarChart({
     inSharedMode = false,
     embedded = false,
 }: TrendsBarChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TIME_SERIES_TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
@@ -252,7 +252,7 @@ export function TrendsBarChart({
             showValuesOnSeries,
             valueLabelFormatter,
             legendConfig,
-            quillTooltipEnabled,
+            TIME_SERIES_TOOLTIP_CONFIG,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { getBarColorFromStatus } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -105,7 +105,11 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         [formatValue, showValuesOnSeries, showPercentagesOnSeries]
     )
 
-    const { series, labels, config } = useMemo(
+    const {
+        series,
+        labels,
+        config: baseConfig,
+    } = useMemo(
         () =>
             buildLifecycleChartModel<IndexedTrendResult, TrendsSeriesMeta>(indexedResults ?? [], {
                 getColor: (status) => getBarColorFromStatus((status ?? 'new') as LifecycleToggle),
@@ -139,6 +143,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             quillTooltipEnabled,
         ]
     )
+    const config = useChartConfig(() => baseConfig, [baseConfig])
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { getBarColorFromStatus } from 'lib/colors'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
@@ -52,7 +52,7 @@ const handleChartError = makeChartErrorHandler('trends-lifecycle-chart')
 const renderLifecycleSeriesLabel = (datum: SeriesDatum): React.ReactNode => datum.label
 
 export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLifecycleChartProps): JSX.Element | null {
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { insightProps, insight, canEditInsight } = useValues(insightLogic)

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartTheme, useChartConfig } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ciRanges } from 'lib/statistics'
@@ -240,7 +240,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
         ]
     )
 
-    const config = useMemo(
+    const config = useChartConfig(
         () =>
             buildTrendsLineTimeSeriesConfig<IndexedTrendResult>({
                 results: indexedResults ?? [],

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -4,7 +4,7 @@ import { useCallback, useMemo } from 'react'
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ciRanges } from 'lib/statistics'
@@ -18,7 +18,6 @@ import { openPersonsModal } from 'scenes/trends/persons-modal/PersonsModal'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -46,11 +45,10 @@ interface TrendsLineChartProps {
 const handleChartError = makeChartErrorHandler('trends-line-chart')
 
 export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps, insight } = useValues(insightLogic)
 
     const legendConfig = useInsightsLegendConfig({ insightProps, inSharedMode })

--- a/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
@@ -5,7 +5,7 @@ import { useCallback, useMemo, type ErrorInfo } from 'react'
 import { PieChart } from '@posthog/quill-charts'
 import type { PieChartConfig, RadialSlicePayload, Series, TooltipContext } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
@@ -22,7 +22,6 @@ import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 import { datasetToActorsQuery } from 'scenes/trends/viz/datasetToActorsQuery'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { cohortsModel } from '~/models/cohortsModel'
 import { groupsModel } from '~/models/groupsModel'
 import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
@@ -50,9 +49,7 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieChartProps): JSX.Element | null {
     const { featureFlags } = useValues(featureFlagLogic)
     const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-    const { isDarkModeOn } = useValues(themeLogic)
-    // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     const { insightProps } = useValues(insightLogic)
     const { baseCurrency } = useValues(teamLogic)

--- a/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsSlopeChart/TrendsSlopeChart.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { SlopeChart, createXAxisTickCallback } from '@posthog/quill-charts'
 import type { Series, SlopeChartConfig, SlopeSeriesMeta } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -13,7 +13,6 @@ import { teamLogic } from 'scenes/teamLogic'
 import { trendsDataLogic } from 'scenes/trends/trendsDataLogic'
 import type { IndexedTrendResult } from 'scenes/trends/types'
 
-import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
@@ -26,8 +25,7 @@ interface TrendsSlopeChartProps {
 const handleChartError = makeChartErrorHandler('trends-slope-chart')
 
 export function TrendsSlopeChart({ context }: TrendsSlopeChartProps): JSX.Element | null {
-    const { isDarkModeOn } = useValues(themeLogic)
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
     const { insightProps } = useValues(insightLogic)
 
     const { indexedResults, currentPeriodResult, getTrendsColor, getTrendsHidden, trendsFilter, interval, showLegend } =

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -3,7 +3,7 @@ import { useValues } from 'kea'
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 import { BarChart } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -170,6 +170,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
         replayScannerLogic({ id: scannerId })
     )
     const theme = useChartTheme()
+    const config = useChartConfig(() => ({ showGrid: false }), [])
     if (!scorerSummary || !scorerHistogram) {
         return (
             <OverviewPanel title="Score distribution">
@@ -190,7 +191,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
                 <BarChart
                     labels={scorerHistogram.labels}
                     series={[{ key: 'count', label: 'Sessions', color: theme.colors[0], data: scorerHistogram.counts }]}
-                    config={{ showGrid: false }}
+                    config={config}
                     theme={theme}
                 />
             </div>

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -1,10 +1,9 @@
 import { useValues } from 'kea'
-import { useMemo } from 'react'
 
 import { LemonTag, Spinner } from '@posthog/lemon-ui'
 import { BarChart } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { LemonProgress } from 'lib/lemon-ui/LemonProgress'
 
 import { replayScannerLogic } from '../replayScannerLogic'
@@ -170,7 +169,7 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
     const { scorerSummary, scorerHistogram, hasActiveObservationFilters, observationStatsApiLoading } = useValues(
         replayScannerLogic({ id: scannerId })
     )
-    const theme = useMemo(() => buildTheme(), [])
+    const theme = useChartTheme()
     if (!scorerSummary || !scorerHistogram) {
         return (
             <OverviewPanel title="Score distribution">

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -11,7 +11,7 @@ import type {
     YAxisConfig,
 } from '@posthog/quill-charts'
 
-import { useChartTheme } from 'lib/charts/hooks'
+import { useChartConfig, useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -111,14 +111,27 @@ export function RevenueAnalyticsChart({
 
     // No xAxis config: the backend ships pre-formatted period labels, so the time-axis date
     // formatter is intentionally left inert (it would otherwise re-format the labels itself).
-    if (kind === 'bar') {
-        const config: TimeSeriesBarChartConfig = {
+    const barConfig = useChartConfig<TimeSeriesBarChartConfig>(
+        () => ({
             yAxis,
             goalLines,
             barLayout: 'stacked',
             divergingStack,
             tooltip: TOOLTIP_CONFIG,
-        }
+        }),
+        [yAxis, goalLines, divergingStack]
+    )
+    const lineConfig = useChartConfig<TimeSeriesLineChartConfig>(
+        () => ({
+            yAxis,
+            goalLines,
+            showCrosshair: true,
+            tooltip: TOOLTIP_CONFIG,
+        }),
+        [yAxis, goalLines]
+    )
+
+    if (kind === 'bar') {
         return (
             <ChartLegend
                 show={showLegend}
@@ -130,7 +143,7 @@ export function RevenueAnalyticsChart({
                     series={series}
                     labels={labels}
                     theme={theme}
-                    config={config}
+                    config={barConfig}
                     tooltip={renderTooltip}
                     className="BarGraph"
                     dataAttr={dataAttr}
@@ -139,12 +152,6 @@ export function RevenueAnalyticsChart({
         )
     }
 
-    const config: TimeSeriesLineChartConfig = {
-        yAxis,
-        goalLines,
-        showCrosshair: true,
-        tooltip: TOOLTIP_CONFIG,
-    }
     return (
         <ChartLegend
             show={showLegend}
@@ -156,7 +163,7 @@ export function RevenueAnalyticsChart({
                 series={series}
                 labels={labels}
                 theme={theme}
-                config={config}
+                config={lineConfig}
                 tooltip={renderTooltip}
                 className="LineGraph"
                 dataAttr={dataAttr}

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -11,7 +11,7 @@ import type {
     YAxisConfig,
 } from '@posthog/quill-charts'
 
-import { buildTheme } from 'lib/charts/utils/theme'
+import { useChartTheme } from 'lib/charts/hooks'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -73,7 +73,7 @@ export function RevenueAnalyticsChart({
     const { dateFilter } = useValues(revenueAnalyticsLogic)
     const { isDarkModeOn } = useValues(themeLogic)
 
-    const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const theme = useChartTheme()
 
     // isDarkModeOn is a dep (not an arg): getColor can resolve theme-dependent CSS colors into
     // concrete values, so the series must rebuild on a light/dark toggle.


### PR DESCRIPTION
## Problem

SQL insights rendered via quill-charts used the default unstyled look — full grid frame, sharp angles, no axis marks. The result felt heavy and visually inconsistent with the rest of the product.

## Changes

- **Monotone curve** — lines use cubic interpolation that passes through every data point without overshoot, giving a gentle bend without distorting peaks
- **Axis lines + tick marks** — grid replaced with a crisp L-shaped axis baseline; short tick marks cross the axis line so there's no subpixel gap
- **Faint grid lines** (6% opacity) via a per-chart theme override — axis lines draw alongside the grid so both coexist; trends and web-analytics charts are unaffected
- **Crosshair** enabled for SQL line charts
- **y-axis tick labels** shifted 3px below the grid line for cleaner alignment
- Applied consistently across line, area, bar, and combo chart paths

## How did you test this code?

Agent-authored with human direction via screenshot feedback. No automated tests for visual rendering.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Sonnet 4.6 1M). The human directed each visual decision — curve type, grid opacity, axis coexistence, tick offset — reviewing results in the browser after each quill-charts dist rebuild. The changes were originally part of a combined PR and split at the author's request.