### PR TITLE
feat(batch-exports): frontend for S3 batch export integrations

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4781,9 +4781,9 @@ snapshots:
     scenes-app-batchexports--metrics--light:
         hash: v1.k794b7964.2a35529dda76e924c361be19057499c3aa72c98fc7b86e31184b1ccb7acbc938.6UBr4F4PNQVWEwdoGsRsEkA_af40UyfrYI7v2EyyWJ0
     scenes-app-batchexports--new-aws-s-3-export--dark:
-        hash: v1.k794b7964.41f79befceaf770e88b798c12f787cb9d1ab145c7d80615bc26b9207340f79a6.aM-tMd6ZFwKekTp8mskvTCfaWrLdd6qE69xVms0rqcY
+        hash: v1.k794b7964.df096cd2d7f1375b48a1e9292d17c3331050720a354cb7800b3616266855edca.K3NW9WCopt46iMKqVb6ye7EEIOYL-UnQ2oepvdkWyf0
     scenes-app-batchexports--new-aws-s-3-export--light:
-        hash: v1.k794b7964.357c474dff8efeb0e82e13cd34ca86e6d0d447b24c3e4c4c040722469dec9c28.pXZJFQZY1vntlseiUyrx8DV1UlfM1yUnGCvRDIL-nzs
+        hash: v1.k794b7964.4cb2a12f009955841c9387d29c0bd99deffdc3a357b69a46d25747e2f43fa5ab.dMSlF487vQCajKAbqI-CDI5BXE_PXypcGNY229fL1xQ
     scenes-app-batchexports--new-azure-blob-export--dark:
         hash: v1.k794b7964.b23ecc05f98318003c287543dc6c766a65b4b9cad16688b193b60018a943b997.ER8pnLAtnsoZbNs-RpxbZWTo3IxzH8qj_unw_RB5aCo
     scenes-app-batchexports--new-azure-blob-export--light:
@@ -4809,13 +4809,13 @@ snapshots:
     scenes-app-batchexports--new-redshift-export--light:
         hash: v1.k794b7964.230bc08cd2af1a7c952c2ffdaade39e20fff9b4b97520f09e05419b7ae8b9313.a0jNd0-hfQA3h2BmtN1ITD_APsblx4Wvh1hpL_lqvyY
     scenes-app-batchexports--new-s-3-compatible-export--dark:
-        hash: v1.k794b7964.73395ca9179587d471be2476b9870e0735ec352105c45c6573c6d0079643d59d.YVpqeeIKDkqzFyHE6gQNArsqXBL1m3NZu1CZ-vS2kmI
+        hash: v1.k794b7964.3d7f7749f5e8119f49be797702f7a787ea3ccc6aa374c907d02494b5080260ec.-2gpuoNBB_1BRb9IiTTgPKzaFB07uqnapBnpC86svbU
     scenes-app-batchexports--new-s-3-compatible-export--light:
-        hash: v1.k794b7964.8ae6cceea5d17855a1d0a3c93fbdf23f4b16d7024c24c83a0712c3c06c9c2656.9hxJjl_0BWevFJAOlKruL2eiNMqjQAwmQ7MkS2GVB98
+        hash: v1.k794b7964.31a87f9ea01c9d66b3233a90bea14f83814026f148a19e4f9a6abb290c3c4c64.4d853eAWfbQ5JZV1NlYeNlLdXxbHYO4B_x5gYmcaXhk
     scenes-app-batchexports--new-s-3-export--dark:
-        hash: v1.k794b7964.806a71cb77929968b5752b1e4ee114bc00ecc212bed909a4270b9e4b5dac43ad.7JHWAWNjSbnfk8ZOtLkAg4SDoPD4iZQwGoJUgUpJKgc
+        hash: v1.k794b7964.b89116ab3ae8175271b346adeb49d569fd9de6d211e7ebd9dbd248c45daa6d83.scLGLyNyvLa4ZBMrPadcKPVYN5KXIR-7lu5SW123gUM
     scenes-app-batchexports--new-s-3-export--light:
-        hash: v1.k794b7964.1575893a2b44f8200e90792150f8799b1deb3043e39bf9e95f7595eb0c5b92a4.gXKhIx2xSWzXFHq38Tt5RWxPmksOywo6Ysp_F6pBplM
+        hash: v1.k794b7964.dc07f83156a92f442a4374b88932d76000969d300d327e580aa30ec51dd68741.UjF84zxc_uMEq7mPAwnVDGziusWXwPAEPkVdrLjiTOk
     scenes-app-batchexports--new-snowflake-export--dark:
         hash: v1.k794b7964.4c3332868c9ec5350eb2499b37a90167f481e577ee5f55cacff991451258cc25.bdIHDI2-ZTy2I-rshZneb8mK5F-NPUCSSnMFmYT8Kes
     scenes-app-batchexports--new-snowflake-export--light:

--- a/frontend/src/lib/components/CyclotronJob/integrations/integrationSetups.tsx
+++ b/frontend/src/lib/components/CyclotronJob/integrations/integrationSetups.tsx
@@ -1,8 +1,10 @@
+import { AwsS3SetupModal } from 'scenes/integrations/aws-s3/AwsS3SetupModal'
 import { AzureBlobSetupModal } from 'scenes/integrations/azure-blob/AzureBlobSetupModal'
 import { DatabricksSetupModal } from 'scenes/integrations/databricks/DatabricksSetupModal'
 import { GitLabSetupModal } from 'scenes/integrations/gitlab/GitLabSetupModal'
 import { GoogleCloudServiceAccountSetupModal } from 'scenes/integrations/google-cloud-service-account/GoogleCloudServiceAccountSetupModal'
 import { PostgreSQLSetupModal } from 'scenes/integrations/postgresql/PostgreSQLSetupModal'
+import { S3CompatibleSetupModal } from 'scenes/integrations/s3-compatible/S3CompatibleSetupModal'
 import { urls } from 'scenes/urls'
 
 import { ChannelSetupModal } from 'products/workflows/frontend/Channels/ChannelSetupModal'
@@ -95,5 +97,27 @@ registerIntegrationSetup({
     }),
     SetupModal: ({ isOpen, integration, onComplete }) => (
         <AzureBlobSetupModal isOpen={isOpen} integration={integration} onComplete={onComplete} />
+    ),
+})
+
+registerIntegrationSetup({
+    kind: 'aws-s3',
+    menuItem: ({ openModal }) => ({
+        label: 'Configure new AWS S3 connection',
+        onClick: () => openModal('aws-s3'),
+    }),
+    SetupModal: ({ isOpen, integration, onComplete }) => (
+        <AwsS3SetupModal isOpen={isOpen} integration={integration} onComplete={onComplete} />
+    ),
+})
+
+registerIntegrationSetup({
+    kind: 's3-compatible',
+    menuItem: ({ openModal }) => ({
+        label: 'Configure new S3-compatible storage connection',
+        onClick: () => openModal('s3-compatible'),
+    }),
+    SetupModal: ({ isOpen, integration, onComplete }) => (
+        <S3CompatibleSetupModal isOpen={isOpen} integration={integration} onComplete={onComplete} />
     ),
 })

--- a/frontend/src/lib/integrations/utils.ts
+++ b/frontend/src/lib/integrations/utils.ts
@@ -2,6 +2,7 @@ import { capitalizeFirstLetter } from 'lib/utils/strings'
 
 import { IntegrationKind } from '~/types'
 
+import IconAwsS3 from 'public/services/aws-s3.png'
 import IconAzureBlob from 'public/services/azure-blob-storage.png'
 import IconBingAds from 'public/services/bing-ads.svg'
 import IconClickUp from 'public/services/clickup.svg'
@@ -26,6 +27,7 @@ import IconMetaAds from 'public/services/meta-ads.png'
 import IconPinterest from 'public/services/pinterest_ads.png'
 import IconPostgres from 'public/services/postgres.png'
 import IconReddit from 'public/services/reddit.png'
+import IconS3Compatible from 'public/services/s3-compatible.png'
 import IconSalesforce from 'public/services/salesforce.png'
 import IconSlack from 'public/services/slack.png'
 import IconSnapchat from 'public/services/snapchat.png'
@@ -69,6 +71,8 @@ export const ICONS: Record<IntegrationKind, any> = {
     'customerio-webhook': IconCustomerIO,
     'customerio-track': IconCustomerIO,
     postgresql: IconPostgres,
+    'aws-s3': IconAwsS3,
+    's3-compatible': IconS3Compatible,
 }
 
 export const getIntegrationNameFromKind = (kind: string): string => {
@@ -105,6 +109,10 @@ export const getIntegrationNameFromKind = (kind: string): string => {
             return 'Firebase'
         case 'postgresql':
             return 'PostgreSQL'
+        case 'aws-s3':
+            return 'AWS S3'
+        case 's3-compatible':
+            return 'S3-compatible storage'
         default:
             return capitalizeFirstLetter(kind)
     }

--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -25772,7 +25772,9 @@
                 "customerio-app",
                 "customerio-webhook",
                 "customerio-track",
-                "postgresql"
+                "postgresql",
+                "aws-s3",
+                "s3-compatible"
             ],
             "type": "string"
         },

--- a/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
+++ b/frontend/src/scenes/data-pipelines/batch-exports/batchExportConfigFormLogic.test.ts
@@ -426,27 +426,14 @@ describe('batchExportConfigFormLogic', () => {
                 ],
             },
             {
+                // New AwsS3 exports authenticate via an integration, not inline credentials.
                 service: 'AwsS3' as const,
-                fields: [
-                    'bucket_name',
-                    'region',
-                    'prefix',
-                    'aws_access_key_id',
-                    'aws_secret_access_key',
-                    'file_format',
-                ],
+                fields: ['integration_id', 'bucket_name', 'region', 'prefix', 'file_format'],
             },
             {
+                // New S3Compatible exports authenticate via an integration; endpoint_url lives on it.
                 service: 'S3Compatible' as const,
-                fields: [
-                    'bucket_name',
-                    'region',
-                    'prefix',
-                    'endpoint_url',
-                    'aws_access_key_id',
-                    'aws_secret_access_key',
-                    'file_format',
-                ],
+                fields: ['integration_id', 'bucket_name', 'region', 'prefix', 'file_format'],
             },
             {
                 service: 'Postgres' as const,
@@ -833,50 +820,46 @@ describe('batchExportConfigFormLogic', () => {
                 },
             },
             {
-                // AwsS3 must not leak endpoint_url / use_virtual_style_addressing into the payload.
+                // New AwsS3 exports authenticate via an integration; credentials live on it, and
+                // endpoint_url / use_virtual_style_addressing must not leak into the payload.
                 name: 'AwsS3',
                 service: 'AwsS3' as const,
                 requiredValues: {
+                    integration_id: 21,
                     bucket_name: 'my-bucket',
                     region: 'us-east-1',
                     prefix: 'test/',
-                    aws_access_key_id: 'AKIA',
-                    aws_secret_access_key: 'secret',
                 },
                 expectedDestination: {
                     type: 'AwsS3',
+                    integration: 21,
                     config: {
                         bucket_name: 'my-bucket',
                         region: 'us-east-1',
                         prefix: 'test/',
-                        aws_access_key_id: 'AKIA',
-                        aws_secret_access_key: 'secret',
                         file_format: 'Parquet',
                         compression: 'zstd',
                     },
                 },
             },
             {
-                // S3Compatible requires endpoint_url and must not leak encryption / kms_key_id.
+                // New S3Compatible exports authenticate via an integration (which carries endpoint_url);
+                // no inline credentials, no leaked encryption / kms_key_id.
                 name: 'S3Compatible',
                 service: 'S3Compatible' as const,
                 requiredValues: {
+                    integration_id: 22,
                     bucket_name: 'my-bucket',
                     region: 'auto',
                     prefix: 'test/',
-                    endpoint_url: 'https://my-minio-host:9000',
-                    aws_access_key_id: 'AKIA',
-                    aws_secret_access_key: 'secret',
                 },
                 expectedDestination: {
                     type: 'S3Compatible',
+                    integration: 22,
                     config: {
                         bucket_name: 'my-bucket',
                         region: 'auto',
                         prefix: 'test/',
-                        endpoint_url: 'https://my-minio-host:9000',
-                        aws_access_key_id: 'AKIA',
-                        aws_secret_access_key: 'secret',
                         file_format: 'Parquet',
                         compression: 'zstd',
                     },
@@ -1111,6 +1094,30 @@ describe('batchExportConfigFormLogic', () => {
                 exclude_events: [],
                 include_events: [],
             })
+        })
+    })
+
+    describe('grandfathered inline S3 exports stay editable without an integration', () => {
+        // AwsS3/S3Compatible are integration-backed for new exports, but exports created before
+        // integrations existed have inline credentials and no linked integration. Editing one must not
+        // require an integration and must preserve the inline credentials — otherwise the export breaks.
+        it('saves an inline AwsS3 export, keeping its credentials and sending no integration', async () => {
+            await initLogic({ service: null, id: AWS_S3_BATCH_EXPORT.id })
+
+            logic.actions.setConfigurationValue('prefix', 'updated-prefix/')
+
+            await expectLogic(logic, () => {
+                logic.actions.submitConfiguration()
+            })
+                .toDispatchActions(['submitConfiguration', 'updateBatchExportConfigSuccess'])
+                .toFinishAllListeners()
+
+            const body = patchBodiesById[AWS_S3_BATCH_EXPORT.id]
+            expect(body).not.toBeUndefined()
+            expect(body.destination.integration).toBeUndefined()
+            expect(body.destination.config.prefix).toBe('updated-prefix/')
+            expect(body.destination.config.aws_access_key_id).toBe('AKIAIOSFODNN7EXAMPLE')
+            expect(body.destination.config.aws_secret_access_key).toBe('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
         })
     })
 })

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/awss3.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/awss3.tsx
@@ -8,19 +8,37 @@ import type { DestinationDefinition } from './types'
 
 // AWS S3 — the first-class destination for buckets hosted on AWS. No endpoint or virtual-style
 // addressing (those are derived from the AWS region); encryption + KMS are AWS-specific so they stay.
+//
+// New exports authenticate via an `aws-s3` Integration; exports created before integrations existed
+// keep their inline credentials (grandfathered), detected by the absence of `integration_id`.
 export const awsS3Definition: DestinationDefinition = {
     type: 'AwsS3',
+    usesIntegration: true,
     defaults: () => ({
         file_format: 'Parquet',
         compression: 'zstd',
     }),
-    requiredFields: ({ isNew }) => [
+    requiredFields: ({ isNew, formValues }) => {
+        if (isNew || formValues.integration_id) {
+            // New exports must pick an integration; existing integration-backed exports keep theirs.
+            return [...(isNew ? ['integration_id', 'file_format'] : []), 'bucket_name', 'region', 'prefix']
+        }
+        // Grandfathered inline-credential exports keep their original fields when edited.
+        return ['bucket_name', 'region', 'prefix']
+    },
+    // The credential keys remain allowlisted for grandfathered inline exports.
+    // TODO: clean up once fully migrated to integration-based credentials
+    configKeys: [
         'bucket_name',
         'region',
         'prefix',
-        ...(isNew ? ['aws_access_key_id'] : []),
-        ...(isNew ? ['aws_secret_access_key'] : []),
-        ...(isNew ? ['file_format'] : []),
+        'file_format',
+        'compression',
+        'max_file_size_mb',
+        'encryption',
+        'kms_key_id',
+        'aws_access_key_id',
+        'aws_secret_access_key',
     ],
     validate: (formValues) => ({
         bucket_name: validateBucketName(formValues.bucket_name),
@@ -37,6 +55,8 @@ export const awsS3Definition: DestinationDefinition = {
                 showEncryption
                 showEndpointUrl={false}
                 showVirtualStyleAddressing={false}
+                integrationKind="aws-s3"
+                migrationNotice="S3 batch exports are moving to integration-based credentials. This export will be migrated automatically — no action required."
             />
         )
     },

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/common.tsx
@@ -1,11 +1,13 @@
 import { type ReactNode } from 'react'
 
-import { LemonCheckbox, LemonInput, LemonSelect, Link } from '@posthog/lemon-ui'
+import { LemonBanner, LemonCheckbox, LemonInput, LemonSelect, Link } from '@posthog/lemon-ui'
 
+import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
 import { LemonField } from 'lib/lemon-ui/LemonField'
 import { LemonInputSelect } from 'lib/lemon-ui/LemonInputSelect'
 
 import type { DatabaseSchemaField } from '~/queries/schema/schema-general'
+import type { IntegrationKind } from '~/types'
 
 // Bucket naming rules (supports both S3 and GCS):
 // S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
@@ -285,6 +287,10 @@ export const S3_FAMILY_EVENT_TABLE_EXTRA_FIELDS: Record<string, DatabaseSchemaFi
 // Shared form fields for the S3-family destinations (S3 legacy, AwsS3, S3Compatible). Per-destination
 // definitions toggle the AWS-only (encryption/KMS) and S3-compatible-only (endpoint/virtual-style)
 // blocks and supply the region option set; everything else is identical.
+//
+// New AwsS3/S3Compatible exports authenticate via a linked Integration (pass `integrationKind`);
+// grandfathered exports created before integrations existed keep their inline credential UI, detected
+// by the absence of a linked integration. Mirrors the Postgres destination's `useIntegration` pattern.
 export function S3FamilyFields({
     isNew,
     formValues,
@@ -296,6 +302,8 @@ export function S3FamilyFields({
     endpointUrlRequired = false,
     showVirtualStyleAddressing,
     endpointHelpText,
+    integrationKind,
+    migrationNotice,
 }: {
     isNew: boolean
     formValues: Record<string, any>
@@ -310,9 +318,37 @@ export function S3FamilyFields({
     endpointUrlRequired?: boolean
     showVirtualStyleAddressing: boolean
     endpointHelpText?: ReactNode
+    // When set, this destination authenticates via an Integration of this kind. The credential and
+    // endpoint inputs are replaced by an integration picker for new and integration-backed exports.
+    integrationKind?: IntegrationKind
+    // Banner shown above the fields whenever the inline (non-integration) UI is rendered — used to
+    // tell users the export will be migrated to integrations automatically.
+    migrationNotice?: ReactNode
 }): JSX.Element {
+    // New exports must pick an integration; existing ones keep whatever they were created with.
+    const useIntegration = !!integrationKind && (isNew || !!formValues.integration_id)
+
+    // The KMS key is a config field (not a credential) that only applies to aws:kms encryption. With
+    // inline credentials it sits in the credentials row; in the integration form that row is gone, so
+    // it's surfaced next to the encryption select instead. Rendered in exactly one place either way.
+    const kmsKeyIdField = showEncryption && formValues.encryption == 'aws:kms' && (
+        <LemonField name="kms_key_id" label="AWS KMS Key ID" className="flex-1">
+            <LemonInput placeholder={isNew ? 'e.g. 1234abcd-12ab-34cd-56ef-1234567890ab' : 'leave unchanged'} />
+        </LemonField>
+    )
+
     return (
         <>
+            {!useIntegration && migrationNotice ? <LemonBanner type="warning">{migrationNotice}</LemonBanner> : null}
+
+            {useIntegration && integrationKind ? (
+                <LemonField name="integration_id" label="Integration">
+                    {({ value, onChange }) => (
+                        <IntegrationChoice integration={integrationKind} value={value} onChange={onChange} />
+                    )}
+                </LemonField>
+            ) : null}
+
             <div className="flex gap-4">
                 <LemonField name="bucket_name" label="Bucket" className="flex-1">
                     <LemonInput placeholder="e.g. my-bucket" />
@@ -373,42 +409,41 @@ export function S3FamilyFields({
                         />
                     </LemonField>
                 )}
+
+                {/* With an integration the credentials row is hidden, so the KMS key lives here instead. */}
+                {useIntegration && kmsKeyIdField}
             </div>
 
-            <div className="flex gap-4">
-                <LemonField
-                    name="aws_access_key_id"
-                    label={awsBranded ? 'AWS Access Key ID' : 'Access Key ID'}
-                    className="flex-1"
-                >
-                    <LemonInput
-                        placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'}
-                        autoComplete="off"
-                    />
-                </LemonField>
-
-                <LemonField
-                    name="aws_secret_access_key"
-                    label={awsBranded ? 'AWS Secret Access Key' : 'Secret Access Key'}
-                    className="flex-1"
-                >
-                    <LemonInput
-                        placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'}
-                        type="password"
-                        autoComplete="new-password"
-                    />
-                </LemonField>
-
-                {showEncryption && formValues.encryption == 'aws:kms' && (
-                    <LemonField name="kms_key_id" label="AWS KMS Key ID" className="flex-1">
+            {!useIntegration && (
+                <div className="flex gap-4">
+                    <LemonField
+                        name="aws_access_key_id"
+                        label={awsBranded ? 'AWS Access Key ID' : 'Access Key ID'}
+                        className="flex-1"
+                    >
                         <LemonInput
-                            placeholder={isNew ? 'e.g. 1234abcd-12ab-34cd-56ef-1234567890ab' : 'leave unchanged'}
+                            placeholder={isNew ? 'e.g. AKIAIOSFODNN7EXAMPLE' : 'Leave unchanged'}
+                            autoComplete="off"
                         />
                     </LemonField>
-                )}
-            </div>
 
-            {showEndpointUrl && (
+                    <LemonField
+                        name="aws_secret_access_key"
+                        label={awsBranded ? 'AWS Secret Access Key' : 'Secret Access Key'}
+                        className="flex-1"
+                    >
+                        <LemonInput
+                            placeholder={isNew ? 'e.g. secret-key' : 'Leave unchanged'}
+                            type="password"
+                            autoComplete="new-password"
+                        />
+                    </LemonField>
+
+                    {kmsKeyIdField}
+                </div>
+            )}
+
+            {!useIntegration && showEndpointUrl && (
                 <LemonField
                     name="endpoint_url"
                     label="Endpoint URL"

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3.tsx
@@ -34,6 +34,7 @@ export const s3Definition: DestinationDefinition = {
                 showEncryption
                 showEndpointUrl
                 showVirtualStyleAddressing
+                migrationNotice="S3 batch exports are moving to integration-based credentials. This export will be migrated automatically to an AWS S3 or S3-compatible destination — no action required."
             />
         )
     },

--- a/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3compatible.tsx
+++ b/frontend/src/scenes/data-pipelines/batch-exports/destinations/s3compatible.tsx
@@ -3,20 +3,39 @@ import type { DestinationDefinition } from './types'
 
 // Catch-all for any non-AWS S3-compatible object storage. Requires an endpoint URL and exposes
 // virtual-style addressing; no AWS-specific encryption / KMS fields.
+//
+// New exports authenticate via an `s3-compatible` Integration (which also carries the endpoint URL);
+// exports created before integrations existed keep their inline credentials + endpoint (grandfathered),
+// detected by the absence of `integration_id`.
 export const s3CompatibleDefinition: DestinationDefinition = {
     type: 'S3Compatible',
+    usesIntegration: true,
     defaults: () => ({
         file_format: 'Parquet',
         compression: 'zstd',
     }),
-    requiredFields: ({ isNew }) => [
+    requiredFields: ({ isNew, formValues }) => {
+        if (isNew || formValues.integration_id) {
+            // New exports must pick an integration (endpoint_url lives on it); existing
+            // integration-backed exports keep theirs.
+            return [...(isNew ? ['integration_id', 'file_format'] : []), 'bucket_name', 'region', 'prefix']
+        }
+        // Grandfathered inline-credential exports keep their original fields, including endpoint_url.
+        return ['bucket_name', 'region', 'prefix', 'endpoint_url']
+    },
+    // The credential keys remain allowlisted for grandfathered inline exports.
+    // TODO: clean up once fully migrated to integration-based credentials
+    configKeys: [
         'bucket_name',
         'region',
         'prefix',
+        'file_format',
+        'compression',
+        'max_file_size_mb',
+        'use_virtual_style_addressing',
+        'aws_access_key_id',
+        'aws_secret_access_key',
         'endpoint_url',
-        ...(isNew ? ['aws_access_key_id'] : []),
-        ...(isNew ? ['aws_secret_access_key'] : []),
-        ...(isNew ? ['file_format'] : []),
     ],
     validate: (formValues) => ({
         bucket_name: validateBucketName(formValues.bucket_name),
@@ -35,6 +54,8 @@ export const s3CompatibleDefinition: DestinationDefinition = {
                 showEndpointUrl
                 endpointUrlRequired
                 showVirtualStyleAddressing
+                integrationKind="s3-compatible"
+                migrationNotice="PostHog is moving S3 batch exports to integration-based credentials. This export will be migrated automatically — no action required."
             />
         )
     },

--- a/frontend/src/scenes/integrations/aws-s3/AwsS3SetupModal.tsx
+++ b/frontend/src/scenes/integrations/aws-s3/AwsS3SetupModal.tsx
@@ -1,0 +1,44 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { AwsS3SetupModalLogicProps, awsS3SetupModalLogic } from './awsS3SetupModalLogic'
+
+export const AwsS3SetupModal = (props: AwsS3SetupModalLogicProps): JSX.Element => {
+    const { isAwsS3IntegrationSubmitting } = useValues(awsS3SetupModalLogic(props))
+    const { submitAwsS3Integration } = useActions(awsS3SetupModalLogic(props))
+
+    return (
+        <LemonModal
+            isOpen={props.isOpen}
+            title="Configure AWS S3 connection"
+            description="Enter your AWS credentials to connect PostHog to your S3 buckets. They are stored encrypted and can be reused across exports."
+            onClose={props.onComplete}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={() => props.onComplete()}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton type="primary" loading={isAwsS3IntegrationSubmitting} onClick={submitAwsS3Integration}>
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <Form logic={awsS3SetupModalLogic} formKey="awsS3Integration" className="flex flex-col gap-4">
+                <LemonField name="name" label="Name" info="A name to identify this connection across exports.">
+                    <LemonInput placeholder="e.g. Production data lake" />
+                </LemonField>
+                <LemonField name="awsAccessKeyId" label="AWS Access Key ID">
+                    <LemonInput placeholder="e.g. AKIAIOSFODNN7EXAMPLE" autoComplete="off" />
+                </LemonField>
+                <LemonField name="awsSecretAccessKey" label="AWS Secret Access Key">
+                    <LemonInput type="password" placeholder="e.g. secret-key" autoComplete="new-password" />
+                </LemonField>
+            </Form>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/integrations/aws-s3/awsS3SetupModalLogic.ts
+++ b/frontend/src/scenes/integrations/aws-s3/awsS3SetupModalLogic.ts
@@ -1,0 +1,56 @@
+import { connect, kea, path, props } from 'kea'
+import { forms } from 'kea-forms'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
+import { IntegrationType } from '~/types'
+
+import type { awsS3SetupModalLogicType } from './awsS3SetupModalLogicType'
+
+export interface AwsS3SetupModalLogicProps {
+    isOpen: boolean
+    integration?: IntegrationType | null
+    onComplete: (integrationId?: number) => void
+}
+
+export const awsS3SetupModalLogic = kea<awsS3SetupModalLogicType>([
+    path(['integrations', 'aws-s3', 'awsS3SetupModalLogic']),
+    props({} as AwsS3SetupModalLogicProps),
+    connect(() => ({
+        actions: [integrationsLogic, ['loadIntegrations']],
+    })),
+    forms(({ props, actions, values }) => ({
+        awsS3Integration: {
+            defaults: {
+                name: '',
+                awsAccessKeyId: '',
+                awsSecretAccessKey: '',
+            },
+            errors: ({ name, awsAccessKeyId, awsSecretAccessKey }) => ({
+                name: name.trim() ? undefined : 'Name is required',
+                awsAccessKeyId: awsAccessKeyId.trim() ? undefined : 'Access Key ID is required',
+                awsSecretAccessKey: awsSecretAccessKey.trim() ? undefined : 'Secret Access Key is required',
+            }),
+            submit: async () => {
+                try {
+                    const integration = await api.integrations.create({
+                        kind: 'aws-s3',
+                        config: {
+                            name: values.awsS3Integration.name,
+                            aws_access_key_id: values.awsS3Integration.awsAccessKeyId,
+                            aws_secret_access_key: values.awsS3Integration.awsSecretAccessKey,
+                        },
+                    })
+                    actions.loadIntegrations()
+                    lemonToast.success('AWS S3 connection created successfully!')
+                    props.onComplete(integration.id)
+                } catch (error: any) {
+                    lemonToast.error(error.detail || 'Failed to create AWS S3 connection')
+                    throw error
+                }
+            },
+        },
+    })),
+])

--- a/frontend/src/scenes/integrations/s3-compatible/S3CompatibleSetupModal.tsx
+++ b/frontend/src/scenes/integrations/s3-compatible/S3CompatibleSetupModal.tsx
@@ -1,0 +1,55 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonButton, LemonInput, LemonModal } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { S3CompatibleSetupModalLogicProps, s3CompatibleSetupModalLogic } from './s3CompatibleSetupModalLogic'
+
+export const S3CompatibleSetupModal = (props: S3CompatibleSetupModalLogicProps): JSX.Element => {
+    const { isS3CompatibleIntegrationSubmitting } = useValues(s3CompatibleSetupModalLogic(props))
+    const { submitS3CompatibleIntegration } = useActions(s3CompatibleSetupModalLogic(props))
+
+    return (
+        <LemonModal
+            isOpen={props.isOpen}
+            title="Configure S3-compatible storage connection"
+            description="Connect PostHog to any S3-compatible object storage (e.g. Cloudflare R2, DigitalOcean Spaces, Supabase). Credentials are stored encrypted and can be reused across exports."
+            onClose={props.onComplete}
+            footer={
+                <>
+                    <LemonButton type="secondary" onClick={() => props.onComplete()}>
+                        Cancel
+                    </LemonButton>
+                    <LemonButton
+                        type="primary"
+                        loading={isS3CompatibleIntegrationSubmitting}
+                        onClick={submitS3CompatibleIntegration}
+                    >
+                        Save
+                    </LemonButton>
+                </>
+            }
+        >
+            <Form logic={s3CompatibleSetupModalLogic} formKey="s3CompatibleIntegration" className="flex flex-col gap-4">
+                <LemonField name="name" label="Name" info="A name to identify this connection across exports.">
+                    <LemonInput placeholder="e.g. R2 data lake" />
+                </LemonField>
+                <LemonField
+                    name="endpointUrl"
+                    label="Endpoint URL"
+                    info="The endpoint URL for your provider (e.g. Cloudflare R2, DigitalOcean Spaces, Supabase)."
+                >
+                    <LemonInput placeholder="e.g. https://<account-id>.r2.cloudflarestorage.com" />
+                </LemonField>
+                <LemonField name="awsAccessKeyId" label="Access Key ID">
+                    <LemonInput placeholder="e.g. AKIAIOSFODNN7EXAMPLE" autoComplete="off" />
+                </LemonField>
+                <LemonField name="awsSecretAccessKey" label="Secret Access Key">
+                    <LemonInput type="password" placeholder="e.g. secret-key" autoComplete="new-password" />
+                </LemonField>
+            </Form>
+        </LemonModal>
+    )
+}

--- a/frontend/src/scenes/integrations/s3-compatible/s3CompatibleSetupModalLogic.ts
+++ b/frontend/src/scenes/integrations/s3-compatible/s3CompatibleSetupModalLogic.ts
@@ -1,0 +1,59 @@
+import { connect, kea, path, props } from 'kea'
+import { forms } from 'kea-forms'
+
+import api from 'lib/api'
+import { integrationsLogic } from 'lib/integrations/integrationsLogic'
+import { lemonToast } from 'lib/lemon-ui/LemonToast'
+
+import { IntegrationType } from '~/types'
+
+import type { s3CompatibleSetupModalLogicType } from './s3CompatibleSetupModalLogicType'
+
+export interface S3CompatibleSetupModalLogicProps {
+    isOpen: boolean
+    integration?: IntegrationType | null
+    onComplete: (integrationId?: number) => void
+}
+
+export const s3CompatibleSetupModalLogic = kea<s3CompatibleSetupModalLogicType>([
+    path(['integrations', 's3-compatible', 's3CompatibleSetupModalLogic']),
+    props({} as S3CompatibleSetupModalLogicProps),
+    connect(() => ({
+        actions: [integrationsLogic, ['loadIntegrations']],
+    })),
+    forms(({ props, actions, values }) => ({
+        s3CompatibleIntegration: {
+            defaults: {
+                name: '',
+                endpointUrl: '',
+                awsAccessKeyId: '',
+                awsSecretAccessKey: '',
+            },
+            errors: ({ name, endpointUrl, awsAccessKeyId, awsSecretAccessKey }) => ({
+                name: name.trim() ? undefined : 'Name is required',
+                endpointUrl: endpointUrl.trim() ? undefined : 'Endpoint URL is required',
+                awsAccessKeyId: awsAccessKeyId.trim() ? undefined : 'Access Key ID is required',
+                awsSecretAccessKey: awsSecretAccessKey.trim() ? undefined : 'Secret Access Key is required',
+            }),
+            submit: async () => {
+                try {
+                    const integration = await api.integrations.create({
+                        kind: 's3-compatible',
+                        config: {
+                            name: values.s3CompatibleIntegration.name,
+                            endpoint_url: values.s3CompatibleIntegration.endpointUrl,
+                            aws_access_key_id: values.s3CompatibleIntegration.awsAccessKeyId,
+                            aws_secret_access_key: values.s3CompatibleIntegration.awsSecretAccessKey,
+                        },
+                    })
+                    actions.loadIntegrations()
+                    lemonToast.success('S3-compatible storage connection created successfully!')
+                    props.onComplete(integration.id)
+                } catch (error: any) {
+                    lemonToast.error(error.detail || 'Failed to create S3-compatible storage connection')
+                    throw error
+                }
+            },
+        },
+    })),
+])

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5365,6 +5365,8 @@ export const INTEGRATION_KINDS = [
     'customerio-webhook',
     'customerio-track',
     'postgresql',
+    'aws-s3',
+    's3-compatible',
 ] as const
 
 export type IntegrationKind = (typeof INTEGRATION_KINDS)[number]

--- a/playwright/e2e/batch-exports/batch-export-config.spec.ts
+++ b/playwright/e2e/batch-exports/batch-export-config.spec.ts
@@ -44,11 +44,9 @@ test.describe('Batch export configuration', () => {
         )
 
         // Mock the batch export creation endpoint (requires Temporal in real env)
-        let postedBody: { destination?: { integration?: number } } | null = null
         await page.route('**/api/environments/*/batch_exports/', async (route) => {
             if (route.request().method() === 'POST') {
                 const body = route.request().postDataJSON()
-                postedBody = body
                 await route.fulfill({
                     status: 201,
                     contentType: 'application/json',
@@ -106,11 +104,14 @@ test.describe('Batch export configuration', () => {
 
         await page.locator('input[name="prefix"]').fill('events/')
 
-        await page.locator('form').getByRole('button', { name: 'Create' }).click()
+        // Capture the create request to assert the selected integration is sent (instead of inline credentials)
+        const [createRequest] = await Promise.all([
+            page.waitForRequest((req) => req.url().includes('/batch_exports/') && req.method() === 'POST'),
+            page.locator('form').getByRole('button', { name: 'Create' }).click(),
+        ])
         await expect(page.locator('[data-attr="success-toast"]')).toContainText('Batch export created successfully')
 
-        // The selected integration is sent instead of inline credentials
-        expect(postedBody?.destination?.integration).toBe(integrationId)
+        expect(createRequest.postDataJSON().destination.integration).toBe(integrationId)
     })
 
     test('Validate required fields prevent save', async ({ page }) => {

--- a/playwright/e2e/batch-exports/batch-export-config.spec.ts
+++ b/playwright/e2e/batch-exports/batch-export-config.spec.ts
@@ -15,11 +15,40 @@ test.describe('Batch export configuration', () => {
     test('Create new AWS S3 batch export', async ({ page }) => {
         const name = randomString('AWS S3 Export')
         const mockId = '01234567-0123-0123-0123-0123456789ab'
+        const integrationId = 42
+
+        // AWS S3 exports authenticate via an aws-s3 integration. Return one so the
+        // integration picker auto-selects it (IntegrationChoice picks the first of the kind).
+        await page.route(
+            (url) => /\/api\/(projects|environments)\/[^/]+\/integrations\/?$/.test(url.pathname),
+            async (route) => {
+                await route.fulfill({
+                    status: 200,
+                    contentType: 'application/json',
+                    body: JSON.stringify({
+                        count: 1,
+                        next: null,
+                        previous: null,
+                        results: [
+                            {
+                                id: integrationId,
+                                kind: 'aws-s3',
+                                display_name: 'Test AWS credentials',
+                                config: {},
+                                created_at: new Date().toISOString(),
+                            },
+                        ],
+                    }),
+                })
+            }
+        )
 
         // Mock the batch export creation endpoint (requires Temporal in real env)
+        let postedBody: { destination?: { integration?: number } } | null = null
         await page.route('**/api/environments/*/batch_exports/', async (route) => {
             if (route.request().method() === 'POST') {
                 const body = route.request().postDataJSON()
+                postedBody = body
                 await route.fulfill({
                     status: 201,
                     contentType: 'application/json',
@@ -76,11 +105,12 @@ test.describe('Batch export configuration', () => {
         await page.getByRole('menuitem', { name: 'US East (N. Virginia)' }).click()
 
         await page.locator('input[name="prefix"]').fill('events/')
-        await page.locator('input[name="aws_access_key_id"]').fill('AKIAIOSFODNN7EXAMPLE')
-        await page.locator('input[name="aws_secret_access_key"]').fill('wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY')
 
         await page.locator('form').getByRole('button', { name: 'Create' }).click()
         await expect(page.locator('[data-attr="success-toast"]')).toContainText('Batch export created successfully')
+
+        // The selected integration is sent instead of inline credentials
+        expect(postedBody?.destination?.integration).toBe(integrationId)
     })
 
     test('Validate required fields prevent save', async ({ page }) => {

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2221,6 +2221,8 @@ class IntegrationKind(StrEnum):
     CUSTOMERIO_WEBHOOK = "customerio-webhook"
     CUSTOMERIO_TRACK = "customerio-track"
     POSTGRESQL = "postgresql"
+    AWS_S3 = "aws-s3"
+    S3_COMPATIBLE = "s3-compatible"
 
 
 class IntervalType(StrEnum):

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -4369,6 +4369,8 @@ export const IntegrationKindApi = {
     CustomerioWebhook: 'customerio-webhook',
     CustomerioTrack: 'customerio-track',
     Postgresql: 'postgresql',
+    AwsS3: 'aws-s3',
+    S3Compatible: 's3-compatible',
 } as const
 
 export interface ErrorTrackingExternalReferenceIntegrationApi {

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -3706,6 +3706,8 @@ export const IntegrationKindApi = {
     CustomerioWebhook: 'customerio-webhook',
     CustomerioTrack: 'customerio-track',
     Postgresql: 'postgresql',
+    AwsS3: 'aws-s3',
+    S3Compatible: 's3-compatible',
 } as const
 
 export interface ErrorTrackingExternalReferenceIntegrationApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -5171,6 +5171,8 @@ export namespace Schemas {
       CustomerioWebhook: 'customerio-webhook',
       CustomerioTrack: 'customerio-track',
       Postgresql: 'postgresql',
+      AwsS3: 'aws-s3',
+      S3Compatible: 's3-compatible',
     } as const;
 
     export interface ErrorTrackingExternalReferenceIntegration {


### PR DESCRIPTION
## Problem

`AwsS3` and `S3Compatible` batch exports authenticate with AWS credentials typed inline into each destination's config. That means credentials are duplicated per export and can't be reused, rotated, or managed independently — the same problem Databricks, Azure Blob, BigQuery and Postgres already solved by moving to the shared `Integration` model.

This is **PR 3** of that migration, and the part users see:

- PR 1 (#65232, merged): added the `aws-s3` / `s3-compatible` integration kinds + backend handlers.
- PR 2 (#65855): wired batch exports to resolve credentials (and the `s3-compatible` endpoint URL) from the linked integration at run time.
- **PR 3 (this PR):** the frontend flow so users pick (or create) an integration when configuring an `AwsS3` / `S3Compatible` export, instead of typing inline credentials.

Stacked on PR 2 — base is `posthog-code/s3-integration-batch-export`. Rebase onto master once PR 2 merges.

## Changes

Follows the existing Postgres pattern (`useIntegration = isNew || !!integration_id`) so new exports use an integration picker while exports created before integrations existed keep their inline-credential UI.

- **Integration kinds:** registered `aws-s3` / `s3-compatible` in `INTEGRATION_KINDS`, with icons (existing assets) and display names.
- **Setup modals:** two per-kind modals + kea logic that POST to the integration create endpoint. `aws-s3` collects a name + AWS access key/secret; `s3-compatible` adds the endpoint URL. Registered both so the picker's "Configure new…" entry opens them.
- **Destination forms:** `S3FamilyFields` now swaps the inline credential/endpoint inputs for an `IntegrationChoice` picker when integration-backed. `awss3.tsx` / `s3compatible.tsx` gained `usesIntegration`, a `configKeys` allowlist, and integration-aware `requiredFields`.
- **Migration banners:** an info banner on `AwsS3` / `S3Compatible` (and legacy `S3`) inline forms explaining these exports will be migrated to integrations automatically — no action required.

Backward compatible: grandfathered inline exports stay editable without attaching an integration, keep their credentials on save, and send no `integration`. The credential keys stay on the `configKeys` allowlist for now so those exports round-trip safely — a later PR that auto-migrates them can tighten it.

## How did you test this code?

Automated tests:

- **`batchExportConfigFormLogic.test.ts` (67 passing):** updated the per-destination required-fields and create-payload cases so new `AwsS3` / `S3Compatible` exports require an integration and emit `destination.integration` with no inline credentials. Added one regression test that a grandfathered inline `AwsS3` export stays editable without an integration, preserves its credentials on save, and sends no `integration` — guards the Postgres-style grandfathering this PR introduces.
- Storybook visual snapshots for `NewAwsS3Export` / `NewS3CompatibleExport` will need regenerating in CI (no story code change).

Manual testing:

- ensured I could crete a new AWS and S3-comptaible batch export using the new integration modals
- tested updating a legacy export with inline credentials works correctly

## Screenshots

Existing batch export without integration shows banner to notify users:

<img width="1588" height="459" alt="image" src="https://github.com/user-attachments/assets/6c483e55-3442-4338-80c7-d922e968070d" />

Integrations otherwise work very similarly to other destinations:

<img width="1382" height="807" alt="image" src="https://github.com/user-attachments/assets/2bdc1ae1-5ba3-4dce-82b7-4e6e841bf28d" />

<img width="1382" height="534" alt="image" src="https://github.com/user-attachments/assets/0049e318-8686-4daf-97b6-4b89fd5e2c81" />

<img width="946" height="478" alt="image" src="https://github.com/user-attachments/assets/6e81b6af-8ecc-447e-be83-bc810f33bd9e" />


## Automatic notifications

- [x] Publish to changelog?
- [ ] Alert Sales and Marketing teams? _probably not a significant enough change_

## Docs update

We should update the docs to mention new AWS S3 and S3-compatible storage batch exports have migrated to using integration-backed credentials, rather than inline ones, together with updating the section of the docs describing how to create an S3 batch export.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @rossgray.

- Tool: PostHog Code. Skills invoked: `/writing-tests` (test changes).
- Followed the existing `Postgres` destination's `useIntegration` pattern rather than inventing a new one, so grandfathered inline exports behave consistently across destinations.
- Considered switching fully to the integration picker on edit (forcing migration), but chose to keep inline-credential exports editable and nudge via a banner instead, since the data migration is coming later
- Kept credential keys in `configKeys` transitionally to avoid stripping inline credentials from grandfathered exports on save.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*