### PR TITLE
chore(llma): steer eval tooling to team provider keys over trial credits

### DIFF
--- a/products/ai_observability/backend/api/evaluation_config.py
+++ b/products/ai_observability/backend/api/evaluation_config.py
@@ -22,12 +22,12 @@ from .provider_keys import LLMProviderKeySerializer
 class EvaluationConfigSerializer(serializers.ModelSerializer):
     trial_evals_remaining = serializers.IntegerField(
         read_only=True,
-        help_text="Number of trial evaluation runs remaining before the team must supply its own provider key.",
+        help_text="Trial runs remaining — a getting-started affordance only; evals should use the team's own provider key.",
     )
     active_provider_key = LLMProviderKeySerializer(
         read_only=True,
         allow_null=True,
-        help_text="Provider key currently used to run llm_judge evaluations. Null when the team is on trial credits.",
+        help_text="Provider key used to run llm_judge evals; null if none configured yet.",
     )
 
     class Meta:
@@ -50,10 +50,10 @@ class EvaluationConfigSerializer(serializers.ModelSerializer):
         ]
         extra_kwargs = {
             "trial_eval_limit": {
-                "help_text": "Maximum number of llm_judge runs the team may execute on PostHog trial credits.",
+                "help_text": "Cap on trial runs — a getting-started affordance only, not for ongoing evals (use the team's own key).",
             },
             "trial_evals_used": {
-                "help_text": "Number of llm_judge runs already consumed against the trial credit pool.",
+                "help_text": "Trial runs consumed (getting-started affordance only).",
             },
             "created_at": {"help_text": "Timestamp when the evaluation config row was created."},
             "updated_at": {"help_text": "Timestamp when the evaluation config row was last modified."},

--- a/products/ai_observability/backend/api/evaluations.py
+++ b/products/ai_observability/backend/api/evaluations.py
@@ -115,7 +115,11 @@ class ModelConfigurationSerializer(serializers.Serializer):
 
     provider = serializers.ChoiceField(choices=LLMProvider.choices)
     model = serializers.CharField(max_length=100)
-    provider_key_id = serializers.UUIDField(required=False, allow_null=True)
+    provider_key_id = serializers.UUIDField(
+        required=False,
+        allow_null=True,
+        help_text="Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.",
+    )
     provider_key_name = serializers.SerializerMethodField(read_only=True)
 
     def get_provider_key_name(self, obj: LLMModelConfiguration) -> str | None:

--- a/products/ai_observability/backend/api/models.py
+++ b/products/ai_observability/backend/api/models.py
@@ -21,7 +21,7 @@ class LLMModelInfoSerializer(serializers.Serializer):
         help_text="Provider-specific model identifier (e.g. 'gpt-4o-mini', 'claude-3-5-sonnet-20241022')."
     )
     posthog_available = serializers.BooleanField(
-        help_text="Whether this model is available on PostHog's trial credits without bringing a provider key."
+        help_text="True if the model can run without a provider key — for getting-started testing only; real evals should use the team's own key."
     )
 
 

--- a/products/ai_observability/frontend/generated/api.schemas.ts
+++ b/products/ai_observability/frontend/generated/api.schemas.ts
@@ -413,7 +413,10 @@ export interface ModelConfigurationApi {
     provider: LLMProviderEnumApi
     /** @maxLength 100 */
     model: string
-    /** @nullable */
+    /**
+     * Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.
+     * @nullable
+     */
     provider_key_id?: string | null
     /** @nullable */
     readonly provider_key_name: string | null
@@ -865,13 +868,13 @@ export interface LLMProviderKeyApi {
 }
 
 export interface EvaluationConfigApi {
-    /** Maximum number of llm_judge runs the team may execute on PostHog trial credits. */
+    /** Cap on trial runs — a getting-started affordance only, not for ongoing evals (use the team's own key). */
     readonly trial_eval_limit: number
-    /** Number of llm_judge runs already consumed against the trial credit pool. */
+    /** Trial runs consumed (getting-started affordance only). */
     readonly trial_evals_used: number
-    /** Number of trial evaluation runs remaining before the team must supply its own provider key. */
+    /** Trial runs remaining — a getting-started affordance only; evals should use the team's own provider key. */
     readonly trial_evals_remaining: number
-    /** Provider key currently used to run llm_judge evaluations. Null when the team is on trial credits. */
+    /** Provider key used to run llm_judge evals; null if none configured yet. */
     readonly active_provider_key: LLMProviderKeyApi | null
     /** Timestamp when the evaluation config row was created. */
     readonly created_at: string
@@ -1143,7 +1146,7 @@ export interface EvaluationSummaryResponseApi {
 export interface LLMModelInfoApi {
     /** Provider-specific model identifier (e.g. 'gpt-4o-mini', 'claude-3-5-sonnet-20241022'). */
     id: string
-    /** Whether this model is available on PostHog's trial credits without bringing a provider key. */
+    /** True if the model can run without a provider key — for getting-started testing only; real evals should use the team's own key. */
     posthog_available: boolean
 }
 

--- a/products/ai_observability/frontend/generated/api.zod.ts
+++ b/products/ai_observability/frontend/generated/api.zod.ts
@@ -214,7 +214,12 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                             '\* `openai` - Openai\n\* `anthropic` - Anthropic\n\* `gemini` - Gemini\n\* `openrouter` - Openrouter\n\* `fireworks` - Fireworks\n\* `azure_openai` - Azure OpenAI\n\* `together_ai` - Together AI'
                         ),
                     model: zod.string().max(evaluationsCreateBodyModelConfigurationOneModelMax),
-                    provider_key_id: zod.uuid().nullish(),
+                    provider_key_id: zod
+                        .uuid()
+                        .nullish()
+                        .describe(
+                            'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
+                        ),
                     provider_key_name: zod.string().nullable(),
                 })
                 .describe('Nested serializer for model configuration.'),
@@ -336,7 +341,12 @@ export const EvaluationsUpdateBody = /* @__PURE__ */ zod.object({
                             '\* `openai` - Openai\n\* `anthropic` - Anthropic\n\* `gemini` - Gemini\n\* `openrouter` - Openrouter\n\* `fireworks` - Fireworks\n\* `azure_openai` - Azure OpenAI\n\* `together_ai` - Together AI'
                         ),
                     model: zod.string().max(evaluationsUpdateBodyModelConfigurationOneModelMax),
-                    provider_key_id: zod.uuid().nullish(),
+                    provider_key_id: zod
+                        .uuid()
+                        .nullish()
+                        .describe(
+                            'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
+                        ),
                     provider_key_name: zod.string().nullable(),
                 })
                 .describe('Nested serializer for model configuration.'),
@@ -460,7 +470,12 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                             '\* `openai` - Openai\n\* `anthropic` - Anthropic\n\* `gemini` - Gemini\n\* `openrouter` - Openrouter\n\* `fireworks` - Fireworks\n\* `azure_openai` - Azure OpenAI\n\* `together_ai` - Together AI'
                         ),
                     model: zod.string().max(evaluationsPartialUpdateBodyModelConfigurationOneModelMax),
-                    provider_key_id: zod.uuid().nullish(),
+                    provider_key_id: zod
+                        .uuid()
+                        .nullish()
+                        .describe(
+                            'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
+                        ),
                     provider_key_name: zod.string().nullable(),
                 })
                 .describe('Nested serializer for model configuration.'),

--- a/products/ai_observability/mcp/tools.yaml
+++ b/products/ai_observability/mcp/tools.yaml
@@ -182,10 +182,9 @@ tools:
             idempotent: true
         title: Get evaluation config
         description: >
-            Retrieve the team's evaluation configuration, including the active LLM provider key used to run llm_judge
-            evaluations and remaining trial credits. Call this before creating an llm_judge evaluation to verify the
-            team has either trial credits available or an active provider key configured — without one, llm_judge runs
-            will fail. Returns trial limits, the active provider key (or null if on trial credits), and timestamps.
+            Retrieve the team's evaluation config and active provider key. Call before creating an llm_judge eval to
+            confirm a provider key is configured — evals should run on the team's own key. Returns the active key and
+            timestamps.
     llma-evaluation-config-set-active-key:
         operation: llm_analytics_evaluation_config_set_active_key_create
         enabled: true
@@ -212,11 +211,11 @@ tools:
             idempotent: false
         title: Create evaluation
         description: >
-            Create a new AI observability evaluation. For 'llm_judge' type, provide evaluation_config.prompt and
-            model_configuration (provider + model). For 'hog' type, provide evaluation_config.source (Hog code returning
-            a boolean). For 'sentiment' type, use output_type='sentiment', omit model_configuration, and optionally set
-            evaluation_config.source='user_messages'. When enabled, the evaluation runs automatically on new
-            $ai_generation events. Results appear as '$ai_evaluation' events.
+            Create an evaluation. 'llm_judge': set evaluation_config.prompt and model_configuration (provider + model +
+            provider_key_id from llma-provider-key-list, preferring a provider the team already has a key for). 'hog':
+            evaluation_config.source (Hog returning a boolean). 'sentiment': output_type='sentiment', omit
+            model_configuration, optional evaluation_config.source='user_messages'. When enabled, runs on new
+            $ai_generation events; results are '$ai_evaluation' events.
     llma-evaluation-delete:
         operation: evaluations_destroy
         enabled: true
@@ -255,12 +254,10 @@ tools:
             idempotent: true
         title: List supported llm_judge models
         description: >
-            List the provider+model combinations supported for llm_judge evaluations. Pass a `provider` query parameter
-            (one of openai, anthropic, gemini, openrouter, fireworks, azure_openai) and optionally `key_id` to scope the
-            list to deployments reachable with a specific provider key (mainly relevant for azure_openai). Each entry
-            returns the model id and whether it is available on PostHog trial credits. Call this before creating an
-            llm_judge evaluation when the user has not specified a model, so a valid provider+model combination is
-            chosen.
+            List provider+model combinations supported for llm_judge. Pass `provider` (openai, anthropic, gemini,
+            openrouter, fireworks, azure_openai); optional `key_id` scopes to a key's reachable deployments (mainly
+            azure_openai). Call before creating an llm_judge eval to pick a valid combo — prefer a provider the team
+            already has a key for (see llma-provider-key-list).
     llma-evaluation-list:
         operation: evaluations_list
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -4136,7 +4136,7 @@
         }
     },
     "llma-evaluation-config-get": {
-        "description": "Retrieve the team's evaluation configuration, including the active LLM provider key used to run llm_judge evaluations and remaining trial credits. Call this before creating an llm_judge evaluation to verify the team has either trial credits available or an active provider key configured — without one, llm_judge runs will fail. Returns trial limits, the active provider key (or null if on trial credits), and timestamps.",
+        "description": "Retrieve the team's evaluation config and active provider key. Call before creating an llm_judge eval to confirm a provider key is configured — evals should run on the team's own key. Returns the active key and timestamps.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get evaluation config",
@@ -4164,7 +4164,7 @@
         }
     },
     "llma-evaluation-create": {
-        "description": "Create a new AI observability evaluation. For 'llm_judge' type, provide evaluation_config.prompt and model_configuration (provider + model). For 'hog' type, provide evaluation_config.source (Hog code returning a boolean). For 'sentiment' type, use output_type='sentiment', omit model_configuration, and optionally set evaluation_config.source='user_messages'. When enabled, the evaluation runs automatically on new $ai_generation events. Results appear as '$ai_evaluation' events.",
+        "description": "Create an evaluation. 'llm_judge': set evaluation_config.prompt and model_configuration (provider + model + provider_key_id from llma-provider-key-list, preferring a provider the team already has a key for). 'hog': evaluation_config.source (Hog returning a boolean). 'sentiment': output_type='sentiment', omit model_configuration, optional evaluation_config.source='user_messages'. When enabled, runs on new $ai_generation events; results are '$ai_evaluation' events.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Create evaluation",
@@ -4206,7 +4206,7 @@
         }
     },
     "llma-evaluation-judge-models": {
-        "description": "List the provider+model combinations supported for llm_judge evaluations. Pass a `provider` query parameter (one of openai, anthropic, gemini, openrouter, fireworks, azure_openai) and optionally `key_id` to scope the list to deployments reachable with a specific provider key (mainly relevant for azure_openai). Each entry returns the model id and whether it is available on PostHog trial credits. Call this before creating an llm_judge evaluation when the user has not specified a model, so a valid provider+model combination is chosen.",
+        "description": "List provider+model combinations supported for llm_judge. Pass `provider` (openai, anthropic, gemini, openrouter, fireworks, azure_openai); optional `key_id` scopes to a key's reachable deployments (mainly azure_openai). Call before creating an llm_judge eval to pick a valid combo — prefer a provider the team already has a key for (see llma-provider-key-list).",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "List supported llm_judge models",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -4432,7 +4432,7 @@
         }
     },
     "llma-evaluation-config-get": {
-        "description": "Retrieve the team's evaluation configuration, including the active LLM provider key used to run llm_judge evaluations and remaining trial credits. Call this before creating an llm_judge evaluation to verify the team has either trial credits available or an active provider key configured — without one, llm_judge runs will fail. Returns trial limits, the active provider key (or null if on trial credits), and timestamps.",
+        "description": "Retrieve the team's evaluation config and active provider key. Call before creating an llm_judge eval to confirm a provider key is configured — evals should run on the team's own key. Returns the active key and timestamps.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Get evaluation config",
@@ -4460,7 +4460,7 @@
         }
     },
     "llma-evaluation-create": {
-        "description": "Create a new AI observability evaluation. For 'llm_judge' type, provide evaluation_config.prompt and model_configuration (provider + model). For 'hog' type, provide evaluation_config.source (Hog code returning a boolean). For 'sentiment' type, use output_type='sentiment', omit model_configuration, and optionally set evaluation_config.source='user_messages'. When enabled, the evaluation runs automatically on new $ai_generation events. Results appear as '$ai_evaluation' events.",
+        "description": "Create an evaluation. 'llm_judge': set evaluation_config.prompt and model_configuration (provider + model + provider_key_id from llma-provider-key-list, preferring a provider the team already has a key for). 'hog': evaluation_config.source (Hog returning a boolean). 'sentiment': output_type='sentiment', omit model_configuration, optional evaluation_config.source='user_messages'. When enabled, runs on new $ai_generation events; results are '$ai_evaluation' events.",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "Create evaluation",
@@ -4502,7 +4502,7 @@
         }
     },
     "llma-evaluation-judge-models": {
-        "description": "List the provider+model combinations supported for llm_judge evaluations. Pass a `provider` query parameter (one of openai, anthropic, gemini, openrouter, fireworks, azure_openai) and optionally `key_id` to scope the list to deployments reachable with a specific provider key (mainly relevant for azure_openai). Each entry returns the model id and whether it is available on PostHog trial credits. Call this before creating an llm_judge evaluation when the user has not specified a model, so a valid provider+model combination is chosen.",
+        "description": "List provider+model combinations supported for llm_judge. Pass `provider` (openai, anthropic, gemini, openrouter, fireworks, azure_openai); optional `key_id` scopes to a key's reachable deployments (mainly azure_openai). Call before creating an llm_judge eval to pick a valid combo — prefer a provider the team already has a key for (see llma-provider-key-list).",
         "category": "AI observability",
         "feature": "llm_analytics",
         "summary": "List supported llm_judge models",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -20300,7 +20300,10 @@ export namespace Schemas {
       provider: LLMProviderEnum;
       /** @maxLength 100 */
       model: string;
-      /** @nullable */
+      /**
+         * Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.
+         * @nullable
+         */
       provider_key_id?: string | null;
       /** @nullable */
       readonly provider_key_name: string | null;
@@ -20395,13 +20398,13 @@ export namespace Schemas {
     }
 
     export interface EvaluationConfig {
-      /** Maximum number of llm_judge runs the team may execute on PostHog trial credits. */
+      /** Cap on trial runs — a getting-started affordance only, not for ongoing evals (use the team's own key). */
       readonly trial_eval_limit: number;
-      /** Number of llm_judge runs already consumed against the trial credit pool. */
+      /** Trial runs consumed (getting-started affordance only). */
       readonly trial_evals_used: number;
-      /** Number of trial evaluation runs remaining before the team must supply its own provider key. */
+      /** Trial runs remaining — a getting-started affordance only; evals should use the team's own provider key. */
       readonly trial_evals_remaining: number;
-      /** Provider key currently used to run llm_judge evaluations. Null when the team is on trial credits. */
+      /** Provider key used to run llm_judge evals; null if none configured yet. */
       readonly active_provider_key: LLMProviderKey | null;
       /** Timestamp when the evaluation config row was created. */
       readonly created_at: string;
@@ -27296,7 +27299,7 @@ export namespace Schemas {
     export interface LLMModelInfo {
       /** Provider-specific model identifier (e.g. 'gpt-4o-mini', 'claude-3-5-sonnet-20241022'). */
       id: string;
-      /** Whether this model is available on PostHog's trial credits without bringing a provider key. */
+      /** True if the model can run without a provider key — for getting-started testing only; real evals should use the team's own key. */
       posthog_available: boolean;
     }
 

--- a/services/mcp/src/generated/ai_observability/api.ts
+++ b/services/mcp/src/generated/ai_observability/api.ts
@@ -235,7 +235,12 @@ export const EvaluationsCreateBody = /* @__PURE__ */ zod.object({
                             '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks\n* `azure_openai` - Azure OpenAI\n* `together_ai` - Together AI'
                         ),
                     model: zod.string().max(evaluationsCreateBodyModelConfigurationOneModelMax),
-                    provider_key_id: zod.uuid().nullish(),
+                    provider_key_id: zod
+                        .uuid()
+                        .nullish()
+                        .describe(
+                            'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
+                        ),
                     provider_key_name: zod.string().nullish(),
                 })
                 .describe('Nested serializer for model configuration.'),
@@ -377,7 +382,12 @@ export const EvaluationsPartialUpdateBody = /* @__PURE__ */ zod.object({
                             '* `openai` - Openai\n* `anthropic` - Anthropic\n* `gemini` - Gemini\n* `openrouter` - Openrouter\n* `fireworks` - Fireworks\n* `azure_openai` - Azure OpenAI\n* `together_ai` - Together AI'
                         ),
                     model: zod.string().max(evaluationsPartialUpdateBodyModelConfigurationOneModelMax),
-                    provider_key_id: zod.uuid().nullish(),
+                    provider_key_id: zod
+                        .uuid()
+                        .nullish()
+                        .describe(
+                            'Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it.'
+                        ),
                     provider_key_name: zod.string().nullish(),
                 })
                 .describe('Nested serializer for model configuration.'),

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-create.json
@@ -122,7 +122,8 @@
                                 {
                                     "type": "null"
                                 }
-                            ]
+                            ],
+                            "description": "Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it."
                         },
                         "provider_key_name": {
                             "anyOf": [

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/llma-evaluation-update.json
@@ -126,7 +126,8 @@
                                 {
                                     "type": "null"
                                 }
-                            ]
+                            ],
+                            "description": "Team provider key to run this eval with (same provider as `provider`). Leave null only for brief pre-key testing; real evals should set it."
                         },
                         "provider_key_name": {
                             "anyOf": [


### PR DESCRIPTION
## Problem

The MCP eval tooling nudged agents toward PostHog trial credits when creating `llm_judge` evaluations. We want users to set up their own key instead (might even remove trial evals in the future).

## Changes

Reworded the eval tool descriptions and serializer `help_text` so agents prefer the team's own provider key, and trial credits are mentioned only in passing as a testing affordance not to rely on.

## How did you test this code?

I'm an agent. No manual testing. Ran `hogli build:openapi` and verified the generated artifacts updated, the new "prefer the team's key" framing is present, and no "trial credits" phrasing remains in the generated MCP tool definitions. No automated tests added — this is a docs/wording change with no logic.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Carlos is the DRI.

Carlos hit this directly: asked the MCP to create an offensive-language `llm_judge` eval, and the agent picked an Anthropic model on trial credits instead of his configured provider key. We debugged why and traced it to the tool/field copy framing trial credits as a normal path. This PR fixes that framing.

- Tools used: Claude Code with the PostHog MCP (`mcp__posthog-local__exec`) and `hogli build:openapi` for regeneration.
- Decisions: keep trial mentions minimal rather than removing the trial fields outright (the fields still back the UI's trial accounting); left the `trial_evaluations` action docstring as-is since it accurately names an endpoint whose job is to migrate evals off trial; prioritized terseness since these strings load into every agent's tool list.
