### PR TITLE
fix(inbox): restore tl;dr lead line in report summaries

### DIFF
--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -65,7 +65,9 @@ Write this the way a sharp colleague would explain it to you – first person, p
 
 The bar to clear: if someone dropped this report (or the PR) on you and said nothing else, this summary alone should make you get it – what's wrong, why it's worth caring about, and what the fix is. They don't need the line-by-line (the code diff is right there); they need the high-level rationale and the gist of the change.
 
-Give it light structure so a busy reader can scan it, three short sections under H2 headings:
+Start with a one-sentence tl;dr on its very first line, before any heading. This single sentence is shown on its own in the inbox list, so it has to stand alone and make someone get the gist without the rest of the summary. Ideally lead with "Users …", spelling out how they're impacted, how many, or how important they are; if it's not users but the team building the product who's affected, say that instead; otherwise just say plainly what's going on. Keep it to one sentence, no heading, no bold, followed by a blank line.
+
+Then give it light structure so a busy reader can scan the rest, three short sections under H2 headings:
 - '## Problem' – what's actually going wrong. Name the real culprit (the specific API, component, query, or behavior) in plain terms an engineer who knows this code will immediately recognize.
 - '## Impact' – who it hurts and how much: users (how many, how badly, how important), or, if it's not users, the team building the product. Lead with the thing that matters.
 - '## Solution' – what you'd do about it: the shape of the fix, not a spec. Omit this section entirely if the report isn't actionable.


### PR DESCRIPTION
## Problem

Commit 98cba066f3f rewrote the report `summary` prompt to open directly with a `## Problem` H2 heading. But the inbox list derives each card's one-line preview from the **first line / first sentence** of the summary (`deriveHeadline()` in `frontend/src/scenes/inbox/utils/reportPresentation.ts`). With a heading first, list cards started showing a broken `## Problem` headline, and the detail view lost its standalone lead sentence too.

## Changes

Restore a one-sentence tl;dr as the leading line of the summary, before any heading — bringing back the original design where the first line *is* the tl;dr. The casual three-section (`## Problem` / `## Impact` / `## Solution`) structure stays intact; the tl;dr just sits above it. Carried over the original "lead with *Users …*" guidance and added that this first line must stand alone, since the list renders it in isolation.

No frontend change needed — the existing extraction logic does the right thing once the tl;dr is back. This is prompt-only, so it affects newly generated/regenerated reports; existing reports keep their current summaries until re-promoted and re-researched.

## How did you test this code?

I'm an agent. No automated tests cover this prompt text and none were added — it's a prompt-wording change validated by reading against `deriveHeadline()`'s first-line/first-sentence extraction and the detail view's markdown rendering. Lint/format/type checks ran on commit via lint-staged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Michael directed this fix. I traced the regression from commit 98cba066f3f back through the frontend consumers of `summary` (the inbox `ReportCard` headline via `deriveHeadline`, and `ReportDetail`'s markdown render), confirmed the heading-first format broke the list headline, and restored the leading tl;dr sentence in `products/signals/backend/report_generation/research.py`. Checked the report-generation fixtures — their summaries are already plain-prose first lines, so no fixture update was needed. No skills were invoked.
