### PR TITLE
fix(insights): split lifecycle percentage denominators

### DIFF
--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -29,7 +29,11 @@ import {
 } from '../shared/handleTrendsChartClick'
 import { buildTrendsSeriesMeta, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
 import { TrendsTooltip } from '../shared/TrendsTooltip'
-import { buildLifecycleChartModel, buildLifecycleValueLabelFormatter } from './trendsLifecycleChartTransforms'
+import {
+    buildLifecycleChartModel,
+    buildLifecycleValueLabelFormatter,
+    lifecyclePrevActiveBaseByDataIndex,
+} from './trendsLifecycleChartTransforms'
 
 interface TrendsLifecycleChartProps {
     context?: QueryContext<InsightVizNode>
@@ -90,13 +94,19 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
         [trendsFilter, baseCurrency]
     )
 
+    const dormantBaseByDataIndex = useMemo(
+        () => lifecyclePrevActiveBaseByDataIndex(indexedResults ?? []),
+        [indexedResults]
+    )
+
     const valueLabelFormatter = useMemo(
         () =>
             buildLifecycleValueLabelFormatter(formatValue, {
                 showValues: !!showValuesOnSeries,
                 showPercentages: !!showPercentagesOnSeries,
+                dormantBaseByDataIndex,
             }),
-        [formatValue, showValuesOnSeries, showPercentagesOnSeries]
+        [formatValue, showValuesOnSeries, showPercentagesOnSeries, dormantBaseByDataIndex]
     )
 
     const { series, labels, config } = useMemo(

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
@@ -257,18 +257,17 @@ describe('buildLifecycleValueLabelFormatter', () => {
         { name: 'values only', showValues: true, showPercentages: false, expected: '20' },
         { name: 'values + percentages', showValues: true, showPercentages: true, expected: '20 (25%)' },
         { name: 'percentages only', showValues: false, showPercentages: true, expected: '25%' },
-    ])('renders an active segment $name as "$expected" (share of active total, dormant excluded)', ({
-        showValues,
-        showPercentages,
-        expected,
-    }) => {
-        const formatter = buildLifecycleValueLabelFormatter(formatValue, {
-            showValues,
-            showPercentages,
-            dormantBaseByDataIndex,
-        })
-        expect(formatter(20, 0, 2, band)).toBe(expected)
-    })
+    ])(
+        'renders an active segment $name as "$expected" (share of active total, dormant excluded)',
+        ({ showValues, showPercentages, expected }) => {
+            const formatter = buildLifecycleValueLabelFormatter(formatValue, {
+                showValues,
+                showPercentages,
+                dormantBaseByDataIndex,
+            })
+            expect(formatter(20, 0, 2, band)).toBe(expected)
+        }
+    )
 
     it('shares the dormant segment against the previous-period active base (churn), not the band', () => {
         const formatter = buildLifecycleValueLabelFormatter(formatValue, {
@@ -301,16 +300,43 @@ describe('buildLifecycleValueLabelFormatter', () => {
 })
 
 describe('lifecyclePrevActiveBaseByDataIndex', () => {
-    it('sums active statuses per period and shifts forward one (dormant churns against the prior base)', () => {
-        const results: TrendsLifecycleResultLike[] = [
-            { status: 'new', label: 'Pageview - new', data: [10, 20, 30] },
-            { status: 'returning', label: 'Pageview - returning', data: [5, 6, 7] },
-            { status: 'resurrecting', label: 'Pageview - resurrecting', data: [1, 2, 3] },
+    const cases: { name: string; results: TrendsLifecycleResultLike[]; expected: number[] }[] = [
+        {
+            // active totals per period = [16, 28, 40]; shifted forward (base[d] = active[d-1]) → [0, 16, 28].
             // Dormant is negative and must be excluded from the active total entirely.
-            { status: 'dormant', label: 'Pageview - dormant', data: [-4, -5, -6] },
-        ]
-        // active totals per period = [16, 28, 40]; shifted forward (base[d] = active[d-1]) → [0, 16, 28].
-        expect(lifecyclePrevActiveBaseByDataIndex(results)).toEqual([0, 16, 28])
+            name: 'sums active statuses, shifts forward one period, and excludes dormant',
+            results: [
+                { status: 'new', label: 'Pageview - new', data: [10, 20, 30] },
+                { status: 'returning', label: 'Pageview - returning', data: [5, 6, 7] },
+                { status: 'resurrecting', label: 'Pageview - resurrecting', data: [1, 2, 3] },
+                { status: 'dormant', label: 'Pageview - dormant', data: [-4, -5, -6] },
+            ],
+            expected: [0, 16, 28],
+        },
+        {
+            // No active series → no prior base in any period, so dormant gets no percentage anywhere.
+            name: 'returns all-zero when every series is dormant',
+            results: [
+                { status: 'dormant', label: 'd1', data: [-3, -4, -5] },
+                { status: 'dormant', label: 'd2', data: [-1, -1, -1] },
+            ],
+            expected: [0, 0, 0],
+        },
+        {
+            // Ragged lengths: period count follows the longest series; shorter series just don't
+            // contribute past their end. active totals = [15, 25, 30, 40] → shifted → [0, 15, 25, 30].
+            name: 'uses the longest data length when series lengths differ',
+            results: [
+                { status: 'new', label: 'new', data: [10, 20, 30, 40] },
+                { status: 'returning', label: 'returning', data: [5, 5] },
+            ],
+            expected: [0, 15, 25, 30],
+        },
+        { name: 'returns an empty array for no results', results: [], expected: [] },
+    ]
+
+    it.each(cases)('$name', ({ results, expected }) => {
+        expect(lifecyclePrevActiveBaseByDataIndex(results)).toEqual(expected)
     })
 })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.test.ts
@@ -10,6 +10,7 @@ import {
     buildTrendsLifecycleConfig,
     buildTrendsLifecycleSeries,
     filterToggledLifecycleResults,
+    lifecyclePrevActiveBaseByDataIndex,
     shortenLifecycleLabel,
     type TrendsLifecycleResultLike,
 } from './trendsLifecycleChartTransforms'
@@ -246,31 +247,70 @@ describe('buildTrendsLifecycleConfig', () => {
 
 describe('buildLifecycleValueLabelFormatter', () => {
     const formatValue = (v: number): string => `${v}`
-    // Diverging band: positive new + negative dormant. abs total = 30, so 20 → 67%, -10 → 33%.
-    const band: ValueLabelContext = { rawValue: 20, bandValues: [20, -10], isPercent: false }
+    // Diverging band at dataIndex 2: two active (positive) statuses summing to 80, plus dormant (-30).
+    // Active segments share the active total (80) — dormant must NOT inflate that denominator, so
+    // 20 → 25% (not 18% of the old abs total of 110). Dormant shares the previous-period base below.
+    const band: ValueLabelContext = { rawValue: 20, bandValues: [20, 60, -30], isPercent: false }
+    const dormantBaseByDataIndex = [0, 0, 40]
 
     it.each([
         { name: 'values only', showValues: true, showPercentages: false, expected: '20' },
-        { name: 'values + percentages', showValues: true, showPercentages: true, expected: '20 (67%)' },
-        { name: 'percentages only', showValues: false, showPercentages: true, expected: '67%' },
-    ])('renders $name as "$expected"', ({ showValues, showPercentages, expected }) => {
-        const formatter = buildLifecycleValueLabelFormatter(formatValue, { showValues, showPercentages })
-        expect(formatter(20, 0, 0, band)).toBe(expected)
+        { name: 'values + percentages', showValues: true, showPercentages: true, expected: '20 (25%)' },
+        { name: 'percentages only', showValues: false, showPercentages: true, expected: '25%' },
+    ])('renders an active segment $name as "$expected" (share of active total, dormant excluded)', ({
+        showValues,
+        showPercentages,
+        expected,
+    }) => {
+        const formatter = buildLifecycleValueLabelFormatter(formatValue, {
+            showValues,
+            showPercentages,
+            dormantBaseByDataIndex,
+        })
+        expect(formatter(20, 0, 2, band)).toBe(expected)
     })
 
-    it('uses absolute values so the negative dormant segment gets a sensible share', () => {
-        const formatter = buildLifecycleValueLabelFormatter(formatValue, { showValues: false, showPercentages: true })
-        expect(formatter(-10, 1, 0, { rawValue: -10, bandValues: [20, -10], isPercent: false })).toBe('33%')
+    it('shares the dormant segment against the previous-period active base (churn), not the band', () => {
+        const formatter = buildLifecycleValueLabelFormatter(formatValue, {
+            showValues: false,
+            showPercentages: true,
+            dormantBaseByDataIndex,
+        })
+        // |-30| / dormantBase[2]=40 = 75% — independent of the current band's own values.
+        expect(formatter(-30, 2, 2, { rawValue: -30, bandValues: [20, 60, -30], isPercent: false })).toBe('75%')
     })
 
-    it('returns an empty string (skip) for percentages-only when the band has no total', () => {
+    it('skips the dormant percentage when there is no previous-period base (first period)', () => {
+        const formatter = buildLifecycleValueLabelFormatter(formatValue, {
+            showValues: false,
+            showPercentages: true,
+            dormantBaseByDataIndex,
+        })
+        expect(formatter(-30, 2, 0, { rawValue: -30, bandValues: [20, -30], isPercent: false })).toBe('')
+    })
+
+    it('returns an empty string (skip) for an active segment when the band has no active total', () => {
         const formatter = buildLifecycleValueLabelFormatter(formatValue, { showValues: false, showPercentages: true })
-        expect(formatter(0, 0, 0, { rawValue: 0, bandValues: [0, 0], isPercent: false })).toBe('')
+        expect(formatter(0, 0, 0, { rawValue: 0, bandValues: [0, -5], isPercent: false })).toBe('')
     })
 
     it('does not append percentages in percent layout (labels already express fractions)', () => {
         const formatter = buildLifecycleValueLabelFormatter(formatValue, { showValues: true, showPercentages: true })
         expect(formatter(0.2, 0, 0, { rawValue: 20, bandValues: [20, 80], isPercent: true })).toBe('0.2')
+    })
+})
+
+describe('lifecyclePrevActiveBaseByDataIndex', () => {
+    it('sums active statuses per period and shifts forward one (dormant churns against the prior base)', () => {
+        const results: TrendsLifecycleResultLike[] = [
+            { status: 'new', label: 'Pageview - new', data: [10, 20, 30] },
+            { status: 'returning', label: 'Pageview - returning', data: [5, 6, 7] },
+            { status: 'resurrecting', label: 'Pageview - resurrecting', data: [1, 2, 3] },
+            // Dormant is negative and must be excluded from the active total entirely.
+            { status: 'dormant', label: 'Pageview - dormant', data: [-4, -5, -6] },
+        ]
+        // active totals per period = [16, 28, 40]; shifted forward (base[d] = active[d-1]) → [0, 16, 28].
+        expect(lifecyclePrevActiveBaseByDataIndex(results)).toEqual([0, 16, 28])
     })
 })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/trendsLifecycleChartTransforms.ts
@@ -28,26 +28,65 @@ function lifecycleStatusOrder(status: string | undefined): number {
 export interface LifecycleValueLabelOptions {
     showValues: boolean
     showPercentages: boolean
+    /** Per-dataIndex denominator for the dormant series — the *previous* period's active total
+     *  (new + returning + resurrecting), produced by `lifecyclePrevActiveBaseByDataIndex`. Dormant
+     *  orgs were active last period and aren't now, so their meaningful share is a churn rate against
+     *  that prior base, not against the current period. Omit it (or a 0 entry) to skip dormant's % . */
+    dormantBaseByDataIndex?: readonly number[]
 }
 
-// Each segment's percentage is its share of the band's absolute total — `abs` so the negative
-// dormant series contributes a sensible denominator instead of cancelling the positives.
+// Active statuses (new/returning/resurrecting) are the positive bars, so each one's percentage is its
+// share of the period's active total (the sum of the positive band values). Dormant is the only
+// negative series — orgs that were active last period and didn't return — so its percentage is a
+// churn rate against the previous period's active total, a deliberately different base. The two
+// groups therefore don't sum to 100%: the positives describe "who is active now", dormant describes
+// "what fraction of last period's actives left".
 export function buildLifecycleValueLabelFormatter(
     formatValue: (value: number) => string,
-    { showValues, showPercentages }: LifecycleValueLabelOptions
+    { showValues, showPercentages, dormantBaseByDataIndex }: LifecycleValueLabelOptions
 ): ValueLabelFormatter {
-    return (value, _seriesIndex, _dataIndex, context) => {
+    return (value, _seriesIndex, dataIndex, context) => {
         const valueText = showValues ? formatValue(value) : ''
         if (!showPercentages || context.isPercent) {
             return valueText
         }
-        const absTotal = context.bandValues.reduce((sum, v) => sum + Math.abs(v), 0)
-        if (absTotal === 0) {
+        const isDormant = context.rawValue < 0
+        const denominator = isDormant
+            ? (dormantBaseByDataIndex?.[dataIndex] ?? 0)
+            : context.bandValues.reduce((sum, v) => (v > 0 ? sum + v : sum), 0)
+        if (denominator === 0) {
             return valueText
         }
-        const pct = Math.round((Math.abs(context.rawValue) / absTotal) * 100)
+        const pct = Math.round((Math.abs(context.rawValue) / denominator) * 100)
         return showValues ? `${valueText} (${pct}%)` : `${pct}%`
     }
+}
+
+/** Per-period churn base for the dormant series: the previous period's active total
+ *  (new + returning + resurrecting). Dormant at period d counts orgs active at d-1 but not d, so its
+ *  share belongs to d-1's active population. `base[0]` is 0 — the period before the first is off the
+ *  chart, so dormant there gets no percentage. Independent of legend toggles: the prior active base
+ *  is a fixed population, unlike the positives' share which re-normalizes among visible series. */
+export function lifecyclePrevActiveBaseByDataIndex(results: readonly TrendsLifecycleResultLike[]): number[] {
+    const periodCount = results.reduce((n, r) => Math.max(n, r.data.length), 0)
+    const activeTotals = new Array<number>(periodCount).fill(0)
+    for (const r of results) {
+        // Dormant is the only negative series; everything else is an active status.
+        if (r.status === 'dormant') {
+            continue
+        }
+        for (let i = 0; i < r.data.length; i++) {
+            const v = r.data[i]
+            if (Number.isFinite(v)) {
+                activeTotals[i] += v
+            }
+        }
+    }
+    const base = new Array<number>(periodCount).fill(0)
+    for (let i = 1; i < periodCount; i++) {
+        base[i] = activeTotals[i - 1]
+    }
+    return base
 }
 
 /** Drops rows whose lifecycle status is toggled off — mirrors the main app's legend toggles, which


### PR DESCRIPTION
## Problem

On the Lifecycle insight, the per-segment percentage labels divided **every** segment by the band's absolute total — `abs(new) + abs(returning) + abs(resurrecting) + abs(dormant)`. Dormant orgs aren't part of the current period's active population (they're the *previous* period's actives who didn't return, drawn below the axis), so folding them into a single denominator produces shares with no clean interpretation and arbitrarily deflates the active shares.

Raised in Slack: should the active statuses be normalized among themselves, and dormant expressed as a churn rate against the prior period?

## Changes

Splits the percentage into two coherent denominators:

- **New / Returning / Resurrecting** → share of the period's **active total** (the sum of the positive band values). Dormant no longer inflates this denominator. These sum to 100%.
- **Dormant** → share of the **previous period's active total** (`new + returning + resurrecting` of period `d-1`) — i.e. the fraction of last period's actives that churned.

The two groups intentionally sit on different bases, so the labels don't sum to 100%: the positives describe *who is active now*, dormant describes *what fraction of last period's actives left*.

Implementation notes:
- The dormant churn base is computed upstream from the full results via a new helper `lifecyclePrevActiveBaseByDataIndex`, keeping the change inside the product rather than extending the shared `@posthog/quill-charts` `ValueLabelContext`.
- The churn base spans all results (not just legend-visible series) — the prior active population is fixed, unlike the positive shares which re-normalize among visible series on legend toggle.
- The first visible period has no prior period on the chart, so dormant there shows no percentage.

Storybook stories that render lifecycle percentages (`StackedWithPercentagesOnSeries`, etc.) will now render different numbers — expected; visual-regression snapshots will regenerate.

## How did you test this code?

I'm an agent. I updated the unit tests in `trendsLifecycleChartTransforms.test.ts` to lock in the new behavior:
- Active segment shares the active total with dormant **excluded** from the denominator (catches a regression back to the lumped abs-total).
- Dormant shares the previous-period active base, independent of the current band (catches computing dormant against its own band).
- Dormant is skipped when there's no prior-period base (first period).
- New helper `lifecyclePrevActiveBaseByDataIndex` sums active statuses and shifts forward one period, excluding dormant.

I could **not** run `jest` or `tsc` in this environment — frontend `node_modules` aren't installed and the pnpm store is empty. Tests need to be run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a Slack thread questioning the lifecycle percentage denominator, confirmed the current behavior in `trendsLifecycleChartTransforms.ts` (single abs-total denominator), and implemented the two-denominator split the thread proposed. Invoked the `/writing-tests` skill before reworking the tests.

Decision: compute the dormant churn base upstream and pass it into the formatter, rather than extending the shared chart `ValueLabelContext` with previous-band data — smaller blast radius, no charts-library change. The active denominator stays band-local (sum of positive band values) since that's already available in the formatter and correctly respects legend toggles.

Not verified locally (no installed frontend deps) — relying on CI for jest + typecheck + visual-regression snapshot regeneration.
