### PR TITLE
feat(phai): add searchable github branch picker to task composer

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -237,7 +237,10 @@ import type {
 } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/rules/types'
 import type { SymbolSetOrder } from 'products/error_tracking/frontend/scenes/ErrorTrackingConfigurationScene/symbol_sets/symbolSetLogic'
 import type { ErrorTrackingRecommendation } from 'products/error_tracking/frontend/scenes/ErrorTrackingScene/tabs/recommendations/types'
-import type { GitHubReposResponseApi } from 'products/integrations/frontend/generated/api.schemas'
+import type {
+    GitHubBranchesResponseApi,
+    GitHubReposResponseApi,
+} from 'products/integrations/frontend/generated/api.schemas'
 import type { LogExplanation } from 'products/logs/frontend/components/LogsViewer/LogDetailsModal/Tabs/ExploreWithAI/types'
 import type { NotebookCollabCursorApi } from 'products/notebooks/frontend/generated/api.schemas'
 import type { Task, TaskListParams, TaskRun, TaskUpsertProps } from 'products/posthog_ai/frontend/types/taskTypes'
@@ -1571,6 +1574,10 @@ export class ApiRequest {
 
     public integrationGitHubRepositories(id: IntegrationType['id'], teamId?: TeamType['id']): ApiRequest {
         return this.integrations(teamId).addPathComponent(id).addPathComponent('github_repos')
+    }
+
+    public integrationGitHubBranches(id: IntegrationType['id'], teamId?: TeamType['id']): ApiRequest {
+        return this.integrations(teamId).addPathComponent(id).addPathComponent('github_branches')
     }
 
     public integrationJiraProjects(id: IntegrationType['id'], teamId?: TeamType['id']): ApiRequest {
@@ -5293,8 +5300,11 @@ const api = {
         async bulkReorder(columns: Record<string, string[]>): Promise<{ updated: number; tasks: Task[] }> {
             return await new ApiRequest().tasks().withAction('bulk_reorder').create({ data: { columns } })
         },
-        async run(id: Task['id']): Promise<Task> {
-            return await new ApiRequest().task(id).withAction('run').create()
+        async run(id: Task['id'], data?: { branch?: string | null }): Promise<Task> {
+            return await new ApiRequest()
+                .task(id)
+                .withAction('run')
+                .create(data ? { data } : undefined)
         },
         runs: {
             async list(taskId: Task['id'], params: Record<string, any> = {}): Promise<PaginatedResponse<TaskRun>> {
@@ -6184,6 +6194,12 @@ const api = {
             params?: { limit?: number; offset?: number; search?: string }
         ): Promise<GitHubReposResponseApi> {
             return await new ApiRequest().integrationGitHubRepositories(id).withQueryString(params).get()
+        },
+        async githubBranches(
+            id: IntegrationType['id'],
+            params: { repo: string; limit?: number; offset?: number; search?: string }
+        ): Promise<GitHubBranchesResponseApi> {
+            return await new ApiRequest().integrationGitHubBranches(id).withQueryString(params).get()
         },
         async githubLinkExisting(
             data: {

--- a/frontend/src/lib/integrations/GitHubBranchCombobox.tsx
+++ b/frontend/src/lib/integrations/GitHubBranchCombobox.tsx
@@ -68,7 +68,7 @@ export function GitHubBranchCombobox({
     // Offer "Use <typed> as branch name" when the search doesn't match an existing branch — lets the agent
     // work on a brand-new branch.
     const createSentinel = CREATE_BRANCH_PREFIX + trimmedSearchQuery
-    const showCreateItem = trimmedSearchQuery.length > 0 && !branches.includes(trimmedSearchQuery)
+    const showCreateItem = trimmedSearchQuery.length > 0 && !loading && !branches.includes(trimmedSearchQuery)
     const items = showCreateItem ? [...branches, createSentinel] : branches
 
     return (

--- a/frontend/src/lib/integrations/GitHubBranchCombobox.tsx
+++ b/frontend/src/lib/integrations/GitHubBranchCombobox.tsx
@@ -1,0 +1,180 @@
+import { useActions, useValues } from 'kea'
+import { type MouseEvent, useEffect, useRef, useState } from 'react'
+
+import { IconGitBranch, IconRefresh } from '@posthog/icons'
+import {
+    Button,
+    Combobox,
+    ComboboxContent,
+    ComboboxEmpty,
+    ComboboxInput,
+    ComboboxItem,
+    ComboboxList,
+    ComboboxListFooter,
+    ComboboxTrigger,
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@posthog/quill'
+
+import { githubBranchSearchLogic } from './githubBranchSearchLogic'
+
+export interface GitHubBranchComboboxProps {
+    integrationId: number
+    /** Repository in `owner/repo` format whose branches to list. */
+    repo: string
+    /** Selected branch name, or empty when nothing is picked. */
+    value: string
+    onChange: (value: string | null) => void
+    disabled?: boolean
+    placeholder?: string
+}
+
+/** Sentinel item value for the "type a new branch name" action. */
+const CREATE_BRANCH_PREFIX = '__create__:'
+
+/**
+ * GitHub branch picker built on Quill's Combobox, mirroring the PostHog Code branch picker: a button
+ * trigger, in-popover server-side search, a paginated "Load more" footer, and a refresh control. It
+ * auto-selects the repository's default branch, and lets the user type a brand-new branch name (committed
+ * via a synthetic "Use \"x\" as branch name" item). Searching/pagination are delegated to
+ * {@link githubBranchSearchLogic}, keyed per repository.
+ */
+export function GitHubBranchCombobox({
+    integrationId,
+    repo,
+    value,
+    onChange,
+    disabled = false,
+    placeholder = 'Select branch...',
+}: GitHubBranchComboboxProps): JSX.Element {
+    const logic = githubBranchSearchLogic({ integrationId, repo })
+    const { branches, defaultBranch, loading, hasMore, searchQuery } = useValues(logic)
+    const { setSearchQuery, loadMore, refresh } = useActions(logic)
+
+    const triggerRef = useRef<HTMLButtonElement>(null)
+    const [open, setOpen] = useState(false)
+
+    const trimmedSearchQuery = searchQuery.trim()
+    const showInlineLoadingState = open && loading
+
+    // Pre-select the repo's default branch once it's known and nothing is chosen yet (matches PostHog Code).
+    useEffect(() => {
+        if (!value && defaultBranch) {
+            onChange(defaultBranch)
+        }
+    }, [value, defaultBranch, onChange])
+
+    // Offer "Use <typed> as branch name" when the search doesn't match an existing branch — lets the agent
+    // work on a brand-new branch.
+    const createSentinel = CREATE_BRANCH_PREFIX + trimmedSearchQuery
+    const showCreateItem = trimmedSearchQuery.length > 0 && !branches.includes(trimmedSearchQuery)
+    const items = showCreateItem ? [...branches, createSentinel] : branches
+
+    return (
+        <Combobox
+            items={items}
+            // Server-side search already filtered the list; don't let the combobox re-filter by input value.
+            filter={null}
+            value={value || null}
+            onValueChange={(next: string | null) => {
+                if (!next) {
+                    onChange(null)
+                    return
+                }
+                onChange(next.startsWith(CREATE_BRANCH_PREFIX) ? next.slice(CREATE_BRANCH_PREFIX.length) : next)
+            }}
+            open={open}
+            onOpenChange={(nextOpen: boolean) => {
+                setOpen(nextOpen)
+                if (!nextOpen && trimmedSearchQuery.length > 0) {
+                    setSearchQuery('')
+                }
+            }}
+            inputValue={searchQuery}
+            onInputValueChange={(next: string) => setSearchQuery(next)}
+            disabled={disabled}
+        >
+            <ComboboxTrigger
+                render={
+                    <Button ref={triggerRef} variant="outline" size="sm" disabled={disabled} aria-label="Branch">
+                        <IconGitBranch className="shrink-0" />
+                        <span className="min-w-0 truncate">{value || placeholder}</span>
+                    </Button>
+                }
+            />
+            <ComboboxContent anchor={triggerRef} side="bottom" sideOffset={6} className="min-w-[280px]">
+                <div className="flex min-w-0 items-center gap-1 pe-2">
+                    <div className="min-w-0 flex-1">
+                        <ComboboxInput placeholder="Search branches..." />
+                    </div>
+                    <Tooltip>
+                        <TooltipTrigger
+                            render={
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    disabled={disabled || loading}
+                                    aria-label="Refresh branches"
+                                    onMouseDown={(event: MouseEvent) => {
+                                        event.preventDefault()
+                                        event.stopPropagation()
+                                    }}
+                                    onClick={(event: MouseEvent) => {
+                                        event.preventDefault()
+                                        event.stopPropagation()
+                                        refresh()
+                                    }}
+                                >
+                                    <IconRefresh className={loading ? 'animate-spin' : undefined} />
+                                </Button>
+                            }
+                        />
+                        <TooltipContent>Refresh branches</TooltipContent>
+                    </Tooltip>
+                </div>
+                <ComboboxEmpty>{showInlineLoadingState ? 'Loading branches...' : 'No branches found.'}</ComboboxEmpty>
+                <ComboboxList>
+                    {(item: string) =>
+                        item.startsWith(CREATE_BRANCH_PREFIX) ? (
+                            <ComboboxItem key={item} value={item}>
+                                Use "{trimmedSearchQuery}" as branch name
+                            </ComboboxItem>
+                        ) : (
+                            <ComboboxItem key={item} value={item}>
+                                {item}
+                            </ComboboxItem>
+                        )
+                    }
+                </ComboboxList>
+
+                {hasMore && (
+                    <ComboboxListFooter>
+                        <div className="px-2 pb-2">
+                            <div className="px-1 pb-2 text-center text-muted text-xs">
+                                {`Showing ${branches.length}+ ${trimmedSearchQuery ? 'matches' : 'branches'}`}
+                            </div>
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                className="w-full justify-center"
+                                disabled={loading}
+                                onMouseDown={(event: MouseEvent) => {
+                                    event.preventDefault()
+                                    event.stopPropagation()
+                                }}
+                                onClick={(event: MouseEvent) => {
+                                    event.preventDefault()
+                                    event.stopPropagation()
+                                    loadMore()
+                                }}
+                            >
+                                Load more
+                            </Button>
+                        </div>
+                    </ComboboxListFooter>
+                )}
+            </ComboboxContent>
+        </Combobox>
+    )
+}

--- a/frontend/src/lib/integrations/githubBranchSearchLogic.ts
+++ b/frontend/src/lib/integrations/githubBranchSearchLogic.ts
@@ -1,0 +1,131 @@
+import { actions, afterMount, isBreakpoint, kea, key, listeners, path, props, reducers } from 'kea'
+
+import api from 'lib/api'
+
+import type { githubBranchSearchLogicType } from './githubBranchSearchLogicType'
+
+const PAGE_SIZE = 50
+const SEARCH_DEBOUNCE_MS = 300
+
+export interface GithubBranchSearchLogicProps {
+    integrationId: number
+    /** Repository in `owner/repo` format whose branches to list. */
+    repo: string
+}
+
+/**
+ * Server-side searchable, paginated GitHub branch source for a single repository. Mirrors
+ * {@link githubRepositorySearchLogic} but for the `github_branches` endpoint (which is repo-scoped), and
+ * additionally captures the repository's default branch so a picker can pre-select it. Keyed by integration
+ * id + repo so each repository's branch list stays independent.
+ */
+export const githubBranchSearchLogic = kea<githubBranchSearchLogicType>([
+    props({} as GithubBranchSearchLogicProps),
+    key((props) => `${props.integrationId}:${props.repo}`),
+    path((key) => ['lib', 'integrations', 'githubBranchSearchLogic', key]),
+
+    actions({
+        setSearchQuery: (searchQuery: string) => ({ searchQuery }),
+        loadPage: (offset: number) => ({ offset }),
+        loadPageSuccess: (branches: string[], defaultBranch: string | null, hasMore: boolean, offset: number) => ({
+            branches,
+            defaultBranch,
+            hasMore,
+            offset,
+        }),
+        loadPageFailure: true,
+        loadMore: true,
+        refresh: true,
+    }),
+
+    reducers({
+        searchQuery: [
+            '',
+            {
+                setSearchQuery: (_, { searchQuery }) => searchQuery,
+            },
+        ],
+        branches: [
+            [] as string[],
+            {
+                setSearchQuery: () => [],
+                refresh: () => [],
+                loadPageSuccess: (state, { branches, offset }) => {
+                    if (offset === 0) {
+                        return branches
+                    }
+                    const seen = new Set(state)
+                    return [...state, ...branches.filter((b) => !seen.has(b))]
+                },
+            },
+        ],
+        // The repo's default branch, surfaced by the endpoint; used by the picker for pre-selection.
+        defaultBranch: [
+            null as string | null,
+            {
+                loadPageSuccess: (state, { defaultBranch }) => defaultBranch ?? state,
+            },
+        ],
+        loading: [
+            false,
+            {
+                setSearchQuery: () => true,
+                refresh: () => true,
+                loadPage: () => true,
+                loadPageSuccess: () => false,
+                loadPageFailure: () => false,
+            },
+        ],
+        hasMore: [
+            false,
+            {
+                loadPageSuccess: (_, { hasMore }) => hasMore,
+                loadPageFailure: () => false,
+            },
+        ],
+        currentOffset: [
+            0,
+            {
+                setSearchQuery: () => 0,
+                refresh: () => 0,
+                loadPageSuccess: (_, { offset }) => offset + PAGE_SIZE,
+            },
+        ],
+    }),
+
+    listeners(({ actions, values, props }) => ({
+        setSearchQuery: async (_, breakpoint) => {
+            await breakpoint(SEARCH_DEBOUNCE_MS)
+            actions.loadPage(0)
+        },
+        refresh: () => {
+            actions.loadPage(0)
+        },
+        loadMore: () => {
+            if (values.hasMore && !values.loading) {
+                actions.loadPage(values.currentOffset)
+            }
+        },
+        loadPage: async ({ offset }, breakpoint) => {
+            try {
+                const response = await api.integrations.githubBranches(props.integrationId, {
+                    repo: props.repo,
+                    limit: PAGE_SIZE,
+                    offset,
+                    search: values.searchQuery.trim() || undefined,
+                })
+                await breakpoint()
+                actions.loadPageSuccess(response.branches, response.default_branch ?? null, response.has_more, offset)
+            } catch (e: any) {
+                if (isBreakpoint(e)) {
+                    throw e
+                }
+                actions.loadPageFailure()
+            }
+        },
+    })),
+
+    afterMount(({ actions }) => {
+        actions.loadPage(0)
+    }),
+])

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/RepositorySelector.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/RepositorySelector.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { LemonSkeleton } from '@posthog/lemon-ui'
 
 import { IntegrationChoice } from 'lib/components/CyclotronJob/integrations/IntegrationChoice'
+import { GitHubBranchCombobox } from 'lib/integrations/GitHubBranchCombobox'
 import { GitHubRepositoryCombobox } from 'lib/integrations/GitHubRepositoryCombobox'
 import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 import { urls } from 'scenes/urls'
@@ -17,9 +18,14 @@ export interface RepositorySelectorProps {
 export function RepositorySelector({ value, onChange }: RepositorySelectorProps): JSX.Element {
     const { integrationsLoading } = useValues(integrationsLogic)
 
-    // The picker selects on `owner/repo`, which is exactly the format the Task API expects.
+    // The picker selects on `owner/repo`, which is exactly the format the Task API expects. Switching repos
+    // clears the branch so the new repo's default branch is picked up.
     const handleRepositoryChange = (repository: string | null): void => {
-        onChange({ ...value, repository: repository ?? undefined })
+        onChange({ ...value, repository: repository ?? undefined, branch: undefined })
+    }
+
+    const handleBranchChange = (branch: string | null): void => {
+        onChange({ ...value, branch: branch ?? undefined })
     }
 
     if (integrationsLoading) {
@@ -38,6 +44,7 @@ export function RepositorySelector({ value, onChange }: RepositorySelectorProps)
                             ...value,
                             integrationId: integrationId ?? undefined,
                             repository: undefined,
+                            branch: undefined,
                         })
                     }
                     redirectUrl={urls.taskTracker()}
@@ -51,6 +58,18 @@ export function RepositorySelector({ value, onChange }: RepositorySelectorProps)
                         integrationId={value.integrationId}
                         value={value.repository ?? ''}
                         onChange={handleRepositoryChange}
+                    />
+                </div>
+            ) : null}
+
+            {value.integrationId && value.repository ? (
+                <div>
+                    <label className="block text-sm font-medium mb-2">Branch</label>
+                    <GitHubBranchCombobox
+                        integrationId={value.integrationId}
+                        repo={value.repository}
+                        value={value.branch ?? ''}
+                        onChange={handleBranchChange}
                     />
                 </div>
             ) : null}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -84,8 +84,9 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
                 const newTask = await api.tasks.create(taskData)
                 lemonToast.success('Task created successfully')
 
-                // Auto-run the task after creation; the detail scene shows the latest run by default.
-                await api.tasks.run(newTask.id)
+                // Auto-run the task after creation; the detail scene shows the latest run by default. The
+                // run checks out the chosen branch (server falls back to the repo's default branch if unset).
+                await api.tasks.run(newTask.id, { branch: repositoryConfig.branch ?? null })
                 router.actions.push(`/tasks/${newTask.id}`)
 
                 actions.submitNewTaskSuccess()

--- a/products/posthog_ai/frontend/types/taskTypes.ts
+++ b/products/posthog_ai/frontend/types/taskTypes.ts
@@ -4,6 +4,8 @@ export interface RepositoryConfig {
     integrationId?: number
     /** `owner/repo` (GitHub `full_name`), same as data warehouse / Cyclotron GitHub pickers */
     repository?: string
+    /** Git branch the run checks out; defaults to the repo's default branch when unset. */
+    branch?: string
 }
 
 export enum OriginProduct {


### PR DESCRIPTION
## Problem

The task composer now has a repository picker (#66326), but PostHog Code also lets you pick the git branch the agent works on — defaulting to the repo's default branch, and letting you start a brand-new branch. Without it, every run uses whatever the server defaults to, with no way to target a branch or spin up a fresh one from the UI.

## Changes

- New `GitHubBranchCombobox` (`frontend/src/lib/integrations/`) built on the Quill `Combobox`, mirroring the PostHog Code branch picker: button trigger, in-popover server-side search, paginated "Load more", refresh, and loading/empty states.
- New `githubBranchSearchLogic` (kea, keyed by integration id + repo) driving the existing `github_branches` endpoint's `search` / `limit` / `offset` params, and capturing the repo's `default_branch`.
- Auto-selects the default branch, and offers a "Use \"x\" as branch name" action when you type a name that doesn't exist yet — so the agent can work on a new branch.
- `api.integrations.githubBranches` wrapper added; `api.tasks.run` now accepts an optional `{ branch }` body so the chosen branch is passed when the task's first run is created (it stays optional — the server falls back to the default branch).
- Wired into `RepositorySelector` below the repo picker (only shown once a repo is chosen). Branch resets when the repo or integration changes.

Branch is a run-level field (`TaskRun.branch`), so this needed no backend change — the endpoint and run-create serializer already supported it.

## How did you test this code?

I'm an agent. Automated checks only — no manual UI testing:

- `pnpm --filter=@posthog/frontend typescript:check` — new/changed files clean (pre-existing typegen-drift errors in unrelated products remain).
- oxlint + oxfmt on the changed files — clean.

No new automated tests added; this mirrors the repo picker's data-fetching/UI pattern. A `githubBranchSearchLogic` unit test (search→page-reset, load-more dedupe, default-branch capture) is the highest-value option if reviewers want coverage.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8), stacked on top of the repository-picker PR (#66326). Two explorer agents mapped the PostHog Code branch picker and posthog's branch plumbing in parallel; I then confirmed the `github_branches` endpoint params and that the `run` action's serializer accepts an optional `branch` (alongside optional `runtime_adapter`/`model`), so a `{branch}`-only run body is valid.

Key decisions: scoped to PostHog Code's cloud-mode behavior (the local/worktree git-checkout paths don't apply here); included the "type a new branch name" affordance per request; placed the picker in the task-creation composer since branch is bound at run creation. This branch is parented on the repo-picker branch because it extends `RepositorySelector`, independent of the other work stacked there.

Conventions followed for `/adopting-generated-api-types` (the `lib/api` touch) and `/writing-kea-logics` (the new logic).
