### PR TITLE
fix(tasks): link "View agent logs" to cloud task page

### DIFF
--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -42,7 +42,7 @@ class TestSlackThreadHandler(TestCase):
         )
         handler = SlackThreadHandler(context)
 
-        handler.post_or_update_progress("In progress...", task_url="posthog-code://task/abc/run/xyz")
+        handler.post_or_update_progress("In progress...", task_url="https://us.posthog.com/project/1/tasks/abc?runId=xyz")
 
         mock_client.chat_postMessage.assert_called_once()
         blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]
@@ -50,6 +50,7 @@ class TestSlackThreadHandler(TestCase):
 
         assert len(actions) == 1
         assert actions[0]["text"]["text"] == "View agent logs"
+        assert actions[0]["url"] == "https://us.posthog.com/project/1/tasks/abc?runId=xyz"
 
     @patch.object(SlackThreadHandler, "_find_progress_message_ts", return_value="1234.9999")
     @patch.object(SlackThreadHandler, "_get_client")

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -42,7 +42,9 @@ class TestSlackThreadHandler(TestCase):
         )
         handler = SlackThreadHandler(context)
 
-        handler.post_or_update_progress("In progress...", task_url="https://us.posthog.com/project/1/tasks/abc?runId=xyz")
+        handler.post_or_update_progress(
+            "In progress...", task_url="https://us.posthog.com/project/1/tasks/abc?runId=xyz"
+        )
 
         mock_client.chat_postMessage.assert_called_once()
         blocks = mock_client.chat_postMessage.call_args.kwargs["blocks"]

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -60,9 +60,6 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             if creator_has_access
             else None
         )
-        logs_deeplink: str | None = (
-            f"posthog-code://task/{task_run.task_id}/run/{task_run.id}" if creator_has_access else None
-        )
         pr_url = (task_run.output or {}).get("pr_url")
 
         if input.sandbox_cleaned:
@@ -105,7 +102,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
                 handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)
-            handler.post_or_update_progress(stage, logs_deeplink)
+            handler.post_or_update_progress(stage, task_url)
     except Exception:
         logger.exception("post_slack_update_failed", run_id=input.run_id)
 

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -116,6 +116,9 @@ class TestPostSlackUpdate(TestCase):
 
         mock_post_progress.assert_called_once()
         assert mock_post_progress.call_args[0][0] == "Cloning repository"
+        # The "View agent logs" button links to the cloud task page (works on
+        # mobile) rather than a desktop-only ``posthog-code://`` deep link.
+        assert mock_post_progress.call_args[0][1] == "http://localhost:8000/project/1/tasks/10?runId=run-1"
 
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
@@ -383,8 +386,8 @@ class TestPostSlackUpdate(TestCase):
         mock_post_completion,
     ):
         # When the task creator is not a PostHog Code user, every handler call
-        # receives ``task_url=None`` (and the progress handler receives
-        # ``logs_deeplink=None``) so the deep-link / web buttons are skipped.
+        # (including the progress handler) receives ``task_url=None`` so the
+        # web buttons are skipped.
         self._access_patcher.stop()
         deny_patcher = patch(
             "products.tasks.backend.temporal.process_task.activities.post_slack_update.has_tasks_access",


### PR DESCRIPTION
## Problem

The Slack progress message posts a **View agent logs** button while a task is running. That button linked to a `posthog-code://task/<id>/run/<id>` deep link, which only resolves on the PostHog Code desktop app. On a phone the link does nothing — there's no desktop app to hand off to.

## Changes

Point the **View agent logs** button at the same cloud task URL the other Slack notifications (completion, error, cancelled, PR-opened) already use: `{SITE_URL}/project/<team_id>/tasks/<task_id>?runId=<run_id>`. This opens fine in a mobile browser. The now-unused `logs_deeplink` is removed.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not manually test in Slack. Automated coverage updated:
- `test_post_slack_update.py::test_in_progress_run_posts_stage` now asserts the progress button receives the cloud task URL (regression: catches a reintroduced desktop-only deep link).
- `test_post_slack_update.py::test_user_without_posthog_code_access_omits_task_url` still passes `None` through for the no-access path.
- `test_slack_thread.py` progress-button test now asserts the rendered button `url` matches the cloud URL it's given.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app from a Slack thread. The reporter noted the "View agent logs" link is dead on mobile because it targets the desktop app. Traced the button to `post_slack_update.py`, where every other notification already used the web `task_url` and only the progress button used the `posthog-code://` deep link — so the fix is just to reuse `task_url` there.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782430646732459)*
