### PR TITLE
fix(data-warehouse): honor configured id/distinct_id over table columns

### DIFF
--- a/posthog/hogql/database/database.py
+++ b/posthog/hogql/database/database.py
@@ -1639,7 +1639,11 @@ class Database(BaseModel):
             if table is None:
                 return root_node
 
-            if "id" not in table.fields.keys():
+            # The configured `id_field` must win even when the source table has its own column
+            # literally named `id`. Without this guard the virtual mapping is skipped and queries
+            # silently resolve to the table's own `id` column instead of the configured field.
+            id_field_is_remapped = warehouse_modifier.id_field != "id"
+            if id_field_is_remapped or "id" not in table.fields.keys():
                 table.fields["id"] = ExpressionField(
                     name="id",
                     expr=parse_expr(warehouse_modifier.id_field),
@@ -1678,13 +1682,21 @@ class Database(BaseModel):
                             ),
                         )
 
-            # TODO: Need to decide how the distinct_id and person_id fields are going to be handled
-            if "distinct_id" not in table.fields.keys():
+            # As with `id` and `timestamp` above, the configured `distinct_id_field` must win over a
+            # source column literally named `distinct_id`; otherwise the virtual mapping is skipped and
+            # the wrong column is used silently.
+            distinct_id_field_is_remapped = warehouse_modifier.distinct_id_field != "distinct_id"
+            if distinct_id_field_is_remapped or "distinct_id" not in table.fields.keys():
                 table.fields["distinct_id"] = ExpressionField(
                     name="distinct_id",
                     expr=parse_expr(warehouse_modifier.distinct_id_field),
                 )
 
+            # person_id is deliberately left as "inject only when absent": the modifier has no
+            # person_id_field to remap from, and a source column literally named `person_id` is
+            # plausibly authoritative (e.g. an already-resolved person UUID), so it should win. When
+            # the table has no `person_id`, derive it from the events join if one exists, else fall
+            # back to the configured distinct_id_field.
             if "person_id" not in table.fields.keys():
                 events_join = next(
                     (

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -1626,8 +1626,8 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         db = Database.create_for(team=self.team, modifiers=modifiers)
 
         field = db.get_table("native_identity_table").fields[virtual_field]
+        # StringDatabaseField implies the column was not wrapped in a remapping ExpressionField
         assert isinstance(field, StringDatabaseField)
-        assert not isinstance(field, ExpressionField)
 
     def test_data_warehouse_events_modifier_keeps_existing_person_id_column(self):
         # Unlike id/distinct_id/timestamp, person_id has no configured field on the modifier to remap
@@ -1663,8 +1663,8 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         db = Database.create_for(team=self.team, modifiers=modifiers)
 
         person_id_field = db.get_table("native_person_id_table").fields["person_id"]
+        # StringDatabaseField implies the column was not wrapped in a remapping ExpressionField
         assert isinstance(person_id_field, StringDatabaseField)
-        assert not isinstance(person_id_field, ExpressionField)
 
     def test_data_warehouse_events_modifiers_with_dot_notation(self):
         credentials = DataWarehouseCredential.objects.create(

--- a/posthog/hogql/database/test/test_database.py
+++ b/posthog/hogql/database/test/test_database.py
@@ -1540,6 +1540,132 @@ class TestDatabase(BaseTest, QueryMatchingTest):
         timestamp_field = db.get_table("native_timestamp_table").fields["timestamp"]
         assert isinstance(timestamp_field, DateTimeDatabaseField)
 
+    @parameterized.expand(
+        [
+            ("id", "real_id"),
+            ("distinct_id", "real_distinct_id"),
+        ]
+    )
+    def test_data_warehouse_events_modifier_remaps_identity_field_over_existing_column(
+        self, virtual_field: str, configured_column: str
+    ):
+        # A warehouse table can have its own column literally named `id` / `distinct_id` while the
+        # series is configured to use a different column. The configured `id_field` / `distinct_id_field`
+        # must win, so the virtual field resolves to the configured column rather than the table's own
+        # decoy column (which would otherwise be selected silently).
+        credentials = DataWarehouseCredential.objects.create(
+            access_key="test_key", access_secret="test_secret", team=self.team
+        )
+        DataWarehouseTable.objects.create(
+            name="decoy_identity_table",
+            format="Parquet",
+            team=self.team,
+            credential=credentials,
+            url_pattern="s3://test/*",
+            columns={
+                "real_id": "String",
+                "real_distinct_id": "String",
+                "id": "String",
+                "distinct_id": "String",
+                "created_at": "DateTime64(3, 'UTC')",
+            },
+        )
+        modifiers = HogQLQueryModifiers(
+            dataWarehouseEventsModifiers=[
+                DataWarehouseEventsModifier(
+                    table_name="decoy_identity_table",
+                    id_field="real_id",
+                    distinct_id_field="real_distinct_id",
+                    timestamp_field="created_at",
+                )
+            ]
+        )
+
+        db = Database.create_for(team=self.team, modifiers=modifiers)
+
+        field = db.get_table("decoy_identity_table").fields[virtual_field]
+        assert isinstance(field, ExpressionField)
+        assert isinstance(field.expr, ast.Field)
+        assert field.expr.chain == [configured_column]
+
+    @parameterized.expand(
+        [
+            ("id",),
+            ("distinct_id",),
+        ]
+    )
+    def test_data_warehouse_events_modifier_keeps_existing_identity_column_when_configured(self, virtual_field: str):
+        # When the configured field name equals the virtual field name, the table's own column is used
+        # directly rather than wrapped in a remapping expression.
+        credentials = DataWarehouseCredential.objects.create(
+            access_key="test_key", access_secret="test_secret", team=self.team
+        )
+        DataWarehouseTable.objects.create(
+            name="native_identity_table",
+            format="Parquet",
+            team=self.team,
+            credential=credentials,
+            url_pattern="s3://test/*",
+            columns={
+                "id": "String",
+                "distinct_id": "String",
+                "created_at": "DateTime64(3, 'UTC')",
+            },
+        )
+        modifiers = HogQLQueryModifiers(
+            dataWarehouseEventsModifiers=[
+                DataWarehouseEventsModifier(
+                    table_name="native_identity_table",
+                    id_field="id",
+                    distinct_id_field="distinct_id",
+                    timestamp_field="created_at",
+                )
+            ]
+        )
+
+        db = Database.create_for(team=self.team, modifiers=modifiers)
+
+        field = db.get_table("native_identity_table").fields[virtual_field]
+        assert isinstance(field, StringDatabaseField)
+        assert not isinstance(field, ExpressionField)
+
+    def test_data_warehouse_events_modifier_keeps_existing_person_id_column(self):
+        # Unlike id/distinct_id/timestamp, person_id has no configured field on the modifier to remap
+        # from, and a native `person_id` column is treated as authoritative (e.g. an already-resolved
+        # person UUID). It must win over the distinct_id-derived fallback rather than being overridden.
+        credentials = DataWarehouseCredential.objects.create(
+            access_key="test_key", access_secret="test_secret", team=self.team
+        )
+        DataWarehouseTable.objects.create(
+            name="native_person_id_table",
+            format="Parquet",
+            team=self.team,
+            credential=credentials,
+            url_pattern="s3://test/*",
+            columns={
+                "id": "String",
+                "user_id": "String",
+                "person_id": "String",
+                "created_at": "DateTime64(3, 'UTC')",
+            },
+        )
+        modifiers = HogQLQueryModifiers(
+            dataWarehouseEventsModifiers=[
+                DataWarehouseEventsModifier(
+                    table_name="native_person_id_table",
+                    id_field="id",
+                    distinct_id_field="user_id",
+                    timestamp_field="created_at",
+                )
+            ]
+        )
+
+        db = Database.create_for(team=self.team, modifiers=modifiers)
+
+        person_id_field = db.get_table("native_person_id_table").fields["person_id"]
+        assert isinstance(person_id_field, StringDatabaseField)
+        assert not isinstance(person_id_field, ExpressionField)
+
     def test_data_warehouse_events_modifiers_with_dot_notation(self):
         credentials = DataWarehouseCredential.objects.create(
             access_key="test_key", access_secret="test_secret", team=self.team

--- a/posthog/hogql_queries/insights/trends/test/data/trends_dw_decoy_distinct_id.csv
+++ b/posthog/hogql_queries/insights/trends/test/data/trends_dw_decoy_distinct_id.csv
@@ -1,0 +1,3 @@
+id,user_id,distinct_id,event_time,prop_1
+1,alice,shared,2023-01-01,a
+2,bob,shared,2023-01-01,b

--- a/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
+++ b/posthog/hogql_queries/insights/trends/test/test_trends_data_warehouse_query.py
@@ -41,6 +41,7 @@ from posthog.hogql.timings import HogQLTimings
 from posthog.hogql_queries.insights.trends.trends_query_builder import TrendsQueryBuilder
 from posthog.hogql_queries.insights.trends.trends_query_runner import TrendsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
+from posthog.models.instance_setting import override_instance_config
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
 from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
@@ -158,6 +159,57 @@ class TestTrendsDataWarehouseQuery(ClickhouseTestMixin, BaseTest):
         assert response.columns is not None
         assert set(response.columns).issubset({"date", "total"})
         assert response.results[0][1] == [1, 1, 1, 1, 0, 0, 0]
+
+    def setup_data_warehouse_with_decoy_distinct_id(self):
+        # Table whose real actor identifier lives in `user_id`, but which also has a column literally
+        # named `distinct_id` (a decoy, e.g. a source-system id). With `aggregate_users_by_distinct_id`,
+        # trends `dau` counts the virtual `distinct_id` field, which must resolve to the configured
+        # `distinct_id_field` (`user_id`) rather than the decoy column, or unique-user counts are wrong.
+        table, _source, _credential, _df, self.cleanUpDataWarehouse = create_data_warehouse_table_from_csv(
+            csv_path=Path(__file__).parent / "data" / "trends_dw_decoy_distinct_id.csv",
+            table_name="test_table_decoy_distinct_id",
+            table_columns={
+                "id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "user_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "distinct_id": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+                "event_time": {"clickhouse": "DateTime64(3, 'UTC')", "hogql": "DateTimeDatabaseField"},
+                "prop_1": {"clickhouse": "String", "hogql": "StringDatabaseField"},
+            },
+            test_bucket=TEST_BUCKET,
+            team=self.team,
+        )
+
+        return table.name
+
+    def test_trends_data_warehouse_uses_configured_distinct_id_field(self):
+        # Regression: with `aggregate_users_by_distinct_id`, trends `dau` counts the virtual `distinct_id`
+        # field, which must resolve to the configured `distinct_id_field` (`user_id`) even when the source
+        # table has its own column named `distinct_id`. Both rows on 2023-01-01 share one decoy
+        # `distinct_id` value but have two distinct `user_id`s, so counting `user_id` yields 2 while
+        # counting the decoy column would yield 1.
+        table_name = self.setup_data_warehouse_with_decoy_distinct_id()
+
+        trends_query = TrendsQuery(
+            kind="TrendsQuery",
+            dateRange=DateRange(date_from="2023-01-01"),
+            series=[
+                DataWarehouseNode(
+                    id=table_name,
+                    table_name=table_name,
+                    id_field="id",
+                    distinct_id_field="user_id",
+                    timestamp_field="event_time",
+                    math="dau",
+                )
+            ],
+        )
+
+        with override_instance_config("AGGREGATE_BY_DISTINCT_IDS_TEAMS", f"{self.team.pk}"), freeze_time("2023-01-07"):
+            response = self.get_response(trends_query=trends_query)
+
+        assert response.columns is not None
+        assert set(response.columns).issubset({"date", "total"})
+        assert response.results[0][1] == [2, 0, 0, 0, 0, 0, 0]
 
     @snapshot_clickhouse_queries
     def test_trends_data_warehouse(self):


### PR DESCRIPTION
## Problem

`DataWarehouseEventsModifier` injects virtual `id`, `timestamp`, `distinct_id`, and `person_id` fields onto a data-warehouse table so query runners can reference them uniformly regardless of which real columns a series is configured to use. The injection only happened when the source table had no column of the same name. So a table with its own column literally named `id` or `distinct_id`, combined with a *different* configured `id_field`/`distinct_id_field`, silently kept the table's own column — queries resolved the wrong column with no error. Same class of silent-wrong-column bug that #63625 fixed for `timestamp`.

## Changes

Stacked on #63625. Widen the `id` and `distinct_id` injection guards in `define_mappings` with a `*_field_is_remapped` disjunct (`warehouse_modifier.id_field != "id"` / `… != "distinct_id"`), mirroring the timestamp fix. The configured field now wins even when a same-named decoy column exists, and it stays a strict no-op when the configured name equals the virtual name.

`person_id` is deliberately left as "inject only when absent". Unlike the other three it has no configured `*_field` on the modifier to remap from, and a native `person_id` column is plausibly authoritative (e.g. an already-resolved person UUID), so it should win. Touching it would risk regressing identity resolution — it also feeds the events-join branch. A test locks in this decision.

Reachability (what drove the scope): the virtual `distinct_id` is consumed by trends `dau` (`count(DISTINCT e.distinct_id)`) when `aggregate_users_by_distinct_id` is on, and via HogQL. The virtual `id` isn't referenced by any hardcoded runner today — only by direct field resolution / user HogQL — so it gets unit coverage but no e2e (no runner path to discriminate). `person_id` is heavily consumed by trends/stickiness but intentionally unchanged.

## How did you test this code?

I'm an agent; I could not run the Postgres/ClickHouse-backed suites in this environment (no Django runtime, services down), so they run in CI. `ruff check`/`format` and `py_compile` pass locally.

Added — each maps to a regression no existing test caught (none combined a same-named decoy column with a remapped field):

- `test_database.py::test_data_warehouse_events_modifier_remaps_identity_field_over_existing_column` (parameterized id/distinct_id) — **fails before the fix**: with a decoy `id`/`distinct_id` column and a different configured field, the virtual field resolved to the decoy; now it resolves to the configured column.
- `test_database.py::test_data_warehouse_events_modifier_keeps_existing_identity_column_when_configured` (parameterized) — guards the no-op: when the configured name equals the virtual name, the native column is used directly rather than needlessly wrapped (catches an over-eager "always inject" implementation).
- `test_database.py::test_data_warehouse_events_modifier_keeps_existing_person_id_column` — locks in the deliberate `person_id` decision: a native `person_id` column must win over the distinct_id fallback.
- `test_trends_data_warehouse_query.py::test_trends_data_warehouse_uses_configured_distinct_id_field` — end-to-end discriminating fixture: trends `dau` with `aggregate_users_by_distinct_id`; the decoy `distinct_id` column shares one value while `user_id` has two, so the result is `[2, …]` after the fix and would be `[1, …]` before.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigation-first follow-up to #63625. Used a read-only Explore subagent to map which trends/stickiness/funnels/lifecycle/retention runners reference the *virtual* `id`/`distinct_id`/`person_id` fields versus reading the configured `series.*_field` directly — that's what scoped the fix to `id` + `distinct_id` and justified leaving `person_id`. Invoked the `/writing-tests` skill to gate the added tests.

Decisions:
- Fixed `id` and `distinct_id`: identical "configured field must win" semantics; the guard is a provable no-op unless explicitly remapped.
- Left `person_id`: no `person_id_field` to key a remap on, native column plausibly authoritative, and the events-join precedence must be preserved.
- No e2e for `id`: no runner consumes the virtual field, so there's nothing to discriminate — unit coverage only, called out rather than forced.
