### PR TITLE
feat(mcp): detect grok as single-exec client

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -88,6 +88,11 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     // Poke is an LLM-driven assistant that renders text, not MCP Apps UI, so it
     // wants the same single-exec mode as the coding agents.
     'poke',
+    // Grok (xAI) — both Grok Build (the terminal coding agent) and the grok.com
+    // assistant connect custom MCP servers and render text rather than MCP Apps
+    // UI, so they benefit from the same single-exec mode and formatted-text
+    // rendering as the other coding agents.
+    'grok',
 ] as const
 
 // Known `x-anthropic-client` (`vendorClient`) header values. Anthropic pools

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -36,6 +36,7 @@ describe('isCliModeEnabledClient', () => {
             ['opencode'],
             ['amp-mcp-client'],
             ['poke'],
+            ['grok'],
         ])('returns true for %s', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })
@@ -63,6 +64,9 @@ describe('isCliModeEnabledClient', () => {
             ['opencode/1.2.3'],
             ['Amp MCP Client'],
             ['Poke'],
+            ['Grok'],
+            ['grok-build'],
+            ['Grok/1.2.3'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })


### PR DESCRIPTION
## Problem

Grok (xAI) connects to the PostHog MCP server but is not recognized in client detection, so it falls into the default mode instead of single-exec (CLI) mode. Like the coding agents and LLM-driven consumers already in the list, it renders text rather than MCP Apps `structuredContent` UI, so it benefits from single-exec mode and formatted-text rendering.

## Changes

Add `grok` to `CODING_AGENT_CLIENT_NAME_FRAGMENTS` in `services/mcp/src/lib/client-detection.ts`. This covers both Grok Build's terminal coding agent and the grok.com assistant via the existing case-insensitive substring match.

## How did you test this code?

I'm an agent (agent-assisted). I added unit cases to `services/mcp/tests/unit/client-detection.test.ts` for the exact `grok` fragment and realistic variants like `Grok`, `grok-build`, and `Grok/1.2.3`. These cases catch a regression where Grok sessions silently drop out of single-exec mode.

Ran:

- `flox activate -- bash -c 'pnpm --filter=@posthog/mcp exec vitest run tests/unit/client-detection.test.ts'`
- `flox activate -- bash -c 'pnpm --dir services/mcp exec oxlint src/lib/client-detection.ts tests/unit/client-detection.test.ts'` (0 errors, one existing `expect-expect` warning in `client-detection.test.ts`)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this only adjusts MCP client detection behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

An agent narrowed the existing MCP client-detection PR to Grok only and rewrote the branch to a single replacement commit. Invoked `/writing-tests` before changing the Vitest coverage; kept the existing substring-matching approach for consistency with the surrounding client fragment list.
