### PR TITLE
fix(e2e): playwright race condition starting services

### DIFF
--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -268,6 +268,8 @@ jobs:
                   export CLICKHOUSE_SERVER_IMAGE=${{ needs.changes.outputs.oldest_supported }}
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
 
+                  PID_FILE="${TMPDIR:-/tmp}/ci-initial-compose.pid"
+
                   (
                     max_attempts=3
                     attempt=1
@@ -279,6 +281,7 @@ jobs:
                         if docker compose -f docker-compose.dev.yml down && \
                           docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d; then
                             echo "Stack started successfully"
+                            rm -f "$PID_FILE"
                             exit 0
                         fi
 
@@ -294,8 +297,10 @@ jobs:
                     done
 
                     echo "Failed to start stack after $max_attempts attempts"
+                    rm -f "$PID_FILE"
                     exit 1
                   ) &
+                  echo $! > "$PID_FILE"
 
             - name: Add service hostnames to /etc/hosts
               shell: bash
@@ -426,6 +431,19 @@ jobs:
               with:
                   username: ${{ vars.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+            - name: Wait for initial Docker Compose to finish
+              shell: bash
+              run: |
+                  PID_FILE="${TMPDIR:-/tmp}/ci-initial-compose.pid"
+                  if [ -f "$PID_FILE" ]; then
+                      bg_pid=$(cat "$PID_FILE")
+                      if kill -0 "$bg_pid" 2>/dev/null; then
+                          echo "Waiting for background compose (pid $bg_pid) to finish..."
+                          while kill -0 "$bg_pid" 2>/dev/null; do sleep 2; done
+                      fi
+                      rm -f "$PID_FILE"
+                  fi
 
             - name: Start Docker services
               env:

--- a/.github/workflows/ci-e2e-playwright.yml
+++ b/.github/workflows/ci-e2e-playwright.yml
@@ -262,45 +262,12 @@ jobs:
                   [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
               continue-on-error: true
 
-            - name: Stop/Start stack with Docker Compose
+            - name: Pull Docker images
               shell: bash
               run: |
                   export CLICKHOUSE_SERVER_IMAGE=${{ needs.changes.outputs.oldest_supported }}
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
-
-                  PID_FILE="${TMPDIR:-/tmp}/ci-initial-compose.pid"
-
-                  (
-                    max_attempts=3
-                    attempt=1
-                    delay=5
-
-                    while [ $attempt -le $max_attempts ]; do
-                        echo "Attempt $attempt of $max_attempts to start stack..."
-
-                        if docker compose -f docker-compose.dev.yml down && \
-                          docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d; then
-                            echo "Stack started successfully"
-                            rm -f "$PID_FILE"
-                            exit 0
-                        fi
-
-                        echo "Failed to start stack on attempt $attempt"
-
-                        if [ $attempt -lt $max_attempts ]; then
-                            sleep_time=$((delay * 2 ** (attempt - 1)))
-                            echo "Waiting ${sleep_time} seconds before retry..."
-                            sleep $sleep_time
-                        fi
-
-                        attempt=$((attempt + 1))
-                    done
-
-                    echo "Failed to start stack after $max_attempts attempts"
-                    rm -f "$PID_FILE"
-                    exit 1
-                  ) &
-                  echo $! > "$PID_FILE"
+                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml pull --quiet &
 
             - name: Add service hostnames to /etc/hosts
               shell: bash
@@ -431,19 +398,6 @@ jobs:
               with:
                   username: ${{ vars.DOCKERHUB_USER }}
                   password: ${{ secrets.DOCKERHUB_TOKEN }}
-
-            - name: Wait for initial Docker Compose to finish
-              shell: bash
-              run: |
-                  PID_FILE="${TMPDIR:-/tmp}/ci-initial-compose.pid"
-                  if [ -f "$PID_FILE" ]; then
-                      bg_pid=$(cat "$PID_FILE")
-                      if kill -0 "$bg_pid" 2>/dev/null; then
-                          echo "Waiting for background compose (pid $bg_pid) to finish..."
-                          while kill -0 "$bg_pid" 2>/dev/null; do sleep 2; done
-                      fi
-                      rm -f "$PID_FILE"
-                  fi
 
             - name: Start Docker services
               env:


### PR DESCRIPTION
## Problem

The "Stop/start stack" step in the playwright e2e setup runs `docker compose up -d` in a background subshell with retries. Later, the "Start Docker services" step runs `compose down` and `compose up` with different profiles. If the background subshell is still retrying when the later step runs, they race. This can cause Docker in an inconsistent state where we try to start two services that share the same port (because they are the same service) and the run fails

## Changes

Replaces the background run of `docker compose down && docker compose up -d` with a background `docker compose pull --quiet`. We don't need the services up until after step 23 (it was tearing the services down anyways, before starting), so just pull the images in the background instead of starting the services.

## How did you test this code?

Run the playwright CI