### PR TITLE
chore(activity-logs): track third-party AI consent toggle

### DIFF
--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -279,6 +279,7 @@ field_name_overrides: dict[AuditableScope, dict[str, str]] = {
         "is_member_join_email_enabled": "member join email notifications",
         "session_cookie_age": "session cookie age",
         "default_experiment_stats_method": "default experiment stats method",
+        "is_ai_data_processing_approved": "third-party AI services",
     },
     "BatchExport": {
         "paused": "enabled",
@@ -536,7 +537,6 @@ field_exclusions: dict[AuditableScope, list[str]] = {
         "setup_section_2_completed",
         "plugins_access_level",
         "is_hipaa",
-        "is_ai_data_processing_approved",
         "never_drop_data",
     ],
     "BatchExport": [

--- a/posthog/test/activity_logging/test_organization_activity_logging.py
+++ b/posthog/test/activity_logging/test_organization_activity_logging.py
@@ -172,6 +172,19 @@ class TestOrganizationActivityLogging(ActivityLogTestHelper):
         assert twofa_change is not None
         self.assertEqual(twofa_change["after"], True)
 
+    def test_organization_ai_data_processing_consent_logging(self):
+        organization = self.create_organization("AI Consent Test Org")
+        self.update_organization(organization["id"], {"is_ai_data_processing_approved": False})
+
+        log = ActivityLog.objects.filter(organization_id=organization["id"], activity="updated").first()
+        assert log is not None
+        assert log.detail is not None
+        changes = log.detail.get("changes", [])
+        consent_change = next((c for c in changes if c["field"] == "third-party AI services"), None)
+        assert consent_change is not None
+        self.assertEqual(consent_change["before"], True)
+        self.assertEqual(consent_change["after"], False)
+
     def test_organization_membership_creation_activity_logging(self):
         org_response = self.create_organization("Test Membership Org")
         org = Organization.objects.get(id=org_response["id"])

--- a/posthog/test/activity_logging/test_organization_activity_logging.py
+++ b/posthog/test/activity_logging/test_organization_activity_logging.py
@@ -179,6 +179,7 @@ class TestOrganizationActivityLogging(ActivityLogTestHelper):
         log = ActivityLog.objects.filter(organization_id=organization["id"], activity="updated").first()
         assert log is not None
         assert log.detail is not None
+        self.assertEqual(log.user, self.user)
         changes = log.detail.get("changes", [])
         consent_change = next((c for c in changes if c["field"] == "third-party AI services"), None)
         assert consent_change is not None


### PR DESCRIPTION
## Problem

The org-level "Enable PostHog features that use third-party AI services" toggle (`is_ai_data_processing_approved`) is the one setting on the `Organization` model that a regular org admin can flip in the UI but that produces **no activity-log entry**. 

<img width="1334" height="358" alt="image (40)" src="https://github.com/user-attachments/assets/9d2e8926-5b5b-48a7-835a-bb1858a84b83" />


The field was swept into `field_exclusions["Organization"]` when Organization activity logging was first added (#36643), alongside genuinely noisy/derived fields (billing internals, relations, deprecated onboarding flags). Because it was the only human-editable toggle in that exclusion set, and because a change to only an excluded field yields empty `changes` (so `log_activity` writes nothing), toggling it left no trace.

## Changes

- Remove `is_ai_data_processing_approved` from `field_exclusions["Organization"]` so consent changes are now recorded under the existing `Organization` activity scope.

## 🤖 Agent context

Investigated a support question about why this toggle wasn't appearing in activity logs, traced it to the `field_exclusions["Organization"]` list, and confirmed via the org serializer's `read_only_fields` that this is the only user-editable toggle among the excluded fields.

No new scope, signal handler, migration, or frontend change is needed — the `Organization` scope and its describer already exist; this field was just being filtered out of the change diff. It will surface in the activity-log scope filter the first time any org records a change to it.

The other excluded compliance/security fields (`is_hipaa`, `never_drop_data`, `plugins_access_level`) are read-only in the org serializer and set out-of-band, so they're intentionally left excluded here.