### PR TITLE
feat(llma): add evaluation runtime counts

### DIFF
--- a/posthog/tasks/ai_observability_usage_report.py
+++ b/posthog/tasks/ai_observability_usage_report.py
@@ -78,6 +78,9 @@ class TeamMetrics:
     ai_evaluation_count: int = 0
     ai_is_error_count: int = 0
     ai_trial_evaluation_count: int = 0
+    ai_llm_judge_evaluation_count: int = 0
+    ai_hog_evaluation_count: int = 0
+    ai_sentiment_evaluation_count: int = 0
     ai_trace_summary_count: int = 0
     ai_generation_summary_count: int = 0
     ai_trace_clusters_count: int = 0
@@ -326,6 +329,11 @@ def _combine_all_metrics_results(results_list: list) -> dict[int, TeamMetrics]:
             # Trial evaluation count (index 27)
             metrics.ai_trial_evaluation_count += row[27] or 0
 
+            # Evaluation runtime counts (indices 28-30)
+            metrics.ai_llm_judge_evaluation_count += row[28] or 0
+            metrics.ai_hog_evaluation_count += row[29] or 0
+            metrics.ai_sentiment_evaluation_count += row[30] or 0
+
     return team_metrics
 
 
@@ -380,7 +388,11 @@ def get_all_ai_metrics(
             countIf(toFloat64OrNull(properties_group_ai['$ai_total_cost_usd']) = 0) as total_cost_zero_count,
             -- Error count
             countIf(properties_group_ai['$ai_is_error'] = 'true') as ai_is_error_count,
-            countIf(event = '$ai_evaluation' AND properties_group_ai['$ai_evaluation_key_type'] = 'posthog') as ai_trial_evaluation_count
+            -- Evaluation counts
+            countIf(event = '$ai_evaluation' AND properties_group_ai['$ai_evaluation_key_type'] = 'posthog') as ai_trial_evaluation_count,
+            countIf(event = '$ai_evaluation' AND properties_group_ai['$ai_evaluation_runtime'] = 'llm_judge') as ai_llm_judge_evaluation_count,
+            countIf(event = '$ai_evaluation' AND properties_group_ai['$ai_evaluation_runtime'] = 'hog') as ai_hog_evaluation_count,
+            countIf(event = '$ai_evaluation' AND properties_group_ai['$ai_evaluation_runtime'] = 'sentiment') as ai_sentiment_evaluation_count
         FROM events
         WHERE team_id IN %(team_ids)s
           AND event IN %(ai_events)s
@@ -758,6 +770,9 @@ def _get_all_ai_observability_reports(
                 "ai_evaluation_count": 0,
                 "ai_is_error_count": 0,
                 "ai_trial_evaluation_count": 0,
+                "ai_llm_judge_evaluation_count": 0,
+                "ai_hog_evaluation_count": 0,
+                "ai_sentiment_evaluation_count": 0,
                 "ai_trace_summary_count": 0,
                 "ai_generation_summary_count": 0,
                 "ai_trace_clusters_count": 0,
@@ -803,6 +818,9 @@ def _get_all_ai_observability_reports(
             report["ai_evaluation_count"] += metrics.ai_evaluation_count
             report["ai_is_error_count"] += metrics.ai_is_error_count
             report["ai_trial_evaluation_count"] += metrics.ai_trial_evaluation_count
+            report["ai_llm_judge_evaluation_count"] += metrics.ai_llm_judge_evaluation_count
+            report["ai_hog_evaluation_count"] += metrics.ai_hog_evaluation_count
+            report["ai_sentiment_evaluation_count"] += metrics.ai_sentiment_evaluation_count
             report["ai_trace_summary_count"] += metrics.ai_trace_summary_count
             report["ai_generation_summary_count"] += metrics.ai_generation_summary_count
             report["ai_trace_clusters_count"] += metrics.ai_trace_clusters_count

--- a/posthog/tasks/test/test_ai_observability_usage_report.py
+++ b/posthog/tasks/test/test_ai_observability_usage_report.py
@@ -91,12 +91,18 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         self._create_ai_events(self.team, distinct_id, "$ai_metric", 1)
         self._create_ai_events(self.team, distinct_id, "$ai_feedback", 4)
         self._create_ai_events(
-            self.team, distinct_id, "$ai_evaluation", 3, properties={"$ai_evaluation_key_type": "posthog"}
+            self.team,
+            distinct_id,
+            "$ai_evaluation",
+            3,
+            properties={"$ai_evaluation_key_type": "posthog", "$ai_evaluation_runtime": "llm_judge"},
         )
         self._create_ai_events(
-            self.team, distinct_id, "$ai_evaluation", 2, properties={"$ai_evaluation_key_type": "byok"}
+            self.team, distinct_id, "$ai_evaluation", 2, properties={"$ai_evaluation_runtime": "hog"}
         )
-        self._create_ai_events(self.team, distinct_id, "$ai_evaluation", 1)
+        self._create_ai_events(
+            self.team, distinct_id, "$ai_evaluation", 1, properties={"$ai_evaluation_runtime": "sentiment"}
+        )
         self._create_ai_events(self.team, distinct_id, "$ai_trace_summary", 7)
         self._create_ai_events(self.team, distinct_id, "$ai_generation_summary", 12)
         self._create_ai_events(self.team, distinct_id, "$ai_trace_clusters", 2)
@@ -141,6 +147,9 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         assert metrics.ai_feedback_count == 4
         assert metrics.ai_evaluation_count == 6
         assert metrics.ai_trial_evaluation_count == 3
+        assert metrics.ai_llm_judge_evaluation_count == 3
+        assert metrics.ai_hog_evaluation_count == 2
+        assert metrics.ai_sentiment_evaluation_count == 1
         assert metrics.ai_trace_summary_count == 7
         assert metrics.ai_generation_summary_count == 12
         assert metrics.ai_trace_clusters_count == 2
@@ -483,10 +492,17 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         # Create comprehensive AI events for team 1
         self._create_ai_events(self.team, distinct_id_1, "$ai_generation", 10)
         self._create_ai_events(
-            self.team, distinct_id_1, "$ai_evaluation", 3, properties={"$ai_evaluation_key_type": "posthog"}
+            self.team,
+            distinct_id_1,
+            "$ai_evaluation",
+            3,
+            properties={"$ai_evaluation_key_type": "posthog", "$ai_evaluation_runtime": "llm_judge"},
         )
         self._create_ai_events(
-            self.team, distinct_id_1, "$ai_evaluation", 2, properties={"$ai_evaluation_key_type": "byok"}
+            self.team, distinct_id_1, "$ai_evaluation", 1, properties={"$ai_evaluation_runtime": "hog"}
+        )
+        self._create_ai_events(
+            self.team, distinct_id_1, "$ai_evaluation", 1, properties={"$ai_evaluation_runtime": "sentiment"}
         )
         self._create_ai_events(
             self.team,
@@ -558,6 +574,9 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         assert org_1_report["ai_generation_count"] == 13  # 10 + 3
         assert org_1_report["ai_evaluation_count"] == 5
         assert org_1_report["ai_trial_evaluation_count"] == 3
+        assert org_1_report["ai_llm_judge_evaluation_count"] == 3
+        assert org_1_report["ai_hog_evaluation_count"] == 1
+        assert org_1_report["ai_sentiment_evaluation_count"] == 1
         assert org_1_report["ai_trace_summary_count"] == 6
         assert org_1_report["ai_generation_summary_count"] == 8
         assert org_1_report["ai_trace_clusters_count"] == 1
@@ -589,6 +608,9 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         assert org_2_report["organization_name"] == org_2.name
         assert org_2_report["ai_embedding_count"] == 7
         assert org_2_report["ai_generation_count"] == 2
+        assert org_2_report["ai_llm_judge_evaluation_count"] == 0
+        assert org_2_report["ai_hog_evaluation_count"] == 0
+        assert org_2_report["ai_sentiment_evaluation_count"] == 0
         assert org_2_report["llm_prompt_fetched_count"] == 1
         assert org_2_report["total_ai_cost_usd"] == pytest.approx(0.050, rel=1e-6)  # 2 * 0.025
         assert org_2_report["ai_trace_summary_count"] == 0
@@ -664,6 +686,9 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         assert org_report["ai_metric_count"] == 0
         assert org_report["ai_feedback_count"] == 0
         assert org_report["ai_evaluation_count"] == 0
+        assert org_report["ai_llm_judge_evaluation_count"] == 0
+        assert org_report["ai_hog_evaluation_count"] == 0
+        assert org_report["ai_sentiment_evaluation_count"] == 0
         assert org_report["ai_trace_summary_count"] == 0
         assert org_report["ai_generation_summary_count"] == 0
         assert org_report["ai_trace_clusters_count"] == 0
@@ -686,10 +711,14 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         self._create_ai_events(self.team, distinct_id_1, "$ai_generation", 10)
         self._create_ai_events(team_2, distinct_id_2, "$ai_generation", 5)
         self._create_ai_events(
-            self.team, distinct_id_1, "$ai_evaluation", 3, properties={"$ai_evaluation_key_type": "posthog"}
+            self.team,
+            distinct_id_1,
+            "$ai_evaluation",
+            3,
+            properties={"$ai_evaluation_key_type": "posthog", "$ai_evaluation_runtime": "llm_judge"},
         )
         self._create_ai_events(
-            team_2, distinct_id_2, "$ai_evaluation", 2, properties={"$ai_evaluation_key_type": "posthog"}
+            team_2, distinct_id_2, "$ai_evaluation", 2, properties={"$ai_evaluation_runtime": "sentiment"}
         )
 
         # Generate reports
@@ -702,7 +731,10 @@ class TestAIObservabilityUsageReport(APIBaseTest, ClickhouseTestMixin, Clickhous
         # Counts should be aggregated across both teams
         assert org_report["ai_generation_count"] == 15  # 10 + 5
         assert org_report["ai_evaluation_count"] == 5  # 3 + 2
-        assert org_report["ai_trial_evaluation_count"] == 5  # 3 + 2
+        assert org_report["ai_trial_evaluation_count"] == 3
+        assert org_report["ai_llm_judge_evaluation_count"] == 3
+        assert org_report["ai_hog_evaluation_count"] == 0
+        assert org_report["ai_sentiment_evaluation_count"] == 2
 
     def test_dimension_breakdown_aggregation_across_teams(self) -> None:
         """Test that dimension breakdowns are correctly aggregated across teams in the same org."""


### PR DESCRIPTION
## Problem

The AI observability usage report only included total `$ai_evaluation` counts and PostHog-key trial counts. It did not expose how evaluations were split across runtime types like LLM judge, Hog, and sentiment.

## Changes

- Add `ai_llm_judge_evaluation_count`, `ai_hog_evaluation_count`, and `ai_sentiment_evaluation_count` to the combined AI metrics query.
- Include those counters in organization-level usage report initialization and aggregation.
- Extend existing usage report tests to cover runtime counts, zero defaults, and multi-team aggregation.

## How did you test this code?

- Automated checks: Python lint, formatting, and type checks passed for the touched files.
- Django/ClickHouse report tests were attempted but could not complete because local Postgres at `127.0.0.1:5432` was unavailable.
- Added coverage catches regressions where `$ai_evaluation_runtime` values stop being counted or stop rolling up into organization usage reports.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This changes internal usage report properties.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex implemented the requested AI observability usage-report breakdown. Skills invoked: `/writing-clickhouse-queries`, `/writing-tests`, `llma-git-workflow`, `create-pr`, and `hogli`.

Chosen shape is three flat report properties matching the known `$ai_evaluation_runtime` values. Existing aggregate counters remain unchanged, including `ai_trial_evaluation_count` as the PostHog-key counter.