### PR TITLE
chore(test): replace real sleep with freeze_time in survey duplicate test

### DIFF
--- a/products/surveys/backend/api/test/test_survey.py
+++ b/products/surveys/backend/api/test/test_survey.py
@@ -1,6 +1,5 @@
 import re
 import json
-import time
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional, cast
@@ -6304,24 +6303,26 @@ class TestSurveyBulkDuplication(APIBaseTest):
 
     def test_bulk_duplicate_multiple_times_to_same_team(self):
         """Test that multiple duplications to the same team create surveys with different timestamps"""
-        # Create first duplicate
-        response1 = self.client.post(
-            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
-            data={"target_team_ids": [self.team2.id]},
-            format="json",
-        )
-        assert response1.status_code == status.HTTP_201_CREATED
+        with freeze_time("2024-01-01 00:00:00") as frozen_time:
+            # Create first duplicate
+            response1 = self.client.post(
+                f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+                data={"target_team_ids": [self.team2.id]},
+                format="json",
+            )
+            assert response1.status_code == status.HTTP_201_CREATED
 
-        # Wait a second to ensure different timestamp
-        time.sleep(1)
+            # Advance the clock so the second duplicate's name timestamp differs (the
+            # duplicate name embeds datetime.now() at second precision)
+            frozen_time.tick(timedelta(seconds=1))
 
-        # Try to create another duplicate (should succeed because timestamp is different)
-        response2 = self.client.post(
-            f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
-            data={"target_team_ids": [self.team2.id]},
-            format="json",
-        )
-        assert response2.status_code == status.HTTP_201_CREATED
+            # Try to create another duplicate (should succeed because timestamp is different)
+            response2 = self.client.post(
+                f"/api/projects/{self.team.project_id}/surveys/{self.source_survey.id}/duplicate_to_projects/",
+                data={"target_team_ids": [self.team2.id]},
+                format="json",
+            )
+            assert response2.status_code == status.HTTP_201_CREATED
 
         # Verify two surveys exist with different names
         team2_surveys = Survey.objects.filter(team=self.team2).order_by("created_at")


### PR DESCRIPTION
## Problem

`test_bulk_duplicate_multiple_times_to_same_team` used `time.sleep(1)` to make two survey duplicates land in different wall-clock seconds. The duplicate name embeds `datetime.now()` at second precision (`survey.py` builds it via `strftime("%Y-%m-%d %H:%M:%S")`), so the test needs the two creations one second apart. A real sleep is slow on every run and is a determinism/isolation smell (`/writing-tests`: no `time.sleep`).

## Changes

Wrapped the two duplicate POSTs in `freeze_time` and ticked the clock forward 1s between them. This gives the exact "different second" guarantee deterministically — strictly better than the real sleep, which only guaranteed `≥1s` and could still straddle a second boundary. Dropped the now-unused `time` import.

Behavior-preserving: the assertions (both 201s, two surveys exist, names differ) are unchanged.

Counts:
- Tests removed: 0 (behavior-preserving)
- Estimated CI wall-time saved: ~1s/run, plus removes a flaky real sleep

Requesting review from: Surveys

## How did you test this code?

I'm an agent. I traced the duplicate-naming code to confirm uniqueness comes from a second-precision `datetime.now()` timestamp, so a 1s `freeze_time` tick reproduces the original guarantee. Verified `ruff format`/`ruff check` clean (via the pinned CI ruff 0.15.16) and that the file parses. I did not run pytest locally (the web environment can't install the backend's git-sourced deps); CI runs the suite on this PR.

## 🤖 Agent context

**Autonomy:** Fully autonomous

From the "highest CI-wall-time opportunities" backlog in `TEST_CLEANUP_RECOMMENDATIONS.md` — the sleep-removal items are the safest of that set because they're behavior-preserving and CI verifies them. Applied the `/writing-tests` determinism bar (use `freeze_time`, not `time.sleep`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NFyiLU6XMPxE138tFSb4nH)_