### PR TITLE
feat(logs): add patterns query runner (even-random sampling)

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,6 +13,14 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
+      @.kind == "RetentionQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
+      @.kind == "StickinessQuery" &&
+      (!exists(@.version) || @.version == null || @.version < 2)
+  )'
+         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/logs/backend/patterns_query_runner.py
+++ b/products/logs/backend/patterns_query_runner.py
@@ -1,0 +1,159 @@
+import datetime as dt
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+from posthog.schema import CachedLogsQueryResponse, LogsQuery
+
+from posthog.hogql import ast
+from posthog.hogql.constants import HogQLGlobalSettings
+from posthog.hogql.parser import parse_expr, parse_select
+from posthog.hogql.query import execute_hogql_query
+
+from posthog.clickhouse.client.connection import Workload
+from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
+
+from products.logs.backend.log_patterns import LogSample, MinedPattern, _env, mine_patterns
+from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
+
+if TYPE_CHECKING:
+    from posthog.models import User
+
+
+class PatternsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):
+    """Mines log templates (Drain3) from an evenly-distributed sample of the matching logs.
+
+    Sampling keeps clustering cheap on large windows: we count the matching rows, then pull
+    at most `LOGS_PATTERNS_SAMPLE_LIMIT` of them spread across the window via a random-modulo
+    predicate, and feed those bodies to `mine_patterns`. `sampled` is True whenever the
+    window held more rows than the sample cap.
+    """
+
+    query: LogsQuery
+    cached_response: CachedLogsQueryResponse
+
+    @cached_property
+    def settings(self) -> HogQLGlobalSettings:
+        # Bytes are intentionally uncapped: a hard `max_bytes_to_read` + "throw" cap 500s on
+        # wide windows (the symbol-stats read-cap cliff), so we bound by wall-clock instead
+        # and let the sample query's LIMIT short-circuit the scan.
+        return HogQLGlobalSettings(
+            max_execution_time=_env("LOGS_PATTERNS_MAX_EXECUTION_TIME", 60, int),
+            max_bytes_to_read=None,
+            read_overflow_mode=None,
+        )
+
+    @cached_property
+    def _sample_limit(self) -> int:
+        return _env("LOGS_PATTERNS_SAMPLE_LIMIT", 10000, int)
+
+    def validate_query_runner_access(self, user: "User") -> bool:
+        # Defensive: this runner is invoked directly via the logs API, never through the generic
+        # /api/projects/:id/query/ endpoint. Mirror LogsQueryRunner and refuse user-initiated
+        # generic-query access so it can't silently bypass that gate if ever registered.
+        from posthog.rbac.user_access_control import UserAccessControlError
+
+        raise UserAccessControlError("logs", "viewer")
+
+    def _calculate(self) -> LogsQueryResponse:
+        total = self._count()
+        sampled = total > self._sample_limit
+        divisor = max(1, total // self._sample_limit) if sampled else 1
+
+        response = self._execute(self._sample_query(divisor))
+        samples = [
+            LogSample(
+                body=row[0],
+                severity_text=row[1],
+                service_name=row[2],
+                timestamp=row[3].replace(tzinfo=dt.UTC),
+            )
+            for row in response.results
+        ]
+        patterns = mine_patterns(samples)
+        return LogsQueryResponse(
+            results={
+                "patterns": [_serialize(p) for p in patterns],
+                "scanned_count": len(samples),
+                "total_count": total,
+                "sampled": sampled,
+            }
+        )
+
+    def to_query(self) -> ast.SelectQuery:
+        # Canonical (unsampled) form for the base runner's query contract; _calculate picks
+        # the runtime divisor.
+        return self._sample_query(divisor=1)
+
+    def _execute(self, query: ast.SelectQuery | ast.SelectSetQuery):
+        return execute_hogql_query(
+            query_type="LogsQuery",
+            query=query,
+            modifiers=self.modifiers,
+            team=self.team,
+            workload=Workload.LOGS,
+            timings=self.timings,
+            limit_context=self.limit_context,
+            settings=self.settings,
+        )
+
+    def _count(self) -> int:
+        response = self._execute(
+            parse_select(
+                "SELECT count() FROM logs WHERE {where}",
+                placeholders={"where": self._where_with_timestamp()},
+            )
+        )
+        return int(response.results[0][0]) if response.results else 0
+
+    def _where_with_timestamp(self) -> ast.Expr:
+        # LogsFilterBuilder.where() filters at day-precision via time_bucket; add explicit
+        # per-row timestamp bounds (half-open) so the sample matches the requested window.
+        return ast.And(
+            exprs=[
+                self.where(),
+                parse_expr(
+                    "timestamp >= {date_from} AND timestamp < {date_to}",
+                    placeholders={
+                        "date_from": ast.Constant(value=self.query_date_range.date_from()),
+                        "date_to": ast.Constant(value=self.query_date_range.date_to()),
+                    },
+                ),
+            ]
+        )
+
+    def _sample_query(self, divisor: int) -> ast.SelectQuery:
+        # Even-random sampling: rand() is per-row uniform and independent of timestamp, so
+        # `rand() % divisor = 0` keeps ~1/divisor of rows spread evenly across the window.
+        # divisor == 1 means no sampling, so we skip the modulo predicate entirely.
+        where: ast.Expr = self._where_with_timestamp()
+        if divisor > 1:
+            where = ast.And(
+                exprs=[
+                    where,
+                    parse_expr("rand() % {divisor} = 0", placeholders={"divisor": ast.Constant(value=divisor)}),
+                ]
+            )
+        query = parse_select(
+            """
+            SELECT body, severity_text, service_name, timestamp
+            FROM logs
+            WHERE {where}
+            LIMIT {limit}
+            """,
+            placeholders={"where": where, "limit": ast.Constant(value=self._sample_limit)},
+        )
+        assert isinstance(query, ast.SelectQuery)
+        return query
+
+
+def _serialize(pattern: MinedPattern) -> dict:
+    return {
+        "pattern": pattern.pattern,
+        "count": pattern.count,
+        "volume_share_pct": pattern.volume_share_pct,
+        "error_count": pattern.error_count,
+        "first_seen": pattern.first_seen.isoformat(),
+        "last_seen": pattern.last_seen.isoformat(),
+        "examples": pattern.examples,
+        "services": pattern.services,
+    }

--- a/products/logs/backend/patterns_query_runner.py
+++ b/products/logs/backend/patterns_query_runner.py
@@ -1,5 +1,6 @@
 import datetime as dt
 from functools import cached_property
+from math import ceil
 from typing import TYPE_CHECKING
 
 from posthog.schema import CachedLogsQueryResponse, LogsQuery
@@ -57,7 +58,7 @@ class PatternsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
     def _calculate(self) -> LogsQueryResponse:
         total = self._count()
         sampled = total > self._sample_limit
-        divisor = max(1, total // self._sample_limit) if sampled else 1
+        divisor = _sample_divisor(total, self._sample_limit)
 
         response = self._execute(self._sample_query(divisor))
         samples = [
@@ -78,6 +79,11 @@ class PatternsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
                 "sampled": sampled,
             }
         )
+
+    def run(self, *args, **kwargs) -> LogsQueryResponse | CachedLogsQueryResponse:
+        response = super().run(*args, **kwargs)
+        assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
+        return response
 
     def to_query(self) -> ast.SelectQuery:
         # Canonical (unsampled) form for the base runner's query contract; _calculate picks
@@ -144,6 +150,14 @@ class PatternsQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunn
         )
         assert isinstance(query, ast.SelectQuery)
         return query
+
+
+def _sample_divisor(total: int, sample_limit: int) -> int:
+    # Round up so total / divisor <= sample_limit: the rand()-modulo predicate alone bounds the
+    # sample and LIMIT never truncates the random subset in (biased) read order.
+    if total <= sample_limit:
+        return 1
+    return ceil(total / sample_limit)
 
 
 def _serialize(pattern: MinedPattern) -> dict:

--- a/products/logs/backend/test/test_patterns_query_runner.py
+++ b/products/logs/backend/test/test_patterns_query_runner.py
@@ -5,12 +5,14 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, ClickhouseTestMixin
 from unittest.mock import patch
 
+from parameterized import parameterized
+
 from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter
 
 from posthog.clickhouse.client import sync_execute
 from posthog.hogql_queries.query_runner import ExecutionMode
 
-from products.logs.backend.patterns_query_runner import PatternsQueryRunner
+from products.logs.backend.patterns_query_runner import PatternsQueryRunner, _sample_divisor
 
 _FROZEN_NOW = "2026-06-23T13:00:00Z"
 _WINDOW = DateRange(date_from="2026-06-23T00:00:00Z", date_to="2026-06-23T13:00:00Z")
@@ -75,6 +77,21 @@ class TestPatternsQueryRunner(ClickhouseTestMixin, APIBaseTest):
         assert results["scanned_count"] <= 5
         # total_count reports the full window size even though the sample is capped.
         assert results["total_count"] == 20
+
+    @parameterized.expand(
+        [
+            (0, 1),
+            (5, 1),
+            (10, 1),
+            (11, 2),
+            (15, 2),
+            (20, 2),
+            (21, 3),
+            (100, 10),
+        ]
+    )
+    def test_sample_divisor_rounds_up_to_keep_sample_within_limit(self, total: int, expected: int) -> None:
+        assert _sample_divisor(total, sample_limit=10) == expected
 
     @freeze_time(_FROZEN_NOW)
     def test_respects_service_filter(self) -> None:

--- a/products/logs/backend/test/test_patterns_query_runner.py
+++ b/products/logs/backend/test/test_patterns_query_runner.py
@@ -1,0 +1,114 @@
+import os
+import json
+
+from freezegun import freeze_time
+from posthog.test.base import APIBaseTest, ClickhouseTestMixin
+from unittest.mock import patch
+
+from posthog.schema import DateRange, FilterLogicalOperator, LogsQuery, PropertyGroupFilter
+
+from posthog.clickhouse.client import sync_execute
+from posthog.hogql_queries.query_runner import ExecutionMode
+
+from products.logs.backend.patterns_query_runner import PatternsQueryRunner
+
+_FROZEN_NOW = "2026-06-23T13:00:00Z"
+_WINDOW = DateRange(date_from="2026-06-23T00:00:00Z", date_to="2026-06-23T13:00:00Z")
+
+
+class TestPatternsQueryRunner(ClickhouseTestMixin, APIBaseTest):
+    def _insert(self, rows: list[dict]) -> None:
+        sql = "".join(json.dumps({"team_id": self.team.id, **r}) + "\n" for r in rows)
+        sync_execute(f"INSERT INTO logs FORMAT JSONEachRow\n{sql}")
+
+    def _log(self, body: str, severity: str = "info", service: str = "api", minute: int = 0) -> dict:
+        return {
+            "timestamp": f"2026-06-23 12:{minute:02d}:00.000000",
+            "body": body,
+            "severity_text": severity,
+            "service_name": service,
+        }
+
+    def _run(self, **overrides) -> dict:
+        query = LogsQuery(
+            dateRange=overrides.pop("dateRange", _WINDOW),
+            filterGroup=overrides.pop("filterGroup", PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[])),
+            severityLevels=overrides.pop("severityLevels", []),
+            serviceNames=overrides.pop("serviceNames", []),
+            searchTerm=overrides.pop("searchTerm", None),
+        )
+        response = PatternsQueryRunner(team=self.team, query=query).run(ExecutionMode.CALCULATE_BLOCKING_ALWAYS)
+        return response.results
+
+    @freeze_time(_FROZEN_NOW)
+    def test_mines_templates_from_clickhouse(self) -> None:
+        self._insert(
+            [
+                self._log(f"User {name} not found", severity="error", service="auth")
+                for name in ("alice", "bob", "carol")
+            ]
+            + [self._log(f"GET /api/orders/{i} ok", service="api") for i in range(2)]
+        )
+
+        results = self._run()
+        patterns = results["patterns"]
+
+        assert results["scanned_count"] == 5
+        assert results["total_count"] == 5
+        assert results["sampled"] is False
+        by_template = {p["pattern"]: p for p in patterns}
+        assert "User <*> not found" in by_template
+        assert by_template["User <*> not found"]["count"] == 3
+        assert by_template["User <*> not found"]["error_count"] == 3
+        assert by_template["User <*> not found"]["services"] == ["auth"]
+
+    @freeze_time(_FROZEN_NOW)
+    def test_sets_sampled_and_caps_scanned_count_above_the_limit(self) -> None:
+        self._insert([self._log(f"request {i} handled") for i in range(20)])
+
+        # Only assert invariants that don't depend on the random sample: `sampled` is a
+        # deterministic function of total vs. limit, and the LIMIT caps `scanned_count`.
+        with patch.dict(os.environ, {"LOGS_PATTERNS_SAMPLE_LIMIT": "5"}):
+            results = self._run()
+
+        assert results["sampled"] is True
+        assert results["scanned_count"] <= 5
+        # total_count reports the full window size even though the sample is capped.
+        assert results["total_count"] == 20
+
+    @freeze_time(_FROZEN_NOW)
+    def test_respects_service_filter(self) -> None:
+        self._insert(
+            [self._log("auth check passed", service="api") for _ in range(3)]
+            + [self._log("query took too long", service="db") for _ in range(2)]
+        )
+
+        results = self._run(serviceNames=["api"])
+
+        assert results["scanned_count"] == 3
+        assert results["sampled"] is False
+        services_seen = {svc for p in results["patterns"] for svc in p["services"]}
+        assert services_seen == {"api"}
+
+    @freeze_time(_FROZEN_NOW)
+    def test_empty_window_returns_no_patterns(self) -> None:
+        results = self._run()
+
+        assert results["patterns"] == []
+        assert results["scanned_count"] == 0
+        assert results["total_count"] == 0
+        assert results["sampled"] is False
+
+    def test_blocks_generic_query_runner_access(self) -> None:
+        from posthog.rbac.user_access_control import UserAccessControlError
+
+        query = LogsQuery(
+            dateRange=_WINDOW,
+            filterGroup=PropertyGroupFilter(type=FilterLogicalOperator.AND_, values=[]),
+            severityLevels=[],
+            serviceNames=[],
+            searchTerm=None,
+        )
+        runner = PatternsQueryRunner(team=self.team, query=query)
+        with self.assertRaises(UserAccessControlError):
+            runner.validate_query_runner_access(self.user)


### PR DESCRIPTION
## Problem

Log pattern mining (Drain3) needed a query runner to fetch a representative sample of logs from ClickHouse, cluster them into templates, and return structured results — without timing out on large time windows.

## Changes

Adds `PatternsQueryRunner`, which:

- Counts matching rows first, then pulls at most `LOGS_PATTERNS_SAMPLE_LIMIT` (default 10 000) rows using a random-modulo predicate (`rand() % divisor = 0`) to spread the sample evenly across the window
- Sets `sampled: true` in the response whenever the window exceeded the sample cap
- Bounds execution by wall-clock time (`LOGS_PATTERNS_MAX_EXECUTION_TIME`, default 60 s) rather than bytes, avoiding 500s on wide windows caused by the symbol-stats read-cap cliff
- Feeds the sampled `LogSample` objects to `mine_patterns` and serializes the resulting `MinedPattern` list (pattern template, count, error count, volume share, first/last seen, examples, services)

## How did you test this code?

Four integration tests against a real ClickHouseDB instance cover:

- **Template mining** — inserts known-shape rows and asserts the expected Drain3 template, count, error count, and service list are returned
- **Sampling cap** — inserts 20 rows, sets `LOGS_PATTERNS_SAMPLE_LIMIT=5` via env patch, and asserts `sampled=True` and `scanned_count ≤ 5`
- **Service filter** — inserts rows for two services, filters to one, and asserts only that service's patterns appear
- **Empty window** — runs against an empty table and asserts zero patterns and `sampled=False`

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — internal backend query runner, no public API surface change.