### PR TITLE
chore(observability): run web memory sampler under ASGI (was wsgi-only)

### DIFF
--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -17,9 +17,9 @@ os.environ["SERVER_GATEWAY_INTERFACE"] = "ASGI"  # Set definitively
 # Get a structlog logger for asgi.py's own messages
 logger = structlog.get_logger(__name__)
 
-# NOTE: OTel and continuous profiling init is deferred to first request via
-# _ensure_post_fork_init() below. Both start background threads (OTel's
-# BatchSpanProcessor, Pyroscope's native profiler) that cannot survive
+# NOTE: OTel, continuous profiling, and the web-memory sampler init are deferred to first
+# request via _ensure_post_fork_init() below. They start background threads (OTel's
+# BatchSpanProcessor, Pyroscope's native profiler, the sampler's loop) that cannot survive
 # fork(). Nginx Unit loads this module in a "prototype" process and then
 # forks workers from it — the forked children inherit dead thread state and
 # corrupted mutexes, causing SIGSEGV / SIGABRT on the worker. Deferring to
@@ -37,10 +37,14 @@ def _ensure_post_fork_init():
     from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
     from posthog.continuous_profiling import start_continuous_profiling
     from posthog.otel_instrumentation import initialize_otel
+    from posthog.web_memory_sampler import start_web_memory_sampler
 
     start_continuous_profiling()
     initialize_otel()
     prewarm_query_cache_cluster_in_background()
+    # Production runs ASGI, so the sampler — previously only started from wsgi.py — never
+    # ran in prod, leaving posthog_web_worker_rss_mb empty. Start it here, post-fork.
+    start_web_memory_sampler()
     _post_fork_initialized = True
 
 


### PR DESCRIPTION
## Problem

Production web pods run under **ASGI** (`posthog/asgi.py`), but `start_web_memory_sampler()` was only invoked from `posthog/wsgi.py`. So in production the per-worker memory instrumentation never ran:

- the `posthog_web_worker_rss_mb` Prometheus gauge stayed empty, and
- the `worker_memory` log line was never emitted.

The only memory signal available for the web tier was pod-level `container_memory_working_set_bytes` (4 workers + sidecars aggregated), which can't show a single worker's RSS climbing toward the cgroup limit before it gets OOM-killed — exactly the signal the sampler was added to provide.

## Changes

Start the sampler from `asgi.py`'s `_ensure_post_fork_init()`, alongside OTel and continuous profiling. That hook runs **post-fork on first request**, which is required here: Nginx Unit imports the module in a prototype process and forks workers from it, so a daemon thread started at module load would only ever sample the idle prototype, never the workers that serve traffic (the sampler's own docstring calls this out).

`wsgi.py`'s call is left intact for WSGI dev/`runserver` paths. No behavior change beyond the sampler's existing daemon thread — 30s interval (`WEB_MEMORY_SAMPLE_INTERVAL_SECONDS`, set ≤0 to disable), a single `livemax` gauge series per pod, best-effort, never breaks startup.

## How did you test this code?

I'm an agent. Ran `ruff check` and `ruff format --check` on `posthog/asgi.py` (both pass). No new test added — this is a one-line wiring of an already-tested helper into the existing deferred-init path; asserting a daemon thread starts under a forking ASGI server isn't meaningfully unit-testable without a heavier harness. Verification after deploy is simply that `posthog_web_worker_rss_mb` becomes non-empty for the web pods.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

While investigating web-tier memory behavior, found that the per-worker RSS sampler was wired only into `wsgi.py` while prod serves via ASGI — so the gauge it exports was always empty. Fix is to start it from the ASGI post-fork init hook for fork-safety (a module-load start samples the prototype, not the workers).

Known follow-up (out of scope here): `wsgi.py` starts the sampler at module load rather than post-fork, so under a forking WSGI server it has the same prototype-vs-worker problem; WSGI isn't the production entrypoint, so it's left as-is.

Tooling: Claude Code. No repo skills were required for this change.
