### PR TITLE
chore(test): use TestCase for agent proxy callback tests

### DIFF
--- a/products/tasks/backend/tests/test_agent_proxy_callback.py
+++ b/products/tasks/backend/tests/test_agent_proxy_callback.py
@@ -3,7 +3,7 @@ from typing import Any
 
 from unittest.mock import patch
 
-from django.test import TransactionTestCase, override_settings
+from django.test import TestCase, override_settings
 
 from parameterized import parameterized
 
@@ -18,7 +18,7 @@ from products.tasks.backend.tests.test_api import TEST_RSA_PRIVATE_KEY
 
 
 @override_settings(SANDBOX_JWT_PRIVATE_KEY=TEST_RSA_PRIVATE_KEY)
-class TestAgentProxyCallback(TransactionTestCase):
+class TestAgentProxyCallback(TestCase):
     def setUp(self) -> None:
         super().setUp()
         reset_sandbox_jwt_key_cache()


### PR DESCRIPTION
## Problem

`TestAgentProxyCallback` (15 tests) used `TransactionTestCase`, which truncates and reseeds every table between tests instead of rolling back a transaction — dramatically slower and a common source of cross-test interference. `/writing-tests` calls this out: use `TestCase` unless you truly need committed transaction boundaries.

## Changes

Flipped the base class `TransactionTestCase` → `TestCase` (and the import). Behavior-preserving — verified the suite has no reason to need `TransactionTestCase`:

- The endpoint handler (`agent_proxy_callback.py`) calls `task_run.heartbeat_workflow(...)` and `notify_task_run_awaiting_input(...)` **directly**, not via `transaction.on_commit`, so the dispatch assertions don't depend on a real commit.
- No threads, `select_for_update`, raw `connections[...]`, or cross-connection visibility anywhere in the file.
- The one delete-then-call case (`test_unknown_run_returns_200_not_dispatched`) is a normal ORM delete + query, fine inside a transaction.

Counts:
- Tests removed: 0 (behavior-preserving)
- Lines changed: 2
- Estimated CI wall-time saved: 15 per-test full-DB flushes become transaction rollbacks

Requesting review from: PostHog Code

## How did you test this code?

I'm an agent. I verified statically that nothing in the file or the handler requires committed-transaction semantics (no `on_commit`, threads, `select_for_update`, or cross-connection reads), so the rollback-based `TestCase` is equivalent here. I did not run pytest locally (the web environment can't install the backend's git-sourced deps); CI runs the suite on this PR — the relevant signal is that all 15 tests stay green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a monorepo-wide test-suite cleanup; this is the single biggest pure CI-wall-time item found in the `products/` Python audit. Before flipping I traced the request handler to confirm dispatch is synchronous (no `transaction.on_commit`), which is the usual reason a callback test needs `TransactionTestCase`. Applied the `/writing-tests` efficiency bar (`TestCase` over `TransactionTestCase`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFyiLU6XMPxE138tFSb4nH)_