### PR TITLE
fix(data-warehouse): resume Square syncs past expired pagination cursors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/square/square.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/square/square.py
@@ -25,13 +25,19 @@ SQUARE_HOSTS = {
     "sandbox": "https://connect.squareupsandbox.com",
 }
 
-PAGE_SIZE = 100
+# Square cursors expire ~5 minutes after they're issued, and a cursor is only spent
+# once the previous page has been processed downstream. Smaller pages mean less
+# per-page processing, so each cursor is far more likely to be used inside its TTL —
+# the main driver of the INVALID_CURSOR failures on large streams (e.g. customers).
+PAGE_SIZE = 50
 REQUEST_TIMEOUT_SECONDS = 60
 
-# A Square cursor that outlives its ~5 minute TTL mid-stream forces a full restart.
-# Allow a few restarts so a transient stall during the re-scan doesn't fail the sync,
-# while still bounding the work for a stream that paginates slower than its cursor lives.
-MAX_CURSOR_RESTARTS = 3
+# A Square cursor that outlives its ~5 minute TTL mid-stream forces a restart. Allow a
+# handful so a transient stall during the re-scan doesn't fail the sync, while still
+# bounding the work for a stream that paginates slower than its cursor lives. Endpoints
+# with a server-side time filter resume from the last value seen instead of re-scanning
+# from zero (see get_rows), so this budget mostly protects the full-refresh streams.
+MAX_CURSOR_RESTARTS = 5
 
 
 class SquareRetryableError(Exception):
@@ -99,6 +105,15 @@ def _build_initial_params(
         params[config.time_filter_param] = _format_rfc3339(db_incremental_field_last_value)
 
     return params
+
+
+def _time_filter_field(config: SquareEndpointConfig) -> Optional[str]:
+    """The record field that ``time_filter_param`` filters on, or ``None`` when the
+    endpoint has no server-side time filter. Used to seed a restart from the last value
+    seen so an expired cursor resumes mid-stream instead of re-scanning from the start."""
+    if not config.time_filter_param or not config.incremental_fields:
+        return None
+    return config.incremental_fields[0]["field"]
 
 
 def validate_credentials(access_token: str, environment: str, schema_name: Optional[str] = None) -> tuple[bool, bool]:
@@ -173,6 +188,11 @@ def get_rows(
 
         return response.json()
 
+    # The record field the server-side time filter applies to (e.g. created_at), if any.
+    # Tracked so a restart can resume from the last value seen rather than from zero.
+    time_field = _time_filter_field(config)
+    last_seen_value: Optional[str] = None
+
     restarts_remaining = MAX_CURSOR_RESTARTS
     while True:
         # Square encodes the original query in the cursor, so subsequent pages are
@@ -181,15 +201,24 @@ def get_rows(
         try:
             data = fetch_page(params)
         except SquareInvalidCursorError:
-            # An expired cursor can't be recovered by retrying it, so restart the
-            # stream from the beginning (merge dedupes on the primary key). A cursor-less
-            # initial request can't trigger this error, so a rejection there signals a
-            # malformed query rather than expiry — surface it instead of looping. The
-            # restart budget bounds the work when a stream keeps outliving its cursor.
+            # An expired cursor can't be recovered by retrying it, so restart the stream
+            # (merge dedupes on the primary key). A cursor-less initial request can't
+            # trigger this error, so a rejection there signals a malformed query rather
+            # than expiry — surface it instead of looping. The restart budget bounds the
+            # work when a stream keeps outliving its cursor.
             if cursor is None or restarts_remaining <= 0:
                 raise
             restarts_remaining -= 1
-            logger.warning(f"Square: cursor for {endpoint} was rejected, restarting stream from the beginning")
+            cursor = None
+            # On an endpoint with a server-side time filter, resume from the last value
+            # we saw so the restart re-scans only the unfinished tail rather than the
+            # whole stream — otherwise it just hits the same ~5 min TTL wall again.
+            # Endpoints without one (e.g. customers) fall back to a full restart.
+            if time_field is not None and last_seen_value is not None and config.time_filter_param is not None:
+                initial_params = {**initial_params, config.time_filter_param: _format_rfc3339(last_seen_value)}
+                logger.warning(f"Square: cursor for {endpoint} was rejected, resuming from last seen {time_field}")
+            else:
+                logger.warning(f"Square: cursor for {endpoint} was rejected, restarting stream from the beginning")
             # Overwrite the stale cursor in the resume store now. Otherwise, if the
             # restart finishes within a single page (no fresh next_cursor to save),
             # the expired cursor lingers until its TTL and every later sync re-scans
@@ -197,7 +226,6 @@ def get_rows(
             # from the start rather than replaying the bad value.
             if config.paginated:
                 resumable_source_manager.save_state(SquareResumeConfig(cursor=""))
-            cursor = None
             continue
 
         items = data.get(config.data_key, [])
@@ -205,6 +233,12 @@ def get_rows(
 
         if items:
             yield items
+            # Advance the time watermark so a later cursor expiry can resume from here.
+            if time_field is not None:
+                for item in items:
+                    value = item.get(time_field)
+                    if isinstance(value, str) and (last_seen_value is None or value > last_seen_value):
+                        last_seen_value = value
             # Save state only after yielding, so a crash re-yields the last batch
             # rather than skipping it (merge dedupes on the primary key). No point
             # persisting a cursor for non-paginated endpoints — there's nothing to

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/square/test_square.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/square/test_square.py
@@ -63,7 +63,7 @@ class TestBuildInitialParams:
                 "payments",
                 True,
                 datetime(2026, 3, 4, 2, 58, 14, tzinfo=UTC),
-                {"begin_time": "2026-03-04T02:58:14.000Z", "sort_order": "ASC", "limit": "100"},
+                {"begin_time": "2026-03-04T02:58:14.000Z", "sort_order": "ASC", "limit": "50"},
                 [],
             ),
             # incremental endpoint, full refresh -> no begin_time
@@ -285,6 +285,27 @@ class TestGetRowsPagination:
 
         saved = [call.args[0] for call in manager.save_state.call_args_list]
         assert saved == [SquareResumeConfig(cursor="")]
+
+    def test_invalid_cursor_resumes_incremental_endpoint_from_last_seen(self) -> None:
+        # An endpoint with a server-side time filter (payments has begin_time) must not
+        # re-scan from zero when a cursor expires mid-stream — it should re-issue the
+        # query seeded with the last created_at it saw, bounding the re-scan to the tail.
+        manager = MagicMock(spec=ResumableSourceManager)
+        manager.can_resume.return_value = False
+
+        responses = [
+            _make_response({"payments": [{"id": "p1", "created_at": "2026-03-04T02:58:14Z"}], "cursor": "cur-1"}),
+            _make_response({"errors": [{"code": "INVALID_CURSOR"}]}, status_code=400),
+            _make_response({"payments": [{"id": "p2", "created_at": "2026-03-05T00:00:00Z"}]}),
+        ]
+        sent_params = self._drive("payments", manager, responses)
+
+        assert "cursor" not in sent_params[0]
+        assert sent_params[1] == {"cursor": "cur-1"}
+        # The restart drops the cursor and seeds begin_time from the last seen created_at
+        # rather than issuing a bare full restart.
+        assert "cursor" not in sent_params[2]
+        assert sent_params[2]["begin_time"] == "2026-03-04T02:58:14Z"
 
     def test_invalid_cursor_restarts_again_when_re_scan_also_expires(self) -> None:
         # A cursor can expire more than once on a slow full-refresh stream: the first


### PR DESCRIPTION
## Problem

Square data-warehouse syncs were failing with `SquareInvalidCursorError` (hundreds of occurrences, the `customers` endpoint being the top offender — visible in error tracking). Square pagination cursors expire ~5 minutes after they're issued, and a cursor is only spent once the previous page has been processed downstream. On a large stream the cursor could expire mid-pagination, and the existing recovery restarted the stream **from zero** — which simply re-hit the same TTL wall and, after exhausting its restart budget, failed the whole sync.

## Changes

- **Time-filter resume** for endpoints that have a server-side time filter (`payments`, `refunds` expose `begin_time`): on an `INVALID_CURSOR` rejection mid-stream, the stream now re-issues the query seeded with the last `created_at` it saw, so the re-scan is bounded to the unfinished tail instead of starting over.
- **Mitigation for full-refresh streams** with no server-side time filter (e.g. `customers`, which only supports `created_at` filtering via the `POST /search` endpoint, deliberately out of scope here): lowered `PAGE_SIZE` (100 → 50) so each cursor is far more likely to be used inside its TTL, and raised `MAX_CURSOR_RESTARTS` (3 → 5).

The headline `customers` failures are mitigated but not fully eliminated by this PR — the complete fix for that endpoint is a migration to `POST /v2/customers/search` (which exposes a `created_at` filter), tracked as follow-up.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing against the live Square API.

Updated `test_square.py` and added `test_invalid_cursor_resumes_incremental_endpoint_from_last_seen`, which catches the regression that a mid-stream cursor expiry on a time-filtered endpoint would otherwise restart from zero rather than seeding `begin_time` from the last record seen. Existing cursor-restart and pagination tests cover the full-refresh fallback path. Full file passes (35 tests). Ran `ruff check`/`ruff format`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated warehouse-source error rates via PostHog error tracking, traced the `customers` failures to `square.py`'s cursor-restart logic, and confirmed via `settings.py` that `GET /v2/customers` has no server-side time filter. Chose the bounded "time-filter resume + page-size/restart mitigation" approach over a larger `POST /search` migration (deferred) in agreement with the DRI. Skill consulted: `posthog:investigating-error-issue`.
