### PR TITLE
feat(mcp): emit skill-store as its own tool domain

### DIFF
--- a/services/mcp/src/lib/instructions.ts
+++ b/services/mcp/src/lib/instructions.ts
@@ -88,6 +88,10 @@ interface ToolItem {
  *   - feature-flag-* / feature-flags-* → "feature-flag" (singular/plural merged)
  * All query-* tools collapse to a single "query" domain (`search query-` lists
  * them); their typed catalog is documented separately in the prompt.
+ *
+ * A prefix in {@link FORCE_SPLIT_PREFIXES} is always emitted as its own domain
+ * and pulled out of its parent family, so e.g. skill-store-* surfaces as a
+ * "skill-store" domain distinct from the rest of the "skill" family.
  */
 export class ToolDomainExtractor {
     /** A family at or below this many tools stays one domain; above it, split
@@ -99,6 +103,9 @@ export class ToolDomainExtractor {
     private static readonly MAX_DOMAIN_SEGMENTS = 3
 
     private static readonly SKIP_CATEGORIES = new Set(['Query wrappers', 'Debug'])
+    /** Name prefixes always emitted as their own domain, separate from the
+     *  family they would otherwise fold into (e.g. skill-store-* vs skill-*). */
+    private static readonly FORCE_SPLIT_PREFIXES = ['skill-store']
     /** Stripped from the front so `get-llm-total-costs` joins the `llm` family
      *  instead of a spurious `get` family. */
     private static readonly LEADING_VERBS = new Set([
@@ -127,12 +134,23 @@ export class ToolDomainExtractor {
     /** query-* tools are kept out of the trie and represented by a single
      *  `query` domain, so the catalog never fragments into per-insight roots. */
     private readonly hasQueryTools: boolean
+    /** Force-split prefixes (see {@link FORCE_SPLIT_PREFIXES}) present in this
+     *  tool set, each emitted verbatim as its own domain. */
+    private readonly forcedDomains: Set<string>
 
     constructor(tools: ToolInfo[]) {
         this.hasQueryTools = tools.some(({ name }) => name.startsWith('query-'))
+        this.forcedDomains = new Set(
+            tools
+                .map(({ name }) => ToolDomainExtractor.forceSplitPrefixFor(name))
+                .filter((prefix): prefix is string => !!prefix)
+        )
         this.items = tools
             .filter(
-                ({ name, category }) => !name.startsWith('query-') && !ToolDomainExtractor.SKIP_CATEGORIES.has(category)
+                ({ name, category }) =>
+                    !name.startsWith('query-') &&
+                    !ToolDomainExtractor.SKIP_CATEGORIES.has(category) &&
+                    !ToolDomainExtractor.forceSplitPrefixFor(name)
             )
             .map(({ name }) => {
                 const segments = ToolDomainExtractor.toSegments(name)
@@ -160,6 +178,9 @@ export class ToolDomainExtractor {
         }
         if (this.hasQueryTools) {
             domains.add('query')
+        }
+        for (const domain of this.forcedDomains) {
+            domains.add(domain)
         }
         return [...domains].sort()
     }
@@ -242,6 +263,15 @@ export class ToolDomainExtractor {
             segments.pop()
         }
         return segments.join('-')
+    }
+
+    /** The force-split prefix a tool belongs to, if any: an exact match or a
+     *  `${prefix}-…` descendant. Matching on the `-` boundary keeps a sibling
+     *  like `skill-create` out (only `skill-store` / `skill-store-*` match). */
+    private static forceSplitPrefixFor(name: string): string | undefined {
+        return ToolDomainExtractor.FORCE_SPLIT_PREFIXES.find(
+            (prefix) => name === prefix || name.startsWith(`${prefix}-`)
+        )
     }
 
     private static toSegments(name: string): string[] {

--- a/services/mcp/tests/unit/instructions.test.ts
+++ b/services/mcp/tests/unit/instructions.test.ts
@@ -151,6 +151,21 @@ describe('buildToolDomainsBlock', () => {
         expect(result).toContain('- feature-flag')
     })
 
+    it('splits skill-store-* into its own domain, separate from the skill family', () => {
+        const tools = [
+            { name: 'skill-create', category: 'Skills' },
+            { name: 'skill-get', category: 'Skills' },
+            { name: 'skill-list', category: 'Skills' },
+            { name: 'skill-store-install-command', category: 'Skills' },
+        ]
+        const result = buildToolDomainsCompact(tools)
+        const domains = result.split('|')
+        expect(domains).toContain('skill')
+        expect(domains).toContain('skill-store')
+        // the store tool is pulled out of the skill family, not listed verbatim
+        expect(result).not.toContain('skill-store-install-command')
+    })
+
     it('should return empty string for empty array', () => {
         expect(buildToolDomainsBlock([])).toBe('')
     })


### PR DESCRIPTION
## Problem

In the MCP server instructions, the `# Tool domains` line is auto-generated by `ToolDomainExtractor`. All `skill-*` tools — including `skill-store-install-command` — collapse into a single `skill` domain because the family stays under the size cap. There was no way for an agent to discover the skill-store tooling as a distinct domain.

## Changes

Added a small force-split mechanism to `ToolDomainExtractor` (`services/mcp/src/lib/instructions.ts`): a `FORCE_SPLIT_PREFIXES` list whose entries are pulled out of their parent family and emitted verbatim as their own domain. Seeded with `skill-store`, so the instructions now list both `skill` and `skill-store` as separate domains. Matching is on the `-` boundary, so sibling tools like `skill-create` stay in the `skill` family.

This mirrors the existing special-case handling for `query-*` tools.

## How did you test this code?

I'm an agent. I added a unit test in `services/mcp/tests/unit/instructions.test.ts` asserting that a tool set containing `skill-create`/`skill-get`/`skill-list`/`skill-store-install-command` yields both a `skill` and a `skill-store` domain, and that the verbose leaf name is not emitted. Ran the suite (`vitest run tests/unit/instructions.test.ts`) — 31 passing — and typechecked the package with no new errors.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: ensure `services/mcp` lists `skill-store` as a separate tool domain in the instructions. The domain string is generated rather than hard-coded, so the fix extends the generator with a reusable force-split prefix list instead of editing any static text. Chose to generalize (a prefix list) over a one-off `skill-store` special case so future splits are a one-line addition.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1782463363479149)*
