### PR TITLE
fix(data-warehouse): stabilize CDC column types across micro-batches

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/activities.py
@@ -50,6 +50,7 @@ from products.warehouse_sources.backend.temporal.data_imports.cdc.batcher import
 from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import (
     MAX_FRIENDLY_MESSAGE_LENGTH,
     CDCErrorInfo,
+    CDCSchemaMergeError,
     classify_cdc_error,
 )
 from products.warehouse_sources.backend.temporal.data_imports.cdc.types import ChangeEvent
@@ -591,7 +592,16 @@ class CDCExtractActivity:
                     key_columns,
                     schema,
                 )
-                batch_result = tracker.s3_writer.write_batch(write_table, batch_index=tracker.batch_index)
+                try:
+                    batch_result = tracker.s3_writer.write_batch(write_table, batch_index=tracker.batch_index)
+                except pa.ArrowTypeError as e:
+                    # The per-batch table is built consistently (typed columns + safe fallback),
+                    # so an Arrow type error here is a cross-batch merge conflict — a column whose
+                    # type genuinely drifted mid-stream. Replaying re-fails identically, so surface
+                    # it as non-retryable instead of looping the schedule.
+                    raise CDCSchemaMergeError(
+                        f"Incompatible column types across CDC batches for {write_resource_name}"
+                    ) from e
                 tracker.batch_results.append(batch_result)
                 tracker.batch_index += 1
                 tracker.total_rows += write_table.num_rows
@@ -782,6 +792,7 @@ class CDCExtractActivity:
             position_serialized=event.position_serialized,
             timestamp=event.timestamp,
             columns=filtered,
+            column_types=event.column_types,
         )
 
     def _qualified_table_name(self, schema: ExternalDataSchema) -> str:

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/batcher.py
@@ -336,6 +336,10 @@ def _events_to_table(events: list[ChangeEvent]) -> pa.Table:
             all_columns[col_name] = None
     column_names = list(all_columns.keys())
 
+    # Authoritative Arrow type per column from the source schema (same for every event
+    # of a relation). Lets all-null micro-batches keep the column's real type.
+    column_types = next((e.column_types for e in events if e.column_types), None) or {}
+
     # Build column arrays
     source_data: dict[str, list] = {col: [] for col in column_names}
     cdc_ops: list[str] = []
@@ -362,12 +366,18 @@ def _events_to_table(events: list[ChangeEvent]) -> pa.Table:
     arrays: list[pa.Array] = []
     fields: list[pa.Field] = []
     for col_name in column_names:
-        try:
-            arr = pa.array(source_data[col_name])
-        except (pa.ArrowInvalid, pa.ArrowTypeError):
-            arr = pa.array([str(v) if v is not None else None for v in source_data[col_name]], type=pa.string())
-        if arr.type == pa.null():
-            arr = arr.cast(pa.string())
+        target_type = column_types.get(col_name)
+        if target_type is not None:
+            # _safe_pa_array falls back to inference, then string, if the values
+            # don't fit the declared type (e.g. a mid-WAL type change).
+            arr = _safe_pa_array(source_data[col_name], target_type)
+        else:
+            try:
+                arr = pa.array(source_data[col_name])
+            except (pa.ArrowInvalid, pa.ArrowTypeError):
+                arr = pa.array([str(v) if v is not None else None for v in source_data[col_name]], type=pa.string())
+            if arr.type == pa.null():
+                arr = arr.cast(pa.string())
         arrays.append(arr)
         fields.append(pa.field(col_name, arr.type))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/errors.py
@@ -31,6 +31,7 @@ class CDCErrorCategory(enum.StrEnum):
     SLOT_IN_USE = "slot_in_use"
     WAL_DECODE_ERROR = "wal_decode_error"
     TRANSACTION_TOO_LARGE = "transaction_too_large"
+    SCHEMA_MERGE_INCOMPATIBLE = "schema_merge_incompatible"
     UNKNOWN = "unknown"
 
 
@@ -47,6 +48,16 @@ class CDCTransactionTooLargeError(Exception):
     Non-retryable: re-decoding replays the same oversized transaction. The decoder guard
     that raises this lives in the source-specific decoder; the type is defined here so the
     shared classifier owns the mapping to ``TRANSACTION_TOO_LARGE``.
+    """
+
+
+class CDCSchemaMergeError(Exception):
+    """A column's values can't be reconciled into one Parquet type across micro-batches.
+
+    Non-retryable: the conflicting batches replay identically, so re-running re-fails. The
+    activity raises this when an Arrow schema merge rejects the data (e.g. a source column
+    that genuinely changed type mid-stream — int in one batch, text in another). Defined
+    here so the shared classifier owns the mapping to ``SCHEMA_MERGE_INCOMPATIBLE``.
     """
 
 
@@ -92,6 +103,12 @@ _CATEGORY_DEFAULTS: dict[CDCErrorCategory, tuple[str, bool]] = {
         "once. Reduce the size of bulk operations on the source, then re-sync.",
         False,
     ),
+    CDCErrorCategory.SCHEMA_MERGE_INCOMPATIBLE: (
+        "A source column changed type partway through the change stream (for example, numbers and text "
+        "in the same column), so the changes can no longer be combined into one table. Disable and "
+        "re-enable change data capture to re-sync from a fresh snapshot.",
+        False,
+    ),
     CDCErrorCategory.UNKNOWN: (
         "Change data capture hit an unexpected error. PostHog will retry automatically — if it "
         "persists, check the source's sync logs or contact support.",
@@ -126,6 +143,8 @@ def classify_cdc_error(exc: BaseException, adapter: CDCSourceAdapter | None) -> 
     for err in _iter_cause_chain(exc):
         if isinstance(err, CDCTransactionTooLargeError):
             return cdc_error_info(CDCErrorCategory.TRANSACTION_TOO_LARGE)
+        if isinstance(err, CDCSchemaMergeError):
+            return cdc_error_info(CDCErrorCategory.SCHEMA_MERGE_INCOMPATIBLE)
         if adapter is not None:
             info = adapter.classify_error(err)
             if info is not None:

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_batcher.py
@@ -26,6 +26,7 @@ def _make_event(
     position: str = "0/100",
     columns: dict | None = None,
     timestamp: datetime | None = None,
+    column_types: dict[str, pa.DataType] | None = None,
 ) -> ChangeEvent:
     return ChangeEvent(
         operation=op,
@@ -33,6 +34,7 @@ def _make_event(
         position_serialized=position,
         timestamp=timestamp or datetime(2025, 6, 15, 12, 0, 0, tzinfo=UTC),
         columns=columns or {"id": 1, "name": "Alice"},
+        column_types=column_types,
     )
 
 
@@ -211,6 +213,45 @@ class TestEventsToTableEdgeCases:
 
         table = tables["users"]
         assert table.column("val").type == pa.string()
+
+    def test_source_type_overrides_all_null_inference(self):
+        # A column that is all-null in a micro-batch must keep its declared source type
+        # rather than being inferred as null/string.
+        types = {"id": pa.int64(), "seats": pa.int64()}
+        batcher = ChangeEventBatcher()
+        batcher.add(_make_event(op="D", columns={"id": 1, "seats": None}, column_types=types))
+        batcher.add(_make_event(op="D", columns={"id": 2, "seats": None}, column_types=types))
+
+        table = batcher.flush()["users"]
+        assert table.column("seats").type == pa.int64()
+
+    def test_all_null_and_concrete_flushes_merge(self):
+        # Reproduces the prod crash: one flush sees `seats` all-null, a later flush sees
+        # concrete ints. Without a declared source type the first is string and the
+        # second int64, and S3BatchWriter's unify_schemas raises int64-vs-string.
+        types = {"id": pa.int64(), "seats": pa.int64()}
+
+        b1 = ChangeEventBatcher()
+        b1.add(_make_event(op="D", columns={"id": 1, "seats": None}, column_types=types))
+        flush1 = b1.flush()["users"]
+
+        b2 = ChangeEventBatcher()
+        b2.add(_make_event(op="I", columns={"id": 2, "seats": 5}, column_types=types))
+        flush2 = b2.flush()["users"]
+
+        # Both Parquet schemas agree, so the cross-flush merge succeeds.
+        merged = pa.unify_schemas([flush1.schema, flush2.schema])
+        assert merged.field("seats").type == pa.int64()
+
+    def test_source_type_falls_back_when_value_does_not_fit(self):
+        # If a value can't be cast to the declared type (e.g. a mid-WAL type change),
+        # the batch must still build rather than raise.
+        types = {"id": pa.int64(), "seats": pa.int64()}
+        batcher = ChangeEventBatcher()
+        batcher.add(_make_event(op="I", columns={"id": 1, "seats": "not-a-number"}, column_types=types))
+
+        table = batcher.flush()["users"]
+        assert table.column("seats").type == pa.string()
 
 
 class TestDeduplicateTable:

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_batcher.py
@@ -1,4 +1,5 @@
 import decimal
+from collections.abc import Mapping
 from datetime import UTC, datetime
 from typing import Literal
 
@@ -26,7 +27,7 @@ def _make_event(
     position: str = "0/100",
     columns: dict | None = None,
     timestamp: datetime | None = None,
-    column_types: dict[str, pa.DataType] | None = None,
+    column_types: Mapping[str, pa.DataType] | None = None,
 ) -> ChangeEvent:
     return ChangeEvent(
         operation=op,

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_errors.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_errors.py
@@ -5,6 +5,7 @@ from products.warehouse_sources.backend.temporal.data_imports.cdc.errors import 
     MAX_FRIENDLY_MESSAGE_LENGTH,
     CDCErrorCategory,
     CDCErrorInfo,
+    CDCSchemaMergeError,
     CDCTransactionTooLargeError,
     cdc_error_info,
     classify_cdc_error,
@@ -36,6 +37,7 @@ class TestCDCErrorInfo:
             (CDCErrorCategory.SLOT_IN_USE, True),
             (CDCErrorCategory.WAL_DECODE_ERROR, False),
             (CDCErrorCategory.TRANSACTION_TOO_LARGE, False),
+            (CDCErrorCategory.SCHEMA_MERGE_INCOMPATIBLE, False),
             (CDCErrorCategory.UNKNOWN, True),
         ]
     )
@@ -79,6 +81,16 @@ class TestClassifyCDCError:
     def test_transaction_too_large_is_classified_without_adapter(self):
         info = classify_cdc_error(CDCTransactionTooLargeError("500001 events"), None)
         assert info.category is CDCErrorCategory.TRANSACTION_TOO_LARGE
+        assert info.retryable is False
+
+    def test_schema_merge_error_is_non_retryable_via_cause_chain(self):
+        # The activity wraps the Arrow type error as CDCSchemaMergeError; classification must
+        # find it through the cause chain and mark the run non-retryable so it stops looping.
+        cause = CDCSchemaMergeError("Incompatible column types across CDC batches for orders")
+        wrapper = RuntimeError("flush failed")
+        wrapper.__cause__ = cause
+        info = classify_cdc_error(wrapper, None)
+        assert info.category is CDCErrorCategory.SCHEMA_MERGE_INCOMPATIBLE
         assert info.retryable is False
 
     def test_non_psycopg_exception_with_slot_message_is_not_classified(self):

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/tests/test_extract_activity.py
@@ -6,6 +6,7 @@ from typing import Literal
 import pytest
 from unittest.mock import MagicMock, patch
 
+import pyarrow as pa
 import psycopg.errors
 
 from products.warehouse_sources.backend.temporal.data_imports.cdc.activities import (
@@ -868,6 +869,61 @@ class TestCDCExtractActivity:
         assert "S3 write failed" not in schema.latest_error
 
         # Slot should NOT have been advanced
+        mock_reader.confirm_position.assert_not_called()
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.PostgresProducer")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.S3BatchWriter")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.get_cdc_adapter")
+    @patch.object(CDCExtractActivity, "_get_cdc_schemas")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataSource")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.ExternalDataJob")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.close_old_connections")
+    def test_unmergeable_schema_fails_non_retryably(
+        self,
+        mock_close_conns,
+        MockJob,
+        MockSourceModel,
+        mock_get_schemas,
+        mock_get_adapter,
+        MockS3Writer,
+        MockProducer,
+        mock_activity,
+    ):
+        source = _make_source()
+        schema = _make_schema("users", cdc_mode="streaming", source=source)
+        events = [_make_event(op="I", table="users", position="0/100")]
+
+        mock_reader, mock_s3, mock_producer, mock_job = _setup_mocks(
+            mock_activity,
+            MockProducer,
+            MockS3Writer,
+            mock_get_adapter,
+            mock_get_schemas,
+            MockSourceModel,
+            MockJob,
+            mock_close_conns,
+            source,
+            [schema],
+            events,
+        )
+
+        # A cross-batch Arrow merge conflict (a column that drifted type mid-stream) surfaces
+        # from write_batch as ArrowTypeError. Replaying re-fails identically, so the run must
+        # stop rather than loop the schedule.
+        mock_s3.write_batch.side_effect = pa.ArrowTypeError(
+            "Unable to merge: Field seats has incompatible types: int64 vs string"
+        )
+
+        inputs = CDCExtractInput(team_id=1, source_id=source.id)
+
+        with pytest.raises(NonRetryableException):
+            cdc_extract_activity(inputs)
+
+        assert schema.status == "Failed"
+        assert schema.latest_error == cdc_error_info(CDCErrorCategory.SCHEMA_MERGE_INCOMPATIBLE).friendly_message
+        # The raw column/type detail never reaches the user-facing message.
+        assert "int64" not in schema.latest_error
         mock_reader.confirm_position.assert_not_called()
 
     @patch("products.warehouse_sources.backend.temporal.data_imports.cdc.activities.activity")

--- a/products/warehouse_sources/backend/temporal/data_imports/cdc/types.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/cdc/types.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Literal, Protocol, Self
+
+import pyarrow as pa
 
 ManagementMode = Literal["posthog", "self_managed"]
 
@@ -48,6 +50,12 @@ class ChangeEvent:
     position_serialized: str
     timestamp: datetime
     columns: dict[str, Any]
+    # Authoritative Arrow type per source column, from the engine's schema metadata
+    # (e.g. Postgres relation OIDs). Lets the batcher type a column the same way in
+    # every micro-batch even when one flush sees it all-null — without it, an all-null
+    # flush is inferred as string while a concrete flush is int64, and the two Parquet
+    # schemas fail to merge. Shared across all events of one relation; None when unknown.
+    column_types: Mapping[str, pa.DataType] | None = None
 
 
 class CDCStreamReader(Protocol):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/decoder.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/decoder.py
@@ -30,6 +30,8 @@ from dataclasses import (
 from datetime import UTC, datetime
 from typing import Any
 
+import pyarrow as pa
+
 from products.warehouse_sources.backend.temporal.data_imports.cdc.types import ChangeEvent
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.position import PgLSN
 
@@ -73,6 +75,9 @@ class Relation:
     table_name: str
     replica_identity: int  # 0=default, 1=nothing, 2=full, 3=index
     columns: list[RelationColumn] = field(default_factory=list)
+    # Arrow type per column, derived once from the column OIDs. Stamped onto every
+    # ChangeEvent so the batcher types all-null micro-batches consistently.
+    column_arrow_types: dict[str, pa.DataType] = field(default_factory=dict)
 
     @property
     def qualified_name(self) -> str:
@@ -221,6 +226,7 @@ class PgOutputDecoder:
             table_name=table_name,
             replica_identity=replica_identity,
             columns=columns,
+            column_arrow_types={col.name: _arrow_type_for_oid(col.type_oid) for col in columns},
         )
 
     def _handle_insert(self, payload: bytes, lsn: str) -> None:
@@ -242,6 +248,7 @@ class PgOutputDecoder:
                 position_serialized=lsn,
                 timestamp=self._tx_timestamp or datetime.now(tz=UTC),
                 columns=columns,
+                column_types=relation.column_arrow_types,
             )
         )
 
@@ -279,6 +286,7 @@ class PgOutputDecoder:
                 position_serialized=lsn,
                 timestamp=self._tx_timestamp or datetime.now(tz=UTC),
                 columns=columns,
+                column_types=relation.column_arrow_types,
             )
         )
 
@@ -309,6 +317,7 @@ class PgOutputDecoder:
                 position_serialized=lsn,
                 timestamp=self._tx_timestamp or datetime.now(tz=UTC),
                 columns=columns,
+                column_types=relation.column_arrow_types,
             )
         )
 
@@ -415,6 +424,24 @@ def _skip_tuple(data: bytes, offset: int, relation: Relation) -> tuple[dict[str,
     # Decode the tuple we just skipped for return value
     columns = _decode_tuple(data[start:offset], relation)
     return columns, offset
+
+
+def _arrow_type_for_oid(type_oid: int) -> pa.DataType:
+    """Arrow type matching the Python value ``_cast_text_value`` produces for this OID.
+
+    Must stay in lockstep with ``_cast_text_value``: bool→bool_, integers→int64,
+    floats→float64, everything else (numeric, json, text, …) stays string. Used to
+    type a column the same way in every micro-batch, so an all-null flush is not
+    inferred as string and then rejected when merged with a concrete int64 flush.
+    """
+    if type_oid == _OID_BOOL:
+        return pa.bool_()
+    elif type_oid in (_OID_INT2, _OID_INT4, _OID_INT8):
+        return pa.int64()
+    elif type_oid in (_OID_FLOAT4, _OID_FLOAT8):
+        return pa.float64()
+    else:
+        return pa.string()
 
 
 def _cast_text_value(text: str, type_oid: int) -> Any:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_decoder.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_decoder.py
@@ -1,6 +1,7 @@
 import struct
 from datetime import UTC, datetime
 
+import pyarrow as pa
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.decoder import (
@@ -249,6 +250,35 @@ class TestPgOutputDecoder:
         assert events[0].columns["id"] == 1
         assert events[0].columns["name"] is None
         assert events[0].columns["email"] == "test@example.com"
+
+    def test_event_carries_column_arrow_types(self):
+        # Events expose the Arrow type per column from the relation OIDs, so the batcher
+        # can type a column the same way even in a micro-batch where it's all-null.
+        decoder = self._setup_decoder_with_relation(
+            columns=[
+                ("id", _OID_INT8, -1),
+                ("seats", _OID_INT4, -1),
+                ("price", _OID_FLOAT8, -1),
+                ("active", _OID_BOOL, -1),
+                ("payload", _OID_JSONB, -1),
+                ("name", _OID_TEXT, -1),
+            ]
+        )
+
+        decoder.decode_message(_make_begin(), "0/100")
+        decoder.decode_message(
+            _make_insert(1, [("t", "1"), ("t", "5"), ("t", "9.5"), ("t", "t"), ("t", "{}"), ("t", "x")]), "0/150"
+        )
+        events = decoder.decode_message(_make_commit(), "0/200")
+
+        assert events[0].column_types == {
+            "id": pa.int64(),
+            "seats": pa.int64(),
+            "price": pa.float64(),
+            "active": pa.bool_(),
+            "payload": pa.string(),
+            "name": pa.string(),
+        }
 
     def test_unchanged_toast_column(self):
         decoder = self._setup_decoder_with_relation(columns=[("id", _OID_INT4, -1), ("big_text", _OID_TEXT, -1)])


### PR DESCRIPTION
## Problem

CDC extraction reads the WAL backlog and writes it to S3 in micro-batch Parquet flushes, inferring each column's Arrow type **per batch**. That makes a column's type depend on the values that happen to land in a given flush:

- A nullable column that is all-null in one flush is inferred as the null type, then coerced to `string` (DeltaLake rejects the null type).
- The same column in a flush with concrete values becomes `int64`.

The writer then merges flush schemas with `unify_schemas`, which rejects `int64` vs `string` and fails the run:

```
ArrowTypeError: Unable to merge: Field seats has incompatible types: int64 vs string
```

Because the failure was flagged retryable, the schedule kept re-running and re-failing the same backlog until the offending rows aged out of the WAL window.

## Changes

Type each column from its **authoritative source type** instead of inferring per batch:

- The pgoutput decoder already knows each column's Postgres OID. It now derives an Arrow type per column (in lockstep with the existing value casting) and stamps it onto every `ChangeEvent`.
- The batcher builds each table using that declared type, so an all-null flush keeps the column's real type (e.g. `int64`) rather than drifting to `string`. Every flush's Parquet schema agrees, so the cross-flush merge succeeds. It falls back to inference (then string) only when a value genuinely doesn't fit.
- The Postgres-specific OID→Arrow mapping stays in the Postgres decoder; `ChangeEvent` and the batcher carry generic Arrow types, so other engines stay unaffected.

For data that is **genuinely** unmergeable — a source column whose type changes mid-stream (int in one batch, text in another) — the write now surfaces as a non-retryable `CDCSchemaMergeError` (category `schema_merge_incompatible`). The schedule stops re-running a deterministic failure, and the user sees a friendly, actionable message instead of an opaque retry loop.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). I added and ran automated tests only — no manual/staging run:

- `test_batcher.py` — a flush where `seats` is all-null and a later flush where it is concrete `int64` now produce mergeable schemas (`unify_schemas` succeeds); declared type overrides all-null inference; falls back to string when a value doesn't fit.
- `test_decoder.py` — decoded events carry the per-column Arrow types derived from relation OIDs (int→int64, float→float64, bool, json/text→string).
- `test_errors.py` — `CDCSchemaMergeError` classifies as non-retryable through the cause chain.
- `test_extract_activity.py` — an `ArrowTypeError` from `write_batch` fails the run with `NonRetryableException` and the friendly schema-merge message (no raw type detail leaked).

All 140 tests across these files pass; `ruff` and `ty` clean. The 13 errors in the broader CDC suite are pre-existing `__no_db__` setup failures (need a live Postgres), unrelated to this change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Daniel reported the production `ArrowTypeError` and directed the root-cause fix.

Approach: empirically confirmed with PyArrow 18.1 that `null` promotes to `int64` under `unify_schemas` but `int64` vs `string` raises even with `promote_options="permissive"` — which isolated the batcher's all-null→string coercion as the true cause rather than genuinely mixed source data. Considered fixing only the writer's schema-tracking merge, but rejected it: the per-flush Parquet files are already written with divergent types, so the downstream DeltaLake load would still fail — the types must be stabilized at write time. Threading the type via `ChangeEvent` (decoder → batcher) was chosen over adding a reader-protocol method so no activity/protocol plumbing was needed and the generic layer stays Arrow-typed.

No repo skills were required for this change.
