### PR TITLE
feat(viz): generate quill charts for SQL results

### DIFF
--- a/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.stories.tsx
+++ b/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.stories.tsx
@@ -1,0 +1,117 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import type { ChartSpec } from './chartSpec'
+import { ChartSpecRenderer } from './ChartSpecRenderer'
+
+// These specs are hand-written to stand in for what an LLM would emit. They prove the rendering
+// half of the gen-UI charts idea end to end, before any model is wired up.
+
+const DAYS = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun']
+const WEEK_DATES = ['2026-06-15', '2026-06-16', '2026-06-17', '2026-06-18', '2026-06-19', '2026-06-20', '2026-06-21']
+
+const comboDualAxis: ChartSpec = {
+    chartType: 'combo',
+    title: 'Revenue vs conversion rate',
+    narrative:
+        'Revenue (bars, left) climbs while conversion rate (line, right) holds steady — growth is from volume, not efficiency.',
+    labels: DAYS,
+    axes: [
+        { id: 'left', format: 'currency', currency: 'USD', label: 'Revenue' },
+        { id: 'right', format: 'percentage', label: 'Conversion' },
+    ],
+    series: [
+        {
+            key: 'revenue',
+            label: 'Revenue',
+            type: 'bar',
+            axis: 'left',
+            data: [4200, 5100, 4800, 6300, 7200, 3100, 2800],
+        },
+        {
+            key: 'cvr',
+            label: 'Conversion rate',
+            type: 'line',
+            axis: 'right',
+            data: [3.1, 3.3, 3.0, 3.4, 3.5, 3.2, 3.1],
+        },
+    ],
+    referenceLines: [{ value: 6000, label: 'Daily target', variant: 'goal', axis: 'left' }],
+}
+
+const stackedBar: ChartSpec = {
+    chartType: 'bar',
+    title: 'Signups by channel',
+    labels: DAYS,
+    series: [
+        { key: 'organic', label: 'Organic', data: [120, 132, 101, 134, 90, 40, 35] },
+        { key: 'paid', label: 'Paid', data: [60, 72, 55, 81, 66, 20, 18] },
+        { key: 'referral', label: 'Referral', data: [30, 28, 41, 35, 44, 12, 10] },
+    ],
+    config: { stacked: true, showLegend: true, showGrid: true },
+}
+
+const horizontalRanked: ChartSpec = {
+    chartType: 'bar',
+    title: 'Top pages by views',
+    labels: ['/home', '/pricing', '/blog', '/docs', '/signup'],
+    series: [{ key: 'views', label: 'Views', data: [9200, 5400, 4800, 3100, 2200] }],
+    config: { horizontal: true, grouped: true, showValueLabels: true },
+    axes: [{ id: 'left', format: 'short' }],
+}
+
+const timeSeriesGoal: ChartSpec = {
+    chartType: 'timeSeriesLine',
+    title: 'Weekly active users',
+    narrative: 'WAU is trending toward the 1k goal line, with a dip over the weekend.',
+    labels: WEEK_DATES,
+    series: [{ key: 'wau', label: 'WAU', fill: true, data: [820, 910, 880, 1010, 1120, 640, 590] }],
+    axes: [{ id: 'left', format: 'short', startAtZero: false }],
+    referenceLines: [{ value: 1000, label: 'Goal', variant: 'goal' }],
+    config: { showLegend: false },
+}
+
+const donut: ChartSpec = {
+    chartType: 'pie',
+    title: 'Traffic by device',
+    labels: ['Desktop', 'Mobile', 'Tablet'],
+    series: [{ key: 'device', label: 'Device', data: [62, 31, 7] }],
+    config: { donut: true },
+    axes: [{ id: 'left', format: 'percentage' }],
+}
+
+const metricCard: ChartSpec = {
+    chartType: 'metricCard',
+    title: 'MRR',
+    labels: WEEK_DATES,
+    series: [{ key: 'mrr', label: 'MRR', data: [41000, 41800, 42200, 43100, 44000, 44200, 45600] }],
+    axes: [{ id: 'left', format: 'currency', currency: 'USD' }],
+}
+
+const SPECS: ChartSpec[] = [comboDualAxis, stackedBar, horizontalRanked, timeSeriesGoal, donut, metricCard]
+
+const meta: Meta<typeof ChartSpecRenderer> = {
+    title: 'Components/ChartSpecRenderer',
+    component: ChartSpecRenderer,
+}
+export default meta
+
+type Story = StoryObj<typeof ChartSpecRenderer>
+
+export const Gallery: Story = {
+    render: () => (
+        <div className="grid grid-cols-2 gap-6 max-w-[1000px]">
+            {SPECS.map((spec, i) => (
+                <div key={i} className="border rounded p-4 bg-surface-primary">
+                    <ChartSpecRenderer spec={spec} height={260} />
+                </div>
+            ))}
+        </div>
+    ),
+}
+
+export const ComboDualAxis: Story = { render: () => <ChartSpecRenderer spec={comboDualAxis} /> }
+export const StackedBar: Story = { render: () => <ChartSpecRenderer spec={stackedBar} /> }
+export const HorizontalRanked: Story = { render: () => <ChartSpecRenderer spec={horizontalRanked} /> }
+export const TimeSeriesWithGoal: Story = { render: () => <ChartSpecRenderer spec={timeSeriesGoal} /> }
+export const Donut: Story = { render: () => <ChartSpecRenderer spec={donut} /> }
+export const MetricCardStory: Story = { name: 'Metric Card', render: () => <ChartSpecRenderer spec={metricCard} /> }

--- a/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.tsx
+++ b/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.tsx
@@ -1,0 +1,213 @@
+import {
+    BarChart,
+    type BarChartConfig,
+    buildYTickFormatter,
+    ComboChart,
+    type ComboChartConfig,
+    LineChart,
+    type LineChartConfig,
+    MetricCard,
+    PieChart,
+    ReferenceLine,
+    type Series,
+    TimeSeriesLineChart,
+    type TimeSeriesLineChartConfig,
+    useChartTheme,
+    ValueLabels,
+    type YAxis,
+    type YAxisConfig,
+} from '@posthog/quill-charts'
+
+import type { ChartSpec, ChartSpecAxis, ChartSpecReferenceLine, ChartSpecValueFormat } from './chartSpec'
+
+function formatterFor(format?: ChartSpecValueFormat, currency?: string): ((value: number) => string) | undefined {
+    if (!format) {
+        return undefined
+    }
+    return buildYTickFormatter({ format, currency })
+}
+
+// Spec series → quill series. `fill`/`dashed` are translated to the structured stroke/fill props.
+function toQuillSeries(spec: ChartSpec): Series[] {
+    return spec.series.map((s) => ({
+        key: s.key,
+        label: s.label,
+        data: s.data,
+        color: s.color,
+        type: s.type,
+        yAxisId: s.axis,
+        fill: s.fill ? { opacity: 0.25, gradient: true } : undefined,
+        stroke: s.dashed ? { pattern: [6, 6] } : undefined,
+    }))
+}
+
+// Spec axes → quill `YAxis[]` (used by the band/line/combo charts via `config.yAxes`).
+function toQuillYAxes(axes?: ChartSpecAxis[]): YAxis[] | undefined {
+    if (!axes?.length) {
+        return undefined
+    }
+    return axes.map((a) => ({
+        id: a.id,
+        position: a.id,
+        scaleType: a.scale,
+        tickFormatter: formatterFor(a.format, a.currency),
+        label: a.label,
+    }))
+}
+
+function referenceLineChildren(lines?: ChartSpecReferenceLine[]): JSX.Element[] | null {
+    if (!lines?.length) {
+        return null
+    }
+    return lines.map((line, i) => (
+        <ReferenceLine
+            key={i}
+            value={line.value}
+            orientation={line.orientation ?? 'horizontal'}
+            label={line.label}
+            variant={line.variant ?? 'goal'}
+            yAxisId={line.axis}
+        />
+    ))
+}
+
+function barLayout(config: ChartSpec['config']): 'stacked' | 'grouped' | 'percent' {
+    if (config?.percent) {
+        return 'percent'
+    }
+    if (config?.grouped) {
+        return 'grouped'
+    }
+    return 'stacked'
+}
+
+export interface ChartSpecRendererProps {
+    spec: ChartSpec
+    /** Height in px for the chart body. Pie/line/bar/combo fill this; MetricCard ignores it. */
+    height?: number
+    className?: string
+}
+
+/** Renders a declarative {@link ChartSpec} into the matching `@posthog/quill-charts` component.
+ *  This is the "render half" of the gen-UI charts idea — an LLM emits the spec, this draws it. */
+export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRendererProps): JSX.Element {
+    const theme = useChartTheme()
+    const series = toQuillSeries(spec)
+    const refLines = referenceLineChildren(spec.referenceLines)
+    const primaryAxis = spec.axes?.[0]
+
+    const body = ((): JSX.Element => {
+        switch (spec.chartType) {
+            case 'line': {
+                const config: LineChartConfig = {
+                    showGrid: spec.config?.showGrid,
+                    yAxes: toQuillYAxes(spec.axes),
+                    yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
+                    floatBaseline: primaryAxis?.startAtZero === false,
+                    legend: { show: spec.config?.showLegend },
+                }
+                return (
+                    <LineChart series={series} labels={spec.labels} config={config} theme={theme}>
+                        {spec.config?.showValueLabels && <ValueLabels />}
+                        {refLines}
+                    </LineChart>
+                )
+            }
+            case 'bar': {
+                const config: BarChartConfig = {
+                    barLayout: barLayout(spec.config),
+                    axisOrientation: spec.config?.horizontal ? 'horizontal' : 'vertical',
+                    showGrid: spec.config?.showGrid,
+                    yAxes: toQuillYAxes(spec.axes),
+                    yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
+                    bars: { cornerRadius: 4 },
+                    legend: { show: spec.config?.showLegend },
+                }
+                return (
+                    <BarChart series={series} labels={spec.labels} config={config} theme={theme}>
+                        {spec.config?.showValueLabels && <ValueLabels />}
+                        {refLines}
+                    </BarChart>
+                )
+            }
+            case 'combo': {
+                const config: ComboChartConfig = {
+                    barLayout: spec.config?.grouped ? 'grouped' : 'stacked',
+                    showGrid: spec.config?.showGrid,
+                    yAxes: toQuillYAxes(spec.axes),
+                    yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
+                    barCornerRadius: 4,
+                }
+                return (
+                    <ComboChart series={series} labels={spec.labels} config={config} theme={theme}>
+                        {refLines}
+                    </ComboChart>
+                )
+            }
+            case 'timeSeriesLine': {
+                const yAxis: YAxisConfig[] | undefined = spec.axes?.map((a) => ({
+                    id: a.id,
+                    position: a.id,
+                    format: a.format,
+                    currency: a.currency,
+                    scale: a.scale,
+                    label: a.label,
+                    startAtZero: a.startAtZero,
+                }))
+                const config: TimeSeriesLineChartConfig = {
+                    xAxis: { timezone: 'UTC', interval: 'day' },
+                    yAxis,
+                    valueLabels: spec.config?.showValueLabels,
+                    legend: { show: spec.config?.showLegend },
+                }
+                return (
+                    <TimeSeriesLineChart series={series} labels={spec.labels} config={config} theme={theme}>
+                        {refLines}
+                    </TimeSeriesLineChart>
+                )
+            }
+            case 'pie': {
+                // One slice per label, taken from the first series.
+                const first = spec.series[0]
+                const sliceSeries: Series[] = spec.labels.map((label, i) => ({
+                    key: `${first.key}-${i}`,
+                    label,
+                    data: [first.data[i] ?? 0],
+                }))
+                return (
+                    <PieChart
+                        series={sliceSeries}
+                        config={{ innerRadiusRatio: spec.config?.donut ? 0.6 : 0, showLabelOnSlice: true }}
+                        valueFormatter={formatterFor(primaryAxis?.format, primaryAxis?.currency)}
+                        theme={theme}
+                    />
+                )
+            }
+            case 'metricCard': {
+                const first = spec.series[0]
+                return (
+                    <MetricCard
+                        title={spec.title ?? first.label}
+                        data={first.data}
+                        labels={spec.labels}
+                        theme={theme}
+                        color={first.color}
+                        formatValue={formatterFor(primaryAxis?.format, primaryAxis?.currency)}
+                        showChange
+                    />
+                )
+            }
+        }
+    })()
+
+    const isCard = spec.chartType === 'metricCard'
+
+    return (
+        <div className={className}>
+            {spec.title && !isCard && <div className="text-sm font-semibold mb-1">{spec.title}</div>}
+            {/* eslint-disable-next-line react/forbid-dom-props -- chart body needs an explicit pixel height */}
+            <div style={isCard ? undefined : { height }}>{body}</div>
+            {spec.narrative && <div className="text-xs text-secondary mt-2">{spec.narrative}</div>}
+        </div>
+    )
+}

--- a/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.tsx
+++ b/frontend/src/lib/components/ChartSpecRenderer/ChartSpecRenderer.tsx
@@ -10,8 +10,11 @@ import {
     PieChart,
     ReferenceLine,
     type Series,
+    TimeSeriesBarChart,
+    type TimeSeriesBarChartConfig,
     TimeSeriesLineChart,
     type TimeSeriesLineChartConfig,
+    type TooltipConfig,
     useChartTheme,
     ValueLabels,
     type YAxis,
@@ -71,6 +74,18 @@ function referenceLineChildren(lines?: ChartSpecReferenceLine[]): JSX.Element[] 
     ))
 }
 
+function toTooltipConfig(config: ChartSpec['config']): TooltipConfig | undefined {
+    if (!config?.tooltipShowTotal && !config?.tooltipPlacement) {
+        return undefined
+    }
+    return { showTotal: config.tooltipShowTotal, placement: config.tooltipPlacement }
+}
+
+// Detects when bar chart labels are ISO date strings so we can swap to TimeSeriesBarChart.
+function looksLikeISODate(label: string): boolean {
+    return /^\d{4}-\d{2}-\d{2}T/.test(label)
+}
+
 function barLayout(config: ChartSpec['config']): 'stacked' | 'grouped' | 'percent' {
     if (config?.percent) {
         return 'percent'
@@ -101,10 +116,19 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
             case 'line': {
                 const config: LineChartConfig = {
                     showGrid: spec.config?.showGrid,
+                    showAxisLines: spec.config?.showAxisLines,
+                    showCrosshair: spec.config?.showCrosshair,
+                    hideXAxis: spec.config?.hideXAxis,
+                    hideYAxis: spec.config?.hideYAxis,
+                    tooltip: toTooltipConfig(spec.config),
                     yAxes: toQuillYAxes(spec.axes),
                     yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
                     floatBaseline: primaryAxis?.startAtZero === false,
-                    legend: { show: spec.config?.showLegend },
+                    legend: {
+                        show: spec.config?.showLegend ?? spec.config?.legendPosition != null,
+                        position: spec.config?.legendPosition,
+                        align: spec.config?.legendAlign,
+                    },
                 }
                 return (
                     <LineChart series={series} labels={spec.labels} config={config} theme={theme}>
@@ -113,18 +137,73 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
                     </LineChart>
                 )
             }
+            case 'timeSeriesBar':
+            // eslint-disable-next-line no-fallthrough
             case 'bar': {
-                const config: BarChartConfig = {
+                const isTimeSeries =
+                    spec.chartType === 'timeSeriesBar' || (spec.labels.length > 0 && looksLikeISODate(spec.labels[0]))
+
+                if (isTimeSeries) {
+                    const yAxisConfig: YAxisConfig | undefined = primaryAxis
+                        ? {
+                              id: primaryAxis.id,
+                              position: primaryAxis.id,
+                              format: primaryAxis.format,
+                              currency: primaryAxis.currency,
+                              scale: primaryAxis.scale,
+                              label: primaryAxis.label,
+                              startAtZero: primaryAxis.startAtZero,
+                          }
+                        : undefined
+                    const tsBarConfig: TimeSeriesBarChartConfig = {
+                        xAxis: { timezone: 'UTC', interval: 'day' },
+                        yAxis: yAxisConfig,
+                        barLayout: barLayout(spec.config),
+                        barCornerRadius: 4,
+                        divergingStack: spec.config?.divergingStack,
+                        fillStyle: spec.config?.barFillStyle,
+                        showCrosshair: spec.config?.showCrosshair,
+                        showAxisLines: spec.config?.showAxisLines,
+                        tooltip: toTooltipConfig(spec.config),
+                        legend: {
+                            show: spec.config?.showLegend ?? spec.config?.legendPosition != null,
+                            position: spec.config?.legendPosition,
+                            align: spec.config?.legendAlign,
+                        },
+                    }
+                    return (
+                        <TimeSeriesBarChart series={series} labels={spec.labels} config={tsBarConfig} theme={theme}>
+                            {spec.config?.showValueLabels && <ValueLabels />}
+                            {refLines}
+                        </TimeSeriesBarChart>
+                    )
+                }
+
+                const barConfig: BarChartConfig = {
                     barLayout: barLayout(spec.config),
                     axisOrientation: spec.config?.horizontal ? 'horizontal' : 'vertical',
                     showGrid: spec.config?.showGrid,
+                    showAxisLines: spec.config?.showAxisLines,
+                    showCrosshair: spec.config?.showCrosshair,
+                    hideXAxis: spec.config?.hideXAxis,
+                    hideYAxis: spec.config?.hideYAxis,
+                    tooltip: toTooltipConfig(spec.config),
                     yAxes: toQuillYAxes(spec.axes),
                     yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
-                    bars: { cornerRadius: 4 },
-                    legend: { show: spec.config?.showLegend },
+                    bars: {
+                        cornerRadius: 4,
+                        fillStyle: spec.config?.barFillStyle,
+                        divergingStack: spec.config?.divergingStack,
+                        roundStackEnds: spec.config?.roundStackEnds,
+                    },
+                    legend: {
+                        show: spec.config?.showLegend ?? spec.config?.legendPosition != null,
+                        position: spec.config?.legendPosition,
+                        align: spec.config?.legendAlign,
+                    },
                 }
                 return (
-                    <BarChart series={series} labels={spec.labels} config={config} theme={theme}>
+                    <BarChart series={series} labels={spec.labels} config={barConfig} theme={theme}>
                         {spec.config?.showValueLabels && <ValueLabels />}
                         {refLines}
                     </BarChart>
@@ -134,6 +213,11 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
                 const config: ComboChartConfig = {
                     barLayout: spec.config?.grouped ? 'grouped' : 'stacked',
                     showGrid: spec.config?.showGrid,
+                    showAxisLines: spec.config?.showAxisLines,
+                    showCrosshair: spec.config?.showCrosshair,
+                    hideXAxis: spec.config?.hideXAxis,
+                    hideYAxis: spec.config?.hideYAxis,
+                    tooltip: toTooltipConfig(spec.config),
                     yAxes: toQuillYAxes(spec.axes),
                     yTickFormatter: primaryAxis ? formatterFor(primaryAxis.format, primaryAxis.currency) : undefined,
                     barCornerRadius: 4,
@@ -158,7 +242,14 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
                     xAxis: { timezone: 'UTC', interval: 'day' },
                     yAxis,
                     valueLabels: spec.config?.showValueLabels,
-                    legend: { show: spec.config?.showLegend },
+                    showCrosshair: spec.config?.showCrosshair,
+                    showAxisLines: spec.config?.showAxisLines,
+                    tooltip: toTooltipConfig(spec.config),
+                    legend: {
+                        show: spec.config?.showLegend ?? spec.config?.legendPosition != null,
+                        position: spec.config?.legendPosition,
+                        align: spec.config?.legendAlign,
+                    },
                 }
                 return (
                     <TimeSeriesLineChart series={series} labels={spec.labels} config={config} theme={theme}>
@@ -174,10 +265,11 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
                     label,
                     data: [first.data[i] ?? 0],
                 }))
+                const innerRadiusRatio = spec.config?.innerRadiusRatio ?? (spec.config?.donut ? 0.6 : 0)
                 return (
                     <PieChart
                         series={sliceSeries}
-                        config={{ innerRadiusRatio: spec.config?.donut ? 0.6 : 0, showLabelOnSlice: true }}
+                        config={{ innerRadiusRatio, showLabelOnSlice: true }}
                         valueFormatter={formatterFor(primaryAxis?.format, primaryAxis?.currency)}
                         theme={theme}
                     />
@@ -193,7 +285,11 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
                         theme={theme}
                         color={first.color}
                         formatValue={formatterFor(primaryAxis?.format, primaryAxis?.currency)}
-                        showChange
+                        showChange={spec.config?.showChange ?? true}
+                        goodDirection={spec.config?.goodDirection}
+                        changeInline={spec.config?.changeInline}
+                        sparklineFill={spec.config?.sparklineFill}
+                        subtitle={spec.config?.subtitle}
                     />
                 )
             }
@@ -206,7 +302,9 @@ export function ChartSpecRenderer({ spec, height = 320, className }: ChartSpecRe
         <div className={className}>
             {spec.title && !isCard && <div className="text-sm font-semibold mb-1">{spec.title}</div>}
             {/* eslint-disable-next-line react/forbid-dom-props -- chart body needs an explicit pixel height */}
-            <div style={isCard ? undefined : { height }}>{body}</div>
+            <div style={isCard ? undefined : { height }} className={isCard ? undefined : 'flex flex-col'}>
+                {body}
+            </div>
             {spec.narrative && <div className="text-xs text-secondary mt-2">{spec.narrative}</div>}
         </div>
     )

--- a/frontend/src/lib/components/ChartSpecRenderer/chartSpec.ts
+++ b/frontend/src/lib/components/ChartSpecRenderer/chartSpec.ts
@@ -64,23 +64,96 @@ export const chartSpecReferenceLineSchema = z
 
 export const chartSpecConfigSchema = z
     .object({
+        // Layout
         stacked: z.boolean().optional().describe('Stack series (bar/area).'),
         grouped: z.boolean().optional().describe('Group bars side by side instead of stacking.'),
         percent: z.boolean().optional().describe('Normalize the stack to 100%.'),
         horizontal: z.boolean().optional().describe('Bar charts only: lay bars out horizontally (ranked list).'),
-        donut: z.boolean().optional().describe('Pie charts only: render as a donut.'),
+        donut: z.boolean().optional().describe('Pie charts only: render as a donut (innerRadiusRatio 0.6).'),
+        innerRadiusRatio: z
+            .number()
+            .min(0)
+            .max(0.95)
+            .optional()
+            .describe(
+                'Pie charts: inner radius as a fraction (0 = pie, 0.4–0.7 = donut ring, 0.85 = thin ring). Overrides donut.'
+            ),
+
+        // Legend
         showLegend: z.boolean().optional().describe('Show an interactive legend.'),
+        legendPosition: z
+            .enum(['top', 'bottom', 'left', 'right'])
+            .optional()
+            .describe("Where the legend sits relative to the plot. Default 'bottom'."),
+        legendAlign: z
+            .enum(['start', 'center', 'end'])
+            .optional()
+            .describe("Legend alignment along its axis. Default 'center'."),
+
+        // Overlays
         showGrid: z.boolean().optional().describe('Show horizontal grid lines.'),
+        showAxisLines: z
+            .boolean()
+            .optional()
+            .describe('Show L-shaped axis baselines only (no interior grid). Ignored when showGrid is true.'),
+        showCrosshair: z.boolean().optional().describe('Show a vertical crosshair line following the cursor.'),
         showValueLabels: z.boolean().optional().describe('Draw the value of each point/bar on the chart.'),
+
+        // Axes
+        hideXAxis: z.boolean().optional().describe('Hide x-axis labels and reduce bottom margin.'),
+        hideYAxis: z.boolean().optional().describe('Hide y-axis labels and reduce left margin.'),
+
+        // Tooltip
+        tooltipShowTotal: z
+            .boolean()
+            .optional()
+            .describe('Show a total row at the bottom of the tooltip. Useful for stacked charts.'),
+        tooltipPlacement: z
+            .enum(['follow-data', 'top', 'cursor'])
+            .optional()
+            .describe(
+                "Tooltip anchor: 'follow-data' (default, tracks highest point), 'top' (fixed), 'cursor' (beside mouse)."
+            ),
+
+        // Bar-specific
+        barFillStyle: z
+            .enum(['flat', 'gradient', 'gloss'])
+            .optional()
+            .describe("Bar fill treatment. 'flat' (default), 'gradient' (diagonal sheen), 'gloss' (radial highlight)."),
+        divergingStack: z
+            .boolean()
+            .optional()
+            .describe('Stacked bar charts: stack negative values below the zero baseline.'),
+        roundStackEnds: z
+            .boolean()
+            .optional()
+            .describe('Stacked bar charts: round both outer ends of the whole stack as a pill.'),
+
+        // MetricCard-specific
+        showChange: z.boolean().optional().describe('Metric card: show a change/trend pill.'),
+        goodDirection: z
+            .enum(['up', 'down'])
+            .optional()
+            .describe("Metric card: which direction is good ('up' = higher is better, 'down' = lower is better)."),
+        changeInline: z
+            .boolean()
+            .optional()
+            .describe('Metric card: render the change pill beside the headline instead of in the header row.'),
+        sparklineFill: z
+            .boolean()
+            .optional()
+            .describe("Metric card: fill the card's remaining height with the sparkline."),
+        subtitle: z.string().optional().describe('Metric card: caption shown under the headline.'),
     })
     .describe('Layout and decoration toggles.')
 
 export const chartSpecSchema = z
     .object({
         chartType: z
-            .enum(['line', 'bar', 'combo', 'timeSeriesLine', 'pie', 'metricCard'])
+            .enum(['line', 'bar', 'combo', 'timeSeriesLine', 'timeSeriesBar', 'pie', 'metricCard'])
             .describe(
-                'The chart family. Use `combo` to mix bars and lines, `timeSeriesLine` when x labels are ISO dates, ' +
+                'The chart family. Use `timeSeriesLine` or `timeSeriesBar` when x labels are ISO date strings ' +
+                    '(they format dates properly); `bar`/`line` for categorical x-axes; `combo` to mix bars and lines; ' +
                     '`metricCard` for a single headline number with a sparkline.'
             ),
         title: z.string().optional().describe('Short chart title.'),

--- a/frontend/src/lib/components/ChartSpecRenderer/chartSpec.ts
+++ b/frontend/src/lib/components/ChartSpecRenderer/chartSpec.ts
@@ -1,0 +1,106 @@
+import { z } from 'zod'
+
+// A generative-UI chart spec: a flat, declarative description of a chart that an LLM can emit and
+// `ChartSpecRenderer` turns into a `@posthog/quill-charts` component. Every field carries a
+// `.describe()` so the same schema can be handed to a model as a structured-output contract.
+
+const valueFormat = z
+    .enum(['numeric', 'short', 'percentage', 'percentage_scaled', 'currency', 'duration', 'duration_ms'])
+    .describe(
+        "How to format values on this axis/series. 'percentage' expects 0–100, 'percentage_scaled' expects 0–1, " +
+            "'duration' expects seconds, 'duration_ms' expects milliseconds, 'short' compacts large numbers (1.2k)."
+    )
+
+export const chartSpecAxisSchema = z
+    .object({
+        id: z.enum(['left', 'right']).describe('Which side this axis is on. Series target it via `series.axis`.'),
+        label: z.string().optional().describe('Axis title shown beside the axis.'),
+        format: valueFormat.optional().describe('Default numeric formatting for ticks on this axis.'),
+        currency: z.string().optional().describe("ISO currency code (e.g. 'USD') when format is 'currency'."),
+        scale: z.enum(['linear', 'log']).optional().describe("Scale type. Defaults to 'linear'."),
+        startAtZero: z
+            .boolean()
+            .optional()
+            .describe('Clamp the baseline to zero (default true). Set false to float the axis to the data range.'),
+    })
+    .describe('A value axis. Provide two (left + right) for a dual-axis chart.')
+
+export const chartSpecSeriesSchema = z
+    .object({
+        key: z.string().describe('Stable unique identifier for the series.'),
+        label: z.string().describe('Human-readable name shown in legend and tooltip.'),
+        data: z.array(z.number()).describe('One value per x-axis label. Must match `labels` length.'),
+        color: z
+            .string()
+            .optional()
+            .describe('CSS color. Omit to auto-assign from the on-brand data palette by index.'),
+        type: z
+            .enum(['line', 'bar', 'area'])
+            .optional()
+            .describe('For combo charts only: how to draw this series. Ignored by single-type charts.'),
+        axis: z
+            .enum(['left', 'right'])
+            .optional()
+            .describe("Which axis to scale against. Defaults to 'left'. Use 'right' for a second axis."),
+        fill: z.boolean().optional().describe('Fill the area under a line (line charts). Ignored for bars.'),
+        dashed: z.boolean().optional().describe('Render the line dashed — handy for forecasts or targets.'),
+    })
+    .describe('A single data series.')
+
+export const chartSpecReferenceLineSchema = z
+    .object({
+        value: z
+            .union([z.number(), z.string()])
+            .describe('A numeric value (horizontal line) or an x-axis label (vertical marker).'),
+        orientation: z.enum(['horizontal', 'vertical']).optional().describe("Defaults to 'horizontal'."),
+        label: z.string().optional().describe('Text label drawn on the line.'),
+        variant: z
+            .enum(['goal', 'alert', 'marker'])
+            .optional()
+            .describe("Visual style: 'goal' (dashed grey), 'alert' (dashed red), 'marker' (solid thin)."),
+        axis: z.enum(['left', 'right']).optional().describe('Which axis a horizontal line is measured against.'),
+    })
+    .describe('An annotation line: a goal/threshold (horizontal) or an event marker (vertical).')
+
+export const chartSpecConfigSchema = z
+    .object({
+        stacked: z.boolean().optional().describe('Stack series (bar/area).'),
+        grouped: z.boolean().optional().describe('Group bars side by side instead of stacking.'),
+        percent: z.boolean().optional().describe('Normalize the stack to 100%.'),
+        horizontal: z.boolean().optional().describe('Bar charts only: lay bars out horizontally (ranked list).'),
+        donut: z.boolean().optional().describe('Pie charts only: render as a donut.'),
+        showLegend: z.boolean().optional().describe('Show an interactive legend.'),
+        showGrid: z.boolean().optional().describe('Show horizontal grid lines.'),
+        showValueLabels: z.boolean().optional().describe('Draw the value of each point/bar on the chart.'),
+    })
+    .describe('Layout and decoration toggles.')
+
+export const chartSpecSchema = z
+    .object({
+        chartType: z
+            .enum(['line', 'bar', 'combo', 'timeSeriesLine', 'pie', 'metricCard'])
+            .describe(
+                'The chart family. Use `combo` to mix bars and lines, `timeSeriesLine` when x labels are ISO dates, ' +
+                    '`metricCard` for a single headline number with a sparkline.'
+            ),
+        title: z.string().optional().describe('Short chart title.'),
+        narrative: z
+            .string()
+            .optional()
+            .describe('One sentence on what this chart shows and why it was chosen — surfaced to the user.'),
+        labels: z
+            .array(z.string())
+            .describe('X-axis labels (ISO date strings for `timeSeriesLine`). Same length as each series `data`.'),
+        series: z.array(chartSpecSeriesSchema).min(1).describe('The series to plot.'),
+        axes: z.array(chartSpecAxisSchema).optional().describe('Axis definitions. Provide two for a dual-axis chart.'),
+        config: chartSpecConfigSchema.optional(),
+        referenceLines: z.array(chartSpecReferenceLineSchema).optional().describe('Goal lines and event markers.'),
+    })
+    .describe('A complete, renderable chart described declaratively.')
+
+export type ChartSpec = z.infer<typeof chartSpecSchema>
+export type ChartSpecSeries = z.infer<typeof chartSpecSeriesSchema>
+export type ChartSpecAxis = z.infer<typeof chartSpecAxisSchema>
+export type ChartSpecReferenceLine = z.infer<typeof chartSpecReferenceLineSchema>
+export type ChartSpecConfig = z.infer<typeof chartSpecConfigSchema>
+export type ChartSpecValueFormat = z.infer<typeof valueFormat>

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -23,6 +23,7 @@ export const DISPLAY_TYPES_TO_CATEGORIES: Record<ChartDisplayType, ChartDisplayC
     // The slope's two points are the first and last interval bucket, so it's time-series at heart;
     // it keeps the group-by interval and InsightDisplayConfig hides the options between the ends.
     [ChartDisplayType.SlopeGraph]: ChartDisplayCategory.TimeSeries,
+    [ChartDisplayType.GeneratedQuill]: ChartDisplayCategory.TotalValue,
 }
 export const NON_TIME_SERIES_DISPLAY_TYPES = Object.entries(DISPLAY_TYPES_TO_CATEGORIES)
     .filter(([, category]) => category === ChartDisplayCategory.TotalValue)

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/GeneratedQuillVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/GeneratedQuillVisualization.tsx
@@ -20,7 +20,10 @@ export function GeneratedQuillVisualization(): JSX.Element {
     const hogqlResponse = response as HogQLQueryResponse | null
     const columns: string[] = hogqlResponse?.columns ?? []
     const rows = (hogqlResponse?.results as unknown[][] | undefined) ?? []
-    const columnTypes = hogqlResponse?.types as (string | null)[] | undefined
+    // HogQL `types` entries are `[columnName, clickhouseType]` tuples — pull out the type string.
+    const columnTypes: (string | null)[] = ((hogqlResponse?.types as unknown[][] | undefined) ?? []).map((t) =>
+        Array.isArray(t) ? ((t[1] as string | undefined) ?? null) : null
+    )
     const canGenerate = columns.length > 0 && rows.length > 0 && !!currentTeamId
 
     const onGenerate = (): void => {
@@ -64,7 +67,7 @@ export function GeneratedQuillVisualization(): JSX.Element {
                 </LemonBanner>
             ))}
 
-            <div className="flex-1 min-h-0">
+            <div className="flex-1 min-h-0 rounded bg-surface-primary overflow-hidden p-2">
                 {generationLoading ? (
                     <div className="flex items-center justify-center h-full">
                         <LoadingBar />

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/GeneratedQuillVisualization.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/GeneratedQuillVisualization.tsx
@@ -1,0 +1,82 @@
+import { useActions, useValues } from 'kea'
+
+import { IconSparkles } from '@posthog/icons'
+import { LemonBanner, LemonButton, LemonInput } from '@posthog/lemon-ui'
+
+import { ChartSpecRenderer } from 'lib/components/ChartSpecRenderer/ChartSpecRenderer'
+import { LoadingBar } from 'lib/lemon-ui/LoadingBar'
+
+import type { HogQLQueryResponse } from '~/queries/schema/schema-general'
+
+import { dataVisualizationLogic } from '../../dataVisualizationLogic'
+import { generatedQuillChartLogic } from './generatedQuillChartLogic'
+
+export function GeneratedQuillVisualization(): JSX.Element {
+    const { response, query, currentTeamId, dataVisualizationProps } = useValues(dataVisualizationLogic)
+    const logic = generatedQuillChartLogic({ key: dataVisualizationProps.key })
+    const { prompt, chartSpec, warnings, generationLoading } = useValues(logic)
+    const { setPrompt, generateChart } = useActions(logic)
+
+    const hogqlResponse = response as HogQLQueryResponse | null
+    const columns: string[] = hogqlResponse?.columns ?? []
+    const rows = (hogqlResponse?.results as unknown[][] | undefined) ?? []
+    const columnTypes = hogqlResponse?.types as (string | null)[] | undefined
+    const canGenerate = columns.length > 0 && rows.length > 0 && !!currentTeamId
+
+    const onGenerate = (): void => {
+        if (!currentTeamId) {
+            return
+        }
+        generateChart({
+            teamId: currentTeamId,
+            query: (query.source as { query?: string }).query ?? '',
+            columns,
+            columnTypes,
+            rows,
+        })
+    }
+
+    return (
+        <div className="flex flex-col gap-3 p-3 h-full">
+            <div className="flex gap-2 items-center">
+                <LemonInput
+                    className="flex-1"
+                    value={prompt}
+                    onChange={setPrompt}
+                    onPressEnter={onGenerate}
+                    placeholder="Describe the chart you want (optional)…"
+                    disabled={generationLoading}
+                />
+                <LemonButton
+                    type="primary"
+                    icon={<IconSparkles />}
+                    onClick={onGenerate}
+                    loading={generationLoading}
+                    disabledReason={!canGenerate ? 'Run a query first' : undefined}
+                >
+                    {chartSpec ? 'Regenerate' : 'Generate'}
+                </LemonButton>
+            </div>
+
+            {warnings.map((warning, i) => (
+                <LemonBanner key={i} type="warning">
+                    {warning}
+                </LemonBanner>
+            ))}
+
+            <div className="flex-1 min-h-0">
+                {generationLoading ? (
+                    <div className="flex items-center justify-center h-full">
+                        <LoadingBar />
+                    </div>
+                ) : chartSpec ? (
+                    <ChartSpecRenderer spec={chartSpec} className="h-full" height={360} />
+                ) : (
+                    <div className="flex items-center justify-center h-full text-secondary">
+                        Generate an on-brand chart from your query results.
+                    </div>
+                )}
+            </div>
+        </div>
+    )
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/chartSpecFromMapping.test.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/chartSpecFromMapping.test.ts
@@ -1,0 +1,58 @@
+import { type ChartSpecMapping, chartSpecFromMapping } from './chartSpecFromMapping'
+
+describe('chartSpecFromMapping', () => {
+    const columns = ['day', 'revenue', 'conversion']
+    const rows: unknown[][] = [
+        ['2026-01-01', 100, 0.1],
+        ['2026-01-02', 200, 0.2],
+    ]
+
+    it('builds an inline ChartSpec from a column mapping and real rows', () => {
+        const mapping: ChartSpecMapping = {
+            chartType: 'combo',
+            title: 'Revenue vs conversion',
+            xColumn: 'day',
+            series: [
+                { column: 'revenue', label: 'Revenue', type: 'bar', axis: 'left' },
+                { column: 'conversion', type: 'line', axis: 'right' },
+            ],
+            axes: [
+                { id: 'left', format: 'currency' },
+                { id: 'right', format: 'percentage_scaled' },
+            ],
+        }
+
+        const spec = chartSpecFromMapping(mapping, columns, rows)
+
+        expect(spec).not.toBeNull()
+        expect(spec?.labels).toEqual(['2026-01-01', '2026-01-02'])
+        expect(spec?.series).toEqual([
+            { key: 'revenue', label: 'Revenue', data: [100, 200], type: 'bar', axis: 'left' },
+            { key: 'conversion', label: 'conversion', data: [0.1, 0.2], type: 'line', axis: 'right' },
+        ])
+        expect(spec?.axes).toHaveLength(2)
+    })
+
+    it('coerces non-numeric and null cells to 0', () => {
+        const mapping: ChartSpecMapping = {
+            chartType: 'bar',
+            xColumn: 'day',
+            series: [{ column: 'revenue' }],
+        }
+        const spec = chartSpecFromMapping(mapping, columns, [
+            ['a', null],
+            ['b', 'nope'],
+        ])
+        expect(spec?.series[0].data).toEqual([0, 0])
+    })
+
+    it('returns null when the x column is missing', () => {
+        const mapping: ChartSpecMapping = { chartType: 'bar', xColumn: 'missing', series: [{ column: 'revenue' }] }
+        expect(chartSpecFromMapping(mapping, columns, rows)).toBeNull()
+    })
+
+    it('returns null when no mapped series column exists', () => {
+        const mapping: ChartSpecMapping = { chartType: 'bar', xColumn: 'day', series: [{ column: 'nope' }] }
+        expect(chartSpecFromMapping(mapping, columns, rows)).toBeNull()
+    })
+})

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/chartSpecFromMapping.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/chartSpecFromMapping.ts
@@ -1,0 +1,90 @@
+import type { ChartSpec, ChartSpecConfig } from 'lib/components/ChartSpecRenderer/chartSpec'
+
+// The mapping the backend returns: result columns assigned to chart roles. The actual data stays
+// client-side — we combine this with the query's rows to build a renderable inline `ChartSpec`.
+export interface ChartSpecMappingSeries {
+    column: string
+    label?: string
+    type?: 'line' | 'bar' | 'area'
+    axis?: 'left' | 'right'
+}
+
+export interface ChartSpecMappingAxis {
+    id: 'left' | 'right'
+    label?: string
+    format?: 'numeric' | 'short' | 'percentage' | 'percentage_scaled' | 'currency' | 'duration' | 'duration_ms'
+    currency?: string
+    scale?: 'linear' | 'log'
+    startAtZero?: boolean
+}
+
+export interface ChartSpecMappingReferenceLine {
+    value: number | string
+    orientation?: 'horizontal' | 'vertical'
+    label?: string
+    variant?: 'goal' | 'alert' | 'marker'
+    axis?: 'left' | 'right'
+}
+
+export interface ChartSpecMapping {
+    chartType: ChartSpec['chartType']
+    title?: string
+    narrative?: string
+    xColumn: string
+    series: ChartSpecMappingSeries[]
+    axes?: ChartSpecMappingAxis[]
+    config?: ChartSpecConfig
+    referenceLines?: ChartSpecMappingReferenceLine[]
+}
+
+function toNumber(value: unknown): number {
+    const n = typeof value === 'number' ? value : Number(value)
+    return Number.isFinite(n) ? n : 0
+}
+
+function toLabel(value: unknown): string {
+    return value == null ? '' : String(value)
+}
+
+/** Build a renderable `ChartSpec` from the backend mapping and the actual query result rows.
+ *  Returns null when the mapped x column isn't present (e.g. the query changed since generation). */
+export function chartSpecFromMapping(
+    mapping: ChartSpecMapping,
+    columns: string[],
+    rows: unknown[][]
+): ChartSpec | null {
+    const indexOf = (name: string): number => columns.indexOf(name)
+
+    const xIndex = indexOf(mapping.xColumn)
+    if (xIndex < 0) {
+        return null
+    }
+
+    const labels = rows.map((row) => toLabel(row[xIndex]))
+
+    const series = mapping.series
+        .map((s) => ({ s, i: indexOf(s.column) }))
+        .filter(({ i }) => i >= 0)
+        .map(({ s, i }) => ({
+            key: s.column,
+            label: s.label ?? s.column,
+            data: rows.map((row) => toNumber(row[i])),
+            type: s.type,
+            axis: s.axis,
+        }))
+
+    if (series.length === 0) {
+        return null
+    }
+
+    return {
+        chartType: mapping.chartType,
+        title: mapping.title,
+        narrative: mapping.narrative,
+        labels,
+        series,
+        axes: mapping.axes,
+        config: mapping.config,
+        referenceLines: mapping.referenceLines,
+    }
+}

--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/generatedQuillChartLogic.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/generatedQuillChartLogic.ts
@@ -1,0 +1,84 @@
+import { actions, kea, key, path, props, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+
+import api from 'lib/api'
+import type { ChartSpec } from 'lib/components/ChartSpecRenderer/chartSpec'
+
+import { type ChartSpecMapping, chartSpecFromMapping } from './chartSpecFromMapping'
+import type { generatedQuillChartLogicType } from './generatedQuillChartLogicType'
+
+export interface GeneratedQuillChartLogicProps {
+    key: string
+}
+
+export interface GenerateChartPayload {
+    teamId: number
+    query: string
+    columns: string[]
+    columnTypes?: (string | null)[]
+    rows: unknown[][]
+}
+
+interface SqlChartSpecResponse {
+    mapping: ChartSpecMapping
+    trace_id: string
+    warnings?: string[]
+}
+
+function buildRequest(
+    prompt: string,
+    query: string,
+    columns: string[],
+    columnTypes: (string | null)[] | undefined,
+    rows: unknown[][]
+): Record<string, unknown> {
+    const sampleRows = rows.slice(0, 20)
+    return {
+        query,
+        prompt: prompt || 'Visualize these results.',
+        columns: columns.map((name, i) => ({
+            name,
+            type: columnTypes?.[i] ?? null,
+            sampleValues: sampleRows
+                .map((row) => row[i])
+                .filter((value) => value != null)
+                .slice(0, 5),
+        })),
+        sampleRows: sampleRows.map((row) => Object.fromEntries(columns.map((name, i) => [name, row[i]]))),
+        rowCount: rows.length,
+    }
+}
+
+export const generatedQuillChartLogic = kea<generatedQuillChartLogicType>([
+    path(['queries', 'nodes', 'DataVisualization', 'Components', 'Charts', 'generatedQuillChartLogic']),
+    props({} as GeneratedQuillChartLogicProps),
+    key((props) => props.key),
+    actions({
+        setPrompt: (prompt: string) => ({ prompt }),
+        generateChart: (payload: GenerateChartPayload) => payload,
+    }),
+    reducers({
+        prompt: ['' as string, { setPrompt: (_, { prompt }) => prompt }],
+        lastColumns: [[] as string[], { generateChart: (_, { columns }) => columns }],
+        lastRows: [[] as unknown[][], { generateChart: (_, { rows }) => rows }],
+    }),
+    loaders(({ values }) => ({
+        generation: [
+            null as SqlChartSpecResponse | null,
+            {
+                generateChart: async ({ teamId, query, columns, columnTypes, rows }) => {
+                    const request = buildRequest(values.prompt, query, columns, columnTypes, rows)
+                    return await api.create<SqlChartSpecResponse>(`api/projects/${teamId}/sql_chart_spec`, request)
+                },
+            },
+        ],
+    })),
+    selectors({
+        chartSpec: [
+            (s) => [s.generation, s.lastColumns, s.lastRows],
+            (generation, lastColumns, lastRows): ChartSpec | null =>
+                generation?.mapping ? chartSpecFromMapping(generation.mapping, lastColumns, lastRows) : null,
+        ],
+        warnings: [(s) => [s.generation], (generation): string[] => generation?.warnings ?? []],
+    }),
+])

--- a/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
+++ b/frontend/src/queries/nodes/DataVisualization/Components/TableDisplay.tsx
@@ -1,6 +1,6 @@
 import { useActions, useValues } from 'kea'
 
-import { IconGraph, IconLifecycle, IconPieChart, IconTrends } from '@posthog/icons'
+import { IconGraph, IconLifecycle, IconPieChart, IconSparkles, IconTrends } from '@posthog/icons'
 import { LemonSelect, LemonSelectOptions, LemonSelectProps } from '@posthog/lemon-ui'
 
 import { Icon123, IconAreaChart, IconHeatmap, IconTableChart } from 'lib/lemon-ui/icons'
@@ -35,6 +35,7 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
         [ChartDisplayType.TwoDimensionalHeatmap]: '2d heatmap',
         [ChartDisplayType.BoxPlot]: 'Box plot',
         [ChartDisplayType.SlopeGraph]: 'Slope graph',
+        [ChartDisplayType.GeneratedQuill]: 'Generate',
     }
 
     const renderDisplayTypeLabel = (displayType: ChartDisplayType): string => {
@@ -112,6 +113,17 @@ export const TableDisplay = ({ disabledReason }: TableDisplayProps): JSX.Element
                     value: ChartDisplayType.TwoDimensionalHeatmap,
                     icon: <IconHeatmap />,
                     label: '2d heatmap',
+                },
+            ],
+        },
+        {
+            title: 'AI',
+            options: [
+                {
+                    value: ChartDisplayType.GeneratedQuill,
+                    icon: <IconSparkles />,
+                    label: 'Generate',
+                    disabledReason: columns.length === 0 ? 'Run a query first' : undefined,
                 },
             ],
         },

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -43,6 +43,7 @@ import { ElapsedTime } from '~/queries/nodes/DataNode/ElapsedTime'
 import { LoadPreviewText } from '~/queries/nodes/DataNode/LoadNext'
 import { QueryExecutionDetails } from '~/queries/nodes/DataNode/QueryExecutionDetails'
 import { DataTableRow } from '~/queries/nodes/DataTable/dataTableLogic'
+import { GeneratedQuillVisualization } from '~/queries/nodes/DataVisualization/Components/Charts/GeneratedQuillVisualization'
 import { LineGraph } from '~/queries/nodes/DataVisualization/Components/Charts/LineGraph'
 import { PieChart } from '~/queries/nodes/DataVisualization/Components/Charts/PieChart'
 import { TwoDimensionalHeatmap } from '~/queries/nodes/DataVisualization/Components/Heatmap/TwoDimensionalHeatmap'
@@ -957,6 +958,8 @@ function InternalDataTableVisualization(
         )
     } else if (effectiveVisualizationType === ChartDisplayType.TwoDimensionalHeatmap) {
         component = <TwoDimensionalHeatmap />
+    } else if (effectiveVisualizationType === ChartDisplayType.GeneratedQuill) {
+        component = <GeneratedQuillVisualization />
     } else if (effectiveVisualizationType === ChartDisplayType.BoldNumber) {
         component = <HogQLBoldNumber />
     }

--- a/frontend/src/scenes/insights/utils/queryUtils.ts
+++ b/frontend/src/scenes/insights/utils/queryUtils.ts
@@ -204,6 +204,9 @@ const groupedChartDisplayTypes: Record<ChartDisplayType, ChartDisplayType> = {
 
     // separate runner — only the two range endpoints, cached on its own key
     [ChartDisplayType.SlopeGraph]: ChartDisplayType.SlopeGraph,
+
+    // SQL editor only — does not affect query grouping
+    [ChartDisplayType.GeneratedQuill]: ChartDisplayType.ActionsBarValue,
 }
 
 /** clean insight queries so that we can check for semantic equality with a deep equality check */

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -2901,6 +2901,8 @@ export enum ChartDisplayType {
     TwoDimensionalHeatmap = 'TwoDimensionalHeatmap',
     BoxPlot = 'BoxPlot',
     SlopeGraph = 'SlopeGraph',
+    /** AI-generated quill chart for SQL editor results (column mapping → ChartSpec). */
+    GeneratedQuill = 'GeneratedQuill',
 }
 export enum ChartDisplayCategory {
     TimeSeries = 'TimeSeries',

--- a/products/data_warehouse/backend/presentation/views/sql_chart_spec.py
+++ b/products/data_warehouse/backend/presentation/views/sql_chart_spec.py
@@ -1,0 +1,115 @@
+import uuid
+from typing import cast
+
+import structlog
+from asgiref.sync import async_to_sync
+from drf_spectacular.utils import OpenApiResponse, extend_schema_field
+from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+from posthog.api.documentation import _FallbackSerializer
+from posthog.api.mixins import ValidatedRequest, validated_request
+from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.models.user import User
+
+from products.data_warehouse.backend.sql_chart_spec_ai import (
+    SQLChartSpecGenerator,
+    SQLChartSpecPayload,
+    build_fallback_chart_mapping,
+)
+
+logger = structlog.get_logger(__name__)
+
+JSON_VALUE_SCHEMA = {
+    "oneOf": [
+        {"type": "string"},
+        {"type": "number"},
+        {"type": "boolean"},
+        {"type": "object", "additionalProperties": True},
+        {"type": "array", "items": {}},
+        {"type": "null"},
+    ]
+}
+
+
+@extend_schema_field(JSON_VALUE_SCHEMA)
+class JSONValueField(serializers.JSONField):
+    pass
+
+
+class SQLChartColumnSerializer(serializers.Serializer):
+    name = serializers.CharField(max_length=256, help_text="Result column name.")
+    type = serializers.CharField(
+        max_length=128, required=False, allow_null=True, allow_blank=True, help_text="Database column type, if known."
+    )
+    semanticType = serializers.ChoiceField(
+        choices=["temporal", "quantitative", "nominal", "ordinal"],
+        required=False,
+        help_text="Best-effort semantic type for the column.",
+    )
+    sampleValues = serializers.ListField(
+        child=JSONValueField(), required=False, max_length=10, help_text="Up to 10 sample values from the column."
+    )
+
+
+class SQLChartSpecRequestSerializer(serializers.Serializer):
+    query = serializers.CharField(max_length=100000, help_text="The SQL query that produced the results.")
+    prompt = serializers.CharField(
+        max_length=4000, allow_blank=True, help_text="User instructions for the chart to generate."
+    )
+    columns = SQLChartColumnSerializer(many=True, help_text="Per-column result shape.")
+    sampleRows = serializers.ListField(
+        child=serializers.DictField(child=JSONValueField()),
+        required=False,
+        max_length=20,
+        help_text="Up to 20 sample rows keyed by column name.",
+    )
+    rowCount = serializers.IntegerField(min_value=0, help_text="Total rows returned by the query.")
+
+    def validate_columns(self, columns: list[dict[str, object]]) -> list[dict[str, object]]:
+        if not columns:
+            raise serializers.ValidationError("At least one column is required.")
+        if len(columns) > 100:
+            raise serializers.ValidationError("At most 100 columns can be sent.")
+        return columns
+
+
+class SQLChartSpecResponseSerializer(serializers.Serializer):
+    mapping = serializers.JSONField(help_text="The generated ChartSpec mapping (columns mapped to chart roles).")
+    trace_id = serializers.CharField(help_text="Trace ID for the generation request.")
+    warnings = serializers.ListField(
+        child=serializers.CharField(), required=False, help_text="Warnings about the generated chart."
+    )
+
+
+class SQLChartSpecViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
+    scope_object = "INTERNAL"
+    serializer_class = _FallbackSerializer
+
+    @validated_request(
+        request_serializer=SQLChartSpecRequestSerializer,
+        responses={
+            200: OpenApiResponse(response=SQLChartSpecResponseSerializer),
+            400: OpenApiResponse(description="Invalid request"),
+        },
+        summary="Generate a quill chart mapping for SQL results",
+        description=(
+            "Maps SQL result columns to a quill ChartSpec. The frontend combines the mapping with the "
+            "actual result rows to render an inline chart — no executable spec is returned."
+        ),
+    )
+    def create(self, request: ValidatedRequest, *args, **kwargs) -> Response:
+        trace_id = f"sql_chart_spec_{uuid.uuid4()}"
+        user = cast(User, request.user)
+        payload = cast(SQLChartSpecPayload, request.validated_data)
+
+        warnings: list[str] = []
+        try:
+            generator = SQLChartSpecGenerator(team=self.team, user=user)
+            mapping = async_to_sync(generator.agenerate)(payload)
+        except Exception:
+            logger.warning("sql_chart_spec.generation_failed", team_id=self.team.id, trace_id=trace_id, exc_info=True)
+            mapping = build_fallback_chart_mapping(payload)
+            warnings.append("AI generation failed, so a basic chart was generated from the result shape.")
+
+        return Response({"mapping": mapping.model_dump(exclude_none=True), "trace_id": trace_id, "warnings": warnings})

--- a/products/data_warehouse/backend/presentation/views/test/test_sql_chart_spec.py
+++ b/products/data_warehouse/backend/presentation/views/test/test_sql_chart_spec.py
@@ -1,0 +1,54 @@
+from posthog.test.base import APIBaseTest
+from unittest import mock
+from unittest.mock import AsyncMock
+
+from products.data_warehouse.backend.sql_chart_spec_ai import ChartSpecMapping
+
+TIMESERIES_REQUEST = {
+    "query": "select day, signups from events",
+    "prompt": "signups over time",
+    "columns": [
+        {"name": "day", "type": "DateTime", "semanticType": "temporal", "sampleValues": ["2026-01-01"]},
+        {"name": "signups", "type": "Int64", "semanticType": "quantitative", "sampleValues": [10]},
+    ],
+    "sampleRows": [{"day": "2026-01-01", "signups": 10}],
+    "rowCount": 1,
+}
+
+
+class TestSQLChartSpecAPI(APIBaseTest):
+    def test_create_returns_generated_mapping(self):
+        mapping = ChartSpecMapping(
+            chartType="timeSeriesLine", xColumn="day", series=[{"column": "signups"}], narrative="Up."
+        )
+        with mock.patch(
+            "products.data_warehouse.backend.presentation.views.sql_chart_spec.SQLChartSpecGenerator.agenerate",
+            new=AsyncMock(return_value=mapping),
+        ):
+            response = self.client.post(f"/api/projects/{self.team.id}/sql_chart_spec/", TIMESERIES_REQUEST)
+
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        assert body["trace_id"].startswith("sql_chart_spec_")
+        assert body["mapping"]["chartType"] == "timeSeriesLine"
+        assert body["mapping"]["xColumn"] == "day"
+        assert body["warnings"] == []
+
+    def test_create_falls_back_when_generation_raises(self):
+        with mock.patch(
+            "products.data_warehouse.backend.presentation.views.sql_chart_spec.SQLChartSpecGenerator.agenerate",
+            new=AsyncMock(side_effect=Exception("llm down")),
+        ):
+            response = self.client.post(f"/api/projects/{self.team.id}/sql_chart_spec/", TIMESERIES_REQUEST)
+
+        assert response.status_code == 200, response.json()
+        body = response.json()
+        assert body["mapping"]["xColumn"] == "day"
+        assert len(body["warnings"]) == 1
+
+    def test_rejects_missing_columns(self):
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/sql_chart_spec/",
+            {"query": "select 1", "prompt": "chart", "columns": [], "rowCount": 0},
+        )
+        assert response.status_code == 400

--- a/products/data_warehouse/backend/routes.py
+++ b/products/data_warehouse/backend/routes.py
@@ -12,6 +12,7 @@ from products.data_warehouse.backend.presentation.views import (
     query_tab_state,
     saved_query,
     saved_query_draft,
+    sql_chart_spec,
     table,
     view_link,
 )
@@ -81,6 +82,9 @@ def register_routes(routers: RouterRegistry) -> None:
         r"data_modeling_jobs", data_modeling_job.DataModelingJobViewSet, "environment_data_modeling_jobs", ["team_id"]
     )
     routers.register_legacy_dual_route(r"lineage", LineageViewSet, "project_lineage", ["team_id"])
+    routers.projects.register(
+        r"sql_chart_spec", sql_chart_spec.SQLChartSpecViewSet, "project_sql_chart_spec", ["team_id"]
+    )
     routers.projects.register(
         r"warehouse_column_annotations",
         column_annotation.WarehouseColumnAnnotationViewSet,

--- a/products/data_warehouse/backend/sql_chart_spec_ai.py
+++ b/products/data_warehouse/backend/sql_chart_spec_ai.py
@@ -1,0 +1,257 @@
+"""AI generation of a quill `ChartSpec` mapping for SQL editor results.
+
+The quill analogue of `sql_visualization_ai.py` (which generates Vega-Lite). The key difference:
+quill charts are inert data, not an executable grammar, so there is no iframe sandbox downstream —
+the frontend renders the spec directly. The model never sees full result data: it maps result
+*columns* (which column is the x-axis, which become series, on which axis, in what format) and the
+frontend fills in the real rows. That avoids hallucinated data and keeps the prompt small.
+"""
+
+from typing import Literal, Optional, TypedDict
+
+import structlog
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import Runnable, RunnableConfig
+from pydantic import BaseModel, ConfigDict, Field
+
+from posthog.models.team import Team
+from posthog.models.user import User
+
+from ee.hogai.chat_agent.schema_generator.parsers import parse_pydantic_structured_output
+from ee.hogai.llm import MaxChatOpenAI
+from ee.hogai.utils.helpers import dereference_schema
+
+logger = structlog.get_logger(__name__)
+
+ChartType = Literal["line", "bar", "combo", "timeSeriesLine", "pie", "metricCard"]
+ValueFormat = Literal["numeric", "short", "percentage", "percentage_scaled", "currency", "duration", "duration_ms"]
+AxisId = Literal["left", "right"]
+SemanticType = Literal["temporal", "quantitative", "nominal", "ordinal"]
+
+
+class ChartMappingAxis(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: AxisId = Field(description="Which side this axis is on. Series target it via `axis`.")
+    label: str | None = Field(default=None, description="Axis title.")
+    format: ValueFormat | None = Field(default=None, description="Numeric format for ticks on this axis.")
+    currency: str | None = Field(default=None, description="ISO currency code when format is 'currency'.")
+    scale: Literal["linear", "log"] | None = Field(default=None)
+    startAtZero: bool | None = Field(default=None, description="False floats the axis to the data range.")
+
+
+class ChartMappingConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stacked: bool | None = None
+    grouped: bool | None = None
+    percent: bool | None = None
+    horizontal: bool | None = Field(default=None, description="Bar charts only: ranked horizontal layout.")
+    donut: bool | None = Field(default=None, description="Pie charts only.")
+    showLegend: bool | None = None
+    showGrid: bool | None = None
+    showValueLabels: bool | None = None
+
+
+class ChartMappingReferenceLine(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    value: float | str = Field(description="Numeric value (horizontal line) or an x label (vertical marker).")
+    orientation: Literal["horizontal", "vertical"] | None = None
+    label: str | None = None
+    variant: Literal["goal", "alert", "marker"] | None = None
+    axis: AxisId | None = None
+
+
+class ChartMappingSeries(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    column: str = Field(description="The result column name supplying this series' numeric values.")
+    label: str | None = Field(default=None, description="Legend label. Defaults to the column name.")
+    type: Literal["line", "bar", "area"] | None = Field(default=None, description="Combo charts only.")
+    axis: AxisId | None = Field(default=None, description="Which axis to scale against. Defaults to 'left'.")
+
+
+class ChartSpecMapping(BaseModel):
+    """What the model emits: columns mapped to chart roles. The frontend turns this + the real rows
+    into a renderable inline `ChartSpec`."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    chartType: ChartType = Field(description="Chart family that best fits the columns.")
+    title: str | None = Field(default=None, description="Short chart title.")
+    narrative: str | None = Field(default=None, description="One plain sentence describing the takeaway.")
+    xColumn: str = Field(description="Result column for the x-axis labels (or pie/metric category).")
+    series: list[ChartMappingSeries] = Field(description="Result columns to plot as series (at least one).")
+    axes: list[ChartMappingAxis] | None = Field(default=None, description="Axis defs; two for a dual-axis chart.")
+    config: ChartMappingConfig | None = None
+    referenceLines: list[ChartMappingReferenceLine] | None = None
+
+
+class ChartSpecMappingOutput(BaseModel):
+    mapping: ChartSpecMapping
+
+
+class SQLChartColumn(TypedDict, total=False):
+    name: str
+    type: str | None
+    semanticType: SemanticType
+    sampleValues: list[object]
+
+
+class SQLChartSpecPayload(TypedDict, total=False):
+    query: str
+    prompt: str
+    columns: list[SQLChartColumn]
+    sampleRows: list[dict[str, object]]
+    rowCount: int
+
+
+SYSTEM_PROMPT = """
+You choose the best chart for a set of SQL query results and describe it as a `ChartSpecMapping`.
+You do NOT receive or output the data — you only map result COLUMNS to chart roles. The frontend
+fills in the real rows.
+
+Guidelines:
+- Pick `chartType` to fit the columns: a temporal column + a numeric column → `timeSeriesLine`
+  (set `xColumn` to the date column); a category column + a numeric column → `bar` (use
+  `config.horizontal` for many categories ranked); part-of-whole → `pie` (`config.donut` for a donut);
+  two numeric columns on different scales → `combo` with a dual axis; a single aggregate → `metricCard`.
+- `xColumn` is the category/date column. `series` are the numeric columns to plot.
+- Set value formatting per axis from the column's semanticType and name: money → `currency` (+ code),
+  rates → `percentage`, durations → `duration`, large counts → `short`.
+- For two series on different scales, give each `axis: 'left'`/`'right'` and define both in `axes`.
+- Add a `referenceLines` goal line when the instruction mentions a target.
+- Always set `narrative` to one plain sentence.
+
+Reference only column names that appear in the provided columns. Return only the mapping.
+""".strip()
+
+USER_PROMPT = """
+Instruction:
+{{prompt}}
+
+SQL query:
+{{query}}
+
+Result columns (name, type, semanticType, sample values):
+{{columns}}
+
+Row count: {{row_count}}
+""".strip()
+
+
+def _chart_mapping_schema() -> dict:
+    return {
+        "name": "output_chart_mapping",
+        "description": "Maps SQL result columns to a quill chart.",
+        "parameters": {
+            "type": "object",
+            "properties": {"mapping": dereference_schema(ChartSpecMapping.model_json_schema())},
+            "additionalProperties": False,
+            "required": ["mapping"],
+        },
+    }
+
+
+CHART_MAPPING_SCHEMA = _chart_mapping_schema()
+
+
+def infer_semantic_type(column_type: str | None) -> SemanticType:
+    if not column_type:
+        return "nominal"
+    lowered = column_type.lower()
+    if "date" in lowered or "time" in lowered:
+        return "temporal"
+    if any(token in lowered for token in ("int", "float", "decimal", "double", "numeric")):
+        return "quantitative"
+    return "nominal"
+
+
+def _column_semantic_type(column: SQLChartColumn) -> SemanticType:
+    return column.get("semanticType") or infer_semantic_type(column.get("type"))
+
+
+def build_fallback_chart_mapping(payload: SQLChartSpecPayload) -> ChartSpecMapping:
+    """Deterministic mapping from the result shape, used when AI generation fails."""
+    columns = payload.get("columns", [])
+    temporal = [c for c in columns if _column_semantic_type(c) == "temporal"]
+    quantitative = [c for c in columns if _column_semantic_type(c) == "quantitative"]
+    dimensions = [c for c in columns if _column_semantic_type(c) in ("nominal", "ordinal")]
+    prompt = (payload.get("prompt") or "").lower()
+
+    x_candidates = temporal or dimensions or columns
+    x_column = x_candidates[0]["name"] if x_candidates else (columns[0]["name"] if columns else "x")
+    value_columns = [c for c in quantitative if c["name"] != x_column] or [c for c in columns if c["name"] != x_column]
+    series = [ChartMappingSeries(column=c["name"]) for c in value_columns[:5]] or [ChartMappingSeries(column=x_column)]
+
+    if ("pie" in prompt or "donut" in prompt) and dimensions and quantitative:
+        chart_type: ChartType = "pie"
+        config = ChartMappingConfig(donut="donut" in prompt)
+    elif temporal and quantitative:
+        chart_type = "timeSeriesLine"
+        config = ChartMappingConfig(showLegend=len(series) > 1)
+    else:
+        chart_type = "bar"
+        config = ChartMappingConfig(horizontal=len(value_columns) <= 1, showLegend=len(series) > 1)
+
+    return ChartSpecMapping(
+        chartType=chart_type,
+        narrative="Basic chart generated from the result shape.",
+        xColumn=x_column,
+        series=series,
+        config=config,
+    )
+
+
+class SQLChartSpecGenerator:
+    def __init__(self, team: Team, user: User) -> None:
+        self._team = team
+        self._user = user
+
+    @property
+    def _model(self) -> Runnable:
+        return MaxChatOpenAI(
+            model="gpt-5.2",
+            temperature=0.3,
+            disable_streaming=True,
+            user=self._user,
+            team=self._team,
+            max_tokens=4096,
+            billable=True,
+            output_version="responses/v1",
+            use_responses_api=True,
+            reasoning={"effort": "none"},
+            model_kwargs={"prompt_cache_key": f"team_{self._team.id}"},
+        ).with_structured_output(CHART_MAPPING_SCHEMA, method="json_schema", include_raw=False)
+
+    def _parse_output(self, output: dict) -> ChartSpecMapping:
+        return parse_pydantic_structured_output(ChartSpecMappingOutput)(output).mapping
+
+    async def agenerate(
+        self, payload: SQLChartSpecPayload, config: Optional[RunnableConfig] = None
+    ) -> ChartSpecMapping:
+        prompt = ChatPromptTemplate.from_messages(
+            [("system", SYSTEM_PROMPT), ("human", USER_PROMPT)],
+            template_format="mustache",
+        )
+        chain = prompt | self._model | self._parse_output
+        return await chain.ainvoke(
+            {
+                "prompt": payload.get("prompt") or "Visualize these results.",
+                "query": payload.get("query") or "",
+                "columns": _format_columns(payload.get("columns", [])),
+                "row_count": payload.get("rowCount", 0),
+            },
+            config,
+        )
+
+
+def _format_columns(columns: list[SQLChartColumn]) -> str:
+    lines = []
+    for column in columns:
+        samples = ", ".join(str(value) for value in (column.get("sampleValues") or [])[:5])
+        lines.append(
+            f"- {column.get('name')} ({column.get('type') or 'unknown'}, {_column_semantic_type(column)}): {samples}"
+        )
+    return "\n".join(lines)

--- a/products/data_warehouse/backend/sql_chart_spec_ai.py
+++ b/products/data_warehouse/backend/sql_chart_spec_ai.py
@@ -18,12 +18,12 @@ from posthog.models.team import Team
 from posthog.models.user import User
 
 from ee.hogai.chat_agent.schema_generator.parsers import parse_pydantic_structured_output
-from ee.hogai.llm import MaxChatOpenAI
+from ee.hogai.llm import MaxChatAnthropic
 from ee.hogai.utils.helpers import dereference_schema
 
 logger = structlog.get_logger(__name__)
 
-ChartType = Literal["line", "bar", "combo", "timeSeriesLine", "pie", "metricCard"]
+ChartType = Literal["line", "bar", "combo", "timeSeriesLine", "timeSeriesBar", "pie", "metricCard"]
 ValueFormat = Literal["numeric", "short", "percentage", "percentage_scaled", "currency", "duration", "duration_ms"]
 AxisId = Literal["left", "right"]
 SemanticType = Literal["temporal", "quantitative", "nominal", "ordinal"]
@@ -43,14 +43,55 @@ class ChartMappingAxis(BaseModel):
 class ChartMappingConfig(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    # Layout
     stacked: bool | None = None
     grouped: bool | None = None
     percent: bool | None = None
     horizontal: bool | None = Field(default=None, description="Bar charts only: ranked horizontal layout.")
-    donut: bool | None = Field(default=None, description="Pie charts only.")
+    donut: bool | None = Field(default=None, description="Pie charts only: standard donut (innerRadiusRatio 0.6).")
+    innerRadiusRatio: float | None = Field(
+        default=None,
+        ge=0,
+        le=0.95,
+        description="Pie: inner radius fraction (0=pie, 0.4–0.7=donut, 0.85=thin ring). Overrides donut.",
+    )
+
+    # Legend
     showLegend: bool | None = None
+    legendPosition: Literal["top", "bottom", "left", "right"] | None = Field(
+        default=None, description="Where the legend sits. Default 'bottom'."
+    )
+    legendAlign: Literal["start", "center", "end"] | None = Field(
+        default=None, description="Legend alignment along its axis. Default 'center'."
+    )
+
+    # Overlays
     showGrid: bool | None = None
+    showAxisLines: bool | None = Field(default=None, description="Show L-shaped axis baselines without grid lines.")
+    showCrosshair: bool | None = Field(default=None, description="Show a vertical crosshair following the cursor.")
     showValueLabels: bool | None = None
+
+    # Axes
+    hideXAxis: bool | None = None
+    hideYAxis: bool | None = None
+
+    # Tooltip
+    tooltipShowTotal: bool | None = Field(default=None, description="Show a total row in the tooltip.")
+    tooltipPlacement: Literal["follow-data", "top", "cursor"] | None = None
+
+    # Bar-specific
+    barFillStyle: Literal["flat", "gradient", "gloss"] | None = Field(default=None, description="Bar charts only.")
+    divergingStack: bool | None = Field(default=None, description="Stacked bar: stack negatives below zero baseline.")
+    roundStackEnds: bool | None = Field(default=None, description="Stacked bar: round outer ends as a pill.")
+
+    # MetricCard-specific
+    showChange: bool | None = Field(default=None, description="Metric card: show change/trend pill.")
+    goodDirection: Literal["up", "down"] | None = Field(
+        default=None, description="Metric card: which direction is good."
+    )
+    changeInline: bool | None = Field(default=None, description="Metric card: pill beside headline instead of header.")
+    sparklineFill: bool | None = Field(default=None, description="Metric card: fill card height with sparkline.")
+    subtitle: str | None = Field(default=None, description="Metric card: caption under the headline.")
 
 
 class ChartMappingReferenceLine(BaseModel):
@@ -113,15 +154,22 @@ You do NOT receive or output the data — you only map result COLUMNS to chart r
 fills in the real rows.
 
 Guidelines:
-- Pick `chartType` to fit the columns: a temporal column + a numeric column → `timeSeriesLine`
-  (set `xColumn` to the date column); a category column + a numeric column → `bar` (use
-  `config.horizontal` for many categories ranked); part-of-whole → `pie` (`config.donut` for a donut);
-  two numeric columns on different scales → `combo` with a dual axis; a single aggregate → `metricCard`.
+- Pick `chartType` to fit the columns: a temporal column + numeric columns → `timeSeriesLine` for
+  lines or `timeSeriesBar` for bars (both format dates correctly on the x-axis); a category column +
+  a numeric column → `bar` (use `config.horizontal` for many categories ranked); part-of-whole → `pie`
+  (`config.donut` for a donut); two numeric columns on different scales → `combo` with a dual axis;
+  a single aggregate → `metricCard`. Never use `bar` when the x column contains ISO date strings —
+  use `timeSeriesBar` instead.
 - `xColumn` is the category/date column. `series` are the numeric columns to plot.
 - Set value formatting per axis from the column's semanticType and name: money → `currency` (+ code),
   rates → `percentage`, durations → `duration`, large counts → `short`.
 - For two series on different scales, give each `axis: 'left'`/`'right'` and define both in `axes`.
 - Add a `referenceLines` goal line when the instruction mentions a target.
+- Honor explicit layout requests: legend position/alignment → `config.legendPosition`/`config.legendAlign`; "hide axes" → `config.hideXAxis`/`config.hideYAxis`; "crosshair" → `config.showCrosshair`; "axis lines" → `config.showAxisLines`.
+- Tooltip: "show total" → `config.tooltipShowTotal`; "pin tooltip" / "tooltip at top" → `config.tooltipPlacement: "top"`.
+- Bar style: "gradient" / "gloss" → `config.barFillStyle`; negative data → `config.divergingStack`; "pill stack" → `config.roundStackEnds`.
+- Pie: use `config.innerRadiusRatio` for precise ring width (e.g. 0.5 for standard, 0.8 for thin ring); `config.donut` is a shorthand for 0.6.
+- Metric card: `config.showChange`, `config.goodDirection` ("lower is better" → "down"), `config.subtitle` for a caption, `config.sparklineFill` to fill the card height.
 - Always set `narrative` to one plain sentence.
 
 Reference only column names that appear in the provided columns. Return only the mapping.
@@ -211,19 +259,15 @@ class SQLChartSpecGenerator:
 
     @property
     def _model(self) -> Runnable:
-        return MaxChatOpenAI(
-            model="gpt-5.2",
+        return MaxChatAnthropic(
+            model="claude-sonnet-4-6",
             temperature=0.3,
-            disable_streaming=True,
+            streaming=False,
             user=self._user,
             team=self._team,
             max_tokens=4096,
             billable=True,
-            output_version="responses/v1",
-            use_responses_api=True,
-            reasoning={"effort": "none"},
-            model_kwargs={"prompt_cache_key": f"team_{self._team.id}"},
-        ).with_structured_output(CHART_MAPPING_SCHEMA, method="json_schema", include_raw=False)
+        ).with_structured_output(CHART_MAPPING_SCHEMA, include_raw=False)
 
     def _parse_output(self, output: dict) -> ChartSpecMapping:
         return parse_pydantic_structured_output(ChartSpecMappingOutput)(output).mapping

--- a/products/data_warehouse/backend/test/test_sql_chart_spec_ai.py
+++ b/products/data_warehouse/backend/test/test_sql_chart_spec_ai.py
@@ -1,0 +1,73 @@
+from posthog.test.base import BaseTest
+from unittest.mock import PropertyMock, patch
+
+from django.test import override_settings
+
+from langchain_core.runnables import RunnableLambda
+
+from products.data_warehouse.backend.sql_chart_spec_ai import (
+    CHART_MAPPING_SCHEMA,
+    ChartSpecMapping,
+    SQLChartSpecGenerator,
+    build_fallback_chart_mapping,
+    infer_semantic_type,
+)
+
+TIMESERIES_PAYLOAD = {
+    "query": "select day, signups from events",
+    "prompt": "show signups over time",
+    "columns": [
+        {"name": "day", "type": "DateTime", "semanticType": "temporal", "sampleValues": ["2026-01-01"]},
+        {"name": "signups", "type": "Int64", "semanticType": "quantitative", "sampleValues": [10, 20]},
+    ],
+    "rowCount": 2,
+}
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestSQLChartSpecGenerator(BaseTest):
+    async def test_agenerate_parses_structured_mapping(self):
+        generator = SQLChartSpecGenerator(self.team, self.user)
+        canned = ChartSpecMapping(
+            chartType="timeSeriesLine",
+            xColumn="day",
+            series=[{"column": "signups", "label": "Signups"}],
+            narrative="Signups are rising.",
+        )
+        with patch.object(SQLChartSpecGenerator, "_model", new_callable=PropertyMock) as model_mock:
+            model_mock.return_value = RunnableLambda(lambda _: {"mapping": canned.model_dump()})
+            mapping = await generator.agenerate(TIMESERIES_PAYLOAD)
+        assert isinstance(mapping, ChartSpecMapping)
+        assert mapping.chartType == "timeSeriesLine"
+        assert mapping.xColumn == "day"
+        assert mapping.series[0].column == "signups"
+
+    def test_fallback_picks_temporal_x_and_numeric_series(self):
+        mapping = build_fallback_chart_mapping(TIMESERIES_PAYLOAD)
+        assert mapping.xColumn == "day"
+        assert [s.column for s in mapping.series] == ["signups"]
+        assert mapping.chartType == "timeSeriesLine"
+
+    def test_fallback_pie_when_prompt_asks(self):
+        payload = {
+            "prompt": "pie of revenue by country",
+            "columns": [
+                {"name": "country", "type": "String", "semanticType": "nominal", "sampleValues": ["US"]},
+                {"name": "revenue", "type": "Float64", "semanticType": "quantitative", "sampleValues": [100.0]},
+            ],
+            "rowCount": 1,
+        }
+        mapping = build_fallback_chart_mapping(payload)
+        assert mapping.chartType == "pie"
+        assert mapping.xColumn == "country"
+
+    def test_infer_semantic_type(self):
+        assert infer_semantic_type("DateTime64") == "temporal"
+        assert infer_semantic_type("Int64") == "quantitative"
+        assert infer_semantic_type("String") == "nominal"
+        assert infer_semantic_type(None) == "nominal"
+
+    def test_schema_is_dereferenced_and_wraps_mapping(self):
+        params = CHART_MAPPING_SCHEMA["parameters"]
+        assert params["required"] == ["mapping"]
+        assert "$defs" not in params["properties"]["mapping"]

--- a/products/posthog_ai/backend/chart_spec/__init__.py
+++ b/products/posthog_ai/backend/chart_spec/__init__.py
@@ -1,0 +1,4 @@
+from .generator import CHART_SPEC_SCHEMA, ChartSpecGenerator, generate_chart_spec_schema
+from .schema import ChartSpec
+
+__all__ = ["CHART_SPEC_SCHEMA", "ChartSpec", "ChartSpecGenerator", "generate_chart_spec_schema"]

--- a/products/posthog_ai/backend/chart_spec/generator.py
+++ b/products/posthog_ai/backend/chart_spec/generator.py
@@ -1,0 +1,85 @@
+"""Generate a `ChartSpec` from a result-set summary using an LLM with structured output.
+
+This is the "AI-as-presentation-layer" half of the gen-UI charts idea: the model never invents data,
+it only decides how to present the rows it is handed. Mirrors the structured-output mechanics of
+`ee/hogai/chat_agent/schema_generator/nodes.py` without coupling to the assistant graph, so it can be
+unit-tested in isolation.
+"""
+
+from typing import Optional
+
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import Runnable, RunnableConfig
+from pydantic import BaseModel
+
+from posthog.models import Team, User
+
+from ee.hogai.chat_agent.schema_generator.parsers import parse_pydantic_structured_output
+from ee.hogai.llm import MaxChatOpenAI
+from ee.hogai.utils.helpers import dereference_schema
+
+from .prompts import CHART_SPEC_HUMAN_PROMPT, CHART_SPEC_SYSTEM_PROMPT
+from .schema import ChartSpec
+
+
+class ChartSpecGeneratorOutput(BaseModel):
+    chart: ChartSpec
+
+
+def generate_chart_spec_schema() -> dict:
+    """Build the function-call schema handed to the model — a fully dereferenced ChartSpec under `chart`."""
+    return {
+        "name": "output_chart_spec",
+        "description": "Outputs a chart specification describing how to present the given data.",
+        "parameters": {
+            "type": "object",
+            "properties": {"chart": dereference_schema(ChartSpec.model_json_schema())},
+            "additionalProperties": False,
+            "required": ["chart"],
+        },
+    }
+
+
+CHART_SPEC_SCHEMA = generate_chart_spec_schema()
+
+
+class ChartSpecGenerator:
+    def __init__(self, team: Team, user: User) -> None:
+        self._team = team
+        self._user = user
+
+    @property
+    def _model(self) -> Runnable:
+        return MaxChatOpenAI(
+            model="gpt-5.2",
+            temperature=0.3,
+            disable_streaming=True,
+            user=self._user,
+            team=self._team,
+            max_tokens=8192,
+            billable=True,
+            output_version="responses/v1",
+            use_responses_api=True,
+            reasoning={"effort": "none"},
+            model_kwargs={"prompt_cache_key": f"team_{self._team.id}"},
+        ).with_structured_output(
+            CHART_SPEC_SCHEMA,
+            method="json_schema",
+            include_raw=False,
+        )
+
+    def _parse_output(self, output: dict) -> ChartSpec:
+        return parse_pydantic_structured_output(ChartSpecGeneratorOutput)(output).chart
+
+    async def agenerate(
+        self, data_summary: str, instruction: str, config: Optional[RunnableConfig] = None
+    ) -> ChartSpec:
+        prompt = ChatPromptTemplate.from_messages(
+            [
+                ("system", CHART_SPEC_SYSTEM_PROMPT),
+                ("human", CHART_SPEC_HUMAN_PROMPT),
+            ],
+            template_format="mustache",
+        )
+        chain = prompt | self._model | self._parse_output
+        return await chain.ainvoke({"data_summary": data_summary, "instruction": instruction}, config)

--- a/products/posthog_ai/backend/chart_spec/prompts.py
+++ b/products/posthog_ai/backend/chart_spec/prompts.py
@@ -1,0 +1,28 @@
+CHART_SPEC_SYSTEM_PROMPT = """
+You are a data visualization expert. You are given a summary of a result set (columns and rows) and a
+short instruction about what the user wants to see. Your job is to choose the single best chart and
+describe it as a `ChartSpec` — you do NOT invent data, you only decide how to present the data you are given.
+
+Guidelines:
+- Pick `chartType` to fit the data: trends over time → `timeSeriesLine` (x labels are ISO dates); comparing
+  categories → `bar` (use `config.horizontal` for a ranked list of many categories); part-of-whole → `pie`
+  (set `config.donut` for a donut); two metrics on different scales (e.g. revenue and a rate) → `combo` with a
+  dual axis; a single headline KPI → `metricCard`.
+- Set value formatting on the relevant axis: money → `currency` (+ `currency` code), rates → `percentage`,
+  durations → `duration`/`duration_ms`, large counts → `short`. Infer the semantic type from the column name.
+- For two series on different scales, give each its own axis (`axis: 'left'`/`'right'`) and define both in `axes`.
+- Add a `referenceLines` goal line when the instruction mentions a target or threshold, and a vertical `marker`
+  for a notable event/date.
+- Always set `narrative` to one plain sentence describing the takeaway.
+- `labels` and every series `data` array MUST be the same length, taken from the provided data.
+
+Return only the `ChartSpec`.
+""".strip()
+
+CHART_SPEC_HUMAN_PROMPT = """
+Data summary:
+{{data_summary}}
+
+Instruction:
+{{instruction}}
+""".strip()

--- a/products/posthog_ai/backend/chart_spec/schema.py
+++ b/products/posthog_ai/backend/chart_spec/schema.py
@@ -1,0 +1,92 @@
+"""Pydantic mirror of the frontend `ChartSpec` (frontend/src/lib/components/ChartSpecRenderer/chartSpec.ts).
+
+Prototype only: in production this type should be authored in the assistant TypeScript schema and
+codegen'd into `posthog/schema.py` via `pnpm schema:build`, so the LLM contract, the Pydantic
+validator, and the React renderer all derive from one source. It is hand-written here to prove the
+generation half in isolation without running the (heavy) schema build.
+
+Field descriptions matter — they are dereferenced into the JSON schema the model fills in.
+"""
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+ChartType = Literal["line", "bar", "combo", "timeSeriesLine", "pie", "metricCard"]
+ValueFormat = Literal["numeric", "short", "percentage", "percentage_scaled", "currency", "duration", "duration_ms"]
+AxisId = Literal["left", "right"]
+
+
+class ChartSpecAxis(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    id: AxisId = Field(description="Which side this axis is on. Series target it via `axis`.")
+    label: str | None = Field(default=None, description="Axis title shown beside the axis.")
+    format: ValueFormat | None = Field(default=None, description="Numeric formatting for ticks on this axis.")
+    currency: str | None = Field(default=None, description="ISO currency code (e.g. 'USD') when format is 'currency'.")
+    scale: Literal["linear", "log"] | None = Field(default=None, description="Scale type. Defaults to 'linear'.")
+    startAtZero: bool | None = Field(
+        default=None, description="Clamp the baseline to zero (default true). False floats to the data range."
+    )
+
+
+class ChartSpecSeries(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    key: str = Field(description="Stable unique identifier for the series.")
+    label: str = Field(description="Human-readable name shown in legend and tooltip.")
+    data: list[float] = Field(description="One value per x-axis label. Must match `labels` length.")
+    color: str | None = Field(default=None, description="CSS color. Omit to auto-assign from the brand palette.")
+    type: Literal["line", "bar", "area"] | None = Field(
+        default=None, description="Combo charts only: how to draw this series."
+    )
+    axis: AxisId | None = Field(default=None, description="Which axis to scale against. Defaults to 'left'.")
+    fill: bool | None = Field(default=None, description="Fill the area under a line (line charts).")
+    dashed: bool | None = Field(default=None, description="Dash the line — handy for forecasts or targets.")
+
+
+class ChartSpecReferenceLine(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    value: float | str = Field(description="A numeric value (horizontal line) or an x-axis label (vertical marker).")
+    orientation: Literal["horizontal", "vertical"] | None = Field(default=None, description="Defaults to 'horizontal'.")
+    label: str | None = Field(default=None, description="Text label drawn on the line.")
+    variant: Literal["goal", "alert", "marker"] | None = Field(
+        default=None, description="Style: 'goal' (dashed grey), 'alert' (dashed red), 'marker' (solid thin)."
+    )
+    axis: AxisId | None = Field(default=None, description="Which axis a horizontal line is measured against.")
+
+
+class ChartSpecConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    stacked: bool | None = Field(default=None, description="Stack series (bar/area).")
+    grouped: bool | None = Field(default=None, description="Group bars side by side instead of stacking.")
+    percent: bool | None = Field(default=None, description="Normalize the stack to 100%.")
+    horizontal: bool | None = Field(default=None, description="Bar charts only: horizontal (ranked list) layout.")
+    donut: bool | None = Field(default=None, description="Pie charts only: render as a donut.")
+    showLegend: bool | None = Field(default=None, description="Show an interactive legend.")
+    showGrid: bool | None = Field(default=None, description="Show horizontal grid lines.")
+    showValueLabels: bool | None = Field(default=None, description="Draw each point/bar value on the chart.")
+
+
+class ChartSpec(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    chartType: ChartType = Field(
+        description="Chart family. 'combo' mixes bars and lines, 'timeSeriesLine' for ISO-date x labels, "
+        "'metricCard' for a single headline number with a sparkline."
+    )
+    title: str | None = Field(default=None, description="Short chart title.")
+    narrative: str | None = Field(
+        default=None, description="One sentence on what this chart shows and why — surfaced to the user."
+    )
+    labels: list[str] = Field(
+        description="X-axis labels (ISO date strings for 'timeSeriesLine'). Same length as each series `data`."
+    )
+    series: list[ChartSpecSeries] = Field(description="The series to plot (at least one).")
+    axes: list[ChartSpecAxis] | None = Field(default=None, description="Axis definitions. Two for a dual-axis chart.")
+    config: ChartSpecConfig | None = Field(default=None, description="Layout and decoration toggles.")
+    referenceLines: list[ChartSpecReferenceLine] | None = Field(
+        default=None, description="Goal lines and event markers."
+    )

--- a/products/posthog_ai/backend/chart_spec/tests/test_chart_spec.py
+++ b/products/posthog_ai/backend/chart_spec/tests/test_chart_spec.py
@@ -1,0 +1,58 @@
+from posthog.test.base import BaseTest
+from unittest.mock import PropertyMock, patch
+
+from django.test import override_settings
+
+from langchain_core.runnables import RunnableLambda
+
+from products.posthog_ai.backend.chart_spec.generator import (
+    ChartSpecGenerator,
+    ChartSpecGeneratorOutput,
+    generate_chart_spec_schema,
+)
+from products.posthog_ai.backend.chart_spec.schema import ChartSpec
+
+COMBO_SPEC = ChartSpec(
+    chartType="combo",
+    title="Revenue vs conversion rate",
+    narrative="Revenue grows on volume while conversion holds steady.",
+    labels=["Mon", "Tue", "Wed"],
+    axes=[
+        {"id": "left", "format": "currency", "currency": "USD"},
+        {"id": "right", "format": "percentage"},
+    ],
+    series=[
+        {"key": "revenue", "label": "Revenue", "type": "bar", "axis": "left", "data": [4200, 5100, 4800]},
+        {"key": "cvr", "label": "Conversion", "type": "line", "axis": "right", "data": [3.1, 3.3, 3.0]},
+    ],
+    referenceLines=[{"value": 5000, "variant": "goal", "axis": "left", "label": "Target"}],
+)
+
+
+@override_settings(IN_UNIT_TESTING=True)
+class TestChartSpecGenerator(BaseTest):
+    async def test_agenerate_parses_structured_output_into_chart_spec(self):
+        generator = ChartSpecGenerator(self.team, self.user)
+        with patch.object(ChartSpecGenerator, "_model", new_callable=PropertyMock) as model_mock:
+            model_mock.return_value = RunnableLambda(lambda _: {"chart": COMBO_SPEC.model_dump()})
+            result = await generator.agenerate(
+                data_summary="columns: day, revenue, conversion_rate",
+                instruction="show revenue against conversion rate",
+            )
+        assert isinstance(result, ChartSpec)
+        assert result.chartType == "combo"
+        assert [s.axis for s in result.series] == ["left", "right"]
+        assert result.referenceLines is not None and result.referenceLines[0].value == 5000
+
+    def test_output_wrapper_validates_a_well_formed_spec(self):
+        wrapped = ChartSpecGeneratorOutput.model_validate({"chart": COMBO_SPEC.model_dump()})
+        assert wrapped.chart.chartType == "combo"
+
+    def test_generated_schema_is_dereferenced_and_wraps_chart(self):
+        schema = generate_chart_spec_schema()
+        params = schema["parameters"]
+        assert params["required"] == ["chart"]
+        assert "chart" in params["properties"]
+        # `$defs`/`$ref` must be inlined so the model sees a self-contained schema.
+        assert "$defs" not in params["properties"]["chart"]
+        assert "$ref" not in str(params["properties"]["chart"].get("properties", {}).get("series", {}))


### PR DESCRIPTION
## Problem

Marius's [#65495](https://github.com/PostHog/posthog/pull/65495) explored generating charts from SQL editor results with Vega-Lite. Vega is enormously expressive, but AI-generated Vega is *executable* (transforms, params, signals, expressions), so it has to run inside a sandboxed iframe with a strict CSP and a postMessage bridge — a large surface area and the only real security boundary in that approach. It also pulls in the `vega`/`vega-lite`/`vega-embed` dependencies and needs its own theming to look like PostHog.

This is an experiment in doing the same thing with `@posthog/quill-charts` instead.

## Changes

A new **Generate** chart type in the SQL editor. Pick it, optionally type a prompt, and the model produces an on-brand quill chart from your results.

The key difference from the Vega approach: the model returns a small, declarative `ChartSpec` **mapping** (which column is the x-axis, which become series, on which axis, in what format) — not an executable spec. The model never sees the full result data; the frontend combines the mapping with the real rows and renders directly. Because a `ChartSpec` is inert data, there is **no iframe, no CSP bridge, and no new charting dependency**, and it inherits quill theming + dark mode for free.

**Backend** (`products/data_warehouse/backend/`)
- `sql_chart_spec_ai.py` — column-mapping generator via `MaxChatOpenAI` structured output, plus a deterministic fallback that builds a basic chart from the result shape when generation fails.
- `presentation/views/sql_chart_spec.py` — `POST .../sql_chart_spec/` endpoint (resilient: always returns something renderable).

**Frontend**
- `lib/components/ChartSpecRenderer/` — a reusable, schema-driven renderer (Zod `ChartSpec` → quill component) with a Storybook gallery. This is the generic gen-UI piece; it's independent of the SQL editor.
- `ChartDisplayType.GeneratedQuill` + a "Generate" entry in the chart-type dropdown + an `OutputPane` branch.
- `GeneratedQuillVisualization.tsx` + `generatedQuillChartLogic.ts` (kea) + `chartSpecFromMapping.ts` (mapping + rows → inline `ChartSpec`).

There's also a small standalone backend `ChartSpec` generator prototype under `products/posthog_ai/backend/chart_spec/` (the generic "AI picks the presentation" half), kept separate from the SQL-editor path.

### Tradeoff

Vega-Lite's ceiling is higher — faceting, layering, maps, regressions, interactive selections. quill-charts covers line/bar/combo/area/pie/time-series/metric/box/slope, which is the common case for charting SQL results, safely and on-brand. The two could coexist (quill as the default, an "advanced" Vega mode for power users).

## How did you test this code?

I'm an agent (PostHog Code). I did **not** manually test in the running app. Automated tests I actually ran:

- Backend: `pytest products/data_warehouse/backend/test/test_sql_chart_spec_ai.py` and `.../presentation/views/test/test_sql_chart_spec.py` — 8 tests pass (generator, deterministic fallback, semantic-type inference, schema dereferencing, API route success/fallback/`400`). Plus `products/posthog_ai/backend/chart_spec/tests/` — 3 pass.
- Frontend: `chartSpecFromMapping.test.ts` (jest) — 4 pass. oxlint clean on all touched files. The leaf util + `ChartSpecRenderer` typecheck clean in isolation.

**Verification gap:** I could not run the full-project TypeScript check locally (it OOMs on this machine), so the app-coupled `.tsx`/logic files are not typechecked end-to-end here. Please rely on CI's `typescript:check`. The feature has not been clicked through in the live SQL editor yet.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @sampennington

Built with PostHog Code (Claude Opus). The work started as a general exploration of gen-UI charts with quill-charts, then pivoted to "do what #65495 did, without Vega." Notable decisions:

- **Data by reference, not by value.** Mirrors Marius's approach — the model maps columns and the frontend supplies rows. This avoids hallucinated data and keeps the prompt tiny.
- **No iframe.** The whole point: a `ChartSpec` is data, so the sandbox layer (the bulk of the Vega PR) disappears.
- **Hand-written schema for now.** The `ChartSpec` Pydantic/Zod types are hand-written and intentionally duplicated rather than codegen'd through `pnpm schema:build` — kept the spike fast. Unifying them via the schema pipeline is the obvious follow-up if this graduates.
- `/improving-drf-endpoints` conventions were followed for the new viewset (`@validated_request`, `help_text` on serializer fields).

This is a draft spike to evaluate the approach, not a finished feature — auto-generation on selection, persistence of the generated spec, and schema unification are deliberately left out.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
