### PR TITLE
refactor(data-warehouse): route data_warehouse's ws reads through the facade

### DIFF
--- a/products/data_warehouse/backend/activity_logging.py
+++ b/products/data_warehouse/backend/activity_logging.py
@@ -7,11 +7,11 @@ from posthog.models.activity_logging.external_data_utils import (
 )
 from posthog.models.signals import model_activity_signal, mutable_receiver
 
-from products.warehouse_sources.backend.models.external_data_schema import (
+from products.warehouse_sources.backend.facade.models import (
     ExternalDataSchema,
+    ExternalDataSource,
     sync_frequency_interval_to_sync_frequency,
 )
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
 
 # Lives here, not in the api/external_data_{schema,source}.py viewsets, so these can wire at
 # AppConfig.ready() without dragging those viewsets (which pull dlt via the data-import pipeline

--- a/products/data_warehouse/backend/logic/data_load/create_table.py
+++ b/products/data_warehouse/backend/logic/data_load/create_table.py
@@ -19,7 +19,7 @@ from products.data_modeling.backend.models.datawarehouse_saved_query import (
     asave_saved_query,
 )
 from products.data_warehouse.backend.s3 import get_size_of_folder
-from products.warehouse_sources.backend.models.table import (
+from products.warehouse_sources.backend.facade.models import (
     DataWarehouseTable,
     acreate_datawarehousetable,
     asave_datawarehousetable,

--- a/products/data_warehouse/backend/logic/data_load/service.py
+++ b/products/data_warehouse/backend/logic/data_load/service.py
@@ -47,8 +47,7 @@ from posthog.temporal.utils import ExternalDataWorkflowInputs
 if TYPE_CHECKING:
     from posthog.models import Team
 
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-    from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 logger = structlog.get_logger(__name__)
 
@@ -381,7 +380,7 @@ async def cancel_workflow(temporal: TemporalClient, workflow_id: str):
 
 
 def is_any_external_data_schema_paused(team_id: int) -> bool:
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     return (
         ExternalDataSchema.objects.exclude(deleted=True)
@@ -488,7 +487,7 @@ def sync_cdc_extraction_schedule(source: ExternalDataSource, create: bool = Fals
     Calculates the interval from the most frequent CDC schema. If no CDC
     schemas are active, deletes the schedule.
     """
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     # `source__deleted=True` is excluded so a deleted source (whose schemas may have been
     # left non-deleted by `soft_delete`) collapses to the "no active CDC schemas" branch below

--- a/products/data_warehouse/backend/logic/data_load/source_templates.py
+++ b/products/data_warehouse/backend/logic/data_load/source_templates.py
@@ -4,8 +4,8 @@ from posthog.temporal.common.logger import get_logger
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
 from products.revenue_analytics.backend.joins import ensure_person_join
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import ExternalDataJob
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 LOGGER = get_logger(__name__)
 

--- a/products/data_warehouse/backend/logic/data_load/test/test_service.py
+++ b/products/data_warehouse/backend/logic/data_load/test/test_service.py
@@ -31,8 +31,7 @@ from products.data_warehouse.backend.logic.data_load.service import (
     get_discover_schemas_schedule,
     get_sync_schedule,
 )
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 pytestmark = [
     pytest.mark.django_db,

--- a/products/data_warehouse/backend/logic/external_data_source/jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/jobs.py
@@ -10,8 +10,7 @@ from products.data_warehouse.backend.tasks import (
     EXTERNAL_DATA_FAILURE_DIGEST_SCHEDULED_COUNTER,
     send_external_data_failure_digest_task,
 )
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.metrics import (
     TERMINAL_JOB_STATUSES,
     emit_data_import_app_metrics,

--- a/products/data_warehouse/backend/logic/external_data_source/notifications.py
+++ b/products/data_warehouse/backend/logic/external_data_source/notifications.py
@@ -9,8 +9,7 @@ import structlog
 
 from posthog.tasks.email import send_external_data_failure_digest
 
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema
 
 logger = structlog.get_logger(__name__)
 

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_jobs.py
@@ -6,9 +6,7 @@ from unittest.mock import MagicMock, patch
 from posthog.models import Organization, Team
 
 from products.data_warehouse.backend.logic.external_data_source.jobs import update_external_job_status
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
 
 pytestmark = [
     pytest.mark.django_db,

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_notifications.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_notifications.py
@@ -12,9 +12,7 @@ from products.data_warehouse.backend.logic.external_data_source.notifications im
     get_team_ids_with_recent_sync_failures,
     notify_external_data_sync_failures,
 )
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
 
 pytestmark = [
     pytest.mark.django_db,

--- a/products/data_warehouse/backend/logic/external_data_source/test/test_webhooks.py
+++ b/products/data_warehouse/backend/logic/external_data_source/test/test_webhooks.py
@@ -11,8 +11,7 @@ from products.data_warehouse.backend.logic.external_data_source.webhooks import 
     get_or_create_webhook_hog_function,
     reconcile_webhook_events,
 )
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
     WebhookCreationResult,
     WebhookSyncResult,

--- a/products/data_warehouse/backend/logic/external_data_source/webhooks.py
+++ b/products/data_warehouse/backend/logic/external_data_source/webhooks.py
@@ -7,7 +7,7 @@ from posthog.models import Team
 
 from products.cdp.backend.models.hog_function_template import HogFunctionTemplate
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
     WebhookCreationResult,
     WebhookDeletionResult,

--- a/products/data_warehouse/backend/management/commands/backfill_cdc_extraction_schedules.py
+++ b/products/data_warehouse/backend/management/commands/backfill_cdc_extraction_schedules.py
@@ -35,8 +35,7 @@ from django.core.management.base import BaseCommand
 import structlog
 
 from products.data_warehouse.backend.logic.data_load.service import bulk_sync_cdc_extraction_schedules, cdc_min_interval
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 logger = structlog.get_logger(__name__)
 

--- a/products/data_warehouse/backend/management/commands/backfill_discovery_schedules.py
+++ b/products/data_warehouse/backend/management/commands/backfill_discovery_schedules.py
@@ -33,9 +33,9 @@ from django.core.management.base import BaseCommand
 import structlog
 
 from products.data_warehouse.backend.logic.data_load.service import bulk_sync_discover_schemas_schedules
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
-from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 

--- a/products/data_warehouse/backend/management/commands/repair_qualified_schema_duplicates.py
+++ b/products/data_warehouse/backend/management/commands/repair_qualified_schema_duplicates.py
@@ -32,9 +32,8 @@ from django.core.management.base import BaseCommand
 
 import structlog
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema, update_should_sync
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource, update_should_sync
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 

--- a/products/data_warehouse/backend/management/commands/update_data_import_schedules.py
+++ b/products/data_warehouse/backend/management/commands/update_data_import_schedules.py
@@ -7,7 +7,7 @@ from django.core.management.base import BaseCommand, CommandError
 import structlog
 
 from products.data_warehouse.backend.logic.data_load.service import bulk_update_external_data_job_schedules
-from products.warehouse_sources.backend.models.external_data_schema import (
+from products.warehouse_sources.backend.facade.models import (
     ExternalDataSchema,
     sync_frequency_to_sync_frequency_interval,
 )

--- a/products/data_warehouse/backend/management/test/test_backfill_cdc_extraction_schedules.py
+++ b/products/data_warehouse/backend/management/test/test_backfill_cdc_extraction_schedules.py
@@ -7,8 +7,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 pytestmark = pytest.mark.django_db
 

--- a/products/data_warehouse/backend/management/test/test_backfill_discovery_schedules.py
+++ b/products/data_warehouse/backend/management/test/test_backfill_discovery_schedules.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
 
 pytestmark = pytest.mark.django_db
 

--- a/products/data_warehouse/backend/management/test/test_update_data_import_schedules.py
+++ b/products/data_warehouse/backend/management/test/test_update_data_import_schedules.py
@@ -16,8 +16,7 @@ from posthog.temporal.common.schedule import describe_schedule, update_schedule
 
 from products.data_warehouse.backend.logic.data_load.service import sync_external_data_job_workflow
 from products.data_warehouse.backend.management.commands.update_data_import_schedules import _get_external_data_schemas
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 pytestmark = [pytest.mark.django_db]
 

--- a/products/data_warehouse/backend/migrations/test/test_migration_0013.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0013.py
@@ -5,9 +5,11 @@ from posthog.test.base import NonAtomicTestMigrations
 
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential as DataWarehouseCredentialModel
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource as ExternalDataSourceModel
-from products.warehouse_sources.backend.models.table import DataWarehouseTable as DataWarehouseTableModel
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential as DataWarehouseCredentialModel,
+    DataWarehouseTable as DataWarehouseTableModel,
+    ExternalDataSource as ExternalDataSourceModel,
+)
 
 pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 

--- a/products/data_warehouse/backend/migrations/test/test_migration_0014.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0014.py
@@ -8,8 +8,10 @@ from parameterized import parameterized
 from products.data_modeling.backend.models.datawarehouse_saved_query import (
     DataWarehouseSavedQuery as DataWarehouseSavedQueryModel,
 )
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential as DataWarehouseCredentialModel
-from products.warehouse_sources.backend.models.table import DataWarehouseTable as DataWarehouseTableModel
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential as DataWarehouseCredentialModel,
+    DataWarehouseTable as DataWarehouseTableModel,
+)
 
 pytestmark = pytest.mark.skip("old migrations slow overall test run down")
 

--- a/products/data_warehouse/backend/migrations/test/test_migration_0020.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0020.py
@@ -5,7 +5,7 @@ import pytest
 
 from django.apps import apps
 
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
 
 migration_module = importlib.import_module(
     "products.data_warehouse.backend.migrations.0020_migrate_github_job_inputs_to_auth_type"

--- a/products/data_warehouse/backend/migrations/test/test_migration_0041.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0041.py
@@ -5,7 +5,7 @@ import pytest
 
 from django.apps import apps
 
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
 
 migration_module = importlib.import_module(
     "products.data_warehouse.backend.migrations.0041_migrate_stripe_job_inputs_to_auth_type"

--- a/products/data_warehouse/backend/migrations/test/test_migration_0046.py
+++ b/products/data_warehouse/backend/migrations/test/test_migration_0046.py
@@ -5,7 +5,7 @@ import pytest
 
 from django.apps import apps
 
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
 
 migration_module = importlib.import_module(
     "products.data_warehouse.backend.migrations.0046_fix_vitally_region_job_inputs"

--- a/products/data_warehouse/backend/mysql_helpers.py
+++ b/products/data_warehouse/backend/mysql_helpers.py
@@ -23,8 +23,11 @@ from products.data_warehouse.backend.direct_mysql import (
     hide_direct_mysql_table,
     upsert_direct_mysql_table,
 )
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.util import mysql_column_to_dwh_column, mysql_columns_to_dwh_columns
+from products.warehouse_sources.backend.facade.models import (
+    ExternalDataSource,
+    mysql_column_to_dwh_column,
+    mysql_columns_to_dwh_columns,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.location import normalize_namespace
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.metadata import (
@@ -133,7 +136,7 @@ def reconcile_mysql_schemas(
 ) -> list[str]:
     """Persist `schema_metadata` on every MySQL row + (direct mode only) upsert its live-query
     `DataWarehouseTable`. Returns stale schema names that got soft-deleted (direct only)."""
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     is_direct = source.is_direct_query
     source_schema_names = [s.name for s in source_schemas]

--- a/products/data_warehouse/backend/postgres_helpers.py
+++ b/products/data_warehouse/backend/postgres_helpers.py
@@ -22,8 +22,8 @@ from products.data_warehouse.backend.direct_postgres import (
     rename_direct_postgres_join_references,
     upsert_direct_postgres_table,
 )
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.util import (
+from products.warehouse_sources.backend.facade.models import (
+    ExternalDataSource,
     postgres_column_to_dwh_column,
     postgres_columns_to_dwh_columns,
 )
@@ -166,7 +166,7 @@ def reconcile_postgres_schemas(
 ) -> list[str]:
     """Persist `schema_metadata` on every Postgres row + (direct mode only) upsert its live-query
     `DataWarehouseTable`. Returns stale schema names that got soft-deleted (direct only)."""
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     is_direct = source.is_direct_query
     source_schema_names = [s.name for s in source_schemas]
@@ -331,7 +331,7 @@ def rename_postgres_schemas_to_match_source_schemas(
     Direct mode (`allow_rename=True`) rewrites `name` in place; warehouse mode pins
     `schema_metadata` only — the rename happens in `postgres_warehouse_migration`.
     """
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     default_schema = (source.job_inputs or {}).get("schema")
     schema_models = list(

--- a/products/data_warehouse/backend/postgres_warehouse_migration.py
+++ b/products/data_warehouse/backend/postgres_warehouse_migration.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from products.data_warehouse.backend.postgres_helpers import rename_postgres_schemas_to_match_source_schemas
 from products.data_warehouse.backend.sql_warehouse_migration import apply_on_refresh
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 
 

--- a/products/data_warehouse/backend/sql_warehouse_migration.py
+++ b/products/data_warehouse/backend/sql_warehouse_migration.py
@@ -9,7 +9,8 @@ from __future__ import annotations
 
 from typing import Any
 
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSource
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 from products.warehouse_sources.backend.temporal.data_imports.naming_convention import NamingConvention
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
@@ -17,7 +18,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql
     fill_missing_from_dotted_name,
     normalize_namespace,
 )
-from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 def _source_has_optional_schema_field(source: Any) -> bool:
@@ -103,7 +103,7 @@ def apply_on_schema_clear(source: ExternalDataSource, old_schema: str) -> None:
     """Pin legacy rows to the OLD schema before the next refresh sees `default_schema=None` and
     misroutes them to `"public"`.
     """
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     rows = list(ExternalDataSchema.objects.filter(team_id=source.team_id, source_id=source.id, deleted=False))
     rows_by_name = {row.name: row for row in rows}
@@ -163,7 +163,7 @@ def apply_on_refresh(*, source: ExternalDataSource, team_id: int) -> dict[str, s
     falls back to `"public"` when `job_inputs.schema` is blank, missing the actual schema.
     Returns `{old_name: new_name}` for callers feeding `sync_old_schemas_with_new_schemas`.
     """
-    from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+    from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
     rows = list(
         ExternalDataSchema.objects.filter(team_id=team_id, source_id=source.id, deleted=False).select_related("table")

--- a/products/data_warehouse/backend/sync_status.py
+++ b/products/data_warehouse/backend/sync_status.py
@@ -7,12 +7,12 @@ from django.db.models import Q
 
 import humanize
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
 if TYPE_CHECKING:
     from posthog.schema import DataWarehouseSyncWarning
 
-    from products.warehouse_sources.backend.models.table import DataWarehouseTable
+    from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
 # When a schema is still in RUNNING state but its last successful sync is older than

--- a/products/data_warehouse/backend/temporal/health_checks/external_data_failure.py
+++ b/products/data_warehouse/backend/temporal/health_checks/external_data_failure.py
@@ -6,7 +6,7 @@ from posthog.temporal.health_checks.detectors import DEFAULT_EXECUTION_POLICY
 from posthog.temporal.health_checks.framework import AlertContent, HealthCheck, Remediation
 from posthog.temporal.health_checks.models import HealthCheckResult
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
 
 class ExternalDataFailureCheck(HealthCheck):

--- a/products/data_warehouse/backend/test/test_repair_qualified_schema_duplicates.py
+++ b/products/data_warehouse/backend/test/test_repair_qualified_schema_duplicates.py
@@ -6,10 +6,8 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 # Patched at the defining module: update_should_sync imports these function-locally now.
 _TEMPORAL = "products.data_warehouse.backend.logic.data_load.service"

--- a/products/data_warehouse/backend/test/test_sql_warehouse_migration.py
+++ b/products/data_warehouse/backend/test/test_sql_warehouse_migration.py
@@ -20,10 +20,9 @@ from products.data_warehouse.backend.sql_warehouse_migration import (
     is_multi_schema_capable_sql_source,
     source_namespace_is_blank,
 )
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.base import SQLSource
-from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 def _sql_source_stub(*, schema_required: bool | None, has_schema_field: bool = True) -> Any:

--- a/products/data_warehouse/backend/test/test_sync_status.py
+++ b/products/data_warehouse/backend/test/test_sync_status.py
@@ -6,11 +6,13 @@ from unittest.mock import MagicMock
 from parameterized import parameterized
 
 from products.data_warehouse.backend.sync_status import get_warehouse_sync_warnings
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential,
+    DataWarehouseTable,
+    ExternalDataSchema,
+    ExternalDataSource,
+)
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 
 class TestWarehouseSyncWarnings(BaseTest):

--- a/products/data_warehouse/backend/test/utils.py
+++ b/products/data_warehouse/backend/test/utils.py
@@ -14,11 +14,13 @@ from posthog.settings import (
     XDIST_SUFFIX,
 )
 
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
-from products.warehouse_sources.backend.models.util import CLICKHOUSE_HOGQL_MAPPING, clean_type
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.hogql import CLICKHOUSE_HOGQL_MAPPING, clean_type
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential,
+    DataWarehouseTable,
+    ExternalDataSource,
+)
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 
 def create_data_warehouse_table_from_csv(

--- a/products/data_warehouse/backend/tests/api/conftest.py
+++ b/products/data_warehouse/backend/tests/api/conftest.py
@@ -32,7 +32,7 @@ from posthog.temporal.tests.data_imports.conftest import (  # noqa: F401
     stripe_subscription,
 )
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema
 
 
 @pytest_asyncio.fixture

--- a/products/data_warehouse/backend/tests/api/test_cdc_table_mode_patch.py
+++ b/products/data_warehouse/backend/tests/api/test_cdc_table_mode_patch.py
@@ -18,10 +18,8 @@ from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
 
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import ExternalDataJob, ExternalDataSchema, ExternalDataSource
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 pytestmark = [pytest.mark.django_db]
 

--- a/products/data_warehouse/backend/tests/api/test_column_annotation.py
+++ b/products/data_warehouse/backend/tests/api/test_column_annotation.py
@@ -3,9 +3,11 @@ from posthog.test.base import APIBaseTest
 from posthog.constants import AvailableFeature
 from posthog.models import OrganizationMembership
 
-from products.warehouse_sources.backend.models.column_annotation import WarehouseColumnAnnotation
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential,
+    DataWarehouseTable,
+    WarehouseColumnAnnotation,
+)
 
 from ee.models.rbac.access_control import AccessControl
 

--- a/products/data_warehouse/backend/tests/api/test_data_warehouse.py
+++ b/products/data_warehouse/backend/tests/api/test_data_warehouse.py
@@ -13,10 +13,12 @@ from products.dashboards.backend.models.dashboard import Dashboard
 from products.dashboards.backend.models.dashboard_tile import DashboardTile
 from products.data_modeling.backend.models.data_modeling_job import DataModelingJob
 from products.data_warehouse.backend.models.team_data_warehouse_config import TeamDataWarehouseConfig
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseTable,
+    ExternalDataJob,
+    ExternalDataSchema,
+    ExternalDataSource,
+)
 
 
 class TestDataWarehouseAPI(APIBaseTest):

--- a/products/data_warehouse/backend/tests/api/test_external_data_schema.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_schema.py
@@ -27,19 +27,19 @@ from posthog.temporal.common.schedule import describe_schedule
 from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_PATTERN
 from products.data_warehouse.backend.logic.external_data_source.webhooks import WebhookHogFunctionCreateResult
 from products.data_warehouse.backend.tests.api.utils import create_external_data_source_ok
-from products.warehouse_sources.backend.models.external_data_schema import (
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseTable,
     ExternalDataSchema,
+    ExternalDataSource,
     update_sync_type_config_keys,
 )
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
     WebhookCreationResult,
     WebhookSyncResult,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source import StripeSource
-from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 pytestmark = [
     pytest.mark.django_db,
@@ -2702,7 +2702,7 @@ class TestCancelExternalDataSchema(APIBaseTest):
             status=ExternalDataSchema.Status.RUNNING,
             sync_type=ExternalDataSchema.SyncType.FULL_REFRESH,
         )
-        from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
+        from products.warehouse_sources.backend.facade.models import ExternalDataJob
 
         job = ExternalDataJob.objects.create(
             team=self.team,

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -42,14 +42,15 @@ from products.data_warehouse.backend.presentation.views.external_data_source imp
     strip_sensitive_from_dict,
 )
 from products.revenue_analytics.backend.joins import get_customer_revenue_view_name
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob
-from products.warehouse_sources.backend.models.external_data_schema import (
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseTable,
+    ExternalDataJob,
     ExternalDataSchema,
+    ExternalDataSource,
+    PendingSourceCredential,
     sync_frequency_interval_to_sync_frequency,
 )
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.pending_source_credential import PendingSourceCredential
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.types import IncrementalFieldType
 from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import BigQuerySourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import (
@@ -91,7 +92,6 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.con
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.settings import (
     ENDPOINTS as STRIPE_ENDPOINTS,
 )
-from products.warehouse_sources.backend.types import IncrementalFieldType
 
 
 class TestExternalDataSource(APIBaseTest):
@@ -7268,8 +7268,8 @@ class TestCreateWebhook(APIBaseTest):
         # Inject a second required webhook field into the source config so we can test
         # that a partial update which omits one required field is accepted while still
         # preserving the existing value on the HogFunction.
+        from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
         from products.warehouse_sources.backend.temporal.data_imports.sources import SourceRegistry
-        from products.warehouse_sources.backend.types import ExternalDataSourceType
 
         original_source = SourceRegistry.get_source(ExternalDataSourceType("Stripe"))
         original_config = original_source.get_source_config

--- a/products/data_warehouse/backend/tests/api/test_external_data_source_access_control.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source_access_control.py
@@ -10,8 +10,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
 from posthog.rbac.user_access_control import UserAccessControl
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import ExternalDataSchema, ExternalDataSource
 
 try:
     from ee.models.rbac.access_control import AccessControl

--- a/products/data_warehouse/backend/tests/api/test_external_data_source_end_to_end.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source_end_to_end.py
@@ -18,9 +18,13 @@ from posthog.temporal.utils import ExternalDataWorkflowInputs
 
 from products.data_modeling.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.warehouse_sources.backend.models.external_data_job import ExternalDataJob, get_latest_run_if_exists
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
+from products.warehouse_sources.backend.facade.models import (
+    ExternalDataJob,
+    ExternalDataSchema,
+    ExternalDataSource,
+    get_latest_run_if_exists,
+)
+from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
 from products.warehouse_sources.backend.temporal.data_imports.external_data_job import ExternalDataJobWorkflow
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.delta_table_helper import (
     DeltaTableHelper,
@@ -29,7 +33,6 @@ from products.warehouse_sources.backend.temporal.data_imports.settings import AC
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.constants import (
     SUBSCRIPTION_RESOURCE_NAME as STRIPE_SUBSCRIPTION_RESOURCE_NAME,
 )
-from products.warehouse_sources.backend.types import DataWarehouseManagedViewSetKind
 
 BUCKET_NAME = "test-pipeline"
 

--- a/products/data_warehouse/backend/tests/api/test_lineage.py
+++ b/products/data_warehouse/backend/tests/api/test_lineage.py
@@ -4,7 +4,7 @@ from posthog.test.db_context_capturing import capture_db_queries
 
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_warehouse.backend.presentation.views.lineage import topological_sort
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
 class TestLineage(APIBaseTest):

--- a/products/data_warehouse/backend/tests/api/test_managed_viewset.py
+++ b/products/data_warehouse/backend/tests/api/test_managed_viewset.py
@@ -6,7 +6,7 @@ from posthog.schema import RevenueAnalyticsEventItem, RevenueCurrencyPropertyCon
 
 from products.data_modeling.backend.models.datawarehouse_managed_viewset import DataWarehouseManagedViewSet
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.warehouse_sources.backend.types import DataWarehouseManagedViewSetKind
+from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
 
 
 # Define child classes for each managed viewset kind

--- a/products/data_warehouse/backend/tests/api/test_postgres_warehouse_migration.py
+++ b/products/data_warehouse/backend/tests/api/test_postgres_warehouse_migration.py
@@ -13,9 +13,7 @@ from unittest.mock import Mock, patch
 
 from rest_framework import status
 
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSchema, ExternalDataSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 
 

--- a/products/data_warehouse/backend/tests/api/test_saved_query.py
+++ b/products/data_warehouse/backend/tests/api/test_saved_query.py
@@ -15,8 +15,8 @@ from products.data_modeling.backend.models.datawarehouse_managed_viewset import 
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
 from products.data_modeling.backend.models.modeling import DataWarehouseModelPath
 from products.data_tools.backend.models.datawarehouse_saved_query_folder import DataWarehouseSavedQueryFolder
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
-from products.warehouse_sources.backend.types import DataWarehouseManagedViewSetKind
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
+from products.warehouse_sources.backend.facade.types import DataWarehouseManagedViewSetKind
 
 
 class TestSavedQuery(APIBaseTest):

--- a/products/data_warehouse/backend/tests/api/test_table.py
+++ b/products/data_warehouse/backend/tests/api/test_table.py
@@ -13,8 +13,7 @@ from parameterized import parameterized
 
 from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_PATTERN
 from products.data_warehouse.backend.presentation.views.table import SimpleTableSerializer
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable, ExternalDataSource
 
 
 class TestTable(APIBaseTest):
@@ -646,7 +645,7 @@ class TestTable(APIBaseTest):
         assert table.url_pattern == "https://your-org.s3.amazonaws.com/bucket/whatever.pqt"
 
     def test_update_table_credential_blank_access_key(self):
-        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.facade.models import DataWarehouseCredential
 
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="original_key", access_secret="original_secret"
@@ -669,7 +668,7 @@ class TestTable(APIBaseTest):
         assert credential.access_key == "original_key"
 
     def test_update_table_credential_blank_access_secret(self):
-        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.facade.models import DataWarehouseCredential
 
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="original_key", access_secret="original_secret"
@@ -692,7 +691,7 @@ class TestTable(APIBaseTest):
         assert credential.access_secret == "original_secret"
 
     def test_update_table_credential_null_field_values_rejected(self):
-        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.facade.models import DataWarehouseCredential
 
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="original_key", access_secret="original_secret"
@@ -717,7 +716,7 @@ class TestTable(APIBaseTest):
         assert credential.access_secret == "original_secret"
 
     def test_update_table_credential_null_rejected(self):
-        from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
+        from products.warehouse_sources.backend.facade.models import DataWarehouseCredential
 
         credential = DataWarehouseCredential.objects.create(
             team=self.team, access_key="original_key", access_secret="original_secret"

--- a/products/data_warehouse/backend/tests/api/test_table_access_control.py
+++ b/products/data_warehouse/backend/tests/api/test_table_access_control.py
@@ -7,7 +7,7 @@ from posthog.models.organization import OrganizationMembership
 from posthog.models.user import User
 
 from products.data_warehouse.backend.tests.api._access_control_base import WarehouseAccessControlTestMixin
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
+from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 try:
     from ee.models.rbac.access_control import AccessControl

--- a/products/data_warehouse/backend/tests/api/test_view_link.py
+++ b/products/data_warehouse/backend/tests/api/test_view_link.py
@@ -11,11 +11,13 @@ from posthog.schema import HogQLQueryResponse
 from posthog.hogql.query import HogQLQueryExecutor
 
 from products.data_tools.backend.models.join import DataWarehouseJoin
-from products.warehouse_sources.backend.models.credential import DataWarehouseCredential
-from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
-from products.warehouse_sources.backend.models.external_data_source import ExternalDataSource
-from products.warehouse_sources.backend.models.table import DataWarehouseTable
-from products.warehouse_sources.backend.types import ExternalDataSourceType
+from products.warehouse_sources.backend.facade.models import (
+    DataWarehouseCredential,
+    DataWarehouseTable,
+    ExternalDataSchema,
+    ExternalDataSource,
+)
+from products.warehouse_sources.backend.facade.types import ExternalDataSourceType
 
 
 class TestViewLinkQuery(APIBaseTest):

--- a/products/warehouse_sources/backend/facade/models.py
+++ b/products/warehouse_sources/backend/facade/models.py
@@ -32,9 +32,17 @@ from products.warehouse_sources.backend.models.external_data_source import (
     get_direct_external_data_source_for_connection,
 )
 from products.warehouse_sources.backend.models.pending_source_credential import PendingSourceCredential
-from products.warehouse_sources.backend.models.table import DataWarehouseTable, DataWarehouseTableColumns
+from products.warehouse_sources.backend.models.ssh_tunnel import SSHTunnel
+from products.warehouse_sources.backend.models.table import (
+    DataWarehouseTable,
+    DataWarehouseTableColumns,
+    acreate_datawarehousetable,
+    asave_datawarehousetable,
+)
 from products.warehouse_sources.backend.models.util import (
+    mysql_column_to_dwh_column,
     mysql_columns_to_dwh_columns,
+    postgres_column_to_dwh_column,
     postgres_columns_to_dwh_columns,
     validate_source_prefix,
     validate_warehouse_table_url_pattern,
@@ -48,12 +56,17 @@ __all__ = [
     "ExternalDataSchema",
     "ExternalDataSource",
     "PendingSourceCredential",
+    "SSHTunnel",
     "WarehouseColumnAnnotation",
+    "acreate_datawarehousetable",
+    "asave_datawarehousetable",
     "get_all_schemas_for_source_id",
     "get_direct_external_data_source_for_connection",
     "get_latest_run_if_exists",
     "get_or_create_datawarehouse_credential",
+    "mysql_column_to_dwh_column",
     "mysql_columns_to_dwh_columns",
+    "postgres_column_to_dwh_column",
     "postgres_columns_to_dwh_columns",
     "sync_frequency_interval_to_sync_frequency",
     "sync_frequency_to_sync_frequency_interval",


### PR DESCRIPTION
## Problem

`warehouse_sources` still carries a large legacy-leak interface block (core/ee/siblings import its models/types/temporal directly) which keeps `backend:contract-check` off. `data_warehouse` was its single biggest consumer — 152 direct `ws.models`/`ws.types` import statements across its non-presentation code (logic, temporal activities, tasks). This routes those through `ws.facade`, the "team-sliced read sweep" the ws legacy-leak comment anticipated.

## Changes

- **Swept data_warehouse's non-presentation `ws.models`/`ws.types` imports onto `ws.facade`** — per-symbol routing: model classes → `facade.models`, the ClickHouse↔HogQL mapping tables → `facade.hogql`, shared enums → `facade.types`.
- **Added the few missing symbols to `ws.facade.models`**: `SSHTunnel`, `acreate_datawarehousetable` / `asave_datawarehousetable`, `mysql_column_to_dwh_column` / `postgres_column_to_dwh_column`.
- **Setup-path modules keep their direct `ws.models` imports** — `direct_mysql` / `direct_postgres` (pulled by `ws.models.table` → `dw.facade.sources` at `django.setup()`) and the dw model modules. Routing them through the *eager* `facade.models` re-enters it mid-load (circular import). This is a justified, pre-existing setup-path coupling, the same shape as `ws.models.table → dw.facade.sources`.

This shrinks the ws legacy-leak's largest chunk. The block itself stays (other consumers + the deliberately-permanent temporal coupling remain), so `backend:contract-check` is unaffected — this is incremental cleanup toward eventually splitting the leak down to its permanent temporal core.

## How did you test this code?

Automated, run locally:
- `tach check --dependencies --interfaces` → All modules validated.
- `lint-imports` → presentation contract KEPT, 0 broken.
- Startup import-budget → **pass** (the setup-path restoration is what keeps it cycle-free; verified the failure mode and the fix).
- Django import smoke on swept modules → OK.
- `ruff` + `py_compile` clean across all 49 changed files.

Behavioral product tests run in CI (the repoint is identity-preserving).

## Docs update

No user-facing docs changes.
