### PR TITLE
feat(customer-analytics): add workflow references to custom property definitions

### DIFF
--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -54,8 +54,14 @@ from products.notebooks.backend.facade import (
 # account -> ResourceNotebook -> notebook relation can't cross a data facade. All account-notebook
 # CRUD goes through `notebooks` (the facade). Tracked by the notebooks legacy-leak interface block.
 from products.notebooks.backend.models import ResourceNotebook
+from products.workflows.backend.services.template_input_usage import get_hog_flows_referencing_template_input_keys
 
 from . import contracts
+
+# The "Update account property" workflow action (Hog template) stores the custom property values it
+# sets keyed by definition id under its ``properties`` input — the link we resolve into references.
+_ACCOUNT_PROPERTY_TEMPLATE_ID = "template-posthog-update-account-property"
+_ACCOUNT_PROPERTY_INPUT_KEY = "properties"
 
 if TYPE_CHECKING:
     from posthog.models.user import User
@@ -654,6 +660,7 @@ def delete_customer_profile_config(
 
 def _to_custom_property_definition_view(
     definition: CustomPropertyDefinition,
+    references: list[contracts.CustomPropertyReference] | None = None,
 ) -> contracts.CustomPropertyDefinitionView:
     return contracts.CustomPropertyDefinitionView(
         id=definition.id,
@@ -664,7 +671,23 @@ def _to_custom_property_definition_view(
         created_at=definition.created_at,
         created_by=definition.created_by_id,
         updated_at=definition.updated_at,
+        references=references or [],
     )
+
+
+def _custom_property_references_by_definition_id(team_id: int) -> dict[str, list[contracts.CustomPropertyReference]]:
+    """Map each referenced definition id to the workflows that set it via the "Update account
+    property" action. One scan of the team's workflows, matched by definition id."""
+    usage = get_hog_flows_referencing_template_input_keys(
+        team_id, _ACCOUNT_PROPERTY_TEMPLATE_ID, _ACCOUNT_PROPERTY_INPUT_KEY
+    )
+    return {
+        definition_id: [
+            contracts.CustomPropertyReference(id=ref.id, name=ref.name, status=ref.status, type="workflow")
+            for ref in refs
+        ]
+        for definition_id, refs in usage.items()
+    }
 
 
 def list_custom_property_definitions(
@@ -674,14 +697,16 @@ def list_custom_property_definitions(
     queryset = CustomPropertyDefinition.objects.filter(team_id=team_id).order_by("name")
     total_count = queryset.count()
     page = queryset[offset : offset + limit]
-    return [_to_custom_property_definition_view(d) for d in page], total_count
+    references = _custom_property_references_by_definition_id(team_id)
+    return [_to_custom_property_definition_view(d, references.get(str(d.id), [])) for d in page], total_count
 
 
 def get_custom_property_definition(team_id: int, definition_id: str) -> contracts.CustomPropertyDefinitionView | None:
     definition = _get_team_scoped(CustomPropertyDefinition, team_id, definition_id)
     if definition is None:
         return None
-    return _to_custom_property_definition_view(definition)
+    references = _custom_property_references_by_definition_id(team_id).get(str(definition.id), [])
+    return _to_custom_property_definition_view(definition, references)
 
 
 def create_custom_property_definition(

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -675,37 +675,63 @@ def _to_custom_property_definition_view(
     )
 
 
-def _custom_property_references_by_definition_id(team_id: int) -> dict[str, list[contracts.CustomPropertyReference]]:
+def _can_read_workflow_references(user_access_control: "UserAccessControl") -> bool:
+    """Whether the caller may see the workflows that reference a custom property.
+
+    ``references`` exposes HogFlow metadata (id, name, status), so it's gated on the caller
+    having at least viewer access to the ``hog_flow`` resource — the property-definition API is
+    authorized as ``account``, and a caller without workflow read access must not enumerate
+    workflows through it. Without RBAC restrictions this resolves to the default (allowed)."""
+    return user_access_control.check_access_level_for_resource("hog_flow", "viewer")
+
+
+def _custom_property_references_by_definition_id(
+    team_id: int, definition_id: str | None = None
+) -> dict[str, list[contracts.CustomPropertyReference]]:
     """Map each referenced definition id to the workflows that set it via the "Update account
-    property" action. One scan of the team's workflows, matched by definition id."""
+    property" action. One scan of the team's workflows, matched by definition id. Pass
+    ``definition_id`` to scan for just that one definition (the single-definition lookup)."""
     usage = get_hog_flows_referencing_template_input_keys(
-        team_id, _ACCOUNT_PROPERTY_TEMPLATE_ID, _ACCOUNT_PROPERTY_INPUT_KEY
+        team_id, _ACCOUNT_PROPERTY_TEMPLATE_ID, _ACCOUNT_PROPERTY_INPUT_KEY, only_value_key=definition_id
     )
     return {
-        definition_id: [
+        referenced_id: [
             contracts.CustomPropertyReference(id=ref.id, name=ref.name, status=ref.status, type="workflow")
             for ref in refs
         ]
-        for definition_id, refs in usage.items()
+        for referenced_id, refs in usage.items()
     }
 
 
 def list_custom_property_definitions(
-    team_id: int, offset: int, limit: int
+    team_id: int, offset: int, limit: int, *, user_access_control: "UserAccessControl"
 ) -> tuple[list[contracts.CustomPropertyDefinitionView], int]:
-    """Custom property definitions for the team, ordered by name. Returns ``(page, total_count)``."""
+    """Custom property definitions for the team, ordered by name. Returns ``(page, total_count)``.
+
+    ``references`` (the workflows referencing each definition) is included only when the caller can
+    read workflows — see ``_can_read_workflow_references``."""
     queryset = CustomPropertyDefinition.objects.filter(team_id=team_id).order_by("name")
     total_count = queryset.count()
     page = queryset[offset : offset + limit]
-    references = _custom_property_references_by_definition_id(team_id)
+    references = (
+        _custom_property_references_by_definition_id(team_id)
+        if _can_read_workflow_references(user_access_control)
+        else {}
+    )
     return [_to_custom_property_definition_view(d, references.get(str(d.id), [])) for d in page], total_count
 
 
-def get_custom_property_definition(team_id: int, definition_id: str) -> contracts.CustomPropertyDefinitionView | None:
+def get_custom_property_definition(
+    team_id: int, definition_id: str, *, user_access_control: "UserAccessControl"
+) -> contracts.CustomPropertyDefinitionView | None:
     definition = _get_team_scoped(CustomPropertyDefinition, team_id, definition_id)
     if definition is None:
         return None
-    references = _custom_property_references_by_definition_id(team_id).get(str(definition.id), [])
+    references: list[contracts.CustomPropertyReference] = []
+    if _can_read_workflow_references(user_access_control):
+        references = _custom_property_references_by_definition_id(team_id, definition_id=str(definition.id)).get(
+            str(definition.id), []
+        )
     return _to_custom_property_definition_view(definition, references)
 
 

--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -239,13 +239,25 @@ class CustomerProfileConfigView:
 
 
 @stdlib_dataclass(frozen=True)
+class CustomPropertyReference:
+    """A place that uses a custom property definition. ``type`` discriminates the kind of
+    referrer (``workflow`` for now); ``id``/``name``/``status`` identify the referring entity."""
+
+    id: str
+    name: str
+    status: str
+    type: str = "workflow"
+
+
+@stdlib_dataclass(frozen=True)
 class CustomPropertyDefinitionView:
     """A team-scoped custom account-property definition as returned by the
     custom-property-definitions endpoints.
 
     Defaults exist so the wrapping serializer can parse partial request bodies (see
     :class:`AccountView`). ``created_by`` is the creator's user id (or ``None``), matching
-    the old model serializer's ``PrimaryKeyRelatedField`` output.
+    the old model serializer's ``PrimaryKeyRelatedField`` output. ``references`` lists where the
+    property is used (workflows), resolved by definition id.
     """
 
     id: UUID | None = None
@@ -256,6 +268,7 @@ class CustomPropertyDefinitionView:
     created_at: datetime | None = None
     created_by: int | None = None
     updated_at: datetime | None = None
+    references: list[CustomPropertyReference] = field(default_factory=list)
 
 
 @stdlib_dataclass(frozen=True)

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -34,6 +34,7 @@ from products.customer_analytics.backend.facade.contracts import (
     CustomerJourneyView,
     CustomerProfileConfigView,
     CustomPropertyDefinitionView,
+    CustomPropertyReference,
 )
 
 # Scope (value, label) pairs, kept in sync with ``CustomerProfileConfig.Scope``. Declared
@@ -265,6 +266,20 @@ class AccountNotebookSerializer(DataclassSerializer):
         ]
 
 
+class CustomPropertyReferenceSerializer(DataclassSerializer):
+    """A place that uses a custom property definition (read-only)."""
+
+    id = serializers.CharField(read_only=True, help_text="Id of the referring entity (e.g. the workflow id).")
+    name = serializers.CharField(read_only=True, help_text="Display name of the referring entity.")
+    status = serializers.CharField(read_only=True, help_text="Status of the referring entity (e.g. workflow status).")
+    type = serializers.CharField(read_only=True, help_text="Kind of reference. Currently always 'workflow'.")
+
+    class Meta:
+        dataclass = CustomPropertyReference
+        ref_name = "CustomPropertyReference"
+        fields = ["id", "name", "status", "type"]
+
+
 class CustomPropertyDefinitionSerializer(DataclassSerializer):
     """A team-scoped definition of a custom account property — the attribute side of the model.
 
@@ -299,6 +314,11 @@ class CustomPropertyDefinitionSerializer(DataclassSerializer):
     created_at = serializers.DateTimeField(read_only=True)
     created_by = serializers.IntegerField(read_only=True, allow_null=True)
     updated_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    references = CustomPropertyReferenceSerializer(
+        many=True,
+        read_only=True,
+        help_text="Workflows that use this property, resolved by definition id.",
+    )
 
     class Meta:
         dataclass = CustomPropertyDefinitionView
@@ -314,6 +334,7 @@ class CustomPropertyDefinitionSerializer(DataclassSerializer):
             "created_at",
             "created_by",
             "updated_at",
+            "references",
         ]
 
 

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -199,12 +199,16 @@ class CustomPropertyDefinitionViewSet(
     def list(self, request: Request, *args, **kwargs) -> Response:
         return self._paginate_via_facade(
             request,
-            lambda offset, limit: api.list_custom_property_definitions(self.team_id, offset=offset, limit=limit),
+            lambda offset, limit: api.list_custom_property_definitions(
+                self.team_id, offset=offset, limit=limit, user_access_control=self.user_access_control
+            ),
             CustomPropertyDefinitionSerializer,
         )
 
     def retrieve(self, request: Request, *args, **kwargs) -> Response:
-        definition = api.get_custom_property_definition(self.team_id, self.kwargs["pk"])
+        definition = api.get_custom_property_definition(
+            self.team_id, self.kwargs["pk"], user_access_control=self.user_access_control
+        )
         if definition is None:
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         return Response(CustomPropertyDefinitionSerializer(instance=definition).data)

--- a/products/customer_analytics/backend/test/test_custom_property_values.py
+++ b/products/customer_analytics/backend/test/test_custom_property_values.py
@@ -3,7 +3,7 @@ from uuid import uuid4
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.db import IntegrityError
 from django.utils import timezone
@@ -331,6 +331,11 @@ class TestSetExternalAccountCustomProperties(BaseTest):
 
 
 class TestCustomPropertyDefinitionReferences(BaseTest):
+    def _uac(self, *, can_read_workflows: bool = True) -> MagicMock:
+        uac = MagicMock()
+        uac.check_access_level_for_resource.return_value = can_read_workflows
+        return uac
+
     def _create_workflow_setting(self, definition_id: str, *, name: str = "Onboarding", status: str = "active"):
         return HogFlow.objects.create(
             team=self.team,
@@ -353,7 +358,9 @@ class TestCustomPropertyDefinitionReferences(BaseTest):
         workflow = self._create_workflow_setting(str(plan.id))
 
         with team_scope(self.team.id):
-            page, _ = facade.list_custom_property_definitions(self.team.id, offset=0, limit=50)
+            page, _ = facade.list_custom_property_definitions(
+                self.team.id, offset=0, limit=50, user_access_control=self._uac()
+            )
         by_id = {view.id: view for view in page}
 
         assert [(r.id, r.name, r.status, r.type) for r in by_id[plan.id].references] == [
@@ -369,6 +376,37 @@ class TestCustomPropertyDefinitionReferences(BaseTest):
         self._create_workflow_setting(str(uuid4()))
 
         with team_scope(self.team.id):
-            page, _ = facade.list_custom_property_definitions(self.team.id, offset=0, limit=50)
+            page, _ = facade.list_custom_property_definitions(
+                self.team.id, offset=0, limit=50, user_access_control=self._uac()
+            )
 
         assert next(v for v in page if v.id == plan.id).references == []
+
+    def test_get_attaches_workflow_references_for_single_definition(self):
+        plan = create_custom_property_definition(team_id=self.team.id, name="Plan")
+        workflow = self._create_workflow_setting(str(plan.id))
+
+        with team_scope(self.team.id):
+            view = facade.get_custom_property_definition(self.team.id, str(plan.id), user_access_control=self._uac())
+
+        assert view is not None
+        assert [(r.id, r.name, r.status, r.type) for r in view.references] == [
+            (str(workflow.id), "Onboarding", "active", "workflow")
+        ]
+
+    def test_references_hidden_without_workflow_read_access(self):
+        # references expose HogFlow metadata, so a caller without hog_flow read access sees none.
+        plan = create_custom_property_definition(team_id=self.team.id, name="Plan")
+        self._create_workflow_setting(str(plan.id))
+
+        with team_scope(self.team.id):
+            page, _ = facade.list_custom_property_definitions(
+                self.team.id, offset=0, limit=50, user_access_control=self._uac(can_read_workflows=False)
+            )
+            view = facade.get_custom_property_definition(
+                self.team.id, str(plan.id), user_access_control=self._uac(can_read_workflows=False)
+            )
+
+        assert next(v for v in page if v.id == plan.id).references == []
+        assert view is not None
+        assert view.references == []

--- a/products/customer_analytics/backend/test/test_custom_property_values.py
+++ b/products/customer_analytics/backend/test/test_custom_property_values.py
@@ -11,6 +11,7 @@ from django.utils import timezone
 from parameterized import parameterized
 
 from posthog.models import Team
+from posthog.models.scoping import team_scope
 
 from products.customer_analytics.backend.facade import (
     api as facade,
@@ -32,6 +33,7 @@ from products.customer_analytics.backend.models import (
 )
 from products.customer_analytics.backend.models.custom_property_value import ACTIVE_VALUE_CONSTRAINT_NAME
 from products.customer_analytics.backend.test.factories import create_account, create_custom_property_definition
+from products.workflows.backend.models import HogFlow
 
 LOGIC_MODULE = "products.customer_analytics.backend.logic.custom_property_values"
 
@@ -326,3 +328,47 @@ class TestSetExternalAccountCustomProperties(BaseTest):
         assert result.error == contracts.ExternalAccountCustomPropertiesError.INVALID_VALUE
         # The good "Plan" write must roll back with the failed "Seats" write — nothing persists.
         assert not CustomPropertyValue.objects.for_team(self.team.id).filter(account=self.account).exists()
+
+
+class TestCustomPropertyDefinitionReferences(BaseTest):
+    def _create_workflow_setting(self, definition_id: str, *, name: str = "Onboarding", status: str = "active"):
+        return HogFlow.objects.create(
+            team=self.team,
+            name=name,
+            status=status,
+            actions=[
+                {
+                    "type": "function",
+                    "config": {
+                        "template_id": "template-posthog-update-account-property",
+                        "inputs": {"properties": {"value": {definition_id: "{event.properties.x}"}}},
+                    },
+                }
+            ],
+        )
+
+    def test_list_attaches_workflow_references_matched_by_id(self):
+        plan = create_custom_property_definition(team_id=self.team.id, name="Plan")
+        create_custom_property_definition(team_id=self.team.id, name="Unused")
+        workflow = self._create_workflow_setting(str(plan.id))
+
+        with team_scope(self.team.id):
+            page, _ = facade.list_custom_property_definitions(self.team.id, offset=0, limit=50)
+        by_id = {view.id: view for view in page}
+
+        assert [(r.id, r.name, r.status, r.type) for r in by_id[plan.id].references] == [
+            (str(workflow.id), "Onboarding", "active", "workflow")
+        ]
+        # A definition no workflow references carries an empty list.
+        unused = next(v for v in page if v.name == "Unused")
+        assert unused.references == []
+
+    def test_reference_matches_id_not_name(self):
+        # A workflow keyed by a stale/foreign id must not attach to a same-named definition.
+        plan = create_custom_property_definition(team_id=self.team.id, name="Plan")
+        self._create_workflow_setting(str(uuid4()))
+
+        with team_scope(self.team.id):
+            page, _ = facade.list_custom_property_definitions(self.team.id, offset=0, limit=50)
+
+        assert next(v for v in page if v.id == plan.id).references == []

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -289,6 +289,20 @@ export const CustomPropertyDisplayTypeEnumApi = {
 } as const
 
 /**
+ * A place that uses a custom property definition (read-only).
+ */
+export interface CustomPropertyReferenceApi {
+    /** Id of the referring entity (e.g. the workflow id). */
+    readonly id: string
+    /** Display name of the referring entity. */
+    readonly name: string
+    /** Status of the referring entity (e.g. workflow status). */
+    readonly status: string
+    /** Kind of reference. Currently always 'workflow'. */
+    readonly type: string
+}
+
+/**
  * A team-scoped definition of a custom account property — the attribute side of the model.
  *
  * Holds only the property's shape (name, display type, big-number flag). Per-account values are
@@ -324,6 +338,8 @@ export interface CustomPropertyDefinitionApi {
     readonly created_by: number | null
     /** @nullable */
     readonly updated_at: string | null
+    /** Workflows that use this property, resolved by definition id. */
+    readonly references: readonly CustomPropertyReferenceApi[]
 }
 
 export interface PaginatedCustomPropertyDefinitionListApi {
@@ -371,6 +387,8 @@ export interface PatchedCustomPropertyDefinitionApi {
     readonly created_by?: number | null
     /** @nullable */
     readonly updated_at?: string | null
+    /** Workflows that use this property, resolved by definition id. */
+    readonly references?: readonly CustomPropertyReferenceApi[]
 }
 
 export interface CustomerJourneyApi {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
@@ -1,14 +1,21 @@
 import { useActions, useValues } from 'kea'
+import { useState } from 'react'
 
-import { IconPencil, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonTable, LemonTableColumns } from '@posthog/lemon-ui'
+import { IconInfo, IconPencil, IconTrash } from '@posthog/icons'
+import { LemonButton, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TZLabel } from 'lib/components/TZLabel'
 import { TeamMembershipLevel } from 'lib/constants'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { Link } from 'lib/lemon-ui/Link'
+import { Popover } from 'lib/lemon-ui/Popover'
+import { urls } from 'scenes/urls'
 
-import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type {
+    CustomPropertyDefinitionApi,
+    CustomPropertyReferenceApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 import { CustomPropertyModal } from './CustomPropertyModal'
@@ -50,6 +57,17 @@ export function CustomPropertiesConfig(): JSX.Element {
             dataIndex: 'description',
             render: (_, definition) =>
                 definition.description ? definition.description : <span className="text-secondary">—</span>,
+        },
+        {
+            title: (
+                <span className="flex items-center gap-1">
+                    References
+                    <Tooltip title="Workflows that set this property using an 'Update account property' action. Click the count to open them.">
+                        <IconInfo className="text-secondary" />
+                    </Tooltip>
+                </span>
+            ),
+            render: (_, definition) => <ReferencesCell references={definition.references} />,
         },
         {
             title: 'Last updated',
@@ -105,5 +123,37 @@ export function CustomPropertiesConfig(): JSX.Element {
             />
             <CustomPropertyModal />
         </div>
+    )
+}
+
+function ReferencesCell({ references }: { references: readonly CustomPropertyReferenceApi[] }): JSX.Element {
+    const [open, setOpen] = useState(false)
+
+    if (!references.length) {
+        return <span className="text-secondary">0</span>
+    }
+
+    return (
+        <Popover
+            visible={open}
+            onClickOutside={() => setOpen(false)}
+            overlay={
+                <div className="flex flex-col gap-1 p-2 max-w-sm">
+                    <span className="text-xs text-secondary">Used in</span>
+                    {references.map((reference) => (
+                        <Link
+                            key={reference.id}
+                            to={urls.workflow(reference.id, 'workflow')}
+                            target="_blank"
+                            targetBlankIcon
+                        >
+                            {reference.name}
+                        </Link>
+                    ))}
+                </div>
+            }
+        >
+            <Link onClick={() => setOpen((isOpen) => !isOpen)}>{references.length}</Link>
+        </Popover>
     )
 }

--- a/products/workflows/backend/services/template_input_usage.py
+++ b/products/workflows/backend/services/template_input_usage.py
@@ -1,0 +1,53 @@
+"""Find workflows (HogFlows) that reference a given function-template input by its keys.
+
+Generic, template-agnostic counterpart to ``integration_usage.py``: the caller supplies the
+``template_id`` and the dictionary ``input_key`` to inspect, and gets back, per key found, the
+workflows that set it. Used (e.g.) to surface which workflows reference a custom property
+definition via the "Update account property" action's ``properties`` input.
+"""
+
+from dataclasses import dataclass
+
+from products.workflows.backend.models import HogFlow
+
+
+@dataclass(frozen=True)
+class HogFlowReference:
+    id: str
+    name: str
+    status: str
+
+
+def get_hog_flows_referencing_template_input_keys(
+    team_id: int, template_id: str, input_key: str
+) -> dict[str, list[HogFlowReference]]:
+    """Map each key present in ``input_key``'s dict (across the team's workflows) to the workflows
+    that set it.
+
+    Scans every saved workflow for the team (all statuses), looking at ``function`` actions whose
+    ``config.template_id`` matches ``template_id`` and reading the dict stored at
+    ``config.inputs[input_key].value``. Keys prefixed with ``$$_`` (templating internals like
+    ``$$_extend_object``) are ignored.
+    """
+    references: dict[str, list[HogFlowReference]] = {}
+    for flow in HogFlow.objects.filter(team_id=team_id):
+        ref: HogFlowReference | None = None
+        for key in _referenced_keys(flow.actions or [], template_id, input_key):
+            if ref is None:
+                ref = HogFlowReference(id=str(flow.id), name=flow.name or str(flow.id), status=flow.status)
+            references.setdefault(key, []).append(ref)
+    return references
+
+
+def _referenced_keys(actions: list[dict], template_id: str, input_key: str) -> set[str]:
+    keys: set[str] = set()
+    for action in actions:
+        if action.get("type") != "function":
+            continue
+        config = action.get("config") or {}
+        if config.get("template_id") != template_id:
+            continue
+        value = ((config.get("inputs") or {}).get(input_key) or {}).get("value")
+        if isinstance(value, dict):
+            keys.update(key for key in value if not (isinstance(key, str) and key.startswith("$$_")))
+    return keys

--- a/products/workflows/backend/services/template_input_usage.py
+++ b/products/workflows/backend/services/template_input_usage.py
@@ -19,7 +19,7 @@ class HogFlowReference:
 
 
 def get_hog_flows_referencing_template_input_keys(
-    team_id: int, template_id: str, input_key: str
+    team_id: int, template_id: str, input_key: str, *, only_value_key: str | None = None
 ) -> dict[str, list[HogFlowReference]]:
     """Map each key present in ``input_key``'s dict (across the team's workflows) to the workflows
     that set it.
@@ -28,18 +28,24 @@ def get_hog_flows_referencing_template_input_keys(
     ``config.template_id`` matches ``template_id`` and reading the dict stored at
     ``config.inputs[input_key].value``. Keys prefixed with ``$$_`` (templating internals like
     ``$$_extend_object``) are ignored.
+
+    When ``only_value_key`` is given, the scan collects references for just that one key (the
+    single-definition lookup path) instead of building the full map.
     """
     references: dict[str, list[HogFlowReference]] = {}
-    for flow in HogFlow.objects.filter(team_id=team_id):
+    # Project to only the columns the scanner reads — the rest (trigger, edges, draft, …) are unused.
+    for flow in HogFlow.objects.filter(team_id=team_id).only("id", "name", "status", "actions"):
         ref: HogFlowReference | None = None
-        for key in _referenced_keys(flow.actions or [], template_id, input_key):
+        for key in _referenced_keys(flow.actions or [], template_id, input_key, only_value_key=only_value_key):
             if ref is None:
                 ref = HogFlowReference(id=str(flow.id), name=flow.name or str(flow.id), status=flow.status)
             references.setdefault(key, []).append(ref)
     return references
 
 
-def _referenced_keys(actions: list[dict], template_id: str, input_key: str) -> set[str]:
+def _referenced_keys(
+    actions: list[dict], template_id: str, input_key: str, *, only_value_key: str | None = None
+) -> set[str]:
     keys: set[str] = set()
     for action in actions:
         if action.get("type") != "function":
@@ -49,5 +55,10 @@ def _referenced_keys(actions: list[dict], template_id: str, input_key: str) -> s
             continue
         value = ((config.get("inputs") or {}).get(input_key) or {}).get("value")
         if isinstance(value, dict):
-            keys.update(key for key in value if not (isinstance(key, str) and key.startswith("$$_")))
+            keys.update(
+                key
+                for key in value
+                if not (isinstance(key, str) and key.startswith("$$_"))
+                and (only_value_key is None or key == only_value_key)
+            )
     return keys

--- a/products/workflows/backend/test/test_template_input_usage.py
+++ b/products/workflows/backend/test/test_template_input_usage.py
@@ -1,0 +1,66 @@
+from posthog.test.base import BaseTest
+
+from products.workflows.backend.models import HogFlow
+from products.workflows.backend.services.template_input_usage import get_hog_flows_referencing_template_input_keys
+
+TEMPLATE_ID = "template-posthog-update-account-property"
+
+
+def _account_property_action(properties: dict[str, str]) -> dict:
+    return {
+        "id": "action_1",
+        "type": "function",
+        "config": {"template_id": TEMPLATE_ID, "inputs": {"properties": {"value": properties}}},
+    }
+
+
+class TestTemplateInputUsage(BaseTest):
+    def _create_flow(self, *, name: str, status: str, actions: list[dict]) -> HogFlow:
+        return HogFlow.objects.create(team=self.team, name=name, status=status, actions=actions)
+
+    def test_maps_each_referenced_key_to_its_workflows_across_statuses(self):
+        draft = self._create_flow(
+            name="Draft flow", status="draft", actions=[_account_property_action({"def-a": "{x}"})]
+        )
+        active = self._create_flow(
+            name="Active flow", status="active", actions=[_account_property_action({"def-a": "1", "def-b": "2"})]
+        )
+
+        usage = get_hog_flows_referencing_template_input_keys(self.team.id, TEMPLATE_ID, "properties")
+
+        assert {ref.id for ref in usage["def-a"]} == {str(draft.id), str(active.id)}
+        assert {ref.id for ref in usage["def-b"]} == {str(active.id)}
+        assert usage["def-a"][0].name in {"Draft flow", "Active flow"}
+        assert usage["def-a"][0].status in {"draft", "active"}
+
+    def test_ignores_other_templates_and_empty_or_internal_keys(self):
+        self._create_flow(
+            name="Other template",
+            status="active",
+            actions=[
+                {
+                    "type": "function",
+                    "config": {"template_id": "template-other", "inputs": {"properties": {"value": {"def-a": "1"}}}},
+                }
+            ],
+        )
+        self._create_flow(
+            name="Internal + empty",
+            status="active",
+            actions=[
+                _account_property_action({"$$_extend_object": "{event.properties}"}),
+                _account_property_action({}),
+            ],
+        )
+
+        usage = get_hog_flows_referencing_template_input_keys(self.team.id, TEMPLATE_ID, "properties")
+
+        assert usage == {}
+
+    def test_scopes_to_team(self):
+        other_team = self._create_flow(name="ours", status="active", actions=[_account_property_action({"def-a": "1"})])
+        assert other_team  # created for this team
+
+        usage = get_hog_flows_referencing_template_input_keys(self.team.id + 1, TEMPLATE_ID, "properties")
+
+        assert usage == {}

--- a/products/workflows/backend/test/test_template_input_usage.py
+++ b/products/workflows/backend/test/test_template_input_usage.py
@@ -57,9 +57,21 @@ class TestTemplateInputUsage(BaseTest):
 
         assert usage == {}
 
+    def test_only_value_key_scans_for_a_single_key(self):
+        active = self._create_flow(
+            name="Active flow", status="active", actions=[_account_property_action({"def-a": "1", "def-b": "2"})]
+        )
+
+        usage = get_hog_flows_referencing_template_input_keys(
+            self.team.id, TEMPLATE_ID, "properties", only_value_key="def-a"
+        )
+
+        assert {ref.id for ref in usage["def-a"]} == {str(active.id)}
+        assert "def-b" not in usage
+
     def test_scopes_to_team(self):
-        other_team = self._create_flow(name="ours", status="active", actions=[_account_property_action({"def-a": "1"})])
-        assert other_team  # created for this team
+        flow = self._create_flow(name="ours", status="active", actions=[_account_property_action({"def-a": "1"})])
+        assert flow  # created for self.team
 
         usage = get_hog_flows_referencing_template_input_keys(self.team.id + 1, TEMPLATE_ID, "properties")
 

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14078,6 +14078,20 @@ export namespace Schemas {
     } as const;
 
     /**
+     * A place that uses a custom property definition (read-only).
+     */
+    export interface CustomPropertyReference {
+      /** Id of the referring entity (e.g. the workflow id). */
+      readonly id: string;
+      /** Display name of the referring entity. */
+      readonly name: string;
+      /** Status of the referring entity (e.g. workflow status). */
+      readonly status: string;
+      /** Kind of reference. Currently always 'workflow'. */
+      readonly type: string;
+    }
+
+    /**
      * A team-scoped definition of a custom account property — the attribute side of the model.
      *
      * Holds only the property's shape (name, display type, big-number flag). Per-account values are
@@ -14113,6 +14127,8 @@ export namespace Schemas {
       readonly created_by: number | null;
       /** @nullable */
       readonly updated_at: string | null;
+      /** Workflows that use this property, resolved by definition id. */
+      readonly references: readonly CustomPropertyReference[];
     }
 
     /**
@@ -36063,6 +36079,8 @@ export namespace Schemas {
       readonly created_by?: number | null;
       /** @nullable */
       readonly updated_at?: string | null;
+      /** Workflows that use this property, resolved by definition id. */
+      readonly references?: readonly CustomPropertyReference[];
     }
 
     export interface PatchedCustomerJourney {

--- a/tach.toml
+++ b/tach.toml
@@ -623,6 +623,7 @@ depends_on = [
     "products.notifications",
     "products.product_analytics",
     "products.warehouse_sources",
+    "products.workflows",
 ]
 layer = "modules"
 


### PR DESCRIPTION
## Problem

The custom property definitions table gives no visibility into where a property is used.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Closes #ISSUE_ID -->

Part of https://github.com/PostHog/posthog/issues/60300

## Changes

- Add a "References" column showing which workflows set each definition
- Match workflows to definitions by **id** via a template-agnostic HogFlow scanner
- Click the count to open a popover linking to each referencing workflow
- References ride along on the definitions list response (one bounded scan per request)
- Expose the scanner from the workflows facade; customer_analytics reaches it via `depends_on`

<!-- If there are frontend changes, please include screenshots. -->

Third of a 3-PR stack. **Base: `posthog-code/account-property-workflow-action`** (PR #66346) — the scanner keys off the template id that PR introduces. Review/merge PR #66345 → #66346 → this.

## How did you test this code?

Agent-authored. Ran `test_template_input_usage.py` and `TestCustomPropertyDefinitionReferences` (5 passed); `tach check --dependencies --interfaces` clean. The author also manually tested the end-to-end flow in the local UI (create a definition → add an "Update account property" action that sets it → save the workflow → confirm the References column links back to that workflow).

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

Authored by PostHog Code.

**Autonomy:** Human-driven (agent-assisted)

Final PR of a 3-PR split. The scanner lives in `products/workflows` and is template-agnostic (template id + input key passed in), so customer_analytics hardcodes nothing workflow-specific and there's no import cycle — `tach.toml` gains the one `depends_on` entry only here. Invoked the `/improving-drf-endpoints` and `pr-description` skills.



