### PR TITLE
chore: remove unused billing-provider webhook HMAC signing

### DIFF
--- a/ee/billing/billing_manager.py
+++ b/ee/billing/billing_manager.py
@@ -1,5 +1,4 @@
 import json
-import time
 from datetime import UTC, datetime, timedelta
 from enum import Enum
 from typing import Any, Optional, cast
@@ -21,17 +20,12 @@ from posthog.models import Organization
 from posthog.models.organization import OrganizationMembership, OrganizationUsageInfo
 from posthog.models.user import User
 
-from ee.api.agentic_provisioning.signature import compute_signature
 from ee.billing.billing_types import BillingProvider, BillingStatus
 from ee.billing.quota_limiting import set_org_usage_summary, update_org_billing_quotas
 from ee.models import License
 from ee.settings import BILLING_SERVICE_URL
 
 logger = structlog.get_logger(__name__)
-
-BILLING_PROVIDER_WEBHOOK_SIGNATURE_HEADER = "X-PostHog-Billing-Provider-Signature"
-BILLING_PROVIDER_WEBHOOK_TIMESTAMP_HEADER = "X-PostHog-Billing-Provider-Timestamp"
-BILLING_PROVIDER_WEBHOOK_SIGNATURE_VERSION = "sha256"
 
 
 class BillingAPIErrorCodes(Enum):
@@ -120,19 +114,6 @@ def build_billing_token(
     )
 
     return encoded_jwt
-
-
-def build_billing_provider_webhook_signature_headers(body: bytes) -> dict[str, str]:
-    secret = getattr(settings, "BILLING_PROVIDER_WEBHOOK_SECRET", "")
-    if not secret:
-        raise ValueError("BILLING_PROVIDER_WEBHOOK_SECRET is not configured")
-
-    timestamp = int(time.time())
-    digest = compute_signature(secret, timestamp, body)
-    return {
-        BILLING_PROVIDER_WEBHOOK_SIGNATURE_HEADER: f"{BILLING_PROVIDER_WEBHOOK_SIGNATURE_VERSION}={digest}",
-        BILLING_PROVIDER_WEBHOOK_TIMESTAMP_HEADER: str(timestamp),
-    }
 
 
 def handle_billing_service_error(res: requests.Response, valid_codes=(200, 201, 404, 401)) -> None:
@@ -769,7 +750,6 @@ class BillingManager:
         ).encode("utf-8")
         headers = {
             **self.get_auth_headers(organization),
-            **build_billing_provider_webhook_signature_headers(body),
             "Content-Type": "application/json",
         }
 

--- a/ee/billing/test/test_billing_manager.py
+++ b/ee/billing/test/test_billing_manager.py
@@ -1,7 +1,5 @@
-import hmac
 import json
 import math
-import hashlib
 import datetime
 from types import SimpleNamespace
 from typing import Any, cast
@@ -9,7 +7,7 @@ from typing import Any, cast
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase
 
 import jwt
 import requests
@@ -20,14 +18,7 @@ from posthog.cloud_utils import TEST_clear_instance_license_cache
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
 
-from ee.billing.billing_manager import (
-    BILLING_PROVIDER_WEBHOOK_SIGNATURE_HEADER,
-    BILLING_PROVIDER_WEBHOOK_SIGNATURE_VERSION,
-    BILLING_PROVIDER_WEBHOOK_TIMESTAMP_HEADER,
-    BillingManager,
-    _get_user_organization_role,
-    build_billing_token,
-)
+from ee.billing.billing_manager import BillingManager, _get_user_organization_role, build_billing_token
 from ee.billing.billing_types import BillingProvider, BillingStatus, Product
 from ee.models.license import License, LicenseManager
 
@@ -424,20 +415,16 @@ class TestBillingManager(BaseTest):
         assert "Open invoices must be resolved first" in str(context.exception)
 
 
-class TestBillingProviderWebhookSigning(SimpleTestCase):
+class TestBillingProviderWebhookForwarding(SimpleTestCase):
     def setUp(self):
         self.license = SimpleNamespace(key="license_id::license_secret")
         self.organization = cast(Organization, SimpleNamespace(id="org_123", name="Test Org"))
 
-    @override_settings(BILLING_PROVIDER_WEBHOOK_SECRET="test_webhook_secret")
-    @patch("ee.billing.billing_manager.time.time", return_value=1700000000)
     @patch(
         "ee.billing.billing_manager.requests.post",
         return_value=MagicMock(status_code=200, ok=True, text="", json=MagicMock(return_value={"status": "ok"})),
     )
-    def test_handle_billing_provider_webhook_signs_forwarded_body(
-        self, billing_post_request_mock: MagicMock, mock_time: MagicMock
-    ):
+    def test_handle_billing_provider_webhook_forwards_body(self, billing_post_request_mock: MagicMock):
         BillingManager(self.license).handle_billing_provider_webhook(
             event_type="marketplace.invoice.paid",
             event_data={"installationId": "icfg_123", "invoiceId": "mi_123"},
@@ -447,40 +434,15 @@ class TestBillingProviderWebhookSigning(SimpleTestCase):
 
         billing_post_request_mock.assert_called_once()
         call_kwargs = billing_post_request_mock.call_args.kwargs
-        body = call_kwargs["data"]
         expected_body = (
             b'{"event_type":"marketplace.invoice.paid",'
             b'"event_data":{"installationId":"icfg_123","invoiceId":"mi_123"},'
             b'"billing_provider":"vercel"}'
         )
-        expected_signature = hmac.new(
-            b"test_webhook_secret",
-            b"1700000000." + expected_body,
-            hashlib.sha256,
-        ).hexdigest()
 
-        assert body == expected_body
-        assert call_kwargs["headers"][BILLING_PROVIDER_WEBHOOK_TIMESTAMP_HEADER] == "1700000000"
-        assert (
-            call_kwargs["headers"][BILLING_PROVIDER_WEBHOOK_SIGNATURE_HEADER]
-            == f"{BILLING_PROVIDER_WEBHOOK_SIGNATURE_VERSION}={expected_signature}"
-        )
+        assert call_kwargs["data"] == expected_body
         assert call_kwargs["headers"]["Content-Type"] == "application/json"
         assert "Authorization" in call_kwargs["headers"]
-
-    @override_settings(BILLING_PROVIDER_WEBHOOK_SECRET="")
-    @patch("ee.billing.billing_manager.requests.post")
-    def test_handle_billing_provider_webhook_requires_signature_secret(self, billing_post_request_mock: MagicMock):
-        with self.assertRaises(ValueError) as context:
-            BillingManager(self.license).handle_billing_provider_webhook(
-                event_type="marketplace.invoice.paid",
-                event_data={"installationId": "icfg_123", "invoiceId": "mi_123"},
-                organization=self.organization,
-                billing_provider="vercel",
-            )
-
-        assert "BILLING_PROVIDER_WEBHOOK_SECRET" in str(context.exception)
-        billing_post_request_mock.assert_not_called()
 
     @parameterized.expand(
         [
@@ -489,7 +451,6 @@ class TestBillingProviderWebhookSigning(SimpleTestCase):
             ("negative_infinity", -math.inf),
         ]
     )
-    @override_settings(BILLING_PROVIDER_WEBHOOK_SECRET="test_webhook_secret")
     @patch("ee.billing.billing_manager.requests.post")
     def test_handle_billing_provider_webhook_rejects_non_finite_numbers(
         self, _name: str, non_finite_number: float, billing_post_request_mock: MagicMock

--- a/ee/settings.py
+++ b/ee/settings.py
@@ -147,7 +147,6 @@ HARMONIC_BASE_URL = get_from_env("HARMONIC_BASE_URL", "https://api.harmonic.ai",
 # Vercel Integration
 VERCEL_CLIENT_INTEGRATION_ID = get_from_env("VERCEL_CLIENT_INTEGRATION_ID", "", type_cast=str)
 VERCEL_CLIENT_INTEGRATION_SECRET = get_from_env("VERCEL_CLIENT_INTEGRATION_SECRET", "", type_cast=str)
-BILLING_PROVIDER_WEBHOOK_SECRET = get_from_env("BILLING_PROVIDER_WEBHOOK_SECRET", "", type_cast=str)
 
 # SCIM Configuration
 # django-scim2 requires these settings


### PR DESCRIPTION
## Problem

PostHog signs the outbound Vercel → billing-service webhook forward with an HMAC (`X-PostHog-Billing-Provider-Signature`, keyed by `BILLING_PROVIDER_WEBHOOK_SECRET`). The billing service never verifies that header — it authenticates the forward via the license JWT (`JwtAuthentication`) instead. So the signer has no verifier.

Left as-is it's pure downside: a secret that must be kept in sync across services, and a `raise ValueError` in the signing helper that would 500 the invoice-paid forward if the secret were ever unset — all for zero verification benefit.

## Changes

Remove the dead signer:
- `build_billing_provider_webhook_signature_headers` and its three header/version constants in `ee/billing/billing_manager.py`, plus the call site in `handle_billing_provider_webhook` (the forward now sends only the auth + content-type headers).
- The `BILLING_PROVIDER_WEBHOOK_SECRET` settings entry in `ee/settings.py`.
- The now-obsolete signing tests; the webhook-forward test is retained (renamed to `TestBillingProviderWebhookForwarding`) and the non-finite-payload guard test is kept.

No behavior change to the billing service: it already ignores the signature. The license-JWT auth on the forward is unchanged.

If we later want defense-in-depth on the `paid_out_of_band` invoice path, a network restriction on the billing webhook or Stripe-side reconciliation is a better fit than a shared rotating secret — can be picked up separately.

## How did you test this code?

I'm an agent (Claude Code). Automated only:
- Ran `ee/billing/test/test_billing_manager.py::TestBillingProviderWebhookForwarding` (4 cases) against the branch — all pass. These assert the forward still posts the expected body with the auth + content-type headers and still rejects non-finite numeric payloads, catching a regression where removing the signer might drop or malform the forwarded request.
- `ruff check` / `ruff format` clean; pre-commit `ty` typecheck passed on commit.
- Grepped the repo for any remaining references to the removed symbols (none) and confirmed `BILLING_PROVIDER_WEBHOOK_SECRET` was never mapped into the deployment env, so there's no chart change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of @rockwrestlerun. The change started as a question about whether this secret was worth keeping; tracing the flow showed the billing service authenticates the forward via the license JWT and never reads the HMAC header, so the signer was dead code. Chose deletion over finishing the verifier because the JWT already gates the endpoint and a shared rotating secret across two services isn't worth its upkeep for an unverified signature. No repo skills were required for this change (pure deletion, no migration/endpoint/test-framework surface beyond removing dead tests).
