### PR TITLE
chore(frontend): add single-file kea typegen wrapper

### DIFF
--- a/docs/published/handbook/engineering/manual-dev-setup.md
+++ b/docs/published/handbook/engineering/manual-dev-setup.md
@@ -132,6 +132,9 @@ On Linux you often have separate packages: `postgres` for the tools, `postgres-s
 
 5. Run `pnpm --filter=@posthog/frontend typegen:write` to generate types for [Kea](https://keajs.org/) state management logics used all over the frontend.
 
+When iterating on one logic file, run `pnpm --filter=@posthog/frontend typegen:file <path-to-logic-file>` instead.
+The path can be absolute, repo-relative like `frontend/src/scenes/foo/fooLogic.ts`, or frontend-relative like `src/scenes/foo/fooLogic.ts`.
+
 > The first time you run typegen, it may get stuck in a loop. If so, cancel the process (`Ctrl+C`), discard all changes in the working directory (`git reset --hard`), and run `pnpm typegen:write` again. You may need to discard all changes once more when the second round of type generation completes.
 
 ## 3. Prepare nodejs services

--- a/frontend/bin/typegen-file.mjs
+++ b/frontend/bin/typegen-file.mjs
@@ -88,17 +88,19 @@ function parseArgs(args) {
 }
 
 function resolveFile(filePath) {
-    const candidates = path.isAbsolute(filePath)
-        ? [filePath]
-        : [
-              path.resolve(process.cwd(), filePath),
-              process.env.INIT_CWD ? path.resolve(process.env.INIT_CWD, filePath) : undefined,
-              path.resolve(frontendDir, filePath),
-              path.resolve(repoRoot, filePath),
-          ]
+    const candidates = (
+        path.isAbsolute(filePath)
+            ? [filePath]
+            : [
+                  path.resolve(process.cwd(), filePath),
+                  process.env.INIT_CWD && path.resolve(process.env.INIT_CWD, filePath),
+                  path.resolve(frontendDir, filePath),
+                  path.resolve(repoRoot, filePath),
+              ]
+    ).filter(Boolean)
 
     for (const candidate of candidates) {
-        if (candidate && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+        if (fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
             return candidate
         }
     }

--- a/frontend/bin/typegen-file.mjs
+++ b/frontend/bin/typegen-file.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+import { spawnSync } from 'child_process'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const scriptPath = fileURLToPath(import.meta.url)
+const frontendDir = path.resolve(path.dirname(scriptPath), '..')
+const repoRoot = path.resolve(frontendDir, '..')
+const localKeaTypegenBin = path.resolve(
+    frontendDir,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'kea-typegen.cmd' : 'kea-typegen'
+)
+
+const { fileArg, passthroughArgs } = parseArgs(process.argv.slice(2))
+
+if (!fileArg) {
+    console.error('Usage: pnpm --filter=@posthog/frontend typegen:file <logic-file> [kea-typegen options]')
+    process.exit(1)
+}
+
+const resolvedFile = resolveFile(fileArg)
+
+if (!resolvedFile) {
+    console.error(`Could not find logic file: ${fileArg}`)
+    console.error('Checked paths relative to the current directory, pnpm INIT_CWD, frontend/, and the repo root.')
+    process.exit(1)
+}
+
+const nodeOptions = process.env.NODE_OPTIONS?.includes('--max-old-space-size')
+    ? process.env.NODE_OPTIONS
+    : [process.env.NODE_OPTIONS, '--max-old-space-size=4096'].filter(Boolean).join(' ')
+
+const result = spawnSync(
+    fs.existsSync(localKeaTypegenBin) ? localKeaTypegenBin : 'kea-typegen',
+    ['write', '--show-ts-errors', '--file', resolvedFile, ...passthroughArgs],
+    {
+        cwd: repoRoot,
+        env: {
+            ...process.env,
+            NODE_OPTIONS: nodeOptions,
+        },
+        stdio: 'inherit',
+    }
+)
+
+if (result.error) {
+    console.error(`Failed to run kea-typegen: ${result.error.message}`)
+    process.exit(1)
+}
+
+process.exit(result.status ?? 1)
+
+function parseArgs(args) {
+    let fileArg
+    const passthroughArgs = []
+
+    for (let index = 0; index < args.length; index++) {
+        const arg = args[index]
+
+        if (arg === '--file' || arg === '-f') {
+            fileArg = args[index + 1]
+            index += 1
+            continue
+        }
+
+        if (arg.startsWith('--file=')) {
+            fileArg = arg.slice('--file='.length)
+            continue
+        }
+
+        if (arg.startsWith('-f=')) {
+            fileArg = arg.slice('-f='.length)
+            continue
+        }
+
+        if (!fileArg && !arg.startsWith('-')) {
+            fileArg = arg
+            continue
+        }
+
+        passthroughArgs.push(arg)
+    }
+
+    return { fileArg, passthroughArgs }
+}
+
+function resolveFile(filePath) {
+    const candidates = path.isAbsolute(filePath)
+        ? [filePath]
+        : [
+              path.resolve(process.cwd(), filePath),
+              process.env.INIT_CWD ? path.resolve(process.env.INIT_CWD, filePath) : undefined,
+              path.resolve(frontendDir, filePath),
+              path.resolve(repoRoot, filePath),
+          ]
+
+    for (const candidate of candidates) {
+        if (candidate && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+            return candidate
+        }
+    }
+
+    return undefined
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -321,7 +321,7 @@
         "jest-canvas-mock": "^2.4.0",
         "jest-environment-jsdom": "^29.3.1",
         "jest-image-snapshot": "^6.1.0",
-        "kea-typegen": "3.7.0",
+        "kea-typegen": "3.7.1",
         "less": "^3.12.2",
         "lint-staged": "catalog:",
         "mockdate": "^3.0.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,7 @@
         "openapi:types": "node ./bin/generate-openapi-types.mjs",
         "typegen:check": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen check",
         "typegen:clean": "cd .. && find frontend/src products common -type f -name '*Type.ts' -delete",
-        "typegen:file": "cd .. && NODE_OPTIONS=--max-old-space-size=4096 kea-typegen write --show-ts-errors --file",
+        "typegen:file": "node ./bin/typegen-file.mjs",
         "typegen:watch": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen watch --delete --show-ts-errors --use-cache",
         "typegen:write": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors --use-cache",
         "typegen:write:no-cache": "cd .. && NODE_OPTIONS=--max-old-space-size=8192 kea-typegen write --delete --show-ts-errors",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1352,8 +1352,8 @@ importers:
         specifier: ^6.1.0
         version: 6.4.0(jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)))
       kea-typegen:
-        specifier: 3.7.0
-        version: 3.7.0(typescript@6.0.3)
+        specifier: 3.7.1
+        version: 3.7.1(typescript@6.0.3)
       less:
         specifier: ^3.12.2
         version: 3.13.1
@@ -13528,9 +13528,6 @@ packages:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
 
-  assert@2.1.0:
-    resolution: {integrity: sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==}
-
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
@@ -16771,10 +16768,6 @@ packages:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
     engines: {node: '>= 0.4'}
 
-  is-nan@1.3.2:
-    resolution: {integrity: sha512-E+zBKpQ2t6MEo1VsonYmluk9NxGrbzpeeLC2xIViuO2EjU2xsXsBPwTr3Ykv9l08UYEVEdWeRZNouaZqF6RN0w==}
-    engines: {node: '>= 0.4'}
-
   is-negative-zero@2.0.2:
     resolution: {integrity: sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==}
     engines: {node: '>= 0.4'}
@@ -17642,8 +17635,8 @@ packages:
     peerDependencies:
       kea: '>= 3'
 
-  kea-typegen@3.7.0:
-    resolution: {integrity: sha512-kBVxLoD3KbEzd5EkAZ+CFnQvMaZrBeC7/7kRu/qN/Nwp5SmZM/Xgp9ziuXTAK2ynbmm5VhQ+FmGjN+UY3YBwfg==}
+  kea-typegen@3.7.1:
+    resolution: {integrity: sha512-hQuV38I9OyCui/0HviWsgblabeN6iE8t2sOCF8cmoAd1Zk5nR3/5kkaepQGvkaqgwBjy8XcWzVgkCimE8jExoQ==}
     hasBin: true
     peerDependencies:
       typescript: 6.0.3
@@ -20597,10 +20590,6 @@ packages:
 
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
-    engines: {node: '>= 4'}
-
-  recast@0.23.4:
-    resolution: {integrity: sha512-qtEDqIZGVcSZCHniWwZWbRy79Dc6Wp3kT/UmDA2RJKBPg7+7k51aQBZirHmUGn5uvHf2rg8DkjizrN26k61ATw==}
     engines: {node: '>= 4'}
 
   rechoir@0.8.0:
@@ -34536,14 +34525,6 @@ snapshots:
 
   assert-plus@1.0.0: {}
 
-  assert@2.1.0:
-    dependencies:
-      call-bind: 1.0.8
-      is-nan: 1.3.2
-      object-is: 1.1.5
-      object.assign: 4.1.7
-      util: 0.12.5
-
   assertion-error@2.0.1: {}
 
   assign-symbols@1.0.0: {}
@@ -38507,11 +38488,6 @@ snapshots:
 
   is-map@2.0.3: {}
 
-  is-nan@1.3.2:
-    dependencies:
-      call-bind: 1.0.8
-      define-properties: 1.2.1
-
   is-negative-zero@2.0.2: {}
 
   is-negative-zero@2.0.3: {}
@@ -40412,13 +40388,13 @@ snapshots:
       kea: 4.0.0-pre.5(react@18.3.1)
       kea-waitfor: 0.2.1(kea@4.0.0-pre.5(react@18.3.1))
 
-  kea-typegen@3.7.0(typescript@6.0.3):
+  kea-typegen@3.7.1(typescript@6.0.3):
     dependencies:
       '@babel/core': 7.29.0
       '@babel/preset-env': 7.23.5(@babel/core@7.29.0)
       '@babel/preset-typescript': 7.23.3(@babel/core@7.29.0)
       prettier: 3.6.2
-      recast: 0.23.4
+      recast: 0.23.11
       ts-clone-node: 3.0.0(typescript@6.0.3)
       typescript: 6.0.3
       yargs: 16.2.0
@@ -44113,14 +44089,6 @@ snapshots:
       esprima: 4.0.1
       source-map: 0.6.1
       tiny-invariant: 1.3.3
-      tslib: 2.8.1
-
-  recast@0.23.4:
-    dependencies:
-      assert: 2.1.0
-      ast-types: 0.16.1
-      esprima: 4.0.1
-      source-map: 0.6.1
       tslib: 2.8.1
 
   rechoir@0.8.0:


### PR DESCRIPTION
## Problem

Frontend developers can use `kea-typegen --file` for a faster local loop, but the existing package script passed paths straight through after changing into the repo root. A common frontend-relative path like `src/lib/approvals/approvalsGateLogic.ts` resolved to a non-existent repo-root path, found zero logics, and exited successfully.

That made editor or task-runner integration easy to misconfigure and hard to trust.

Separately, the normal `kea-typegen watch` loop is the workflow we keep running during frontend development, but older `kea-typegen` releases still reprocessed too much project state after each change.

## Changes

Added a small frontend wrapper for `typegen:file` that resolves the target logic file before invoking the installed `kea-typegen` binary from the repo root.

It now accepts absolute paths, repo-relative paths, frontend-relative paths, and explicit `--file` / `-f` forms. Missing paths fail clearly instead of silently doing no work.

Bumped the frontend dependency to `kea-typegen@3.7.1`, which includes the upstream incremental watch mode change. With the watch process already running, changed logic files can now reuse the previous project scan instead of forcing the same broad reprocessing on every save.

The manual development setup docs now mention the single-file command and supported path shapes.

## How did you test this code?

Agent-authored validation performed locally:

- `pnpm --filter=@posthog/frontend typegen:file frontend/src/lib/approvals/approvalsGateLogic.ts --quiet`
- `pnpm --filter=@posthog/frontend typegen:file src/lib/approvals/approvalsGateLogic.ts --quiet`
- `pnpm typegen:file src/lib/approvals/approvalsGateLogic.ts --quiet` from `frontend/`
- `pnpm --filter=@posthog/frontend typegen:file /path/to/posthog/frontend/src/lib/approvals/approvalsGateLogic.ts --quiet`
- `pnpm --filter=@posthog/frontend typegen:file products/metrics/frontend/components/metricNamePickerLogic.ts --quiet`
- `pnpm --filter=@posthog/frontend typegen:file --file=src/lib/approvals/approvalsGateLogic.ts --quiet`
- `pnpm --filter=@posthog/frontend typegen:file src/lib/approvals/notARealLogic.ts --quiet` exits non-zero with a clear error
- `node --check frontend/bin/typegen-file.mjs`
- `pnpm exec oxfmt --check frontend/bin/typegen-file.mjs docs/published/handbook/engineering/manual-dev-setup.md frontend/package.json`
- `pnpm --filter=@posthog/frontend exec kea-typegen --version` reports `3.7.1`
- `pnpm --filter=@posthog/frontend typegen:file src/lib/approvals/approvalsGateLogic.ts --quiet`
- `pnpm install --lockfile-only --frozen-lockfile --filter=@posthog/frontend`

Measured local timing before the `3.7.1` package bump: full `typegen:check --quiet` took 34.02 seconds and failed on existing generated type drift; single-file runs were 17-25 seconds cold and roughly 5-12 seconds warm.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Updated `docs/published/handbook/engineering/manual-dev-setup.md` with the single-file command.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change in response to a request to evaluate whether the single-file Kea typegen loop had real devex wins and implement the practical improvement if so. The `github:yeet` skill was used for the branch, commit, push, and PR flow.

The first local win is a reliable PostHog `typegen:file` wrapper for editor and task-runner integrations. After testing the broader dev loop, the companion upstream change was released as `kea-typegen@3.7.1`, so this PR now also consumes that published package for incremental watch mode.