### PR TITLE
fix(conversations): stop unsaved-changes prompt re-firing on tickets

### DIFF
--- a/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
+++ b/products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts
@@ -580,8 +580,24 @@ export const supportTicketSceneLogic = kea<supportTicketSceneLogicType>([
         cache.disposables.disposeAll()
         impersonationNoticeLogic.findMounted()?.actions.setTicketContext(null)
     }),
-    beforeUnload(({ values }) => ({
-        enabled: () => values.hasPendingWork,
+    beforeUnload(({ values, actions }) => ({
+        enabled: (newLocation) => {
+            if (!values.hasPendingWork) {
+                return false
+            }
+            // Ignore in-page navigations (e.g. opening a side panel) that keep the same path
+            if (newLocation && newLocation.pathname === router.values.location.pathname) {
+                return false
+            }
+            return true
+        },
         message: 'You have unsaved changes. Are you sure you want to leave?',
+        onConfirm: () => {
+            // Re-sync local form reducers to the last-known server ticket so hasUnsavedChanges
+            // recomputes to false and the prompt does not re-fire on the next navigation.
+            if (values.ticket) {
+                actions.setTicket(values.ticket)
+            }
+        },
     })),
 ])


### PR DESCRIPTION
## Problem

On a support ticket, after editing a field (status, priority, assignee, tags, snooze) and navigating away, the browser shows **"You have unsaved changes. Are you sure you want to leave?"**. Clicking **OK** lets you leave — but the prompt then re-appears on *every* subsequent navigation, indefinitely, even when there's nothing left to save.

The `beforeUnload` guard in `supportTicketSceneLogic` had no `onConfirm` callback. `hasUnsavedChanges` is derived by diffing the local form reducers against the loaded `ticket`, and that diff is only cleared by `setTicket(...)` (fresh load or successful save). When the user clicked OK, kea-router allowed the navigation but the local edits were never discarded, so the still-mounted logic's `enabled()` kept returning `true` and re-prompted forever.

## Changes

`products/conversations/frontend/scenes/ticket/supportTicketSceneLogic.ts`:

- Add an `onConfirm` that re-syncs the form reducers to the loaded ticket via `setTicket(values.ticket)`, so `hasUnsavedChanges` recomputes to `false` once the user confirms and the prompt stops re-firing. This mirrors the established pattern in `featureFlagLogic` (`resetFeatureFlag`), `definitionEditLogic` (`resetEditDefinition`), and `sessionRecordingsPlaylistSceneLogic` (`setFilters`) — the ticket guard was the outlier missing it.
- Guard `enabled` against same-path in-app navigations (e.g. opening a side panel) so they don't trigger the prompt at all.

## How did you test this code?

I'm an agent. I ran the frontend TypeScript check — no new errors from this change (pre-existing unrelated errors in `mcp_analytics/frontend` remain). I did not run the app manually.

Suggested manual verification for the reviewer:
1. Open a support ticket, change a field without saving.
2. Navigate away → prompt appears → click OK → navigation proceeds.
3. Navigate again → **no** repeated prompt (the bug).
4. Change a field, click Cancel → navigation blocked, edits preserved.
5. Change a field, Save changes, navigate → no prompt.

No automated test currently covers this kea-router guard closure; the fix is a one-line behavioral change whose underlying reducer reset is already exercised by existing reducer behavior, so no new test was added.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). The bug was reported with a screenshot of the recurring dialog; I traced it to the missing `onConfirm` on the ticket scene's `beforeUnload` guard by comparing against other scenes that use the guard correctly. No repo skills were required for this change. Chose `setTicket(values.ticket)` for the reset since it's an existing action that already resets all five dirty-tracked reducers; added the same-path guard opportunistically to match the `featureFlagLogic` pattern.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
