### PR TITLE
feat(signals): teach scouts to use stable scratchpad keys

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -61,6 +61,28 @@ _BASE_PROMPT_TAIL = """# How a run works
    fill space. The harness parses the JSON and writes `summary` to the run row
    as searchable prose.
 
+# Scratchpad keys
+
+`remember` upserts on `key`: writing a key that already exists *overwrites it in
+place*. A key is a stable identity, not a log entry — it must name the *thing*
+you're tracking, never *when* you saw it. Embedding a date, timestamp, or run id
+in a key mints a brand-new row every run, never reclaims the old one, and — for a
+dedupe key — guarantees next run's key won't match the entity you already
+surfaced, defeating the dedupe it was meant to do.
+
+- **Run state / cursors** (a "last scan" marker, a rolling baseline, "where I got
+  to") → one fixed key like `pattern:<domain>:cursor`, with the timestamp *in the
+  content*. Overwrite it each run.
+- **Dedupe / "already surfaced X"** → key off the stable identity of the thing —
+  `dedupe:<domain>:<issue_id>`, `<account_external_id>`, `<file_path>` — with no
+  date. Put the dates you saw it *in the content* ("surfaced 2026-05-01,
+  re-confirmed 2026-06-09"); re-confirming updates the same row in place.
+- **One row per real external item** (a specific Discord message id, a specific
+  alert id) is fine — that's bounded by real events, not by time.
+
+Good: `dedupe:error_tracking:019de34e`, `pattern:apm:cursor`.
+Bad: `dedupe:error_tracking:019de34e-2026-06-09`, `pattern:apm:scan-2026-06-09-0400`.
+
 # Recency lens
 
 Default to recent windows (~last 72h) when querying — fresh evidence is usually

--- a/products/signals/backend/scout_harness/serializers.py
+++ b/products/signals/backend/scout_harness/serializers.py
@@ -330,7 +330,12 @@ class RememberRequestSerializer(serializers.Serializer):
 
     key = serializers.CharField(
         max_length=300,
-        help_text="Agent-chosen semantic key. Re-using a key updates the existing entry in place.",
+        help_text=(
+            "Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. "
+            "Key off the *stable identity* of what you're tracking — never embed a date, timestamp, or run "
+            "id (that mints a new row every run and breaks dedupe). For run state/cursors, use one fixed key "
+            "and keep the timestamp in `content`."
+        ),
     )
     content = serializers.CharField(
         max_length=MAX_SCRATCHPAD_CONTENT_LENGTH,

--- a/products/signals/frontend/generated/api.schemas.ts
+++ b/products/signals/frontend/generated/api.schemas.ts
@@ -1385,7 +1385,7 @@ export interface ScratchpadEntryApi {
  */
 export interface RememberRequestApi {
     /**
-     * Agent-chosen semantic key. Re-using a key updates the existing entry in place.
+     * Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. Key off the *stable identity* of what you're tracking — never embed a date, timestamp, or run id (that mints a new row every run and breaks dedupe). For run state/cursors, use one fixed key and keep the timestamp in `content`.
      * @maxLength 300
      */
     key: string

--- a/products/signals/frontend/generated/api.zod.ts
+++ b/products/signals/frontend/generated/api.zod.ts
@@ -345,7 +345,9 @@ export const SignalsScoutScratchpadRememberBody = /* @__PURE__ */ zod
         key: zod
             .string()
             .max(signalsScoutScratchpadRememberBodyKeyMax)
-            .describe('Agent-chosen semantic key. Re-using a key updates the existing entry in place.'),
+            .describe(
+                "Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. Key off the \*stable identity\* of what you're tracking — never embed a date, timestamp, or run id (that mints a new row every run and breaks dedupe). For run state\/cursors, use one fixed key and keep the timestamp in `content`."
+            ),
         content: zod
             .string()
             .max(signalsScoutScratchpadRememberBodyContentMax)

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -526,7 +526,10 @@ tools:
         title: Remember a scratchpad entry
         description: >
             Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so
-            this is an upsert rather than a strict create. Optionally pass `run_id` to record which run wrote it.
+            this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking,
+            not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and
+            defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass
+            `run_id` to record which run wrote it.
     signals-scout-scratchpad-search:
         operation: signals_scout_scratchpad_search
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6359,7 +6359,7 @@
         }
     },
     "signals-scout-scratchpad-remember": {
-        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Optionally pass `run_id` to record which run wrote it.",
+        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass `run_id` to record which run wrote it.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Remember a scratchpad entry",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6868,7 +6868,7 @@
         }
     },
     "signals-scout-scratchpad-remember": {
-        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Optionally pass `run_id` to record which run wrote it.",
+        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass `run_id` to record which run wrote it.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Remember a scratchpad entry",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -46107,7 +46107,7 @@ export namespace Schemas {
      */
     export interface RememberRequest {
       /**
-         * Agent-chosen semantic key. Re-using a key updates the existing entry in place.
+         * Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. Key off the *stable identity* of what you're tracking — never embed a date, timestamp, or run id (that mints a new row every run and breaks dedupe). For run state/cursors, use one fixed key and keep the timestamp in `content`.
          * @maxLength 300
          */
       key: string;

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -717,7 +717,9 @@ export const SignalsScoutScratchpadRememberBody = /* @__PURE__ */ zod
         key: zod
             .string()
             .max(signalsScoutScratchpadRememberBodyKeyMax)
-            .describe('Agent-chosen semantic key. Re-using a key updates the existing entry in place.'),
+            .describe(
+                "Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. Key off the *stable identity* of what you're tracking — never embed a date, timestamp, or run id (that mints a new row every run and breaks dedupe). For run state/cursors, use one fixed key and keep the timestamp in `content`."
+            ),
         content: zod
             .string()
             .max(signalsScoutScratchpadRememberBodyContentMax)

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-remember.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/signals-scout-scratchpad-remember.json
@@ -8,7 +8,7 @@
             "type": "string"
         },
         "key": {
-            "description": "Agent-chosen semantic key. Re-using a key updates the existing entry in place.",
+            "description": "Agent-chosen semantic key, unique per team; re-using a key overwrites the entry in place. Key off the *stable identity* of what you're tracking — never embed a date, timestamp, or run id (that mints a new row every run and breaks dedupe). For run state/cursors, use one fixed key and keep the timestamp in `content`.",
             "maxLength": 300,
             "type": "string"
         },


### PR DESCRIPTION
## Problem

The scout scratchpad (`SignalScratchpad`) is durable per-team memory keyed on `(team, key)`, and `remember` upserts in place — re-using a key overwrites the existing row. But scouts routinely bake **dates, timestamps, and run ids into the key** (`dedupe:experiments:42-srm-2026-06-09`, `pattern:apm:scan-2026-06-09-0400`, `dedupe:team_self_driving:1782398887`). Every run then mints a brand-new row instead of overwriting one, so the table grows without bound and never compacts.

Two things drive it, and neither is the agent being careless — it's that the system never told it otherwise:

- **No key-naming guidance exists anywhere the agent looks** — not in the base scout prompt, not in the `remember` tool description, not in the `key` field `help_text`. The upsert-in-place semantics are documented; the implication ("so don't put a date in the key") never is.
- A dated **dedupe** key is self-defeating: next run computes a new date, the key doesn't match, and the entity gets re-surfaced — the opposite of dedupe.

## Changes

Add the missing key convention in the three places the agent actually reads, so it's consistent in-prompt and at the call site:

- **Base scout prompt** (`scout_harness/prompt.py`) — a new "Scratchpad keys" section: keys are stable identities, not log lines; run state/cursors use one fixed key with the timestamp in `content`; dedupe keys use the stable identity of the thing (issue id, account id, file path) with dates recorded in `content`; one row per real external item is fine. Includes good/bad examples.
- **`remember` tool description** (`mcp/tools.yaml`) and **`key` field `help_text`** (`scout_harness/serializers.py`) — a one-line version of the same rule, so it shows up in the generated MCP tool schema and OpenAPI spec.

Regenerated the OpenAPI / frontend / MCP artifacts for the changed serializer and tool description.

This is the behavior-shaping half. A follow-up will add a retention sweep (prune on `updated_at`) as a backstop to cap total size and clean up existing dated keys.

Note for reviewers: the canonical `signals-scout-*` SKILL.md templates themselves show dated dedupe-key examples (e.g. `dedupe:apm:{service}:{operation}:{date}`), so they reinforce the old pattern and should get a companion pass — intentionally left out of this PR to keep it focused on the shared harness surface.

## How did you test this code?

I'm an agent (Claude Code). No manual testing. Automated checks run:

- `hogli build:openapi` — regenerated OpenAPI/MCP artifacts; verified the new guidance landed in `tool-definitions-all.json` and `api.schemas.ts`.
- `ruff format` / `ruff check` on the changed Python — clean.
- lint-staged pre-commit (ruff, `ty check`, formatters) — passed.

No new tests: the change is prose in a prompt, a tool description, and a field `help_text` — no behavior change, and the existing `TestRemember` / `TestSearchScratchpad` suites already cover the upsert path. No realistic regression a new test would catch.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation started from a question about how fast the scout scratchpad grows per day. Querying the synced warehouse table showed the store is append-only (every distinct `key` = a permanent row, no compaction) and that ~a third of keys embed a date/timestamp/long-id — the unbounded-growth driver. Root-caused to missing key-naming guidance in the harness; this PR adds it.

- **Tools:** Claude Code (Opus 4.8); PostHog MCP `execute-sql` for the warehouse analysis; `Explore` subagent to map the scratchpad read/write/prompt code.
- **Skills:** none invoked for the edit itself. `/django-migrations` and `/improving-drf-endpoints` are flagged for the planned follow-ups (retention sweep + any serializer/index work), not this PR.
- **Decisions:** scoped this PR to the shared harness surface (prompt + tool/help_text). Rejected a hard write-path validator that rejects dated keys — legit keys (Discord snowflake ids, account ids, numeric file paths) contain digits and would false-positive, so enforcement belongs in guidance. Retention/TTL deferred to a follow-up so the behavior fix lands clean and deletion risk is reviewed separately.
