### PR TITLE
fix(mcp): playwright-style race starting docker services

### DIFF
--- a/.github/workflows/ci-mcp.yml
+++ b/.github/workflows/ci-mcp.yml
@@ -285,40 +285,13 @@ jobs:
                   [ -d "data" ] && docker run --rm -v "$(pwd)/data:/data" alpine sh -c "rm -rf /data/seaweedfs /data/minio" || true
               continue-on-error: true
 
-            - name: Stop/Start stack with Docker Compose
+            - name: Pull Docker images
               shell: bash
               env:
                   COMPOSE_PROFILES: temporal
               run: |
                   cp posthog/user_scripts/latest_user_defined_function.xml docker/clickhouse/user_defined_function.xml
-                  (
-                      max_attempts=3
-                      attempt=1
-                      delay=5
-
-                      while [ $attempt -le $max_attempts ]; do
-                          echo "Attempt $attempt of $max_attempts to start stack..."
-
-                          if docker compose -f docker-compose.dev.yml down && \
-                            docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml up -d; then
-                              echo "Stack started successfully"
-                              exit 0
-                          fi
-
-                          echo "Failed to start stack on attempt $attempt"
-
-                          if [ $attempt -lt $max_attempts ]; then
-                              sleep_time=$((delay * 2 ** (attempt - 1)))
-                              echo "Waiting ${sleep_time} seconds before retry..."
-                              sleep $sleep_time
-                          fi
-
-                          attempt=$((attempt + 1))
-                      done
-
-                      echo "Failed to start stack after $max_attempts attempts"
-                      exit 1
-                  ) &
+                  docker compose -f docker-compose.dev.yml -f docker-compose.profiles.yml pull --quiet &
 
             - name: Add service hostnames to /etc/hosts
               shell: bash


### PR DESCRIPTION
## Problem

The "Stop/Start stack" step backgrounds `compose down && up -d` with retries; a later step runs `bin/ci-wait-for-docker launch --down`, which tears down and restarts the same stack. If the background subshell is still retrying, the two race on the same Compose project/ports and the run fails.

Same bug fixed for Playwright in [fix(e2e): playwright race](https://github.com/PostHog/posthog/pull/66159). `ci-mcp.yml` was the only other workflow still hand-rolling this start — the rest use `ci-wait-for-docker`.

## Changes

Swap the background `down && up -d` subshell for `docker compose pull --quiet &`. Services aren't needed until the later `launch --down` step, so just warm the image cache — `pull` binds no ports, so it can't race.

## How did you test this code?

Agent-authored, no manual testing — one-for-one mirror of the validated Playwright fix. Relies on this PR's MCP CI run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Raúl asked me (Claude Code) to generalize the Playwright race fix. Audit found `ci-mcp.yml` as the sole remaining workflow with the racy backgrounded `down && up -d` + redundant `launch --down`; applied the same swap.
