### PR TITLE
fix(data-warehouse): keep OAuth source connection inside onboarding

### DIFF
--- a/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseQueryVariant.tsx
+++ b/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseQueryVariant.tsx
@@ -157,7 +157,11 @@ function DataWarehouseQueryInner(): JSX.Element {
     const { reportOnboardingStepCompleted } = useActions(eventUsageLogic)
     const { availableSourcesLoading } = useValues(availableSourcesLogic)
     const { connectors } = useValues(sourceWizardLogic)
-    const [phase, setPhase] = useState<'value-prop' | 'setup'>('value-prop')
+    // An OAuth round-trip returns to this step with ?kind=<source>; start on the setup phase so
+    // InlineSourceSetup is mounted to resume the wizard rather than showing the value-prop screen.
+    const [phase, setPhase] = useState<'value-prop' | 'setup'>(() =>
+        new URLSearchParams(window.location.search).get('kind') ? 'setup' : 'value-prop'
+    )
     const [sceneIndex, setSceneIndex] = useState(0)
 
     const visibleConnectors = connectors.filter((c: SourceConfig) => !c.unreleasedSource)

--- a/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseQueryVariant.tsx
+++ b/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseQueryVariant.tsx
@@ -24,7 +24,7 @@ import { InlineSourceSetup } from 'products/data_warehouse/frontend/shared/compo
 
 import { onboardingLogic } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
-import { ConnectorIconGrid, DataWarehouseOnboardingLoadingPlaceholder } from './components'
+import { ConnectorIconGrid, DataWarehouseOnboardingLoadingPlaceholder, initialOnboardingPhase } from './components'
 
 // The query skeleton is fixed — SELECT, FROM, JOIN, ON stay put.
 // Only the slots (comment, columns, source, posthog table, on clause,
@@ -157,11 +157,7 @@ function DataWarehouseQueryInner(): JSX.Element {
     const { reportOnboardingStepCompleted } = useActions(eventUsageLogic)
     const { availableSourcesLoading } = useValues(availableSourcesLogic)
     const { connectors } = useValues(sourceWizardLogic)
-    // An OAuth round-trip returns to this step with ?kind=<source>; start on the setup phase so
-    // InlineSourceSetup is mounted to resume the wizard rather than showing the value-prop screen.
-    const [phase, setPhase] = useState<'value-prop' | 'setup'>(() =>
-        new URLSearchParams(window.location.search).get('kind') ? 'setup' : 'value-prop'
-    )
+    const [phase, setPhase] = useState<'value-prop' | 'setup'>(initialOnboardingPhase)
     const [sceneIndex, setSceneIndex] = useState(0)
 
     const visibleConnectors = connectors.filter((c: SourceConfig) => !c.unreleasedSource)

--- a/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseValuePropVariant.tsx
+++ b/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseValuePropVariant.tsx
@@ -71,7 +71,11 @@ function DataWarehouseValuePropInner(): JSX.Element {
     const { reportOnboardingStepCompleted } = useActions(eventUsageLogic)
     const { availableSourcesLoading } = useValues(availableSourcesLogic)
     const { connectors } = useValues(sourceWizardLogic)
-    const [phase, setPhase] = useState<'value-prop' | 'setup'>('value-prop')
+    // An OAuth round-trip returns to this step with ?kind=<source>; start on the setup phase so
+    // InlineSourceSetup is mounted to resume the wizard rather than showing the value-prop screen.
+    const [phase, setPhase] = useState<'value-prop' | 'setup'>(() =>
+        new URLSearchParams(window.location.search).get('kind') ? 'setup' : 'value-prop'
+    )
 
     const visibleConnectors = connectors.filter((c: SourceConfig) => !c.unreleasedSource)
 

--- a/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseValuePropVariant.tsx
+++ b/frontend/src/scenes/onboarding/legacy/data-warehouse/DataWarehouseValuePropVariant.tsx
@@ -21,7 +21,7 @@ import { InlineSourceSetup } from 'products/data_warehouse/frontend/shared/compo
 
 import { onboardingLogic } from '../onboardingLogic'
 import { OnboardingStep } from '../OnboardingStep'
-import { ConnectorIconGrid, DataWarehouseOnboardingLoadingPlaceholder } from './components'
+import { ConnectorIconGrid, DataWarehouseOnboardingLoadingPlaceholder, initialOnboardingPhase } from './components'
 
 const EXAMPLE_QUERIES = [
     {
@@ -71,11 +71,7 @@ function DataWarehouseValuePropInner(): JSX.Element {
     const { reportOnboardingStepCompleted } = useActions(eventUsageLogic)
     const { availableSourcesLoading } = useValues(availableSourcesLogic)
     const { connectors } = useValues(sourceWizardLogic)
-    // An OAuth round-trip returns to this step with ?kind=<source>; start on the setup phase so
-    // InlineSourceSetup is mounted to resume the wizard rather than showing the value-prop screen.
-    const [phase, setPhase] = useState<'value-prop' | 'setup'>(() =>
-        new URLSearchParams(window.location.search).get('kind') ? 'setup' : 'value-prop'
-    )
+    const [phase, setPhase] = useState<'value-prop' | 'setup'>(initialOnboardingPhase)
 
     const visibleConnectors = connectors.filter((c: SourceConfig) => !c.unreleasedSource)
 

--- a/frontend/src/scenes/onboarding/legacy/data-warehouse/components.tsx
+++ b/frontend/src/scenes/onboarding/legacy/data-warehouse/components.tsx
@@ -15,6 +15,12 @@ export function DataWarehouseOnboardingLoadingPlaceholder(): JSX.Element {
     )
 }
 
+// An OAuth round-trip returns to this step with ?kind=<source>; start on the setup phase so
+// InlineSourceSetup is mounted to resume the wizard rather than showing the value-prop screen.
+export function initialOnboardingPhase(): 'value-prop' | 'setup' {
+    return new URLSearchParams(window.location.search).get('kind') ? 'setup' : 'value-prop'
+}
+
 export function useDataWarehouseLoadingState(): { isLoading: boolean } {
     const { availableSources, availableSourcesLoading } = useValues(availableSourcesLogic)
     return { isLoading: availableSourcesLoading || availableSources === null }

--- a/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
+++ b/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
@@ -1,5 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
-import { useState } from 'react'
+import { router } from 'kea-router'
+import { useEffect, useState } from 'react'
 
 import { IconDatabase, IconPlus } from '@posthog/icons'
 import { LemonButton, LemonCard, LemonSkeleton } from '@posthog/lemon-ui'
@@ -37,6 +38,7 @@ function InternalInlineSourceSetup({
 }: InlineSourceSetupProps): JSX.Element {
     const { connectors } = useValues(sourceWizardLogic)
     const { onClear } = useActions(sourceWizardLogic)
+    const { searchParams } = useValues(router)
 
     const [currentView, setCurrentView] = useState<InlineSourceSetupView>('selection')
     const [selectedSource, setSelectedSource] = useState<ExternalDataSourceType | null>(null)
@@ -44,6 +46,23 @@ function InternalInlineSourceSetup({
 
     // Filter out unreleased sources
     const availableConnectors = connectors.filter((c: SourceConfig) => !c.unreleasedSource)
+
+    // Resume an OAuth round-trip: an OAuth source redirects the whole page to the provider and
+    // back to this onboarding URL with ?kind=<source>. On mount, re-open the wizard for that
+    // source so the user lands back where they left off (credentials are restored by the wizard
+    // from the state saved before the redirect). Runs once — subsequent picks use the grid.
+    useEffect(() => {
+        const kind = searchParams.kind
+        if (!kind) {
+            return
+        }
+        const match = availableConnectors.find((c) => c.name.toLowerCase() === String(kind).toLowerCase())
+        if (match) {
+            setSelectedSource(match.name)
+            setCurrentView('connecting')
+        }
+        // oxlint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
     const featuredSources = availableConnectors.filter((c: SourceConfig) => c.featured)
     const hiddenSources = availableConnectors.filter((c: SourceConfig) => !c.featured)
     const sourcesToShow = expanded ? availableConnectors : featuredSources

--- a/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
+++ b/products/data_warehouse/frontend/shared/components/InlineSourceSetup.tsx
@@ -38,7 +38,8 @@ function InternalInlineSourceSetup({
 }: InlineSourceSetupProps): JSX.Element {
     const { connectors } = useValues(sourceWizardLogic)
     const { onClear } = useActions(sourceWizardLogic)
-    const { searchParams } = useValues(router)
+    const { searchParams, location } = useValues(router)
+    const { replace } = useActions(router)
 
     const [currentView, setCurrentView] = useState<InlineSourceSetupView>('selection')
     const [selectedSource, setSelectedSource] = useState<ExternalDataSourceType | null>(null)
@@ -61,6 +62,10 @@ function InternalInlineSourceSetup({
             setSelectedSource(match.name)
             setCurrentView('connecting')
         }
+        // Consume the param so a later remount (refresh, back-navigation, cancel) doesn't force the
+        // wizard back open after the connection has already been handled.
+        const { kind: _kind, ...restParams } = searchParams
+        replace(location.pathname, restParams)
         // oxlint-disable-next-line react-hooks/exhaustive-deps
     }, [])
     const featuredSources = availableConnectors.filter((c: SourceConfig) => c.featured)

--- a/products/data_warehouse/frontend/shared/components/forms/IntegrationChoice.tsx
+++ b/products/data_warehouse/frontend/shared/components/forms/IntegrationChoice.tsx
@@ -1,4 +1,5 @@
-import { useActions } from 'kea'
+import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
 
 import {
     IntegrationChoice,
@@ -20,12 +21,29 @@ export function SourceIntegrationChoice({
     ...props
 }: SourceIntegrationChoiceProps): JSX.Element {
     const { saveFormStateBeforeRedirect } = useActions(sourceWizardLogic)
+    const { location } = useValues(router)
     const sourceKind = sourceConfig.name.toLowerCase()
+
+    // In onboarding the wizard is embedded in the page. A full-page OAuth redirect to the
+    // standalone new-source scene would drop the user out of the onboarding flow, so when we're
+    // on an onboarding route we return to the current onboarding URL with the source kind instead.
+    // InlineSourceSetup reads that kind on mount and resumes the wizard (credentials are restored
+    // from the state saved by beforeRedirect). Outside onboarding the standalone scene is correct.
+    const isOnboarding = location.pathname.includes('/onboarding')
+    let redirectUrl: string
+    if (isOnboarding) {
+        const params = new URLSearchParams(location.search)
+        params.set('kind', sourceKind)
+        redirectUrl = `${location.pathname}?${params.toString()}`
+    } else {
+        redirectUrl = urls.dataWarehouseSourceNew(sourceKind)
+    }
+
     return (
         <IntegrationChoice
             {...props}
             integration={integration ?? sourceKind}
-            redirectUrl={urls.dataWarehouseSourceNew(sourceKind)}
+            redirectUrl={redirectUrl}
             beforeRedirect={saveFormStateBeforeRedirect}
         />
     )


### PR DESCRIPTION
## Problem

In the data warehouse onboarding step, connecting an OAuth-based source (Hubspot, Salesforce, Google Ads, …) redirected the whole page to the **standalone** `/data-warehouse/new-source` scene. After the OAuth round-trip the user finished on the standalone wizard page, dropped out of the onboarding flow.

## Changes

`SourceIntegrationChoice` (the wizard-bound OAuth control) now checks the current route. When the wizard is embedded in an onboarding page, it sends the OAuth flow back to the **current onboarding URL** with `?kind=<source>` instead of the standalone scene. On return:

- `InlineSourceSetup` reads `kind` on mount and re-opens the wizard for that source.
- The wizard resumes at the credentials step via the existing `initialSource` → `setInitialConnector` → `restoreSourceFormState` path, so credentials entered before the redirect are restored (saved by the existing `beforeRedirect` / `saveFormStateBeforeRedirect`).
- The two `ONBOARDING_DATA_WAREHOUSE_VALUE_PROP` value-prop arms start on the `setup` phase when a `kind` param is present, so the picker is mounted to resume.

Deliberately contained: the standalone scene and the connect page are **untouched** — the only behavioural change is gated behind the `/onboarding` route check. No wizard logic, `SourceForm`, or kea-typegen changes were needed.

## How did you test this code?

I'm an agent (Claude Code). **This change is not verified end-to-end** and needs a manual check before merge: the OAuth round-trip can't be exercised by CI (it needs a live provider), and my environment can't run the frontend toolchain (incomplete `node_modules` — jest/tsc/typegen don't run here).

Please verify on a running stack / devbox: start DW onboarding, connect an OAuth source (e.g. Hubspot), complete the provider OAuth, and confirm you land **back in onboarding** (not `/data-warehouse/new-source`) with the wizard resumed and credentials intact. Also smoke-test a non-onboarding OAuth connect (standalone new-source scene + the connect page) to confirm they're unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split from a five-point onboarding critique (the picker/table improvements are in a separate PR). Chosen approach is the least invasive of the options considered: a route-aware redirect in `SourceIntegrationChoice` + a mount-time resume in `InlineSourceSetup`, rather than threading a return URL through the shared `SourceForm` (used by 3 surfaces) or adding a kea selector (typegen can't run in this env). Note: shares `InlineSourceSetup.tsx` with the picker PR, so a trivial rebase may be needed depending on merge order.
