### PR TITLE
fix(signals): route scout model override with its runtime adapter

### DIFF
--- a/products/signals/backend/scout_harness/model_selection.py
+++ b/products/signals/backend/scout_harness/model_selection.py
@@ -93,6 +93,12 @@ RUNTIME_ADAPTER_KEY = "runtime_adapter"
 RUNTIME_ADAPTER_CLAUDE = "claude"
 RUNTIME_ADAPTER_CODEX = "codex"
 
+# The runtimes a payload may pin explicitly. An unknown value (typo, unsupported runtime) is dropped
+# back to id inference rather than threaded onward: it would otherwise be written into the run state
+# and blow up downstream when cast to the `RuntimeAdapter` enum — failing the run the gate must never
+# be able to break.
+_KNOWN_RUNTIME_ADAPTERS = frozenset({RUNTIME_ADAPTER_CLAUDE, RUNTIME_ADAPTER_CODEX})
+
 
 @dataclass(frozen=True)
 class ScoutModel:
@@ -172,13 +178,14 @@ def _parse_model_spec(spec: object) -> tuple[float | None, str | None]:
     A model entry's value is either a bare number (its fraction; runtime inferred from the id) or an
     object `{"fraction": <0..1>, "runtime_adapter": "claude"|"codex"}` that pins the runtime
     explicitly. Returns `(None, ...)` for a malformed fraction (not a positive number, or a bool) so
-    the caller drops the entry rather than failing the run. A non-string `runtime_adapter` is ignored
-    (treated as unset → inferred), so a typo there can't route the run nowhere.
+    the caller drops the entry rather than failing the run. A `runtime_adapter` that isn't one of the
+    known runtimes (non-string, typo, unsupported) is ignored (treated as unset → inferred from the
+    id), so a payload typo can't route the run onto a runtime the agent server can't honor.
     """
     if isinstance(spec, dict):
         weight = spec.get(FRACTION_KEY)
         adapter_value = spec.get(RUNTIME_ADAPTER_KEY)
-        adapter = adapter_value if isinstance(adapter_value, str) and adapter_value else None
+        adapter = adapter_value if adapter_value in _KNOWN_RUNTIME_ADAPTERS else None
     else:
         weight = spec
         adapter = None

--- a/products/signals/backend/scout_harness/model_selection.py
+++ b/products/signals/backend/scout_harness/model_selection.py
@@ -185,7 +185,9 @@ def _parse_model_spec(spec: object) -> tuple[float | None, str | None]:
     if isinstance(spec, dict):
         weight = spec.get(FRACTION_KEY)
         adapter_value = spec.get(RUNTIME_ADAPTER_KEY)
-        adapter = adapter_value if adapter_value in _KNOWN_RUNTIME_ADAPTERS else None
+        # `isinstance` first: an unhashable value (JSON array/object) would raise from the set
+        # membership test, and that escapes `_read_payload`'s guard and would fail the run.
+        adapter = adapter_value if isinstance(adapter_value, str) and adapter_value in _KNOWN_RUNTIME_ADAPTERS else None
     else:
         weight = spec
         adapter = None

--- a/products/signals/backend/scout_harness/model_selection.py
+++ b/products/signals/backend/scout_harness/model_selection.py
@@ -3,9 +3,12 @@
 Default posture: leave the agent model unset (`None`) so the sandbox agent server uses its
 built-in default. The flag lets scouts be routed onto other models — for no-deploy A/B/n trials of
 new models (open-weights GLM, a newer GPT, …) against the default on the real scout workload. The
-resolved string is passed straight through `CustomPromptSandboxContext.model` → `Task.create_and_run`
-→ the agent server, and per-run model is tagged on each `$ai_generation` so runs are comparable by
-model in LLM analytics.
+resolved model is passed — together with the runtime adapter that can serve it — straight through
+`CustomPromptSandboxContext` → `Task.create_and_run` → the agent server, and per-run model is tagged
+on each `$ai_generation` so runs are comparable by model in LLM analytics. The runtime adapter must
+travel with the model: the agent server only knows two runtimes (`claude` → Anthropic, `codex` →
+OpenAI) and derives the provider from the runtime, so a model id handed over with no runtime can't be
+routed and silently falls back to the server default.
 
 Everything is driven by the flag's JSON payload, keyed by team → scout → model, so a single payload
 configures any number of teams (team 2, internal side projects, …) with a different model mix each —
@@ -30,7 +33,9 @@ distinct_id) is the single source of truth; a team with no entry runs entirely o
 - `scouts` — `{skill_name: {model_id: fraction}}`. Each value maps a model id to the fraction of
   that scout's runs (0..1) it serves. `signals-scout-team-self-driving` above runs 20% on glm-5.2,
   20% on gpt-5.5, and the remaining 60% on the agent-server default. `"*"` is the fallback
-  distribution for scouts not listed explicitly.
+  distribution for scouts not listed explicitly. A model's value may instead be an object
+  `{"fraction": 0.2, "runtime_adapter": "codex"}` to pin its runtime explicitly; with the bare-number
+  form the runtime is inferred from the id (`claude-*` → `claude`, everything else → `codex`).
 - The reserved `"default"` key inside a scout's map names the model the *remaining* (unallocated)
   runs use instead of the agent-server default — its value is a model-id string, not a fraction.
 
@@ -46,6 +51,7 @@ from __future__ import annotations
 
 import json
 import hashlib
+from dataclasses import dataclass
 
 import posthoganalytics
 
@@ -75,6 +81,42 @@ WILDCARD = "*"
 # of the agent-server default). Its value is a model-id string, not a fraction — a model id of
 # literally "default" is not addressable, which is fine (real ids look like `@cf/...`, `gpt-5.5`).
 DEFAULT_MODEL_KEY = "default"
+
+# Keys recognized in the object form of a model entry (the alternative to a bare fraction):
+# `{"fraction": <0..1>, "runtime_adapter": "claude"|"codex"}`.
+FRACTION_KEY = "fraction"
+RUNTIME_ADAPTER_KEY = "runtime_adapter"
+
+# The two agent runtimes the agent server exposes. A model id alone can't be routed — the server
+# derives its provider (Anthropic / OpenAI) from the runtime — so every routed model also carries a
+# runtime, either pinned in the payload or inferred from the id by `_infer_runtime_adapter`.
+RUNTIME_ADAPTER_CLAUDE = "claude"
+RUNTIME_ADAPTER_CODEX = "codex"
+
+
+@dataclass(frozen=True)
+class ScoutModel:
+    """The agent-model override resolved for one scout run.
+
+    `model` is the model id; `None` keeps the agent-server default (and `runtime_adapter` is then
+    also `None`). When a model is chosen, `runtime_adapter` names the agent runtime that can serve it
+    — it must travel with the model because the agent server derives the LLM provider from the
+    runtime, and a model id handed over with no runtime can't be routed (it silently falls back to
+    the server default, which is the bug this resolution exists to avoid).
+    """
+
+    model: str | None
+    runtime_adapter: str | None
+
+
+def _infer_runtime_adapter(model_id: str) -> str:
+    """The agent runtime that can serve `model_id`, inferred from the id.
+
+    Anthropic ids (`claude-*`, `bedrock/...anthropic.claude-*`) route to the `claude` runtime;
+    everything else — GPT ids and the open-weights `@cf/...` GLM ids, all OpenAI-compatible — routes
+    to the `codex` runtime. An explicit `runtime_adapter` in the payload overrides this.
+    """
+    return RUNTIME_ADAPTER_CLAUDE if "claude" in model_id.lower() else RUNTIME_ADAPTER_CODEX
 
 
 def _read_payload() -> dict | None:
@@ -124,34 +166,61 @@ def _team_scouts(payload: object, team_id: int, canonical_team_id: int) -> dict:
     return scouts if isinstance(scouts, dict) else {}
 
 
-def _scout_config(scouts: dict, skill_name: str) -> tuple[dict[str, float], str | None]:
-    """The `(distribution, default_model)` for one scout from a team's scout map.
+def _parse_model_spec(spec: object) -> tuple[float | None, str | None]:
+    """A `(fraction, runtime_adapter)` from one model entry's value.
+
+    A model entry's value is either a bare number (its fraction; runtime inferred from the id) or an
+    object `{"fraction": <0..1>, "runtime_adapter": "claude"|"codex"}` that pins the runtime
+    explicitly. Returns `(None, ...)` for a malformed fraction (not a positive number, or a bool) so
+    the caller drops the entry rather than failing the run. A non-string `runtime_adapter` is ignored
+    (treated as unset → inferred), so a typo there can't route the run nowhere.
+    """
+    if isinstance(spec, dict):
+        weight = spec.get(FRACTION_KEY)
+        adapter_value = spec.get(RUNTIME_ADAPTER_KEY)
+        adapter = adapter_value if isinstance(adapter_value, str) and adapter_value else None
+    else:
+        weight = spec
+        adapter = None
+    if not isinstance(weight, int | float) or isinstance(weight, bool) or weight <= 0:
+        return None, adapter
+    return min(1.0, float(weight)), adapter
+
+
+def _scout_config(scouts: dict, skill_name: str) -> tuple[dict[str, float], dict[str, str], str | None]:
+    """The `(distribution, adapters, default_model)` for one scout from a team's scout map.
 
     Looks up `scouts[skill_name]`, falling back to the `"*"` scout wildcard. The reserved `"default"`
     string key is pulled out as `default_model` (the model for the unallocated remainder; `None` =
-    agent-server default); every other entry is a `model_id -> fraction` weight. Defensive — a
-    missing/non-object scout entry, or a malformed weight (not a positive number, or a bool) is
-    dropped rather than failing the run, so a typo can't crash a scout or route it unintended.
+    agent-server default); every other entry is a `model_id -> fraction | {fraction, runtime_adapter}`
+    weight. `adapters` carries only the model ids whose runtime was pinned explicitly in the payload;
+    the rest are inferred from the id at resolve time. Defensive — a missing/non-object scout entry,
+    or a malformed weight (not a positive number, or a bool) is dropped rather than failing the run,
+    so a typo can't crash a scout or route it unintended.
     """
     raw = scouts.get(skill_name)
     if not isinstance(raw, dict):
         raw = scouts.get(WILDCARD)
     if not isinstance(raw, dict):
-        return {}, None
+        return {}, {}, None
 
     default_value = raw.get(DEFAULT_MODEL_KEY)
     default_model = default_value if isinstance(default_value, str) and default_value else None
 
     distribution: dict[str, float] = {}
-    for model_id, weight in raw.items():
+    adapters: dict[str, str] = {}
+    for model_id, spec in raw.items():
         if model_id == DEFAULT_MODEL_KEY:
             continue
         if not isinstance(model_id, str) or not model_id:
             continue
-        if not isinstance(weight, int | float) or isinstance(weight, bool) or weight <= 0:
+        fraction, adapter = _parse_model_spec(spec)
+        if fraction is None:
             continue
-        distribution[model_id] = min(1.0, float(weight))
-    return distribution, default_model
+        distribution[model_id] = fraction
+        if adapter is not None:
+            adapters[model_id] = adapter
+    return distribution, adapters, default_model
 
 
 def _bucket(run_id: str) -> float:
@@ -181,16 +250,20 @@ def _select_model(run_id: str, distribution: dict[str, float], default_model: st
     return default_model
 
 
-def resolve_scout_model(team: Team, skill_name: str, run_id: str) -> str | None:
-    """The agent-model override for one scout run, or `None` to keep the agent-server default.
+def resolve_scout_model(team: Team, skill_name: str, run_id: str) -> ScoutModel:
+    """The agent-model override for one scout run, with the runtime that can serve it.
 
     Resolves this team's scout map from the `scouts-model-selection` payload, then this scout's
-    per-run model from its distribution. Returns `None` (agent-server default) when the team has no
-    entry, the scout has no distribution, or the run falls in the unallocated remainder with no
-    named `default`. A payload read failure is swallowed and falls back to the default model —
-    gating the model must never be able to fail a scout run.
+    per-run model from its distribution, then the runtime adapter for the chosen model (pinned in the
+    payload, else inferred from the id). Returns `ScoutModel(None, None)` (agent-server default) when
+    the team has no entry, the scout has no distribution, or the run falls in the unallocated
+    remainder with no named `default`. A payload read failure is swallowed and falls back to the
+    default model — gating the model must never be able to fail a scout run.
     """
     payload = _read_payload()
     scouts = _team_scouts(payload, team.id, team.parent_team_id or team.id)
-    distribution, default_model = _scout_config(scouts, skill_name)
-    return _select_model(run_id, distribution, default_model)
+    distribution, adapters, default_model = _scout_config(scouts, skill_name)
+    model = _select_model(run_id, distribution, default_model)
+    if model is None:
+        return ScoutModel(model=None, runtime_adapter=None)
+    return ScoutModel(model=model, runtime_adapter=adapters.get(model) or _infer_runtime_adapter(model))

--- a/products/signals/backend/scout_harness/runner.py
+++ b/products/signals/backend/scout_harness/runner.py
@@ -209,12 +209,15 @@ async def arun_signals_scout(
     run_id = uuid7()
     started_at = timezone.now()
 
-    # Resolve the scout's agent model from the `scouts-model-selection` gate. `None` keeps the
-    # agent-server default; an override routes this run on that model. The flag payload is a
+    # Resolve the scout's agent model from the `scouts-model-selection` gate. A `None` model keeps the
+    # agent-server default; an override routes this run on that model, paired with the runtime adapter
+    # that can serve it (the agent server can't route a model without one). The flag payload is a
     # per-team, per-scout model distribution, bucketed per run on `run_id` — so a scout can A/B/n
     # across models against itself across runs. Resolved once here so the whole run is consistent.
     # Off the event loop — the flag read does blocking network I/O.
-    model = await database_sync_to_async(resolve_scout_model, thread_sensitive=False)(team, skill.name, str(run_id))
+    scout_model = await database_sync_to_async(resolve_scout_model, thread_sensitive=False)(
+        team, skill.name, str(run_id)
+    )
     try:
         last_message, task_run_id = await _spawn_and_run(
             team=team,
@@ -225,7 +228,8 @@ async def arun_signals_scout(
             repository=repository,
             verbose=verbose,
             user_id=user_id,
-            model=model,
+            model=scout_model.model,
+            runtime_adapter=scout_model.runtime_adapter,
         )
         runtime_s = time.monotonic() - started
         emitted_count, _ = await database_sync_to_async(_read_run_metrics, thread_sensitive=False)(
@@ -345,11 +349,13 @@ async def _spawn_and_run(
     verbose: bool,
     user_id: int,
     model: str | None,
+    runtime_adapter: str | None,
 ) -> tuple[str, str]:
     """Spawn the sandbox, create the bridge row before the first turn, run the agent.
 
     `user_id` is the acting user resolved (and validated non-None) by the caller. `model` is the
-    agent-model override (`None` keeps the agent-server default). Returns
+    agent-model override (`None` keeps the agent-server default), and `runtime_adapter` is the runtime
+    that serves it (paired with `model` — the agent server derives the provider from it). Returns
     `(last_message, task_run_id)`.
     """
     sandbox_env_id = await database_sync_to_async(get_or_create_signals_sandbox_env, thread_sensitive=False)(
@@ -387,6 +393,10 @@ async def _spawn_and_run(
         # (the `scouts-model-selection` gate routes it here). The model the gateway actually serves
         # is tagged on each $ai_generation, so per-run model is queryable in LLM analytics.
         model=model,
+        # The runtime that serves `model`. Paired with it because the agent server derives the LLM
+        # provider from the runtime — a model with no runtime can't be routed and falls back to the
+        # server default. `None` alongside a `None` model keeps the agent-server defaults for both.
+        runtime_adapter=runtime_adapter,
     )
     prompt = build_run_prompt(skill, run_id=str(run_id), team_id=team.id, started_at=started_at)
     logger.info(

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -22,6 +22,7 @@ from posthog.sync import database_sync_to_async
 
 from products.signals.backend.models import SignalScoutConfig, SignalScoutRun
 from products.signals.backend.scout_harness.limits import STALE_RUN_CUTOFF_S
+from products.signals.backend.scout_harness.model_selection import ScoutModel
 from products.signals.backend.scout_harness.prompt import build_run_prompt
 from products.signals.backend.scout_harness.runner import RunResult, arun_signals_scout
 from products.signals.backend.scout_harness.skill_loader import (
@@ -301,15 +302,18 @@ async def test_run_tags_session_with_scout_ai_stage(ateam, aerrors_skill):
 @pytest.mark.asyncio
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    "resolved_model, expected_context_model",
+    "resolved, expected_model, expected_runtime_adapter",
     [
-        ("@cf/zai-org/glm-5.2", "@cf/zai-org/glm-5.2"),
-        (None, None),
+        (ScoutModel(model="@cf/zai-org/glm-5.2", runtime_adapter="codex"), "@cf/zai-org/glm-5.2", "codex"),
+        (ScoutModel(model=None, runtime_adapter=None), None, None),
     ],
 )
-async def test_run_pins_sandbox_to_resolved_scout_model(ateam, aerrors_skill, resolved_model, expected_context_model):
-    # The `scouts-glm` gate resolves an agent-model override (glm-5.2) or None (agent-server
-    # default); the runner must hand that straight to the sandbox via the context's `model` field.
+async def test_run_pins_sandbox_to_resolved_scout_model(
+    ateam, aerrors_skill, resolved, expected_model, expected_runtime_adapter
+):
+    # The `scouts-model-selection` gate resolves an agent-model override (glm-5.2 on the codex
+    # runtime) or the agent-server default (None/None); the runner must hand both straight to the
+    # sandbox via the context — the runtime travels with the model so the agent server can route it.
     session, result = await database_sync_to_async(_make_fake_session, thread_sensitive=False)(ateam)
     captured: dict = {}
 
@@ -323,7 +327,7 @@ async def test_run_pins_sandbox_to_resolved_scout_model(ateam, aerrors_skill, re
         patch("products.signals.backend.scout_harness.runner.MultiTurnSession.start", new=_capture_start),
         patch(
             "products.signals.backend.scout_harness.runner.resolve_scout_model",
-            return_value=resolved_model,
+            return_value=resolved,
         ),
         patch(
             "products.signals.backend.scout_harness.runner.get_or_create_signals_sandbox_env",
@@ -336,7 +340,8 @@ async def test_run_pins_sandbox_to_resolved_scout_model(ateam, aerrors_skill, re
     ):
         await arun_signals_scout(team_id=ateam.id, skill_name="signals-scout-errors")
 
-    assert captured["context"].model == expected_context_model
+    assert captured["context"].model == expected_model
+    assert captured["context"].runtime_adapter == expected_runtime_adapter
 
 
 @pytest.mark.asyncio

--- a/products/signals/backend/test/test_scout_model_selection.py
+++ b/products/signals/backend/test/test_scout_model_selection.py
@@ -70,20 +70,30 @@ class TestResolveScoutModel:
             resolve_scout_model(_fake_team(), _SKILL, _RUN_ID)
         assert mock_payload.call_args.args[0] == "scouts-model-selection"
 
-    def test_infers_codex_runtime_for_glm(self) -> None:
-        # A routed non-Claude model must carry a runtime, else the agent server can't route it. GLM
-        # is OpenAI-compatible, so it infers the `codex` runtime.
-        resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: 1}}))
-        assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="codex")
-
-    def test_infers_claude_runtime_for_claude_model(self) -> None:
-        resolved = _resolve_full(payload=_scouts({_SKILL: {"claude-opus-4-8": 1}}))
-        assert resolved == ScoutModel(model="claude-opus-4-8", runtime_adapter="claude")
+    @parameterized.expand(
+        [
+            # A routed model must carry a runtime, else the agent server can't route it. Claude ids
+            # infer `claude`; everything else (GLM, GPT — all OpenAI-compatible) infers `codex`.
+            ("glm_infers_codex", GLM_MODEL, "codex"),
+            ("gpt_infers_codex", _GPT, "codex"),
+            ("claude_infers_claude", "claude-opus-4-8", "claude"),
+        ]
+    )
+    def test_infers_runtime_from_model_id(self, _name: str, model: str, expected_adapter: str) -> None:
+        assert _resolve_full(payload=_scouts({_SKILL: {model: 1}})) == ScoutModel(
+            model=model, runtime_adapter=expected_adapter
+        )
 
     def test_explicit_runtime_adapter_overrides_inference(self) -> None:
         # Object form pins the runtime explicitly, beating the id-based inference (which would say codex).
         resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": "claude"}}}))
         assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="claude")
+
+    def test_unknown_explicit_runtime_adapter_falls_back_to_inference(self) -> None:
+        # A typo'd runtime ("cluade") must not reach the run state — it'd blow up when cast to the
+        # RuntimeAdapter enum downstream. Drop it and infer from the id instead.
+        resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": "cluade"}}}))
+        assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="codex")
 
     def test_object_form_drops_malformed_fraction(self) -> None:
         # A pinned runtime can't rescue a malformed fraction — the entry is dropped, agent default kept.
@@ -161,4 +171,4 @@ class TestResolveScoutModel:
     def test_payload_read_failure_keeps_agent_default(self) -> None:
         # A scout must never fail to run because the gate was unreachable — fall back to the default.
         with patch(_PAYLOAD_PATH, side_effect=RuntimeError("flag service down")):
-            assert resolve_scout_model(_fake_team(), _SKILL, _RUN_ID) is None
+            assert resolve_scout_model(_fake_team(), _SKILL, _RUN_ID) == ScoutModel(model=None, runtime_adapter=None)

--- a/products/signals/backend/test/test_scout_model_selection.py
+++ b/products/signals/backend/test/test_scout_model_selection.py
@@ -9,7 +9,7 @@ from parameterized import parameterized
 
 from posthog.models.team.team import Team
 
-from products.signals.backend.scout_harness.model_selection import GLM_MODEL, resolve_scout_model
+from products.signals.backend.scout_harness.model_selection import GLM_MODEL, ScoutModel, resolve_scout_model
 
 _PAYLOAD_PATH = "products.signals.backend.scout_harness.model_selection.posthoganalytics.get_feature_flag_payload"
 
@@ -25,9 +25,15 @@ def _fake_team(team_id: int = _TEAM_ID, parent_team_id: int | None = None) -> Te
     return cast(Team, SimpleNamespace(id=team_id, parent_team_id=parent_team_id))
 
 
-def _resolve(skill: str = _SKILL, run_id: str = _RUN_ID, *, team: Team | None = None, payload: object) -> str | None:
+def _resolve_full(
+    skill: str = _SKILL, run_id: str = _RUN_ID, *, team: Team | None = None, payload: object
+) -> ScoutModel:
     with patch(_PAYLOAD_PATH, return_value=payload):
         return resolve_scout_model(team or _fake_team(), skill, run_id)
+
+
+def _resolve(skill: str = _SKILL, run_id: str = _RUN_ID, *, team: Team | None = None, payload: object) -> str | None:
+    return _resolve_full(skill=skill, run_id=run_id, team=team, payload=payload).model
 
 
 def _scouts(scouts: dict, team_id: int = _TEAM_ID) -> dict:
@@ -63,6 +69,37 @@ class TestResolveScoutModel:
         with patch(_PAYLOAD_PATH, return_value=None) as mock_payload:
             resolve_scout_model(_fake_team(), _SKILL, _RUN_ID)
         assert mock_payload.call_args.args[0] == "scouts-model-selection"
+
+    def test_infers_codex_runtime_for_glm(self) -> None:
+        # A routed non-Claude model must carry a runtime, else the agent server can't route it. GLM
+        # is OpenAI-compatible, so it infers the `codex` runtime.
+        resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: 1}}))
+        assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="codex")
+
+    def test_infers_claude_runtime_for_claude_model(self) -> None:
+        resolved = _resolve_full(payload=_scouts({_SKILL: {"claude-opus-4-8": 1}}))
+        assert resolved == ScoutModel(model="claude-opus-4-8", runtime_adapter="claude")
+
+    def test_explicit_runtime_adapter_overrides_inference(self) -> None:
+        # Object form pins the runtime explicitly, beating the id-based inference (which would say codex).
+        resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": "claude"}}}))
+        assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="claude")
+
+    def test_object_form_drops_malformed_fraction(self) -> None:
+        # A pinned runtime can't rescue a malformed fraction — the entry is dropped, agent default kept.
+        resolved = _resolve_full(
+            payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": "lots", "runtime_adapter": "codex"}}})
+        )
+        assert resolved == ScoutModel(model=None, runtime_adapter=None)
+
+    def test_named_default_remainder_infers_its_runtime(self) -> None:
+        # The remainder model (named `default`) also gets a runtime inferred from its id. With no
+        # fractional models, every run lands in the remainder, so this is deterministic.
+        resolved = _resolve_full(payload=_scouts({_SKILL: {"default": GLM_MODEL}}))
+        assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="codex")
+
+    def test_unconfigured_keeps_both_defaults(self) -> None:
+        assert _resolve_full(payload=None) == ScoutModel(model=None, runtime_adapter=None)
 
     def test_each_team_gets_its_own_config(self) -> None:
         # One payload, two teams, different model per team — the whole point of the team key.

--- a/products/signals/backend/test/test_scout_model_selection.py
+++ b/products/signals/backend/test/test_scout_model_selection.py
@@ -89,10 +89,21 @@ class TestResolveScoutModel:
         resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": "claude"}}}))
         assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="claude")
 
-    def test_unknown_explicit_runtime_adapter_falls_back_to_inference(self) -> None:
-        # A typo'd runtime ("cluade") must not reach the run state — it'd blow up when cast to the
-        # RuntimeAdapter enum downstream. Drop it and infer from the id instead.
-        resolved = _resolve_full(payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": "cluade"}}}))
+    @parameterized.expand(
+        [
+            # A bad runtime must not reach the run state — it'd blow up when cast to the RuntimeAdapter
+            # enum downstream. Drop it and infer from the id instead. The unhashable cases (list/dict)
+            # would also raise from the set-membership test if not guarded, failing the run.
+            ("typo", "cluade"),
+            ("non_string", 5),
+            ("list", ["codex"]),
+            ("dict", {"codex": 1}),
+        ]
+    )
+    def test_bad_explicit_runtime_adapter_falls_back_to_inference(self, _name: str, bad_adapter: object) -> None:
+        resolved = _resolve_full(
+            payload=_scouts({_SKILL: {GLM_MODEL: {"fraction": 1, "runtime_adapter": bad_adapter}}})
+        )
         assert resolved == ScoutModel(model=GLM_MODEL, runtime_adapter="codex")
 
     def test_object_form_drops_malformed_fraction(self) -> None:

--- a/products/tasks/backend/logic/services/custom_prompt_internals.py
+++ b/products/tasks/backend/logic/services/custom_prompt_internals.py
@@ -95,6 +95,11 @@ class CustomPromptSandboxContext:
     """Override the agent model (e.g. ``"claude-opus-4-8"``). Falls back to the
     agent server's default when ``None``. Used by evals to pin a specific
     model so cross-run comparisons are stable."""
+    runtime_adapter: str | None = None
+    """The agent runtime that serves ``model`` (``"claude"`` → Anthropic, ``"codex"`` → OpenAI).
+    Set it alongside a non-default ``model``: the agent server derives the provider from the runtime,
+    so a model handed over with no runtime can't be routed and falls back to the server default.
+    ``None`` keeps the agent server's default runtime (only valid when ``model`` is also ``None``)."""
     sandbox_resources: SandboxResources | None = None
     """Override the sandbox's compute (CPU / memory). Unset fields keep the
     SandboxConfig defaults (4 cores / 16 GB)."""
@@ -143,6 +148,7 @@ async def create_task_and_trigger(
         posthog_mcp_scopes=posthog_mcp_scopes,
         sandbox_environment_id=context.sandbox_environment_id,
         model=context.model,
+        runtime_adapter=context.runtime_adapter,
         internal=internal,
         sandbox_resources=context.sandbox_resources,
         sandbox_timeout_seconds=context.sandbox_timeout_seconds,

--- a/products/tasks/backend/models.py
+++ b/products/tasks/backend/models.py
@@ -337,6 +337,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         output_schema: type[BaseModel] | dict | None = None,
         interaction_origin: str | None = None,
         model: str | None = None,
+        runtime_adapter: str | None = None,
         initial_permission_mode: str | None = None,
         sandbox_resources: "SandboxResources | None" = None,
         sandbox_timeout_seconds: int | None = None,
@@ -354,7 +355,9 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         from products.tasks.backend.temporal.process_task.utils import (
             PrAuthorshipMode,
             RunSource,
+            RuntimeAdapter,
             get_pr_authorship_mode,
+            get_provider_for_runtime_adapter,
             resolve_user_github_integration_for_task,
             user_github_integration_is_usable,
         )
@@ -444,6 +447,19 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
 
         if model:
             extra_state["model"] = model
+
+        # The model's runtime adapter and the provider derived from it. The agent server can't route
+        # a model without its runtime (it resolves the provider from the runtime), so callers that pin
+        # a non-default model must pass the matching runtime — mirrors the warm path in `facade/api`.
+        # Codex runs need permission mode `auto` (same default the warm path applies) so a headless
+        # run doesn't stall waiting on a prompt; an explicit `initial_permission_mode` still wins.
+        if runtime_adapter:
+            extra_state["runtime_adapter"] = runtime_adapter
+            provider = get_provider_for_runtime_adapter(runtime_adapter)
+            if provider is not None:
+                extra_state["provider"] = provider.value
+            if initial_permission_mode is None and runtime_adapter == RuntimeAdapter.CODEX.value:
+                initial_permission_mode = "auto"
 
         # Forwarded to the in-sandbox agent and lifted onto its $ai_generation traces as an
         # `ai_stage` property (see TaskProcessingContext / agent-server configureEnvironment).
@@ -540,6 +556,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
         output_schema: type[BaseModel] | dict | None = None,
         interaction_origin: str | None = None,
         model: str | None = None,
+        runtime_adapter: str | None = None,
         initial_permission_mode: str | None = None,
         sandbox_resources: "SandboxResources | None" = None,
         sandbox_timeout_seconds: int | None = None,
@@ -564,6 +581,7 @@ class Task(FileSystemSyncMixin, DeletedMetaFields, models.Model):
             output_schema=output_schema,
             interaction_origin=interaction_origin,
             model=model,
+            runtime_adapter=runtime_adapter,
             initial_permission_mode=initial_permission_mode,
             sandbox_resources=sandbox_resources,
             sandbox_timeout_seconds=sandbox_timeout_seconds,


### PR DESCRIPTION
## Problem

We merged model selection for Signals scouts (the `scouts-model-selection` flag), pointed three team-2 scouts at `@cf/zai-org/glm-5.2`, and got **zero GLM generations**. All three scouts ran repeatedly after the flag went live but every `$ai_generation` stayed on `claude-opus-4-8`.

Root cause: the gate set only `model` on the run. The agent server knows two runtimes — `claude` → Anthropic, `codex` → OpenAI — and derives the LLM provider from the **runtime**, not the model id. Everywhere else (the normal Tasks flow in `facade/api.py`) `model` is always set together with `runtime_adapter` + a derived `provider`. The scout path left `runtime_adapter`/`provider` unset, so a routed run still booted the default Claude runtime, which can't serve `@cf/...` GLM and silently fell back to its default Claude model. A model id with no runtime is effectively unroutable.

## Changes

- `resolve_scout_model` now returns a `ScoutModel(model, runtime_adapter)`. The runtime is inferred from the model id (`claude-*` → `claude`, everything else incl. `@cf/...` GLM and GPT → the OpenAI-compatible `codex`), and can be pinned explicitly per model via the new object form in the flag payload: `{"@cf/zai-org/glm-5.2": {"fraction": 0.5, "runtime_adapter": "codex"}}`. The bare-fraction form still works.
- Threaded `runtime_adapter` through `CustomPromptSandboxContext` → `create_task_and_trigger` → `Task.create_and_run`/`_build_task`, which now writes `runtime_adapter` + the derived `provider` into the run state (and defaults codex runs to `auto` permission mode, like the warm path, so a headless run doesn't stall on a prompt). This mirrors how the normal Tasks flow has always paired the three.

No payload edit is required to start GLM flowing — inference routes `@cf/zai-org/glm-5.2` to `codex` automatically. The explicit override is there for when inference is ever wrong.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** run the suite — `flox`/`hogli` aren't available in this environment. I ran `ruff check` + `ruff format` (clean) on the touched files and verified the pure selection/inference logic in a standalone script (0.8 fraction → ~81% GLM, all tagged `codex`; explicit override wins; malformed fraction dropped). Automated tests added/updated:

- `test_scout_model_selection.py` — codex inference for GLM, claude inference for Claude ids, explicit-override-beats-inference, malformed object-form fraction dropped, named-default remainder inherits inferred runtime. These catch a regression no existing test did: a routed model losing (or mis-inferring) its runtime.
- `test_scout_harness.py::test_run_pins_sandbox_to_resolved_scout_model` — updated to assert the runtime adapter is threaded onto the sandbox context alongside the model, not just the model.

Worth a maintainer sanity-checking the one assumption I couldn't verify from this repo: that `@cf/zai-org/glm-5.2` is served by the `codex`/OpenAI-compatible runtime. If GLM needs different routing, the explicit `runtime_adapter` payload override covers it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread: queried LLM-analytics ($ai_generation by `ai_product='signals'`, `ai_stage='scout'`, `task_title` scout name) to confirm all three flagged scouts ran post-go-live but 100% on `claude-opus-4-8`, then traced the model wiring from `resolve_scout_model` through the sandbox context, `Task.create_and_run`, and the run-state → agent-server boundary to find the missing runtime adapter. Tools: PostHog MCP (insight/SQL queries, feature-flag inspection), Claude Code.

Considered an explicit-only payload schema (operator must specify the adapter) vs id-based inference; chose inference-with-explicit-override so the live rollout starts working without a payload edit while keeping an escape hatch.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782478799235269)*
