### PR TITLE
fix(hog-charts): fix tooltip scroll behaviour and tighten horizontal padding

### DIFF
--- a/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
+++ b/frontend/src/queries/nodes/DataVisualization/Components/Charts/sqlLineGraphAdapter.ts
@@ -454,7 +454,10 @@ export function buildBarChartConfig({
         barLayout,
         legend: buildLegendConfig(chartSettings),
         valueLabels: buildValueLabelsConfig(chartSettings, ySeriesData),
-        tooltip: { enabled: true, pinnable: true, placement: 'cursor', ...(labelFormatter ? { labelFormatter } : {}) },
+        tooltip: {
+            ...buildSqlTooltipConfig(chartSettings, ySeriesData),
+            ...(labelFormatter ? { labelFormatter } : {}),
+        },
     }
 }
 

--- a/packages/quill/packages/charts/src/charts/BarChart/BarTooltip.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarTooltip.tsx
@@ -56,8 +56,8 @@ export function BarTooltip<Meta>({
     return <>{userTooltip ? userTooltip(ctx) : <DefaultTooltip {...ctx} {...tooltipConfig} />}</>
 }
 
-/** Moves the cursor-resolved segment to seriesData[0] and (for sparse-stacked overlap)
- *  re-reads its value at its own dataIndex so it isn't a zero from a band-collapsed cell. */
+/** Filters seriesData to only the segments hit by the cursor, and (for sparse-stacked overlap)
+ *  re-reads the visible segment's value at its own dataIndex so it isn't a zero from a band-collapsed cell. */
 function narrowSeriesByCursor<Meta>(
     ctx: TooltipContext<Meta>,
     scales: BarScaleSet,
@@ -109,19 +109,13 @@ function narrowSeriesByCursor<Meta>(
         visibleKey = visible.series.key
         visibleDataIndex = visible.dataIndex
     }
-    let filtered = ctx.seriesData.filter((entry) => hits.has(entry.series.key))
-    if (isStackedLayout(layout) && filtered.length > 1 && visibleKey) {
-        const idx = filtered.findIndex((entry) => entry.series.key === visibleKey)
-        if (idx > 0) {
-            filtered = [filtered[idx], ...filtered.filter((_, i) => i !== idx)]
-        }
-    }
+    const filtered = ctx.seriesData.filter((entry) => hits.has(entry.series.key))
     // For sparse-stacked overlap ctx.dataIndex is a zero cell for the visible series. Rewrite
     // the entry's value (and ctx.dataIndex) to the segment's own index so row clicks route
     // correctly downstream.
     if (visibleKey != null && visibleDataIndex != null && visibleDataIndex !== ctx.dataIndex) {
         const di = visibleDataIndex
-        filtered = filtered.map((entry) => {
+        const revalued = filtered.map((entry) => {
             if (entry.series.key !== visibleKey) {
                 return entry
             }
@@ -129,7 +123,7 @@ function narrowSeriesByCursor<Meta>(
             const value = typeof raw === 'number' && Number.isFinite(raw) ? raw : entry.value
             return { ...entry, value }
         })
-        return { ...ctx, seriesData: filtered, dataIndex: di }
+        return { ...ctx, seriesData: revalued, dataIndex: di }
     }
     return { ...ctx, seriesData: filtered }
 }

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -65,10 +65,15 @@ export function DefaultTooltip<Meta = unknown>({
         setCanScrollDown(el.scrollTop + el.clientHeight < el.scrollHeight - 1)
     }, [])
 
+    // Reset to top when moving to a new data point so the list always starts fresh.
     useEffect(() => {
+        if (scrollContainerRef.current) {
+            scrollContainerRef.current.scrollTop = 0
+        }
         updateScrollFades()
-    }, [rows, updateScrollFades])
+    }, [label, updateScrollFades])
 
+    // If the closest row is outside the visible area, scroll to bring it in.
     useEffect(() => {
         if (!closestKey || !scrollContainerRef.current) {
             return
@@ -78,17 +83,19 @@ export function DefaultTooltip<Meta = unknown>({
         if (!el) {
             return
         }
-        // Scroll only the tooltip container — scrollIntoView would walk all scroll ancestors.
         const elTop = el.offsetTop
         const elBottom = elTop + el.offsetHeight
         const containerTop = container.scrollTop
         const containerBottom = containerTop + container.clientHeight
-        if (elBottom > containerBottom) {
-            container.scrollTop = elBottom - container.clientHeight
-        } else if (elTop < containerTop) {
-            container.scrollTop = elTop
+        // Account for the 20% fade gradient at each end so rows aren't scrolled into the fade zone.
+        const fadeBuffer = Math.round(container.clientHeight * 0.2)
+        if (elBottom > containerBottom - fadeBuffer) {
+            container.scrollTop = elBottom - container.clientHeight + fadeBuffer
+        } else if (elTop < containerTop + fadeBuffer) {
+            container.scrollTop = Math.max(0, elTop - fadeBuffer)
         }
-    }, [closestKey])
+        updateScrollFades()
+    }, [closestKey, updateScrollFades])
 
     const maskImage = (() => {
         if (canScrollUp && canScrollDown) {
@@ -126,7 +133,7 @@ export function DefaultTooltip<Meta = unknown>({
                             key={s.series.key}
                             data-attr="hog-chart-tooltip-row"
                             data-closest={isClosest ? 'true' : undefined}
-                            className={`flex items-center gap-2 min-w-0${isClosest ? ' font-semibold' : ''}`}
+                            className={`flex items-center gap-2 min-w-0 py-0.5 px-1.5${isClosest ? ' font-semibold' : ''}`}
                             style={
                                 isClosest
                                     ? { backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: '4px' }

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -127,6 +127,11 @@ export function DefaultTooltip<Meta = unknown>({
                             data-attr="hog-chart-tooltip-row"
                             data-closest={isClosest ? 'true' : undefined}
                             className={`flex items-center gap-2 min-w-0${isClosest ? ' font-semibold' : ''}`}
+                            style={
+                                isClosest
+                                    ? { backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: '4px' }
+                                    : undefined
+                            }
                         >
                             <TooltipSwatch color={s.color} />
                             <span data-attr="hog-chart-tooltip-series" className="flex-1 min-w-0 truncate">

--- a/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
+++ b/packages/quill/packages/charts/src/overlays/DefaultTooltip.tsx
@@ -133,12 +133,7 @@ export function DefaultTooltip<Meta = unknown>({
                             key={s.series.key}
                             data-attr="hog-chart-tooltip-row"
                             data-closest={isClosest ? 'true' : undefined}
-                            className={`flex items-center gap-2 min-w-0 py-0.5 px-1.5${isClosest ? ' font-semibold' : ''}`}
-                            style={
-                                isClosest
-                                    ? { backgroundColor: 'rgba(255,255,255,0.08)', borderRadius: '4px' }
-                                    : undefined
-                            }
+                            className={`flex items-center gap-2 min-w-0 py-0.5 px-1.5${isClosest ? ' font-semibold bg-current/8 rounded-sm' : ''}`}
                         >
                             <TooltipSwatch color={s.color} />
                             <span data-attr="hog-chart-tooltip-series" className="flex-1 min-w-0 truncate">

--- a/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
+++ b/packages/quill/packages/charts/src/overlays/TooltipSurface.tsx
@@ -29,7 +29,7 @@ export function TooltipSurface({
                 width: 'fit-content',
                 maxWidth: '20rem',
                 paddingBlock: '0.375rem',
-                paddingInline: '0.75rem',
+                paddingInline: '0.5rem',
                 fontSize: 'var(--text-xs, 0.75rem)',
                 lineHeight: 1.4,
                 borderRadius: 'var(--radius-sm, 0.375rem)',


### PR DESCRIPTION
## Problem

In stacked bar charts, the tooltip's closest-row scroll was firing on every hover position change as the cursor moved up/down within a bar. Because the tooltip list order doesn't match the bar's visual stacking order, this caused the list to constantly jump mid-scroll, cutting off rows at the top. Separately, rows near the bottom of a scrollable tooltip could sit inside the 20% fade gradient and appear unreadable even though they were technically within bounds.

## Changes

- Reset scroll to top whenever the hovered data point changes (label change), so the list always starts fresh when moving to a new bar
- Keep scroll-into-view for the closest row, but only fire it when the row is actually outside the visible area
- Account for the 20% fade gradient at each end: trigger scroll when a row enters the fade zone, and position it clear of the gradient after scrolling
- Reduce `TooltipSurface` `paddingInline` from `0.75rem` to `0.5rem` to close excess horizontal gap
- Add `py-0.5 px-1.5` padding to tooltip rows for the highlighted row background to have breathing room

## How did you test this code?

I'm an agent — no manual testing done. No automated tests cover this scroll behaviour.

## Publish to changelog?