### PR TITLE
fix(surveys): expose question id in MCP survey schema so edits keep responses attached

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -395,6 +395,14 @@ class SurveyQuestionValidationRuleSerializer(serializers.Serializer):
 
 
 class SurveyBaseQuestionSchemaSerializer(serializers.Serializer):
+    id = serializers.CharField(
+        required=False,
+        help_text=(
+            "Stable question identifier (UUID). When editing an existing question, send back its current id so "
+            "its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the "
+            "server generates one."
+        ),
+    )
     type = serializers.ChoiceField(
         choices=["open", "link", "rating", "single_choice", "multiple_choice"],
         required=True,

--- a/products/surveys/frontend/generated/api.schemas.ts
+++ b/products/surveys/frontend/generated/api.schemas.ts
@@ -831,6 +831,8 @@ export const DescriptionContentTypeEnumApi = {
 } as const
 
 export interface SurveyOpenQuestionSchemaApi {
+    /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+    id?: string
     type: SurveyOpenQuestionSchemaTypeEnumApi
     /** Question text shown to respondents. */
     question: string
@@ -858,6 +860,8 @@ export const SurveyLinkQuestionSchemaTypeEnumApi = {
 } as const
 
 export interface SurveyLinkQuestionSchemaApi {
+    /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+    id?: string
     type: SurveyLinkQuestionSchemaTypeEnumApi
     /** Question text shown to respondents. */
     question: string
@@ -985,6 +989,8 @@ export type SurveyBranchingSchemaApi =
     | SurveyResponseBasedBranchingApi
 
 export interface SurveyRatingQuestionSchemaApi {
+    /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+    id?: string
     type: SurveyRatingQuestionSchemaTypeEnumApi
     /** Question text shown to respondents. */
     question: string
@@ -1027,6 +1033,8 @@ export const SurveySingleChoiceQuestionSchemaTypeEnumApi = {
 } as const
 
 export interface SurveySingleChoiceQuestionSchemaApi {
+    /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+    id?: string
     type: SurveySingleChoiceQuestionSchemaTypeEnumApi
     /** Question text shown to respondents. */
     question: string
@@ -1065,6 +1073,8 @@ export const SurveyMultipleChoiceQuestionSchemaTypeEnumApi = {
 } as const
 
 export interface SurveyMultipleChoiceQuestionSchemaApi {
+    /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+    id?: string
     type: SurveyMultipleChoiceQuestionSchemaTypeEnumApi
     /** Question text shown to respondents. */
     question: string

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -393,6 +393,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
         .array(
             zod.union([
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['open']).describe('\* `open` - open'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -405,6 +411,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                     buttonText: zod.string().optional().describe('Custom button label.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['link']).describe('\* `link` - link'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -418,6 +430,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                     link: zod.string().describe('HTTPS or mailto URL for link questions.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['rating']).describe('\* `rating` - rating'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -502,6 +520,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['single_choice']).describe('\* `single_choice` - single_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -585,6 +609,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['multiple_choice']).describe('\* `multiple_choice` - multiple_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1293,6 +1323,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
         .array(
             zod.union([
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['open']).describe('\* `open` - open'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1305,6 +1341,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                     buttonText: zod.string().optional().describe('Custom button label.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['link']).describe('\* `link` - link'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1318,6 +1360,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                     link: zod.string().describe('HTTPS or mailto URL for link questions.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['rating']).describe('\* `rating` - rating'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1402,6 +1450,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['single_choice']).describe('\* `single_choice` - single_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1485,6 +1539,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['multiple_choice']).describe('\* `multiple_choice` - multiple_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -40122,6 +40122,8 @@ export namespace Schemas {
     } as const;
 
     export interface SurveyOpenQuestionSchema {
+      /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+      id?: string;
       type: SurveyOpenQuestionSchemaTypeEnum;
       /** Question text shown to respondents. */
       question: string;
@@ -40149,6 +40151,8 @@ export namespace Schemas {
     } as const;
 
     export interface SurveyLinkQuestionSchema {
+      /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+      id?: string;
       type: SurveyLinkQuestionSchemaTypeEnum;
       /** Question text shown to respondents. */
       question: string;
@@ -40272,6 +40276,8 @@ export namespace Schemas {
     export type SurveyBranchingSchema = SurveyNextQuestionBranching | SurveyEndBranching | SurveySpecificQuestionBranching | SurveyResponseBasedBranching;
 
     export interface SurveyRatingQuestionSchema {
+      /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+      id?: string;
       type: SurveyRatingQuestionSchemaTypeEnum;
       /** Question text shown to respondents. */
       question: string;
@@ -40314,6 +40320,8 @@ export namespace Schemas {
     } as const;
 
     export interface SurveySingleChoiceQuestionSchema {
+      /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+      id?: string;
       type: SurveySingleChoiceQuestionSchemaTypeEnum;
       /** Question text shown to respondents. */
       question: string;
@@ -40352,6 +40360,8 @@ export namespace Schemas {
     } as const;
 
     export interface SurveyMultipleChoiceQuestionSchema {
+      /** Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one. */
+      id?: string;
       type: SurveyMultipleChoiceQuestionSchemaTypeEnum;
       /** Question text shown to respondents. */
       question: string;

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -413,6 +413,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
         .array(
             zod.union([
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['open']).describe('* `open` - open'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -425,6 +431,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                     buttonText: zod.string().optional().describe('Custom button label.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['link']).describe('* `link` - link'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -438,6 +450,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                     link: zod.string().describe('HTTPS or mailto URL for link questions.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['rating']).describe('* `rating` - rating'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -522,6 +540,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['single_choice']).describe('* `single_choice` - single_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -605,6 +629,12 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['multiple_choice']).describe('* `multiple_choice` - multiple_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1220,6 +1250,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
         .array(
             zod.union([
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['open']).describe('* `open` - open'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1232,6 +1268,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                     buttonText: zod.string().optional().describe('Custom button label.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['link']).describe('* `link` - link'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1245,6 +1287,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                     link: zod.string().describe('HTTPS or mailto URL for link questions.'),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['rating']).describe('* `rating` - rating'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1329,6 +1377,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['single_choice']).describe('* `single_choice` - single_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),
@@ -1412,6 +1466,12 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
                         .optional(),
                 }),
                 zod.object({
+                    id: zod
+                        .string()
+                        .optional()
+                        .describe(
+                            'Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.'
+                        ),
                     type: zod.enum(['multiple_choice']).describe('* `multiple_choice` - multiple_choice'),
                     question: zod.string().describe('Question text shown to respondents.'),
                     description: zod.string().optional().describe('Optional helper text.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-create.json
@@ -275,6 +275,10 @@
                                         "enum": ["html", "text"],
                                         "type": "string"
                                     },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
+                                    },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",
                                         "type": "boolean"
@@ -305,6 +309,10 @@
                                     "descriptionContentType": {
                                         "description": "Format for the description field.\n\n* `text` - text\n* `html` - html",
                                         "enum": ["html", "text"],
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
                                         "type": "string"
                                     },
                                     "link": {
@@ -425,6 +433,10 @@
                                     "display": {
                                         "description": "Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.\n\n* `number` - number\n* `emoji` - emoji",
                                         "enum": ["number", "emoji"],
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
                                         "type": "string"
                                     },
                                     "lowerBoundLabel": {
@@ -564,6 +576,10 @@
                                         "description": "Whether the final option should be an open-text choice (for example, 'Other').",
                                         "type": "boolean"
                                     },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
+                                    },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",
                                         "type": "boolean"
@@ -612,6 +628,10 @@
                                     "hasOpenChoice": {
                                         "description": "Whether the final option should be an open-text choice (for example, 'Other').",
                                         "type": "boolean"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
                                     },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/survey-update.json
@@ -295,6 +295,10 @@
                                         "enum": ["html", "text"],
                                         "type": "string"
                                     },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
+                                    },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",
                                         "type": "boolean"
@@ -325,6 +329,10 @@
                                     "descriptionContentType": {
                                         "description": "Format for the description field.\n\n* `text` - text\n* `html` - html",
                                         "enum": ["html", "text"],
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
                                         "type": "string"
                                     },
                                     "link": {
@@ -445,6 +453,10 @@
                                     "display": {
                                         "description": "Display format: 'number' shows numeric scale, 'emoji' shows emoji scale.\n\n* `number` - number\n* `emoji` - emoji",
                                         "enum": ["number", "emoji"],
+                                        "type": "string"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
                                         "type": "string"
                                     },
                                     "lowerBoundLabel": {
@@ -584,6 +596,10 @@
                                         "description": "Whether the final option should be an open-text choice (for example, 'Other').",
                                         "type": "boolean"
                                     },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
+                                    },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",
                                         "type": "boolean"
@@ -632,6 +648,10 @@
                                     "hasOpenChoice": {
                                         "description": "Whether the final option should be an open-text choice (for example, 'Other').",
                                         "type": "boolean"
+                                    },
+                                    "id": {
+                                        "description": "Stable question identifier (UUID). When editing an existing question, send back its current id so its responses (keyed by $survey_response_<id>) stay attached; omit it for new questions and the server generates one.",
+                                        "type": "string"
                                     },
                                     "optional": {
                                         "description": "Whether respondents may skip this question.",

--- a/services/mcp/tests/unit/schema.survey-question-id.test.ts
+++ b/services/mcp/tests/unit/schema.survey-question-id.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { SurveysCreateBody, SurveysPartialUpdateBody } from '@/generated/surveys/api'
+
+// Regression guard: survey responses are keyed $survey_response_<question_id>, so the MCP
+// survey tools must let callers send back an existing question id on edit. If the `id` field
+// is dropped from the question schema, zod silently strips it and every edit regenerates the
+// UUID, orphaning historical responses (support ticket 61130).
+describe('Survey question id preservation', () => {
+    it.each([
+        ['survey-create', SurveysCreateBody.shape.questions],
+        ['survey-update', SurveysPartialUpdateBody.shape.questions],
+    ])('preserves an explicit question id through %s validation', (_label, questionsSchema) => {
+        const existingId = '0190a1b2-c3d4-7e8f-9012-3456789abcde'
+
+        const result = questionsSchema.safeParse([
+            { type: 'open', question: 'How was your experience?', id: existingId },
+        ])
+
+        expect(result.success).toBe(true)
+        expect(result.data?.[0]).toMatchObject({ id: existingId })
+    })
+})


### PR DESCRIPTION
## Problem

The MCP survey tools (`survey-create` / `survey-update`) silently dropped the `id` field from every question. Survey responses are keyed `$survey_response_<question_id>`, so editing an existing survey's questions through the MCP, even flipping a single boolean, regenerated every question UUID and detached the entire historical response set from the survey's results. 

(The API itself is fine. The bug was just that the OpenAPI/zod schema never exposed an `id` field for callers to send, so zod stripped it during validation before the request was forwarded.)

Reported by a customer in [support ticket 61130](https://posthoghelp.zendesk.com/agent/tickets/61130).

## Changes

`SurveyBaseQuestionSchemaSerializer` (`products/surveys/backend/api/survey.py`) is the schema-only serializer — reached solely via `@extend_schema_field` for OpenAPI/codegen, never instantiated for runtime validation — that all five question types inherit from. It had no `id` field, so `id` never made it into the generated zod.

- Added an optional `id` `CharField` (with `help_text`) to that base serializer.
- Regenerated with `hogli build:openapi`, propagating `id` into the four generated files (frontend `api.schemas.ts` / `api.zod.ts` and the two MCP generated files). Pure additions, no other schema movement.

Runtime was already correct and is untouched: `validate_questions` copies `{**raw_question}` (never strips `id`) and `ensure_question_ids` only mints a UUID when `id` is absent. The read serializer already emits `id`, so an agent's fetch → edit → send roundtrip is now consistent end-to-end. This also resolves the existing instruction in `products/surveys/mcp/tools.yaml` that told agents to preserve question ids they previously had no field to send.

Out of scope: the same base serializer also omits `translations` and `validation` (both handled at runtime).

## How did you test this code?

I'm an agent (PostHog Code). I did not manually test via the UI or MCP. Automated checks I actually ran:

- New regression test `services/mcp/tests/unit/schema.survey-question-id.test.ts` — a pure zod `safeParse`, parameterized over the create and update body schemas, asserting an explicit question `id` survives validation. It fails precisely if someone drops `id` from the schema serializer (zod strips unknown keys by default — the exact mechanism behind this bug). No existing test caught this: the backend tests cover the REST layer, which always preserved `id`. 2/2 passing.
- Adjacent MCP schema tests (`schema.feature-flag-filters.test.ts`) still pass.
- `ruff check` clean on the serializer; MCP `tsgo` typecheck clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Opus 4.8), directed by @slshults. A separate Claude Code session traced the root cause from the symptom (regenerated UUIDs) back through the generated zod to the backend schema serializer; this session independently verified each link in that chain against the code before making the change, then regenerated and tested.

Skills invoked: `/improving-drf-endpoints` (before touching the serializer) and `/writing-tests` (to gate the regression test to the cheapest level that catches the bug).

Decisions: fix at the backend serializer rather than the generated file (which is marked do-not-edit); keep it `id`-only rather than also closing the `translations`/`validation` schema drift; place the regression test as a pure zod parse rather than a heavier MCP integration test, since the bug lives entirely in schema validation. A `code-reviewer` pass confirmed the change is doc/codegen-only with no runtime effect.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
