### PR TITLE
fix(endpoints): route ducklake shadow comparison to long_running queue

### DIFF
--- a/products/endpoints/backend/tasks.py
+++ b/products/endpoints/backend/tasks.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from celery import shared_task
 from structlog import get_logger
 
+from posthog.celery_queues import CeleryQueue
 from posthog.scoping_audit import skip_team_scope_audit
 
 from products.endpoints.backend.metrics import ENDPOINT_MATERIALIZATION_EVENT_TOTAL
@@ -17,7 +18,7 @@ logger = get_logger(__name__)
 STALE_THRESHOLD_DAYS = 30
 
 
-@shared_task(ignore_result=True)
+@shared_task(ignore_result=True, queue=CeleryQueue.LONG_RUNNING.value)
 @skip_team_scope_audit
 def shadow_compare_ducklake_execution(
     team_id: int,


### PR DESCRIPTION
## Problem

The DuckLake execution shadow (`shadow_compare_ducklake_execution`) re-runs endpoint queries against duckgres to collect CH-vs-DuckLake timing data. These runs are slow — a single shadow can hold a worker for several minutes (and in practice much longer for heavy queries). Running on the default `celery` queue, they contend for worker slots with latency-sensitive default-queue work and can build a backlog of pending tasks.

## Changes

- Route `shadow_compare_ducklake_execution` to `CeleryQueue.LONG_RUNNING` instead of the default queue.

`long_running` is the queue purpose-built for "any task that has a good chance of taking more than a few seconds" and is already consumed by dedicated workers (it's in the default `CELERY_WORKER_QUEUES` set), so no infra/charts change is needed. We deliberately do **not** add a task time limit or statement timeout — the goal is to keep collecting full timing data, just off the hot path.

## How did you test this code?

I'm an agent (human-driven). `ruff check` passes on the changed file. I did not get a green unit-test run locally — the dev Postgres was unavailable, so the existing shadow tests errored at DB connection, not on this change; none of them assert queue routing regardless. I confirmed `long_running` is a real, consumed queue via `bin/celery-queues.env` and the live worker config.

No test added: this is a one-line decorator config; a test asserting the queue value would only restate the code.

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigating the DuckLake endpoint-execution shadow, we confirmed it now serves real internal queries correctly but very slowly, and that its Celery tasks were piling up on the default queue. This PR moves them to the existing `long_running` queue.

- Tool: Claude Code. Skill invoked: `/quick-fix-pr` (branch off master, stamphog + squash automerge).
- Decision: reuse the existing `long_running` queue rather than create a dedicated `ducklake_shadow` queue — a new queue would need a matching worker consumer in the charts repo first, or tasks would strand on an unconsumed queue. A dedicated queue remains the escalation if shadow volume ever grows enough to disturb cohort calculations (which also use `long_running`).
- Deliberately no timeout/time-limit added — we want to keep collecting timing data.
