### PR TITLE
fix(ci): stop fork PRs failing on cross-shard unused snapshots

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -2263,6 +2263,26 @@ jobs:
               shell: bash
               run: echo "PYTEST_ARGS=--snapshot-update --snapshot-warn-unused" >> $GITHUB_ENV
 
+            - name: Warn (don't fail) on unused snapshots for sharded CHECK runs
+              # CHECK mode (fork PRs, the 'no-snapshot-update' label) runs without
+              # --snapshot-update, so the steps above don't fire and no snapshot flags
+              # are set. But pytest-split shards individual tests across runners, so each
+              # shard only exercises a subset of the snapshots in a given file — every
+              # snapshot owned by a test that landed on another shard is reported as
+              # "unused". Under sharding that signal is structurally unreliable, so without
+              # --snapshot-warn-unused a shard fails on those false positives even when
+              # every test that ran passed (the snapshot report's "N snapshots unused"
+              # line). Every non-fork run (UPDATE, poe, compat) already passes the flag;
+              # this just makes forks symmetric. Trade-off: it downgrades unused snapshots
+              # to a warning, so genuinely orphaned snapshots go uncaught here — but they
+              # already do everywhere else, and sharding makes per-shard orphan detection
+              # impossible regardless. Snapshot *mismatches* and missing snapshots still
+              # fail, so real value drift is still caught. Mutually exclusive with the
+              # steps above (mode != update, not poe, not compat).
+              if: ${{ needs.changes.outputs.backend == 'true' && needs.detect-snapshot-mode.outputs.mode != 'update' && !matrix.person-on-events && !matrix.compat }}
+              shell: bash
+              run: echo "PYTEST_ARGS=--snapshot-warn-unused" >> $GITHUB_ENV
+
             # Tests
             - name: Log test environment diagnostics
               if: ${{ needs.changes.outputs.backend == 'true' && matrix.segment == 'Core' }}


### PR DESCRIPTION
## Problem

Fork PRs that touch the backend reliably fail the `Django tests – Core/Temporal` shards on a snapshot check even when every test passes. Recent examples (#65355, #63351, #65961, #65375) are all from external contributors and all went red on shard 14/22 with an identical signature: `603 passed, 0 failed`, then `203 snapshots passed. 97 snapshots unused.`, then exit 1.

The cause is structural, not the contributors' code. `pytest-split` shards individual tests across 22 runners, so any given shard runs only a fraction of the tests and sees every snapshot owned by a test that landed on another shard as "unused". syrupy fails the run on unused snapshots unless `--snapshot-warn-unused` is passed. The snapshot-flag steps only set that flag in UPDATE mode, persons-on-events, and compat. Fork PRs are forced into CHECK mode (forks can't run the bot that commits snapshot updates back), and that path set no snapshot flags at all, so the unused-snapshot false positives fail the shard.

Every internal PR and master push already runs with `--snapshot-warn-unused`, so they never hit this. Forks were the only ones held to a standard that sharding makes impossible to meet.

## Changes

Add `--snapshot-warn-unused` to `PYTEST_ARGS` for sharded CHECK-mode runs, which previously got no snapshot flags. It's one new step, mutually exclusive with the existing two across every matrix combination (`mode != update`, not persons-on-events, not compat). It fixes both the Core and Temporal sharded runs, since both consume `$PYTEST_ARGS`.

This makes fork CHECK runs symmetric with every other run. The flag downgrades only the unused check. Snapshot mismatches and missing snapshots still fail, so genuine value drift is still caught.

One trade-off, stated plainly: this eliminates unused-snapshot enforcement for forks rather than relocating it, so genuinely orphaned snapshots go uncaught on these runs. That's already the case for every internal PR and master, and per-shard orphan detection is impossible under sharding regardless. If we want real orphan detection back, the follow-up is a separate unsharded job that sees the whole suite at once. That's deliberately out of scope here to keep the fix minimal.

## How did you test this code?

No CI run proves this yet. The real proof is a fork PR going green, which only shows once this is on master. Static verification I did:

- Confirmed the four failing PRs are all forks (`isCrossRepository: true`) based on the current master tip, with byte-identical failure signatures (`603 passed`, `97 snapshots unused`, exit 1) on shard 14/22, so it isn't their diffs.
- Confirmed master is green on the same commit those branches fork from, ruling out a master regression.
- Traced the mode logic: `detect-snapshot-mode` returns CHECK for forks, the existing flag steps don't fire, and `$PYTEST_ARGS` is empty at both the Core and Temporal pytest call sites.
- Walked the new step's `if` against every matrix cell (update/check by poe/compat, Core and Temporal) to confirm mutual exclusivity and no `GITHUB_ENV` clobber.
- YAML validates, and `hogli format:yaml` ran clean via lint-staged.