### PR TITLE
fix(tasks): allow null runtime hints on task write serializers

### DIFF
--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -342,6 +342,7 @@ class TaskWriteSerializer(serializers.Serializer):
         choices=[adapter.value for adapter in RuntimeAdapter],
         required=False,
         default=None,
+        allow_null=True,
         write_only=True,
         help_text=(
             "Selected runtime adapter ('claude' or 'codex'). Write-only and not persisted on the task: "
@@ -353,6 +354,7 @@ class TaskWriteSerializer(serializers.Serializer):
         required=False,
         default=None,
         allow_blank=False,
+        allow_null=True,
         write_only=True,
         help_text="Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.",
     )
@@ -360,6 +362,7 @@ class TaskWriteSerializer(serializers.Serializer):
         choices=[effort.value for effort in PUBLIC_REASONING_EFFORTS],
         required=False,
         default=None,
+        allow_null=True,
         write_only=True,
         help_text="Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.",
     )
@@ -1230,6 +1233,7 @@ class WarmTaskRequestSerializer(serializers.Serializer):
         choices=[adapter.value for adapter in RuntimeAdapter],
         required=False,
         default=None,
+        allow_null=True,
         help_text=(
             "Agent runtime adapter to warm the sandbox on ('claude' or 'codex'). The warm Run starts the "
             "agent on this runtime so a matching submit reuses it; a submit selecting a different runtime "
@@ -1240,12 +1244,14 @@ class WarmTaskRequestSerializer(serializers.Serializer):
         required=False,
         default=None,
         allow_blank=False,
+        allow_null=True,
         help_text="LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run.",
     )
     reasoning_effort = serializers.ChoiceField(
         choices=[effort.value for effort in PUBLIC_REASONING_EFFORTS],
         required=False,
         default=None,
+        allow_null=True,
         help_text="Reasoning effort to warm the sandbox on for models that expose an effort control.",
     )
 

--- a/products/tasks/backend/presentation/serializers.py
+++ b/products/tasks/backend/presentation/serializers.py
@@ -338,6 +338,11 @@ class TaskWriteSerializer(serializers.Serializer):
             "is otherwise carried on the run). Omit to match a warm Run on the default branch."
         ),
     )
+    # These three warm-reuse hints are all optional: clients send an explicit
+    # null when nothing is selected, so they take allow_null=True (null == "no
+    # selection", same as omitting the key — it's read back as None downstream).
+    # null and "" are not interchangeable: model keeps allow_blank=False so an
+    # empty string, which is never a valid model id, is still rejected.
     runtime_adapter = serializers.ChoiceField(
         choices=[adapter.value for adapter in RuntimeAdapter],
         required=False,

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -882,6 +882,26 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(data["description"], "New Description")
         self.assertEqual(data["repository"], "posthog/posthog")
 
+    def test_create_task_accepts_null_runtime_fields(self):
+        # The Code app's cloud-task flows (e.g. Discuss) send the write-only
+        # runtime hints as explicit `null` when nothing is selected. `default=None`
+        # alone rejects an explicit null ("This field may not be null."), so these
+        # fields carry allow_null=True. Regression for that 400.
+        response = self.client.post(
+            "/api/projects/@current/tasks/",
+            {
+                "title": "New Task",
+                "description": "New Description",
+                "repository": "posthog/posthog",
+                "runtime_adapter": None,
+                "model": None,
+                "reasoning_effort": None,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
     def test_create_task_defaults_origin_product(self):
         response = self.client.post(
             "/api/projects/@current/tasks/",

--- a/products/tasks/frontend/generated/api.schemas.ts
+++ b/products/tasks/frontend/generated/api.schemas.ts
@@ -496,9 +496,12 @@ export interface TaskWriteApi {
      *
      * * `claude` - claude
      * * `codex` - codex */
-    runtime_adapter?: RuntimeAdapterEnumApi
-    /** Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model. */
-    model?: string
+    runtime_adapter?: RuntimeAdapterEnumApi | null
+    /**
+     * Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.
+     * @nullable
+     */
+    model?: string | null
     /** Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.
      *
      * * `low` - low
@@ -506,7 +509,7 @@ export interface TaskWriteApi {
      * * `high` - high
      * * `xhigh` - xhigh
      * * `max` - max */
-    reasoning_effort?: ReasoningEffortEnumApi
+    reasoning_effort?: ReasoningEffortEnumApi | null
 }
 
 /**
@@ -583,9 +586,12 @@ export interface PatchedTaskWriteApi {
      *
      * * `claude` - claude
      * * `codex` - codex */
-    runtime_adapter?: RuntimeAdapterEnumApi
-    /** Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model. */
-    model?: string
+    runtime_adapter?: RuntimeAdapterEnumApi | null
+    /**
+     * Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.
+     * @nullable
+     */
+    model?: string | null
     /** Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.
      *
      * * `low` - low
@@ -593,7 +599,7 @@ export interface PatchedTaskWriteApi {
      * * `high` - high
      * * `xhigh` - xhigh
      * * `max` - max */
-    reasoning_effort?: ReasoningEffortEnumApi
+    reasoning_effort?: ReasoningEffortEnumApi | null
 }
 
 /**
@@ -1923,9 +1929,12 @@ export interface WarmTaskRequestApi {
      *
      * * `claude` - claude
      * * `codex` - codex */
-    runtime_adapter?: RuntimeAdapterEnumApi
-    /** LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run. */
-    model?: string
+    runtime_adapter?: RuntimeAdapterEnumApi | null
+    /**
+     * LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run.
+     * @nullable
+     */
+    model?: string | null
     /** Reasoning effort to warm the sandbox on for models that expose an effort control.
      *
      * * `low` - low
@@ -1933,7 +1942,7 @@ export interface WarmTaskRequestApi {
      * * `high` - high
      * * `xhigh` - xhigh
      * * `max` - max */
-    reasoning_effort?: ReasoningEffortEnumApi
+    reasoning_effort?: ReasoningEffortEnumApi | null
 }
 
 /**

--- a/products/tasks/frontend/generated/api.zod.ts
+++ b/products/tasks/frontend/generated/api.zod.ts
@@ -300,21 +300,26 @@ export const TasksCreateBody = /* @__PURE__ */ zod
                 'Branch the user has selected for this cloud task. Write-only and not persisted on the task itself: used only to reuse a matching pre-warmed sandbox Run on creation (the branch is otherwise carried on the run). Omit to match a warm Run on the default branch.'
             ),
         runtime_adapter: zod
-            .enum(['claude', 'codex'])
-            .describe('\* `claude` - claude\n\* `codex` - codex')
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
             .optional()
             .describe(
                 "Selected runtime adapter ('claude' or 'codex'). Write-only and not persisted on the task: used only to reuse a pre-warmed Run started on the same runtime. A value differing from the warm Run's runtime skips reuse so the task isn't silently run on the wrong runtime.\n\n\* `claude` - claude\n\* `codex` - codex"
             ),
         model: zod
             .string()
-            .optional()
+            .nullish()
             .describe(
                 'Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.'
             ),
         reasoning_effort: zod
-            .enum(['low', 'medium', 'high', 'xhigh', 'max'])
-            .describe('\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max')
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
+                    ),
+                zod.null(),
+            ])
             .optional()
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
@@ -402,21 +407,26 @@ export const TasksUpdateBody = /* @__PURE__ */ zod
                 'Branch the user has selected for this cloud task. Write-only and not persisted on the task itself: used only to reuse a matching pre-warmed sandbox Run on creation (the branch is otherwise carried on the run). Omit to match a warm Run on the default branch.'
             ),
         runtime_adapter: zod
-            .enum(['claude', 'codex'])
-            .describe('\* `claude` - claude\n\* `codex` - codex')
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
             .optional()
             .describe(
                 "Selected runtime adapter ('claude' or 'codex'). Write-only and not persisted on the task: used only to reuse a pre-warmed Run started on the same runtime. A value differing from the warm Run's runtime skips reuse so the task isn't silently run on the wrong runtime.\n\n\* `claude` - claude\n\* `codex` - codex"
             ),
         model: zod
             .string()
-            .optional()
+            .nullish()
             .describe(
                 'Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.'
             ),
         reasoning_effort: zod
-            .enum(['low', 'medium', 'high', 'xhigh', 'max'])
-            .describe('\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max')
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
+                    ),
+                zod.null(),
+            ])
             .optional()
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
@@ -504,21 +514,26 @@ export const TasksPartialUpdateBody = /* @__PURE__ */ zod
                 'Branch the user has selected for this cloud task. Write-only and not persisted on the task itself: used only to reuse a matching pre-warmed sandbox Run on creation (the branch is otherwise carried on the run). Omit to match a warm Run on the default branch.'
             ),
         runtime_adapter: zod
-            .enum(['claude', 'codex'])
-            .describe('\* `claude` - claude\n\* `codex` - codex')
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
             .optional()
             .describe(
                 "Selected runtime adapter ('claude' or 'codex'). Write-only and not persisted on the task: used only to reuse a pre-warmed Run started on the same runtime. A value differing from the warm Run's runtime skips reuse so the task isn't silently run on the wrong runtime.\n\n\* `claude` - claude\n\* `codex` - codex"
             ),
         model: zod
             .string()
-            .optional()
+            .nullish()
             .describe(
                 'Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.'
             ),
         reasoning_effort: zod
-            .enum(['low', 'medium', 'high', 'xhigh', 'max'])
-            .describe('\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max')
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
+                    ),
+                zod.null(),
+            ])
             .optional()
             .describe(
                 'Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
@@ -1275,21 +1290,26 @@ export const TasksWarmCreateBody = /* @__PURE__ */ zod
                 "Branch to check out in the warm sandbox. Defaults to the repository's default branch when omitted."
             ),
         runtime_adapter: zod
-            .enum(['claude', 'codex'])
-            .describe('\* `claude` - claude\n\* `codex` - codex')
+            .union([zod.enum(['claude', 'codex']).describe('\* `claude` - claude\n\* `codex` - codex'), zod.null()])
             .optional()
             .describe(
                 "Agent runtime adapter to warm the sandbox on ('claude' or 'codex'). The warm Run starts the agent on this runtime so a matching submit reuses it; a submit selecting a different runtime falls through to a cold Run instead of reusing a mismatched warm session.\n\n\* `claude` - claude\n\* `codex` - codex"
             ),
         model: zod
             .string()
-            .optional()
+            .nullish()
             .describe(
                 "LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run."
             ),
         reasoning_effort: zod
-            .enum(['low', 'medium', 'high', 'xhigh', 'max'])
-            .describe('\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max')
+            .union([
+                zod
+                    .enum(['low', 'medium', 'high', 'xhigh', 'max'])
+                    .describe(
+                        '\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'
+                    ),
+                zod.null(),
+            ])
             .optional()
             .describe(
                 'Reasoning effort to warm the sandbox on for models that expose an effort control.\n\n\* `low` - low\n\* `medium` - medium\n\* `high` - high\n\* `xhigh` - xhigh\n\* `max` - max'

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -41067,9 +41067,12 @@ export namespace Schemas {
        *
        * * `claude` - claude
        * * `codex` - codex */
-      runtime_adapter?: RuntimeAdapterEnum;
-      /** Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model. */
-      model?: string;
+      runtime_adapter?: RuntimeAdapterEnum | null;
+      /**
+         * Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.
+         * @nullable
+         */
+      model?: string | null;
       /** Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.
        *
        * * `low` - low
@@ -41077,7 +41080,7 @@ export namespace Schemas {
        * * `high` - high
        * * `xhigh` - xhigh
        * * `max` - max */
-      reasoning_effort?: ReasoningEffortEnum;
+      reasoning_effort?: ReasoningEffortEnum | null;
     }
 
     export type PatchedTeamDefaultModifiers = { [key: string]: unknown };
@@ -51268,9 +51271,12 @@ export namespace Schemas {
        *
        * * `claude` - claude
        * * `codex` - codex */
-      runtime_adapter?: RuntimeAdapterEnum;
-      /** Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model. */
-      model?: string;
+      runtime_adapter?: RuntimeAdapterEnum | null;
+      /**
+         * Selected LLM model identifier. Write-only; used only to reuse a warm Run started on the same model.
+         * @nullable
+         */
+      model?: string | null;
       /** Selected reasoning effort. Write-only; used only to reuse a warm Run started on the same effort.
        *
        * * `low` - low
@@ -51278,7 +51284,7 @@ export namespace Schemas {
        * * `high` - high
        * * `xhigh` - xhigh
        * * `max` - max */
-      reasoning_effort?: ReasoningEffortEnum;
+      reasoning_effort?: ReasoningEffortEnum | null;
     }
 
     export type TeamDefaultModifiers = { [key: string]: unknown };
@@ -52205,9 +52211,12 @@ export namespace Schemas {
        *
        * * `claude` - claude
        * * `codex` - codex */
-      runtime_adapter?: RuntimeAdapterEnum;
-      /** LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run. */
-      model?: string;
+      runtime_adapter?: RuntimeAdapterEnum | null;
+      /**
+         * LLM model identifier to warm the sandbox on. A submit selecting a different model won't reuse this warm Run.
+         * @nullable
+         */
+      model?: string | null;
       /** Reasoning effort to warm the sandbox on for models that expose an effort control.
        *
        * * `low` - low
@@ -52215,7 +52224,7 @@ export namespace Schemas {
        * * `high` - high
        * * `xhigh` - xhigh
        * * `max` - max */
-      reasoning_effort?: ReasoningEffortEnum;
+      reasoning_effort?: ReasoningEffortEnum | null;
     }
 
     /**


### PR DESCRIPTION
## Problem

The PostHog Code app's one-click cloud-task flows (Discuss a report, warm sandbox) broke with a 400:

```
[400] {"type":"validation_error","code":"null","detail":"This field may not be null.","attr":"reasoning_effort"}
```

The write-only runtime hints (`runtime_adapter`, `model`, `reasoning_effort`) on `TaskWriteSerializer` (the task-create endpoint) and `WarmTaskRequestSerializer` were declared `required=False, default=None` but **without** `allow_null=True`. `default=None` only fills in a *missing* key — an explicit `null` still gets validated and rejected. The Code app sends these hints as explicit `null` when nothing is selected (Discuss routinely does, since it drops the persisted reasoning effort whenever the model resolver falls back to a default), so task creation 400'd.

The read serializer (`TaskRunDetailSerializer`) already had `allow_null=True`; the newer write serializers just didn't carry it over.

## Changes

Add `allow_null=True` to `runtime_adapter` / `model` / `reasoning_effort` on `TaskWriteSerializer` and `WarmTaskRequestSerializer`. `null` now means "no selection", which is exactly how the backend already treats it downstream (`validated_data.pop(..., None)` + `or None` normalization in `_find_idling_warm_run`), so behavior is unchanged apart from no longer rejecting the null.

## How did you test this code?

I'm an agent (PostHog Code). Added a regression test, `test_create_task_accepts_null_runtime_fields`, that POSTs the runtime fields as explicit `null` and asserts a 201 — it reproduces the reported 400 against the old serializer. I could **not** run the Django suite in my sandbox (no Postgres available; it errors at DB connection setup), but the test collects cleanly and both changed files compile. Please run `pytest products/tasks/backend/tests/test_api.py -k create_task` in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a Slack thread reporting "Discuss is not working". Traced the failing payload through the Code app (`taskCreationSaga.ts` sends `reasoning_effort: reasoningLevel ?? null` for cloud tasks; the runner drops the effort to `undefined` on a model swap) to this serializer. Root cause is the missing `allow_null` on the write fields added in #66099. Chose the backend `allow_null=True` fix over tightening the frontend coercion because it addresses the actual contract (the backend already treats `None`/null as "unset") and covers every flow that posts these hints.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782468461561939?thread_ts=1782468461.561939&cid=C09SK2PAGKF)*
