### PR TITLE
feat(dashboards): reorder add widget modal and badge popular widgets

### DIFF
--- a/products/dashboards/frontend/widget_types/catalog.ts
+++ b/products/dashboards/frontend/widget_types/catalog.ts
@@ -146,6 +146,8 @@ export type DashboardWidgetCatalogEntry = {
     groupId: keyof typeof DASHBOARD_WIDGET_GROUP_LABELS | (string & {})
     /** Widget variant label within the group (also used as fallback card title). */
     label: string
+    /** Short promo badge shown next to the label in the Add widget picker (e.g. "Most popular"). */
+    badge?: string
     description: string
     defaultConfig: Record<string, unknown>
     defaultLayout: { w: number; h: number; minW: number; minH?: number }
@@ -172,6 +174,7 @@ export const DASHBOARD_WIDGET_CATALOG = {
     error_tracking_list: {
         groupId: 'error_tracking',
         label: 'Top issues',
+        badge: 'Crowd favorite',
         description: 'Ranked list of the most impactful error tracking issues.',
         headerTitle: 'Top issues',
         defaultConfig: errorTrackingWidgetConfigSchema.parse({
@@ -199,6 +202,7 @@ export const DASHBOARD_WIDGET_CATALOG = {
     session_replay_list: {
         groupId: 'session_replay',
         label: 'Recent recordings',
+        badge: 'Crowd favorite',
         description: 'Recent session recordings you can open in the replay player.',
         headerTitle: 'Recent recordings',
         defaultConfig: sessionReplayWidgetConfigSchema.parse({
@@ -375,7 +379,13 @@ function getDashboardWidgetCatalogGroups(): DashboardWidgetCatalogGroup[] {
         group.widgets.push({ widgetType: widgetType as DashboardWidgetCatalogKey, entry })
     }
 
-    return [...groupsById.values()].sort((a, b) => a.groupLabel.localeCompare(b.groupLabel))
+    const groupDisplayOrder = ['session_replay', 'error_tracking', 'activity', 'logs', 'experiments']
+
+    return [...groupsById.values()].sort((a, b) => {
+        const aIndex = groupDisplayOrder.indexOf(a.groupId)
+        const bIndex = groupDisplayOrder.indexOf(b.groupId)
+        return (aIndex === -1 ? Infinity : aIndex) - (bIndex === -1 ? Infinity : bIndex)
+    })
 }
 
 export const DASHBOARD_WIDGET_CATALOG_GROUPS = getDashboardWidgetCatalogGroups()

--- a/products/dashboards/frontend/widgets/AddWidgetModal.tsx
+++ b/products/dashboards/frontend/widgets/AddWidgetModal.tsx
@@ -62,6 +62,7 @@ function AddWidgetCatalogPicker({
     return (
         <WidgetTypePickerCard
             label={entry.label}
+            badge={entry.badge}
             description={entry.description}
             selected={selected}
             preview={WidgetPreview ? <WidgetPreview /> : <div />}

--- a/products/dashboards/frontend/widgets/WidgetTypePickerCard.tsx
+++ b/products/dashboards/frontend/widgets/WidgetTypePickerCard.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx'
 
-import { IconCheck } from '@posthog/icons'
+import { IconCheck, IconStarFilled } from '@posthog/icons'
 
 type WidgetTypePickerCardProps = {
     label: string
+    badge?: string
     description: string
     selected: boolean
     preview: JSX.Element
@@ -26,6 +27,7 @@ function WidgetTypePickerSelectionIndicator({ selected }: { selected: boolean })
 
 export function WidgetTypePickerCard({
     label,
+    badge,
     description,
     selected,
     preview,
@@ -38,7 +40,7 @@ export function WidgetTypePickerCard({
             aria-label={label}
             tabIndex={0}
             className={clsx(
-                'text-left w-full rounded border p-3 transition-colors cursor-pointer',
+                'text-left w-full overflow-hidden rounded border transition-colors cursor-pointer',
                 'focus:outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2',
                 selected ? 'border-accent bg-accent/5 ring-1 ring-accent' : 'border-primary hover:border-accent/40'
             )}
@@ -50,13 +52,21 @@ export function WidgetTypePickerCard({
                 }
             }}
         >
-            <div className="flex items-center justify-between gap-2">
-                <div className="font-semibold">{label}</div>
-                <WidgetTypePickerSelectionIndicator selected={selected} />
-            </div>
-            <p className="text-xs text-muted m-0 mt-0.5 mb-2">{description}</p>
-            <div className="pointer-events-none select-none overflow-hidden rounded" aria-hidden="true">
-                {preview}
+            {badge ? (
+                <div className="flex items-center gap-1 bg-accent-highlight-secondary px-3 py-1 text-xs font-semibold text-accent">
+                    <IconStarFilled className="text-sm" />
+                    {badge}
+                </div>
+            ) : null}
+            <div className="p-3">
+                <div className="flex items-center justify-between gap-2">
+                    <span className="font-semibold">{label}</span>
+                    <WidgetTypePickerSelectionIndicator selected={selected} />
+                </div>
+                <p className="text-xs text-muted m-0 mt-0.5 mb-2">{description}</p>
+                <div className="pointer-events-none select-none overflow-hidden rounded" aria-hidden="true">
+                    {preview}
+                </div>
             </div>
         </div>
     )


### PR DESCRIPTION
## Problem

The Add widget modal listed groups alphabetically, burying the widgets people use most.

## Changes

<img width="2520" height="1830" alt="CleanShot 2026-06-26 at 10 20 38@2x" src="https://github.com/user-attachments/assets/c97e3ec4-0a23-492e-ab92-b4f9e9f0a075" />


- Reorder groups: session replay → error tracking → activity → logs → experiments
- Add a "Crowd favorite" banner to the most popular widgets (error tracking "Top issues" and session replay "Recent recordings"), driven by a new optional `badge` field in the widget catalog

## How did you test this code?

Agent (PostHog Code). Ran the frontend typecheck, no errors. No manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Matt directed the reorder and the badge styling (landed on a top banner with a filled star, copy "Crowd favorite"). Badge is data-driven via the catalog `badge` field. No skills needed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
