### PR TITLE
fix(posthog-ai): show gerund loader only while the agent is thinking

### DIFF
--- a/products/posthog_ai/frontend/components/ThreadView.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.tsx
@@ -55,16 +55,13 @@ export function ThreadView({
         threadItems,
         toolInvocations,
         isThinking,
-        streamPhase,
+        showThinkingIndicator,
         runArtifacts,
         turnComplete,
         currentRunStatus,
         contextUsage,
     } = useValues(runStreamLogic)
     const turnCancelled = currentRunStatus === 'cancelled'
-    const hasActiveProgressItem = threadItems.some(
-        (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
-    )
 
     // Header/footer are kept as memoized leaf components with stable element identity so they don't rebuild
     // `VirtualizedThread`'s `renderRow` (and re-sweep visible rows) on every streamed frame. Each is wrapped
@@ -80,7 +77,6 @@ export function ThreadView({
         [branch, baseBranch, repo]
     )
 
-    const showThinking = streamPhase === 'thinking' && !hasActiveProgressItem
     // Post-turn only: a reconnect refetch can fold in a pr_url mid-run, so gate on !isThinking.
     const pullRequestUrl = !isThinking ? runArtifacts.prUrl : undefined
     // Context usage rides the thread footer, but only between turns (idle) — never while the agent is
@@ -88,17 +84,17 @@ export function ThreadView({
     const showContextUsageFooter = showContextUsage && !isThinking && !!contextUsage
     const footer = useMemo(
         () =>
-            showThinking || pullRequestUrl || showContextUsageFooter ? (
+            showThinkingIndicator || pullRequestUrl || showContextUsageFooter ? (
                 <VirtualizedThread.Row className={rowClassName}>
                     <ThreadFooter
-                        showThinking={showThinking}
+                        showThinking={showThinkingIndicator}
                         pullRequestUrl={pullRequestUrl}
                         prBranch={branch}
                         showContextUsage={showContextUsageFooter}
                     />
                 </VirtualizedThread.Row>
             ) : undefined,
-        [showThinking, pullRequestUrl, branch, showContextUsageFooter]
+        [showThinkingIndicator, pullRequestUrl, branch, showContextUsageFooter]
     )
 
     const renderItem = useCallback(

--- a/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.test.ts
@@ -286,6 +286,48 @@ describe('runStreamLogic', () => {
         })
     })
 
+    describe('showThinkingIndicator', () => {
+        const runStartedFrame = notification('_posthog/run_started', {})
+        const messageChunk = sessionUpdate({
+            sessionUpdate: 'agent_message_chunk',
+            messageId: 'm1',
+            content: { text: 'Hi' },
+        })
+        const messageFinal = sessionUpdate({ sessionUpdate: 'agent_message', messageId: 'm1', content: { text: 'Hi' } })
+        const toolStart = sessionUpdate({
+            sessionUpdate: 'tool_call',
+            toolCallId: 't1',
+            serverName: 'posthog',
+            toolName: 'exec',
+            status: 'in_progress',
+        })
+        const toolDone = sessionUpdate({ sessionUpdate: 'tool_call_update', toolCallId: 't1', status: 'completed' })
+        const progressActive = notification('_posthog/progress', {
+            group: 'g',
+            step: 's',
+            label: 'Working',
+            status: 'in_progress',
+        })
+        const turnComplete = notification('_posthog/turn_complete', {})
+
+        it.each<[string, StoredLogEntry[], boolean]>([
+            ['idle gap after run start shows the loader', [runStartedFrame], true],
+            ['a streaming answer hides the loader', [runStartedFrame, messageChunk], false],
+            ['a finalized answer mid-turn shows the loader', [runStartedFrame, messageChunk, messageFinal], true],
+            ['a running tool hides the loader', [runStartedFrame, toolStart], false],
+            ['a completed tool shows the loader', [runStartedFrame, toolStart, toolDone], true],
+            ['a running progress step hides the loader', [runStartedFrame, progressActive], false],
+            ['no run in flight hides the loader', [], false],
+            ['a completed turn hides the loader', [runStartedFrame, messageFinal, turnComplete], false],
+        ])('%s', async (_name, frames, expected) => {
+            await expectLogic(logic, () => {
+                frames.forEach((frame) => logic.actions.ingestAcpFrame(frame))
+            }).toFinishAllListeners()
+
+            expect(logic.values.showThinkingIndicator).toEqual(expected)
+        })
+    })
+
     describe('assistant message buffering without messageId', () => {
         it('keeps two consecutive turns without a messageId in separate thread items', async () => {
             const frames: StoredLogEntry[] = [

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -1540,6 +1540,46 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 return 'idle'
             },
         ],
+        /**
+         * Whether the bottom-of-thread gerund loader ("Thinking…", "Pondering…") should show. The
+         * loader is a *gap filler*: it stands in only while the agent is working a turn but nothing
+         * visible is streaming at the tail — i.e. it is genuinely "thinking". It hides the moment the
+         * tail produces visible output: a streaming assistant message, an in-flight tool call, or a
+         * running structured-progress activity (each already conveys "the agent is busy"). Reasoning is
+         * deliberately NOT a hide condition — the gerund is what fills the thinking/reasoning period
+         * (and the explicit `agent_thought_chunk` thinking signal arrives during exactly these gaps).
+         */
+        showThinkingIndicator: [
+            (s) => [s.streamPhase, s.threadItems, s.toolInvocations],
+            (streamPhase, threadItems, toolInvocations): boolean => {
+                if (streamPhase !== 'thinking') {
+                    return false
+                }
+                // Scan the current turn only (items after the last separator).
+                const turnStart = threadItems.findLastIndex((item) => item.type === 'turn_separator') + 1
+                for (let i = turnStart; i < threadItems.length; i++) {
+                    const item = threadItems[i]
+                    // A running structured-progress activity owns the "busy" line.
+                    if (item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')) {
+                        return false
+                    }
+                    // A tool actively running already shows its own spinner.
+                    if (
+                        item.type === 'tool_invocation' &&
+                        item.toolCallId &&
+                        ['pending', 'in_progress'].includes(toolInvocations.get(item.toolCallId)?.status ?? '')
+                    ) {
+                        return false
+                    }
+                }
+                // The visible tail is streaming answer text — that's writing, not thinking.
+                const tail = threadItems[threadItems.length - 1]
+                if (tail?.type === 'assistant_message' && tail.complete !== true) {
+                    return false
+                }
+                return true
+            },
+        ],
         /** Whether the run exposes any git artifact worth surfacing — gates the pre/post-turn coding UI. */
         hasGitArtifacts: [
             (s) => [s.runArtifacts],


### PR DESCRIPTION
## Problem

In the PostHog AI **sandbox** runtime, the bottom-of-thread gerund loader (the randomized "Thinking…", "Pondering…", "Crunching…" line) spun for the **entire** agent turn. Its visibility was gated only on `streamPhase === 'thinking'`, which is true the whole time a run is in flight and the turn isn't complete. So the loader kept spinning even while the agent was clearly doing something visible — streaming its answer text, or running a tool whose card already shows its own spinner. It read as "thinking" when the agent was actually writing or working.

## Changes

The loader is now a **gap filler**: it shows only while the agent is working a turn but nothing visible is streaming at the tail — i.e. genuinely thinking.

- New pure selector `showThinkingIndicator` in `sandboxStreamLogic.ts`. It returns `true` only when `streamPhase === 'thinking'` **and** the current turn has no streaming assistant message at the tail, no pending/in-progress tool, and no in-progress structured-progress step. Reasoning gaps keep showing it (the explicit `agent_thought_chunk` thinking signal arrives during exactly these gaps).
- `SandboxThreadView.tsx` consumes the selector and drops the inline `hasActiveProgressItem` / `streamPhase` computation — per the sandbox convention that streaming/visibility logic lives in the logic, not the component body.

Behavior summary:

| Agent state | Gerund loader |
| --- | --- |
| Cold start / between steps (reasoning gap) | shown |
| Streaming answer text | hidden |
| Tool running (pending/in_progress) | hidden |
| Structured progress step running | hidden |
| Turn complete / errored / read-only replay | hidden |

We deliberately do **not** suppress the loader during reasoning — the inline reasoning line (`assistant_thought` → `ReasoningAnswer`) only renders when the agent emits thinking tokens, which currently it doesn't, so the gerund is what fills that period.

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8); I did not manually click through the running app. Automated only:

- Added a parameterized `describe('showThinkingIndicator')` block (8 cases) in `sandboxStreamLogic.test.ts`. It guards the regression this PR fixes: the loader must hide while answer text streams and while a tool runs, and show in the cold-start / post-tool / post-message gaps, and turn off once the turn completes. No existing test asserted the loader's gating.
- Full `sandboxStreamLogic` suite passes (156/156).
- oxlint clean on the three changed files; `tsgo` reports no errors in them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI assigned.

Built with Claude Code (Opus 4.8). The interesting decision was *what* "thinking" should mean. I traced the wire protocol and found the agent does emit an explicit thinking signal (`agent_thought_chunk`, relayed and folded into `assistant_thought` items), but it only fires when extended thinking is enabled — which is off right now. A strict signal-driven loader would therefore almost never show. After confirming with the human, we chose the "busy-but-idle" heuristic instead: show whenever the agent is working but not visibly streaming text / running a tool. That covers every reasoning gap and naturally includes the periods when thinking notifications do arrive, without depending on the backend emitting them.

No repo skills were invoked (no migration/DRF/API-type surface touched); this is a frontend kea-logic + presenter change.
