### PR TITLE
feat(flags): allow feature_flag:read scope for project secret API keys

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -170,7 +170,7 @@ export const API_SCOPES: APIScope[] = [
 ]
 API_SCOPES.sort((a, b) => a.objectName.localeCompare(b.objectName))
 
-export const PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION = ['endpoint:read'] as const
+export const PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION = ['endpoint:read', 'feature_flag:read'] as const
 
 export type ProjectSecretAPIKeyAllowedScope = (typeof PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION)[number]
 
@@ -263,6 +263,7 @@ export type ProjectSecretAPIKeyScopePreset = {
 
 export const PROJECT_SECRET_API_KEY_SCOPE_PRESETS: ProjectSecretAPIKeyScopePreset[] = [
     { value: 'endpoint_execution', label: 'Endpoint execution', scopes: ['endpoint:read'] },
+    { value: 'local_evaluation', label: 'Local feature flag evaluation', scopes: ['feature_flag:read'] },
     { value: 'llm_gateway', label: 'AI gateway access', scopes: ['llm_gateway:read'] },
 ]
 

--- a/posthog/api/test/test_project_secret_api_keys.py
+++ b/posthog/api/test/test_project_secret_api_keys.py
@@ -76,6 +76,14 @@ class TestProjectSecretAPIKeysAPI(APIBaseTest):
         assert data["last_used_at"] is None
         assert data["value"].startswith("phs_")
 
+    def test_create_feature_flag_read_scope(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/project_secret_api_keys",
+            {"label": "local eval key", "scopes": ["feature_flag:read"]},
+        )
+        assert response.status_code == 201
+        assert response.json()["scopes"] == ["feature_flag:read"]
+
     def test_create_too_many_api_keys(self):
         for i in range(0, MAX_PROJECT_SECRET_API_KEYS_PER_TEAM):
             self.client.post(

--- a/posthog/scopes.py
+++ b/posthog/scopes.py
@@ -152,6 +152,9 @@ OAUTH_HIDDEN_SCOPE_OBJECTS: frozenset[APIScopeObject] = frozenset({"wizard_sessi
 # ai-gateway flag in ProjectSecretAPIKeySerializer, not unconditionally like the entries here.
 PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION: list[tuple[APIScopeObject, APIScopeActions]] = [
     ("endpoint", "read"),
+    # SDK local evaluation and remote config. The Rust feature-flags service already
+    # validates feature_flag:read PSAKs on the flag-definitions path; this makes them creatable.
+    ("feature_flag", "read"),
 ]
 
 # Server-side scope assignment string-set constants (see RFC: server-side scope


### PR DESCRIPTION
## Problem

The Rust feature-flags service already accepts PSAKs with `feature_flag:read` on the `/flags/definitions` path, but there was no way to create such a key: the backend allowed-list and the frontend scope picker both only offered `endpoint:read`.

This is Phase 1 of #63111 (migrating Feature Flag Secure API Keys to Project Secret API Keys).

Closes #66175

## Changes

- `posthog/scopes.py`: adds `("feature_flag", "read")` to `PROJECT_SECRET_API_KEY_ALLOWED_API_SCOPE_ACTION`, making the scope accepted at creation time.
- `frontend/src/lib/scopes.tsx`: adds `feature_flag:read` to the frontend allowed-scope list (a parallel hand-maintained copy) and adds a "Local feature flag evaluation" preset to the PSAK preset dropdown.
- `posthog/api/test/test_project_secret_api_keys.py`: adds a test that creating a key with `feature_flag:read` returns 201 and echoes the scope back.

`feature_flag:write` is intentionally left out. No surface in this migration writes flags: `remote_config` is a GET with `required_scopes=["feature_flag:read"]`, and local evaluation, live debugger, and the conversations external API are all read. Adding a write-capable service credential with no consumer would widen attack surface in a PR whose point is to harden a plaintext credential. Add `write` later alongside a consumer that needs it.

## How did you test this code?

Automated: `test_create_feature_flag_read_scope` covers the backend path (201 + correct scope in response).

Manual: created a PSAK with `feature_flag:read` via the settings UI (with the `project-secret-api-keys` flag enabled) and confirmed it authenticates against `/flags/definitions` in the local dev stack.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (claude-opus-4-8). The human identified that PSAKs needed `feature_flag:read` support for SDK local evaluation. The agent discovered the frontend kept a separate hand-maintained scope list (`scopes.tsx`) that was not updated alongside the backend, added both the scope and the preset, ran the test suite and formatter, and manually verified the UI flow worked before committing.
