### PR TITLE
feat(mcp-analytics): event-gated onboarding into the wizard flow

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -30902,6 +30902,7 @@
                 "logs",
                 "marketing_analytics",
                 "max",
+                "mcp_analytics",
                 "mobile_replay",
                 "notebooks",
                 "persons",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -7512,6 +7512,7 @@ export enum ProductKey {
     LOGS = 'logs',
     MARKETING_ANALYTICS = 'marketing_analytics',
     MAX = 'max',
+    MCP_ANALYTICS = 'mcp_analytics',
     MOBILE_REPLAY = 'mobile_replay',
     NOTEBOOKS = 'notebooks',
     PERSONS = 'persons',

--- a/frontend/src/scenes/onboarding/legacy/stepProviderRegistry.ts
+++ b/frontend/src/scenes/onboarding/legacy/stepProviderRegistry.ts
@@ -6,6 +6,7 @@ import { errorTrackingOnboarding } from 'products/error_tracking/frontend/onboar
 import { experimentsOnboarding } from 'products/experiments/frontend/onboarding/steps'
 import { featureFlagsOnboarding } from 'products/feature_flags/frontend/onboarding/steps'
 import { logsOnboarding } from 'products/logs/frontend/onboarding/steps'
+import { mcpAnalyticsOnboarding } from 'products/mcp_analytics/frontend/onboarding/steps'
 import { productAnalyticsOnboarding } from 'products/product_analytics/frontend/onboarding/steps'
 import { sessionReplayOnboarding } from 'products/session_replay/frontend/onboarding/steps'
 import { surveysOnboarding } from 'products/surveys/frontend/onboarding/steps'
@@ -36,4 +37,5 @@ export const onboardingProviderRegistry: Partial<Record<ProductKey, ProductOnboa
     [ProductKey.AI_OBSERVABILITY]: aiObservabilityOnboarding,
     [ProductKey.WORKFLOWS]: workflowsOnboarding,
     [ProductKey.LOGS]: logsOnboarding,
+    [ProductKey.MCP_ANALYTICS]: mcpAnalyticsOnboarding,
 }

--- a/frontend/src/scenes/onboarding/shared/utils.tsx
+++ b/frontend/src/scenes/onboarding/shared/utils.tsx
@@ -313,4 +313,21 @@ export const availableOnboardingProducts: AvailableOnboardingProducts = {
         scene: Scene.Logs,
         setupEffort: 'low',
     },
+    [ProductKey.MCP_ANALYTICS]: {
+        name: 'MCP analytics',
+        description: 'See how AI agents use your MCP server — tool calls, intent, and failures',
+        userCentricDescription: 'Understand how agents actually use your MCP tools',
+        capabilities: ['Tool call tracking', 'Agent intent clustering', 'Error & latency monitoring'],
+        valueProps: [
+            { title: 'Every tool call', problem: 'See exactly what the agent sent, got back, and how long it took' },
+            { title: 'Agent intent', problem: 'Know what agents were trying to do, not just which tools they ran' },
+            { title: 'Failures & gaps', problem: 'Catch failing tools and capabilities agents wish you had' },
+        ],
+        hedgehog: RobotHog,
+        icon: 'IconLlmAnalytics',
+        iconColor: 'rgb(182 42 217)',
+        url: urls.mcpAnalyticsDashboard(),
+        scene: Scene.MCPAnalytics,
+        setupEffort: 'low',
+    },
 }

--- a/frontend/src/scenes/sceneTypes.ts
+++ b/frontend/src/scenes/sceneTypes.ts
@@ -198,6 +198,7 @@ export enum Scene {
     AIObservabilityTrace = 'AIObservabilityTrace',
     AIObservabilityUsers = 'AIObservabilityUsers',
     Logs = 'Logs',
+    MCPAnalytics = 'MCPAnalytics',
     LogsAlertDetail = 'LogsAlertDetail',
     LogsAlertNotificationDetail = 'LogsAlertNotificationDetail',
     LogsSamplingNew = 'LogsSamplingNew',

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -6830,7 +6830,8 @@ export type AvailableOnboardingProducts = Record<
     | ProductKey.ERROR_TRACKING
     | ProductKey.AI_OBSERVABILITY
     | ProductKey.WORKFLOWS
-    | ProductKey.LOGS,
+    | ProductKey.LOGS
+    | ProductKey.MCP_ANALYTICS,
     OnboardingProduct
 >
 

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2732,6 +2732,7 @@ class ProductKey(StrEnum):
     LOGS = "logs"
     MARKETING_ANALYTICS = "marketing_analytics"
     MAX = "max"
+    MCP_ANALYTICS = "mcp_analytics"
     MOBILE_REPLAY = "mobile_replay"
     NOTEBOOKS = "notebooks"
     PERSONS = "persons"

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboard.stories.tsx
@@ -313,6 +313,11 @@ const meta: Meta = {
                     if (body?.query?.kind === 'MCPHarnessBreakdownQuery') {
                         return [200, { results: HARNESS_RESULTS }]
                     }
+                    // Onboarding gate: report the project as instrumented so the scene
+                    // renders the dashboard/tabs instead of the empty state.
+                    if (query.includes('has_initialize')) {
+                        return [200, { results: [[true, true]] }]
+                    }
                     if (query.includes('AS session_id')) {
                         return [200, { results: SESSION_RESULTS }]
                     }

--- a/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
@@ -1,6 +1,6 @@
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
-import { BuilderHog3, WavingHog } from 'lib/components/hedgehogs'
+import { BuilderHog3, DetectiveHog, WavingHog } from 'lib/components/hedgehogs'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { urls } from 'scenes/urls'
 
@@ -10,6 +10,22 @@ import { OnboardingStepKey } from '~/types'
 import type { MCPOnboardingState } from './mcpAnalyticsOnboardingLogic'
 
 const DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
+
+const onboardingUrl = (): string =>
+    urls.onboarding({ productKey: ProductKey.MCP_ANALYTICS, stepKey: OnboardingStepKey.INSTALL })
+
+/** Branded loading state shown while we work out whether the project has MCP events yet. */
+export function MCPAnalyticsLoading(): JSX.Element {
+    return (
+        <div className="flex flex-col items-center justify-center gap-4 py-20 text-center">
+            <DetectiveHog className="w-32 h-32" />
+            <div className="flex items-center gap-2 text-secondary">
+                <Spinner />
+                <span>Checking for MCP activity…</span>
+            </div>
+        </div>
+    )
+}
 
 /** Shown until the project captures its first `$mcp_tool_call`. Routes setup into the onboarding flow. */
 export function MCPAnalyticsOnboarding({ state }: { state: Exclude<MCPOnboardingState, 'onboarded'> }): JSX.Element {
@@ -30,17 +46,16 @@ export function MCPAnalyticsOnboarding({ state }: { state: Exclude<MCPOnboarding
             docsURL={DOCS_URL}
             actionElementOverride={
                 connected ? (
-                    <p className="text-sm text-secondary m-0">
-                        Waiting for the first <code>$mcp_tool_call</code> — this page refreshes itself.
-                    </p>
+                    <div className="flex flex-col items-start gap-3">
+                        <p className="text-sm text-secondary m-0">
+                            Waiting for the first <code>$mcp_tool_call</code> — this page refreshes itself.
+                        </p>
+                        <LemonButton type="secondary" to={onboardingUrl()}>
+                            Back to setup
+                        </LemonButton>
+                    </div>
                 ) : (
-                    <LemonButton
-                        type="primary"
-                        to={urls.onboarding({
-                            productKey: ProductKey.MCP_ANALYTICS,
-                            stepKey: OnboardingStepKey.INSTALL,
-                        })}
-                    >
+                    <LemonButton type="primary" to={onboardingUrl()}>
                         Set up MCP analytics
                     </LemonButton>
                 )

--- a/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
@@ -1,0 +1,50 @@
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { BuilderHog3, WavingHog } from 'lib/components/hedgehogs'
+import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { OnboardingStepKey } from '~/types'
+
+import type { MCPOnboardingState } from './mcpAnalyticsOnboardingLogic'
+
+const DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
+
+/** Shown until the project captures its first `$mcp_tool_call`. Routes setup into the onboarding flow. */
+export function MCPAnalyticsOnboarding({ state }: { state: Exclude<MCPOnboardingState, 'onboarded'> }): JSX.Element {
+    const connected = state === 'connected-no-calls'
+
+    return (
+        <ProductIntroduction
+            productName="MCP analytics"
+            thingName="tool call"
+            isEmpty
+            customHog={connected ? WavingHog : BuilderHog3}
+            titleOverride={connected ? "You're connected — now make a tool call" : 'See how agents use your MCP server'}
+            description={
+                connected
+                    ? "We've seen your MCP server connect, but it hasn't handled a tool call yet. Trigger a tool from your agent and this page fills in on its own."
+                    : 'Instrument your MCP server with the @posthog/mcp SDK and every tool call, agent intent, and failure lands here.'
+            }
+            docsURL={DOCS_URL}
+            actionElementOverride={
+                connected ? (
+                    <p className="text-sm text-secondary m-0">
+                        Waiting for the first <code>$mcp_tool_call</code> — this page refreshes itself.
+                    </p>
+                ) : (
+                    <LemonButton
+                        type="primary"
+                        to={urls.onboarding({
+                            productKey: ProductKey.MCP_ANALYTICS,
+                            stepKey: OnboardingStepKey.INSTALL,
+                        })}
+                    >
+                        Set up MCP analytics
+                    </LemonButton>
+                )
+            }
+        />
+    )
+}

--- a/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsOnboarding.tsx
@@ -1,18 +1,15 @@
 import { LemonButton, Spinner } from '@posthog/lemon-ui'
 
-import { BuilderHog3, DetectiveHog, WavingHog } from 'lib/components/hedgehogs'
-import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
-import { urls } from 'scenes/urls'
-
-import { ProductKey } from '~/queries/schema/schema-general'
-import { OnboardingStepKey } from '~/types'
+import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
+import { DetectiveHog, WavingHog } from 'lib/components/hedgehogs'
 
 import type { MCPOnboardingState } from './mcpAnalyticsOnboardingLogic'
-
-const DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
-
-const onboardingUrl = (): string =>
-    urls.onboarding({ productKey: ProductKey.MCP_ANALYTICS, stepKey: OnboardingStepKey.INSTALL })
+import {
+    MCP_ANALYTICS_DOCS_URL,
+    MCPAnalyticsInstallHero,
+    MCPListeningIndicator,
+    useMCPAnalyticsWizardCommand,
+} from './onboarding/MCPAnalyticsInstall'
 
 /** Branded loading state shown while we work out whether the project has MCP events yet. */
 export function MCPAnalyticsLoading(): JSX.Element {
@@ -27,39 +24,53 @@ export function MCPAnalyticsLoading(): JSX.Element {
     )
 }
 
-/** Shown until the project captures its first `$mcp_tool_call`. Routes setup into the onboarding flow. */
-export function MCPAnalyticsOnboarding({ state }: { state: Exclude<MCPOnboardingState, 'onboarded'> }): JSX.Element {
-    const connected = state === 'connected-no-calls'
+/**
+ * Shown once the server is wired up (`$mcp_initialize` seen) but no tool call has landed yet.
+ * They're already instrumented, so the hero is "make a tool call" + the live indicator; the
+ * wizard command is demoted to a secondary "instrument another server" affordance.
+ */
+function ConnectedNoCalls(): JSX.Element {
+    const { command, isCloudOrDev } = useMCPAnalyticsWizardCommand()
 
     return (
-        <ProductIntroduction
-            productName="MCP analytics"
-            thingName="tool call"
-            isEmpty
-            customHog={connected ? WavingHog : BuilderHog3}
-            titleOverride={connected ? "You're connected — now make a tool call" : 'See how agents use your MCP server'}
-            description={
-                connected
-                    ? "We've seen your MCP server connect, but it hasn't handled a tool call yet. Trigger a tool from your agent and this page fills in on its own."
-                    : 'Instrument your MCP server with the @posthog/mcp SDK and every tool call, agent intent, and failure lands here.'
-            }
-            docsURL={DOCS_URL}
-            actionElementOverride={
-                connected ? (
-                    <div className="flex flex-col items-start gap-3">
-                        <p className="text-sm text-secondary m-0">
-                            Waiting for the first <code>$mcp_tool_call</code> — this page refreshes itself.
-                        </p>
-                        <LemonButton type="secondary" to={onboardingUrl()}>
-                            Back to setup
-                        </LemonButton>
-                    </div>
-                ) : (
-                    <LemonButton type="primary" to={onboardingUrl()}>
-                        Set up MCP analytics
-                    </LemonButton>
-                )
-            }
-        />
+        <div className="flex flex-col items-center text-center gap-6 py-12 max-w-xl mx-auto">
+            <WavingHog className="w-32 h-32" />
+            <div className="space-y-2">
+                <h2 className="text-2xl font-bold">You're connected — now make a tool call</h2>
+                <p className="text-muted m-0">
+                    We've seen your MCP server connect, but it hasn't handled a tool call yet. Trigger a tool from your
+                    agent and this page fills in on its own.
+                </p>
+            </div>
+            <MCPListeningIndicator />
+            {isCloudOrDev && (
+                <div className="w-full flex flex-col items-center gap-2 pt-2">
+                    <p className="text-xs text-muted m-0">Instrumenting another server? Re-run setup:</p>
+                    <CommandBlock
+                        command={command}
+                        copyLabel="MCP wizard command"
+                        ariaLabel="Copy MCP analytics wizard command"
+                        size="sm"
+                        className="bg-bg-light border border-border"
+                    />
+                </div>
+            )}
+            <LemonButton type="tertiary" size="small" to={MCP_ANALYTICS_DOCS_URL} targetBlank>
+                Read the docs
+            </LemonButton>
+        </div>
+    )
+}
+
+/** Shown until the project captures its first `$mcp_tool_call`. Tailors by signal state. */
+export function MCPAnalyticsOnboarding({ state }: { state: Exclude<MCPOnboardingState, 'onboarded'> }): JSX.Element {
+    if (state === 'connected-no-calls') {
+        return <ConnectedNoCalls />
+    }
+    // not-instrumented: lead with the full install hero — same treatment as the onboarding page.
+    return (
+        <div className="py-8">
+            <MCPAnalyticsInstallHero />
+        </div>
     )
 }

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { router, combineUrl } from 'kea-router'
 
-import { LemonButton, LemonSkeleton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
+import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
@@ -11,7 +11,7 @@ import { SceneExport } from '~/scenes/sceneTypes'
 
 import { MCPAnalyticsClustering } from './clustering/MCPAnalyticsClustering'
 import { MCPAnalyticsDashboard } from './MCPAnalyticsDashboard'
-import { MCPAnalyticsOnboarding } from './MCPAnalyticsOnboarding'
+import { MCPAnalyticsLoading, MCPAnalyticsOnboarding } from './MCPAnalyticsOnboarding'
 import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
 import { MCPAnalyticsTab, TAB_DESCRIPTIONS, mcpAnalyticsSceneLogic } from './mcpAnalyticsSceneLogic'
 import { MCPAnalyticsToolQuality } from './MCPAnalyticsToolQuality'
@@ -76,7 +76,7 @@ export function MCPAnalyticsScene(): JSX.Element {
                 query failure. Hold the skeleton rather than falling through to the empty
                 dashboard (the very state this onboarding exists to avoid); the 20s poll retries. */}
             {signals === null ? (
-                <LemonSkeleton className="h-64 w-full" />
+                <MCPAnalyticsLoading />
             ) : onboardingState && onboardingState !== 'onboarded' ? (
                 <MCPAnalyticsOnboarding state={onboardingState} />
             ) : (

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -64,7 +64,7 @@ export function MCPAnalyticsScene(): JSX.Element {
         <SceneContent>
             <SceneTitleSection
                 name="MCP analytics"
-                description={TAB_DESCRIPTIONS[activeTab]}
+                description={onboardingState === 'onboarded' ? TAB_DESCRIPTIONS[activeTab] : null}
                 resourceType={{ type: 'llm_analytics' }}
                 actions={
                     <LemonButton to={DEFAULT_DOCS_URL} type="secondary" targetBlank size="small">

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -27,7 +27,7 @@ const DEFAULT_DOCS_URL = 'https://posthog.com/docs/mcp-analytics/installation'
 export function MCPAnalyticsScene(): JSX.Element {
     const { searchParams } = useValues(router)
     const { activeTab } = useValues(mcpAnalyticsSceneLogic)
-    const { onboardingState, signals, signalsLoading } = useValues(mcpAnalyticsOnboardingLogic)
+    const { onboardingState, signals } = useValues(mcpAnalyticsOnboardingLogic)
 
     const tabs: LemonTab<MCPAnalyticsTab>[] = [
         {
@@ -72,7 +72,10 @@ export function MCPAnalyticsScene(): JSX.Element {
                     </LemonButton>
                 }
             />
-            {signalsLoading && signals === null ? (
+            {/* `signals === null` means we don't know yet — still loading, or a transient
+                query failure. Hold the skeleton rather than falling through to the empty
+                dashboard (the very state this onboarding exists to avoid); the 20s poll retries. */}
+            {signals === null ? (
                 <LemonSkeleton className="h-64 w-full" />
             ) : onboardingState && onboardingState !== 'onboarded' ? (
                 <MCPAnalyticsOnboarding state={onboardingState} />

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -1,7 +1,7 @@
 import { useValues } from 'kea'
 import { router, combineUrl } from 'kea-router'
 
-import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
+import { LemonButton, LemonSkeleton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
 
@@ -11,6 +11,8 @@ import { SceneExport } from '~/scenes/sceneTypes'
 
 import { MCPAnalyticsClustering } from './clustering/MCPAnalyticsClustering'
 import { MCPAnalyticsDashboard } from './MCPAnalyticsDashboard'
+import { MCPAnalyticsOnboarding } from './MCPAnalyticsOnboarding'
+import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
 import { MCPAnalyticsTab, TAB_DESCRIPTIONS, mcpAnalyticsSceneLogic } from './mcpAnalyticsSceneLogic'
 import { MCPAnalyticsToolQuality } from './MCPAnalyticsToolQuality'
 import { MCPSessionsPlaylist } from './sessions/MCPSessionsPlaylist'
@@ -25,6 +27,7 @@ const DEFAULT_DOCS_URL = 'https://posthog.com/docs/mcp-analytics/installation'
 export function MCPAnalyticsScene(): JSX.Element {
     const { searchParams } = useValues(router)
     const { activeTab } = useValues(mcpAnalyticsSceneLogic)
+    const { onboardingState, signals, signalsLoading } = useValues(mcpAnalyticsOnboardingLogic)
 
     const tabs: LemonTab<MCPAnalyticsTab>[] = [
         {
@@ -69,7 +72,13 @@ export function MCPAnalyticsScene(): JSX.Element {
                     </LemonButton>
                 }
             />
-            <LemonTabs activeKey={activeTab} data-attr="mcp-analytics-tabs" tabs={tabs} sceneInset />
+            {signalsLoading && signals === null ? (
+                <LemonSkeleton className="h-64 w-full" />
+            ) : onboardingState && onboardingState !== 'onboarded' ? (
+                <MCPAnalyticsOnboarding state={onboardingState} />
+            ) : (
+                <LemonTabs activeKey={activeTab} data-attr="mcp-analytics-tabs" tabs={tabs} sceneInset />
+            )}
         </SceneContent>
     )
 }

--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
@@ -46,7 +46,10 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
                 })) as HogQLQueryResponse
                 breakpoint()
                 const row = (response?.results?.[0] as unknown[] | undefined) ?? []
-                return { hasInitialize: Boolean(row[0]), hasToolCall: Boolean(row[1]) }
+                // ClickHouse returns the `> 0` comparisons as 0/1; coerce numerically so a
+                // stringified "0" can never read as truthy (Boolean("0") would).
+                const truthy = (value: unknown): boolean => Number(value) > 0
+                return { hasInitialize: truthy(row[0]), hasToolCall: truthy(row[1]) }
             },
         },
     }),

--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
@@ -1,0 +1,86 @@
+import { afterMount, kea, listeners, path, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+
+import { HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+
+import type { mcpAnalyticsOnboardingLogicType } from './mcpAnalyticsOnboardingLogicType'
+
+export type MCPOnboardingState = 'not-instrumented' | 'connected-no-calls' | 'onboarded'
+
+export interface MCPOnboardingSignals {
+    /** A client has completed the MCP handshake — proves the SDK wrap is live. */
+    hasInitialize: boolean
+    /** A tool has actually been called — the server is in use. */
+    hasToolCall: boolean
+}
+
+// Two-signal funnel over all history. `$mcp_initialize` fires when an agent
+// connects (before any tool call), so it distinguishes "instrumented but no
+// traffic yet" from "not instrumented at all" — without it, a freshly-wired
+// server that hasn't been called looks identical to one that was never set up.
+// Filtering on the two event names hits the events sort key, so this stays cheap.
+const ONBOARDING_SIGNAL_QUERY = `
+SELECT
+    countIf(event = '$mcp_initialize') > 0 AS has_initialize,
+    countIf(event = '$mcp_tool_call') > 0 AS has_tool_call
+FROM events
+WHERE event IN ('$mcp_initialize', '$mcp_tool_call')
+`
+
+// While the user is still onboarding we re-check on a timer so the page flips to
+// the dashboard on its own the moment the first events land. The disposables
+// plugin pauses this on hidden tabs and tears it down on unmount.
+const POLL_INTERVAL_MS = 20000
+
+export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>([
+    path(['products', 'mcp_analytics', 'frontend', 'mcpAnalyticsOnboardingLogic']),
+    loaders({
+        signals: {
+            __default: null as MCPOnboardingSignals | null,
+            loadSignals: async (_: void, breakpoint): Promise<MCPOnboardingSignals> => {
+                const response = (await api.query({
+                    kind: NodeKind.HogQLQuery,
+                    query: ONBOARDING_SIGNAL_QUERY,
+                })) as HogQLQueryResponse
+                breakpoint()
+                const row = (response?.results?.[0] as unknown[] | undefined) ?? []
+                return { hasInitialize: Boolean(row[0]), hasToolCall: Boolean(row[1]) }
+            },
+        },
+    }),
+    selectors({
+        onboardingState: [
+            (s) => [s.signals],
+            (signals): MCPOnboardingState | null => {
+                if (!signals) {
+                    return null
+                }
+                if (signals.hasToolCall) {
+                    return 'onboarded'
+                }
+                if (signals.hasInitialize) {
+                    return 'connected-no-calls'
+                }
+                return 'not-instrumented'
+            },
+        ],
+        isOnboarded: [(s) => [s.onboardingState], (onboardingState): boolean => onboardingState === 'onboarded'],
+    }),
+    listeners(({ values, cache }) => ({
+        loadSignalsSuccess: () => {
+            // Once tool calls show up the gate flips for good — stop polling.
+            if (values.isOnboarded) {
+                cache.disposables.dispose('poll')
+            }
+        },
+    })),
+    afterMount(({ actions, cache }) => {
+        actions.loadSignals()
+        cache.disposables.add(() => {
+            const id = window.setInterval(() => actions.loadSignals(), POLL_INTERVAL_MS)
+            return () => clearInterval(id)
+        }, 'poll')
+    }),
+])

--- a/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
@@ -1,7 +1,14 @@
-import { connect, kea, path, selectors } from 'kea'
+import { connect, kea, listeners, path, selectors } from 'kea'
+import { router } from 'kea-router'
 
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
 import { sceneLogic } from '~/scenes/sceneLogic'
+import { OnboardingStepKey } from '~/types'
 
+import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
 import type { mcpAnalyticsSceneLogicType } from './mcpAnalyticsSceneLogicType'
 
 export type MCPAnalyticsTab = 'dashboard' | 'sessions' | 'tool-quality' | 'intent-clustering'
@@ -24,7 +31,14 @@ const SCENE_KEY_TO_TAB: Record<string, MCPAnalyticsTab> = {
 export const mcpAnalyticsSceneLogic = kea<mcpAnalyticsSceneLogicType>([
     path(['products', 'mcp_analytics', 'frontend', 'mcpAnalyticsSceneLogic']),
     connect(() => ({
-        values: [sceneLogic, ['sceneKey']],
+        values: [
+            sceneLogic,
+            ['sceneKey'],
+            mcpAnalyticsOnboardingLogic,
+            ['onboardingState'],
+            teamLogic,
+            ['currentTeam'],
+        ],
     })),
     selectors({
         activeTab: [
@@ -32,4 +46,18 @@ export const mcpAnalyticsSceneLogic = kea<mcpAnalyticsSceneLogicType>([
             (sceneKey: string): MCPAnalyticsTab => SCENE_KEY_TO_TAB[sceneKey] ?? 'dashboard',
         ],
     }),
+    listeners(({ values }) => ({
+        // Send never-set-up projects straight into the polished onboarding flow,
+        // rather than the bare in-scene card. Guarded on `has_completed_onboarding_for`
+        // so the post-onboarding return to the dashboard doesn't bounce back here —
+        // once they've been through setup we let the in-scene "waiting" state show.
+        [mcpAnalyticsOnboardingLogic.actionTypes.loadSignalsSuccess]: () => {
+            const completed = values.currentTeam?.has_completed_onboarding_for?.[ProductKey.MCP_ANALYTICS]
+            if (values.onboardingState === 'not-instrumented' && !completed) {
+                router.actions.replace(
+                    urls.onboarding({ productKey: ProductKey.MCP_ANALYTICS, stepKey: OnboardingStepKey.INSTALL })
+                )
+            }
+        },
+    })),
 ])

--- a/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
@@ -14,7 +14,7 @@ import type { mcpAnalyticsSceneLogicType } from './mcpAnalyticsSceneLogicType'
 export type MCPAnalyticsTab = 'dashboard' | 'sessions' | 'tool-quality' | 'intent-clustering'
 
 export const TAB_DESCRIPTIONS: Record<MCPAnalyticsTab, string> = {
-    dashboard: 'Overview of your MCP usage.',
+    dashboard: 'Tool call volume, error rates, and latency across your MCP server.',
     sessions: 'Sessions where users interacted with your MCP tools.',
     'tool-quality': 'Understand how reliably your MCP tools support user workflows.',
     'intent-clustering':

--- a/products/mcp_analytics/frontend/onboarding/MCPAnalyticsInstall.tsx
+++ b/products/mcp_analytics/frontend/onboarding/MCPAnalyticsInstall.tsx
@@ -1,0 +1,119 @@
+import { useValues } from 'kea'
+
+import { IconCheckCircle } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
+import { cn } from 'lib/utils/css-classes'
+import { WIZARD_HOG_URL } from 'scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock'
+import { useWizardCommand } from 'scenes/onboarding/shared/SetupWizardBanner'
+import { teamLogic } from 'scenes/teamLogic'
+
+import { mcpAnalyticsOnboardingLogic } from '../mcpAnalyticsOnboardingLogic'
+
+export const MCP_ANALYTICS_DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
+
+// The shared wizard hook only emits the base command; slot in our subcommand right
+// after the package reference (before any flags like `--region eu`). Matching
+// `@posthog/wizard@<anything>` keeps this working if the hook ever pins a version;
+// the fallback guarantees the subcommand is never silently dropped.
+const WIZARD_PKG_RE = /@posthog\/wizard@\S+/
+
+export function useMCPAnalyticsWizardCommand(): { command: string; isCloudOrDev: boolean } {
+    const { wizardCommand, isCloudOrDev } = useWizardCommand()
+    const { currentTeam } = useValues(teamLogic)
+    const base = WIZARD_PKG_RE.test(wizardCommand)
+        ? wizardCommand.replace(WIZARD_PKG_RE, '$& mcp-analytics')
+        : `${wizardCommand} mcp-analytics`
+    // Pin the project so the wizard targets this team directly — and, once the consent
+    // screen honors the hint, pre-selects it. Harmless if the user authorizes the same project.
+    const command = currentTeam?.id ? `${base} --project-id=${currentTeam.id}` : base
+    return { command, isCloudOrDev }
+}
+
+/** Live "are events arriving yet?" status, driven by the same poll the scene uses. */
+export function MCPListeningIndicator(): JSX.Element {
+    const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
+
+    if (onboardingState === 'onboarded') {
+        return (
+            <div className="flex items-center gap-2 text-success">
+                <IconCheckCircle className="text-lg" />
+                <span>Tool calls are flowing — you're all set.</span>
+            </div>
+        )
+    }
+    if (onboardingState === 'connected-no-calls') {
+        return (
+            <div className="flex items-center gap-2 text-secondary">
+                <IconCheckCircle className="text-lg text-success" />
+                <span>Server connected — waiting for the first tool call…</span>
+            </div>
+        )
+    }
+    return (
+        <div className="flex items-center gap-2 text-secondary">
+            <Spinner />
+            <span>Listening for your first MCP event…</span>
+        </div>
+    )
+}
+
+/**
+ * The "instrument in one command" hero — heading, rainbow wizard command, project nudge, and
+ * a live listening indicator. Shared by the onboarding step and the in-scene empty state so the
+ * two surfaces can't drift.
+ */
+export function MCPAnalyticsInstallHero(): JSX.Element {
+    const { command, isCloudOrDev } = useMCPAnalyticsWizardCommand()
+    const { currentTeam } = useValues(teamLogic)
+
+    return (
+        <div className="w-full max-w-2xl mx-auto space-y-8">
+            <div className="text-center space-y-3">
+                <h2 className="text-2xl font-bold">Skip the setup. Instrument in one command.</h2>
+                <p className="text-muted">
+                    Run this from your MCP server's project root. The wizard detects how your server is built, installs
+                    the <code>@posthog/mcp</code> SDK, wires up your credentials, and starts capturing every tool call,
+                    agent intent, and failure.
+                </p>
+                <p className="text-muted text-xs">LLM inference is on us, no API key needed.</p>
+            </div>
+
+            {isCloudOrDev && (
+                <div className="flex items-center gap-6">
+                    <img
+                        src={WIZARD_HOG_URL}
+                        alt="PostHog wizard hedgehog"
+                        className={cn('w-28 h-28 hidden md:block shrink-0')}
+                    />
+                    <div className="flex-1 min-w-0 flex flex-col gap-3">
+                        <CommandBlock
+                            command={command}
+                            copyLabel="MCP wizard command"
+                            ariaLabel="Copy MCP analytics wizard command"
+                            size="md"
+                            decoration="rainbow"
+                            className="bg-bg-light border border-border hover:border-primary"
+                        />
+                        <p className="text-xs text-muted mb-0">
+                            {currentTeam?.name ? (
+                                <>
+                                    Authorize access to <strong>{currentTeam.name}</strong> when prompted.{' '}
+                                </>
+                            ) : null}
+                            Then make a tool call — this page fills in the moment events arrive.
+                        </p>
+                    </div>
+                </div>
+            )}
+
+            <div className="flex flex-col items-center gap-2">
+                <MCPListeningIndicator />
+                <LemonButton type="tertiary" size="small" to={MCP_ANALYTICS_DOCS_URL} targetBlank>
+                    Prefer to set it up manually? Read the docs
+                </LemonButton>
+            </div>
+        </div>
+    )
+}

--- a/products/mcp_analytics/frontend/onboarding/steps.tsx
+++ b/products/mcp_analytics/frontend/onboarding/steps.tsx
@@ -1,0 +1,132 @@
+import { useActions, useValues } from 'kea'
+import { useEffect } from 'react'
+
+import { IconCheckCircle } from '@posthog/icons'
+import { LemonButton, Spinner } from '@posthog/lemon-ui'
+
+import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
+import { cn } from 'lib/utils/css-classes'
+import { onboardingLogic } from 'scenes/onboarding/legacy/onboardingLogic'
+import { OnboardingStep } from 'scenes/onboarding/legacy/OnboardingStep'
+import { WIZARD_HOG_URL } from 'scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock'
+import { type ProductOnboardingProvider } from 'scenes/onboarding/legacy/types'
+import { useWizardCommand } from 'scenes/onboarding/shared/SetupWizardBanner'
+import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
+
+import { ProductKey } from '~/queries/schema/schema-general'
+import { OnboardingStepKey } from '~/types'
+
+import { mcpAnalyticsOnboardingLogic } from '../mcpAnalyticsOnboardingLogic'
+
+const DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
+
+/** Live "are events arriving yet?" status, driven by the same poll the scene uses. */
+function ListeningIndicator(): JSX.Element {
+    const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
+
+    if (onboardingState === 'onboarded') {
+        return (
+            <div className="flex items-center gap-2 text-success">
+                <IconCheckCircle className="text-lg" />
+                <span>Tool calls are flowing — you're all set.</span>
+            </div>
+        )
+    }
+    if (onboardingState === 'connected-no-calls') {
+        return (
+            <div className="flex items-center gap-2 text-secondary">
+                <IconCheckCircle className="text-lg text-success" />
+                <span>Server connected — waiting for the first tool call…</span>
+            </div>
+        )
+    }
+    return (
+        <div className="flex items-center gap-2 text-secondary">
+            <Spinner />
+            <span>Listening for your first MCP event…</span>
+        </div>
+    )
+}
+
+function MCPAnalyticsInstallStep(): JSX.Element {
+    const { wizardCommand, isCloudOrDev } = useWizardCommand()
+    const { currentTeam } = useValues(teamLogic)
+    const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
+    const { completeOnboarding } = useActions(onboardingLogic)
+    // The shared wizard hook only emits the base command; slot in our subcommand.
+    const command = wizardCommand.replace('@posthog/wizard@latest', '@posthog/wizard@latest mcp-analytics')
+
+    // The moment tool calls start flowing the setup worked — whisk them to their data
+    // instead of making them click "Go to dashboard".
+    useEffect(() => {
+        if (onboardingState === 'onboarded') {
+            completeOnboarding()
+        }
+    }, [onboardingState, completeOnboarding])
+
+    return (
+        <OnboardingStep title="Install" stepKey={OnboardingStepKey.INSTALL} continueText="Go to dashboard">
+            <div className="mt-6 space-y-8">
+                <div className="text-center max-w-2xl mx-auto space-y-3">
+                    <h2 className="text-2xl font-bold">Skip the setup. Instrument in one command.</h2>
+                    <p className="text-muted">
+                        Run this from your MCP server's project root. The wizard detects how your server is built,
+                        installs the <code>@posthog/mcp</code> SDK, wires up your credentials, and starts capturing
+                        every tool call, agent intent, and failure.
+                    </p>
+                    <p className="text-muted text-xs">LLM inference is on us, no API key needed.</p>
+                </div>
+
+                {isCloudOrDev && (
+                    <div className="flex items-center gap-6">
+                        <img
+                            src={WIZARD_HOG_URL}
+                            alt="PostHog wizard hedgehog"
+                            className={cn('w-28 h-28 hidden md:block shrink-0')}
+                        />
+                        <div className="flex-1 min-w-0 flex flex-col gap-3">
+                            <CommandBlock
+                                command={command}
+                                copyLabel="MCP wizard command"
+                                ariaLabel="Copy MCP analytics wizard command"
+                                size="md"
+                                decoration="rainbow"
+                                className="bg-bg-light border border-border hover:border-primary"
+                            />
+                            <p className="text-xs text-muted mb-0">
+                                {currentTeam?.name ? (
+                                    <>
+                                        When the wizard asks which project to use, choose{' '}
+                                        <strong>{currentTeam.name}</strong>.{' '}
+                                    </>
+                                ) : null}
+                                Then make a tool call — this page fills in the moment events arrive.
+                            </p>
+                        </div>
+                    </div>
+                )}
+
+                <div className="flex flex-col items-center gap-2">
+                    <ListeningIndicator />
+                    <LemonButton type="tertiary" size="small" to={DOCS_URL}>
+                        Prefer to set it up manually? Read the docs
+                    </LemonButton>
+                </div>
+            </div>
+        </OnboardingStep>
+    )
+}
+
+export const mcpAnalyticsOnboarding: ProductOnboardingProvider = {
+    steps: (ctx) => [
+        {
+            id: `${OnboardingStepKey.INSTALL}:${ProductKey.MCP_ANALYTICS}`,
+            productKey: ProductKey.MCP_ANALYTICS,
+            stepKey: OnboardingStepKey.INSTALL,
+            role: ctx.role,
+            render: () => <MCPAnalyticsInstallStep />,
+        },
+    ],
+    completeRedirectUrl: () => urls.mcpAnalyticsDashboard(),
+}

--- a/products/mcp_analytics/frontend/onboarding/steps.tsx
+++ b/products/mcp_analytics/frontend/onboarding/steps.tsx
@@ -1,67 +1,20 @@
 import { useActions, useValues } from 'kea'
 import { useEffect } from 'react'
 
-import { IconCheckCircle } from '@posthog/icons'
-import { LemonButton, Spinner } from '@posthog/lemon-ui'
-
-import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
-import { cn } from 'lib/utils/css-classes'
 import { onboardingLogic } from 'scenes/onboarding/legacy/onboardingLogic'
 import { OnboardingStep } from 'scenes/onboarding/legacy/OnboardingStep'
-import { WIZARD_HOG_URL } from 'scenes/onboarding/legacy/sdks/OnboardingInstallStep/WizardCommandBlock'
 import { type ProductOnboardingProvider } from 'scenes/onboarding/legacy/types'
-import { useWizardCommand } from 'scenes/onboarding/shared/SetupWizardBanner'
-import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
 
 import { ProductKey } from '~/queries/schema/schema-general'
 import { OnboardingStepKey } from '~/types'
 
 import { mcpAnalyticsOnboardingLogic } from '../mcpAnalyticsOnboardingLogic'
-
-const DOCS_URL = 'https://posthog.com/docs/mcp-analytics'
-
-/** Live "are events arriving yet?" status, driven by the same poll the scene uses. */
-function ListeningIndicator(): JSX.Element {
-    const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
-
-    if (onboardingState === 'onboarded') {
-        return (
-            <div className="flex items-center gap-2 text-success">
-                <IconCheckCircle className="text-lg" />
-                <span>Tool calls are flowing — you're all set.</span>
-            </div>
-        )
-    }
-    if (onboardingState === 'connected-no-calls') {
-        return (
-            <div className="flex items-center gap-2 text-secondary">
-                <IconCheckCircle className="text-lg text-success" />
-                <span>Server connected — waiting for the first tool call…</span>
-            </div>
-        )
-    }
-    return (
-        <div className="flex items-center gap-2 text-secondary">
-            <Spinner />
-            <span>Listening for your first MCP event…</span>
-        </div>
-    )
-}
+import { MCPAnalyticsInstallHero } from './MCPAnalyticsInstall'
 
 function MCPAnalyticsInstallStep(): JSX.Element {
-    const { wizardCommand, isCloudOrDev } = useWizardCommand()
-    const { currentTeam } = useValues(teamLogic)
     const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
     const { completeOnboarding } = useActions(onboardingLogic)
-    // The shared wizard hook only emits the base command; slot in our subcommand right
-    // after the package reference (before any flags like `--region eu`). Matching
-    // `@posthog/wizard@<anything>` keeps this working if the hook ever pins a version;
-    // the fallback guarantees the subcommand is never silently dropped.
-    const WIZARD_PKG_RE = /@posthog\/wizard@\S+/
-    const command = WIZARD_PKG_RE.test(wizardCommand)
-        ? wizardCommand.replace(WIZARD_PKG_RE, '$& mcp-analytics')
-        : `${wizardCommand} mcp-analytics`
 
     // The moment tool calls start flowing the setup worked — whisk them to their data
     // instead of making them click "Go to dashboard".
@@ -73,52 +26,8 @@ function MCPAnalyticsInstallStep(): JSX.Element {
 
     return (
         <OnboardingStep title="Install" stepKey={OnboardingStepKey.INSTALL} continueText="Go to dashboard">
-            <div className="mt-6 space-y-8">
-                <div className="text-center max-w-2xl mx-auto space-y-3">
-                    <h2 className="text-2xl font-bold">Skip the setup. Instrument in one command.</h2>
-                    <p className="text-muted">
-                        Run this from your MCP server's project root. The wizard detects how your server is built,
-                        installs the <code>@posthog/mcp</code> SDK, wires up your credentials, and starts capturing
-                        every tool call, agent intent, and failure.
-                    </p>
-                    <p className="text-muted text-xs">LLM inference is on us, no API key needed.</p>
-                </div>
-
-                {isCloudOrDev && (
-                    <div className="flex items-center gap-6">
-                        <img
-                            src={WIZARD_HOG_URL}
-                            alt="PostHog wizard hedgehog"
-                            className={cn('w-28 h-28 hidden md:block shrink-0')}
-                        />
-                        <div className="flex-1 min-w-0 flex flex-col gap-3">
-                            <CommandBlock
-                                command={command}
-                                copyLabel="MCP wizard command"
-                                ariaLabel="Copy MCP analytics wizard command"
-                                size="md"
-                                decoration="rainbow"
-                                className="bg-bg-light border border-border hover:border-primary"
-                            />
-                            <p className="text-xs text-muted mb-0">
-                                {currentTeam?.name ? (
-                                    <>
-                                        When the wizard asks which project to use, choose{' '}
-                                        <strong>{currentTeam.name}</strong>.{' '}
-                                    </>
-                                ) : null}
-                                Then make a tool call — this page fills in the moment events arrive.
-                            </p>
-                        </div>
-                    </div>
-                )}
-
-                <div className="flex flex-col items-center gap-2">
-                    <ListeningIndicator />
-                    <LemonButton type="tertiary" size="small" to={DOCS_URL}>
-                        Prefer to set it up manually? Read the docs
-                    </LemonButton>
-                </div>
+            <div className="mt-6">
+                <MCPAnalyticsInstallHero />
             </div>
         </OnboardingStep>
     )

--- a/products/mcp_analytics/frontend/onboarding/steps.tsx
+++ b/products/mcp_analytics/frontend/onboarding/steps.tsx
@@ -54,8 +54,14 @@ function MCPAnalyticsInstallStep(): JSX.Element {
     const { currentTeam } = useValues(teamLogic)
     const { onboardingState } = useValues(mcpAnalyticsOnboardingLogic)
     const { completeOnboarding } = useActions(onboardingLogic)
-    // The shared wizard hook only emits the base command; slot in our subcommand.
-    const command = wizardCommand.replace('@posthog/wizard@latest', '@posthog/wizard@latest mcp-analytics')
+    // The shared wizard hook only emits the base command; slot in our subcommand right
+    // after the package reference (before any flags like `--region eu`). Matching
+    // `@posthog/wizard@<anything>` keeps this working if the hook ever pins a version;
+    // the fallback guarantees the subcommand is never silently dropped.
+    const WIZARD_PKG_RE = /@posthog\/wizard@\S+/
+    const command = WIZARD_PKG_RE.test(wizardCommand)
+        ? wizardCommand.replace(WIZARD_PKG_RE, '$& mcp-analytics')
+        : `${wizardCommand} mcp-analytics`
 
     // The moment tool calls start flowing the setup worked — whisk them to their data
     // instead of making them click "Go to dashboard".


### PR DESCRIPTION
## Problem

MCP analytics had no real onboarding. A project with no MCP events landed on flat-zero dashboards with no guidance, and there was no path from "I want this" to "events are flowing." We want the same polished, event-gated onboarding every other product gets — so a customer is considered onboarded only once we actually see their MCP events.

## Changes

All behind the existing **`mcp-analytics`** early-access flag.

- **Event-gated onboarding logic** (`mcpAnalyticsOnboardingLogic`): a two-signal funnel over `$mcp_initialize` (server connected) and `$mcp_tool_call` (in use), unbounded in time, polled every 20s via `cache.disposables` so the UI flips on its own when events land — and stops polling once onboarded.
- **Registers MCP analytics as a first-class onboarding product** at `/onboarding/mcp_analytics`: `ProductKey.MCP_ANALYTICS`, `Scene.MCPAnalytics`, an `availableOnboardingProducts` entry, and a provider. The install step reuses the polished wizard primitives (rainbow `CommandBlock` + wizard hog) showing `npx @posthog/wizard mcp-analytics`, an in-app docs side-panel shortcut, and a live "listening for events" indicator.
- **Scene gate** (`mcpAnalyticsSceneLogic` + `MCPAnalyticsScene`): never-set-up projects auto-redirect into the onboarding flow (guarded on `has_completed_onboarding_for` so the post-onboarding return doesn't loop); instrumented-but-no-calls shows a waiting state; events flowing shows the dashboard. Onboarding auto-advances to the dashboard the moment tool calls arrive.
- A nudge to pick the current project when the wizard prompts, to avoid instrumenting the wrong one.

<img width="2578" height="1668" alt="CleanShot 2026-06-26 at 13 08 03@2x" src="https://github.com/user-attachments/assets/6de4a73e-c007-4152-a3e6-125888a817da" />


## How did you test this code?

I'm an agent (PostHog Code). I did **not** manually click through the running UI — the DRI is verifying locally. Automated checks I actually ran:

- `tsgo --noEmit`: no new type errors from these files (the repo-wide `*LogicType` errors in this checkout are missing kea typegen, regenerated by CI).
- `oxlint` + `oxfmt`: clean on all touched files.
- kea typegen generated for the new/changed logics.

The companion wizard command (`@posthog/wizard mcp-analytics`, v2.32) and skill (context-mill v1.24) are already released; the official-SDK instrumentation path was verified end-to-end on a real third-party server. The mcp-handler and custom-dispatcher paths, and the full live loop (run wizard → tool call → dashboard), are pending DRI verification.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI assigned.

Built with PostHog Code, directed by the DRI. Skills invoked: `/using-kea-disposables` (for the 20s poll teardown). Notable decisions:
- Chose a **two-signal funnel** (`$mcp_initialize` → `$mcp_tool_call`) over a single "any event" check so an instrumented-but-not-yet-called server isn't misread as "not set up."
- Reused the **onboarding framework** rather than a bespoke empty state, after the first cut (a plain `ProductIntroduction`) didn't match the polish of other products' `/onboarding` pages.
- Built a **custom install step** instead of the stock `OnboardingInstallStep`, because the shared `WizardCommandBlock` hardcodes the base wizard command (no subcommand) and shows SDK-framework chips that are misleading for MCP servers.
- Known follow-ups (not in this PR): the wizard only honors `--project-id` on the CI path, so the project-pick is currently a copy nudge — a wizard change to honor it post-OAuth is the real fix; and mcp-handler/custom-dispatcher path verification.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
