### PR TITLE
chore(replay-vision): add skill for exploring and acting on observations

### DIFF
--- a/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
+++ b/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
@@ -25,7 +25,7 @@ and doing something useful with it. For creating or sizing scanners, use [[creat
 
 If a scanner has `emits_signals: true`, its observations also feed the Signals pipeline and may surface as
 Inbox **signal reports** (clusters of related findings). When the user's intent is "work the reports", that's
-the inbox path — see *Acting on findings* below.
+the inbox path — see _Acting on findings_ below.
 
 ## Step 1 — Anchor on the scanner
 
@@ -41,9 +41,9 @@ know it's a monitor; a score only means something against the scorer's `scale`).
 Pick the axis that matches the question:
 
 - **What has this scanner found, over time?** → `vision-scanners-observations-list` (the workhorse). Filter to
-  `status=succeeded` to get only sessions with a finding, then narrow by `verdict` (monitors), `tags`
-  (classifiers), or score, and `order_by` (e.g. `-result_score`, `-completed_at`) to surface the strongest
-  hits first.
+  `status=succeeded` to get only sessions with a finding, then narrow by `verdict` (monitors) or `tags`
+  (classifiers). Scorers aren't filtered by score — rank them with `order_by=-result_score` instead. Use
+  `order_by` (e.g. `-result_score`, `-completed_at`) to surface the strongest hits first.
 - **What did every scanner find about one session?** → `vision-observations-list` (the `session_id` query
   parameter is REQUIRED). Use this while investigating a single recording.
 - **The full detail of one finding** → `vision-scanners-observations-get` or `vision-observations-retrieve` —
@@ -52,12 +52,12 @@ Pick the axis that matches the question:
 
 Triage `status` so you don't mistake a non-result for "nothing wrong":
 
-| status | meaning | typical `error_reason` |
-| --- | --- | --- |
-| `succeeded` | has a `scanner_result` | — |
-| `ineligible` | session couldn't be analysed — a normal outcome, not an error | `too_short`, `no_recording`, `too_inactive`, `too_long`, `no_events` |
-| `failed` | the scan errored | `provider_rejected`, `validation_failed`, `rasterization_failed`, `provider_transient`, `internal_error` |
-| `pending` / `running` | still in flight | — |
+| status                | meaning                                                       | typical `error_reason`                                                                                   |
+| --------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------- |
+| `succeeded`           | has a `scanner_result`                                        | —                                                                                                        |
+| `ineligible`          | session couldn't be analysed — a normal outcome, not an error | `too_short`, `no_recording`, `too_inactive`, `too_long`, `no_events`                                     |
+| `failed`              | the scan errored                                              | `provider_rejected`, `validation_failed`, `rasterization_failed`, `provider_transient`, `internal_error` |
+| `pending` / `running` | still in flight                                               | —                                                                                                        |
 
 A scanner that looks like it "found nothing" is often producing mostly `ineligible` observations — check the
 mix before concluding.

--- a/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
+++ b/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: exploring-replay-vision-observations
+description: "Guides agents through pulling a Replay Vision scanner's observations, reading the findings, and acting on them — summarizing patterns across sessions, drilling into individual recordings, and turning real, corroborated issues into PostHog tasks, insights, or an investigating-replay hand-off.\nTRIGGER when: user wants to pull/read/triage Replay Vision observations, asks \"what has my scanner found\", wants to act on or summarize scanner findings, turn observations into tasks/work, or points at a /replay-vision/<scanner-id> URL.\nDO NOT TRIGGER when: creating or sizing a scanner (use creating-replay-vision-scanners), running a one-off scan you don't then analyse, or authoring a signals scout."
+---
+
+# Exploring Replay Vision observations
+
+A scanner is a standing LLM probe over session recordings; each time it runs against a session it records
+one **observation**. This skill is about the other half of the loop — reading what the scanners have found
+and doing something useful with it. For creating or sizing scanners, use [[creating-replay-vision-scanners]].
+
+## Mental model
+
+- **Scanner → observations.** One observation = one scan of one session. There is at most one observation
+  per `(scanner, session)`.
+- **The finding lives in `scanner_result`.** Its shape depends on the scanner's `scanner_type`, but it always
+  carries a `confidence`:
+  - `monitor` → a `verdict` (`yes` / `no` / `inconclusive`) plus an open-ended observation.
+  - `classifier` → one or more `tags` from the scanner's label set.
+  - `scorer` → a numeric score on the scanner's `scale`.
+  - `summarizer` → a free-text summary (optionally with facet embeddings).
+- **Only `succeeded` observations carry a finding.** Triage the rest by `status`/`error_reason` (see below).
+- **Observations are LLM judgments, not ground truth.** One observation is one model's read of one session —
+  corroborate before you act on it.
+
+If a scanner has `emits_signals: true`, its observations also feed the Signals pipeline and may surface as
+Inbox **signal reports** (clusters of related findings). When the user's intent is "work the reports", that's
+the inbox path — see *Acting on findings* below.
+
+## Step 1 — Anchor on the scanner
+
+If the user gave a `/project/<id>/replay-vision/<scanner-id>` URL, that path segment is the scanner ID.
+Otherwise list them with `vision-scanners-list` and pick the relevant one.
+
+Then call `vision-scanners-get` to read its configuration **before** reading results — the `scanner_type` and
+`scanner_config.prompt` tell you how to interpret `scanner_result` (a `verdict` field only makes sense once you
+know it's a monitor; a score only means something against the scorer's `scale`).
+
+## Step 2 — Pull the observations
+
+Pick the axis that matches the question:
+
+- **What has this scanner found, over time?** → `vision-scanners-observations-list` (the workhorse). Filter to
+  `status=succeeded` to get only sessions with a finding, then narrow by `verdict` (monitors), `tags`
+  (classifiers), or score, and `order_by` (e.g. `-result_score`, `-completed_at`) to surface the strongest
+  hits first.
+- **What did every scanner find about one session?** → `vision-observations-list` (the `session_id` query
+  parameter is REQUIRED). Use this while investigating a single recording.
+- **The full detail of one finding** → `vision-scanners-observations-get` or `vision-observations-retrieve` —
+  returns the frozen `scanner_snapshot` (config at run time) and the complete `scanner_result`, including any
+  event citations that link the finding back to specific events in the recording.
+
+Triage `status` so you don't mistake a non-result for "nothing wrong":
+
+| status | meaning | typical `error_reason` |
+| --- | --- | --- |
+| `succeeded` | has a `scanner_result` | — |
+| `ineligible` | session couldn't be analysed — a normal outcome, not an error | `too_short`, `no_recording`, `too_inactive`, `too_long`, `no_events` |
+| `failed` | the scan errored | `provider_rejected`, `validation_failed`, `rasterization_failed`, `provider_transient`, `internal_error` |
+| `pending` / `running` | still in flight | — |
+
+A scanner that looks like it "found nothing" is often producing mostly `ineligible` observations — check the
+mix before concluding.
+
+## Step 3 — Read the findings
+
+- **Monitors:** focus on `verdict: yes`; treat `inconclusive` as a weak signal. The observation text is the
+  substance.
+- **Classifiers:** group by `tags` to see the distribution of what's happening across sessions.
+- **Scorers:** look at the tails (highest/lowest scores), not just the average.
+- **Summarizers:** read for recurring themes across summaries.
+
+Weight by `confidence`, and don't over-index on a single observation. To understand a specific hit, take its
+`session_id` and either cross-reference other scanners (`vision-observations-list`) or drill into the actual
+recording with the [[investigating-replay]] skill and the session-recording MCP tools.
+
+To test a scanner's lens against a specific session that doesn't have an observation yet, trigger one on demand
+with `vision-scanners-scan-session` — it's async (minutes; rasterising the recording + the LLM call are slow)
+and, like all observations, runs at most once per `(scanner, session)`.
+
+## Step 4 — Act on the findings
+
+Match the action to the user's intent, and **corroborate before you create work**:
+
+- **Summarize a pattern.** Report the finding back with the numbers and a few representative `session_id`s
+  (e.g. "12 of 40 succeeded observations flagged checkout confusion; sessions A, B, C"). Cite, don't assert.
+- **Turn a real issue into work.** When a finding is corroborated across several sessions (not one
+  low-confidence hit), file it: create a PostHog task or insight to track it, and link the supporting
+  `session_id`s so a human can watch the evidence. Prefer one task per distinct issue over one task per
+  observation.
+- **Work the Inbox.** If the scanner emits signals, its findings may already be clustered into signal reports —
+  read and act on those with `inbox-reports-list` + `inbox-report-artefacts-list` (the report's work log is the
+  evidence). See the [[inbox-exploration]] skill; that path also records your work against the report.
+
+The discipline that matters: a single observation is one model's judgment on one recording. Confirm a finding
+reproduces across observations (or against the raw recording) before turning it into a task, an alert, or a
+claim — the same rigor the signals pipeline applies before it promotes observations to a report.
+
+## Gotchas
+
+- **Only `succeeded` observations have a `scanner_result`** — everything else is triage metadata.
+- **`ineligible` ≠ `failed`.** Ineligible is a normal terminal outcome (e.g. the recording was too short), not
+  a bug to chase.
+- **One observation per `(scanner, session)`** — re-scanning a session that already has any observation
+  (even ineligible/failed) is a no-op.
+- **Findings are snapshotted.** Each observation keeps the `scanner_snapshot` it ran under, so older
+  observations may reflect a previous prompt/config (`scanner_version`).
+- **Quota is shared.** On-demand scans count against the org's monthly budget — check `vision-quota-retrieve`
+  before triggering a batch of them.

--- a/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
+++ b/products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md
@@ -84,9 +84,12 @@ Match the action to the user's intent, and **corroborate before you create work*
 
 - **Summarize a pattern.** Report the finding back with the numbers and a few representative `session_id`s
   (e.g. "12 of 40 succeeded observations flagged checkout confusion; sessions A, B, C"). Cite, don't assert.
-- **Turn a real issue into work.** When a finding is corroborated across several sessions (not one
-  low-confidence hit), file it: create a PostHog task or insight to track it, and link the supporting
-  `session_id`s so a human can watch the evidence. Prefer one task per distinct issue over one task per
+- **Make it trackable.** When a finding is corroborated across several sessions (not one low-confidence
+  hit), capture it durably with the tools that exist: create an `insight` or `notebook` to track its
+  frequency, bundle the supporting recordings into a session-recording playlist so a human can watch the
+  evidence, and add an `annotation` if it marks a regression. There is **no MCP tool to open a PostHog
+  task directly** — to route a finding into tracked work, use the Inbox path below (for signal-emitting
+  scanners) or hand the summary to a human or coding agent to act on. Group by distinct issue, not per
   observation.
 - **Work the Inbox.** If the scanner emits signals, its findings may already be clustered into signal reports —
   read and act on those with `inbox-reports-list` + `inbox-report-artefacts-list` (the report's work log is the


### PR DESCRIPTION
## Problem

I audited the MCP tooling PostHog ships for Replay Vision. The read/scan/manage surface is already comprehensive — `products/replay_vision/mcp/tools.yaml` has ~12 enabled tools covering scanners (list/get/create/update/delete/estimate/scan-session) and observations (list by scanner, list by session, get one, quota). They're gated behind the `replay-vision` feature flag, which is why they don't show up in a default MCP session.

What's missing isn't a tool — it's the **workflow knowledge**. There's a `creating-replay-vision-scanners` skill for making scanners, but nothing teaches an agent the other half of the loop: pull a scanner's observations, interpret the findings by scanner type, corroborate them, and act on them. That's exactly the job ("pull the observations and act on the findings with an agent") that prompted this.

## Changes

- New skill `products/replay_vision/skills/exploring-replay-vision-observations/SKILL.md`. It walks an agent through:
  - **Anchor** on the scanner (from a `/replay-vision/<id>` URL or `vision-scanners-list`) and read its config first, so `scanner_result` is interpreted correctly per type.
  - **Pull** observations along the right axis (`vision-scanners-observations-list` for one scanner over time; `vision-observations-list` for one session across scanners; `…-get` for full detail with event citations), and triage `status`/`error_reason` so `ineligible`/`failed` aren't mistaken for "nothing found".
  - **Read** findings by type (monitor verdicts, classifier tags, scorer tails, summarizer themes), weighted by confidence.
  - **Act** — summarize with cited `session_id`s, file corroborated issues as tasks/insights, or work the Inbox reports when the scanner emits signals — with the discipline of corroborating before creating work (a single observation is one LLM judgment).
  - Hands off to `creating-replay-vision-scanners` and `investigating-replay` rather than duplicating them.

Passes `hogli lint:skills` (95 skills OK).

## How did you test this code?

I'm an agent (Claude Code). This is a markdown skill — validated with `hogli lint:skills`. No runtime code.

## Docs update

The skill itself is the agent-facing documentation; CI publishes skills to PostHog/skills on merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom asked me to look at the Replay Vision MCP tools and build out tooling + skills for the gaps, with the goal of pulling observations and acting on findings via an agent. Built with Claude Code; used the `implementing-mcp-tools` and `writing-skills` skills.

Finding to flag for the reviewer: the read/scan tooling already exists, so I did **not** add new tools here. The one genuine tooling gap I found is the disabled aggregate-stats tool `vision_scanners_observations_stats_retrieve` (status/coverage/verdict/tag/score breakdowns for a scanner — a one-call "what did this scanner find" summary). Enabling it is a one-line `enabled: true` flip in `tools.yaml` plus a `hogli build:openapi` regen of the committed MCP codegen artifacts; I left it out of this PR because the codegen pipeline's Node steps need the repo's `.nvmrc` Node (my environment is on an older Node), and a YAML-only change would fail the codegen drift check. Happy to do that as a fast follow in a proper environment if you want it.
