### PR TITLE
fix(tiktok_ads): retry internal service timeout code 51039

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py
@@ -737,6 +737,7 @@ class TestTikTokAdsPaginator:
             ("validation_error", 40002, "Invalid parameter", False),  # Client error - not retryable
             ("server_error", 50000, "Internal server error", True),
             ("internal_service_timeout", 51001, "internal service timeout", True),  # Transient - retryable
+            ("internal_service_timeout_51039", 51039, "internal service timeout", True),  # Transient - retryable
         ]
     )
     def test_update_state_api_error_codes(self, name, api_code, message, should_be_retryable):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py
@@ -402,6 +402,7 @@ class TikTokAdsPaginator(BasePaginator):
                     50000,  # System error
                     50002,  # Error processing request on TikTok side. Please see error message for details.
                     51001,  # Internal service timeout. Transient TikTok-side error; safe to retry.
+                    51039,  # Internal service timeout. Transient TikTok-side error; safe to retry.
                     51305,  # Satellite service error
                     60001,  # The system is in maintenance.
                 ]


### PR DESCRIPTION
## Problem

The `tiktok_ads` data-warehouse import source surfaced a `ValueError` in error tracking:

> `TikTok API client error (non-retryable): internal service timeout (code: 51039)`

raised at `products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/utils.py:414` in `TikTokAdsPaginator.update_state`.

Error code `51039` is a transient, TikTok-side "internal service timeout" — the kind of error that should be retried. But it wasn't in the paginator's `retryable_codes` set, so it fell into the non-retryable branch, raised a `ValueError` carrying the `non-retryable` prefix, and failed the import job immediately. Its sibling code `51001`, with the identical "Internal service timeout" meaning, is already in the retryable set and explicitly commented as "Transient TikTok-side error; safe to retry."

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f03ca-f716-7bf1-9034-47bbabf9f3ba

## Changes

Add `51039` to `retryable_codes` in `TikTokAdsPaginator.update_state`, alongside the existing `51001`. The error now raises `TikTokAdsAPIError` (retryable) instead of a non-retryable `ValueError`, so it's retried with the existing exponential backoff rather than failing the job.

This is the right call over extending `NonRetryableErrors`: a service-side timeout is transient infrastructure noise, not a customer credential/config problem, so we should retry rather than stop.

## How did you test this code?

I'm an agent. I added a parameterized case (`51039`, "internal service timeout") to the existing `test_update_state_api_error_codes` test asserting the code is recognised as retryable (raises `TikTokAdsAPIError`). This catches a regression that no existing case covered: only `51001` was exercised for the timeout-is-retryable path, so a transient `51039` timeout would have silently kept failing the job.

Automated tests run:

- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/tiktok_ads/test/test_tiktok_ads_utils.py` — 78 passed
- `ruff check` on the two changed files — clean

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the `tiktok_ads` source. Confirmed via the PostHog error-tracking MCP tools that the failure genuinely originates in `tiktok_ads/utils.py:update_state` (full stack trace traced from the paginator through the import pipeline's `handle_non_retryable_error`), then read the source's error-handling code.

Decision: treated this as a fixable bug rather than a `NonRetryableErrors` extension. Code `51039` is a transient TikTok-side timeout — same class as the already-retryable `51001` — so the correct fix is to retry it, not to confirm it as non-retryable. Scoped strictly to adding the one code plus a regression test; no retry-policy or unrelated changes. Checked open PRs (including the maintainer's) first to rule out a duplicate.
