### PR TITLE
fix(experiments): skip running-time request on each recalculation poll

### DIFF
--- a/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
+++ b/frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts
@@ -6,6 +6,7 @@ import api from 'lib/api'
 import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { objectsEqual } from 'lib/utils/objects'
 
 import { experimentsConfigLogic } from '~/scenes/settings/environment/experimentsConfigLogic'
 import { ConversionRateInputType, Experiment } from '~/types'
@@ -307,13 +308,22 @@ export const runningTimeLogic = kea<runningTimeLogicType>([
     }),
 
     subscriptions(({ actions }) => ({
-        automaticCalculationInput: (input: RunningTimeCalculationInputApi | null) => {
-            if (input) {
+        // kea-subscriptions fires on reference change. The recalc poll replaces the metric-results array every
+        // tick, so these inputs get a fresh object reference even when their values are identical, which would
+        // re-fire the calculation POST on every poll. Skip the dispatch unless the value actually changed.
+        automaticCalculationInput: (
+            input: RunningTimeCalculationInputApi | null,
+            oldInput: RunningTimeCalculationInputApi | null
+        ) => {
+            if (input && !objectsEqual(input, oldInput)) {
                 actions.loadAutomaticCalculation(input)
             }
         },
-        manualPreviewInput: (input: RunningTimeCalculationInputApi | null) => {
-            if (input) {
+        manualPreviewInput: (
+            input: RunningTimeCalculationInputApi | null,
+            oldInput: RunningTimeCalculationInputApi | null
+        ) => {
+            if (input && !objectsEqual(input, oldInput)) {
                 actions.loadManualPreview(input)
             }
         },


### PR DESCRIPTION
## Problem

While the experiment results poll for recalculation, two extra POSTs to `calculate_running_time` fire on every poll tick. Root cause: `runningTimeLogic` watches `automaticCalculationInput` (and `manualPreviewInput`) via `kea-subscriptions`, which fires on reference change. Each poll calls `setPrimaryMetricsResults` with a freshly built array, so `metricsWithResults` and the derived `automaticCalculationInput` selector produce a new object reference every tick even when the values are identical. The subscription sees the new reference as a change and re-dispatches the calculation, hammering the endpoint for the duration of the run.

## Changes

This PR dedupes the subscription by value so the running-time calculation only fires when its input actually changes.

The two subscriptions now compare the new input against the previous one with `objectsEqual` and skip the dispatch when they are value-equal. Reference churn from the poll no longer triggers a redundant `calculate_running_time` POST; a genuine input change (MDE edit, mode switch, first real result) still fires it.

- `frontend/src/scenes/experiments/RunningTimeCalculator/runningTimeLogic.ts`

## How did you test this code?

```bash
pnpm --filter=@posthog/frontend typescript:check
```

![cat-type-small](https://github.com/user-attachments/assets/0f495a5b-066d-4380-b5b3-dda6bd87ac5d)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **yes**

Skills used:

- /systematic-debugging (superpowers)
- /writing-kea-logics (local)

Relevant decisions:

- Fixed at the subscription rather than memoizing the `automaticCalculationInput` selector reference, because `kea-subscriptions` compares by reference and a value-equality guard in the subscription is the smallest, most direct stop for the redundant dispatch.
- Used the existing `objectsEqual` helper and the subscription's `(new, old)` signature rather than tracking the last-fired payload in `cache`, keeping the dedupe stateless.