### PR TITLE
fix(warehouse): keep newest row per key in v3 webhook merge

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/typings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/typings.py
@@ -61,6 +61,11 @@ class SourceResponse:
     rows_to_sync: Optional[int] = None
     has_duplicate_primary_keys: Optional[bool] = None
     """Whether incremental tables have non-unique primary keys"""
+    version_keys: Optional[list[str]] = None
+    """Ordered columns (compared newest-first, NULLs last) that rank rows sharing a primary key, so the
+    load merge keeps the latest state per key instead of whichever row happened to land last in the batch.
+    None preserves the legacy unordered upsert. Set by sources whose rows are mutable and arrive as an
+    event stream — e.g. GitHub webhook runs/jobs that emit queued -> in_progress -> completed for one id."""
     xmin_ceiling_xid: Optional[int] = None
     """xmin syncs: bare 32-bit ceiling captured this run, persisted as the next run's lower bound."""
     xmin_ceiling_xid8: Optional[int] = None

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -541,13 +541,17 @@ def _merge_batch(
         for key in (version_keys or [])
         if (normalized := NamingConvention.normalize_identifier(key)) in columns
     ]
-    if version_keys and not normalized_version_keys:
-        # Declared but none present — a renamed/dropped column would silently disable the
-        # no-rollback guard, so make the regression observable instead of mysterious.
+    missing_version_keys = [
+        key for key in (version_keys or []) if NamingConvention.normalize_identifier(key) not in columns
+    ]
+    if missing_version_keys:
+        # Any missing declared key weakens the no-rollback guard (and if all are gone, disables it).
+        # A column rename would otherwise drift silently, so surface exactly which keys dropped.
         logger.warning(
             "duckgres_merge_version_keys_absent",
             duckgres_schema=duckgres_schema,
             duckgres_table=duckgres_table,
+            missing_version_keys=missing_version_keys,
             declared_version_keys=version_keys,
         )
 
@@ -564,6 +568,8 @@ def _merge_batch(
     insert_columns = sql.SQL(", ").join(sql.Identifier(column) for column in columns)
     insert_values = sql.SQL(", ").join(sql.SQL("source.{}").format(sql.Identifier(column)) for column in columns)
 
+    source_relation: sql.Composable
+    matched_clause: sql.Composable
     if normalized_version_keys:
         # Event-streamed sources (e.g. GitHub webhook runs/jobs) emit several rows per key —
         # queued, then in_progress, then completed. Two guards make the latest state win

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -47,6 +47,7 @@ class BatchApplyOperation:
     kind: Literal["replace", "create", "insert", "merge"]
     ensure_target_columns: bool = False
     primary_keys: list[str] | None = None
+    version_keys: list[str] | None = None
 
 
 def process_batch(batch: PendingBatch) -> None:
@@ -261,7 +262,12 @@ def _plan_batch_operation(
         primary_keys = _primary_keys(batch)
         if not primary_keys:
             raise ValueError("Duckgres incremental batches require primary keys")
-        return BatchApplyOperation(kind="merge", ensure_target_columns=True, primary_keys=primary_keys)
+        return BatchApplyOperation(
+            kind="merge",
+            ensure_target_columns=True,
+            primary_keys=primary_keys,
+            version_keys=_version_keys(batch),
+        )
 
     if batch.sync_type in ("full_refresh", "append"):
         return BatchApplyOperation(kind="insert", ensure_target_columns=True)
@@ -449,7 +455,15 @@ def _apply_batch_operation(
     if operation.kind == "merge":
         if operation.primary_keys is None:
             raise ValueError("Duckgres merge operation requires primary keys")
-        _merge_batch(conn, duckgres_schema, duckgres_table, s3_path, columns, operation.primary_keys)
+        _merge_batch(
+            conn,
+            duckgres_schema,
+            duckgres_table,
+            s3_path,
+            columns,
+            operation.primary_keys,
+            operation.version_keys,
+        )
         return
     raise ValueError(f"Unsupported Duckgres apply operation: {operation.kind}")
 
@@ -474,6 +488,37 @@ def _insert_batch(
     )
 
 
+def _version_guard_clause(version_keys: list[str]) -> sql.Composed:
+    """Predicate that's TRUE when the source row is at least as new as the target under the same
+    `<key> DESC NULLS LAST` ordering the QUALIFY uses — i.e. a lexicographic compare of the version
+    tuple. This is what keeps the no-rollback guarantee across batches (QUALIFY only acts within a
+    batch), and it covers every version key, not just the terminal one, so a stale event can't
+    regress an intermediate field either. Equal tuples pass through so idempotent re-delivery is a
+    harmless no-op rewrite.
+    """
+
+    def newer(key: str) -> sql.Composed:
+        # source.key ranks strictly ahead of target.key: a present value beats NULL (NULLS LAST),
+        # and among present values a larger one is newer.
+        col = sql.Identifier(key)
+        return sql.SQL(
+            "((target.{c} IS NULL AND source.{c} IS NOT NULL) "
+            "OR (source.{c} IS NOT NULL AND target.{c} IS NOT NULL AND source.{c} > target.{c}))"
+        ).format(c=col)
+
+    def equal(key: str) -> sql.Composed:
+        col = sql.Identifier(key)
+        return sql.SQL("((source.{c} IS NULL AND target.{c} IS NULL) OR (source.{c} = target.{c}))").format(c=col)
+
+    terms: list[sql.Composed] = []
+    equal_prefix: list[sql.Composed] = []
+    for key in version_keys:
+        terms.append(sql.SQL("({})").format(sql.SQL(" AND ").join([*equal_prefix, newer(key)])))
+        equal_prefix.append(equal(key))
+    terms.append(sql.SQL("({})").format(sql.SQL(" AND ").join(equal_prefix)))
+    return sql.SQL("({})").format(sql.SQL(" OR ").join(terms))
+
+
 def _merge_batch(
     conn: psycopg.Connection[Any],
     duckgres_schema: str,
@@ -481,11 +526,30 @@ def _merge_batch(
     s3_path: str,
     columns: list[str],
     primary_keys: list[str],
+    version_keys: list[str] | None = None,
 ) -> None:
     normalized_primary_keys = [NamingConvention.normalize_identifier(key) for key in primary_keys]
     missing_keys = [key for key in normalized_primary_keys if key not in columns]
     if missing_keys:
         raise ValueError(f"Duckgres incremental batch missing primary keys: {missing_keys}")
+
+    # A source can declare version keys an endpoint doesn't actually emit, so keep only the ones
+    # present in this batch. If none survive, fall back to the legacy unordered upsert below so
+    # the batch still loads rather than erroring.
+    normalized_version_keys = [
+        normalized
+        for key in (version_keys or [])
+        if (normalized := NamingConvention.normalize_identifier(key)) in columns
+    ]
+    if version_keys and not normalized_version_keys:
+        # Declared but none present — a renamed/dropped column would silently disable the
+        # no-rollback guard, so make the regression observable instead of mysterious.
+        logger.warning(
+            "duckgres_merge_version_keys_absent",
+            duckgres_schema=duckgres_schema,
+            duckgres_table=duckgres_table,
+            declared_version_keys=version_keys,
+        )
 
     update_columns = [column for column in columns if column not in normalized_primary_keys]
     if not update_columns:
@@ -500,12 +564,34 @@ def _merge_batch(
     insert_columns = sql.SQL(", ").join(sql.Identifier(column) for column in columns)
     insert_values = sql.SQL(", ").join(sql.SQL("source.{}").format(sql.Identifier(column)) for column in columns)
 
-    matched_clause = sql.SQL("WHEN MATCHED THEN UPDATE SET {}").format(update_clause)
+    if normalized_version_keys:
+        # Event-streamed sources (e.g. GitHub webhook runs/jobs) emit several rows per key —
+        # queued, then in_progress, then completed. Two guards make the latest state win
+        # deterministically instead of leaving it to batch/file order:
+        #   1. collapse the source to the newest row per key (QUALIFY row_number), and
+        #   2. only overwrite when the source row is at least as new as the target under that
+        #      same ordering, so a late or out-of-order event can't roll a row back — neither
+        #      its terminal field nor an intermediate one (QUALIFY only dedupes within a batch;
+        #      this guard is what holds across batches).
+        order_clause = sql.SQL(", ").join(
+            sql.SQL("{} DESC NULLS LAST").format(sql.Identifier(key)) for key in normalized_version_keys
+        )
+        partition_clause = sql.SQL(", ").join(sql.Identifier(key) for key in normalized_primary_keys)
+        source_relation = sql.SQL(
+            "(SELECT * FROM read_parquet(%s) QUALIFY row_number() OVER (PARTITION BY {} ORDER BY {}) = 1)"
+        ).format(partition_clause, order_clause)
+
+        matched_clause = sql.SQL("WHEN MATCHED AND {guard} THEN UPDATE SET {updates}").format(
+            guard=_version_guard_clause(normalized_version_keys), updates=update_clause
+        )
+    else:
+        source_relation = sql.SQL("read_parquet(%s)")
+        matched_clause = sql.SQL("WHEN MATCHED THEN UPDATE SET {}").format(update_clause)
 
     query = sql.SQL(
         """
         MERGE INTO {}.{} AS target
-        USING read_parquet(%s) AS source
+        USING {} AS source
         ON {}
         {}
         WHEN NOT MATCHED THEN INSERT ({}) VALUES ({})
@@ -513,6 +599,7 @@ def _merge_batch(
     ).format(
         sql.Identifier(duckgres_schema),
         sql.Identifier(duckgres_table),
+        source_relation,
         on_clause,
         matched_clause,
         insert_columns,
@@ -525,4 +612,11 @@ def _primary_keys(batch: PendingBatch) -> list[str]:
     raw = batch.metadata.get("primary_keys")
     if not isinstance(raw, list):
         return []
+    return [str(key) for key in raw]
+
+
+def _version_keys(batch: PendingBatch) -> list[str] | None:
+    raw = batch.metadata.get("version_keys")
+    if not isinstance(raw, list):
+        return None
     return [str(key) for key in raw]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -1,14 +1,23 @@
+import tempfile
+from pathlib import Path
 from typing import Any
 
 import pytest
 from unittest.mock import MagicMock, Mock, patch
+
+import duckdb
+import pyarrow as pa
+import pyarrow.parquet as pq
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor import (
     DuckgresColumn,
     _ensure_duckgres_apply_table,
     _insert_batch,
     _mark_duckgres_batch_applied,
+    _merge_batch,
+    _plan_batch_operation,
     _process_batch,
+    _version_keys,
 )
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.jobs_db import (
     PendingBatch,
@@ -449,3 +458,160 @@ def test_duckgres_apply_marker_is_scoped_by_schema_id() -> None:
         2,
         "00000000-0000-0000-0000-000000000001",
     ]
+
+
+# --- version-aware merge (webhook latest-state-wins fix) ---
+#
+# Event-streamed sources emit several rows per id (queued -> in_progress -> completed). Without a
+# version key the merge keeps whichever event landed last in batch/file order, which froze rows
+# pre-completion. These run the real SQL `_merge_batch` builds against DuckDB (the duckgres dialect)
+# to prove the latest state wins regardless of arrival order.
+
+_JOB_COLUMNS = ["id", "status", "completed_at", "started_at", "created_at"]
+_JOB_VERSION_KEYS = ["completed_at", "started_at", "created_at"]
+# Pin the schema so an all-NULL timestamp column doesn't get inferred as INT and break the
+# string merge — the real warehouse rows store these GitHub timestamps as strings.
+_JOB_ARROW_SCHEMA = pa.schema(
+    [
+        ("id", pa.int64()),
+        ("status", pa.string()),
+        ("completed_at", pa.string()),
+        ("started_at", pa.string()),
+        ("created_at", pa.string()),
+    ]
+)
+
+
+class _QueryCapturingConn:
+    """Captures the query `_merge_batch` composes so the test can run it on a real DuckDB session."""
+
+    def __init__(self) -> None:
+        self.query: Any = None
+
+    def execute(self, query: Any, params: Any = None) -> None:
+        self.query = query
+
+
+def _write_parquet(rows: list[dict[str, Any]], columns: list[str], path: Path) -> None:
+    table = pa.table({col: [row.get(col) for row in rows] for col in columns}, schema=_JOB_ARROW_SCHEMA)
+    pq.write_table(table, path)
+
+
+def _run_merge_on_duckdb(
+    target_rows: list[dict[str, Any]],
+    source_rows: list[dict[str, Any]],
+    *,
+    version_keys: list[str] | None,
+) -> dict[int, dict[str, Any]]:
+    # `target_rows` model the rows a prior batch already merged in; `source_rows` are the incoming
+    # batch — so the same helper exercises both within-batch dedup and cross-batch overwrite/guard.
+    with tempfile.TemporaryDirectory() as tmp:
+        target_parquet = Path(tmp) / "target.parquet"
+        source_parquet = Path(tmp) / "source.parquet"
+        _write_parquet(target_rows, _JOB_COLUMNS, target_parquet)
+        _write_parquet(source_rows, _JOB_COLUMNS, source_parquet)
+
+        duck = duckdb.connect()
+        duck.execute(f"CREATE TABLE main.jobs AS SELECT * FROM read_parquet('{target_parquet}')")
+
+        capturing = _QueryCapturingConn()
+        _merge_batch(capturing, "main", "jobs", str(source_parquet), _JOB_COLUMNS, ["id"], version_keys)
+        # `_merge_batch` leaves the parquet path as a `%s` bind param; inline it to run on DuckDB.
+        rendered = capturing.query.as_string(None).replace("%s", f"'{source_parquet}'")
+        duck.execute(rendered)
+
+        rows = duck.execute(f"SELECT {', '.join(_JOB_COLUMNS)} FROM main.jobs").fetchall()
+        return {int(row[0]): dict(zip(_JOB_COLUMNS, row)) for row in rows}
+
+
+def _status(result: dict[int, dict[str, Any]]) -> dict[int, str]:
+    return {id: row["status"] for id, row in result.items()}
+
+
+def _job(
+    id: int, status: str, *, created: str, started: str | None = None, completed: str | None = None
+) -> dict[str, Any]:
+    return {"id": id, "status": status, "created_at": created, "started_at": started, "completed_at": completed}
+
+
+@pytest.mark.parametrize(
+    "target_rows, source_rows, expected",
+    [
+        # Whole lifecycle in one batch, deliberately not completed-last: QUALIFY must still keep completed.
+        (
+            [_job(1, "in_progress", created="t0", started="t1")],
+            [
+                _job(1, "queued", created="t0"),
+                _job(1, "completed", created="t0", started="t1", completed="t2"),
+                _job(1, "in_progress", created="t0", started="t1"),
+            ],
+            {1: "completed"},
+        ),
+        # A late/out-of-order in_progress event must not roll a completed row back.
+        (
+            [_job(1, "completed", created="t0", started="t1", completed="t2")],
+            [_job(1, "in_progress", created="t0", started="t3")],
+            {1: "completed"},
+        ),
+        # Unseen id is inserted, existing rows untouched.
+        (
+            [_job(1, "completed", created="t0", started="t1", completed="t2")],
+            [_job(2, "completed", created="u0", started="u1", completed="u2")],
+            {1: "completed", 2: "completed"},
+        ),
+    ],
+    ids=["completed_wins_within_batch", "no_rollback_to_stale", "new_id_inserted"],
+)
+def test_version_aware_merge_keeps_latest_state(
+    target_rows: list[dict[str, Any]], source_rows: list[dict[str, Any]], expected: dict[int, str]
+) -> None:
+    result = _run_merge_on_duckdb(target_rows, source_rows, version_keys=_JOB_VERSION_KEYS)
+    assert _status(result) == expected
+
+
+@pytest.mark.parametrize(
+    "incoming_started, expected_started",
+    [
+        ("t3", "t5"),  # stale event arriving in a later batch must NOT roll started_at back
+        ("t9", "t9"),  # genuinely newer in_progress event advances the row
+    ],
+    ids=["stale_intermediate_ignored", "newer_intermediate_applies"],
+)
+def test_version_guard_protects_intermediate_fields_across_batches(
+    incoming_started: str, expected_started: str
+) -> None:
+    # Both rows are pre-completion (completed_at NULL), so a terminal-only guard would let either
+    # win — the full version-tuple comparison is what keeps the newer started_at.
+    result = _run_merge_on_duckdb(
+        [_job(1, "in_progress", created="t0", started="t5")],
+        [_job(1, "in_progress", created="t0", started=incoming_started)],
+        version_keys=_JOB_VERSION_KEYS,
+    )
+    assert result[1]["started_at"] == expected_started
+
+
+def test_merge_without_version_keys_still_upserts() -> None:
+    # Sources that declare no version key keep the legacy unconditional upsert.
+    result = _run_merge_on_duckdb(
+        [_job(1, "old", created="t0")],
+        [_job(1, "new", created="t0", completed="t2")],
+        version_keys=None,
+    )
+    assert _status(result) == {1: "new"}
+
+
+def test_version_keys_reads_batch_metadata() -> None:
+    assert _version_keys(_make_batch(metadata={"version_keys": ["updated_at"]})) == ["updated_at"]
+    assert _version_keys(_make_batch(metadata={})) is None
+
+
+def test_plan_batch_operation_threads_version_keys_into_merge() -> None:
+    batch = _make_batch(metadata={"primary_keys": ["id"], "version_keys": ["completed_at"]})
+    with patch(
+        "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor._table_exists",
+        return_value=True,
+    ):
+        operation = _plan_batch_operation(_make_conn(), batch, duckgres_schema="s", duckgres_table="t")
+    assert operation.kind == "merge"
+    assert operation.primary_keys == ["id"]
+    assert operation.version_keys == ["completed_at"]

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -1,6 +1,6 @@
 import tempfile
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from unittest.mock import MagicMock, Mock, patch
@@ -473,11 +473,11 @@ _JOB_VERSION_KEYS = ["completed_at", "started_at", "created_at"]
 # string merge — the real warehouse rows store these GitHub timestamps as strings.
 _JOB_ARROW_SCHEMA = pa.schema(
     [
-        ("id", pa.int64()),
-        ("status", pa.string()),
-        ("completed_at", pa.string()),
-        ("started_at", pa.string()),
-        ("created_at", pa.string()),
+        pa.field("id", pa.int64()),
+        pa.field("status", pa.string()),
+        pa.field("completed_at", pa.string()),
+        pa.field("started_at", pa.string()),
+        pa.field("created_at", pa.string()),
     ]
 )
 
@@ -515,9 +515,11 @@ def _run_merge_on_duckdb(
         duck.execute(f"CREATE TABLE main.jobs AS SELECT * FROM read_parquet('{target_parquet}')")
 
         capturing = _QueryCapturingConn()
-        _merge_batch(capturing, "main", "jobs", str(source_parquet), _JOB_COLUMNS, ["id"], version_keys)
-        # `_merge_batch` leaves the parquet path as a `%s` bind param; inline it to run on DuckDB.
-        rendered = capturing.query.as_string(None).replace("%s", f"'{source_parquet}'")
+        _merge_batch(cast(Any, capturing), "main", "jobs", str(source_parquet), _JOB_COLUMNS, ["id"], version_keys)
+        # `_merge_batch` leaves the parquet path as a `%s` bind param; inline it (single-quote-escaped)
+        # to run on DuckDB directly.
+        escaped_path = str(source_parquet).replace("'", "''")
+        rendered = capturing.query.as_string(None).replace("%s", f"'{escaped_path}'")
         duck.execute(rendered)
 
         rows = duck.execute(f"SELECT {', '.join(_JOB_COLUMNS)} FROM main.jobs").fetchall()

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/pipeline.py
@@ -170,6 +170,7 @@ class PipelineV3(Generic[ResumableData]):
             run_uuid=self._s3_batch_writer.get_run_uuid(),
             logger=self._logger,
             primary_keys=self._resource.primary_keys,
+            version_keys=self._resource.version_keys,
             is_resume=is_resume,
             partition_count=partition_count,
             partition_size=partition_size,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -108,6 +108,7 @@ class PendingBatch:
             "data_folder": self.metadata.get("data_folder"),
             "schema_path": self.metadata.get("schema_path"),
             "primary_keys": self.metadata.get("primary_keys"),
+            "version_keys": self.metadata.get("version_keys"),
             "partition_count": self.metadata.get("partition_count"),
             "partition_size": self.metadata.get("partition_size"),
             "partition_keys": self.metadata.get("partition_keys"),

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/producer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/producer.py
@@ -44,6 +44,7 @@ class PostgresProducer:
         run_uuid: str,
         logger: FilteringBoundLogger,
         primary_keys: list[str] | None = None,
+        version_keys: list[str] | None = None,
         is_resume: bool = False,
         partition_count: int | None = None,
         partition_size: int | None = None,
@@ -64,6 +65,7 @@ class PostgresProducer:
         self._sync_type = sync_type
         self._run_uuid = run_uuid
         self._primary_keys = primary_keys
+        self._version_keys = version_keys
         self._is_resume = is_resume
         self._logger = logger
         self._partition_count = partition_count
@@ -110,6 +112,8 @@ class PostgresProducer:
             metadata["schema_path"] = schema_path
         if self._primary_keys is not None:
             metadata["primary_keys"] = self._primary_keys
+        if self._version_keys is not None:
+            metadata["version_keys"] = self._version_keys
         if self._partition_count is not None:
             metadata["partition_count"] = self._partition_count
         if self._partition_size is not None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
@@ -69,9 +69,13 @@ class WebhookSourceManager:
             try:
                 ls_res = await s3._ls(prefix, detail=True)
                 ls_values = ls_res.values() if isinstance(ls_res, dict) else ls_res
-                files = [
-                    f"s3://{f['Key']}" for f in ls_values if f["type"] != "directory" and f["Key"].endswith(".parquet")
-                ]
+                entries = [f for f in ls_values if f["type"] != "directory" and f["Key"].endswith(".parquet")]
+                # Read oldest-first (by S3 mtime, Key as a stable tiebreak) so a key's events reach
+                # the load merge in arrival order. This only reduces churn — the merge's version
+                # guard is the real correctness backstop. The leading `is None` flag sends entries
+                # without a LastModified to the end without ever comparing None to a timestamp.
+                entries.sort(key=lambda f: (f.get("LastModified") is None, f.get("LastModified"), f["Key"]))
+                files = [f"s3://{f['Key']}" for f in entries]
 
                 await self._logger.adebug("list_webhook_parquet_files", prefix=prefix, file_count=len(files))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/github.py
@@ -673,6 +673,7 @@ def github_source(
         name=endpoint,
         items=items,
         primary_keys=[endpoint_config.primary_key],
+        version_keys=endpoint_config.version_keys,
         sort_mode=actual_sort_mode,
         partition_count=1,
         partition_size=1,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/github/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/github/settings.py
@@ -14,6 +14,12 @@ class GithubEndpointConfig:
     page_size: int = 100  # GitHub default, max is 100
     sort_mode: Literal["asc", "desc"] = "asc"
     primary_key: str = "id"  # Primary key for upsert operations
+    # Ordered columns (compared newest-first, NULLs last) that rank rows sharing a
+    # primary key so the load merge keeps the latest state. GitHub webhook rows are
+    # mutable — one run/job emits queued -> in_progress -> completed as separate events
+    # — and without an ordering key the merge keeps whichever event landed last in the
+    # batch, which froze ~1 in 5 jobs pre-completion. None = legacy unordered upsert.
+    version_keys: Optional[list[str]] = None
     # Body key to drill into when the API wraps results in an envelope
     # (e.g. /actions/runs returns {"total_count": N, "workflow_runs": [...]}).
     # None means the response body is itself the list.
@@ -132,6 +138,9 @@ GITHUB_ENDPOINTS: dict[str, GithubEndpointConfig] = {
         ],
         default_incremental_field="created_at",
         sort_mode="desc",  # API always returns newest-first; sort/direction are ignored
+        # workflow_run carries updated_at, which GitHub bumps on every status change — the
+        # natural recency key so a completed run is never clobbered by a stale earlier event.
+        version_keys=["updated_at"],
         response_data_path="workflow_runs",
     ),
     "workflow_jobs": GithubEndpointConfig(
@@ -174,6 +183,10 @@ GITHUB_ENDPOINTS: dict[str, GithubEndpointConfig] = {
         # window since the latest job. Repos that genuinely want history should run a
         # deliberate one-off backfill, not pay for it on every connect.
         initial_lookback_days=0,
+        # workflow_job has no updated_at, so rank by how far the job progressed:
+        # completed_at (terminal) outranks started_at (running) outranks created_at (queued).
+        # Each is NULL until the job reaches that stage, so NULLs-last keeps the latest state.
+        version_keys=["completed_at", "started_at", "created_at"],
     ),
 }
 


### PR DESCRIPTION
## Problem

Engineering analytics ingests GitHub workflow runs and jobs through the data warehouse webhook path. Those rows are mutable — one run or job emits `queued`, then `in_progress`, then `completed` as separate webhook events sharing a primary key. The v3 duckgres load consolidated them with an unconditional `MERGE ... WHEN MATCHED THEN UPDATE` and no source-side dedup, so which version survived came down to batch and S3 file ordering, not recency.

The result: a large share of jobs sit frozen in a non-terminal state long after they finished — their `completed` event was dropped or overwritten. Cross-checking against the polled `workflow_runs` table, nearly all of the stuck jobs have a parent run that already completed, so they are genuinely done; the pipeline just lost the final state.

## Changes

- Add an optional, ordered `version_keys` to `SourceResponse`, threaded through the v3 producer into batch metadata (mirrors how `primary_keys` already flows).
- Make the duckgres merge version-aware when `version_keys` is set:
  - collapse the source batch to the newest row per key with `QUALIFY row_number()`, and
  - guard `WHEN MATCHED` so an update only lands when the source row is at least as new as the target under that same ordering — compared **lexicographically over all version keys**, not just the terminal one, so a stale event can't regress an intermediate field either.
- GitHub declares the keys: `updated_at` for runs (monotonic, bumps on every change); `completed_at, started_at, created_at` for jobs (no `updated_at` in the payload).
- Sources that set no `version_keys` keep the exact legacy upsert — opt-in, near-zero blast radius.
- Smaller hardening from review: order webhook S3 files oldest-first (churn only — the merge guard is the real backstop), warn when declared version keys are absent from a batch (so a rename doesn't silently disable the guard), and carry `version_keys` through the `to_export_signal` bridge.

## How did you test this code?

I'm an agent; I have not manually run this against a live warehouse. Automated tests only, in `pipeline_v3/duckgres/test_processor.py`, executed against a real DuckDB session (the duckgres dialect):

- `completed` wins even when it isn't the last row in a batch (within-batch QUALIFY dedup).
- a stale `in_progress` arriving in a **later** batch does not roll back a completed row, nor regress `started_at` on a still-running row — the cross-batch case a terminal-only guard would miss.
- a genuinely newer event still advances the row; an unseen id inserts.
- a source without `version_keys` keeps the legacy upsert.
- plumbing: `version_keys` reads from batch metadata and reaches the merge operation.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @webjunkie. Started from "why is engineering analytics webhook data stale and partly frozen", traced it through the v3 duckgres load path, and confirmed the root cause is the order-dependent merge — not the consumer batch-skip that recent warehouse-sources reliability fixes already addressed (those are deployed, and the stuck rate persisted after them).

Ran `/code-review medium` over the diff. It caught that the first cut guarded only the terminal version column, so a stale event could still regress intermediate fields across batches (QUALIFY only dedupes within a batch). Reworked the guard into the full lexicographic version-tuple comparison in response, and added the cross-batch test for it. Also took the review's cheaper findings: the absent-keys warning, the `to_export_signal` parity, and a type-stable S3 sort key.

Scoped deliberately to the duckgres path. The v3 delta path has the same arrival-order dedup and would need the same fix for any source routed through it — flagging for @estefaniarabadan as the warehouse-sources owner rather than expanding this PR.
