### PR TITLE
chore(test): remove framework-behavior temporal server tests

### DIFF
--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -500,5 +500,3 @@ test_gauge 100.0
         # Should not raise any exception
         await server.stop()
         await server.stop()  # Multiple stops should also be safe
-
-

--- a/posthog/temporal/tests/common/test_combined_metrics_server.py
+++ b/posthog/temporal/tests/common/test_combined_metrics_server.py
@@ -1,5 +1,4 @@
 import time
-import socket
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -161,26 +160,6 @@ temporal_long_request_latency_bucket{namespace="default",operation="PollActivity
             # prometheus_client metrics should still be served
             assert test_counter in content
             assert "temporal" not in content
-        finally:
-            await server.stop()
-
-    @pytest.mark.asyncio
-    async def test_returns_404_for_unknown_paths(self, isolated_registry):
-        temporal_port = get_free_port()
-        metrics_port = get_free_port()
-
-        server = CombinedMetricsServer(
-            port=metrics_port,
-            temporal_metrics_url=f"http://127.0.0.1:{temporal_port}/metrics",
-            registry=isolated_registry,
-        )
-        await server.start()
-
-        try:
-            url = f"http://127.0.0.1:{metrics_port}/unknown"
-            async with ClientSession() as session:
-                async with session.get(url) as response:
-                    assert response.status == 404
         finally:
             await server.stop()
 
@@ -523,12 +502,3 @@ test_gauge 100.0
         await server.stop()  # Multiple stops should also be safe
 
 
-class TestGetFreePort:
-    def test_returns_available_port(self):
-        port = get_free_port()
-        assert isinstance(port, int)
-        assert port > 0
-
-        # Verify the port is actually available
-        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-            s.bind(("127.0.0.1", port))

--- a/posthog/temporal/tests/common/test_health_server.py
+++ b/posthog/temporal/tests/common/test_health_server.py
@@ -216,4 +216,3 @@ class TestHealthCheckServer:
                     assert response.status == 200
                     data = await response.json()
                     assert data["idle_seconds"] < 1.0
-

--- a/posthog/temporal/tests/common/test_health_server.py
+++ b/posthog/temporal/tests/common/test_health_server.py
@@ -1,5 +1,4 @@
 import time
-import asyncio
 from contextlib import asynccontextmanager
 from datetime import timedelta
 
@@ -115,15 +114,6 @@ class TestHealthCheckServer:
                     data = await response.json()
                     assert data["status"] == "healthy"
 
-    async def test_unknown_path_returns_404(self):
-        """Test that unknown paths return 404."""
-
-        tracker = LivenessTracker()
-        async with create_server(tracker):
-            async with ClientSession() as session:
-                async with session.get("http://localhost:18001/unknown") as response:
-                    assert response.status == 404
-
     async def test_server_can_be_started_and_stopped(self):
         """Test that server can be cleanly started and stopped."""
 
@@ -163,26 +153,6 @@ class TestHealthCheckServer:
         tracker = LivenessTracker()
         server = HealthCheckServer(port=18003, liveness_tracker=tracker, max_idle_seconds=2.0)
         await server.stop()  # Should not raise
-
-    async def test_healthz_handles_concurrent_requests(self):
-        """Test that the server can handle multiple concurrent health checks."""
-
-        tracker = LivenessTracker()
-        async with create_server(tracker):
-            tracker.record_activity_execution()
-
-            async def check_health():
-                async with ClientSession() as session:
-                    async with session.get("http://localhost:18001/healthz") as response:
-                        assert response.status == 200
-                        return await response.json()
-
-            # Make 10 concurrent requests
-            results = await asyncio.gather(*[check_health() for _ in range(10)])
-
-            # All should succeed
-            assert len(results) == 10
-            assert all(r["status"] == "healthy" for r in results)
 
     async def test_idle_time_accuracy(self):
         """Test that idle_time is calculated accurately."""
@@ -247,22 +217,3 @@ class TestHealthCheckServer:
                     data = await response.json()
                     assert data["idle_seconds"] < 1.0
 
-    async def test_different_max_idle_thresholds(self):
-        """Test that different max_idle_seconds values work correctly."""
-
-        tracker = LivenessTracker()
-        # Create server with very short threshold
-        server = HealthCheckServer(port=18004, liveness_tracker=tracker, max_idle_seconds=0.5)
-        await server.start()
-
-        try:
-            tracker.record_activity_execution()
-            await asyncio.sleep(0.7)
-
-            async with ClientSession() as session:
-                async with session.get("http://localhost:18004/healthz") as response:
-                    assert response.status == 503
-                    data = await response.json()
-                    assert data["max_idle_seconds"] == 0.5
-        finally:
-            await server.stop()


### PR DESCRIPTION
## Problem

The temporal health-check and combined-metrics server tests included cases that assert aiohttp/stdlib behavior rather than our code, plus one redundant case that paid a real `asyncio.sleep(0.7)` every run. These are the "trivial/framework" and "redundant" no's from `/writing-tests` — they break on harmless changes and slow the suite without catching a realistic regression.

## Changes

`test_combined_metrics_server.py`:
- `test_returns_404_for_unknown_paths` — server registers only `/metrics` and `/`, no custom 404 handler, so this is aiohttp's default router.
- `test_returns_available_port` (whole `TestGetFreePort` class) — `get_free_port` is a thin stdlib bind wrapper; the `-> int` annotation covers the type and every other test proves it returns a bindable port by using it (the re-bind also reintroduces a TOCTOU race).

`test_health_server.py`:
- `test_unknown_path_returns_404` — only `/healthz` and `/readyz` are registered; 404 is aiohttp default.
- `test_healthz_handles_concurrent_requests` — the handler holds no per-request state, so this tests aiohttp concurrency; healthy→200 is already covered by `test_healthz_returns_healthy_when_recently_active`.
- `test_different_max_idle_thresholds` — same 503 + configurable-threshold path as `test_healthz_returns_unhealthy_when_idle_too_long`, and it used a real `asyncio.sleep(0.7)` (slow + flaky) where the timing tests use `freeze_time`.

Removed the now-unused `asyncio` and `socket` imports. The substantive tests — metric passthrough/newline handling, temporal-unavailable / HTTP-error / **timeout** graceful degradation, start-twice / stop-noop, and the idle-time/heartbeat liveness logic (via `freeze_time`) — all stay.

Counts:
- Tests removed: 5
- Lines removed: 79
- Estimated CI wall-time saved: removes a real 0.7s `asyncio.sleep` + several framework cases

Requesting review from: Platform

## How did you test this code?

I'm an agent. I confirmed against the server sources that only the real routes are registered (so the 404s are framework behavior), that the kept timing tests already cover configurability via `freeze_time`, and that the files still parse with no unused imports. I did not run pytest locally (the web environment can't install the backend's git-sourced deps); CI runs the suite on this PR.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a monorepo-wide low-value-test cleanup. Each deletion was checked against the server source to confirm it asserts framework behavior or a path a sibling already covers. Notably left `test_handles_temporal_timeout` in place — it catches a real regression (the 5s scrape timeout); its ~5s cost would need an injectable timeout in production code to fix, which is out of scope for a test-only PR. Applied the `/writing-tests` value bar.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFyiLU6XMPxE138tFSb4nH)_