### PR TITLE
fix(ingestion-consumer): emit ingestion_pipeline/lane metric labels

### DIFF
--- a/rust/ingestion-consumer/src/config.rs
+++ b/rust/ingestion-consumer/src/config.rs
@@ -237,6 +237,20 @@ pub struct Config {
 
     #[envconfig(default = "true")]
     pub export_prometheus: bool,
+
+    // ---- Metric labels (match Node.js global default labels) ----
+    /// Ingestion pipeline this consumer serves (e.g. `analytics`). Emitted as a
+    /// global `ingestion_pipeline` label on every metric, mirroring the Node.js
+    /// `initializePrometheusLabels` default labels so dashboards, alerts, and
+    /// KEDA lag triggers select this consumer's series the same way.
+    #[envconfig(from = "INGESTION_PIPELINE")]
+    pub ingestion_pipeline: Option<String>,
+
+    /// Ingestion lane this consumer serves (e.g. `main`, `overflow`). Emitted as
+    /// a global `ingestion_lane` label on every metric, matching the Node.js
+    /// default labels. The lag-based KEDA autoscaler selects on this label.
+    #[envconfig(from = "INGESTION_LANE")]
+    pub ingestion_lane: Option<String>,
 }
 
 /// Parse `KAFKA_CONSUMER_*` env vars into rdkafka config key-value pairs.

--- a/rust/ingestion-consumer/src/consumer.rs
+++ b/rust/ingestion-consumer/src/consumer.rs
@@ -243,10 +243,18 @@ impl IngestionConsumer {
         let dispatcher = Arc::clone(&self.dispatcher);
         let transport = Arc::clone(&self.transport);
         let group_id = self.group_id.clone();
+        let max_batch_size = self.batch_size;
 
         let handle = tokio::spawn(async move {
-            Self::process_collected_batch(collected, task_batch_id, dispatcher, transport, group_id)
-                .await
+            Self::process_collected_batch(
+                collected,
+                task_batch_id,
+                dispatcher,
+                transport,
+                group_id,
+                max_batch_size,
+            )
+            .await
         });
 
         info!(
@@ -379,12 +387,21 @@ impl IngestionConsumer {
         dispatcher: Arc<Dispatcher>,
         transport: Arc<HttpTransport>,
         group_id: String,
+        max_batch_size: usize,
     ) -> anyhow::Result<ProcessedBatch> {
         let batch_size = collected.messages.len();
         let start = Instant::now();
 
         counter!("ingestion_consumer_messages_received_total").increment(batch_size as u64);
         gauge!("ingestion_consumer_batch_size").set(batch_size as f64);
+
+        // Batch fill ratio (batch size / configured max) — matches Node.js
+        // `consumer_batch_utilization`. A useful scaling signal: sustained high
+        // utilization means batches are saturating and the consumer is demand-bound.
+        if max_batch_size > 0 {
+            gauge!("consumer_batch_utilization", "groupId" => group_id.clone())
+                .set(batch_size as f64 / max_batch_size as f64);
+        }
 
         // Batch size distribution — matches Node.js `consumer_batch_size` histogram.
         histogram!("consumer_batch_size").record(batch_size as f64);

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -79,7 +79,7 @@ async fn async_main(config: Config) -> Result<()> {
 
     tracing_subscriber::registry().with(log_layer).init();
 
-    info!(?config, "Starting ingestion consumer");
+    info!("Starting ingestion consumer");
 
     // Lifecycle manager handles signals, health, and shutdown coordination
     let mut manager = Manager::builder("ingestion-consumer")

--- a/rust/ingestion-consumer/src/main.rs
+++ b/rust/ingestion-consumer/src/main.rs
@@ -103,31 +103,44 @@ async fn async_main(config: Config) -> Result<()> {
     // Install Prometheus recorder with custom histogram buckets matching the
     // Node.js ingestion consumer, so existing dashboards and alerts work during switchover.
     let recorder_handle = if config.export_prometheus {
+        let mut builder = PrometheusBuilder::new()
+            .set_buckets_for_metric(
+                Matcher::Full("ingestion_lag_ms_histogram".into()),
+                &[
+                    1_000.0, 2_000.0, 5_000.0, 10_000.0, 30_000.0, 60_000.0, 120_000.0, 300_000.0,
+                    600_000.0, 900_000.0,
+                ],
+            )
+            .expect("ingestion_lag_ms_histogram buckets")
+            .set_buckets_for_metric(
+                Matcher::Full("consumer_batch_size".into()),
+                &[
+                    0.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1_000.0, 1_500.0, 2_000.0, 3_000.0,
+                ],
+            )
+            .expect("consumer_batch_size buckets")
+            .set_buckets_for_metric(
+                Matcher::Full("consumer_batch_size_kb".into()),
+                &[
+                    0.0, 128.0, 512.0, 1_024.0, 5_120.0, 10_240.0, 20_480.0, 51_200.0, 102_400.0,
+                    204_800.0,
+                ],
+            )
+            .expect("consumer_batch_size_kb buckets");
+
+        // Global default labels (match the Node.js `initializePrometheusLabels`
+        // defaults): every metric carries ingestion_pipeline / ingestion_lane so
+        // dashboards, alerts, and the lag-based KEDA autoscaler select this
+        // consumer's series — notably `ingestion_lag_ms` for the scaling triggers.
+        if let Some(pipeline) = config.ingestion_pipeline.as_deref() {
+            builder = builder.add_global_label("ingestion_pipeline", pipeline);
+        }
+        if let Some(lane) = config.ingestion_lane.as_deref() {
+            builder = builder.add_global_label("ingestion_lane", lane);
+        }
+
         Some(
-            PrometheusBuilder::new()
-                .set_buckets_for_metric(
-                    Matcher::Full("ingestion_lag_ms_histogram".into()),
-                    &[
-                        1_000.0, 2_000.0, 5_000.0, 10_000.0, 30_000.0, 60_000.0, 120_000.0,
-                        300_000.0, 600_000.0, 900_000.0,
-                    ],
-                )
-                .expect("ingestion_lag_ms_histogram buckets")
-                .set_buckets_for_metric(
-                    Matcher::Full("consumer_batch_size".into()),
-                    &[
-                        0.0, 50.0, 100.0, 250.0, 500.0, 750.0, 1_000.0, 1_500.0, 2_000.0, 3_000.0,
-                    ],
-                )
-                .expect("consumer_batch_size buckets")
-                .set_buckets_for_metric(
-                    Matcher::Full("consumer_batch_size_kb".into()),
-                    &[
-                        0.0, 128.0, 512.0, 1_024.0, 5_120.0, 10_240.0, 20_480.0, 51_200.0,
-                        102_400.0, 204_800.0,
-                    ],
-                )
-                .expect("consumer_batch_size_kb buckets")
+            builder
                 .install_recorder()
                 .expect("failed to install Prometheus recorder"),
         )


### PR DESCRIPTION
## Problem

The Rust ingestion consumer never tagged its metrics with `ingestion_pipeline` / `ingestion_lane`, unlike the Node.js ingestion services (which set them as global default labels via `initializePrometheusLabels`). The consumer's KEDA lag triggers select `ingestion_lag_ms{ingestion_pipeline="analytics", ingestion_lane="main"}` — a selector that matched **zero** series, so the autoscaler read lag as `0`, fell back to CPU only, and (as an I/O-bound dispatcher that never hits a CPU target) sat pinned at min replicas while Kafka lag ran into the millions.

It also lacked the `consumer_batch_utilization` signal the Node.js consumer exposes.

## Changes

- Read `INGESTION_PIPELINE` and `INGESTION_LANE` from env (optional) in `config.rs`.
- Apply them as global Prometheus labels on the recorder in `main.rs` (`add_global_label`), mirroring the Node.js default-label behavior. Every consumer metric — notably `ingestion_lag_ms` — now carries both labels, so the existing KEDA lag triggers match and lag-based autoscaling fires.
- Add a `consumer_batch_utilization` gauge (`batch size / configured max`, labeled by `groupId`) in `consumer.rs`, mirroring the Node.js metric of the same name.

The chart already sets both env values for this deployment (`INGESTION_LANE: "main"`, inherited `INGESTION_PIPELINE: "analytics"`), so no consumer config change is needed there. The labels are emitted only when the envs are present, so this is a no-op for any deployment that doesn't set them.

## How did you test this code?

I'm an agent (Claude Code). I did not run or deploy the service. Automated checks I ran in the worktree:

- `cargo fmt` — clean
- `cargo clippy -p ingestion-consumer --all-targets --all-features -- -D warnings` — clean
- `cargo test -p ingestion-consumer --lib` — 104 passed

No new unit test: the change is metric-label/config wiring that mirrors existing (untested) metric emissions; a test of `batch_size / max_batch_size` wouldn't catch a realistic regression. Behavioral verification is operational — the missing-label root cause was confirmed against live metrics, and correctness will show up as the consumer scaling on lag once deployed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @jose-sequeira

Investigated why the split parallel consumer wasn't autoscaling despite multi-million-message Kafka lag. Root cause: its KEDA lag triggers query `ingestion_lag_ms` filtered by `ingestion_pipeline`/`ingestion_lane`, but the Rust consumer never emitted those labels (only the Node.js services do). Considered two fixes: (A) drop the `ingestion_lane` selector from the chart's KEDA queries, or (B) emit the labels from the consumer. Chose **B** so the consumer owns its pipeline/lane identity consistently with the Node.js services and all its dashboards/alerts get the labels — not just the lag metric. Tooling: Claude Code; no repo skills invoked.

Companion charts change (resourcing + autoscaling config) is a separate PR in PostHog/charts.
