### PR TITLE
fix(experiments): allow setting multiple_variant_handling via experiment-update

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -18951,6 +18951,11 @@
                 },
                 "filterTestAccounts": {
                     "type": "boolean"
+                },
+                "multiple_variant_handling": {
+                    "description": "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure.",
+                    "enum": ["exclude", "first_seen"],
+                    "type": "string"
                 }
             },
             "type": "object"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -4053,6 +4053,9 @@ export interface ExperimentApiExposureConfig {
 export interface ExperimentApiExposureCriteria {
     filterTestAccounts?: boolean
     exposure_config?: ExperimentApiExposureConfig
+    /** How to handle entities exposed to multiple variants. 'exclude' (default) drops them from
+     *  the analysis; 'first_seen' assigns them to the variant from their earliest exposure. */
+    multiple_variant_handling?: 'exclude' | 'first_seen'
 }
 
 export const enum ExperimentMetricType {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -4944,6 +4944,14 @@ class ExperimentApiExposureCriteria(BaseModel):
     )
     exposure_config: ExperimentApiExposureConfig | None = None
     filterTestAccounts: bool | None = None
+    multiple_variant_handling: MultipleVariantHandling | None = Field(
+        default=None,
+        description=(
+            "How to handle entities exposed to multiple variants. 'exclude' (default)"
+            " drops them from the analysis; 'first_seen' assigns them to the variant"
+            " from their earliest exposure."
+        ),
+    )
 
 
 class ExperimentApiMetric(BaseModel):

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -7538,3 +7538,28 @@ class TestExperimentSerializerSuperset(unittest.TestCase):
             mismatches,
             "Shared fields have mismatched read_only/required between serializers:\n" + "\n".join(mismatches),
         )
+
+
+class TestExperimentApiExposureCriteriaParity(unittest.TestCase):
+    """Structural guard: the slim API exposure-criteria schema must expose every writable field.
+
+    ``exposure_criteria`` is stored as a plain JSONField, so the backend accepts any field at
+    runtime. ``ExperimentApiExposureCriteria`` is the slim type that drives the OpenAPI spec and,
+    downstream, the MCP tool / frontend write schema. A field honored at runtime (read from
+    ``ExperimentExposureCriteria``) but missing from the slim type is silently stripped by the
+    generated client before it ever reaches the API — which is how ``multiple_variant_handling``
+    looked settable via ``experiment-get`` yet never saved via ``experiment-update``.
+    """
+
+    def test_api_schema_exposes_every_runtime_field(self) -> None:
+        from posthog.schema import ExperimentApiExposureCriteria, ExperimentExposureCriteria
+
+        runtime_fields = set(ExperimentExposureCriteria.model_fields)
+        api_fields = set(ExperimentApiExposureCriteria.model_fields)
+        dropped = runtime_fields - api_fields
+        self.assertFalse(
+            dropped,
+            f"ExperimentApiExposureCriteria omits exposure_criteria fields the runtime honors: {dropped}. "
+            "Generated write clients (MCP, frontend) strip these silently — add them to the slim API "
+            "type in frontend/src/queries/schema/schema-general.ts and rerun hogli build:schema.",
+        )

--- a/products/experiments/frontend/generated/api.schemas.ts
+++ b/products/experiments/frontend/generated/api.schemas.ts
@@ -513,9 +513,18 @@ export interface ExperimentApiExposureConfigApi {
     properties: EventPropertyFilterApi[]
 }
 
+export type MultipleVariantHandlingApi = (typeof MultipleVariantHandlingApi)[keyof typeof MultipleVariantHandlingApi]
+
+export const MultipleVariantHandlingApi = {
+    Exclude: 'exclude',
+    FirstSeen: 'first_seen',
+} as const
+
 export interface ExperimentApiExposureCriteriaApi {
     exposure_config?: ExperimentApiExposureConfigApi | null
     filterTestAccounts?: boolean | null
+    /** How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure. */
+    multiple_variant_handling?: MultipleVariantHandlingApi | null
 }
 
 export type KindApi = (typeof KindApi)[keyof typeof KindApi]

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -21010,6 +21010,8 @@ export namespace Schemas {
     export interface ExperimentApiExposureCriteria {
       exposure_config?: ExperimentApiExposureConfig | null;
       filterTestAccounts?: boolean | null;
+      /** How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure. */
+      multiple_variant_handling?: MultipleVariantHandling | null;
     }
 
     export type Kind = typeof Kind[keyof typeof Kind];

--- a/services/mcp/src/generated/experiments/api.ts
+++ b/services/mcp/src/generated/experiments/api.ts
@@ -494,6 +494,12 @@ export const ExperimentsCreateBody = /* @__PURE__ */ zod
                         ])
                         .optional(),
                     filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
+                    multiple_variant_handling: zod
+                        .union([zod.enum(['exclude', 'first_seen']), zod.null()])
+                        .optional()
+                        .describe(
+                            "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure."
+                        ),
                 }),
                 zod.null(),
             ])
@@ -2879,6 +2885,12 @@ export const ExperimentsPartialUpdateBody = /* @__PURE__ */ zod
                         ])
                         .optional(),
                     filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
+                    multiple_variant_handling: zod
+                        .union([zod.enum(['exclude', 'first_seen']), zod.null()])
+                        .optional()
+                        .describe(
+                            "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure."
+                        ),
                 }),
                 zod.null(),
             ])
@@ -5329,6 +5341,12 @@ export const ExperimentsDuplicateCreateBody = /* @__PURE__ */ zod
                         ])
                         .optional(),
                     filterTestAccounts: zod.union([zod.boolean(), zod.null()]).optional(),
+                    multiple_variant_handling: zod
+                        .union([zod.enum(['exclude', 'first_seen']), zod.null()])
+                        .optional()
+                        .describe(
+                            "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure."
+                        ),
                 }),
                 zod.null(),
             ])

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-create.json
@@ -186,6 +186,18 @@
                                     "type": "null"
                                 }
                             ]
+                        },
+                        "multiple_variant_handling": {
+                            "anyOf": [
+                                {
+                                    "enum": ["exclude", "first_seen"],
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure."
                         }
                     },
                     "type": "object"

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/experiment-update.json
@@ -214,6 +214,18 @@
                                     "type": "null"
                                 }
                             ]
+                        },
+                        "multiple_variant_handling": {
+                            "anyOf": [
+                                {
+                                    "enum": ["exclude", "first_seen"],
+                                    "type": "string"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ],
+                            "description": "How to handle entities exposed to multiple variants. 'exclude' (default) drops them from the analysis; 'first_seen' assigns them to the variant from their earliest exposure."
                         }
                     },
                     "type": "object"


### PR DESCRIPTION
## Problem

A user tried to flip `multiple_variant_handling` on an experiment through the MCP `experiment-update` tool. `experiment-get` showed the current value, but passing it to `experiment-update` succeeded with no error and never saved.

`multiple_variant_handling` lives inside the experiment's `exposure_criteria` JSON and is read at runtime from there. The backend stores `exposure_criteria` as a plain `JSONField`, so it always accepted the field — the gap was purely in the generated write schema.

The serializer's `exposure_criteria` field is annotated with `@extend_schema_field(ExperimentApiExposureCriteria)`, a deliberately slim API type that keeps the OpenAPI/MCP schema compact. That slim type was missing `multiple_variant_handling`, so the chain serializer → OpenAPI → Orval → MCP zod produced an `experiment-update` body where `exposure_criteria` only allowed `exposure_config` and `filterTestAccounts`. A default `zod.object()` silently strips unknown keys, so the field was dropped before the request ever left the client. `experiment-get` showed it because the read path returns the raw stored JSON.

## Changes

One source edit: added `multiple_variant_handling?: 'exclude' | 'first_seen'` to the slim `ExperimentApiExposureCriteria` in `frontend/src/queries/schema/schema-general.ts`, with a JSDoc description that flows down into the MCP tool parameter description. Everything else is regenerated codegen (`pnpm run schema:build` + `pnpm run openapi:build`):

- `posthog/schema.py`, `frontend/src/queries/schema.json`
- `products/experiments/frontend/generated/api.schemas.ts`
- `services/mcp/src/api/generated.ts`, `services/mcp/src/generated/experiments/api.ts` (the zod strip point now accepts the field)

This also covers `experiment-create` and `experiment-duplicate`, which share the same slim type.

## How did you test this code?

- Test added
- Tested locally: multiple variant handling is now correctly persisted via the experiment update MCP tool

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). Skills invoked while producing this PR: `/implementing-mcp-tools` and `/improving-drf-endpoints`.
- Key decision: the root cause looked like it could be fixed either on the serializer side (point the `@extend_schema_field` at the full `ExperimentExposureCriteria`) or by extending the slim type. Chose to extend the slim `ExperimentApiExposureCriteria` instead — switching to the full type would re-introduce the heavy union expansion the slim API types were created to avoid. The runtime already persists the field, so no backend logic changed.
- Chose a structural pydantic-parity test over a DB-backed end-to-end API test: the bug lived in the generated write contract, not the runtime, so a backend persistence test would have passed even before the fix. The parity test guards the actual failure surface and is fast.
