### PR TITLE
chore(mcp): rename session intent button label

### DIFF
--- a/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
+++ b/products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx
@@ -205,7 +205,7 @@ export function MCPSessionDetail(): JSX.Element {
                         loading={isSelectedSessionGenerating}
                         onClick={() => generateIntent(selectedSession.session_id)}
                     >
-                        {isSelectedSessionGenerating ? 'Thinking…' : "What's the session intent?"}
+                        {isSelectedSessionGenerating ? 'Thinking…' : 'Summarize session intent'}
                     </LemonButton>
                 )}
             </footer>


### PR DESCRIPTION
## Problem

In the mcp analytics sessions tab, the button shown before a session intent has been generated read "What's the session intent?". A more action-oriented label reads better as a button.

## Changes

Renamed the button label to "Summarize session intent". The "Thinking…" loading state is unchanged. Pure copy change in `products/mcp_analytics/frontend/sessions/MCPSessionDetail.tsx`.

## How did you test this code?

I'm an agent. This is a one-line string change with no logic or type impact; lint-staged formatting ran on commit. No automated tests were added or run beyond that.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at a human's direction. The task was a simple button-label copy change in the mcp analytics sessions tab; located the string, renamed it, and kept the loading-state text intact. No skills were needed for a single-line frontend string edit.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
