### PR TITLE
feat(phai): add server-side search filter to TaskTracker

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6749,25 +6749,25 @@ snapshots:
     scenes-app-surveys-surveyresponsekeysreference--webhook--light:
         hash: v1.k794b7964.9b5c484a3a1bd7a09c266a1f164e3ed9eef3ffabbcd12253f0843b3f0b69a808.cc6Rai2vShlFJA_KypMbVcc1IIaVX0nTcZ29RPEEZjo
     scenes-app-tasks--empty--dark:
-        hash: v1.k794b7964.a4d6867ee7ae54ba44c7f6f4002d6e33fa830d206ac6afa05f2b89e0ca95e346.PDSiDJLaSvGtlHV3OjGJ6kswEGvkiWvnCzctD2gAQ5g
+        hash: v1.k794b7964.2a229a3f53490cc99b64a15121f858f85ee90be46ce4c8264ed9ad1a0fd2fd88.w9qFySaTmjgYwFxL10ckNfEHq1-F9ZuJbzLn-wtE9Ag
     scenes-app-tasks--empty--light:
-        hash: v1.k794b7964.29c0f8bc2017536737772598446346d98313568315f72ededbf1d039607547e0.OU_OMY38iwmrrhLdUcM_p-SzDyhjQdoWZzMPV68MXL4
+        hash: v1.k794b7964.26738f6d7f71991a943cb09851df2e75ba06e297db673178542b54d143d446b2.Al9AsDXcTSwZjXBKJa1DQFB9hodBSgVGFbFCsoZAYas
     scenes-app-tasks--list-load-error--dark:
-        hash: v1.k794b7964.a60a5d6cd5201b8e3f6621a7282d1b87a916e7d3da33702fa37e4ea04cfe3e0b.JjeTJaTZTYuFHMtutyvlUxleGBRoHAXfwBh9uAZO36I
+        hash: v1.k794b7964.d4c5ccf7f63724f0add4de82ec33eb7bb01df963666920af61d6699e3b709155.hdfAIjYpVUPW-72JAMt-60gOKVyqQBvnLnz4SNIAkl0
     scenes-app-tasks--list-load-error--light:
-        hash: v1.k794b7964.083e8fe00fe541815b5c7252bf2ebe087ac6742ccb968f789f0f24869fb97d91.pXzJliBz214_88INCoXcrF8TKRrqEKezPr2pOsrOm2c
+        hash: v1.k794b7964.b5cad08684e6c9bbae28221cd49e4c90b759821314638988f8031ad132a07964.8vDj1yR82QM88WRq78IUHodUMAYB74Ic2-spmA-neZY
     scenes-app-tasks--list-with-composer--dark:
-        hash: v1.k794b7964.5435b6f664c848c8e1724754d4e7226c8c29408bc8aa28a760ec383ddd9164aa.nyXHi9_h37_s0KjS06fJ8LjfegSLs-eaCz947neTM38
+        hash: v1.k794b7964.16c59902a774acd3799d2f1e33b365f6950445d060eb0c333bd1727c87784663.2Rdgn90Q9bAlOZbR0J-Tkj0xEBC5CQDAj5pLgbjGMqo
     scenes-app-tasks--list-with-composer--light:
-        hash: v1.k794b7964.0873123f13ccdc83104f94c89d562a43c89b7c2c788e1264f499d38f7a78ad79.oJw7QWMutjxv893Qy26gGCEIbfcgvZD71mvuvmhT8hc
+        hash: v1.k794b7964.537a4a32d45e825b4e70af09861da3ff8544e48b6537081ae77692fe3d427d52.5FLb9BmdvoEzENBWY8hb5o0htemfLsUVgdcfWHrD5Yc
     scenes-app-tasks--loading--dark:
-        hash: v1.k794b7964.336253fda9c68bf83ca28b871bf27884477122fca2ec37ebabe896328ffccd20.yWEkLajqfOOsGTBOfDpai_9PPPhAVlBe8gq4gUyv62s
+        hash: v1.k794b7964.dd70956f52ca13614528b72cc7f564a4cbf44034df75dc80faee0451b97aa88d.Q6CBG7oYAO_mE1n0nSRxGWuazxzUtLXnLHC55zls8_U
     scenes-app-tasks--loading--light:
-        hash: v1.k794b7964.a36e51410e0365e0eefa8ae7895f8ee93f7cea01c4cb1c5d46ae406ae3ebf7b1.zLw6TK1IHBMqzeQkNJZL76OXqSWt-REC_xKRb-IsCrM
+        hash: v1.k794b7964.e7e9c42f73ffcafe77e8afd6113b31f1a237ddadfe22fe873dd3688909f1da61.Y7Mr50uPW0-Kx5HPq8M872WEc5qlJzPz6rQ35su7F20
     scenes-app-tasks--mobile-list--dark:
-        hash: v1.k794b7964.8ba0a2f099119b20d8165074c51c01fcf933ad76a5f6b2a3600f44fb4c8a0d14.lKHlmKnSsLNUVbsTq_V8UcjjN4NDXJ2Onuu1t3Giqg4
+        hash: v1.k794b7964.8b8954327495955b38c9d7cb370d629a455427020afa88d02bb245aa0c0179b8.INO40pNr6q1c-n7E0o__E3IxQLCkNMXAWWYHJiwYleY
     scenes-app-tasks--mobile-list--light:
-        hash: v1.k794b7964.1e8d64703050ec1702624407ddc5891bc41f4dac998bde052d43f13fbffcd9a7.sxnMNRCbiRGpf0zx8A7h5dnxb2FqCTpez_6Hr4_TOfA
+        hash: v1.k794b7964.d037ad8f6622654e28ff3a9d072c5a6eafdda8f5c647860a89557bcbe3c779f0.YJudQaFNTmR90w12ID3HRugQSz8-AernL6qG01j-doQ
     scenes-app-tasks--mobile-new-task--dark:
         hash: v1.k794b7964.94c3479bf0e00dc38972551e04e81ea755a13e4679b81f935f1ff12c501e95ae.GExTQnD2Sx1EQlmYDqHNccqQfyYRW-aYBkH9B3AbwjU
     scenes-app-tasks--mobile-new-task--light:
@@ -6777,33 +6777,33 @@ snapshots:
     scenes-app-tasks--mobile-task-selected--light:
         hash: v1.k794b7964.fcba0f8e9e7360da3c671debfff263fc22467c9820e5706207523add08e29d99.Nr7dbzdN-8LSM4JvLEOty1cjbb4zz4XFhGfJp9pH8iQ
     scenes-app-tasks--new-task--dark:
-        hash: v1.k794b7964.5435b6f664c848c8e1724754d4e7226c8c29408bc8aa28a760ec383ddd9164aa.DtHTFuTejBqpfhCO8FgLuAhKadOx0aeFUMTb7gKTXWU
+        hash: v1.k794b7964.16c59902a774acd3799d2f1e33b365f6950445d060eb0c333bd1727c87784663.lE9tbirpfGIJfkIw5H4dXX9fncaqnaM-qcD1J3x8Yv4
     scenes-app-tasks--new-task--light:
-        hash: v1.k794b7964.0873123f13ccdc83104f94c89d562a43c89b7c2c788e1264f499d38f7a78ad79.Zi2QsmppKkEO3piOxpmRAC-s1BFLahgR9MqWLhWuih0
+        hash: v1.k794b7964.3674cdd577b0a22f9459dfd9e7c6e98c36a7bf3b9a68e8e7508ac6a0366708d7.QZSXTiTa56QfQlAsFFRfl5KniKwm0rvJdkIvjwliLmM
     scenes-app-tasks--task-detail-loading--dark:
-        hash: v1.k794b7964.036059c7da17026e0b6bcefd1424e247f6704e22e0ea2224c7923fa158a893cd.mCbM-Nn0alpVZeNCLn0Rtm7H0tdQGjxNfw2VwvQWbzk
+        hash: v1.k794b7964.b09744582ebfb6d0aa98cd13bad8cdcf8822be75bcae6b2cbcc629ad1f3ba6f6.4hjsH9SRmNf7A_4bXyDGyRhiP9gpMa1Hd_h9929iSNQ
     scenes-app-tasks--task-detail-loading--light:
-        hash: v1.k794b7964.a57d30a1035c87baa14e1968c697c7a8fec37125ac89432c87a9d08a325c6755.uf5e5AuhnUeCjIkXs4beBgD0ZJzUfhh-e3gSkTmxkLM
+        hash: v1.k794b7964.372a0b839c9e364b8a9cb88029baf5501fab530236912036f1bb7cadad2a9f2d.ZwOyzAplL-7oLsLZhs8U80XVHSBQX2trxvpcQusiG_E
     scenes-app-tasks--task-load-error--dark:
-        hash: v1.k794b7964.b945c04a5f6ce7dce2c1b38e46cf57df2c5f18eb8ba2f7ee8973c78035125465.kggPLzQhG1IhgnDvoy6odZpMs16As580yZ-09bNNr2o
+        hash: v1.k794b7964.86670a5cd725be9f8f82ae187271572354582f97b015033a674a3fe074e60078.3X4ATJf6GjVtAx40icISr3TrfHsuzqiHMYyBJjGxFHQ
     scenes-app-tasks--task-load-error--light:
-        hash: v1.k794b7964.9d1c4617ee0818a03ace8f5e1124f4dc066d60d8e61f8868ff3de57955759759._FR6XkStwjzkudJOFHITRTteTaOUzk0Qr_chrjJHxtQ
+        hash: v1.k794b7964.70305b1c71a4dd3a98b7e3368f95c21bfdeb7e30ecbf34cfaeb042d30fcb9b02.SO61ZIAaFT9t8RNUEzVKaARbKiWWji1u0EtyIZDCM3Q
     scenes-app-tasks--task-not-found--dark:
-        hash: v1.k794b7964.45b9708ac9d52cd9205ba49d9dacbf22ae862bd93592c3b1cfd6ebbca82388b3.g0kAG9SMKfXB2L7iu5dFWxxk0R0qRD5o0t9S8OxfMS8
+        hash: v1.k794b7964.332754636998443379bc65295201d607195b95e6734c01a7bcaee404f4db5f76.2_b9jxdDF0AdI1LvwwFScEqQ2FmMkGuijl-HVr5iARU
     scenes-app-tasks--task-not-found--light:
-        hash: v1.k794b7964.4984e3b1be757bea26eb62183f1ff0f8d765654e57e88119164140d08eb86a22.PzkPd5Gio2FjQVIClJaRykwCa5WtEdFzlCPW7UazGnk
+        hash: v1.k794b7964.9e2c572e5d759abb2cd78a8550c9f7947b595fbf49081c4f94b0da200371f272.iZlhOSdAT4QYkRzPpd06UeuoQqd2Qs21o6C5UPVce2Y
     scenes-app-tasks--task-run-not-found--dark:
-        hash: v1.k794b7964.948ed15dc2cacf0c1ae3511803830c1aadbc6f1ae2a0bd271db71ddfba928338.sWKmNqmJfo11A77GadBwwJSCIJbCU2sYMPFWojdnr1k
+        hash: v1.k794b7964.ed230a981c24663792c1df13d16dd8461f35fe15e4aa1965894084fbab68b117.rhSCibvjYukRnr74a1jUyVEWHUygAfzKqD7aOHjPBwc
     scenes-app-tasks--task-run-not-found--light:
-        hash: v1.k794b7964.2b03d9bda67392d193e5ccc1793b4c2d38e5774fece2a95d0ffe72b1bc51d972.vqP6OdDP9_HMGGsodTSmbMlOi9xdl0Xw5ELBoXF4TkQ
+        hash: v1.k794b7964.2ba26c7d208c96437ce4d9c9a7f9fed85125b5ac37f7e901a65391ffb7a300cb.R6p-TsMtTeS78M-yuAwGoC5C_iqX26NW6w2Bvc0zxo4
     scenes-app-tasks--task-runs-load-error--dark:
-        hash: v1.k794b7964.476ad4a74ebba7c06613b27f169471dcb9221a852eae3265ad4618b3141bb43c.TeXVuyo4ziRfDOfHg6lllLZ16ppKxvi7TAN-w2Aae3U
+        hash: v1.k794b7964.c540707360fc3fbda25bfc57c8a0e8ef4c24074ca8baccf39ed2231b4df8b1d8.gYnxqtXSk1a31kKxA6Vek67Ytabt4BayCmKhw9FBBoU
     scenes-app-tasks--task-runs-load-error--light:
-        hash: v1.k794b7964.dd3089cd902fc9598e5850a1c5693766c861df7e3c448f947860dcf90252df60.AXhOq0KvByljMk7iWLipy8o4ny2fhhsn6-3MYBW-Z6g
+        hash: v1.k794b7964.49c406248302859f8a551be6668b1a92984cbb087272d782562dba210158a8d8.LocFi59O--ouDjbYebmk1tJoXk6L4bmL4j4-KgaKYxI
     scenes-app-tasks--task-selected--dark:
-        hash: v1.k794b7964.43141d26e6c595c08b802fc27b45f0b789b9a30e6adb9f89cc7cf6f84589af0c.igILN389iz6FTrt2YEcIXOkKbmvVa0O4V3dGEt67IyI
+        hash: v1.k794b7964.b3b7094f97b9140b6a58a9886a5166cfa9140870a7a907160fcf347377773b61.AKASaTJicvtjc8NQAG_SM2R2cvVEyoXYVkseLCAM_14
     scenes-app-tasks--task-selected--light:
-        hash: v1.k794b7964.e4fe2d6614fb9c055af9651beb6f0c419b1103ecea61b67f5cdcd5071429e3c9.LPqOfl6yK7UKwgvALvn7RmWj3OeOo36NAlMLcsf84iQ
+        hash: v1.k794b7964.7cd83d720d4daa8e45308d356b736e73177946088853cd744c86c6b6780d1a36.Ey-ysUe5bUVxNJrobBpq1pkzP9ysopvIVJgSOWyE87I
     scenes-app-user-interviews-invite-preview-modal--emailable--dark:
         hash: v1.k794b7964.0cd3e50dcd442e57712b0ebe06d6952c589a4c88c49fca26771c9e17bc07e6dc.iNYX9Up5MvnGHGT7ku7yMuFIJ0NnbSspOz6Ce0Kb2cU
     scenes-app-user-interviews-invite-preview-modal--emailable--light:

--- a/products/posthog_ai/frontend/logics/tasksLogic.ts
+++ b/products/posthog_ai/frontend/logics/tasksLogic.ts
@@ -19,6 +19,7 @@ export const tasksLogic = kea<tasksLogicType>([
     actions({
         openTask: (taskId: Task['id']) => ({ taskId }),
         updateTask: (task: Task) => ({ task }),
+        setSearchQuery: (search: string) => ({ search }),
     }),
 
     loaders(({ values }) => ({
@@ -66,6 +67,12 @@ export const tasksLogic = kea<tasksLogicType>([
         tasks: {
             updateTask: (state, { task }) => state.map((t) => (t.id === task.id ? task : t)),
         },
+        searchQuery: [
+            '' as string,
+            {
+                setSearchQuery: (_, { search }) => search,
+            },
+        ],
         tasksError: [
             null as string | null,
             {
@@ -75,9 +82,15 @@ export const tasksLogic = kea<tasksLogicType>([
         ],
     }),
 
-    listeners(() => ({
+    listeners(({ actions }) => ({
         openTask: ({ taskId }) => {
             router.actions.push(`/tasks/${taskId}`)
+        },
+        // Debounce typing before hitting the server; the loader's own `breakpoint` then drops any
+        // response that a newer query has already superseded.
+        setSearchQuery: async ({ search }, breakpoint) => {
+            await breakpoint(300)
+            actions.loadTasks({ search: search || undefined })
         },
     })),
 ])

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TasksListColumn.tsx
@@ -1,7 +1,7 @@
 import { useActions, useValues } from 'kea'
 
 import { IconPlus, IconPlusSmall } from '@posthog/icons'
-import { LemonBanner, LemonButton, LemonDivider, LemonSkeleton } from '@posthog/lemon-ui'
+import { LemonBanner, LemonButton, LemonDivider, LemonInput, LemonSkeleton } from '@posthog/lemon-ui'
 
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
 import { Link } from 'lib/lemon-ui/Link'
@@ -18,8 +18,8 @@ interface TasksListColumnProps {
 }
 
 export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListColumnProps): JSX.Element {
-    const { tasks, tasksLoading, tasksError } = useValues(tasksLogic)
-    const { loadTasks } = useActions(tasksLogic)
+    const { tasks, tasksLoading, tasksError, searchQuery } = useValues(tasksLogic)
+    const { loadTasks, setSearchQuery } = useActions(tasksLogic)
 
     const rows =
         tasksLoading && tasks.length === 0 ? (
@@ -34,7 +34,7 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
             <LemonBanner
                 type="error"
                 className="mx-1"
-                action={{ children: 'Retry', onClick: () => loadTasks() }}
+                action={{ children: 'Retry', onClick: () => loadTasks({ search: searchQuery || undefined }) }}
                 data-attr="tasks-load-error"
             >
                 <p className="mb-0">We couldn't load your tasks.</p>
@@ -42,17 +42,28 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
             </LemonBanner>
         ) : tasks.length === 0 ? (
             <div className="flex flex-col items-center justify-center text-center py-8 text-muted">
-                <p className="text-sm mb-0">No tasks yet</p>
+                <p className="text-sm mb-0">{searchQuery ? 'No tasks match your search' : 'No tasks yet'}</p>
             </div>
         ) : (
             tasks.map((task) => <TaskListItem key={task.id} task={task} isActive={task.id === selectedTaskId} />)
         )
+
+    const searchInput = (
+        <LemonInput
+            type="search"
+            placeholder="Search tasks…"
+            value={searchQuery}
+            onChange={setSearchQuery}
+            data-attr="tasks-search"
+        />
+    )
 
     if (isMobile) {
         // The page (main) scrolls — no inner scroll container. Extra bottom padding keeps the last
         // rows clear of the floating create button.
         return (
             <>
+                <div className="px-1 pb-2">{searchInput}</div>
                 <div className="flex flex-col gap-1 pb-24">{rows}</div>
                 <LemonButton
                     type="primary"
@@ -81,6 +92,7 @@ export function TasksListColumn({ selectedTaskId, isMobile = false }: TasksListC
                     <IconPlusSmall className="size-4" />
                 </Link>
             </div>
+            <div className="px-1 pb-2 shrink-0">{searchInput}</div>
             <LemonDivider className="m-0 shrink-0" />
 
             <ScrollableShadows


### PR DESCRIPTION
## Problem

Users landing on the TaskTracker (`/tasks`) have no way to filter the task list — they have to scroll through everything to find a specific task. The backend `api.tasks.list()` endpoint already supports a `search` query param for server-side filtering, but nothing in the frontend was wiring it up.

## Changes

- Added a `setSearchQuery` action and `searchQuery` reducer to `tasksLogic`.
- Added a `setSearchQuery` listener that debounces 300 ms before calling `loadTasks({ search })`, so keystrokes don't spam the API. The loader's existing `breakpoint()` call drops any response that a newer in-flight query has already superseded, preventing stale results from clobbering the latest state.
- Added a `LemonInput type="search"` above the task list in both desktop and mobile layouts (`TasksListColumn`).
- Empty state now distinguishes "No tasks match your search" from "No tasks yet".
- The error-state Retry button re-runs `loadTasks` preserving the current `searchQuery` term, so a retry after a network blip doesn't silently drop the active filter.

## How did you test this code?

I'm an agent and did not run a live browser smoke-test. This is a frontend-only wiring change: it exposes a `search` param the backend already filters on and reuses the loader's existing `breakpoint` cancellation, so no new automated tests were added. The meaningful paths to verify by hand are typing to filter, clearing to restore the full list, and confirming the error-state Retry preserves the active query.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. The kea logic changes (new action, reducer, and debounced listener) followed `/writing-kea-logics` conventions — business logic stays in the logic file, the component only binds values and dispatches actions. The `listeners(({ actions }) => ({` destructuring was added so the listener can dispatch `actions.loadTasks` directly. No architectural decisions were needed beyond that; the backend filter and the loader's `breakpoint` pattern were already in place.
