### PR TITLE
fix(funnels): improve step funnel tooltip spacing and alignment

### DIFF
--- a/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/FunnelBarVertical.scss
@@ -212,8 +212,22 @@
 .FunnelTooltip {
     width: 20rem;
 
-    .LemonRow__content {
+    &__header {
+        display: flex;
+        gap: 0.5rem;
+        align-items: flex-start;
+        line-height: 1.5rem; // Match the step-number Lettermark height so icon and title align
+    }
+
+    &__title {
+        min-width: 0; // Let long event names wrap instead of overflowing the tooltip
         overflow-wrap: anywhere;
+    }
+
+    &__separator {
+        margin: 0 0.25rem;
+        font-weight: 400;
+        color: var(--color-text-secondary);
     }
 
     table {
@@ -222,19 +236,23 @@
         border-collapse: collapse;
     }
 
-    tr {
-        height: 1.75rem;
+    td {
+        height: 1.5rem;
+        vertical-align: middle;
     }
 
+    // Labels and values share the tooltip's outer padding as their left/right edge, so
+    // the metric labels line up with the header's step-number icon above them.
     td:first-child {
-        padding: 0 0.5rem;
+        padding-right: 0.5rem;
         font-weight: 500;
+        color: var(--color-text-secondary);
     }
 
     td:last-child {
-        padding-right: 0.5rem;
         font-weight: 600;
         text-align: right;
+        white-space: nowrap;
     }
 
     .table-subtext {

--- a/frontend/src/scenes/funnels/FunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/FunnelTooltip.tsx
@@ -4,7 +4,6 @@ import { useEffect, useRef } from 'react'
 
 import { EntityFilterInfo } from 'lib/components/EntityFilterInfo'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { LemonRow } from 'lib/lemon-ui/LemonRow'
 import { Lettermark, LettermarkColor } from 'lib/lemon-ui/Lettermark'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { humanFriendlyNumber, percentage } from 'lib/utils/numbers'
@@ -49,6 +48,21 @@ export function FunnelTooltip({
 }: FunnelTooltipProps): JSX.Element {
     const { allCohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+    // Pure compare bars (no real breakdown) show only the period; breakdown and
+    // breakdown + compare bars show the breakdown value (plus the period if any).
+    const headerLabel = funnelTooltipHeaderLabel({
+        breakdownLabel:
+            !series.compare_label || hasBreakdown(series.breakdown_value)
+                ? formatBreakdownLabel(
+                      series.breakdown_value,
+                      breakdownFilter,
+                      allCohorts.results,
+                      formatPropertyValueForDisplay
+                  )
+                : null,
+        compareLabel: series.compare_label,
+        comparePeriodDateRange,
+    })
     return (
         <div
             data-attr="funnel-tooltip"
@@ -58,28 +72,19 @@ export function FunnelTooltip({
                 'shadow-none': embedded,
             })}
         >
-            <LemonRow icon={<Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />} fullWidth>
-                <strong>
+            <div className="FunnelTooltip__header">
+                <Lettermark name={stepIndex + 1} color={LettermarkColor.Gray} />
+                <strong className="FunnelTooltip__title">
                     <EntityFilterInfo filter={getActionFilterFromFunnelStep(series)} allowWrap />
-                    <span className="mx-1">•</span>
-                    {funnelTooltipHeaderLabel({
-                        // Pure compare bars (no real breakdown) show only the period; breakdown and
-                        // breakdown + compare bars show the breakdown value (plus the period if any).
-                        breakdownLabel:
-                            !series.compare_label || hasBreakdown(series.breakdown_value)
-                                ? formatBreakdownLabel(
-                                      series.breakdown_value,
-                                      breakdownFilter,
-                                      allCohorts.results,
-                                      formatPropertyValueForDisplay
-                                  )
-                                : null,
-                        compareLabel: series.compare_label,
-                        comparePeriodDateRange,
-                    })}
+                    {headerLabel && (
+                        <>
+                            <span className="FunnelTooltip__separator">•</span>
+                            {headerLabel}
+                        </>
+                    )}
                 </strong>
-            </LemonRow>
-            <LemonDivider className="my-2" />
+            </div>
+            <LemonDivider className="my-1" />
             <table>
                 <tbody>
                     <tr>
@@ -118,7 +123,7 @@ export function FunnelTooltip({
             </table>
             {showPersonsModal && (
                 <>
-                    <LemonDivider className="my-2" />
+                    <LemonDivider className="my-1" />
                     <ClickToInspectActors groupTypeLabel={groupTypeLabel} />
                 </>
             )}


### PR DESCRIPTION
## Problem

The hover tooltip on step funnels looked messy, mostly from bad whitespace. The header was built from a `LemonRow` — a heavyweight list-row component with a 40px `min-height` — so a single line of content floated in a tall band of dead space. On top of that, the `•` separator rendered even when there was no breakdown/compare label after it (leaving a dangling bullet), labels were double-padded and didn't share a clean left edge with the header icon, and the rows + dividers were loosely spaced.

## Changes

All three funnel visualizations (legacy vertical bar, horizontal steps, steps bar) share `FunnelTooltip`, so this fixes the tooltip everywhere.

- Replace the `LemonRow` header with a lean flex `<div>` whose line-height matches the step-number `Lettermark`, removing the `min-height` bloat and aligning the icon with the title.
- Only render the `•` separator when a trailing label actually exists — no more dangling bullet/trailing space.
- Align the metric labels to the header icon on a single left rail (drop the doubled cell padding), keep values right-aligned to the matching edge, and add `white-space: nowrap` so numbers/durations never wrap.
- Tighten rows (1.75rem → 1.5rem) and de-emphasize the label column for clearer label/value hierarchy.
- Tighten both dividers (`my-2` → `my-1`).

The header content itself (step number, event name, breakdown/compare label) is unchanged — only layout and spacing.

I couldn't attach screenshots: as an agent I had no browser/app in this environment. The `Components/FunnelTooltip` stories (`Default`, `WithLongName`, `WithLongUnbrokenName`) in `FunnelTooltip.stories.tsx` cover the layout and long-name wrapping for reviewers who want to eyeball it.

## How did you test this code?

I'm an agent. I did **not** run automated tests locally — the frontend toolchain wasn't installed in my environment (`node_modules` absent, so `tsgo`/oxlint/oxfmt/Storybook couldn't run). I verified the change by tracing the rendered box model and the header-label edge cases (plain, breakdown, compare, and empty-label) by hand. CI will run typecheck, lint, and Storybook visual regression. There are no committed snapshots for the `FunnelTooltip` stories, so nothing stale to regenerate.

No tests were added: this is a pure styling/markup change with no new logic branch worth a dedicated regression test beyond what the existing stories already render.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @thmsobrmlr (assigned as DRI).

Authored with Claude Code (Opus 4.8). No repo skills were invoked — this is a self-contained frontend styling change touching no migrations, DRF endpoints, generated API types, or tests, so none of the mandatory-skill triggers applied.

Decisions worth flagging for review:
- Chose to **replace** the `LemonRow` rather than override its `min-height` in SCSS, because the frontend guide explicitly says not to use `LemonRow` for layout. The replacement re-implements the long-name wrapping (`min-width: 0` + `overflow-wrap: anywhere`) that the old `.LemonRow__content` rule provided.
- Set the header `line-height` to `1.5rem` to match the 24px `Lettermark` so the icon and title align cleanly on a single line and the icon hangs at the top for multi-line names.
- Left the pre-existing `• Baseline` placeholder (shown on plain no-breakdown funnels) **out of scope** — that's a content question, not whitespace. Happy to suppress it in a follow-up if wanted.
