### PR TITLE
perf(signals): batch source config status lookups to fix N+1 on inbox load

### DIFF
--- a/products/signals/backend/serializers.py
+++ b/products/signals/backend/serializers.py
@@ -1,6 +1,7 @@
 import json
 import logging
 from collections.abc import Mapping
+from functools import cached_property
 from typing import cast
 
 from asgiref.sync import async_to_sync
@@ -56,65 +57,79 @@ class SignalSourceConfigSerializer(serializers.ModelSerializer):
 
     def get_status(self, obj: SignalSourceConfig) -> str | None:
         if obj.source_type == SignalSourceConfig.SourceType.SESSION_ANALYSIS_CLUSTER:
-            return self._get_session_analysis_status(obj.team_id)
+            return "running" if self._session_analysis_running else None
 
         mapping = _DATA_IMPORT_SOURCE_MAP.get((obj.source_product, obj.source_type))
         if mapping is None:
             return None
         ext_source_type, schema_name = mapping
-        return self._get_data_import_status(obj.team_id, ext_source_type, schema_name)
+        return self._data_import_schema_statuses.get((ext_source_type, schema_name))
 
-    # Per-row Temporal RPC: serializing N source configs issues N of these on inbox load.
-    # The span surfaces that cost so the N+1 is visible per request in APM.
-    @tracer.start_as_current_span("signals.source_config.session_analysis_status")
-    def _get_session_analysis_status(self, team_id: int) -> str | None:
-        """ "running" iff any `summarize-session` workflow for this team is currently executing."""
+    @cached_property
+    def _session_analysis_running(self) -> bool:
+        """True iff any `summarize-session` workflow is running for this team.
+
+        Fires once per serializer instance (i.e. once per list request) rather than once per row.
+        The viewset is team-scoped, so all rows share the same team_id.
+        """
+        team_id = self.context.get("team_id")
+        if team_id is None:
+            return False
         query = f'PostHogTeamId = {team_id} AND WorkflowType = "summarize-session" AND ExecutionStatus = "Running"'
+        with tracer.start_as_current_span("signals.source_config.session_analysis_status") as span:
+            try:
+                temporal = sync_connect()
 
-        try:
-            temporal = sync_connect()
+                async def has_running() -> bool:
+                    async for _ in temporal.list_workflows(query=query, page_size=1):
+                        return True
+                    return False
 
-            async def has_running() -> bool:
-                async for _ in temporal.list_workflows(query=query, page_size=1):
-                    return True
+                return async_to_sync(has_running)()
+            except Exception as e:
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR))
+                logger.warning("Failed to list session summarization workflows: %s", e)
                 return False
 
-            if async_to_sync(has_running)():
-                return "running"
-        except Exception as e:
-            # The except swallows the error, so OTel won't auto-record it on the span — mark it
-            # failed explicitly, else an unreachable Temporal looks like a successful no-op in APM.
-            span = trace.get_current_span()
-            span.record_exception(e)
-            span.set_status(Status(StatusCode.ERROR))
-            logger.warning("Failed to list session summarization workflows: %s", e)
-        return None
+    @cached_property
+    def _data_import_schema_statuses(self) -> dict[tuple[str, str], str | None]:
+        """Prefetch all data-import schema statuses for this team in one query.
 
-    def _get_data_import_status(self, team_id: int, ext_source_type: str, schema_name: str) -> str | None:
+        Fires once per serializer instance rather than once per row. Keyed by
+        (ext_source_type, schema_name) — the same lookup the old per-row path used.
+        """
         from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
-        schema = (
+        team_id = self.context.get("team_id")
+        if team_id is None:
+            return {}
+
+        needed_source_types = {ext_source_type for ext_source_type, _ in _DATA_IMPORT_SOURCE_MAP.values()}
+        rows = (
             ExternalDataSchema.objects.filter(
                 team_id=team_id,
-                source__source_type=ext_source_type,
-                name=schema_name,
+                source__source_type__in=needed_source_types,
             )
             .exclude(source__deleted=True)
-            .first()
+            .values("source__source_type", "name", "status")
         )
-        if schema is None:
-            return None
-        if schema.status == ExternalDataSchema.Status.RUNNING:
-            return "running"
-        if schema.status == ExternalDataSchema.Status.COMPLETED:
-            return "completed"
-        if schema.status in (
-            ExternalDataSchema.Status.FAILED,
-            ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
-            ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
-        ):
-            return "failed"
-        return None
+
+        result: dict[tuple[str, str], str | None] = {}
+        for row in rows:
+            key = (row["source__source_type"], row["name"])
+            s = row["status"]
+            if s == ExternalDataSchema.Status.RUNNING:
+                result[key] = "running"
+            elif s == ExternalDataSchema.Status.COMPLETED:
+                result[key] = "completed"
+            elif s in (
+                ExternalDataSchema.Status.FAILED,
+                ExternalDataSchema.Status.BILLING_LIMIT_REACHED,
+                ExternalDataSchema.Status.BILLING_LIMIT_TOO_LOW,
+            ):
+                result[key] = "failed"
+        return result
 
     def validate(self, attrs: dict) -> dict:
         source_product = attrs.get("source_product", getattr(self.instance, "source_product", None))

--- a/products/signals/backend/test/test_signal_source_config_api.py
+++ b/products/signals/backend/test/test_signal_source_config_api.py
@@ -1,4 +1,8 @@
 from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock, patch
+
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 
 from parameterized import parameterized
 from rest_framework import status
@@ -364,6 +368,58 @@ class TestSignalSourceConfigAPI(APIBaseTest):
         self.client.logout()
         response = self.client.get(self._url())
         assert response.status_code in (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN)
+
+    # --- Status batching (N+1 guard) ---
+
+    def test_data_import_status_db_query_not_scaled_by_row_count(self):
+        # Three data-import rows — without the cached_property fix, ExternalDataSchema
+        # is queried once per row instead of once for the whole list.
+        for source_product, source_type in [
+            ("github", "issue"),
+            ("linear", "issue"),
+            ("zendesk", "ticket"),
+        ]:
+            SignalSourceConfig.objects.create(
+                team=self.team,
+                source_product=source_product,
+                source_type=source_type,
+                created_by=self.user,
+            )
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(self._url())
+
+        assert response.status_code == status.HTTP_200_OK
+        assert len(response.json()["results"]) == 3
+
+        schema_queries = [q for q in ctx.captured_queries if "externaldataschema" in q["sql"].lower()]
+        assert len(schema_queries) == 1, (
+            f"Expected 1 ExternalDataSchema query for {len(response.json()['results'])} rows, got {len(schema_queries)}"
+        )
+
+    def test_session_analysis_temporal_rpc_called_once_per_request(self):
+        # Without the cached_property fix, sync_connect would fire once per
+        # SESSION_ANALYSIS_CLUSTER row. Even with the unique constraint limiting
+        # this to 1 row per team today, the cache prevents breakage if that changes.
+        SignalSourceConfig.objects.create(
+            team=self.team,
+            source_product="session_replay",
+            source_type="session_analysis_cluster",
+            created_by=self.user,
+        )
+
+        async def _no_running_workflows(*args, **kwargs):
+            return
+            yield  # makes this an async generator
+
+        mock_temporal = MagicMock()
+        mock_temporal.list_workflows = _no_running_workflows
+
+        with patch("products.signals.backend.serializers.sync_connect", return_value=mock_temporal) as mock_connect:
+            response = self.client.get(self._url())
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_connect.assert_called_once()
 
 
 class TestScoutSourceCanonicalization(APIBaseTest):


### PR DESCRIPTION
## Problem

\`SignalSourceConfigSerializer.get_status\` was making one \`ExternalDataSchema\` DB query per data-import row and one Temporal network RPC per session-analysis row on every inbox load. The original code had a self-documenting comment: *"Per-row Temporal RPC: serializing N source configs issues N of these on inbox load."*

APM trace data (\`signals.source_config.session_analysis_status\` spans in PostHog's own logs product) confirms the Temporal RPC takes **90–300ms** (median ~150ms) per call. With a team that has multiple source configs, this produced N round-trips instead of 1, holding pgbouncer connections longer per request.

**Relationship to the ongoing pgbouncer write-pool saturation:** this is a real N+1 worth fixing but is likely **not** the primary cause of the June 22–25 incidents. Trace data only exists from June 24 onwards (no spans from the June 22–23 incident), call frequency is low (handful of times per hour — inbox load only, not every page load), and the 90–300ms RPC doesn't explain the scale of saturation seen. The main culprit was the \`UserSerializer\` N+1 fixed in PR #66048. This PR removes a genuine secondary source of unnecessary connection hold time.

## Changes

- \`_data_import_schema_statuses\`: replaces per-row \`ExternalDataSchema.objects.filter()\` with a \`@cached_property\` that fetches all schemas for the team in one query, keyed by \`(source_type, schema_name)\`. One DB query per list request regardless of row count.
- \`_session_analysis_running\`: replaces per-row \`sync_connect()\` + \`list_workflows()\` Temporal RPC with a \`@cached_property\` that fires once per request. \`get_status\` reads the cached bool directly.
- Both properties read \`team_id\` from \`self.context["team_id"]\` (set by \`TeamAndOrgViewSetMixin\`) — all rows in the list belong to the same team, so one lookup covers the whole response.

## How did you test this code?

Agent-authored. Two tests added to \`test_signal_source_config_api.py\`:

- \`test_data_import_status_db_query_not_scaled_by_row_count\`: creates 3 data-import configs (github/linear/zendesk), lists them, uses \`CaptureQueriesContext\` to assert exactly 1 SQL query hits \`externaldataschema\` — catches regression back to per-row queries.
- \`test_session_analysis_temporal_rpc_called_once_per_request\`: mocks \`sync_connect\`, lists configs, asserts called exactly once — catches regression back to per-row RPC.

Pre-existing tests unaffected (verified on origin/master).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the ongoing pgbouncer write-pool saturation (June 23rd incident + intermittent post-fix spikes). Found this serializer's self-documented N+1 while grepping for patterns similar to the \`UserSerializer\` fix (PR #66048). Confirmed the Temporal RPC cost using \`query-apm-spans\` against PostHog's own APM data — spans show 90–300ms each, fired a handful of times per hour. Absence of trace data from June 22–23 and low call frequency ruled this out as the primary incident cause, but the fix reduces unnecessary connection hold time regardless.

Skills invoked: \`/writing-tests\`