### PR TITLE
feat(logs): scaffold patterns tab behind feature flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -346,6 +346,7 @@ export const FEATURE_FLAGS = {
     LOGS: 'logs', // owner: #team-logs
     LOGS_ALERTING: 'logs-alerting', // owner: #team-logs
     LOGS_FACET_RAIL: 'logs-facet-rail', // owner: #team-logs
+    LOGS_PATTERNS_VIEW: 'logs-patterns-view', // owner: #team-logs
     LOGS_SAVED_VIEWS: 'logs-saved-views', // owner: #team-logs
     LOGS_SERVICES_VIEW: 'logs-services-view', // owner: #team-logs
     LOGS_SETTINGS: 'logs-settings', // owner: #team-logs

--- a/products/logs/frontend/LogsScene.tsx
+++ b/products/logs/frontend/LogsScene.tsx
@@ -15,6 +15,7 @@ import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { ProductKey } from '~/queries/schema/schema-general'
 
 import { LogsAlertingSection } from 'products/logs/frontend/components/LogsAlerting/LogsAlertingSection'
+import { LogsPatterns } from 'products/logs/frontend/components/LogsPatterns/LogsPatterns'
 import { LogsServices } from 'products/logs/frontend/components/LogsServices/LogsServices'
 import { LogsSqlEditor } from 'products/logs/frontend/components/LogsSqlEditor/LogsSqlEditor'
 import { LogsViewer } from 'products/logs/frontend/components/LogsViewer'
@@ -90,12 +91,14 @@ const LogsSceneTabbedContent = (): JSX.Element => {
     const { activeTab } = useValues(logsSceneLogic)
     const { setActiveTab } = useActions(logsSceneLogic)
     const { hasLogs, teamHasLogsCheckFailed } = useValues(logsIngestionLogic)
+    const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
     const showServicesView = useFeatureFlag('LOGS_SERVICES_VIEW')
     const showAlerting = useFeatureFlag('LOGS_ALERTING')
     const showSqlView = useFeatureFlag('LOGS_SQL_VIEW')
 
     const tabs: { key: LogsSceneActiveTab; label: string }[] = [
         { key: 'viewer', label: 'Viewer' },
+        ...(showPatternsView ? [{ key: 'patterns' as const, label: 'Patterns' }] : []),
         ...(showServicesView ? [{ key: 'services' as const, label: 'Services' }] : []),
         ...(showAlerting ? [{ key: 'alerts' as const, label: 'Alerts' }] : []),
         ...(showSqlView ? [{ key: 'sql' as const, label: 'SQL' }] : []),
@@ -142,6 +145,7 @@ const LogsSceneTabbedContent = (): JSX.Element => {
                     </div>
                 </LogsSetupPrompt>
             )}
+            {activeTab === 'patterns' && showPatternsView && <LogsPatterns />}
             {activeTab === 'services' && showServicesView && (
                 <>
                     <LogsServices />

--- a/products/logs/frontend/components/LogsPatterns/LogsPatterns.tsx
+++ b/products/logs/frontend/components/LogsPatterns/LogsPatterns.tsx
@@ -1,0 +1,9 @@
+export function LogsPatterns(): JSX.Element {
+    // Scaffold only — the mined-patterns table and its logic land in a follow-up.
+    return (
+        <div className="flex flex-col gap-2 py-2 flex-1 min-h-0" data-attr="logs-patterns">
+            <h3 className="m-0">Patterns</h3>
+            <p className="text-muted m-0">Log pattern mining will appear here.</p>
+        </div>
+    )
+}

--- a/products/logs/frontend/logsSceneLogic.tsx
+++ b/products/logs/frontend/logsSceneLogic.tsx
@@ -40,8 +40,8 @@ export const getLogsSqlEditorTabId = (id: string): string => `logs-sql-editor-${
 // A static id would persist across projects in the same browser, leaking one project's pinned log payloads into another.
 export const LOGS_SCENE_VIEWER_ID = `logs-scene-${window.POSTHOG_APP_CONTEXT?.current_team?.id ?? 'unknown'}`
 
-export type LogsSceneActiveTab = 'viewer' | 'services' | 'alerts' | 'sql' | 'configuration'
-const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'services', 'alerts', 'sql', 'configuration']
+export type LogsSceneActiveTab = 'viewer' | 'patterns' | 'services' | 'alerts' | 'sql' | 'configuration'
+const VALID_ACTIVE_TABS: LogsSceneActiveTab[] = ['viewer', 'patterns', 'services', 'alerts', 'sql', 'configuration']
 export const DEFAULT_ACTIVE_TAB: LogsSceneActiveTab = 'viewer'
 
 const resolveActiveTabFromParams = (params: Params): LogsSceneActiveTab | null => {


### PR DESCRIPTION
## Problem

The Logs scene has no entry point for log pattern mining. A "Patterns" tab needs to exist in the UI before the underlying data table and logic can be wired up in a follow-up.

## Changes

- Adds a `LOGS_PATTERNS_VIEW` feature flag to gate the new tab.
- Adds `'patterns'` to the `LogsSceneActiveTab` union type and `VALID_ACTIVE_TABS` array.
- Introduces a scaffold `LogsPatterns` component that renders a placeholder — the mined-patterns table and its logic land in a follow-up PR.
- Wires the tab into `LogsSceneTabbedContent` so it appears (behind the flag) between the Viewer and Services tabs.

## How did you test this code?

Enable the `logs-patterns-view` feature flag and navigate to the Logs scene — the Patterns tab should appear and render the placeholder content. Disabling the flag should hide the tab entirely.

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

N/A — scaffold only, no user-facing functionality yet.