### PR TITLE
chore(tasks): emit agent-server boot-time metric for the runs dashboard

### DIFF
--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -945,15 +945,7 @@ class DockerSandbox(SandboxBase):
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)
 
     def read_agent_server_boot_ms(self) -> int | None:
-        try:
-            result = self.execute(
-                f"curl -s --max-time 5 http://localhost:{AGENT_SERVER_PORT}/health", timeout_seconds=10
-            )
-            payload = json.loads(result.stdout or "{}")
-            boot_ms = payload.get("bootMs")
-            return int(boot_ms) if isinstance(boot_ms, int | float) else None
-        except Exception:
-            return None
+        return self._read_health_boot_ms(AGENT_SERVER_PORT)
 
     def create_snapshot(self) -> str:
         if not self.is_running():

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -944,6 +944,17 @@ class DockerSandbox(SandboxBase):
 
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts, poll_interval)
 
+    def read_agent_server_boot_ms(self) -> int | None:
+        try:
+            result = self.execute(
+                f"curl -s --max-time 5 http://localhost:{AGENT_SERVER_PORT}/health", timeout_seconds=10
+            )
+            payload = json.loads(result.stdout or "{}")
+            boot_ms = payload.get("bootMs")
+            return int(boot_ms) if isinstance(boot_ms, int | float) else None
+        except Exception:
+            return None
+
     def create_snapshot(self) -> str:
         if not self.is_running():
             raise SandboxExecutionError(

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -938,6 +938,17 @@ class ModalSandbox(SandboxBase):
     def _agent_server_is_healthy(self) -> bool:
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts=1, poll_interval=0.0)
 
+    def read_agent_server_boot_ms(self) -> int | None:
+        try:
+            result = self.execute(
+                f"curl -s --max-time 5 http://localhost:{AGENT_SERVER_PORT}/health", timeout_seconds=10
+            )
+            payload = json.loads(result.stdout or "{}")
+            boot_ms = payload.get("bootMs")
+            return int(boot_ms) if isinstance(boot_ms, int | float) else None
+        except Exception:
+            return None
+
     def _free_agent_server_port(self) -> None:
         self.execute(
             "pkill -TERM -f agent-server 2>/dev/null || true; "

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -939,15 +939,7 @@ class ModalSandbox(SandboxBase):
         return wait_for_health_check(self.execute, self.id, AGENT_SERVER_PORT, max_attempts=1, poll_interval=0.0)
 
     def read_agent_server_boot_ms(self) -> int | None:
-        try:
-            result = self.execute(
-                f"curl -s --max-time 5 http://localhost:{AGENT_SERVER_PORT}/health", timeout_seconds=10
-            )
-            payload = json.loads(result.stdout or "{}")
-            boot_ms = payload.get("bootMs")
-            return int(boot_ms) if isinstance(boot_ms, int | float) else None
-        except Exception:
-            return None
+        return self._read_health_boot_ms(AGENT_SERVER_PORT)
 
     def _free_agent_server_port(self) -> None:
         self.execute(

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -274,6 +274,9 @@ class SandboxBase(ABC):
     @abstractmethod
     def is_running(self) -> bool: ...
 
+    def read_agent_server_boot_ms(self) -> int | None:
+        return None
+
     def __enter__(self) -> Self:
         return self
 

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 import re
+import json
 import shlex
 from abc import ABC, abstractmethod
 from collections.abc import Callable, Iterable
@@ -276,6 +277,15 @@ class SandboxBase(ABC):
 
     def read_agent_server_boot_ms(self) -> int | None:
         return None
+
+    def _read_health_boot_ms(self, port: int) -> int | None:
+        try:
+            result = self.execute(f"curl -s --max-time 5 http://localhost:{port}/health", timeout_seconds=10)
+            payload = json.loads(result.stdout or "{}")
+            boot_ms = payload.get("bootMs")
+            return int(boot_ms) if isinstance(boot_ms, int | float) else None
+        except Exception:
+            return None
 
     def __enter__(self) -> Self:
         return self

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -79,11 +79,10 @@ def increment_sandbox_created(runtime: str) -> None:
         pass
 
 
-def record_agent_server_boot_ms(boot_ms: int, used_snapshot: bool | None = None) -> None:
+def record_agent_server_boot_ms(boot_ms: int) -> None:
     try:
         attributes: Attributes = {
             "step": "agent_server_boot",
-            "used_snapshot": _bool_label(used_snapshot),
             "status": "COMPLETED",
         }
         _metric_meter(attributes).create_histogram_timedelta(

--- a/products/tasks/backend/temporal/metrics.py
+++ b/products/tasks/backend/temporal/metrics.py
@@ -79,6 +79,22 @@ def increment_sandbox_created(runtime: str) -> None:
         pass
 
 
+def record_agent_server_boot_ms(boot_ms: int, used_snapshot: bool | None = None) -> None:
+    try:
+        attributes: Attributes = {
+            "step": "agent_server_boot",
+            "used_snapshot": _bool_label(used_snapshot),
+            "status": "COMPLETED",
+        }
+        _metric_meter(attributes).create_histogram_timedelta(
+            "tasks_process_sandbox_step_latency",
+            "Latency for get_sandbox_for_repository sub-steps",
+            unit="ms",
+        ).record(dt.timedelta(milliseconds=boot_ms))
+    except Exception:
+        pass
+
+
 class StepTimer:
     def __init__(self, step: str, used_snapshot: bool | None = None) -> None:
         self.step = step

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -17,6 +17,7 @@ from products.tasks.backend.logic.services.agentsh import ENV_FILE, ENV_WRAPPER_
 from products.tasks.backend.logic.services.connection_token import create_sandbox_event_ingest_token
 from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxBase
 from products.tasks.backend.models import Task, TaskRun
+from products.tasks.backend.temporal.metrics import record_agent_server_boot_ms
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
 from products.tasks.backend.temporal.process_task.utils import (
@@ -308,6 +309,10 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
         # Connectivity diagnostics — run inside the agentsh exec context when
         # domains are restricted so we can verify the env wrapper + DNS proxy work.
         _run_connectivity_diagnostics(ctx, sandbox)
+
+        boot_ms = sandbox.read_agent_server_boot_ms()
+        if boot_ms is not None:
+            record_agent_server_boot_ms(boot_ms)
 
         emit_agent_log(ctx.run_id, "debug", f"Agent server started at {sandbox_url}")
         activity.logger.info(f"Agent server started at {sandbox_url} for task {ctx.task_id}")


### PR DESCRIPTION
## Problem

Cloud-task agent-server spawn time — node process start to a usable session (`hasSession=true`, what the backend health poll waits on) — isn't on any dashboard. We can't see boot latency or catch regressions for background-agent runs. We want it as a first-class series on the "Cloud background agents runs" dashboard.

## Changes

- The `start_agent_server` activity reads the agent-server's `bootMs` from `/health` once the server is healthy, and records it onto the existing `tasks_process_sandbox_step_latency` histogram with `step="agent_server_boot"`.
- New `Sandbox.read_agent_server_boot_ms()` — Modal and Docker each curl `/health` on their own in-sandbox port (8080 / 47821); the base returns `None`
