### PR TITLE
fix(experiments): accept action-based exposure in MCP results schema

### DIFF
--- a/services/mcp/src/schema/experiments.ts
+++ b/services/mcp/src/schema/experiments.ts
@@ -21,9 +21,24 @@ const ExperimentEventExposureConfigSchema = z.object({
     properties: z.array(z.any()),
 })
 
+// Action-based exposure: the experiment counts a user as exposed when they match a
+// PostHog action (kind 'ActionsNode', identified by numeric `id`) rather than a custom
+// event. The backend resolves the action by id, so id + properties round-trip faithfully
+// into the ExperimentExposureQuery.
+const ExperimentActionExposureConfigSchema = z.object({
+    kind: z.literal('ActionsNode'),
+    id: z.number(),
+    properties: z.array(z.any()).optional(),
+})
+
+const ExperimentExposureConfigSchema = z.union([
+    ExperimentEventExposureConfigSchema,
+    ExperimentActionExposureConfigSchema,
+])
+
 const ExperimentExposureCriteriaSchema = z.object({
     filterTestAccounts: z.boolean().optional(),
-    exposure_config: ExperimentEventExposureConfigSchema.optional(),
+    exposure_config: ExperimentExposureConfigSchema.optional(),
     multiple_variant_handling: z.enum(['exclude', 'first_seen']).optional(),
 })
 

--- a/services/mcp/tests/unit/experiments-results-transform.test.ts
+++ b/services/mcp/tests/unit/experiments-results-transform.test.ts
@@ -19,7 +19,12 @@
 import { describe, expect, it } from 'vitest'
 
 import type { Experiment } from '@/schema/experiments'
-import { buildMetricEntries, ExperimentSchema, transformExperimentResults } from '@/schema/experiments'
+import {
+    buildMetricEntries,
+    ExperimentExposureQuerySchema,
+    ExperimentSchema,
+    transformExperimentResults,
+} from '@/schema/experiments'
 
 const baseExposures = {
     kind: 'ExperimentExposureQuery' as const,
@@ -397,5 +402,58 @@ describe('transformExperimentResults', () => {
         expect(bdVariants[0]?.step_sessions).toBeUndefined()
         expect(bdVariants[0]?.sum).toBe(55)
         expect(bdVariants[0]?.step_counts).toEqual([55, 27])
+    })
+})
+
+describe('exposure_criteria parsing — action-based exposure', () => {
+    // Regression: experiment-results-get threw a ZodError ("expected
+    // ExperimentEventExposureConfig") whenever the experiment's exposure was gated
+    // on an action (kind 'ActionsNode') instead of a custom event, because the
+    // shared exposure schema only modeled the event variant. The experiment GET and
+    // the ExperimentExposureQuery built from it (client.ts) both run through this
+    // schema, so a narrow union broke results for every action-exposure experiment.
+    const actionExposureCriteria = {
+        filterTestAccounts: true,
+        exposure_config: { kind: 'ActionsNode' as const, id: 3, properties: [] },
+    }
+
+    it('parses an experiment whose exposure_config is an ActionsNode and preserves kind + id', () => {
+        const experiment = makeExperiment({ exposure_criteria: actionExposureCriteria })
+        expect(experiment.exposure_criteria?.exposure_config).toEqual({
+            kind: 'ActionsNode',
+            id: 3,
+            properties: [],
+        })
+    })
+
+    it('still parses the event-based exposure_config variant', () => {
+        const experiment = makeExperiment({
+            exposure_criteria: {
+                filterTestAccounts: true,
+                exposure_config: {
+                    kind: 'ExperimentEventExposureConfig' as const,
+                    event: '$pageview',
+                    properties: [],
+                },
+            },
+        })
+        expect(experiment.exposure_criteria?.exposure_config).toEqual({
+            kind: 'ExperimentEventExposureConfig',
+            event: '$pageview',
+            properties: [],
+        })
+    })
+
+    it('accepts an ExperimentExposureQuery carrying action-based exposure criteria (the client.ts throw site)', () => {
+        // client.ts builds this query from experiment.exposure_criteria and parses it
+        // before POSTing to /query/. This is the exact call that surfaced the bug.
+        const parsed = ExperimentExposureQuerySchema.parse({
+            kind: 'ExperimentExposureQuery',
+            experiment_id: 9,
+            experiment_name: 'New upload button',
+            exposure_criteria: actionExposureCriteria,
+            start_date: '2026-01-01T00:00:00Z',
+        })
+        expect(parsed.exposure_criteria?.exposure_config).toEqual({ kind: 'ActionsNode', id: 3, properties: [] })
     })
 })


### PR DESCRIPTION
## Problem

The `experiment-results-get` MCP tool crashed with a ZodError for any experiment whose exposure criteria is a PostHog action (`kind: ActionsNode`) instead of a custom event. The shared exposure-criteria schema only modeled the event variant, so both reading the experiment and building the `ExperimentExposureQuery` failed before any results could be computed. Action-based exposure is fully supported elsewhere (create/update/get all accept it), so results were silently broken for that entire class of experiments.

## Changes

- `services/mcp/src/schema/experiments.ts`: `exposure_config` is now a `z.union` of the existing `ExperimentEventExposureConfig` and a new `ActionsNode` variant (`{ kind, id, properties? }`), matching the canonical generated union (`ExperimentEventExposureConfig | ActionsNode`). Both `ExperimentSchema` and `ExperimentExposureQuerySchema` consume the shared criteria schema, so this single change fixes the whole results path.
- Added regression tests for the action variant, the unchanged event variant, and the `ExperimentExposureQuerySchema.parse` call site that actually threw.

## How did you test this code?

I'm an agent (Claude Code) and this was human-directed. I did not do manual testing beyond what's listed.

Automated:
- `services/mcp` unit suite — 1916 passing, including the 3 new regression tests in `experiments-results-transform.test.ts`.
- `tsgo --noEmit` typecheck clean; oxfmt formatting applied.

Live verification:
- Reproduced the original ZodError by calling `experiment-results-get` on a running experiment configured with action-based exposure.
- Applied the fix, restarted the local MCP server, and re-ran the same call — it now returns the full results payload (exposures + metric rows) instead of erroring. Zero exposure counts are expected (fresh demo experiment), the schema rejection is gone.

The new tests catch a regression no existing test did: parsing an experiment / exposure query whose `exposure_config` is an `ActionsNode`. Previously every test only exercised the event variant.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change — internal MCP schema fix with no user-facing API surface change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). The bug was reproduced by setting up a repro experiment (action + action-gated exposure) via the PostHog MCP tools, then traced to the hand-written exposure schema.
- Skills: the PostHog `creating-experiments` and `configuring-experiment-analytics` MCP skills were used while building the repro experiment. No repo code-modification skills applied — this is a TypeScript MCP schema change, not a DRF/migration change.
- Decision: fixed at the single shared schema rather than patching each consumer. `fetchJson` does no runtime validation, so the only throw site was `ExperimentExposureQuerySchema.parse` in `client.ts`; the action variant is modeled minimally (`{ kind, id, properties? }`) since the backend resolves the action by `id`, mirroring how the event variant is kept lean.
