### PR TITLE
feat(tracing): surface traces matching on non-root spans

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2938,6 +2938,9 @@ const api = {
                 limit?: number
                 after?: string
                 offset?: number
+                // Select traces by their root span only (true) vs. by any matching span (false). When
+                // false, traces matched via a child span are returned with their root span included.
+                rootSpans?: boolean
                 prefetchSpans?: number
             },
             signal?: AbortSignal

--- a/products/tracing/frontend/TracingFilterBar.tsx
+++ b/products/tracing/frontend/TracingFilterBar.tsx
@@ -81,9 +81,10 @@ const dateMapping: DateMappingOption[] = [
 export function TracingFilterBar(): JSX.Element {
     const { spansLoading } = useValues(tracingDataLogic())
     const { runQuery } = useActions(tracingDataLogic())
-    const { filters, utcDateRange } = useValues(tracingFiltersLogic())
-    const { setDateRange, setServiceNames, setFilterGroup, setCompareMode } = useActions(tracingFiltersLogic())
-    const { dateRange, serviceNames, filterGroup, compareMode } = filters
+    const { filters, utcDateRange, hasSpanFilters } = useValues(tracingFiltersLogic())
+    const { setDateRange, setServiceNames, setFilterGroup, setCompareMode, setHideNonMatchingSpans } =
+        useActions(tracingFiltersLogic())
+    const { dateRange, serviceNames, filterGroup, compareMode, hideNonMatchingSpans } = filters
 
     return (
         <TracingFilterGroup filterGroup={filterGroup} onFilterGroupChange={setFilterGroup}>
@@ -145,6 +146,16 @@ export function TracingFilterBar(): JSX.Element {
                                 }}
                             />
                         </div>
+                        {hasSpanFilters && !compareMode && (
+                            <LemonSwitch
+                                label="Hide non-matching"
+                                tooltip="Only show traces whose root span matches the filters. When off, traces that match via a child span are also shown, with the non-matching root greyed out."
+                                checked={hideNonMatchingSpans}
+                                onChange={setHideNonMatchingSpans}
+                                bordered
+                                size="small"
+                            />
+                        )}
                         <LemonSwitch
                             label="Compare"
                             checked={compareMode}

--- a/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
+++ b/products/tracing/frontend/components/VirtualizedSpanList/VirtualizedSpanList.tsx
@@ -2,7 +2,7 @@ import { CSSProperties, ReactNode, useCallback, useEffect, useMemo, useRef } fro
 import { List, useDynamicRowHeight, useListRef } from 'react-window'
 
 import { IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonTag } from '@posthog/lemon-ui'
+import { LemonButton, LemonTag, Tooltip } from '@posthog/lemon-ui'
 
 import { AutoSizer } from 'lib/components/AutoSizer'
 import { SizeProps } from 'lib/components/AutoSizer/AutoSizer'
@@ -153,6 +153,9 @@ function SpanRow({
     onClick: () => void
 }): JSX.Element {
     const status = STATUS_CODE_LABELS[span.status_code] ?? { label: String(span.status_code), type: 'default' as const }
+    // The root span itself didn't match the filter — its trace surfaced via a matching child span.
+    // Dim the row so matching traces stand out, mirroring the greyed-out spans in the waterfall.
+    const isUnmatched = !span.matched_filter
 
     return (
         <div
@@ -182,12 +185,19 @@ function SpanRow({
             </Cell>
             <Cell width={COL_WIDTH.timestamp}>{new Date(span.timestamp).toLocaleString()}</Cell>
             <Cell>
-                <span className="flex items-center gap-2 truncate">
+                <span className={cn('flex items-center gap-2 truncate', isUnmatched && 'opacity-50')}>
                     <span className="truncate">{span.name}</span>
                     {isRootSpan(span) && (
                         <LemonTag type="highlight" size="small">
                             trace
                         </LemonTag>
+                    )}
+                    {isUnmatched && (
+                        <Tooltip title="This trace matched your filters via a child span, not its root span. Open it to see the matching spans.">
+                            <LemonTag type="muted" size="small">
+                                matched in child
+                            </LemonTag>
+                        </Tooltip>
                     )}
                 </span>
             </Cell>

--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -170,7 +170,10 @@ describe('tracingDataLogic', () => {
 
         it.each([
             { name: 'a service filter', apply: () => tracingFiltersLogic().actions.setServiceNames(['web']) },
-            { name: 'a property filter', apply: () => tracingFiltersLogic().actions.setFilterGroup(filterGroupWithValue) },
+            {
+                name: 'a property filter',
+                apply: () => tracingFiltersLogic().actions.setFilterGroup(filterGroupWithValue),
+            },
         ])('matches any span once $name is set', ({ apply }) => {
             apply()
             expect(logic.values.rootSpansOnly).toBe(false)

--- a/products/tracing/frontend/tracingDataLogic.test.ts
+++ b/products/tracing/frontend/tracingDataLogic.test.ts
@@ -2,10 +2,28 @@ import posthog from 'posthog-js'
 
 import { AggregatedSpanRow } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator, PropertyFilterType, PropertyOperator, UniversalFiltersGroup } from '~/types'
 
 import { tracingDataLogic } from './tracingDataLogic'
 import { tracingFiltersLogic } from './tracingFiltersLogic'
 import type { Span } from './types'
+
+const filterGroupWithValue: UniversalFiltersGroup = {
+    type: FilterLogicalOperator.And,
+    values: [
+        {
+            type: FilterLogicalOperator.And,
+            values: [
+                {
+                    key: 'span_name',
+                    value: 'redis',
+                    operator: PropertyOperator.IContains,
+                    type: PropertyFilterType.Event,
+                },
+            ],
+        },
+    ],
+}
 
 const createMockAggregatedRow = (name: string): AggregatedSpanRow => ({
     service_name: 'svc',
@@ -138,6 +156,30 @@ describe('tracingDataLogic', () => {
             logic.actions.clearSpans()
             expect(logic.values.visibleRowRange).toBeNull()
             expect(logic.values.visibleRowDateRange).toBeNull()
+        })
+    })
+
+    describe('rootSpansOnly trace-selection mode', () => {
+        beforeEach(() => {
+            logic = mountWithSpans([])
+        })
+
+        it('stays root-only when no span filter is set', () => {
+            expect(logic.values.rootSpansOnly).toBe(true)
+        })
+
+        it.each([
+            { name: 'a service filter', apply: () => tracingFiltersLogic().actions.setServiceNames(['web']) },
+            { name: 'a property filter', apply: () => tracingFiltersLogic().actions.setFilterGroup(filterGroupWithValue) },
+        ])('matches any span once $name is set', ({ apply }) => {
+            apply()
+            expect(logic.values.rootSpansOnly).toBe(false)
+        })
+
+        it('reverts to root-only when "hide non-matching" is on, even with a filter', () => {
+            tracingFiltersLogic().actions.setServiceNames(['web'])
+            tracingFiltersLogic().actions.setHideNonMatchingSpans(true)
+            expect(logic.values.rootSpansOnly).toBe(true)
         })
     })
 

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -84,7 +84,10 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
     path(['products', 'tracing', 'frontend', 'tracingDataLogic']),
 
     connect(() => ({
-        values: [tracingFiltersLogic(), ['filters', 'orderBy', 'utcDateRange', 'currentWindowMs', 'previousWindowMs']],
+        values: [
+            tracingFiltersLogic(),
+            ['filters', 'orderBy', 'hasSpanFilters', 'utcDateRange', 'currentWindowMs', 'previousWindowMs'],
+        ],
     })),
 
     actions({
@@ -280,6 +283,7 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                             serviceNames:
                                 values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                             filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            rootSpans: values.rootSpansOnly,
                             prefetchSpans: PREFETCH_SPANS,
                             limit: DEFAULT_PAGE_SIZE,
                         },
@@ -314,6 +318,7 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
                             serviceNames:
                                 values.filters.serviceNames.length > 0 ? values.filters.serviceNames : undefined,
                             filterGroup: values.filters.filterGroup as PropertyGroupFilter,
+                            rootSpans: values.rootSpansOnly,
                             prefetchSpans: PREFETCH_SPANS,
                             limit: DEFAULT_PAGE_SIZE,
                             ...pagination,
@@ -580,6 +585,16 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
             (spans: Span[]): Span[] => {
                 return spans.filter((s) => s.is_root_span)
             },
+        ],
+        // Trace-selection mode for the list query. With a span filter active we match traces on ANY
+        // span (root or child) so a filter on a non-root span still surfaces its trace — non-matching
+        // root rows are then greyed out. "Hide non-matching" flips back to root-only selection. Without
+        // a span filter we stay root-only: every span matches anyway, and the root-only subquery is
+        // cheaper than grouping across all spans.
+        rootSpansOnly: [
+            (s) => [s.hasSpanFilters, s.filters],
+            (hasSpanFilters: boolean, filters: TracingFilters): boolean =>
+                !hasSpanFilters || filters.hideNonMatchingSpans,
         ],
         // Memoized separately so visibleRowDurationRange (recomputed on every scroll tick) doesn't
         // re-allocate the durations array — this only changes when the loaded spans do.

--- a/products/tracing/frontend/tracingDataLogic.ts
+++ b/products/tracing/frontend/tracingDataLogic.ts
@@ -86,7 +86,15 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
     connect(() => ({
         values: [
             tracingFiltersLogic(),
-            ['filters', 'orderBy', 'hasSpanFilters', 'utcDateRange', 'currentWindowMs', 'previousWindowMs'],
+            [
+                'filters',
+                'orderBy',
+                'hasSpanFilters',
+                'hideNonMatchingSpans',
+                'utcDateRange',
+                'currentWindowMs',
+                'previousWindowMs',
+            ],
         ],
     })),
 
@@ -592,9 +600,9 @@ export const tracingDataLogic = kea<tracingDataLogicType>([
         // a span filter we stay root-only: every span matches anyway, and the root-only subquery is
         // cheaper than grouping across all spans.
         rootSpansOnly: [
-            (s) => [s.hasSpanFilters, s.filters],
-            (hasSpanFilters: boolean, filters: TracingFilters): boolean =>
-                !hasSpanFilters || filters.hideNonMatchingSpans,
+            (s) => [s.hasSpanFilters, s.hideNonMatchingSpans],
+            (hasSpanFilters: boolean, hideNonMatchingSpans: boolean): boolean =>
+                !hasSpanFilters || hideNonMatchingSpans,
         ],
         // Memoized separately so visibleRowDurationRange (recomputed on every scroll tick) doesn't
         // re-allocate the durations array — this only changes when the loaded spans do.

--- a/products/tracing/frontend/tracingFiltersLogic.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.ts
@@ -1,6 +1,7 @@
 import { actions, kea, path, reducers, selectors } from 'kea'
 
 import { DEFAULT_UNIVERSAL_GROUP_FILTER } from 'lib/components/UniversalFilters/universalFiltersLogic'
+import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/utils'
 import { dayjs } from 'lib/dayjs'
 
 import { DateRange } from '~/queries/schema/schema-general'
@@ -12,6 +13,16 @@ export const DEFAULT_DATE_RANGE: DateRange = { date_from: '-1h', date_to: null }
 export const DEFAULT_SERVICE_NAMES: string[] = []
 export const DEFAULT_ORDER_BY = 'timestamp' as const
 export const DEFAULT_ORDER_DIRECTION = 'DESC' as const
+export const DEFAULT_HIDE_NON_MATCHING_SPANS = false
+
+// True when the filter group holds at least one real (non-group) property filter. Used to decide
+// whether to expand trace selection to any matching span (see tracingDataLogic) — there's nothing to
+// match against, and no perf reason to leave the cheap root-only path, when no span filter is set.
+export function groupFilterHasValues(group: UniversalFiltersGroup): boolean {
+    return group.values.some((value) =>
+        isUniversalGroupFilterLike(value) ? groupFilterHasValues(value) : true
+    )
+}
 
 // Column the list is ordered by, and its direction. timestamp+DESC is "latest" (keyset paginated via
 // the `after` cursor); duration+DESC/ASC is slowest/fastest (offset paginated). See tracingDataLogic.
@@ -30,6 +41,12 @@ export interface TracingFilters {
     orderBy: TracingOrderBy
     orderDirection: TracingOrderDirection
     compareMode: boolean
+    /**
+     * When a span filter is set we surface every trace with a matching span (root or child) and grey
+     * out the non-matching ones. Flipping this on reverts to root-only selection — only traces whose
+     * root span matches are listed.
+     */
+    hideNonMatchingSpans: boolean
     /** User-positioned overrides for the two compare windows. Null until the overlay is dragged. */
     currentWindowOverride: OverlayWindow | null
     previousWindowOverride: OverlayWindow | null
@@ -44,6 +61,7 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
         setFilterGroup: (filterGroup: UniversalFiltersGroup) => ({ filterGroup }),
         setSort: (orderBy: TracingOrderBy, orderDirection: TracingOrderDirection) => ({ orderBy, orderDirection }),
         setCompareMode: (compareMode: boolean) => ({ compareMode }),
+        setHideNonMatchingSpans: (hideNonMatchingSpans: boolean) => ({ hideNonMatchingSpans }),
         /**
          * Persist the user-dragged overlay windows. Both must be supplied. Setting these
          * never touches dateRange — the sparkline range is locked once compare mode is on.
@@ -97,6 +115,13 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 setFilters: (state, { filters }) => filters.compareMode ?? state,
             },
         ],
+        hideNonMatchingSpans: [
+            DEFAULT_HIDE_NON_MATCHING_SPANS as boolean,
+            {
+                setHideNonMatchingSpans: (_, { hideNonMatchingSpans }) => hideNonMatchingSpans,
+                setFilters: (state, { filters }) => filters.hideNonMatchingSpans ?? state,
+            },
+        ],
         currentWindowOverride: [
             null as OverlayWindow | null,
             {
@@ -128,6 +153,7 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 s.orderBy,
                 s.orderDirection,
                 s.compareMode,
+                s.hideNonMatchingSpans,
                 s.currentWindowOverride,
                 s.previousWindowOverride,
             ],
@@ -138,6 +164,7 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 orderBy,
                 orderDirection,
                 compareMode,
+                hideNonMatchingSpans,
                 currentWindowOverride,
                 previousWindowOverride
             ): TracingFilters => ({
@@ -147,9 +174,18 @@ export const tracingFiltersLogic = kea<tracingFiltersLogicType>([
                 orderBy,
                 orderDirection,
                 compareMode,
+                hideNonMatchingSpans,
                 currentWindowOverride,
                 previousWindowOverride,
             }),
+        ],
+        // Whether any span-level filter is active (a property filter or a service selection). Drives
+        // the "match any span" trace selection and the visibility of the "Hide non-matching" toggle —
+        // with no span filter, every span trivially matches, so there's nothing to grey or hide.
+        hasSpanFilters: [
+            (s) => [s.filterGroup, s.serviceNames],
+            (filterGroup: UniversalFiltersGroup, serviceNames: string[]): boolean =>
+                groupFilterHasValues(filterGroup) || serviceNames.length > 0,
         ],
         utcDateRange: [
             (s) => [s.dateRange],

--- a/products/tracing/frontend/tracingFiltersLogic.ts
+++ b/products/tracing/frontend/tracingFiltersLogic.ts
@@ -19,9 +19,7 @@ export const DEFAULT_HIDE_NON_MATCHING_SPANS = false
 // whether to expand trace selection to any matching span (see tracingDataLogic) — there's nothing to
 // match against, and no perf reason to leave the cheap root-only path, when no span filter is set.
 export function groupFilterHasValues(group: UniversalFiltersGroup): boolean {
-    return group.values.some((value) =>
-        isUniversalGroupFilterLike(value) ? groupFilterHasValues(value) : true
-    )
+    return group.values.some((value) => (isUniversalGroupFilterLike(value) ? groupFilterHasValues(value) : true))
 }
 
 // Column the list is ordered by, and its direction. timestamp+DESC is "latest" (keyset paginated via

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -52,7 +52,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
                 'isDurationMode',
             ],
             tracingFiltersLogic(),
-            ['filters', 'utcDateRange', 'sparklineWindowMs', 'currentWindowMs', 'previousWindowMs'],
+            ['filters', 'hasSpanFilters', 'utcDateRange', 'sparklineWindowMs', 'currentWindowMs', 'previousWindowMs'],
         ],
         actions: [
             tracingDataLogic(),
@@ -379,7 +379,10 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
             if (values.filters.compareMode) {
                 searchParams.compare = 'true'
             }
-            if (values.filters.hideNonMatchingSpans !== DEFAULT_HIDE_NON_MATCHING_SPANS) {
+            // Only serialize the toggle while a span filter is active — otherwise a stale `true` (set,
+            // then filters cleared) would travel in shared links and silently flip the recipient into
+            // root-only mode the moment they add a filter.
+            if (values.hasSpanFilters && values.filters.hideNonMatchingSpans !== DEFAULT_HIDE_NON_MATCHING_SPANS) {
                 searchParams.hideNonMatching = String(values.filters.hideNonMatchingSpans)
             }
 

--- a/products/tracing/frontend/tracingSceneLogic.ts
+++ b/products/tracing/frontend/tracingSceneLogic.ts
@@ -13,6 +13,7 @@ import { Breadcrumb } from '~/types'
 import { PREFETCH_SPANS, tracingDataLogic } from './tracingDataLogic'
 import {
     DEFAULT_DATE_RANGE,
+    DEFAULT_HIDE_NON_MATCHING_SPANS,
     DEFAULT_ORDER_BY,
     DEFAULT_ORDER_DIRECTION,
     DEFAULT_SERVICE_NAMES,
@@ -71,6 +72,7 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
                 'setFilterGroup',
                 'setSort',
                 'setCompareMode',
+                'setHideNonMatchingSpans',
                 'setOverlayWindows',
                 'setFilters',
             ],
@@ -218,6 +220,8 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
         setSort: ({ orderBy, orderDirection }) =>
             actions.handleFilterChange('sort', { column: orderBy, direction: orderDirection }),
         setCompareMode: ({ compareMode }) => actions.handleFilterChange('compare_mode', { enabled: compareMode }),
+        setHideNonMatchingSpans: ({ hideNonMatchingSpans }) =>
+            actions.handleFilterChange('hide_non_matching_spans', { enabled: hideNonMatchingSpans }),
         setOverlayWindows: () => {
             // Overlay drags only refetch the aggregation — the sparkline canvas range
             // stays fixed while the user moves windows around within it. If the compare-flame
@@ -304,6 +308,13 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
                 hasChanges = true
             }
 
+            const hideNonMatchingFromUrl =
+                searchParams.hideNonMatching === 'true' || searchParams.hideNonMatching === true
+            if (hideNonMatchingFromUrl !== values.filters.hideNonMatchingSpans) {
+                filtersFromUrl.hideNonMatchingSpans = hideNonMatchingFromUrl
+                hasChanges = true
+            }
+
             if (hasChanges) {
                 actions.setFilters(filtersFromUrl)
             } else if (!values.hasRunQuery) {
@@ -367,6 +378,9 @@ export const tracingSceneLogic = kea<tracingSceneLogicType>([
             }
             if (values.filters.compareMode) {
                 searchParams.compare = 'true'
+            }
+            if (values.filters.hideNonMatchingSpans !== DEFAULT_HIDE_NON_MATCHING_SPANS) {
+                searchParams.hideNonMatching = String(values.filters.hideNonMatchingSpans)
             }
 
             actions.runQuery()


### PR DESCRIPTION
## Problem

The trace list only shows root spans, and it also *selects* traces by their root span only. So when you filter by something that lives on a non-root span — a child span's id, name, or service — the matching span's trace never makes it into the list and you get zero results, which is confusing. You filtered for something that clearly exists, and nothing comes back.

## Changes

When a span filter is active, the list now selects traces on *any* matching span (root or child) and greys out the rows whose root span didn't itself match — those surfaced via a child. Opening such a trace drops you into the waterfall, which already greys non-matching spans, so the matching child stands out. This mirrors how Jaeger surfaces a whole trace when any span matches, but with an explicit hint about *which* spans matched.

A **Hide non-matching** toggle (shown only when a span filter is set) reverts to the original root-only selection for when you only care about traces whose root matched.

With no span filter set, nothing changes — we stay on the cheaper root-only selection path, since every span trivially matches anyway.

The backend already supported all of this: `TraceSpansQuery.rootSpans=false` matches any span and returns each span's `matched_filter` flag, with regression coverage in `test_root_spans_filter.py`. This PR is the frontend wiring (plus list greying and the toggle); no backend change.

## How did you test this code?

I'm an agent (PostHog Slack app). I added a unit test in `tracingDataLogic.test.ts` covering the new `rootSpansOnly` decision: root-only with no filter, match-any once a service or property filter is set, and back to root-only when "Hide non-matching" is on. I did not run the suite or do manual testing in this environment (frontend tooling/`node_modules` not installed here) — CI will run lint, typecheck, and tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built from a Slack thread where the non-root-span filtering gap was described. The key discovery during exploration: the backend query layer (`products/tracing/backend/logic.py`) already implements match-any trace selection and per-span `matched_filter`, and the waterfall view already greys non-matching spans — production was just defaulting the list to `rootSpans=true`. So the change is small and lives almost entirely in the tracing frontend logics: thread an explicit `rootSpans` param through `api.tracing.listSpans`, derive it from filter presence + the new toggle, grey non-matching root rows, and add the `hideNonMatchingSpans` filter (with URL persistence).

Service filters are treated as span filters too (a trace whose root is service A but has a child on service B surfaces when filtering for B), matching the intent encoded in the existing backend test. No skills were strictly required (no serializer/migration/taxonomic changes); `api.ts` is a handwritten custom-action client returning untyped records, so generated-type adoption was out of scope for the one optional boolean added.
