### PR TITLE
feat(metrics): expose metric_events in HogQL

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -99,7 +99,13 @@ from posthog.hogql.database.schema.logs import LogAttributesTable, LogsKafkaMetr
 from posthog.hogql.database.schema.marketing_conversions_preaggregated import MarketingConversionsPreaggregatedTable
 from posthog.hogql.database.schema.marketing_costs_preaggregated import MarketingCostsPreaggregatedTable
 from posthog.hogql.database.schema.marketing_touchpoints_preaggregated import MarketingTouchpointsPreaggregatedTable
-from posthog.hogql.database.schema.metrics import MetricAttributesTable, MetricsKafkaMetricsTable, MetricsTable
+from posthog.hogql.database.schema.metrics import (
+    MetricAttributesTable,
+    MetricSamplesTable,
+    MetricSeriesTable,
+    MetricsKafkaMetricsTable,
+    MetricsTable,
+)
 from posthog.hogql.database.schema.numbers import NumbersTable
 from posthog.hogql.database.schema.person_distinct_id_overrides import (
     PersonDistinctIdOverridesTable,
@@ -375,6 +381,8 @@ def _construct_database_root_node(*, include_posthog_tables: bool) -> TableNode:
                         name="session_replay_features", table=SessionReplayFeaturesTable()
                     ),
                     "metrics": TableNode(name="metrics", table=MetricsTable()),
+                    "metric_samples": TableNode(name="metric_samples", table=MetricSamplesTable()),
+                    "metric_series": TableNode(name="metric_series", table=MetricSeriesTable()),
                     "metric_attributes": TableNode(name="metric_attributes", table=MetricAttributesTable()),
                     "metrics_kafka_metrics": TableNode(name="metrics_kafka_metrics", table=MetricsKafkaMetricsTable()),
                     "error_tracking_fingerprint_issue_state": TableNode(

--- a/posthog/hogql/database/schema/metrics.py
+++ b/posthog/hogql/database/schema/metrics.py
@@ -102,6 +102,71 @@ class MetricsTable(Table):
         return "metrics"
 
 
+class MetricSamplesTable(Table):
+    description: str = "Raw metric emissions: one tiny row per sample (value + timestamp), keyed to a series via `series_fingerprint` and carrying an optional `trace_id` for the metric->trace pivot. Join to `metric_series` for labels. Distinct from `metrics`, which is pre-aggregated."
+    workload: Workload | None = Workload.LOGS
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "metric_name": StringDatabaseField(name="metric_name", nullable=False),
+        "series_fingerprint": IntegerDatabaseField(
+            name="series_fingerprint",
+            nullable=False,
+            description="Hash of the series' label set; join key to `metric_series`.",
+        ),
+        "timestamp": DateTimeDatabaseField(
+            name="timestamp", nullable=False, description="When the metric was emitted (UTC)."
+        ),
+        "value": FloatDatabaseField(name="value", nullable=False, description="The emitted value."),
+        "trace_id": StringDatabaseField(
+            name="trace_id",
+            nullable=False,
+            description="Trace this emission belongs to; empty if none. Pivot to spans/logs.",
+        ),
+        "span_id": StringDatabaseField(name="span_id", nullable=False),
+        "trace_flags": IntegerDatabaseField(name="trace_flags", nullable=False),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "metric_samples"
+
+    def to_printed_hogql(self):
+        return "metric_samples"
+
+
+class MetricSeriesTable(Table):
+    description: str = "One row per unique metric series (metric + label set), keyed by `series_fingerprint`. Labels are stored here once and joined to `metric_samples` at query time."
+    workload: Workload | None = Workload.LOGS
+
+    fields: dict[str, FieldOrTable] = {
+        "team_id": IntegerDatabaseField(name="team_id", nullable=False),
+        "metric_name": StringDatabaseField(name="metric_name", nullable=False),
+        "series_fingerprint": IntegerDatabaseField(
+            name="series_fingerprint",
+            nullable=False,
+            description="Hash of the label set; join key from `metric_samples`.",
+        ),
+        "metric_type": StringDatabaseField(
+            name="metric_type",
+            nullable=False,
+            description="OTel metric type (gauge, sum, histogram, summary, exponential_histogram).",
+        ),
+        "unit": StringDatabaseField(name="unit", nullable=False),
+        "service_name": StringDatabaseField(name="service_name", nullable=False),
+        "resource_attributes": MapStringDatabaseField(name="resource_attributes", nullable=False),
+        "attributes": MapStringDatabaseField(name="attributes", nullable=False),
+        "last_seen": DateTimeDatabaseField(
+            name="last_seen", nullable=False, description="Most recent sample timestamp seen for this series."
+        ),
+    }
+
+    def to_printed_clickhouse(self, context):
+        return "metric_series"
+
+    def to_printed_hogql(self):
+        return "metric_series"
+
+
 class MetricAttributesTable(Table):
     description: str = "Distinct metric attribute key/value pairs with occurrence counts, used to power metric attribute autocomplete and faceting."
     workload: Workload | None = Workload.LOGS


### PR DESCRIPTION
## Problem

The two storage tables (added in the PR below this in the stack) need to be queryable from HogQL — for the SQL editor, the query runners, and dogfooding.

## Changes

Registers both under the `posthog` namespace, replacing the single `metric_events` table:

- `posthog.metric_samples` — the tiny sample rows (`value`/`timestamp`/`trace_id` + the `series_fingerprint` join key).
- `posthog.metric_series` — the deduped labels (`metric_type`/`unit`/`service_name` + the attribute maps).

`team_id` isolation is enforced by the HogQL layer on every reference. Field descriptions surface through `system.information_schema`.

## How did you test this code?

Agent (PostHog Code), automated only. Compiled HogQL → ClickHouse SQL through the real printer for both tables and the `samples⋈series` join — `team_id` filters are injected on every reference, including **both sides of the join**. `test_database.py` green (99 passed). `ruff` clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Schema descriptions are self-documenting via `system.information_schema`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Application code only, stacked on the table migration. Two tables instead of one because the storage is a series/samples split; consumers join on `series_fingerprint`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
