### PR TITLE
fix(mongodb): redact raw driver errors from source validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -55,6 +55,19 @@ _MONGO_HOST_UNRESOLVED_MESSAGE = (
     "string is spelled correctly."
 )
 
+_MONGO_AUTHENTICATION_FAILED_MESSAGE = (
+    "MongoDB authentication failed. Please check the username and password for this source."
+)
+
+_MONGO_NOT_AUTHORIZED_MESSAGE = (
+    "PostHog connected to MongoDB, but this user isn't authorized to list collections on the "
+    "database. Grant the user a read role on the database (e.g. read or readAnyDatabase) and try again."
+)
+
+_MONGO_CONNECT_FAILED_MESSAGE = (
+    "Could not connect to your MongoDB database. Check your connection string and credentials, then try again."
+)
+
 # Substrings pymongo embeds in ServerSelectionTimeoutError when the OS can't resolve the host.
 _DNS_RESOLUTION_FAILURE_MARKERS = (
     "No address associated with hostname",
@@ -71,7 +84,7 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
         return ExternalDataSourceType.MONGODB
 
     def get_non_retryable_errors(self) -> dict[str, str | None]:
-        auth_failed_msg = "MongoDB authentication failed. Please check the username and password for this source."
+        auth_failed_msg = _MONGO_AUTHENTICATION_FAILED_MESSAGE
         return {
             "The DNS query name does not exist": None,
             # pymongo raises InvalidURI("Username and password must be escaped according to RFC 3986,
@@ -95,6 +108,13 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             # 'authentication failed' here doesn't match the capitalised entries above (matching is
             # case-sensitive), so key off the stable Atlas-specific 'bad auth' prefix.
             "bad auth": auth_failed_msg,
+            # pymongo raises OperationFailure with codeName 'Unauthorized' (code 13) and errmsg
+            # 'not authorized on <db> to execute command ...' when the user authenticates but lacks
+            # a read role on the database. str(e) appends the full server response (clusterTime,
+            # signature, BSON ids) via pymongo's _format_detailed_error, so the raw text must never
+            # reach the user — match the stable 'not authorized' fragment. Granting permission is a
+            # config change the user must make, so this never recovers on retry.
+            "not authorized": _MONGO_NOT_AUTHORIZED_MESSAGE,
             "SSL handshake failed": None,
             # Atlas SQL / Data Federation endpoints live under *.query.mongodb.net and are served by
             # a query proxy the standard MongoDB driver can't drive: the handshake is closed, the
@@ -191,8 +211,14 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             if len(collection_names) == 0:
                 return False, "No collections found in database"
         except OperationFailure as e:
+            # pymongo's OperationFailure stringifies the full server response — clusterTime,
+            # signature hashes, BSON ids — so str(e) must never be surfaced. Map the stable error
+            # markers to a clean message; an authorization failure ("not authorized") means the
+            # credentials are valid but lack read access, which is distinct from a bad password.
             capture_exception(e)
-            return False, f"MongoDB authentication failed: {str(e)}"
+            if "not authorized" in str(e):
+                return False, _MONGO_NOT_AUTHORIZED_MESSAGE
+            return False, _MONGO_AUTHENTICATION_FAILED_MESSAGE
         except ServerSelectionTimeoutError as e:
             # pymongo dumps a verbose topology description into str(e); surface a concise,
             # actionable message instead. A DNS failure means the host doesn't resolve at all,
@@ -204,7 +230,13 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
             return False, _MONGO_UNREACHABLE_MESSAGE
         except Exception as e:
             capture_exception(e)
-            return False, f"Failed to connect to MongoDB database: {str(e)}"
+            # pymongo raises InvalidURI with the RFC-3986 hint before any network call when the
+            # credentials contain unescaped reserved characters; surface the actionable message
+            # rather than the raw driver string. Any other exception falls back to a generic message
+            # so internal exception text never reaches the user.
+            if "must be escaped according to RFC 3986" in str(e):
+                return False, _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
+            return False, _MONGO_CONNECT_FAILED_MESSAGE
 
         return True, None
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -8,7 +8,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mo
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source import (
     _DNS_RESOLUTION_FAILURE_MARKERS,
+    _MONGO_AUTHENTICATION_FAILED_MESSAGE,
+    _MONGO_CONNECT_FAILED_MESSAGE,
     _MONGO_HOST_UNRESOLVED_MESSAGE,
+    _MONGO_NOT_AUTHORIZED_MESSAGE,
+    _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
     _MONGO_UNREACHABLE_MESSAGE,
     MongoDBSource,
 )
@@ -87,3 +91,70 @@ class TestMongoValidateCredentialsServerSelection:
 
         assert ok is False
         assert err == _MONGO_UNREACHABLE_MESSAGE
+
+
+class TestMongoValidateCredentialsOperationFailure:
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_not_authorized_returns_clean_message_and_redacts_internals(self, mock_get_collections):
+        from pymongo.errors import OperationFailure
+
+        # pymongo appends the full server response (clusterTime, signature, BSON ids) to str(e).
+        # All values here are synthetic — the real driver error must never reach the user.
+        details = {
+            "ok": 0.0,
+            "errmsg": "not authorized on demo_db to execute command { listCollections: 1 }",
+            "code": 13,
+            "codeName": "Unauthorized",
+            "$clusterTime": {"clusterTime": "Timestamp(1, 1)", "signature": {"keyId": 1234567890}},
+        }
+        mock_get_collections.side_effect = OperationFailure(
+            "not authorized on demo_db to execute command { listCollections: 1 }", 13, details
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_NOT_AUTHORIZED_MESSAGE
+        for leaked in ("full error", "signature", "clusterTime", "keyId", "demo_db"):
+            assert leaked not in (err or "")
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_authentication_failure_returns_clean_message(self, mock_get_collections):
+        from pymongo.errors import OperationFailure
+
+        mock_get_collections.side_effect = OperationFailure(
+            "Authentication failed.", 18, {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18}
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_AUTHENTICATION_FAILED_MESSAGE
+        assert "full error" not in (err or "")
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_unescaped_credentials_returns_actionable_message(self, mock_get_collections):
+        from pymongo.errors import InvalidURI
+
+        mock_get_collections.side_effect = InvalidURI(
+            "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_unknown_connect_error_returns_generic_message_without_internals(self, mock_get_collections):
+        mock_get_collections.side_effect = Exception("some-internal-driver-detail-xyz")
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_CONNECT_FAILED_MESSAGE
+        assert "xyz" not in (err or "")

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -1,6 +1,8 @@
 import pytest
 from unittest.mock import patch
 
+from pymongo.errors import InvalidURI, OperationFailure
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MongoDBSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
     DATABASE_NAME_REQUIRED_ERROR,
@@ -94,67 +96,54 @@ class TestMongoValidateCredentialsServerSelection:
 
 
 class TestMongoValidateCredentialsOperationFailure:
+    # All values here are synthetic — pymongo appends the full server response (clusterTime,
+    # signature, BSON ids) to str(e), and that raw text must never reach the user. Each row
+    # exercises a distinct branch: two inside `except OperationFailure`, two inside `except Exception`.
+    @pytest.mark.parametrize(
+        "exc, expected_message, forbidden",
+        [
+            (
+                OperationFailure(
+                    "not authorized on demo_db to execute command { listCollections: 1 }",
+                    13,
+                    {
+                        "ok": 0.0,
+                        "errmsg": "not authorized on demo_db to execute command { listCollections: 1 }",
+                        "code": 13,
+                        "codeName": "Unauthorized",
+                        "$clusterTime": {"clusterTime": "Timestamp(1, 1)", "signature": {"keyId": 1234567890}},
+                    },
+                ),
+                _MONGO_NOT_AUTHORIZED_MESSAGE,
+                ("full error", "signature", "clusterTime", "keyId", "demo_db"),
+            ),
+            (
+                OperationFailure(
+                    "Authentication failed.", 18, {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18}
+                ),
+                _MONGO_AUTHENTICATION_FAILED_MESSAGE,
+                ("full error",),
+            ),
+            (
+                InvalidURI("Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"),
+                _MONGO_UNESCAPED_CREDENTIALS_MESSAGE,
+                (),
+            ),
+            (
+                Exception("some-internal-driver-detail-xyz"),
+                _MONGO_CONNECT_FAILED_MESSAGE,
+                ("xyz",),
+            ),
+        ],
+    )
     @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_not_authorized_returns_clean_message_and_redacts_internals(self, mock_get_collections):
-        from pymongo.errors import OperationFailure
-
-        # pymongo appends the full server response (clusterTime, signature, BSON ids) to str(e).
-        # All values here are synthetic — the real driver error must never reach the user.
-        details = {
-            "ok": 0.0,
-            "errmsg": "not authorized on demo_db to execute command { listCollections: 1 }",
-            "code": 13,
-            "codeName": "Unauthorized",
-            "$clusterTime": {"clusterTime": "Timestamp(1, 1)", "signature": {"keyId": 1234567890}},
-        }
-        mock_get_collections.side_effect = OperationFailure(
-            "not authorized on demo_db to execute command { listCollections: 1 }", 13, details
-        )
+    def test_returns_clean_message_without_internals(self, mock_get_collections, exc, expected_message, forbidden):
+        mock_get_collections.side_effect = exc
         config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
 
         ok, err = MongoDBSource().validate_credentials(config, team_id=1)
 
         assert ok is False
-        assert err == _MONGO_NOT_AUTHORIZED_MESSAGE
-        for leaked in ("full error", "signature", "clusterTime", "keyId", "demo_db"):
+        assert err == expected_message
+        for leaked in forbidden:
             assert leaked not in (err or "")
-
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_authentication_failure_returns_clean_message(self, mock_get_collections):
-        from pymongo.errors import OperationFailure
-
-        mock_get_collections.side_effect = OperationFailure(
-            "Authentication failed.", 18, {"ok": 0.0, "errmsg": "Authentication failed.", "code": 18}
-        )
-        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
-
-        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert err == _MONGO_AUTHENTICATION_FAILED_MESSAGE
-        assert "full error" not in (err or "")
-
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_unescaped_credentials_returns_actionable_message(self, mock_get_collections):
-        from pymongo.errors import InvalidURI
-
-        mock_get_collections.side_effect = InvalidURI(
-            "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"
-        )
-        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
-
-        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert err == _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
-
-    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
-    def test_unknown_connect_error_returns_generic_message_without_internals(self, mock_get_collections):
-        mock_get_collections.side_effect = Exception("some-internal-driver-detail-xyz")
-        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
-
-        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
-
-        assert ok is False
-        assert err == _MONGO_CONNECT_FAILED_MESSAGE
-        assert "xyz" not in (err or "")


### PR DESCRIPTION
## Problem

Creating a MongoDB data-warehouse source could surface raw pymongo exception text straight to the user in the setup wizard. When the supplied credentials authenticate but lack permission to list collections, pymongo raises an `OperationFailure` whose string form embeds the **entire server response** — cluster time, signature hashes, key ids, BSON identifiers. Our handler wrapped that verbatim as `"MongoDB authentication failed: " + str(e)`, so all of that internal cluster metadata leaked into the error toast. It also mislabeled an *authorization* problem as an *authentication* one. The generic catch-all branch echoed the raw driver string too.

## Changes

In `MongoDBSource.validate_credentials`, map the stable error markers to clean, user-facing messages instead of interpolating `str(e)`:

- **Authorization failures** (`not authorized`) now return a dedicated message explaining the user authenticated fine but lacks a read role on the database — distinct from a bad password.
- **Unescaped credentials** (the RFC-3986 hint pymongo raises before any network call) reuse the existing actionable message that was previously only applied on the sync path.
- **Any other connect failure** falls back to a generic "check your connection string and credentials" message. The real exception is still sent to error capture for our own debugging.

Also added the `not authorized` marker to `get_non_retryable_errors` so a mid-sync authorization failure gets the same clean message rather than leaking the raw response.

This mirrors the existing `ServerSelectionTimeoutError` handling, which already redacts pymongo's verbose topology dump in favor of a concise message.

## How did you test this code?

I'm an agent. I added unit tests in `test_database_name.py` covering the validation paths, asserting on stable non-sensitive substrings only (no real customer values):

- authorization failure returns the clean message **and** the raw internals (`full error`, `signature`, `clusterTime`, `keyId`, db name) are absent from the surfaced message — the regression that motivated this fix
- authentication failure returns the auth message with no `full error` leak
- unescaped-credentials error returns the actionable RFC-3986 message
- an unknown connect error returns the generic message and does not echo the raw exception text

I verified the pymongo exception string shapes my marker matching relies on (`not authorized`, `full error`, `signature` all present in `str(OperationFailure(...))`; `InvalidURI` is a plain `Exception` carrying the RFC marker). The Django-based test runner isn't available in my sandbox, so I did not execute the pytest suite here; the new tests are plain (no DB) and follow directly from the verified exception behavior.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of data-warehouse source-creation failures and classified each error message. Most were clean, actionable user messages (wrong API key, unreachable host, missing permissions) needing no change. MongoDB was the one clear case of internal driver output leaking to users. Other source types (Postgres, Supabase, MySQL, Stripe, Google Ads, etc.) were reviewed and left unchanged — their messages are our own constants, not raw exceptions.

Scope kept deliberately narrow: error-message handling only, no change to sync behavior or schema discovery. Tests assert on stable substrings and explicitly check that sensitive driver internals are redacted.