### PR TITLE
chore: reassign query performance ownership to analytics platform

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -302,12 +302,12 @@ posthog/tasks/usage_report.py @PostHog/team-billing
 posthog/temporal/usage_report/ @PostHog/team-billing
 posthog/temporal/quota_limiting/ @PostHog/team-billing
 
-# Query performance - owned by @PostHog/team-query-performance
-posthog/queries/ @PostHog/team-query-performance
-posthog/caching/ @PostHog/team-query-performance
-posthog/hogql/database/schema/sessions*.py @PostHog/team-query-performance
-posthog/models/raw_sessions/** @PostHog/team-query-performance
-posthog/models/sessions/** @PostHog/team-query-performance
+# Query performance (merged into Analytics Platform) - owned by @PostHog/team-analytics-platform
+posthog/queries/ @PostHog/team-analytics-platform
+posthog/caching/ @PostHog/team-analytics-platform
+posthog/hogql/database/schema/sessions*.py @PostHog/team-analytics-platform
+posthog/models/raw_sessions/** @PostHog/team-analytics-platform
+posthog/models/sessions/** @PostHog/team-analytics-platform
 
 # Ingestion (persons identity pipeline) - owned by @PostHog/team-ingestion
 posthog/temporal/delete_persons/ @PostHog/team-ingestion


### PR DESCRIPTION
## Problem

The query performance and analytics platform teams are merging, so code currently owned by `@PostHog/team-query-performance` needs to be reassigned to `@PostHog/team-analytics-platform`.

## Changes

Reassigned the five `CODEOWNERS-soft` path rules previously owned by `@PostHog/team-query-performance` (`posthog/queries/`, `posthog/caching/`, `posthog/hogql/database/schema/sessions*.py`, `posthog/models/raw_sessions/**`, `posthog/models/sessions/**`) to `@PostHog/team-analytics-platform`. The rules were left in their original position to preserve last-match-wins precedence, and the section comment now notes the merge.

The hard `CODEOWNERS` file had no query-performance entries, and no `products/*/product.yaml` listed `team-query-performance` as an owner, so no changes were needed there.

## How did you test this code?

I'm an agent. No automated tests apply to a CODEOWNERS-soft mapping change; verified via grep that no `team-query-performance` references remain anywhere under `.github/` or `products/`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: reassign code ownership from query performance to analytics platform as the teams merge. Invoked the `/establishing-code-ownership` skill to confirm the two ownership sources (`product.yaml` and `CODEOWNERS`/`CODEOWNERS-soft`) and verify the change was complete and precedence-preserving.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1782480118465169)*
