### PR TITLE
fix(actions): resolve semver operators in action tooltip instead of "equals"

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5577,17 +5577,17 @@ snapshots:
     scenes-app-inbox-detail--run-ready--light:
         hash: v1.k794b7964.2fbb263dadddfb78130f7ce6666d5ef10151ebec9143e7f00ab0285bd3b9a21f.wRvvBPNYIVLvm3HJy8POg4TxUHmaOjEp_67VyRIArWM
     scenes-app-inbox-scene--empty--dark:
-        hash: v1.k794b7964.07bbc30ba986f803bfcfebf60c66bced035a3cc92027cc4e68a61a054b5f1a79.AIhrVbfGy3V_Qf0ztzWk0Nnn1xRRcQOVAm-UKvsxRu4
+        hash: v1.k794b7964.0730c341122d1d593f4e6acf7a176e05bdd79e9ca6bf5f785a909fd57ad274f1.V4Hgc6xF9-5hiq75aqzZWcbiemdqMe3fdbcMqVHbg7U
     scenes-app-inbox-scene--empty--light:
-        hash: v1.k794b7964.81373ae7fc298f00118487ead6d1428029a544201629904c20f9a99480ece69e.vzR527beBDJ4lfpCtunMDoJPtDCUF0GrVe-qhybPoBw
+        hash: v1.k794b7964.90d34c77f6dfa354d95f502f7760a2f663a7a9c30de1da3a731653b59f904cb0.9pu-wR68QOchxE47ApZFjYMJWmmrkN7VZFAnnGxeCW4
     scenes-app-inbox-scene--inbox--dark:
         hash: v1.k794b7964.eae93d2c506e66eb23f36e19f05bf6f07286d9a895dbad8f970c009fd98f1d53.AqLzv_So4UaxCTEYyb-ZB24M8Z4KF2Zq8PyO-8FDfos
     scenes-app-inbox-scene--inbox--light:
         hash: v1.k794b7964.f9b5a6f1ecd482963d9850ced2d07c1ea729d2d63be8679db907709e5a6fde89.kWZ_EUm4zZwm068_9nLGo5dWzvu78oVbcMTHqOHOEcY
     scenes-app-inbox-scene--self-driving-onboarding--dark:
-        hash: v1.k794b7964.07bbc30ba986f803bfcfebf60c66bced035a3cc92027cc4e68a61a054b5f1a79.eytb8nwcGuLgvygTe-3DnU6crJjt5ETtILVPFApVZv4
+        hash: v1.k794b7964.0730c341122d1d593f4e6acf7a176e05bdd79e9ca6bf5f785a909fd57ad274f1.qRvNaIt3BFQkYn9JRfSKCXUScoTY331T7aAtb5jHXsk
     scenes-app-inbox-scene--self-driving-onboarding--light:
-        hash: v1.k794b7964.81373ae7fc298f00118487ead6d1428029a544201629904c20f9a99480ece69e.SZPaHh2iZfhjafspeG-7DlvjUq9PQdf5esp2MCjMd2w
+        hash: v1.k794b7964.90d34c77f6dfa354d95f502f7760a2f663a7a9c30de1da3a731653b59f904cb0.Cxe2TZ9k11cuJdK6Z16NsJT2jJrHWTwC_8jh7MMztE4
     scenes-app-inbox-scene--self-driving-paused--dark:
         hash: v1.k794b7964.eae93d2c506e66eb23f36e19f05bf6f07286d9a895dbad8f970c009fd98f1d53.7hksyy3ldoFdJY9rpLYMe7FNYuMAi-U1Vlh3OGhv3wY
     scenes-app-inbox-scene--self-driving-paused--light:

--- a/frontend/src/lib/components/DefinitionPopover/utils.test.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.test.ts
@@ -10,19 +10,21 @@ describe('DefinitionPopover operator helpers', () => {
             [PropertyOperator.LessThanOrEqual, 'less than or equal'],
             [PropertyOperator.GreaterThan, 'greater than'],
             [PropertyOperator.IContains, 'contains'],
+            // Semver operators live outside the generic map and must still resolve, not fall back to "equals"
+            [PropertyOperator.SemverGte, 'greater than or equal (semver)'],
         ])('maps a typed property with operator %s to "%s"', (operator, expected) => {
             const property = { type: PropertyFilterType.Event, key: 'amount', value: 5, operator } as AnyPropertyFilter
             expect(genericOperatorToHumanName(property)).toBe(expected)
         })
 
-        it('reads the operator from a legacy action step property that has no type', () => {
+        it.each([
+            [PropertyOperator.GreaterThanOrEqual, 'greater than or equal'],
+            // A semver `>=` filter on e.g. $os_version (no `type` on the legacy step) — the reported bug
+            [PropertyOperator.SemverGte, 'greater than or equal (semver)'],
+        ])('reads operator %s from a legacy action step property that has no type', (operator, expected) => {
             // Legacy action step properties are stored without a `type` field
-            const property = {
-                key: 'amount',
-                value: 5,
-                operator: PropertyOperator.GreaterThanOrEqual,
-            } as AnyPropertyFilter
-            expect(genericOperatorToHumanName(property)).toBe('greater than or equal')
+            const property = { key: '$os_version', value: '14.4.1', operator } as AnyPropertyFilter
+            expect(genericOperatorToHumanName(property)).toBe(expected)
         })
 
         it.each([null, undefined, {} as AnyPropertyFilter])('falls back to "equals" for %s', (property) => {

--- a/frontend/src/lib/components/DefinitionPopover/utils.test.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.test.ts
@@ -19,8 +19,10 @@ describe('DefinitionPopover operator helpers', () => {
 
         it.each([
             [PropertyOperator.GreaterThanOrEqual, 'greater than or equal'],
-            // A semver `>=` filter on e.g. $os_version (no `type` on the legacy step) — the reported bug
+            // Semver filters on e.g. $os_version (no `type` on the legacy step) — the reported bug
             [PropertyOperator.SemverGte, 'greater than or equal (semver)'],
+            [PropertyOperator.SemverLte, 'less than or equal (semver)'],
+            [PropertyOperator.SemverEq, 'equals (semver)'],
         ])('reads operator %s from a legacy action step property that has no type', (operator, expected) => {
             // Legacy action step properties are stored without a `type` field
             const property = { key: '$os_version', value: '14.4.1', operator } as AnyPropertyFilter

--- a/frontend/src/lib/components/DefinitionPopover/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.ts
@@ -1,5 +1,5 @@
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { allOperatorsMapping } from 'lib/utils/operators'
+import { allOperatorsMapping, genericOperatorMap } from 'lib/utils/operators'
 
 import { AnyPropertyFilter, PropertyFilterValue, PropertyOperator } from '~/types'
 
@@ -15,10 +15,13 @@ export function operatorToHumanName(operator?: string): string {
 
 export function genericOperatorToHumanName(property?: AnyPropertyFilter | null): string {
     // Legacy action step properties have no `type`, so isPropertyFilterWithOperator would reject them
-    // and collapse every operator to "equals" — read the operator directly instead. Delegate to the
-    // full operator map so semver (e.g. semver_gte), numeric and other operators resolve, not just the
-    // small generic subset.
+    // and collapse every operator to "equals" — read the operator directly instead. Prefer the curated
+    // generic labels, but fall back to the full operator map (covers semver etc.) rather than a
+    // hardcoded "equals" for anything outside the generic subset.
     const operator = property && 'operator' in property ? property.operator : undefined
+    if (operator && genericOperatorMap[operator]) {
+        return genericOperatorMap[operator].slice(2)
+    }
     return allOperatorsToHumanName(operator)
 }
 

--- a/frontend/src/lib/components/DefinitionPopover/utils.ts
+++ b/frontend/src/lib/components/DefinitionPopover/utils.ts
@@ -1,5 +1,5 @@
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
-import { allOperatorsMapping, genericOperatorMap } from 'lib/utils/operators'
+import { allOperatorsMapping } from 'lib/utils/operators'
 
 import { AnyPropertyFilter, PropertyFilterValue, PropertyOperator } from '~/types'
 
@@ -15,12 +15,11 @@ export function operatorToHumanName(operator?: string): string {
 
 export function genericOperatorToHumanName(property?: AnyPropertyFilter | null): string {
     // Legacy action step properties have no `type`, so isPropertyFilterWithOperator would reject them
-    // and collapse every operator to "equals" — read the operator directly instead.
+    // and collapse every operator to "equals" — read the operator directly instead. Delegate to the
+    // full operator map so semver (e.g. semver_gte), numeric and other operators resolve, not just the
+    // small generic subset.
     const operator = property && 'operator' in property ? property.operator : undefined
-    if (operator && genericOperatorMap[operator]) {
-        return genericOperatorMap[operator].slice(2)
-    }
-    return 'equals'
+    return allOperatorsToHumanName(operator)
 }
 
 // Most operator labels carry a 2-char "<symbol> " prefix that slice(2) strips (e.g. "= equals"


### PR DESCRIPTION
## Problem

A follow-up to #66033. An action step whose property uses a **semver** comparison — e.g. `$os_version ≥ 14.4.1` — still rendered as "equals" in the taxonomic-filter action tooltip (the experiment exposure event dropdown). The `≥` symbol made it look like a plain `gte`, but semver filters are stored under a different operator key (`semver_gte`).

#66033 fixed the type-guard problem but kept looking the operator up in `genericOperatorMap`, which only contains the generic `gt`/`gte`/`lt`/`lte` family. The semver operators live in a separate map, so `semver_gte` missed the lookup and fell through to the hardcoded `"equals"`.

## Changes

`genericOperatorToHumanName` now delegates to its sibling `allOperatorsToHumanName`, which already resolves against the full `allOperatorsMapping` (semver, numeric, duration, and prefix-less cohort operators). A `semver_gte` filter now reads **"greater than or equal (semver)"** instead of "equals", and the same applies to every other operator outside the generic subset.

This affects both action-tooltip render paths, since both call this helper: the legacy `ActionPopoverInfo` and the new Quill `ActionMatchGroups` preview.

### Before / after

Rendered from the **real** `ActionMatchGroups` component against the reported repro action (legacy steps with no `type`, semver operators on `$os_version` / `app_version` / `build_version`) — left/before on the merged code, right/after on this branch:

| Before (merged) | After (this branch) |
| --- | --- |
| ![before](https://raw.githubusercontent.com/PostHog/posthog/008518d22eed9a74c58e265de21d3092377cd396/.pr-assets/operator-before.png) | ![after](https://raw.githubusercontent.com/PostHog/posthog/008518d22eed9a74c58e265de21d3092377cd396/.pr-assets/operator-after.png) |

<sub>Images are hosted on an off-branch commit blob and are **not** part of this PR's diff — nothing to clean up before merge.</sub>

### Also fixed: action preview blank on the rebuild filter's "All" tab

A second, related issue the reporter hit in the **rebuild** taxonomic-filter menu: an action's match-group detail showed only on the Actions tab, not the "All" tab. When the committed action isn't among the rows currently shown in the all scope, the preview falls back to a lightweight `{ id, name }` selection shim that carries no `steps`, so `ActionMatchGroups` rendered nothing. It now hydrates the shim from `actionsModel` (`actionsById`) when `steps` are absent, so the match groups render regardless of which entry is highlighted. Rebuild-menu only — the legacy popover already renders the full action.

## How did you test this code?

I'm an agent. I did **not** manually test in the browser. Verification:
- Reproduced the root cause against the real reported data shape (`$os_version semver_gte 14.4.1`, a legacy step with no `type`).
- Extended the `genericOperatorToHumanName` unit tests with semver cases — `semver_gte`, `semver_lte`, `semver_eq` — as both typed properties and the legacy no-`type` shape that matches the bug. **20/20 pass.**
- Generated the before/after screenshots above by server-rendering the real `ActionMatchGroups` component with the merged vs. branch helper.
- Added an `ActionMatchGroups` test that mounts `actionsModel` and asserts a step-less `{ id, name }` shim hydrates its match groups (the "All" tab regression), plus the already-has-steps and unknown-action paths. **3/3 pass.**
- Full `TaxonomicFilter/menu` suite green (39/39); oxlint + oxfmt clean on the changed files. Typecheck clean for the changed files (the local run also flags an unrelated `@posthog/quill` workspace-resolution gap that hits unchanged files too and resolves on CI).

The new operator tests catch the regression #66033's tests missed (an operator in the broader map but not `genericOperatorMap`); the new preview test catches the blank-"All"-tab regression (a highlighted entry whose item lacks `steps`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: Vasco de Krijger.

Authored by the PostHog Slack agent from a support thread. The original fix (#66033) addressed the type-guard half of the bug; the reporter confirmed `>=` still showed as "equals", and provided a repro action. Inspecting that action's raw step JSON revealed the operator was `semver_gte`, not `gte` — the value is a semantic version, so PostHog stores the semver operator variant, which `genericOperatorMap` doesn't include. Chose to reuse the existing `allOperatorsToHumanName` rather than widen `genericOperatorMap`, keeping a single source of truth for operator labels.

The reporter then flagged a second, related issue (action preview blank on the rebuild filter's "All" tab); it's bundled into this PR rather than a separate one because the work was directed to continue on this branch. Happy to split it out if a reviewer prefers.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782280765547529?thread_ts=1782280765.547529&cid=C0ACRAMJUAG)*

