### PR TITLE
chore(warehouse): document webhook table transformers in source skill

### DIFF
--- a/.agents/skills/implementing-warehouse-sources/SKILL.md
+++ b/.agents/skills/implementing-warehouse-sources/SKILL.md
@@ -298,6 +298,7 @@ Save state **after** yielding each batch, not before — so if we crash we re-yi
 - Add `webhookFields` to `SourceConfig` for post-setup inputs (e.g. signing secret).
 - In `source_for_pipeline`, call `self.get_webhook_source_manager(inputs)` and pass its iterator alongside the pull iterator so a single sync pulls historical + webhook-delivered rows.
 - Populate `SourceSchema.supports_webhooks=True` only for endpoints where webhooks are actually viable (usually incremental/append-only ones).
+- **De-dupe within a webhook batch with a `table_transformer`.** `WebhookSourceManager.get_items()` takes an optional `table_transformer: Callable[[pa.Table], pa.Table]` applied after the raw webhook payloads are deserialized into row dicts. Delta merge only de-dupes _across_ syncs (on `primary_keys`), not within a single source batch — so when one batch can carry multiple events for the same object (e.g. `customer.created` then `customer.updated`), pass a transformer that keeps only the latest version per id. Reference: `_webhook_table_transformer` in `stripe/stripe.py`, wired via `webhook_source_manager.get_items(table_transformer=_webhook_table_transformer)` in `stripe_source`. It groups rows by `object.id`, keeps the one with the greatest event `created` timestamp, and rebuilds the table shaped like the underlying object (ready to merge on `primary_keys=["id"]`).
 
 ## Multi-schema SQL database sources
 


### PR DESCRIPTION
## Problem

The `implementing-warehouse-sources` skill documents the webhook source pattern but doesn't mention a subtle pitfall: a single webhook batch can contain multiple events for the same object (e.g. `customer.created` then `customer.updated`), and delta merge only de-dupes _across_ syncs, not within a batch. Anyone implementing a new webhook source could land stale rows without knowing the `table_transformer` hook exists.

## Changes

Add a bullet to the "Webhook source pattern" section of the skill explaining the optional `table_transformer` argument to `WebhookSourceManager.get_items()`, why it's needed (within-batch dedup), and pointing at the Stripe `_webhook_table_transformer` as the canonical example.

Docs-only change to an agent skill — no production code touched.

## How did you test this code?

I'm an agent. No automated tests apply — this is a markdown skill doc. I verified the referenced code (`_webhook_table_transformer` and the `get_items(table_transformer=...)` wiring in `stripe/stripe.py`) exists and matches the description.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom asked to document the webhook table transformer pattern (e.g. the Stripe table transformer used to de-dupe incoming webhook events so only the latest version is merged) in the warehouse source skill. I located the `implementing-warehouse-sources` SKILL.md and the Stripe `_webhook_table_transformer`, confirmed how it's wired through `WebhookSourceManager.get_items()`, and added a concise bullet under the existing webhook pattern section. No skills were invoked to produce this change.
