### PR TITLE
chore(test): remove trivial oauth and scope model tests

### DIFF
--- a/posthog/models/test/test_oauth.py
+++ b/posthog/models/test/test_oauth.py
@@ -1,4 +1,3 @@
-import uuid
 from datetime import timedelta
 
 from freezegun import freeze_time
@@ -15,7 +14,6 @@ from posthog.models.oauth import (
     OAuthAccessToken,
     OAuthApplication,
     OAuthGrant,
-    OAuthIDToken,
     OAuthRefreshToken,
     revoke_application_sessions,
     revoke_oauth_session,
@@ -26,21 +24,6 @@ class TestOAuthModels(TestCase):
     def setUp(self):
         self.organization = Organization.objects.create(name="Test Org")
         self.user = User.objects.create(email="test@example.com")
-
-    def test_create_oauth_application(self):
-        app = OAuthApplication.objects.create(
-            name="Test App",
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        self.assertEqual(app.name, "Test App")
-        self.assertEqual(app.client_id, "test_client_id")
-        self.assertEqual(app.algorithm, "RS256")
 
     def _make_app(self, name: str, client_id: str, **overrides) -> OAuthApplication:
         return OAuthApplication.objects.create(
@@ -60,15 +43,6 @@ class TestOAuthModels(TestCase):
         self.assertEqual(app.scopes, [])
         app.refresh_from_db()
         self.assertEqual(app.scopes, [])
-
-    def test_oauth_application_scopes_persists_explicit_list(self):
-        app = self._make_app(
-            "Scopes Explicit",
-            "scopes_explicit_client",
-            scopes=["insight:read", "llm_gateway:read"],
-        )
-        app.refresh_from_db()
-        self.assertEqual(app.scopes, ["insight:read", "llm_gateway:read"])
 
     @parameterized.expand(
         [
@@ -116,30 +90,6 @@ class TestOAuthModels(TestCase):
         self.assertEqual(app.required_scopes, ["insight:read"])
         self.assertEqual(app.ceiling_scopes, ["insight:read", "dashboard:read"])
 
-    def test_oauth_access_token_label_defaults_to_empty_string(self):
-        app = self._make_app("Token Label Default", "token_label_default_client")
-        token = OAuthAccessToken.objects.create(
-            application=app,
-            user=self.user,
-            token="default_label_token",
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-        self.assertEqual(token.label, "")
-        token.refresh_from_db()
-        self.assertEqual(token.label, "")
-
-    def test_oauth_access_token_label_persists_explicit_value(self):
-        app = self._make_app("Token Label Explicit", "token_label_explicit_client")
-        token = OAuthAccessToken.objects.create(
-            application=app,
-            user=self.user,
-            token="labeled_token",
-            expires=timezone.now() + timedelta(minutes=5),
-            label="laptop-2026",
-        )
-        token.refresh_from_db()
-        self.assertEqual(token.label, "laptop-2026")
-
     @freeze_time("2024-01-01 00:00:00")
     def test_create_oauth_application_with_skip_authorization_fails(self):
         # Test that creating an application with skip_authorization=True raises an error
@@ -155,66 +105,6 @@ class TestOAuthModels(TestCase):
                 algorithm="RS256",
                 skip_authorization=True,  # This should trigger the constraint
             )
-
-    def test_create_oauth_grant(self):
-        app = OAuthApplication.objects.create(
-            name="Test App",
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        grant = OAuthGrant.objects.create(
-            application=app,
-            user=self.user,
-            code="test_code",
-            code_challenge="test_challenge",
-            code_challenge_method="S256",
-            expires=timezone.now() + timedelta(minutes=15),
-        )
-        self.assertEqual(grant.code, "test_code")
-        self.assertEqual(grant.code_challenge_method, "S256")
-
-    def test_token_expiry(self):
-        app = OAuthApplication.objects.create(
-            name="Test App",
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        grant = OAuthGrant.objects.create(
-            application=app,
-            user=self.user,
-            code="test_code",
-            code_challenge="test_challenge",
-            code_challenge_method="S256",
-            expires=timezone.now() + timedelta(minutes=5),
-            scoped_organizations=[self.organization.id],
-        )
-        self.assertTrue(grant.expires > timezone.now())
-
-        with freeze_time(timezone.now() + timedelta(minutes=10)):
-            self.assertTrue(grant.expires < timezone.now())
-
-    def test_create_oauth_application_with_https_redirect_url(self):
-        app = OAuthApplication.objects.create(
-            name="Secure App",
-            client_id="secure_client_id",
-            client_secret="secure_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",  # HTTPS URL
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        self.assertEqual(app.redirect_uris, "https://example.com/callback")
 
     @override_settings(DEBUG=False)
     def test_cannot_create_application_with_http_redirect_url_when_debug_is_false(self):
@@ -496,114 +386,6 @@ class TestOAuthModels(TestCase):
                 organization=self.organization,
                 algorithm="RS256",
             )
-
-    def test_token_revocation(self):
-        app = OAuthApplication.objects.create(
-            name="Revocable App",
-            client_id="revocable_client_id",
-            client_secret="revocable_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        grant = OAuthGrant.objects.create(
-            application=app,
-            user=self.user,
-            code="revocable_code",
-            code_challenge="revocable_challenge",
-            code_challenge_method="S256",
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-        grant.delete()
-        with self.assertRaises(OAuthGrant.DoesNotExist):
-            OAuthGrant.objects.get(code="revocable_code")
-
-    def test_application_deletion_cascades(self):
-        app = OAuthApplication.objects.create(
-            name="Cascade Delete App",
-            client_id="cascade_client_id",
-            client_secret="cascade_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-        OAuthGrant.objects.create(
-            application=app,
-            user=self.user,
-            code="cascade_code",
-            code_challenge="cascade_challenge",
-            code_challenge_method="S256",
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-        app_id = app.id
-        app.delete()
-        self.assertFalse(OAuthGrant.objects.filter(application_id=app_id).exists())
-
-    def test_user_and_organization_association(self):
-        app = OAuthApplication.objects.create(
-            name="Association App",
-            client_id="association_client_id",
-            client_secret="association_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-
-        self.assertEqual(app.organization, self.organization)
-
-    def test_oauth_models_have_reverse_relationships(self):
-        app = OAuthApplication.objects.create(
-            name="Test App",
-            client_id="test_client_id",
-            client_secret="test_client_secret",
-            client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
-            authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
-            redirect_uris="https://example.com/callback",
-            organization=self.organization,
-            algorithm="RS256",
-        )
-
-        grant = OAuthGrant.objects.create(
-            application=app,
-            user=self.user,
-            code="test_code",
-            code_challenge="test_challenge",
-            code_challenge_method="S256",
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-
-        id_token = OAuthIDToken.objects.create(
-            application=app,
-            user=self.user,
-            jti=uuid.uuid4(),
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-
-        access_token = OAuthAccessToken.objects.create(
-            application=app,
-            user=self.user,
-            token="test_token",
-            expires=timezone.now() + timedelta(minutes=5),
-        )
-
-        refresh_token = OAuthRefreshToken.objects.create(
-            application=app,
-            user=self.user,
-            token="test_token",
-        )
-
-        self.assertIn(app, self.organization.oauth_applications.all())
-
-        self.assertIn(grant, self.user.oauth_grants.all())
-        self.assertIn(id_token, self.user.oauth_id_tokens.all())
-        self.assertIn(access_token, self.user.oauth_access_tokens.all())
-        self.assertIn(refresh_token, self.user.oauth_refresh_tokens.all())
 
     def test_get_allowed_schemes_extracts_schemes_from_redirect_uris(self):
         app = OAuthApplication.objects.create(

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -72,26 +72,10 @@ class TestDowngradeScopesToReadOnly(BaseTest):
         self.assertEqual(result.count("feature_flag:read"), 1)
         self.assertIn("openid", result)
 
-    def test_wildcard_only_token(self) -> None:
-        # Bare `*` alone is the OAuth full-access shorthand and must NOT pass through.
-        self.assertNotIn(":write", downgrade_scopes_to_read_only("*"))
-        self.assertNotEqual(downgrade_scopes_to_read_only("*"), "*")
-
 
 class TestScopeSets(BaseTest):
     def test_all_scopes_matches_scope_descriptions_keys(self) -> None:
         self.assertEqual(ALL_SCOPES, frozenset(get_scope_descriptions().keys()))
-
-    @parameterized.expand(
-        [
-            ("insight:read",),
-            ("insight:write",),
-            ("llm_gateway:read",),
-            ("llm_gateway:write",),
-        ]
-    )
-    def test_all_scopes_contains_known_string(self, scope: str) -> None:
-        self.assertIn(scope, ALL_SCOPES)
 
     @parameterized.expand([(f"{obj}:{action}",) for obj in INTERNAL_API_SCOPE_OBJECTS for action in API_SCOPE_ACTIONS])
     def test_all_scopes_excludes_internal_scope(self, scope: str) -> None:
@@ -101,22 +85,9 @@ class TestScopeSets(BaseTest):
         self.assertTrue(PRIVILEGED_SCOPES.issubset(ALL_SCOPES))
         self.assertIn("llm_gateway:read", PRIVILEGED_SCOPES)
 
-    def test_oauth_hidden_scopes_expands_oauth_hidden_objects_to_strings(self) -> None:
-        # OAUTH_HIDDEN_SCOPES is the `obj:action` STRING form of
-        # OAUTH_HIDDEN_SCOPE_OBJECTS, intersected with ALL_SCOPES so phantom
-        # combinations can't leak in.
-        expected = (
-            frozenset(f"{obj}:{action}" for obj in OAUTH_HIDDEN_SCOPE_OBJECTS for action in API_SCOPE_ACTIONS)
-            & ALL_SCOPES
-        )
-        self.assertEqual(OAUTH_HIDDEN_SCOPES, expected)
-
     def test_unprivileged_scopes_excludes_privileged_and_hidden(self) -> None:
         self.assertTrue(UNPRIVILEGED_SCOPES.isdisjoint(PRIVILEGED_SCOPES))
         self.assertTrue(UNPRIVILEGED_SCOPES.isdisjoint(OAUTH_HIDDEN_SCOPES))
-
-    def test_unprivileged_scopes_subset_of_all_scopes(self) -> None:
-        self.assertTrue(UNPRIVILEGED_SCOPES.issubset(ALL_SCOPES))
 
     @parameterized.expand([("openid",), ("profile",), ("email",)])
     def test_unprivileged_scopes_excludes_oidc(self, oidc: str) -> None:
@@ -169,13 +140,6 @@ class TestScopeSets(BaseTest):
             self.assertLessEqual(len(scope), 100, f"{scope} exceeds OAuthApplication.scopes CharField max_length=100")
 
 
-class TestScopeBucketInvariants(SimpleTestCase):
-    def test_signal_scout_internal_is_internal(self) -> None:
-        # The scout internal scope must stay in INTERNAL_API_SCOPE_OBJECTS so it is
-        # strict-excluded from PAK descriptions, OAuth metadata, and the /authorize
-        # allowlist. It is minted server-side only (direct OAuthAccessToken insert).
-        assert "signal_scout_internal" in INTERNAL_API_SCOPE_OBJECTS
-
 
 class TestGetOAuthScopesSupported(SimpleTestCase):
     def test_signal_scout_internal_write_is_not_advertised(self) -> None:
@@ -186,15 +150,6 @@ class TestGetOAuthScopesSupported(SimpleTestCase):
         # every subsequent run's prompt). It must NOT appear in the advertised scope set.
         assert "signal_scout_internal:write" not in get_oauth_scopes_supported()
         assert "signal_scout_internal:read" not in get_oauth_scopes_supported()
-
-    @parameterized.expand(
-        [
-            ("user_interview_DO_NOT_USE:read",),
-            ("user_interview_DO_NOT_USE:write",),
-        ]
-    )
-    def test_oauth_hidden_scopes_are_not_advertised(self, scope: str) -> None:
-        assert scope not in get_oauth_scopes_supported()
 
     def test_internal_scopes_are_not_advertised(self) -> None:
         advertised = set(get_oauth_scopes_supported())

--- a/posthog/test/test_scopes.py
+++ b/posthog/test/test_scopes.py
@@ -140,7 +140,6 @@ class TestScopeSets(BaseTest):
             self.assertLessEqual(len(scope), 100, f"{scope} exceeds OAuthApplication.scopes CharField max_length=100")
 
 
-
 class TestGetOAuthScopesSupported(SimpleTestCase):
     def test_signal_scout_internal_write_is_not_advertised(self) -> None:
         # Security invariant — the scout sandbox token carries `signal_scout_internal:write`


### PR DESCRIPTION
## Problem

`test_oauth.py` and `test_scopes.py` accumulated tests that assert framework behavior or constants rather than any PostHog logic — the kind `/writing-tests` flags as "don't write it" (trivial/framework, change-detector, vacuous). They cost Django `TestCase` setup time and break on harmless refactors without catching a realistic regression.

## Changes

`posthog/models/test/test_oauth.py` — removed 11 tests that only:
- echoed constructor args back (`test_create_oauth_application`, `…_with_https_redirect_url`, `…_user_and_organization_association`)
- exercised Django ORM round-trips / cascade / reverse-relations (`…_scopes_persists_explicit_list`, `…_label_*`, `test_create_oauth_grant`, `test_token_revocation` (a `grant.delete()` + `DoesNotExist`), `test_application_deletion_cascades`, `test_oauth_models_have_reverse_relationships`)
- tested datetime comparison + freezegun, not product expiry logic (`test_token_expiry`)

The real coverage stays: redirect-uri validation (loopback / malicious-localhost / custom-scheme / blocked-scheme / fragment / no-host), scope-split validation, `get_allowed_schemes`, and the revocation helpers `revoke_oauth_session` / `revoke_application_sessions`. Kept `test_unique_client_id_constraint` (lower-confidence, security-adjacent).

`posthog/test/test_scopes.py` — removed 6:
- `test_unprivileged_scopes_subset_of_all_scopes` — mathematically guaranteed (set difference can't produce a superset)
- `test_oauth_hidden_scopes_expands_…` — change-detector recomputing the source definition verbatim; the real invariant is covered by the "not advertised" surface tests
- `test_signal_scout_internal_is_internal` (whole `TestScopeBucketInvariants` class) — constant membership already enforced at the real surfaces (`test_signal_scout_internal_write_is_not_advertised`, `…_are_not_pak_descriptions`)
- `test_oauth_hidden_scopes_are_not_advertised` — asserts `user_interview_DO_NOT_USE:*`, a scope object that no longer exists in `scopes.py` (vacuously true)
- `test_all_scopes_contains_known_string` — constant membership spot-check
- `test_wildcard_only_token` — subsumed by `test_wildcard_expands_to_all_public_read_scopes`

Kept `test_unprivileged_scopes_excludes_oidc` (lower-confidence). All retained scope-resolution logic tests (`scopes_within_ceiling`, `effective_ceiling`, `narrow_scopes_to_ceiling`, etc.) untouched.

Counts:
- Tests removed: 17 (11 + 6)
- Lines removed: 263
- Estimated CI wall-time saved: ~12 Django `TestCase` setups + minor unit overhead

Requesting review from: Team Security

## How did you test this code?

I'm an agent. I verified statically: both files still parse (AST), the intended tests are gone and the retained tests present, and the two now-unused imports (`uuid`, `OAuthIDToken`) were removed while all other imports remain used. I did not run pytest locally (the web environment can't install the backend's git-sourced deps); CI runs the suite on this PR.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a monorepo-wide low-value-test cleanup, drawn from a pre-vetted worklist and independently re-validated here against current code. Each deletion was adversarially re-checked (can I name a realistic regression it catches? if yes, keep it) — that's why two lower-confidence, security-adjacent tests were retained. Invoked the `/writing-tests` value bar. Deletions were applied via an AST line-span remover and verified to re-parse.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFyiLU6XMPxE138tFSb4nH)_