### PR TITLE
feat(hogql): type string-search functions

### DIFF
--- a/posthog/hogql/functions/clickhouse/strings.py
+++ b/posthog/hogql/functions/clickhouse/strings.py
@@ -1,12 +1,32 @@
-from posthog.hogql.ast import IntegerType, StringType
+from posthog.hogql.ast import BooleanType, IntegerType, StringType
 
 from ..core import HogQLFunctionMeta
+
+# Shared return-type signatures for string search/predicate helpers. These ClickHouse functions
+# have a fixed return family regardless of which valid overload is used. Modeling them removes a
+# large share of `missing_function_signature` type-inference gaps for common analytics queries.
+# Predicates (match/startsWith/hasToken/…) return a 0/1 flag, modeled as Boolean to match how the
+# resolver already types the like/ilike family; counts/positions/lengths return an integer; and
+# extractors return a String. (The like/ilike/notLike/notILike family is already typed as Boolean
+# by generic inference, which runs ahead of legacy signatures, so it needs no signature here.)
+_STR_TO_INT: list = [((StringType(),), IntegerType())]
+_STR_STR_TO_INT: list = [((StringType(), StringType()), IntegerType())]
+_STR_STR_OPT_INT_TO_INT: list = [
+    ((StringType(), StringType()), IntegerType()),
+    ((StringType(), StringType(), IntegerType()), IntegerType()),
+]
+_STR_STR_TO_BOOL: list = [((StringType(), StringType()), BooleanType())]
+_STR_STR_TO_STR: list = [((StringType(), StringType()), StringType())]
+_STR_STR_OPT_INT_TO_STR: list = [
+    ((StringType(), StringType()), StringType()),
+    ((StringType(), StringType(), IntegerType()), StringType()),
+]
 
 # Keep in sync with the posthog.com repository: contents/docs/sql/clickhouse-functions.mdx
 STRING_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "left": HogQLFunctionMeta("leftUTF8", 2, 2, signatures=[((StringType(), IntegerType()), StringType())]),
     "right": HogQLFunctionMeta("rightUTF8", 2, 2, signatures=[((StringType(), IntegerType()), StringType())]),
-    "lengthUTF8": HogQLFunctionMeta("lengthUTF8", 1, 1),
+    "lengthUTF8": HogQLFunctionMeta("lengthUTF8", 1, 1, signatures=_STR_TO_INT),
     "leftPad": HogQLFunctionMeta("leftPad", 2, 3),
     "rightPad": HogQLFunctionMeta("rightPad", 2, 3),
     "leftPadUTF8": HogQLFunctionMeta("leftPadUTF8", 2, 3),
@@ -30,22 +50,24 @@ STRING_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "base64Encode": HogQLFunctionMeta("base64Encode", 1, 1),
     "base64Decode": HogQLFunctionMeta("base64Decode", 1, 1),
     "tryBase64Decode": HogQLFunctionMeta("tryBase64Decode", 1, 1),
-    "endsWith": HogQLFunctionMeta("endsWith", 2, 2),
-    "startsWith": HogQLFunctionMeta("startsWith", 2, 2),
+    "endsWith": HogQLFunctionMeta("endsWith", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "startsWith": HogQLFunctionMeta("startsWith", 2, 2, signatures=_STR_STR_TO_BOOL),
     "encodeXMLComponent": HogQLFunctionMeta("encodeXMLComponent", 1, 1),
     "decodeXMLComponent": HogQLFunctionMeta("decodeXMLComponent", 1, 1),
     "extractTextFromHTML": HogQLFunctionMeta("extractTextFromHTML", 1, 1),
-    "ascii": HogQLFunctionMeta("ascii", 1, 1, case_sensitive=False),
+    "ascii": HogQLFunctionMeta("ascii", 1, 1, case_sensitive=False, signatures=_STR_TO_INT),
     "concatWithSeparator": HogQLFunctionMeta("concatWithSeparator", 2, None),
 }
 
 # searching in strings
 # Keep in sync with the posthog.com repository: contents/docs/sql/clickhouse-functions.mdx
 STRING_SEARCH_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
-    "position": HogQLFunctionMeta("position", 2, 3, case_sensitive=False),
-    "positionCaseInsensitive": HogQLFunctionMeta("positionCaseInsensitive", 2, 3),
-    "positionUTF8": HogQLFunctionMeta("positionUTF8", 2, 3),
-    "positionCaseInsensitiveUTF8": HogQLFunctionMeta("positionCaseInsensitiveUTF8", 2, 3),
+    "position": HogQLFunctionMeta("position", 2, 3, case_sensitive=False, signatures=_STR_STR_OPT_INT_TO_INT),
+    "positionCaseInsensitive": HogQLFunctionMeta("positionCaseInsensitive", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT),
+    "positionUTF8": HogQLFunctionMeta("positionUTF8", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT),
+    "positionCaseInsensitiveUTF8": HogQLFunctionMeta(
+        "positionCaseInsensitiveUTF8", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT
+    ),
     "multiSearchAllPositions": HogQLFunctionMeta("multiSearchAllPositions", 2, 2),
     "multiSearchAllPositionsUTF8": HogQLFunctionMeta("multiSearchAllPositionsUTF8", 2, 2),
     "multiSearchFirstPosition": HogQLFunctionMeta("multiSearchFirstPosition", 2, 2),
@@ -64,14 +86,14 @@ STRING_SEARCH_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "multiSearchFirstPositionCaseInsensitiveUTF8": HogQLFunctionMeta(
         "multiSearchFirstPositionCaseInsensitiveUTF8", 2, 2
     ),
-    "match": HogQLFunctionMeta("match", 2, 2),
+    "match": HogQLFunctionMeta("match", 2, 2, signatures=_STR_STR_TO_BOOL),
     "multiMatchAny": HogQLFunctionMeta("multiMatchAny", 2, 2),
     "multiMatchAnyIndex": HogQLFunctionMeta("multiMatchAnyIndex", 2, 2),
     "multiMatchAllIndices": HogQLFunctionMeta("multiMatchAllIndices", 2, 2),
     "multiFuzzyMatchAny": HogQLFunctionMeta("multiFuzzyMatchAny", 3, 3),
     "multiFuzzyMatchAnyIndex": HogQLFunctionMeta("multiFuzzyMatchAnyIndex", 3, 3),
     "multiFuzzyMatchAllIndices": HogQLFunctionMeta("multiFuzzyMatchAllIndices", 3, 3),
-    "extract": HogQLFunctionMeta("extract", 2, 2, case_sensitive=False),
+    "extract": HogQLFunctionMeta("extract", 2, 2, case_sensitive=False, signatures=_STR_STR_TO_STR),
     "extractAll": HogQLFunctionMeta("extractAll", 2, 2),
     "extractAllGroupsHorizontal": HogQLFunctionMeta("extractAllGroupsHorizontal", 2, 2),
     "extractAllGroupsVertical": HogQLFunctionMeta("extractAllGroupsVertical", 2, 2),
@@ -80,7 +102,7 @@ STRING_SEARCH_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "ilike": HogQLFunctionMeta("ilike", 2, 2),
     "notLike": HogQLFunctionMeta("notLike", 2, 2),
     "notILike": HogQLFunctionMeta("notILike", 2, 2),
-    "locate": HogQLFunctionMeta("locate", 2, 3),
+    "locate": HogQLFunctionMeta("locate", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT),
     "ngramDistance": HogQLFunctionMeta("ngramDistance", 2, 2),
     "ngramDistanceCaseInsensitive": HogQLFunctionMeta("ngramDistanceCaseInsensitive", 2, 2),
     "ngramDistanceUTF8": HogQLFunctionMeta("ngramDistanceUTF8", 2, 2),
@@ -89,22 +111,32 @@ STRING_SEARCH_FUNCTIONS: dict[str, HogQLFunctionMeta] = {
     "ngramSearchCaseInsensitive": HogQLFunctionMeta("ngramSearchCaseInsensitive", 2, 2),
     "ngramSearchUTF8": HogQLFunctionMeta("ngramSearchUTF8", 2, 2),
     "ngramSearchCaseInsensitiveUTF8": HogQLFunctionMeta("ngramSearchCaseInsensitiveUTF8", 2, 2),
-    "countSubstrings": HogQLFunctionMeta("countSubstrings", 2, 3),
-    "countSubstringsCaseInsensitive": HogQLFunctionMeta("countSubstringsCaseInsensitive", 2, 3),
-    "countSubstringsCaseInsensitiveUTF8": HogQLFunctionMeta("countSubstringsCaseInsensitiveUTF8", 2, 3),
-    "countMatches": HogQLFunctionMeta("countMatches", 2, 2),
-    "countMatchesCaseInsensitive": HogQLFunctionMeta("countMatchesCaseInsensitive", 2, 2),
-    "hasSubsequence": HogQLFunctionMeta("hasSubsequence", 2, 2),
-    "hasSubsequenceCaseInsensitive": HogQLFunctionMeta("hasSubsequenceCaseInsensitive", 2, 2),
-    "hasSubsequenceUTF8": HogQLFunctionMeta("hasSubsequenceUTF8", 2, 2),
-    "hasSubsequenceCaseInsensitiveUTF8": HogQLFunctionMeta("hasSubsequenceCaseInsensitiveUTF8", 2, 2),
-    "hasToken": HogQLFunctionMeta("hasToken", 2, 2),
-    "hasTokenCaseInsensitive": HogQLFunctionMeta("hasTokenCaseInsensitive", 2, 2),
-    "hasTokenOrNull": HogQLFunctionMeta("hasTokenOrNull", 2, 2),
-    "hasTokenCaseInsensitiveOrNull": HogQLFunctionMeta("hasTokenCaseInsensitiveOrNull", 2, 2),
+    "countSubstrings": HogQLFunctionMeta("countSubstrings", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT),
+    "countSubstringsCaseInsensitive": HogQLFunctionMeta(
+        "countSubstringsCaseInsensitive", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT
+    ),
+    "countSubstringsCaseInsensitiveUTF8": HogQLFunctionMeta(
+        "countSubstringsCaseInsensitiveUTF8", 2, 3, signatures=_STR_STR_OPT_INT_TO_INT
+    ),
+    "countMatches": HogQLFunctionMeta("countMatches", 2, 2, signatures=_STR_STR_TO_INT),
+    "countMatchesCaseInsensitive": HogQLFunctionMeta("countMatchesCaseInsensitive", 2, 2, signatures=_STR_STR_TO_INT),
+    "hasSubsequence": HogQLFunctionMeta("hasSubsequence", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "hasSubsequenceCaseInsensitive": HogQLFunctionMeta(
+        "hasSubsequenceCaseInsensitive", 2, 2, signatures=_STR_STR_TO_BOOL
+    ),
+    "hasSubsequenceUTF8": HogQLFunctionMeta("hasSubsequenceUTF8", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "hasSubsequenceCaseInsensitiveUTF8": HogQLFunctionMeta(
+        "hasSubsequenceCaseInsensitiveUTF8", 2, 2, signatures=_STR_STR_TO_BOOL
+    ),
+    "hasToken": HogQLFunctionMeta("hasToken", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "hasTokenCaseInsensitive": HogQLFunctionMeta("hasTokenCaseInsensitive", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "hasTokenOrNull": HogQLFunctionMeta("hasTokenOrNull", 2, 2, signatures=_STR_STR_TO_BOOL),
+    "hasTokenCaseInsensitiveOrNull": HogQLFunctionMeta(
+        "hasTokenCaseInsensitiveOrNull", 2, 2, signatures=_STR_STR_TO_BOOL
+    ),
     "hasAllTokens": HogQLFunctionMeta("hasAllTokens", 2, 2),
     "hasAnyTokens": HogQLFunctionMeta("hasAnyTokens", 2, 2),
-    "regexpExtract": HogQLFunctionMeta("regexpExtract", 2, 3),
+    "regexpExtract": HogQLFunctionMeta("regexpExtract", 2, 3, signatures=_STR_STR_OPT_INT_TO_STR),
 }
 
 # replacing in strings

--- a/posthog/hogql/test/test_type_system.py
+++ b/posthog/hogql/test/test_type_system.py
@@ -602,6 +602,25 @@ class TestHogQLTypeSystem:
             ast.ArrayType(nullable=False, item_type=ast.StringType(nullable=False)),
         )
 
+    def test_resolver_infers_string_search_function_types(self) -> None:
+        # Predicates return a 0/1 flag, modeled as Boolean (consistent with like/ilike).
+        self._assert_first_column_type("SELECT match('abc', 'a')", ast.BooleanType(nullable=False))
+        self._assert_first_column_type("SELECT startsWith('abc', 'a')", ast.BooleanType(nullable=False))
+        self._assert_first_column_type("SELECT endsWith('abc', 'c')", ast.BooleanType(nullable=False))
+        self._assert_first_column_type("SELECT hasToken('a b c', 'b')", ast.BooleanType(nullable=False))
+        self._assert_first_column_type("SELECT hasSubsequence('abc', 'ac')", ast.BooleanType(nullable=False))
+        # Counts, positions and lengths return the integer family (UInt64/Int32).
+        self._assert_first_column_type("SELECT position('abc', 'b')", ast.IntegerType(nullable=False))
+        self._assert_first_column_type("SELECT position('abc', 'b', 1)", ast.IntegerType(nullable=False))
+        self._assert_first_column_type("SELECT countSubstrings('aaa', 'a')", ast.IntegerType(nullable=False))
+        self._assert_first_column_type("SELECT lengthUTF8('abc')", ast.IntegerType(nullable=False))
+        self._assert_first_column_type("SELECT ascii('a')", ast.IntegerType(nullable=False))
+        # Extractors return a String.
+        self._assert_first_column_type("SELECT extract('abc', '(b)')", ast.StringType(nullable=False))
+        self._assert_first_column_type("SELECT regexpExtract('abc', '(b)')", ast.StringType(nullable=False))
+        # Nullability propagates from the arguments: a nullable haystack yields a nullable result.
+        self._assert_first_column_type("SELECT match(properties.foo, 'a') FROM events", ast.BooleanType(nullable=True))
+
     def test_resolver_infers_common_url_function_types(self) -> None:
         self._assert_first_column_type("SELECT protocol('https://posthog.com')", ast.StringType(nullable=False))
         self._assert_first_column_type(


### PR DESCRIPTION
## Problem

HogQL's type system infers return types for function calls, but ~25 common string search/predicate/count/extraction helpers (`match`, `position`, `startsWith`, `hasToken`, `countSubstrings`, `extract`, `regexpExtract`, …) had no signature, so every call resolved to `UnknownType`. An unknown type is an optimizer barrier: it poisons type unification for surrounding expressions and blocks any type-driven decision (cast simplification, nullability wrapper removal, future argument validation) from reaching those queries.

Production type-observability metrics (1% sampled, last 7d) show this is the single largest genuine coverage gap: the `string` function group is ~24k `missing_function_signature` events/week, second only to `array`, and `missing_function_signature` is ~96% of all type-inference unknowns. The gap is concentrated in product analytics queries.

This is the first slice of a broader function-coverage effort; array and math batches and an aggregate-combinator inference rule follow separately.

## Changes

Added return-type signatures to the string search/predicate/count/extraction helpers in `posthog/hogql/functions/clickhouse/strings.py`:

- **Predicates → `Boolean`**: `match`, `startsWith`, `endsWith`, `hasToken` (+ case/null variants), `hasSubsequence` (+ variants). Modeled as Boolean to match how the resolver already types the `like`/`ilike` family, and consistent with ClickHouse's 0/1 `UInt8` result.
- **Counts / positions / lengths → `Integer`**: `position` (+ case/UTF8 variants), `locate`, `countSubstrings` (+ variants), `countMatches` (+ variant), `lengthUTF8`, `ascii`.
- **Extractors → `String`**: `extract`, `regexpExtract`.

This is **pure type metadata** — it does not change emitted ClickHouse SQL. The consumers that would change SQL (the opt-in cast/nullability simplifier) remain off by default; this commit only widens where they can eventually apply. The observable effect is the `string` group's `missing_function_signature` counter dropping and the precise-return-type rate rising.

Notable detail surfaced while doing this: the `like`/`ilike`/`notLike`/`notILike` family is already typed as `Boolean` by generic inference, which runs ahead of legacy signatures — so those need no signature here, and the redundant ones were removed.

## How did you test this code?

I'm an agent (Claude Code); listing only automated checks I actually ran:

- Added `test_resolver_infers_string_search_function_types` asserting each shape resolves correctly (Boolean / Integer / String) plus nullability propagation from a nullable argument — this catches the regression where these functions silently fall back to `UnknownType`, which no existing test covered.
- Full `posthog/hogql/test/test_type_system.py` (41 tests) and the printer suite `posthog/hogql/printer/test/test_printer.py` (725 tests, 186 snapshots): green, no snapshot churn.
- Verified **no emitted-SQL change**: printed representative queries using these functions before and after the change through the test harness; every statement was byte-identical (no nullability wrappers added or removed).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @georgemunyoro. This came out of investigating a production `ILLEGAL_TYPE_OF_ARGUMENT` bug, which led to a broader review of how little the new HogQL type system is currently utilised. We pulled prod type-observability metrics from Grafana (VictoriaMetrics) to rank coverage gaps by real query volume, cross-referenced against a local catalog-inventory sweep to get the per-function list, and picked string-search as the highest impact-per-effort first slice.

Key decision: model the predicates as `Boolean` rather than `Integer`. Initial attempt used `Integer` for everything, but the test surfaced that generic inference already types `like`/`ilike` as `Boolean` (and shadows legacy signatures). Aligning the other predicates to `Boolean` keeps the catalog internally consistent and matches ClickHouse's `UInt8` predicate result (integer family at runtime, but treated as a boolean throughout HogQL like the existing comparison/predicate functions).

No repo skills were invoked. Signatures are intentionally inference-only (return types), not argument contracts — a separate, faithful argument-contract mechanism is planned for resolve-time validation later.
