### PR TITLE
fix(postgres): round decimals exceeding max scale instead of failing sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -418,6 +418,20 @@ def test_table_from_py_list_huge_int_column_falls_back_to_string():
     assert table.column("column").to_pylist() == [str(enormous), "5"]
 
 
+def test_table_from_py_list_decimal_exceeding_max_scale_is_rounded():
+    # An unconstrained Postgres `numeric` can carry more decimal places than Delta Lake's max
+    # scale (32). pyarrow refuses to rescale it ("Rescaling Decimal256 value would cause data
+    # loss"); the value must be rounded to the max scale rather than crashing the whole sync.
+    value = decimal.Decimal("1." + "1" * 80)
+
+    table = table_from_py_list([{"column": value}])
+
+    col_type = table.schema.field("column").type
+    assert pa.types.is_decimal256(col_type)
+    assert col_type.scale == 32
+    assert table.column("column").to_pylist() == [decimal.Decimal("1." + "1" * 32)]
+
+
 def test_table_from_py_list_normal_int_column_stays_int64():
     # Values within int64 are unaffected by the overflow handling.
     table = table_from_py_list([{"column": 1}, {"column": 2}, {"column": None}])

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -422,14 +422,24 @@ def test_table_from_py_list_decimal_exceeding_max_scale_is_rounded():
     # An unconstrained Postgres `numeric` can carry more decimal places than Delta Lake's max
     # scale (32). pyarrow refuses to rescale it ("Rescaling Decimal256 value would cause data
     # loss"); the value must be rounded to the max scale rather than crashing the whole sync.
+    # A None is mixed in to exercise the null-passthrough in the quantize retry path.
     value = decimal.Decimal("1." + "1" * 80)
 
-    table = table_from_py_list([{"column": value}])
+    table = table_from_py_list([{"column": value}, {"column": None}])
 
     col_type = table.schema.field("column").type
     assert pa.types.is_decimal256(col_type)
     assert col_type.scale == 32
-    assert table.column("column").to_pylist() == [decimal.Decimal("1." + "1" * 32)]
+    assert table.column("column").to_pylist() == [decimal.Decimal("1." + "1" * 32), None]
+
+
+def test_table_from_py_list_decimal_too_large_for_decimal256_raises():
+    # A value whose integer part can't fit decimal256(76, 32) even after rounding to the max
+    # scale is genuinely unrepresentable, so the hard ValueError must still surface.
+    value = decimal.Decimal("9" * 45 + "." + "1" * 40)
+
+    with pytest.raises(ValueError, match="Cannot build decimal array from values"):
+        table_from_py_list([{"column": value}])
 
 
 def test_table_from_py_list_normal_int_column_stays_int64():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -624,6 +624,14 @@ def _get_max_decimal_type(values: list[decimal.Decimal]) -> pa.Decimal128Type | 
     return build_pyarrow_decimal_type(max_precision, max_scale)
 
 
+def _quantize_to_scale(value: decimal.Decimal, scale: int) -> decimal.Decimal:
+    quantum = decimal.Decimal(1).scaleb(-scale)
+    with decimal.localcontext() as ctx:
+        # Hold decimal256's full 76 digits while rounding so the quantize itself can't overflow.
+        ctx.prec = 76
+        return value.quantize(quantum, rounding=decimal.ROUND_HALF_EVEN)
+
+
 def _decimal_array_from_values(values: list[decimal.Decimal | None]) -> pa.Array:
     non_null = [v for v in values if v is not None]
     if non_null:
@@ -632,10 +640,19 @@ def _decimal_array_from_values(values: list[decimal.Decimal | None]) -> pa.Array
             return pa.array(values, type=optimal_type)
         except pa.ArrowInvalid:
             pass
+
+    fallback_type = pa.decimal256(76, MAX_NUMERIC_SCALE)
     try:
-        return pa.array(values, type=pa.decimal256(76, MAX_NUMERIC_SCALE))
-    except Exception as exc:
-        raise ValueError("Cannot build decimal array from values") from exc
+        return pa.array(values, type=fallback_type)
+    except Exception:
+        # A value carries more decimal places than Delta Lake's max scale (e.g. an unconstrained
+        # Postgres `numeric`). pyarrow refuses to silently truncate, so round to the max scale
+        # ourselves rather than failing the whole sync.
+        try:
+            quantized = [None if v is None else _quantize_to_scale(v, MAX_NUMERIC_SCALE) for v in values]
+            return pa.array(quantized, type=fallback_type)
+        except Exception as exc:
+            raise ValueError("Cannot build decimal array from values") from exc
 
 
 def _python_type_to_pyarrow_type(type_: type, value: Any):


### PR DESCRIPTION
## Problem

A Postgres import was crashing with `ArrowInvalid: Rescaling Decimal256 value would cause data loss` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f0444-b27a-73b0-9378-f2c3bc31de41)).

An unconstrained Postgres `numeric` column can hold values with more than 76 total significant digits — in particular more decimal places than Delta Lake's maximum decimal scale of 32. When we build the pyarrow array for such a column, even the widest fallback type we use, `decimal256(76, 32)`, can't represent the value: pyarrow refuses to silently truncate the extra decimal places and raises `ArrowInvalid`. `_decimal_array_from_values` then re-raised this as `ValueError("Cannot build decimal array from values")`, failing the entire table import rather than the offending value.

## Changes

When the `decimal256(76, 32)` fallback fails, round each value to the max supported scale (`ROUND_HALF_EVEN`, in a 76-digit decimal context so the quantize itself can't overflow) and build the array from the rounded values. This accepts the unavoidable precision loss for values that exceed what Delta Lake can store, instead of crashing the sync. Values that genuinely can't be represented at all (e.g. an integer part wider than the type) still surface the original `ValueError`.

The fix lives in the shared `table_from_iterator` helper (`pipelines/pipeline/utils.py`) since that's where the failing frame is, so it applies to every SQL source that funnels through it, not just Postgres.

## How did you test this code?

I'm an agent. Automated tests only — no manual testing.

- Added `test_table_from_py_list_decimal_exceeding_max_scale_is_rounded`, which feeds a decimal with 80 fractional digits through `table_from_py_list` and asserts the column is built as `decimal256(76, 32)` with the value rounded to 32 places. It reproduces the production `ValueError` on `master` and passes with the fix.
- Ran the full `test_pipeline_utils.py` suite (78 passed) plus `ruff check` / `ruff format --check` on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres warehouse source. Confirmed the stack trace originates in our code: `postgres.get_rows` → `table_from_iterator` → `_process_batch` → `_decimal_array_from_values`, where the `decimal256(76, 32)` fallback raised `ArrowInvalid` on a value with >32 decimal places. Reproduced the exact `ArrowInvalid`/`ValueError` chain with pyarrow 18.1.0 before writing the fix.

Classified this as a fixable bug rather than a user/upstream error: the customer's data is valid, our pipeline was just too fragile to store high-precision decimals. Rounding to the max storable scale is graceful degradation (32 decimal places far exceeds any analytics need), so I rounded rather than extending `NonRetryableErrors`. Kept the change scoped to the fallback path and preserved the existing `ValueError` for genuinely unrepresentable values. Checked open PRs (including the maintainer's) for an existing fix — none found.