### PR TITLE
feat(flags): enable feature-flag-called dedup on turbo and team2 lanes

### DIFF
--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -84,13 +84,10 @@ export type PersonBatchWritingMode = 'BATCH' | 'SHADOW' | 'NONE'
  * distinction is load-bearing for processing-time logic like dedup, so the lane
  * type is derived from these two sets to keep the categorization in one place.
  */
-export const REALTIME_INGESTION_LANES = ['main', 'overflow', 'turbo'] as const
+export const REALTIME_INGESTION_LANES = ['main', 'overflow', 'turbo', 'team2'] as const
 export const DELAYED_INGESTION_LANES = ['historical', 'async'] as const
 
-export type IngestionLane =
-    | (typeof REALTIME_INGESTION_LANES)[number]
-    | (typeof DELAYED_INGESTION_LANES)[number]
-    | 'team2'
+export type IngestionLane = (typeof REALTIME_INGESTION_LANES)[number] | (typeof DELAYED_INGESTION_LANES)[number]
 
 export type IngestionConsumerConfig = {
     INGESTION_LANE: IngestionLane | null

--- a/nodejs/src/ingestion/config.ts
+++ b/nodejs/src/ingestion/config.ts
@@ -78,7 +78,19 @@ export type KafkaConsumerBaseConfig = Pick<
 export type PersonBatchWritingDbWriteMode = 'NO_ASSERT' | 'ASSERT_VERSION'
 export type PersonBatchWritingMode = 'BATCH' | 'SHADOW' | 'NONE'
 
-export type IngestionLane = 'main' | 'overflow' | 'turbo' | 'historical' | 'async'
+/**
+ * Real-time lanes process live events and share `main`'s processing-time SLO.
+ * Delayed lanes process backfilled or async events on their own timeline. The
+ * distinction is load-bearing for processing-time logic like dedup, so the lane
+ * type is derived from these two sets to keep the categorization in one place.
+ */
+export const REALTIME_INGESTION_LANES = ['main', 'overflow', 'turbo'] as const
+export const DELAYED_INGESTION_LANES = ['historical', 'async'] as const
+
+export type IngestionLane =
+    | (typeof REALTIME_INGESTION_LANES)[number]
+    | (typeof DELAYED_INGESTION_LANES)[number]
+    | 'team2'
 
 export type IngestionConsumerConfig = {
     INGESTION_LANE: IngestionLane | null

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.test.ts
@@ -117,6 +117,8 @@ describe('RedisFeatureFlagCalledDedupService', () => {
         it.each<[IngestionLane | null, boolean]>([
             ['main', true],
             ['overflow', true],
+            ['turbo', true],
+            ['team2', true],
             [null, true],
             ['historical', false],
             ['async', false],

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
@@ -141,14 +141,13 @@ export type FeatureFlagCalledDedupEnvConfig = Pick<
 >
 
 /**
- * Lanes that may dedup: the real-time lanes plus `team2`, plus `null` for local
- * dev, where no lane is set. Derived from REALTIME_INGESTION_LANES so a new
- * real-time lane is covered automatically; delayed lanes are excluded by
- * construction. `team2` is added explicitly because it is a real-time lane that
- * is not part of REALTIME_INGESTION_LANES. See
- * `createFeatureFlagCalledDedupService` for why delayed lanes must never dedup.
+ * Lanes that may dedup: the real-time lanes plus `null` for local dev, where
+ * no lane is set. Derived from REALTIME_INGESTION_LANES so a new real-time
+ * lane is covered automatically; delayed lanes are excluded by construction.
+ * See `createFeatureFlagCalledDedupService` for why delayed lanes must never
+ * dedup.
  */
-const DEDUP_ALLOWED_LANES: readonly (IngestionLane | null)[] = [...REALTIME_INGESTION_LANES, 'team2', null]
+const DEDUP_ALLOWED_LANES: readonly (IngestionLane | null)[] = [...REALTIME_INGESTION_LANES, null]
 
 /**
  * Builds the dedup service from ingestion config, or undefined when the dedup

--- a/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
+++ b/nodejs/src/ingestion/utils/feature-flag-called-dedup/feature-flag-called-dedup-service.ts
@@ -4,7 +4,7 @@ import { Redis } from 'ioredis'
 import { timeoutGuard } from '~/common/utils/db/utils'
 import { parseTeamsList } from '~/common/utils/env-utils'
 import { logger } from '~/common/utils/logger'
-import { IngestionConsumerConfig, IngestionLane } from '~/ingestion/config'
+import { IngestionConsumerConfig, IngestionLane, REALTIME_INGESTION_LANES } from '~/ingestion/config'
 import { RedisPool } from '~/types'
 
 import { featureFlagCalledDedupRedisLatency, featureFlagCalledDedupRedisOpsTotal } from './metrics'
@@ -140,8 +140,15 @@ export type FeatureFlagCalledDedupEnvConfig = Pick<
     | 'INGESTION_FEATURE_FLAG_CALLED_DEDUP_TTL_SECONDS'
 >
 
-/** Lanes that may dedup. `null` covers local dev, where no lane is set. */
-const DEDUP_ALLOWED_LANES: readonly (IngestionLane | null)[] = ['main', 'overflow', null]
+/**
+ * Lanes that may dedup: the real-time lanes plus `team2`, plus `null` for local
+ * dev, where no lane is set. Derived from REALTIME_INGESTION_LANES so a new
+ * real-time lane is covered automatically; delayed lanes are excluded by
+ * construction. `team2` is added explicitly because it is a real-time lane that
+ * is not part of REALTIME_INGESTION_LANES. See
+ * `createFeatureFlagCalledDedupService` for why delayed lanes must never dedup.
+ */
+const DEDUP_ALLOWED_LANES: readonly (IngestionLane | null)[] = [...REALTIME_INGESTION_LANES, 'team2', null]
 
 /**
  * Builds the dedup service from ingestion config, or undefined when the dedup
@@ -150,7 +157,9 @@ const DEDUP_ALLOWED_LANES: readonly (IngestionLane | null)[] = ['main', 'overflo
  * The dedup window is processing-time, not event-time, so lanes that process
  * delayed events (historical, async) must never dedup: a backfilled event is
  * not a duplicate of the live event that claimed its tuple an hour ago. The
- * lane gate holds even if the dedup env vars leak into a shared config.
+ * real-time lanes in DEDUP_ALLOWED_LANES all share that processing-time
+ * window, so they may dedup. The lane gate holds even if the dedup env vars
+ * leak into a shared config.
  */
 export function createFeatureFlagCalledDedupService(
     redisPool: RedisPool,


### PR DESCRIPTION
## Problem

`$feature_flag_called` dedup was only enabled on the `main` and `overflow` ingestion lanes. The `turbo` and `team2` lanes process live events on the same processing-time SLO, so they can dedup too, but were left out. Widening dedup to them cuts more redundant `$feature_flag_called` volume.

## Changes

Lane categorization now lives in one place. `config.ts` defines `REALTIME_INGESTION_LANES` (`main`, `overflow`, `turbo`) and `DELAYED_INGESTION_LANES` (`historical`, `async`), and the `IngestionLane` type is derived from them plus `team2`.

The dedup allowlist is derived from `REALTIME_INGESTION_LANES` rather than hardcoded, so any future real-time lane is covered automatically. `team2` is added explicitly since it's a real-time lane that sits outside that set. Delayed lanes stay excluded by construction, which preserves the existing invariant: dedup is processing-time based, so a backfilled event must never be treated as a duplicate of the live event that claimed its tuple earlier.

## How did you test this code?

I'm an agent (Claude), driven by Phil. Automated tests run:

- `feature-flag-called-dedup-service.ts` unit suite, 45/45 passing, including the lane gate cases asserting `turbo` and `team2` dedup while `historical`/`async` do not.
- eslint on the three changed files: clean.

Typecheck on the package surfaced only pre-existing errors in `src/cdp/*` from unbuilt native workspace packages, none in the changed files.