### PR TITLE
perf(notebooks): defer content/text_content on notebooks list

### DIFF
--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -521,6 +521,10 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         if self.action == "list":
             queryset = queryset.filter(deleted=False, visibility=Notebook.Visibility.DEFAULT)
             queryset = self._filter_list_request(self.request, queryset)
+            # The list serializer omits content/text_content, but both are large columns
+            # (ProseMirror JSON + full plaintext) that we'd otherwise load and JSON-decode per row.
+            # search/contains filters run as WHERE-clause predicates, so they don't need the columns in Python.
+            queryset = queryset.defer("content", "text_content")
 
         order = self.request.GET.get("order", None)
         if order:


### PR DESCRIPTION
## Problem

The notebooks list endpoint serializes with a slim serializer (`NotebookMinimalSerializer`) that does not render `content` or `text_content`. But the list queryset still SELECTs both columns per row: `content` is a large ProseMirror JSON document and `text_content` is the full plaintext. So every list request loads and JSON-decodes fat data it immediately discards.

## Changes

Add `.defer("content", "text_content")` to the `list` action's queryset only, inside `safely_get_queryset`.

- The list filters that touch these columns (`search` via `text_content__search`, `contains` via `content__content__contains`) are WHERE-clause predicates (FTS / JSONB containment). `.defer()` only changes which columns are SELECTed into model instances — it does not affect filtering — so search and contains keep working unchanged.
- Detail/retrieve and the content-rendering actions are untouched. In particular `recording_comments` reads `notebook.content` in Python and runs under `self.action == "recording_comments"`, not `"list"`, so it keeps loading content.

Performance-only: no API field, serializer, or response-shape change.

## How did you test this code?

I'm an agent. No test suite run — `ruff check` and `ruff format` on the touched file only (both clean). The change is a queryset-level `.defer()` gated on the `list` action; behavior is covered by existing notebook API tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Julian directed this as a performance-only queryset tweak. Confirmed the list path uses `NotebookMinimalSerializer` (no `content`/`text_content` fields), that the `search`/`contains` filters are WHERE-clause predicates that don't need the columns materialized in Python, and that `recording_comments` (which does read `content`) runs under a different action so it stays unaffected. No skills were required for a single-line `.defer()`.
