### PR TITLE
feat(observability): log streaming responses that hold DB connections open

### DIFF
--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -20,7 +20,7 @@ from django.db import (
     connections as db_connections,
 )
 from django.db.models import QuerySet
-from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.http.response import HttpResponseRedirectBase
 from django.middleware.csrf import CsrfViewMiddleware
 from django.shortcuts import redirect
@@ -786,7 +786,7 @@ def per_request_logging_context_middleware(
             # can be minutes for SSE endpoints (AI chat, dashboard tiles, etc.).
             # Endpoints that use sse_streaming_response() release connections
             # before returning, so this only fires for ones that don't.
-            if response is not None and isinstance(response, StreamingHttpResponse):
+            if response is not None and getattr(response, "streaming", False):
                 held = [
                     conn.alias
                     for conn in db_connections.all(initialized_only=True)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -15,9 +15,12 @@ from django.conf import settings
 from django.contrib.auth import BACKEND_SESSION_KEY, logout
 from django.core.cache import cache
 from django.core.exceptions import MiddlewareNotUsed
-from django.db import connection
+from django.db import (
+    connection,
+    connections as db_connections,
+)
 from django.db.models import QuerySet
-from django.http import HttpRequest, HttpResponse, JsonResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.http.response import HttpResponseRedirectBase
 from django.middleware.csrf import CsrfViewMiddleware
 from django.shortcuts import redirect
@@ -750,6 +753,7 @@ def per_request_logging_context_middleware(
             if mcp_conversation_id:
                 span.set_attribute("mcp.conversation_id", mcp_conversation_id)
 
+        response = None
         try:
             response = get_response(request)
         finally:
@@ -775,6 +779,30 @@ def per_request_logging_context_middleware(
                     method=request.method,
                     worker_pid=os.getpid(),
                 )
+            # Detect streaming responses that are holding DB connections open.
+            # Under ASGI, a StreamingHttpResponse keeps the request alive until
+            # the stream ends — any connection still open at this point stays
+            # pinned to a pgbouncer slot for the entire stream duration, which
+            # can be minutes for SSE endpoints (AI chat, dashboard tiles, etc.).
+            # Endpoints that use sse_streaming_response() release connections
+            # before returning, so this only fires for ones that don't.
+            if isinstance(response, StreamingHttpResponse):
+                held = [
+                    alias
+                    for alias in db_connections
+                    if db_connections[alias].connection is not None and not db_connections[alias].in_atomic_block
+                ]
+                if held:
+                    _user = getattr(request, "user", None)
+                    logger.warning(
+                        "stream_with_held_connections",
+                        held_connections=len(held),
+                        aliases=held,
+                        request_path=request.path,
+                        method=request.method,
+                        worker_pid=os.getpid(),
+                        team_id=_user.current_team_id if _user is not None and _user.is_authenticated else None,
+                    )
 
         return response
 

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -753,7 +753,7 @@ def per_request_logging_context_middleware(
             if mcp_conversation_id:
                 span.set_attribute("mcp.conversation_id", mcp_conversation_id)
 
-        response = None
+        response: HttpResponse | None = None
         try:
             response = get_response(request)
         finally:

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -788,9 +788,9 @@ def per_request_logging_context_middleware(
             # before returning, so this only fires for ones that don't.
             if isinstance(response, StreamingHttpResponse):
                 held = [
-                    alias
-                    for alias in db_connections
-                    if db_connections[alias].connection is not None and not db_connections[alias].in_atomic_block
+                    conn.alias
+                    for conn in db_connections.all(initialized_only=True)
+                    if conn.connection is not None and not conn.in_atomic_block
                 ]
                 if held:
                     _user = getattr(request, "user", None)

--- a/posthog/middleware.py
+++ b/posthog/middleware.py
@@ -786,7 +786,7 @@ def per_request_logging_context_middleware(
             # can be minutes for SSE endpoints (AI chat, dashboard tiles, etc.).
             # Endpoints that use sse_streaming_response() release connections
             # before returning, so this only fires for ones that don't.
-            if isinstance(response, StreamingHttpResponse):
+            if response is not None and isinstance(response, StreamingHttpResponse):
                 held = [
                     conn.alias
                     for conn in db_connections.all(initialized_only=True)


### PR DESCRIPTION
## Problem

Under ASGI (which the new posthog-web-django stack runs on), a \`StreamingHttpResponse\` keeps the HTTP request alive until the entire stream is consumed. Any DB connection still open at that point stays pinned to a pgbouncer slot for the full stream duration — which can be **minutes** for long-lived SSE endpoints like AI chat (\`/api/conversation\`), dashboard tile loading, session replay progress, or notebook execution.

The existing \`sse_streaming_response()\` helper in \`posthog/api/streaming.py\` already handles this correctly: it calls \`_release_request_connections()\` before returning the stream. But many streaming endpoints construct \`StreamingHttpResponse\` directly and bypass this.

We've observed pgbouncer write-pool saturation where a single pod hits its 75-connection limit while siblings stay idle. The timing and pattern is consistent with long-lived streams holding connections — but we don't have direct proof yet.

## Changes

Adds a \`stream_with_held_connections\` warning log in \`per_request_logging_context_middleware\`. It fires when:
- The view returns a \`StreamingHttpResponse\`  
- AND at least one DB connection is still open at that point

Log fields: \`held_connections\` (count), \`aliases\` (which DB aliases), \`request_path\`, \`method\`, \`worker_pid\`, \`team_id\`.

If this fires during pgbouncer saturation events it confirms the hypothesis. If it doesn't fire, the stream connection theory is ruled out and we look elsewhere.

## How did you test this code?

Agent-authored. Existing \`posthog/test/test_request_memory.py\` tests pass. No new test — this is diagnostic logging that requires production traffic to verify; the condition (returning \`StreamingHttpResponse\` with an open connection) is correct by inspection of the code path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigating the ongoing pgbouncer write-pool saturation. After ruling out several hypotheses via Grafana/Loki/Prometheus data, found that streaming responses (SSE for AI chat, dashboards, session replay, etc.) likely hold DB connections open for their full duration under ASGI. The \`sse_streaming_response()\` helper already documents this exact risk and has the fix, but many endpoints bypass it. This log makes the hypothesis testable against production traffic without requiring a code change to the streaming endpoints themselves.

Skills invoked: none (single-file logging addition).