### PR TITLE
fix(web-analytics): serve page-reports URL search from precompute

### DIFF
--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -151,6 +151,7 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                 'compareFilter',
                 'webAnalyticsFilters',
                 'isPathCleaningEnabled',
+                'controls',
             ],
             featureFlagLogic,
             ['featureFlags'],
@@ -228,13 +229,10 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                                 // gate requires includeBounceRate, so request it even though the
                                 // picker only reads the path column (the URL set/order is unchanged).
                                 // A search term adds a pathname filter, which the gate rejects, so
-                                // those queries stay on the live path.
+                                // those queries stay on the live path. Reuse the dashboard's resolved
+                                // tri-state so an explicit user opt-out in the menu is honored here too.
                                 includeBounceRate: true,
-                                useWebAnalyticsPrecompute: values.featureFlags[
-                                    FEATURE_FLAGS.WEB_ANALYTICS_PRECOMPUTE_TOGGLE
-                                ]
-                                    ? true
-                                    : undefined,
+                                useWebAnalyticsPrecompute: values.controls.useWebAnalyticsPrecompute,
                                 dateRange,
                                 properties: searchTerm
                                     ? [

--- a/frontend/src/scenes/web-analytics/pageReportsLogic.ts
+++ b/frontend/src/scenes/web-analytics/pageReportsLogic.ts
@@ -223,6 +223,18 @@ export const pageReportsLogic = kea<pageReportsLogicType>({
                                 kind: NodeKind.WebStatsTableQuery,
                                 breakdownBy: WebStatsBreakdown.Page,
                                 includeHost: true,
+                                // Serve the unfiltered URL list from the paths lazy-precompute
+                                // instead of a multi-second live scan. The precompute eligibility
+                                // gate requires includeBounceRate, so request it even though the
+                                // picker only reads the path column (the URL set/order is unchanged).
+                                // A search term adds a pathname filter, which the gate rejects, so
+                                // those queries stay on the live path.
+                                includeBounceRate: true,
+                                useWebAnalyticsPrecompute: values.featureFlags[
+                                    FEATURE_FLAGS.WEB_ANALYTICS_PRECOMPUTE_TOGGLE
+                                ]
+                                    ? true
+                                    : undefined,
                                 dateRange,
                                 properties: searchTerm
                                     ? [


### PR DESCRIPTION
## Problem

The Page Reports ranked URL search (`pageReportsLogic.loadPagesUrls`, behind `PAGE_REPORTS_RANKED_URL_SEARCH`) fires a raw `WebStatsTableQuery` (`Page` breakdown, no bounce, no precompute opt-in), so it always runs **live HogQL** — ~14–20s on a high-cardinality team (observed in prod). This is the slow query behind a "the dashboard took a while to load" report; the dashboard's own paths tile is already precomputed and fast (~300 ms), so the slow first paint was this URL-search query, not the tile.

## Changes

- Make the ranked URL-search query **precompute-eligible**: request `includeBounceRate: true` and opt into precompute via the `WEB_ANALYTICS_PRECOMPUTE_TOGGLE` flag — mirroring the dashboard paths tile. The paths lazy-precompute gate requires `includeBounceRate`; the picker only reads the path column, so the URL set and order are unchanged.
- The unfiltered initial URL list now serves from the precompute table. A search term adds a `pathname` filter, which the precompute gate rejects (it only admits an optional `$host` filter), so search queries intentionally stay on the live path (filtered + debounced).

## How did you test this code?

Agent-authored (Claude Code). Traced it in prod `system.query_log`: the slow `Page` / `bounce=false` / `precompute=null` `stats_table_simple_breakdown_query` (~14–20s) matched `loadPagesUrls` exactly, while the dashboard paths tile already served from precompute at ~156–330 ms. Frontend `typescript:check` passes for the changed file (the only errors are pre-existing stale-typegen in `products/workflows`, untouched here).

No new unit test: a kea loader test would assert the exact `api.query` payload — a change-detector that breaks on unrelated refactors — and the equivalent precompute-flag wiring is already covered for the dashboard tile in `webAnalyticsLogic.test.ts`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Found while investigating a slow web-analytics first paint. Prod query_log showed a 20s live `Page` query that turned out to be the Page Reports ranked URL search, never wired to precompute. Considered relaxing the backend paths-precompute `includeBounceRate` requirement instead, but the frontend opt-in is lower-risk and isolated — the backend gate relaxation (let the precompute serve no-bounce reads) is a reasonable cleaner follow-up.
