### PR TITLE
chore(data-warehouse): fix direct-postgres SSRF guard test team-id collision

### DIFF
--- a/posthog/hogql/test/test_direct_postgres_query.py
+++ b/posthog/hogql/test/test_direct_postgres_query.py
@@ -1264,7 +1264,9 @@ class TestDirectPostgresQuery(APIBaseTest):
             'column "posthog_dashboard.name" must appear in the GROUP BY clause or be used in an aggregate function',
         )
 
-    @override_settings(CLOUD_DEPLOYMENT="US")
+    # DEV (not US/EU) keeps the host guard active without the internal-team allowlist, which the
+    # test team's auto-assigned id can otherwise collide with (US team_id 2 / EU team_id 1).
+    @override_settings(CLOUD_DEPLOYMENT="DEV")
     @patch("posthog.hogql.direct_sql.postgres_adapter.psycopg.connect")
     def test_execute_direct_postgres_query_blocks_internal_host(self, mock_connect):
         source = ExternalDataSource.objects.create(


### PR DESCRIPTION
## Problem

PostHog lets customers connect their own databases and run SQL against them. To prevent SSRF attacks (where someone could point a connection at an internal address like `localhost` to snoop on PostHog's own servers), there's a guard that rejects queries to internal hosts before any connection is attempted. The test `test_execute_direct_postgres_query_blocks_internal_host` exists to prove that guard works: it sets up a connection to `localhost` and checks that the query gets blocked.

The guard has one deliberate exception: PostHog's own internal teams are allowed to use internal addresses. Specifically, US team id 2 and EU team id 1 get a pass.

Every test creates a throwaway team in a test database. Normally that team gets a high auto-assigned id, so it never matches the special "id 2" exception. But on CI shard 12, the test database is empty enough that the throwaway team gets assigned id 2. The guard sees "trusted US team 2, allow `localhost`" and lets it through. The test expects a block, gets an allow, and fails. It passed locally because a developer database already has many teams, so the test team always gets a high id.

Nothing is broken in the guard itself. It did exactly what it's supposed to do. The test was fragile because it accidentally depended on the throwaway team never drawing id 2.

## Changes

Run the test under `CLOUD_DEPLOYMENT="DEV"` instead of `"US"`. `DEV` is still a cloud deployment, so `is_cloud()` stays true and the guard runs, but the US/EU internal-team allowlist never applies. `localhost` gets blocked for any team id, so the test can't be tripped up by whichever id the throwaway team draws. The guard is unchanged.

## How did you test this code?

Automated only.

Confirmed the bypass directly: under `CLOUD_DEPLOYMENT="US"`, `_is_host_safe("localhost", 2)` returns `(True, None)` (the CI red condition); under `"DEV"` it returns `(False, …)` for team ids 1, 2, and 999. Ran the full `posthog/hogql/test/test_direct_postgres_query.py` suite (85 tests) and all pass.

No new unit test is added. The allowlist contract is already pinned in `products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py` via `test_blocks_internal_ip` and `test_allows_internal_ip_for_whitelisted_team_us`/`_eu`.