### PR TITLE
fix(tasks): push task list pagination into SQL

### DIFF
--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -2415,13 +2415,23 @@ async def select_repository_for_message(team_id: int, user_id: int, message: str
 
 
 def list_tasks(
-    team_id: int, user_id: int | None, *, filters: dict, is_debug_or_staff: bool
-) -> list[contracts.TaskDetailDTO]:
-    """All visible tasks for the team, mirroring ``TaskViewSet.safely_get_queryset`` for ``list``.
+    team_id: int,
+    user_id: int | None,
+    *,
+    filters: dict,
+    is_debug_or_staff: bool,
+    limit: int | None = None,
+    offset: int = 0,
+) -> tuple[int, list[contracts.TaskDetailDTO]]:
+    """A page of visible tasks for the team, plus the total match count.
 
     ``filters`` carries the request query params (origin_product, stage, organization, repository,
     created_by, search, status, internal, archived). ``is_debug_or_staff`` gates the ``internal``
     filter exactly as the original view did (``settings.DEBUG or request.user.is_staff``).
+
+    ``limit``/``offset`` are pushed into SQL so only the requested page (and its prefetched runs) is
+    materialized — without them a large team's entire task set would be loaded per request. Returns
+    ``(total_count, page_dtos)`` so the caller can build a paginated response.
     """
     qs = _visible_task_qs(team_id, user_id).order_by("-created_at")
 
@@ -2489,7 +2499,13 @@ def list_tasks(
     if stage:
         qs = qs.distinct()
 
-    return [_task_detail_to_dto(task) for task in qs]
+    total = qs.count()
+    if limit is not None:
+        qs = qs[offset : offset + limit]
+    elif offset:
+        qs = qs[offset:]
+
+    return total, [_task_detail_to_dto(task) for task in qs]
 
 
 def list_task_repositories(team_id: int, user_id: int | None) -> list[str]:

--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -222,13 +222,25 @@ class TaskViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         filters["internal"] = getattr(request, "validated_query_data", {}).get("internal")
         filters["archived"] = getattr(request, "validated_query_data", {}).get("archived")
         is_debug_or_staff = settings.DEBUG or request.user.is_staff
-        tasks = tasks_facade.list_tasks(
-            self.team_id, self._user_id(), filters=filters, is_debug_or_staff=is_debug_or_staff
+
+        # Resolve limit/offset before calling the facade so pagination is pushed into SQL.
+        # Paginating the returned list instead would materialize every task (and run) in the team.
+        paginator = self.paginator
+        limit = paginator.get_limit(request)
+        offset = paginator.get_offset(request)
+        count, tasks = tasks_facade.list_tasks(
+            self.team_id,
+            self._user_id(),
+            filters=filters,
+            is_debug_or_staff=is_debug_or_staff,
+            limit=limit,
+            offset=offset,
         )
-        page = self.paginate_queryset(tasks)
-        if page is not None:
-            return self.get_paginated_response(TaskSerializer(page, many=True).data)
-        return Response(TaskSerializer(tasks, many=True).data)
+        paginator.count = count
+        paginator.limit = limit
+        paginator.offset = offset
+        paginator.request = request
+        return paginator.get_paginated_response(TaskSerializer(tasks, many=True).data)
 
     @extend_schema(
         responses={200: OpenApiResponse(response=TaskSerializer, description="Task")},

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -820,6 +820,38 @@ class TestTaskAPI(BaseTaskAPITest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.json()["results"]), 2)
 
+    @parameterized.expand(
+        [
+            ("first_page", 2, 0, "LIMIT 2", 2),
+            ("with_offset", 2, 3, "LIMIT 2 OFFSET 3", 2),
+        ]
+    )
+    def test_list_tasks_pushes_pagination_into_sql(self, _name, limit, offset, expected_clause, expected_len):
+        # Regression: limit/offset must be applied in SQL, not by materializing every task (and run)
+        # for the team and slicing in Python — the latter times out large teams on any page size.
+        for i in range(5):
+            task = self.create_task(f"Task {i}")
+            TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
+
+        with CaptureQueriesContext(connection) as ctx:
+            response = self.client.get(f"/api/projects/@current/tasks/?limit={limit}&offset={offset}")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        data = response.json()
+        self.assertEqual(data["count"], 5)
+        self.assertEqual(len(data["results"]), expected_len)
+
+        # The task SELECT (not the COUNT) must carry the page bounds rather than fetching every row.
+        task_selects = [
+            q["sql"]
+            for q in ctx.captured_queries
+            if 'FROM "posthog_task"' in q["sql"] and "COUNT(" not in q["sql"].upper()
+        ]
+        self.assertTrue(
+            any(expected_clause in sql for sql in task_selects),
+            f"pagination was not pushed into SQL; task queries: {task_selects}",
+        )
+
     def test_retrieve_task(self):
         task = self.create_task("Test Task")
 


### PR DESCRIPTION
## Problem

`GET /api/projects/:team_id/tasks/` was timing out (504 in production), and no tasks could load anywhere. Even `?limit=1` — the cheapest possible page — hung, which is the tell: request cost was independent of page size.

The list endpoint materialized **every** visible task for the team and prefetched **every** task run, built a DTO for each, and only then sliced to the requested page in Python. Pagination was cosmetic — the `LIMIT`/`OFFSET` never reached SQL. For teams with many tasks/runs that scan blows past the gateway timeout.

This was a regression from the facade-isolation change (#64627): the pre-refactor viewset returned a lazy queryset that DRF's `LimitOffsetPagination` sliced in SQL; the refactored facade `list_tasks` eagerly returned `[_task_detail_to_dto(t) for t in qs]`, defeating that.

## Changes

- `facade.list_tasks` now takes `limit`/`offset`, applies them to the queryset (so the page bound lands in SQL), and returns `(total_count, page_dtos)`.
- `TaskViewSet.list` resolves limit/offset from the paginator before calling the facade and builds the paginated response from the returned count + page — so only the requested page (and its prefetched runs) is loaded.
- Response shape is unchanged (same `TaskSerializer`, same paginated envelope), so no OpenAPI/type regeneration is needed.

## How did you test this code?

- Added a parameterized regression test (`test_list_tasks_pushes_pagination_into_sql`) that captures the executed SQL and asserts the task `SELECT` carries the page `LIMIT`/`OFFSET` and that `count` reflects the full match set. It catches a regression no existing test did: the previous tests asserted correct `results`/`count` (which the broken in-memory slice still produced) but never that the bound reached SQL. Verified it **fails** against the pre-fix code (captured query ends in `ORDER BY ... DESC` with no `LIMIT`) and passes with the fix.
- Ran the full `TestTaskAPI` class (122 tests) — all pass.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?
