### PR TITLE
fix(billing): show product name in usage limit approaching banner

### DIFF
--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -586,21 +586,13 @@ describe('buildUsageLimitApproachingMessage', () => {
         )
     })
 
-    it('should use the product name even when usage_key is missing', () => {
-        const result = buildUsageLimitApproachingMessage([{ name: 'Session replay', percentage_usage: 0.9 }])
-        expect(result.message).toContain('Session replay allocation')
-    })
-
-    it('should fall back to usage_key when name is missing', () => {
-        const result = buildUsageLimitApproachingMessage([
-            { name: '', percentage_usage: 0.9, usage_key: 'signals_credits' },
-        ])
-        expect(result.message).toContain('signals_credits allocation')
-    })
-
-    it('should fall back to "usage" when both name and usage_key are missing', () => {
-        const result = buildUsageLimitApproachingMessage([{ name: '', percentage_usage: 0.9 }])
-        expect(result.message).toContain('usage allocation')
+    it.each([
+        { name: 'Session replay', usage_key: undefined, expected: 'Session replay allocation' },
+        { name: '', usage_key: 'signals_credits', expected: 'signals_credits allocation' },
+        { name: '', usage_key: undefined, expected: 'usage allocation' },
+    ])('should resolve label to "$expected" (name="$name", usage_key=$usage_key)', ({ name, usage_key, expected }) => {
+        const result = buildUsageLimitApproachingMessage([{ name, percentage_usage: 0.9, usage_key }])
+        expect(result.message).toContain(expected)
     })
 
     it('should format percentage with up to 2 decimal places', () => {

--- a/frontend/src/scenes/billing/billing-utils.spec.ts
+++ b/frontend/src/scenes/billing/billing-utils.spec.ts
@@ -572,7 +572,7 @@ describe('buildUsageLimitApproachingMessage', () => {
             { name: 'Session replay', percentage_usage: 0.9, usage_key: 'recordings' },
         ])
         expect(result.title).toEqual('You will soon hit your usage limit')
-        expect(result.message).toEqual('You have currently used 90% of your recordings allocation.')
+        expect(result.message).toEqual('You have currently used 90% of your Session replay allocation.')
     })
 
     it('should build message for multiple products', () => {
@@ -582,12 +582,24 @@ describe('buildUsageLimitApproachingMessage', () => {
         ])
         expect(result.title).toEqual('You will soon hit your usage limits')
         expect(result.message).toEqual(
-            'You are approaching your usage limits: 90% of your recordings allocation, 87% of your feature_flag_requests allocation.'
+            'You are approaching your usage limits: 90% of your Session replay allocation, 87% of your Feature flags & Experiments allocation.'
         )
     })
 
-    it('should handle missing usage_key', () => {
+    it('should use the product name even when usage_key is missing', () => {
         const result = buildUsageLimitApproachingMessage([{ name: 'Session replay', percentage_usage: 0.9 }])
+        expect(result.message).toContain('Session replay allocation')
+    })
+
+    it('should fall back to usage_key when name is missing', () => {
+        const result = buildUsageLimitApproachingMessage([
+            { name: '', percentage_usage: 0.9, usage_key: 'signals_credits' },
+        ])
+        expect(result.message).toContain('signals_credits allocation')
+    })
+
+    it('should fall back to "usage" when both name and usage_key are missing', () => {
+        const result = buildUsageLimitApproachingMessage([{ name: '', percentage_usage: 0.9 }])
         expect(result.message).toContain('usage allocation')
     })
 

--- a/frontend/src/scenes/billing/billing-utils.ts
+++ b/frontend/src/scenes/billing/billing-utils.ts
@@ -696,8 +696,8 @@ export function buildUsageLimitApproachingMessage(
 
     const usageDetails = products.map((p) => {
         const percentage = parseFloat((p.percentage_usage * 100).toFixed(2))
-        const usageKey = p.usage_key?.toLowerCase() || 'usage'
-        return `${percentage}% of your ${usageKey} allocation`
+        const productName = p.name || p.usage_key?.toLowerCase() || 'usage'
+        return `${percentage}% of your ${productName} allocation`
     })
 
     const roleName = membershipLevelToName.get(minimumBillingAccessLevel)


### PR DESCRIPTION
## Problem

When an org hits a usage limit, the "approaching limit" banner reads "You have currently used 100% of your **signals_credits** allocation." `signals_credits` is the raw billing quota identifier (the `QuotaResource` enum value), not a name a user recognizes. For the Inbox product it should read "...100% of your **Inbox** allocation."

## Changes

`buildUsageLimitApproachingMessage` in `billing-utils.ts` interpolated `product.usage_key` into the banner text. It now uses the human-readable `product.name` (which is already passed in and used by the sibling `buildUsageLimitExceededMessage`), falling back to `usage_key` then `'usage'` if a name isn't available. Updated the unit tests to assert the product name and cover the fallback chain.

## How did you test this code?

I'm an agent (PostHog Slack app). I updated the existing Jest unit tests in `billing-utils.spec.ts` to assert the new behavior and the name → usage_key → "usage" fallback chain. I could not run Jest in my sandbox (not installed), so the suite still needs to run in CI — the changes are a one-line template fix plus mechanical test updates.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Fix was driven by a user report in Slack that the usage-limit banner showed `signals_credits` instead of "Inbox". Root cause: the approaching-limit message builder used `usage_key` while the exceeded-limit builder used `name`. Fixed for consistency by preferring `name`. No skills were required for this change.
