### PR TITLE
fix(funnels): remove forced min-height on step table headers

### DIFF
--- a/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
+++ b/frontend/src/scenes/insights/views/Funnels/FunnelStepsTable.tsx
@@ -176,7 +176,7 @@ export function FunnelStepsTable(): JSX.Element | null {
             title: (
                 <LemonRow
                     icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />}
-                    style={{ font: 'inherit', padding: 0 }}
+                    style={{ font: 'inherit', padding: 0, minHeight: 0 }}
                     size="small"
                 >
                     <EntityFilterInfo


### PR DESCRIPTION
## Problem

The breakdown funnel step table renders each step's column header through a `LemonRow`. Its inline `style={{ font: 'inherit', padding: 0 }}` neutralizes the row's font and padding so it blends into the `<th>`, but it never overrode `LemonRow`'s `min-height` (`2rem` for `size="small"`). So every step header was pinned taller than its actual content (the Lettermark + event name), rendering bulkier than the plain-text group headers beside it.

## Changes

- Add `minHeight: 0` to the existing inline style on the funnel step header `LemonRow`, so it collapses to its content height and lines up with the adjacent headers.
- Scoped deliberately to the call site. `LemonRow`'s `min-height` is long-standing and shared by menus, buttons, and rows across the app, so it's left untouched to avoid regressing those.

## How did you test this code?

I'm an agent. I did **not** run automated tests or manual browser verification — this checkout has no `node_modules`, so `format`/`typecheck`/dev-server were unavailable. The change is a single valid `CSSProperties` field (`minHeight: 0`) added to an inline style that already sets `padding`/`font`. Diagnosis was via CSS analysis of `LemonRow.scss` (`.LemonRow--small { min-height: 2rem }`) and the `Lettermark` sizing. A quick visual check of a funnel with a breakdown is worth doing before merge — happy to attach a before/after if useful.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes — internal UI tweak.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a report that a `min-height` on `LemonRow` was making funnel step table headers render oddly. Finding: the `min-height` is **not** a recent change on `master` — it's original to `LemonRow` (blame only surfaces a Dec 2025 reformatting pass), and the funnel header has used this `LemonRow` pattern since 2022. The actual mechanism is that the header's inline style zeroes padding/font but not `min-height`, pinning the header to 2rem.

Chose the call-site override (`minHeight: 0`) over editing `LemonRow.scss` because the shared component's height is intentional everywhere else (menus, buttons, dropdown rows) — a global change would be a wide blast radius for a localized symptom. Left the two "significance highlight" `LemonRow` pills in the same table untouched, since the report was specifically about the step headers.

Tooling: Claude Code (Opus 4.8). No repo-provided skills were applicable to this one-line frontend change.
