### PR TITLE
fix(admin): link org usage to Metabase customer usage dashboard

### DIFF
--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -223,7 +223,7 @@ class OrganizationAdmin(admin.ModelAdmin):
             f"{metabase_host}/dashboard/139-customer-usage-breakdown"
             f"?tab=35-events&organization_id={organization.id}&lookback_days=30&search_event=%20"
         )
-        return format_html('<a target="_blank" href="{}">See usage on PostHog →</a>', url)
+        return format_html('<a target="_blank" href="{}">See usage on Metabase →</a>', url)
 
     @admin.display(description="Limited Products")
     def limited_products_display(self, organization: Organization):

--- a/posthog/admin/admins/organization_admin.py
+++ b/posthog/admin/admins/organization_admin.py
@@ -213,10 +213,17 @@ class OrganizationAdmin(admin.ModelAdmin):
         return format_html(f'<a href="{url}">Billing →</a>')
 
     def usage_posthog(self, organization: Organization):
-        return format_html(
-            '<a target="_blank" href="/insights/new?insight=TRENDS&interval=day&display=ActionsLineGraph&events=%5B%7B%22id%22%3A%22%24pageview%22%2C%22name%22%3A%22%24pageview%22%2C%22type%22%3A%22events%22%2C%22order%22%3A0%2C%22math%22%3A%22dau%22%7D%5D&properties=%5B%7B%22key%22%3A%22organization_id%22%2C%22value%22%3A%22{}%22%2C%22operator%22%3A%22exact%22%2C%22type%22%3A%22person%22%7D%5D&actions=%5B%5D&new_entity=%5B%5D">See usage on PostHog →</a>',
-            organization.id,
+        # Route to the region-appropriate Metabase customer usage breakdown dashboard.
+        metabase_host = (
+            "https://metabase.prod-eu.posthog.dev"
+            if settings.CLOUD_DEPLOYMENT == "EU"
+            else "https://metabase.prod-us.posthog.dev"
         )
+        url = (
+            f"{metabase_host}/dashboard/139-customer-usage-breakdown"
+            f"?tab=35-events&organization_id={organization.id}&lookback_days=30&search_event=%20"
+        )
+        return format_html('<a target="_blank" href="{}">See usage on PostHog →</a>', url)
 
     @admin.display(description="Limited Products")
     def limited_products_display(self, organization: Organization):


### PR DESCRIPTION
## Problem

On the Django admin organization page, the "See usage on PostHog →" link opened a blank *new insight* editor rather than a usage dashboard, so it wasn't actually useful for seeing a customer's usage.

## Changes

Point the link at the region-appropriate Metabase "Customer usage breakdown" dashboard (dashboard 139), filtered by `organization_id`. Routing follows `settings.CLOUD_DEPLOYMENT`:

- EU → `https://metabase.prod-eu.posthog.dev`
- US (and everything else) → `https://metabase.prod-us.posthog.dev`

## How did you test this code?

I'm an agent — I did not manually test in a running admin. The change is a pure URL-construction swap inside `usage_posthog`; verified `ruff format`/`ruff check` pass. The region-routing pattern mirrors the existing `metabase_debug_query_url` helper in `posthog/dags/sessions.py`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Abhischek Thottakara via a Slack thread. The original link built a TRENDS insight URL; replaced it with the Metabase customer usage breakdown dashboard the billing team actually uses, with US/EU host routing keyed off `CLOUD_DEPLOYMENT`. Dropped the example's `project_id` param since the admin context is org-scoped (orgs span multiple projects) — the dashboard filters fine on `organization_id` alone.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782411943618879?thread_ts=1782411943.618879&cid=C0ACRAMJUAG)*
