### PR TITLE
fix(hogql): correct interval string parsing in rust and cpp parsers

### DIFF
--- a/common/hogql_parser/package.json
+++ b/common/hogql_parser/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@posthog/hogql-parser",
-    "version": "1.3.72",
+    "version": "1.3.75",
     "description": "WebAssembly HogQL Parser - Parse HogQL queries in JavaScript/TypeScript",
     "keywords": [
         "antlr4",

--- a/common/hogql_parser/parser_json.cpp
+++ b/common/hogql_parser/parser_json.cpp
@@ -1826,7 +1826,8 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
         throw NotImplementedError(("Unsupported interval count: " + count_str).c_str());
       }
     }
-    int countInt = std::stoi(count_str);
+    // ClickHouse stores intervals as Int64, so accept the full Int64 range (stoll), not just int32 (stoi).
+    int64_t countInt = std::stoll(count_str);
 
     std::string name;
     if (unit_str == "second" || unit_str == "seconds") {

--- a/common/hogql_parser/parser_json.cpp
+++ b/common/hogql_parser/parser_json.cpp
@@ -1821,13 +1821,23 @@ class HogQLParseTreeJSONConverter : public HogQLParserBaseVisitor {
     std::string count_str = text.substr(0, space_pos);
     std::string unit_str = text.substr(space_pos + 1);
 
+    bool count_valid = !count_str.empty();
     for (char c : count_str) {
       if (!std::isdigit(static_cast<unsigned char>(c))) {
-        throw NotImplementedError(("Unsupported interval count: " + count_str).c_str());
+        count_valid = false;
+        break;
       }
     }
-    // ClickHouse stores intervals as Int64, so accept the full Int64 range (stoll), not just int32 (stoi).
-    int64_t countInt = std::stoll(count_str);
+    if (!count_valid) {
+      throw NotImplementedError(("Unsupported interval count: '" + count_str + "' is not a valid integer").c_str());
+    }
+    // ClickHouse stores intervals as Int64, so accept the full Int64 range (stoll, not int32 stoi).
+    int64_t countInt;
+    try {
+      countInt = std::stoll(count_str);
+    } catch (const std::out_of_range&) {
+      throw NotImplementedError(("Unsupported interval count: '" + count_str + "' is too large").c_str());
+    }
 
     std::string name;
     if (unit_str == "second" || unit_str == "seconds") {

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.74",
+    version="1.3.75",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.72",
+    version="1.3.73",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/common/hogql_parser/setup.py
+++ b/common/hogql_parser/setup.py
@@ -36,7 +36,7 @@ module = Extension(
 
 setup(
     name="hogql_parser",
-    version="1.3.73",
+    version="1.3.74",
     url="https://github.com/PostHog/posthog/tree/master/common/hogql_parser",
     description="HogQL parser for internal PostHog use",
     author="PostHog Inc.",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -68,7 +68,7 @@
         "@posthog/docs-onboarding": "workspace:*",
         "@posthog/esbuilder": "workspace:*",
         "@posthog/hedgehog-mode": "^0.0.52",
-        "@posthog/hogql-parser": "1.3.72",
+        "@posthog/hogql-parser": "1.3.75",
         "@posthog/hogvm": "workspace:*",
         "@posthog/icons": "^0.37.2",
         "@posthog/products-access-control": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -305,7 +305,7 @@ importers:
         version: 3.12.1
       jest:
         specifier: 'catalog:'
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@22.18.8)
       oxfmt:
         specifier: 'catalog:'
         version: 0.35.0
@@ -360,7 +360,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -388,7 +388,7 @@ importers:
         version: 29.5.14
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
 
   common/storybook:
     dependencies:
@@ -451,10 +451,10 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       '@storybook/react-webpack5':
         specifier: ^10.4.3
-        version: 10.4.6(@swc/core@1.15.18)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
+        version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/jest-image-snapshot':
         specifier: ^6.4.0
         version: 6.4.1
@@ -481,7 +481,7 @@ importers:
         version: 5.5.3(webpack@5.105.4)
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0))
       less-loader:
         specifier: ^7.0.2
         version: 7.3.0(less@4.2.2)(webpack@5.105.4)
@@ -505,7 +505,7 @@ importers:
         version: 2.0.0(webpack@5.105.4)
       webpack:
         specifier: ^5.94.0
-        version: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+        version: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli:
         specifier: ^5.1.4
         version: 5.1.4(webpack@5.105.4)
@@ -592,8 +592,8 @@ importers:
         specifier: ^0.0.52
         version: 0.0.52(prop-types@15.8.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/hogql-parser':
-        specifier: 1.3.72
-        version: 1.3.72
+        specifier: 1.3.75
+        version: 1.3.75
       '@posthog/hogvm':
         specifier: workspace:*
         version: link:../common/hogvm/typescript
@@ -1839,7 +1839,7 @@ importers:
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(esbuild@0.28.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@4.60.4)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(vite@5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15))
       '@storybook/test-runner':
         specifier: ^0.24.4
-        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@tailwindcss/vite':
         specifier: ^4.1.17
         version: 4.2.2(vite@5.4.21(@types/node@25.8.0)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0))
@@ -1860,7 +1860,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1976,7 +1976,7 @@ importers:
         version: 5.2.0(vite@6.4.2(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -2598,7 +2598,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -2831,7 +2831,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -2951,7 +2951,7 @@ importers:
         version: 14.6.1(@testing-library/dom@10.4.0)
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
 
   products/data_modeling:
     dependencies:
@@ -3341,7 +3341,7 @@ importers:
         version: 2.1.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3521,7 +3521,7 @@ importers:
         version: 3.1.3
       jest:
         specifier: '*'
-        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+        version: 29.7.0
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -4173,7 +4173,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -9902,8 +9902,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/hogql-parser@1.3.72':
-    resolution: {integrity: sha512-bdHVvxnSZmllOCYLBaxr6icvwhkHlUgCziaR/OdNjz+GYrtIUVwlg9pqFt4KrRf7M4mEh2SWc9WfHcsbN5E5yw==}
+  '@posthog/hogql-parser@1.3.75':
+    resolution: {integrity: sha512-r282QitLBwxaT5YHGi6iAq1lCE5SMkg0Oq/qzvqNio4jh/P4lK70UpyTRMDZ6VFbqJWDg8Ly7T6TBUHxhmmiVg==}
 
   '@posthog/icons@0.36.4':
     resolution: {integrity: sha512-xnusbGNz/5vSMUWdEViWuai7D/gxiMZSDDnP6s/acndMqzN+W4asPUgUNnTUps7OyAS1IKaO9zxhdikFrtooJA==}
@@ -22550,8 +22550,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.436.0:
-    resolution: {integrity: sha512-c/Mo8MHhHrRC3r7QS6bh1uoCwDoG1vT0267ov66RGYpVPFGG1JXNcUKzsK3k1kt7PfJ5eXWqLyEn3Gs0w3IDfw==}
+  unlayer-types@1.437.0:
+    resolution: {integrity: sha512-CUYl/aS63Mtj31bCpyCzQdfhl3JxEm0TivaHHOjX4CBHCwHU8XC4F4Gi9/DibkJh8BjHX2ssk9tc/W1Rv8VsYg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -27347,7 +27347,7 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))':
+  '@jest/core@29.7.0':
     dependencies:
       '@jest/console': 29.7.0
       '@jest/reporters': 29.7.0
@@ -27361,7 +27361,7 @@ snapshots:
       exit: 0.1.2
       graceful-fs: 4.2.11
       jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
       jest-regex-util: 29.6.3
@@ -27417,42 +27417,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
-    dependencies:
-      '@jest/console': 29.7.0
-      '@jest/reporters': 29.7.0
-      '@jest/test-result': 29.7.0
-      '@jest/transform': 29.7.0
-      '@jest/types': 29.6.3
-      '@types/node': 22.18.8
-      ansi-escapes: 4.3.2
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      exit: 0.1.2
-      graceful-fs: 4.2.11
-      jest-changed-files: 29.7.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
-      jest-haste-map: 29.7.0
-      jest-message-util: 29.7.0
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-resolve-dependencies: 29.7.0
-      jest-runner: 29.7.0
-      jest-runtime: 29.7.0
-      jest-snapshot: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      jest-watcher: 29.7.0
-      micromatch: 4.0.8
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-ansi: 6.0.1
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-      - ts-node
-
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))':
+  '@jest/core@30.0.5':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27467,7 +27432,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@22.18.8)
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -27524,7 +27489,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27539,7 +27504,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -30361,7 +30326,7 @@ snapshots:
     transitivePeerDependencies:
       - prop-types
 
-  '@posthog/hogql-parser@1.3.72': {}
+  '@posthog/hogql-parser@1.3.75': {}
 
   '@posthog/icons@0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -31794,7 +31759,7 @@ snapshots:
       - rollup
       - webpack
 
-  '@storybook/builder-webpack5@10.4.6(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/builder-webpack5@10.4.6(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       case-sensitive-paths-webpack-plugin: 2.4.0
@@ -31806,9 +31771,9 @@ snapshots:
       magic-string: 0.30.21
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       style-loader: 4.0.0(webpack@5.105.4)
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4)
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4)
       ts-dedent: 2.2.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.105.4)
       webpack-hot-middleware: 2.25.4
       webpack-virtual-modules: 0.6.2
@@ -31853,7 +31818,7 @@ snapshots:
       esbuild: 0.28.0
       rollup: 4.60.4
       vite: 7.3.5(@types/node@25.8.0)(jiti@2.6.1)(less@4.2.2)(lightningcss@1.32.0)(sass-embedded@1.70.0)(sass@1.56.0)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   '@storybook/csf@0.1.13':
     dependencies:
@@ -31866,7 +31831,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/preset-react-webpack@10.4.6(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/preset-react-webpack@10.4.6(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 10.4.6(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@6.0.3)(webpack@5.105.4)
@@ -31879,7 +31844,7 @@ snapshots:
       semver: 7.8.0
       storybook: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -31908,7 +31873,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@6.0.3)
       tslib: 2.8.1
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -31954,10 +31919,10 @@ snapshots:
       - typescript
       - webpack
 
-  '@storybook/react-webpack5@10.4.6(@swc/core@1.15.18)(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
+  '@storybook/react-webpack5@10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)':
     dependencies:
-      '@storybook/builder-webpack5': 10.4.6(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
-      '@storybook/preset-react-webpack': 10.4.6(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
+      '@storybook/builder-webpack5': 10.4.6(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
+      '@storybook/preset-react-webpack': 10.4.6(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)(webpack-cli@5.1.4)
       '@storybook/react': 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -32015,7 +31980,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
+  '@storybook/test-runner@0.24.4(@types/node@25.8.0)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/generator': 7.29.1
@@ -32025,14 +31990,14 @@ snapshots:
       '@swc/core': 1.15.18
       '@swc/jest': 0.2.39(@swc/core@1.15.18)
       expect-playwright: 0.8.0
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-circus: 30.0.5
       jest-environment-node: 30.0.5
       jest-junit: 16.0.0
       jest-process-manager: 0.4.0
       jest-runner: 30.0.5
       jest-serializer-html: 7.1.0
-      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+      jest-watch-typeahead: 3.0.1(jest@30.0.5(@types/node@25.8.0))
       nyc: 15.1.0
       playwright: 1.60.0
       playwright-core: 1.60.0
@@ -34324,17 +34289,17 @@ snapshots:
 
   '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack@5.105.4)':
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack@5.105.4)
 
   '@xmldom/xmldom@0.8.13': {}
@@ -34844,7 +34809,7 @@ snapshots:
       loader-utils: 2.0.4
       make-dir: 3.1.0
       schema-utils: 2.7.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   babel-plugin-istanbul@6.1.1:
     dependencies:
@@ -35748,13 +35713,28 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
 
-  create-jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  create-jest@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      prompts: 2.4.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  create-jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      exit: 0.1.2
+      graceful-fs: 4.2.11
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -35778,13 +35758,13 @@ snapshots:
       - supports-color
       - ts-node
 
-  create-jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  create-jest@29.7.0(@types/node@25.8.0):
     dependencies:
       '@jest/types': 29.6.3
       chalk: 4.1.2
       exit: 0.1.2
       graceful-fs: 4.2.11
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       prompts: 2.4.2
     transitivePeerDependencies:
@@ -35881,7 +35861,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       schema-utils: 2.7.1
       semver: 6.3.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   css-loader@7.1.4(webpack@5.105.4):
     dependencies:
@@ -35894,7 +35874,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.8.0
     optionalDependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   css-prefers-color-scheme@10.0.0(postcss@8.5.15):
     dependencies:
@@ -37479,7 +37459,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   file-uri-to-path@1.0.0: {}
 
@@ -37598,7 +37578,7 @@ snapshots:
       semver: 7.8.0
       tapable: 2.3.3
       typescript: 6.0.3
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   form-data@4.0.5:
     dependencies:
@@ -38260,7 +38240,7 @@ snapshots:
   html-webpack-harddisk-plugin@2.0.0(html-webpack-plugin@5.5.3(webpack@5.105.4))(webpack@5.105.4):
     dependencies:
       html-webpack-plugin: 5.5.3(webpack@5.105.4)
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   html-webpack-plugin@5.5.3(webpack@5.105.4):
     dependencies:
@@ -38269,7 +38249,7 @@ snapshots:
       lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.2.1
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -38997,16 +38977,35 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest-cli@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-cli@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      create-jest: 29.7.0
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest-cli@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/test-result': 29.7.0
+      '@jest/types': 29.6.3
+      chalk: 4.1.2
+      create-jest: 29.7.0(@types/node@22.18.8)
+      exit: 0.1.2
+      import-local: 3.2.0
+      jest-config: 29.7.0(@types/node@22.18.8)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -39035,16 +39034,16 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/test-result': 29.7.0
       '@jest/types': 29.6.3
       chalk: 4.1.2
-      create-jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      create-jest: 29.7.0(@types/node@25.8.0)
       exit: 0.1.2
       import-local: 3.2.0
-      jest-config: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 29.7.0(@types/node@25.8.0)
       jest-util: 29.7.0
       jest-validate: 29.7.0
       yargs: 17.7.2
@@ -39073,15 +39072,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -39092,15 +39091,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -39145,7 +39144,35 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest-config@29.7.0:
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/test-sequencer': 29.7.0
+      '@jest/types': 29.6.3
+      babel-jest: 29.7.0(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 3.8.0
+      deepmerge: 4.3.1
+      glob: 7.2.3
+      graceful-fs: 4.2.11
+      jest-circus: 29.7.0
+      jest-environment-node: 29.7.0
+      jest-get-type: 29.6.3
+      jest-regex-util: 29.6.3
+      jest-resolve: 29.7.0
+      jest-runner: 29.7.0
+      jest-util: 29.7.0
+      jest-validate: 29.7.0
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 29.7.0
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@29.7.0(@types/node@22.18.8):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -39171,7 +39198,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39207,38 +39233,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/test-sequencer': 29.7.0
-      '@jest/types': 29.6.3
-      babel-jest: 29.7.0(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 3.8.0
-      deepmerge: 4.3.1
-      glob: 7.2.3
-      graceful-fs: 4.2.11
-      jest-circus: 29.7.0
-      jest-environment-node: 29.7.0
-      jest-get-type: 29.6.3
-      jest-regex-util: 29.6.3
-      jest-resolve: 29.7.0
-      jest-runner: 29.7.0
-      jest-util: 29.7.0
-      jest-validate: 29.7.0
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 29.7.0
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@29.7.0(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/test-sequencer': 29.7.0
@@ -39264,12 +39259,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.0.5(@types/node@22.18.8):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39297,7 +39291,6 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39336,7 +39329,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39364,12 +39357,13 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-config@30.0.5(@types/node@25.8.0):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39397,12 +39391,11 @@ snapshots:
       strip-json-comments: 3.1.1
     optionalDependencies:
       '@types/node': 25.8.0
-      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
       '@jest/get-type': 30.0.1
@@ -39429,7 +39422,9 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
+      '@types/node': 25.8.0
       esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39632,7 +39627,7 @@ snapshots:
     optionalDependencies:
       jest: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
 
-  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@29.7.0(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -39643,9 +39638,9 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 29.7.0(@types/node@25.8.0)
 
-  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-image-snapshot@6.4.0(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       chalk: 4.1.2
       get-stdin: 5.0.1
@@ -39656,7 +39651,7 @@ snapshots:
       rimraf: 2.7.1
       ssim.js: 3.5.0
     optionalDependencies:
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
 
   jest-jasmine2@27.5.1:
     dependencies:
@@ -40211,11 +40206,11 @@ snapshots:
       leven: 3.1.0
       pretty-format: 30.0.5
 
-  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))):
+  jest-watch-typeahead@3.0.1(jest@30.0.5(@types/node@25.8.0)):
     dependencies:
       ansi-escapes: 7.0.0
       chalk: 5.6.2
-      jest: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest: 30.0.5(@types/node@25.8.0)
       jest-regex-util: 30.0.1
       jest-watcher: 30.0.5
       slash: 5.1.0
@@ -40287,12 +40282,24 @@ snapshots:
       - ts-node
       - utf-8-validate
 
-  jest@29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3)):
+  jest@29.7.0:
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-cli: 29.7.0
+    transitivePeerDependencies:
+      - '@types/node'
+      - babel-plugin-macros
+      - supports-color
+      - ts-node
+
+  jest@29.7.0(@types/node@22.18.8):
+    dependencies:
+      '@jest/core': 29.7.0
+      '@jest/types': 29.6.3
+      import-local: 3.2.0
+      jest-cli: 29.7.0(@types/node@22.18.8)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40311,12 +40318,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@29.7.0(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 29.7.0(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 29.7.0
       '@jest/types': 29.6.3
       import-local: 3.2.0
-      jest-cli: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 29.7.0(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40336,12 +40343,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40349,12 +40356,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40666,7 +40673,7 @@ snapshots:
       less: 4.2.2
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   less@3.13.1:
     dependencies:
@@ -42972,7 +42979,7 @@ snapshots:
       postcss: 8.5.15
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   postcss-logical@8.0.0(postcss@8.5.15):
     dependencies:
@@ -43741,7 +43748,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   rc-cascader@3.34.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -44151,7 +44158,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.436.0
+      unlayer-types: 1.437.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -44794,7 +44801,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 3.3.0
       semver: 7.7.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
     optionalDependencies:
       sass: 1.56.0
 
@@ -45498,11 +45505,11 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   style-loader@4.0.0(webpack@5.105.4):
     dependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   style-search@0.1.0: {}
 
@@ -45884,20 +45891,6 @@ snapshots:
       postcss: 8.5.15
     optional: true
 
-  terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4):
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.46.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
-    optionalDependencies:
-      '@swc/core': 1.15.18
-      cssnano: 7.0.6(postcss@8.5.15)
-      esbuild: 0.28.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-
   terser-webpack-plugin@5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
@@ -45909,6 +45902,19 @@ snapshots:
       '@swc/core': 1.15.18
       cssnano: 7.0.6(postcss@8.5.15)
       esbuild: 0.28.0
+      postcss: 8.5.15
+
+  terser-webpack-plugin@5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4):
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.29
+      jest-worker: 27.5.1
+      schema-utils: 4.3.3
+      terser: 5.46.0
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+    optionalDependencies:
+      cssnano: 7.0.6(postcss@8.5.15)
+      esbuild: 0.28.0
+      lightningcss: 1.32.0
       postcss: 8.5.15
 
   terser@5.46.0:
@@ -46131,27 +46137,6 @@ snapshots:
       safe-stable-stringify: 2.5.0
       tslib: 2.8.1
       typescript: 6.0.3
-
-  ts-node@10.9.1(@swc/core@1.11.4)(@types/node@22.18.8)(typescript@6.0.3):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.9
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.3
-      '@types/node': 22.18.8
-      acorn: 8.15.0
-      acorn-walk: 8.3.2
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 6.0.3
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.4
-    optional: true
 
   ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3):
     dependencies:
@@ -46525,7 +46510,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.436.0: {}
+  unlayer-types@1.437.0: {}
 
   unpipe@1.0.0: {}
 
@@ -47142,7 +47127,7 @@ snapshots:
       import-local: 3.1.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
       webpack-merge: 5.8.0
 
   webpack-dev-middleware@6.1.3(webpack@5.105.4):
@@ -47153,7 +47138,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
+      webpack: 5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   webpack-hot-middleware@2.25.4:
     dependencies:
@@ -47212,49 +47197,6 @@ snapshots:
       - uglify-js
     optional: true
 
-  webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4):
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-      '@webassemblyjs/ast': 1.14.1
-      '@webassemblyjs/wasm-edit': 1.14.1
-      '@webassemblyjs/wasm-parser': 1.14.1
-      acorn: 8.16.0
-      acorn-import-phases: 1.0.4(acorn@8.16.0)
-      browserslist: 4.28.1
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.22.1
-      es-module-lexer: 2.0.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.1
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.0
-      terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4)
-      watchpack: 2.5.1
-      webpack-sources: 3.3.4
-    optionalDependencies:
-      webpack-cli: 5.1.4(webpack@5.105.4)
-    transitivePeerDependencies:
-      - '@minify-html/node'
-      - '@swc/core'
-      - '@swc/css'
-      - '@swc/html'
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
   webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15):
     dependencies:
       '@types/eslint-scope': 3.7.7
@@ -47282,6 +47224,49 @@ snapshots:
       terser-webpack-plugin: 5.6.0(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15)(webpack@5.105.4(@swc/core@1.15.18)(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.3.4
+    transitivePeerDependencies:
+      - '@minify-html/node'
+      - '@swc/core'
+      - '@swc/css'
+      - '@swc/html'
+      - clean-css
+      - cssnano
+      - csso
+      - esbuild
+      - html-minifier-terser
+      - lightningcss
+      - postcss
+      - uglify-js
+
+  webpack@5.105.4(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4):
+    dependencies:
+      '@types/eslint-scope': 3.7.7
+      '@types/estree': 1.0.8
+      '@types/json-schema': 7.0.15
+      '@webassemblyjs/ast': 1.14.1
+      '@webassemblyjs/wasm-edit': 1.14.1
+      '@webassemblyjs/wasm-parser': 1.14.1
+      acorn: 8.16.0
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
+      browserslist: 4.28.1
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.22.1
+      es-module-lexer: 2.0.0
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.11
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.1
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 4.3.3
+      tapable: 2.3.0
+      terser-webpack-plugin: 5.6.0(cssnano@7.0.6(postcss@8.5.15))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack@5.105.4)
+      watchpack: 2.5.1
+      webpack-sources: 3.3.4
+    optionalDependencies:
+      webpack-cli: 5.1.4(webpack@5.105.4)
     transitivePeerDependencies:
       - '@minify-html/node'
       - '@swc/core'

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6454,15 +6454,21 @@ def parser_test_factory(backend: HogQLParserBackend):
         def test_interval_combined_string_validates_count_and_unit(self):
             # `INTERVAL '<count> <unit>'` requires an ASCII-digit count and a literal-lowercase unit; each invalid input must surface the same error string in both parsers.
             cases = (
-                ("INTERVAL 'twenty days'", "Unsupported interval count: twenty"),
-                ("INTERVAL '-1 day'", "Unsupported interval count: -1"),
-                ("INTERVAL '1.5 days'", "Unsupported interval count: 1.5"),
-                # ClickHouse stores intervals as Int64, so both parsers convert the count with `std::stoll` (i64). A value past Int64 max is out_of_range. `stoll`'s `what()` text differs by stdlib (libc++ adds the `: out of range` / `: no conversion` suffix, libstdc++ doesn't); match the platform-independent prefix only.
-                ("INTERVAL '9223372036854775808 day'", "Unknown error: stoll"),
-                ("INTERVAL '99999999999999999999 day'", "Unknown error: stoll"),
-                # A space-but-empty count (`' '`, `' day'`) isn't a digit-check failure — cpp's per-char isdigit loop is vacuous, then `std::stoll("")` throws. rust used to reject the empty count with "Unsupported interval count:" before reaching the stoll step.
-                ("INTERVAL ' '", "Unknown error: stoll"),
-                ("INTERVAL ' day'", "Unknown error: stoll"),
+                ("INTERVAL 'twenty days'", "Unsupported interval count: 'twenty' is not a valid integer"),
+                ("INTERVAL '-1 day'", "Unsupported interval count: '-1' is not a valid integer"),
+                ("INTERVAL '1.5 days'", "Unsupported interval count: '1.5' is not a valid integer"),
+                # A space-but-empty count (`' '`, `' day'`) is reported the same way — the count before the space isn't a valid integer.
+                ("INTERVAL ' '", "Unsupported interval count: '' is not a valid integer"),
+                ("INTERVAL ' day'", "Unsupported interval count: '' is not a valid integer"),
+                # ClickHouse stores intervals as Int64, so both parsers convert the count with `std::stoll` (i64); a value past Int64 max is rejected as too large. Both parsers emit this exact message (no leaked stdlib `stoll` text), so assert it in full.
+                (
+                    "INTERVAL '9223372036854775808 day'",
+                    "Unsupported interval count: '9223372036854775808' is too large",
+                ),
+                (
+                    "INTERVAL '99999999999999999999 day'",
+                    "Unsupported interval count: '99999999999999999999' is too large",
+                ),
                 ("INTERVAL '1 SECOND'", "Unsupported interval unit: SECOND"),
                 # cpp accepts only the singular or single-`s` plural unit; a doubled plural is rejected. rust used to strip every trailing `s` and silently accept `dayss` as `day`.
                 ("INTERVAL '1 dayss'", "Unsupported interval unit: dayss"),

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6477,6 +6477,13 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ("INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
                 ("INTERVAL 'x'", "Unsupported interval type: must be in the format '<count> <unit>'"),
                 ("now() - INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
+                # A nested string-valued interval (`INTERVAL INTERVAL '<count> <unit>' <unit>`) reaches the same count/unit validation through a different call site; assert the edge cases there too so the two sites can't drift.
+                ("INTERVAL INTERVAL ' day' MONTH", "Unsupported interval count: '' is not a valid integer"),
+                (
+                    "INTERVAL INTERVAL '9223372036854775808 day' MONTH",
+                    "Unsupported interval count: '9223372036854775808' is too large",
+                ),
+                ("INTERVAL INTERVAL '1 dayss' MONTH", "Unsupported interval unit: dayss"),
             )
             for src, expected_msg in cases:
                 with self.assertRaises(ExposedHogQLError, msg=src) as cpp_cm:

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6465,6 +6465,9 @@ def parser_test_factory(backend: HogQLParserBackend):
                 # `std::stoi` returns `int`, so a count past INT_MAX (2147483647) is out_of_range. rust used to parse the count as i64 and silently accept these.
                 ("INTERVAL '2147483648 day'", "Unknown error: stoi"),
                 ("INTERVAL '1 SECOND'", "Unsupported interval unit: SECOND"),
+                # cpp accepts only the singular or single-`s` plural unit; a doubled plural is rejected. rust used to strip every trailing `s` and silently accept `dayss` as `day`.
+                ("INTERVAL '1 dayss'", "Unsupported interval unit: dayss"),
+                ("INTERVAL '1 secondss'", "Unsupported interval unit: secondss"),
                 # A string with no internal space can't be `<count> <unit>`: cpp commits to ColumnExprIntervalString and its visitor rejects with this message. rust used to fall through to the expr+unit form and raise a "expected interval unit keyword" SyntaxError instead — same base class, so only the message asserts the divergence.
                 ("INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
                 ("INTERVAL 'x'", "Unsupported interval type: must be in the format '<count> <unit>'"),

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6457,13 +6457,12 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ("INTERVAL 'twenty days'", "Unsupported interval count: twenty"),
                 ("INTERVAL '-1 day'", "Unsupported interval count: -1"),
                 ("INTERVAL '1.5 days'", "Unsupported interval count: 1.5"),
-                # `stoi`'s `what()` text differs by stdlib (libc++ adds the `: out of range` / `: no conversion` suffix, libstdc++ doesn't); match the platform-independent prefix only.
-                ("INTERVAL '99999999999999999999 day'", "Unknown error: stoi"),
-                # A space-but-empty count (`' '`, `' day'`) isn't a digit-check failure — cpp's per-char isdigit loop is vacuous, then `std::stoi("")` throws. rust used to reject the empty count with "Unsupported interval count:" before reaching the stoi step.
-                ("INTERVAL ' '", "Unknown error: stoi"),
-                ("INTERVAL ' day'", "Unknown error: stoi"),
-                # `std::stoi` returns `int`, so a count past INT_MAX (2147483647) is out_of_range. rust used to parse the count as i64 and silently accept these.
-                ("INTERVAL '2147483648 day'", "Unknown error: stoi"),
+                # ClickHouse stores intervals as Int64, so both parsers convert the count with `std::stoll` (i64). A value past Int64 max is out_of_range. `stoll`'s `what()` text differs by stdlib (libc++ adds the `: out of range` / `: no conversion` suffix, libstdc++ doesn't); match the platform-independent prefix only.
+                ("INTERVAL '9223372036854775808 day'", "Unknown error: stoll"),
+                ("INTERVAL '99999999999999999999 day'", "Unknown error: stoll"),
+                # A space-but-empty count (`' '`, `' day'`) isn't a digit-check failure — cpp's per-char isdigit loop is vacuous, then `std::stoll("")` throws. rust used to reject the empty count with "Unsupported interval count:" before reaching the stoll step.
+                ("INTERVAL ' '", "Unknown error: stoll"),
+                ("INTERVAL ' day'", "Unknown error: stoll"),
                 ("INTERVAL '1 SECOND'", "Unsupported interval unit: SECOND"),
                 # cpp accepts only the singular or single-`s` plural unit; a doubled plural is rejected. rust used to strip every trailing `s` and silently accept `dayss` as `day`.
                 ("INTERVAL '1 dayss'", "Unsupported interval unit: dayss"),
@@ -6488,8 +6487,13 @@ def parser_test_factory(backend: HogQLParserBackend):
             # on both backends — the fall-back to the string-form rejection must not
             # pre-empt these. `interval 'x' day` takes the same path with the unit
             # immediately after the string.
-            # `INTERVAL '2147483647 day'` is the largest count `std::stoi` accepts (INT_MAX) — it must still parse, guarding the boundary against the out_of_range reject case above.
-            for src in ("INTERVAL 'a' || 'b' hour", "INTERVAL 'x' day", "INTERVAL '2147483647 day'"):
+            # Counts past int32 (`2147483648`) up to Int64 max (`9223372036854775807`) must parse — ClickHouse stores intervals as Int64, so `std::stoll` accepts the whole range. This guards the boundary against the out_of_range reject case above.
+            for src in (
+                "INTERVAL 'a' || 'b' hour",
+                "INTERVAL 'x' day",
+                "INTERVAL '2147483648 day'",
+                "INTERVAL '9223372036854775807 day'",
+            ):
                 self.assertEqual(parse_expr(src, backend="cpp-json"), parse_expr(src, backend=backend), msg=src)
 
         def test_in_cohort_falls_back_to_identifier_when_rhs_missing(self):

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6457,8 +6457,13 @@ def parser_test_factory(backend: HogQLParserBackend):
                 ("INTERVAL 'twenty days'", "Unsupported interval count: twenty"),
                 ("INTERVAL '-1 day'", "Unsupported interval count: -1"),
                 ("INTERVAL '1.5 days'", "Unsupported interval count: 1.5"),
-                # `stoi`'s `out_of_range::what()` differs by stdlib (libc++ adds `: out of range`, libstdc++ doesn't); match the platform-independent prefix only.
+                # `stoi`'s `what()` text differs by stdlib (libc++ adds the `: out of range` / `: no conversion` suffix, libstdc++ doesn't); match the platform-independent prefix only.
                 ("INTERVAL '99999999999999999999 day'", "Unknown error: stoi"),
+                # A space-but-empty count (`' '`, `' day'`) isn't a digit-check failure — cpp's per-char isdigit loop is vacuous, then `std::stoi("")` throws. rust used to reject the empty count with "Unsupported interval count:" before reaching the stoi step.
+                ("INTERVAL ' '", "Unknown error: stoi"),
+                ("INTERVAL ' day'", "Unknown error: stoi"),
+                # `std::stoi` returns `int`, so a count past INT_MAX (2147483647) is out_of_range. rust used to parse the count as i64 and silently accept these.
+                ("INTERVAL '2147483648 day'", "Unknown error: stoi"),
                 ("INTERVAL '1 SECOND'", "Unsupported interval unit: SECOND"),
                 # A string with no internal space can't be `<count> <unit>`: cpp commits to ColumnExprIntervalString and its visitor rejects with this message. rust used to fall through to the expr+unit form and raise a "expected interval unit keyword" SyntaxError instead — same base class, so only the message asserts the divergence.
                 ("INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
@@ -6480,7 +6485,8 @@ def parser_test_factory(backend: HogQLParserBackend):
             # on both backends — the fall-back to the string-form rejection must not
             # pre-empt these. `interval 'x' day` takes the same path with the unit
             # immediately after the string.
-            for src in ("INTERVAL 'a' || 'b' hour", "INTERVAL 'x' day"):
+            # `INTERVAL '2147483647 day'` is the largest count `std::stoi` accepts (INT_MAX) — it must still parse, guarding the boundary against the out_of_range reject case above.
+            for src in ("INTERVAL 'a' || 'b' hour", "INTERVAL 'x' day", "INTERVAL '2147483647 day'"):
                 self.assertEqual(parse_expr(src, backend="cpp-json"), parse_expr(src, backend=backend), msg=src)
 
         def test_in_cohort_falls_back_to_identifier_when_rhs_missing(self):

--- a/posthog/hogql/test/_test_parser.py
+++ b/posthog/hogql/test/_test_parser.py
@@ -6460,6 +6460,10 @@ def parser_test_factory(backend: HogQLParserBackend):
                 # `stoi`'s `out_of_range::what()` differs by stdlib (libc++ adds `: out of range`, libstdc++ doesn't); match the platform-independent prefix only.
                 ("INTERVAL '99999999999999999999 day'", "Unknown error: stoi"),
                 ("INTERVAL '1 SECOND'", "Unsupported interval unit: SECOND"),
+                # A string with no internal space can't be `<count> <unit>`: cpp commits to ColumnExprIntervalString and its visitor rejects with this message. rust used to fall through to the expr+unit form and raise a "expected interval unit keyword" SyntaxError instead — same base class, so only the message asserts the divergence.
+                ("INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
+                ("INTERVAL 'x'", "Unsupported interval type: must be in the format '<count> <unit>'"),
+                ("now() - INTERVAL ''", "Unsupported interval type: must be in the format '<count> <unit>'"),
             )
             for src, expected_msg in cases:
                 with self.assertRaises(ExposedHogQLError, msg=src) as cpp_cm:
@@ -6471,6 +6475,13 @@ def parser_test_factory(backend: HogQLParserBackend):
             # Guard: valid combined-string and expr+unit forms still parse.
             for src in ("INTERVAL '1 day'", "INTERVAL '5 days'", "INTERVAL 1 day", "INTERVAL 1 DAY"):
                 self._assert_ast(src, "expr")
+            # Guard: a no-space string that is only the HEAD of a longer
+            # unit-terminated value still parses as `ColumnExprInterval` (expr+unit)
+            # on both backends — the fall-back to the string-form rejection must not
+            # pre-empt these. `interval 'x' day` takes the same path with the unit
+            # immediately after the string.
+            for src in ("INTERVAL 'a' || 'b' hour", "INTERVAL 'x' day"):
+                self.assertEqual(parse_expr(src, backend="cpp-json"), parse_expr(src, backend=backend), msg=src)
 
         def test_in_cohort_falls_back_to_identifier_when_rhs_missing(self):
             # `IN COHORT` only commits when a columnExpr follows; otherwise `cohort` is the IN rhs identifier (`a IN cohort` → Compare(a, "in", Field('cohort'))).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.74",
+    "hogql-parser==1.3.75",
     "hogql-parser-rs==1.3.104",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.102",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.103",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.103",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.104",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ dependencies = [
     "grimp~=3.14",
     "grpcio~=1.71.0",
     "gspread==6.2.1",
-    "hogql-parser==1.3.72",
+    "hogql-parser==1.3.74",
     "hogql-parser-rs==1.3.104",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
     "grpcio~=1.71.0",
     "gspread==6.2.1",
     "hogql-parser==1.3.72",
-    "hogql-parser-rs==1.3.99",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
+    "hogql-parser-rs==1.3.102",  # built from rust/hogql/parser via the build-hogql-parser-rs workflow + published to PyPI; rebuild locally with `uv pip install -e rust/hogql/parser` when iterating
     "humanize~=4.12.3",
     "infi-clickhouse-orm",
     "jsonref==1.1.0",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.100"
+version = "1.3.101"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.101"
+version = "1.3.102"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.103"
+version = "1.3.104"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.102"
+version = "1.3.103"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.104"
+version = "1.3.105"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "hogql_parser_rs"
-version = "1.3.99"
+version = "1.3.100"
 dependencies = [
  "pyo3",
  "serde_json",

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.99); each ships as its own PyPI wheel.
-version = "1.3.99"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.100); each ships as its own PyPI wheel.
+version = "1.3.100"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.103); each ships as its own PyPI wheel.
-version = "1.3.103"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.104); each ships as its own PyPI wheel.
+version = "1.3.104"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.100); each ships as its own PyPI wheel.
-version = "1.3.100"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.101); each ships as its own PyPI wheel.
+version = "1.3.101"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.104); each ships as its own PyPI wheel.
-version = "1.3.104"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.105); each ships as its own PyPI wheel.
+version = "1.3.105"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.102); each ships as its own PyPI wheel.
-version = "1.3.102"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.103); each ships as its own PyPI wheel.
+version = "1.3.103"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/Cargo.toml
+++ b/rust/hogql/parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hogql_parser_rs"
-# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.101); each ships as its own PyPI wheel.
-version = "1.3.101"
+# Versioned independently from the cpp parser in `common/hogql_parser/setup.py`. Both started from the same HogQL grammar revision, but the Rust port is bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.102); each ships as its own PyPI wheel.
+version = "1.3.102"
 edition = "2021"
 publish = false
 

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.104).
-version = "1.3.104"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.105).
+version = "1.3.105"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.103).
-version = "1.3.103"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.104).
+version = "1.3.104"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.102).
-version = "1.3.102"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.103).
+version = "1.3.103"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.100).
-version = "1.3.100"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.101).
+version = "1.3.101"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.99).
-version = "1.3.99"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.100).
+version = "1.3.100"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/pyproject.toml
+++ b/rust/hogql/parser/pyproject.toml
@@ -8,8 +8,8 @@ build-backend = "maturin"
 
 [project]
 name = "hogql_parser_rs"
-# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.101).
-version = "1.3.101"
+# Mirrors `rust/hogql/parser/Cargo.toml` (always identical). Tracks but is NOT locked to `common/hogql_parser/setup.py`: the Rust port is versioned independently and bumped on its own whenever the hand-rolled parser changes (cpp is currently 1.3.72, this is 1.3.102).
+version = "1.3.102"
 description = "Hand-rolled Rust HogQL parser with C++-parity AST output"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/hogql/parser/src/parse.rs
+++ b/rust/hogql/parser/src/parse.rs
@@ -1399,15 +1399,18 @@ pub(crate) fn interval_call_name(unit: &str) -> Option<&'static str> {
 /// (`INTERVAL 5 SECOND`) uses the case-insensitive helper because
 /// keywords come from the lexer (which is case-insensitive).
 pub(crate) fn interval_call_name_case_sensitive(unit: &str) -> Option<&'static str> {
-    match unit.trim_end_matches('s') {
-        "second" => Some("toIntervalSecond"),
-        "minute" => Some("toIntervalMinute"),
-        "hour" => Some("toIntervalHour"),
-        "day" => Some("toIntervalDay"),
-        "week" => Some("toIntervalWeek"),
-        "month" => Some("toIntervalMonth"),
-        "quarter" => Some("toIntervalQuarter"),
-        "year" => Some("toIntervalYear"),
+    // cpp matches each unit against exactly its singular OR single-`s` plural.
+    // `trim_end_matches('s')` would strip *every* trailing `s`, over-accepting
+    // doubled plurals (`dayss`, `secondss`) that cpp rejects.
+    match unit {
+        "second" | "seconds" => Some("toIntervalSecond"),
+        "minute" | "minutes" => Some("toIntervalMinute"),
+        "hour" | "hours" => Some("toIntervalHour"),
+        "day" | "days" => Some("toIntervalDay"),
+        "week" | "weeks" => Some("toIntervalWeek"),
+        "month" | "months" => Some("toIntervalMonth"),
+        "quarter" | "quarters" => Some("toIntervalQuarter"),
+        "year" | "years" => Some("toIntervalYear"),
         _ => None,
     }
 }

--- a/rust/hogql/parser/src/parse/expr.rs
+++ b/rust/hogql/parser/src/parse/expr.rs
@@ -1330,26 +1330,42 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                     str_tok.end,
                 ));
             }
-            // Reaching here means the string has no internal space (the split
-            // failed) and — per the branch guard — no trailing unit keyword:
-            // cpp's `ColumnExprIntervalString`, which `visitColumnExprIntervalString`
-            // rejects (it isn't `<count> <unit>`). The unvisited-clause case
-            // (`{x} order by interval 'p'`) was already handled by the
-            // suppress short-circuit above, so a strict reject is all that's
-            // left — fall through to the expr+unit form: parse the string as
-            // the value expression and let the trailing unit keyword
-            // close the INTERVAL.
+            // The string has no internal space (the split failed) and — per the
+            // branch guard — no trailing unit keyword. cpp's ALL(*) still prefers
+            // `ColumnExprInterval` (expr+unit) when the no-space string is only the
+            // HEAD of a longer unit-terminated value (`interval 'a' || 'b' hour`),
+            // so try that form first. If it fails (no unit keyword closes the
+            // value, e.g. bare `interval ''` / `interval 'x' + 1`), cpp falls back
+            // to `ColumnExprIntervalString`, whose visitor rejects a string that
+            // isn't `<count> <unit>`. Reproduce that rejection rather than leaking
+            // the expr+unit form's "expected interval unit keyword" syntax error.
+            // A fatal error from the value parse (a committed nested rejection)
+            // surfaces as-is, matching cpp.
+            let cp = self.checkpoint();
+            return match self.parse_interval_value_unit_form() {
+                Ok(v) => Ok(v),
+                Err(e) if e.fatal => Err(e),
+                Err(_) => {
+                    self.restore(cp)?;
+                    self.bump()?;
+                    Err(ParseError::not_implemented_fatal(
+                        "Unsupported interval type: must be in the format '<count> <unit>'",
+                        str_tok.start,
+                        str_tok.end,
+                    ))
+                }
+            };
         }
-        // `INTERVAL <expr> <unit>` — the grammar admits a full
-        // columnExpr for the value, so we parse at BP=0 (greedy).
-        // The unit-keyword tokens (SECOND/MINUTE/…/YEAR) aren't binary
-        // or postfix operators, so the Pratt loop naturally halts
-        // before them. AND/OR/BETWEEN that surround the INTERVAL in
-        // an outer expression bind correctly because the SECOND
-        // keyword terminates the interval value before they're seen
-        // — the outer call gets to those operators after parse_interval_expr
-        // returns.
-        //
+        self.parse_interval_value_unit_form()
+    }
+
+    /// `INTERVAL <expr> <unit>` (cpp's `ColumnExprInterval`): parse a full
+    /// columnExpr value at BP=0 (greedy), then require one of the eight singular
+    /// unit keywords. The unit-keyword tokens (`SECOND`/`MINUTE`/…/`YEAR`) aren't
+    /// binary or postfix operators, so the Pratt loop halts before them; AND / OR
+    /// / BETWEEN that surround the INTERVAL in an outer expression bind correctly
+    /// because the unit keyword terminates the value before they're seen.
+    fn parse_interval_value_unit_form(&mut self) -> Result<E::Value, ParseError> {
         // Flag the value's leading primary so a nested INTERVAL there yields
         // the unit to us rather than eating it (see `parse_primary`). One-shot:
         // `parse_primary` takes it, so only that first primary is affected.
@@ -1369,7 +1385,7 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         // identifier / quoted identifier is never a unit — cpp rejects
         // all of those (`INTERVAL 1 hours`, `INTERVAL 1 "hour"`). The
         // plural-tolerant `INTERVAL '5 days'` form is the *string*
-        // branch above, handled before this point.
+        // branch in `parse_interval_expr`, handled before this point.
         let unit_tok = self.bump()?;
         let unit_name = match unit_tok.kind {
             TokenKind::Keyword(

--- a/rust/hogql/parser/src/parse/expr.rs
+++ b/rust/hogql/parser/src/parse/expr.rs
@@ -1281,54 +1281,9 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                 ));
             }
             if let Some((count_str, unit)) = raw.split_once(' ') {
-                // cpp's `visitColumnExprIntervalString` requires the
-                // count to be a non-negative decimal integer (`isdigit`
-                // per char, `stoi` for the convert), and matches the
-                // unit against a literal-lowercase set (so `SECOND`
-                // rejects with "Unsupported interval unit: SECOND").
-                // Rust used to lowercase the unit and silently
-                // substitute `Constant(0)` for any unparseable count
-                // — `INTERVAL 'twenty days'` quietly became "0 days".
-                let count_valid =
-                    !count_str.is_empty() && count_str.bytes().all(|b| b.is_ascii_digit());
-                if !count_valid {
-                    self.bump()?;
-                    return Err(ParseError::not_implemented_fatal(
-                        format!("Unsupported interval count: {count_str}"),
-                        str_tok.start,
-                        str_tok.end,
-                    ));
-                }
-                let count: i64 = match count_str.parse() {
-                    Ok(n) => n,
-                    Err(_) => {
-                        self.bump()?;
-                        return Err(ParseError::not_implemented_fatal(
-                            "Unknown error: stoi: out of range",
-                            str_tok.start,
-                            str_tok.end,
-                        ));
-                    }
-                };
-                // cpp's unit check is literal-lowercase — case-sensitive
-                // against the lowercase singular / plural forms. Match
-                // that here rather than `interval_call_name`'s
-                // case-insensitive helper.
-                let unit_name = interval_call_name_case_sensitive(unit);
-                if let Some(unit_name) = unit_name {
-                    self.bump()?;
-                    return Ok(self
-                        .emit
-                        .call(unit_name, vec![self.emit.constant(self.emit.int(count))]));
-                }
-                // Unit not lowercase / not recognised — cpp errors
-                // here even though the count was valid.
-                self.bump()?;
-                return Err(ParseError::not_implemented_fatal(
-                    format!("Unsupported interval unit: {unit}"),
-                    str_tok.start,
-                    str_tok.end,
-                ));
+                // `INTERVAL '<count> <unit>'` carries both inside one string;
+                // cpp's `visitColumnExprIntervalString` validates and emits it.
+                return self.emit_interval_combined_string(count_str, unit, str_tok);
             }
             // The string has no internal space (the split failed) and — per the
             // branch guard — no trailing unit keyword. cpp's ALL(*) still prefers
@@ -1446,38 +1401,65 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                 str_tok.end,
             ));
         };
-        let count_valid = !count_str.is_empty() && count_str.bytes().all(|b| b.is_ascii_digit());
-        if !count_valid {
-            self.bump()?;
+        self.emit_interval_combined_string(count_str, unit, str_tok)
+    }
+
+    /// Validate and emit a `<count> <unit>` combined-string INTERVAL (cpp's
+    /// `visitColumnExprIntervalString`). `str_tok` is the string literal at the
+    /// cursor; it is consumed here, and anchors every error. Shared by the
+    /// top-level combined-string branch of `parse_interval_expr` and the nested
+    /// `parse_interval_string_only`.
+    ///
+    /// Emulates cpp's `std::stoi` over the count: cpp digit-checks each char (an
+    /// empty count vacuously passes that loop), then converts. `std::stoi`
+    /// returns `int`, so an empty string is an `invalid_argument` ("no
+    /// conversion") and a value past `INT_MAX` is `out_of_range` — parsing the
+    /// count as `i64` would silently accept `interval '3000000000 day'`, which
+    /// cpp rejects. The unit is matched case-sensitively against cpp's
+    /// literal-lowercase singular / plural set (so `SECOND` rejects).
+    fn emit_interval_combined_string(
+        &mut self,
+        count_str: &str,
+        unit: &str,
+        str_tok: Token,
+    ) -> Result<E::Value, ParseError> {
+        self.bump()?;
+        if !count_str.bytes().all(|b| b.is_ascii_digit()) {
             return Err(ParseError::not_implemented_fatal(
                 format!("Unsupported interval count: {count_str}"),
                 str_tok.start,
                 str_tok.end,
             ));
         }
-        let count: i64 = match count_str.parse() {
-            Ok(n) => n,
-            Err(_) => {
-                self.bump()?;
-                return Err(ParseError::not_implemented_fatal(
-                    "Unknown error: stoi: out of range",
-                    str_tok.start,
-                    str_tok.end,
-                ));
+        let count: i32 = if count_str.is_empty() {
+            return Err(ParseError::not_implemented_fatal(
+                "Unknown error: stoi: no conversion",
+                str_tok.start,
+                str_tok.end,
+            ));
+        } else {
+            match count_str.parse::<i32>() {
+                Ok(n) => n,
+                Err(_) => {
+                    return Err(ParseError::not_implemented_fatal(
+                        "Unknown error: stoi: out of range",
+                        str_tok.start,
+                        str_tok.end,
+                    ));
+                }
             }
         };
         let Some(unit_name) = interval_call_name_case_sensitive(unit) else {
-            self.bump()?;
             return Err(ParseError::not_implemented_fatal(
                 format!("Unsupported interval unit: {unit}"),
                 str_tok.start,
                 str_tok.end,
             ));
         };
-        self.bump()?;
-        Ok(self
-            .emit
-            .call(unit_name, vec![self.emit.constant(self.emit.int(count))]))
+        Ok(self.emit.call(
+            unit_name,
+            vec![self.emit.constant(self.emit.int(count as i64))],
+        ))
     }
 
     /// For a nested string-valued INTERVAL (`peek0 == interval`, `peek1 ==

--- a/rust/hogql/parser/src/parse/expr.rs
+++ b/rust/hogql/parser/src/parse/expr.rs
@@ -1410,13 +1410,12 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
     /// top-level combined-string branch of `parse_interval_expr` and the nested
     /// `parse_interval_string_only`.
     ///
-    /// Emulates cpp's `std::stoi` over the count: cpp digit-checks each char (an
-    /// empty count vacuously passes that loop), then converts. `std::stoi`
-    /// returns `int`, so an empty string is an `invalid_argument` ("no
-    /// conversion") and a value past `INT_MAX` is `out_of_range` — parsing the
-    /// count as `i64` would silently accept `interval '3000000000 day'`, which
-    /// cpp rejects. The unit is matched case-sensitively against cpp's
-    /// literal-lowercase singular / plural set (so `SECOND` rejects).
+    /// Emulates cpp's `std::stoll` over the count: cpp digit-checks each char (an
+    /// empty count vacuously passes that loop), then converts. ClickHouse stores
+    /// intervals as Int64, so the count is accepted across the full Int64 range;
+    /// an empty string is an `invalid_argument` ("no conversion") and a value past
+    /// Int64 max is `out_of_range`. The unit is matched case-sensitively against
+    /// cpp's literal-lowercase singular / plural set (so `SECOND` rejects).
     fn emit_interval_combined_string(
         &mut self,
         count_str: &str,
@@ -1431,18 +1430,18 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                 str_tok.end,
             ));
         }
-        let count: i32 = if count_str.is_empty() {
+        let count: i64 = if count_str.is_empty() {
             return Err(ParseError::not_implemented_fatal(
-                "Unknown error: stoi: no conversion",
+                "Unknown error: stoll: no conversion",
                 str_tok.start,
                 str_tok.end,
             ));
         } else {
-            match count_str.parse::<i32>() {
+            match count_str.parse::<i64>() {
                 Ok(n) => n,
                 Err(_) => {
                     return Err(ParseError::not_implemented_fatal(
-                        "Unknown error: stoi: out of range",
+                        "Unknown error: stoll: out of range",
                         str_tok.start,
                         str_tok.end,
                     ));
@@ -1456,10 +1455,9 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
                 str_tok.end,
             ));
         };
-        Ok(self.emit.call(
-            unit_name,
-            vec![self.emit.constant(self.emit.int(count as i64))],
-        ))
+        Ok(self
+            .emit
+            .call(unit_name, vec![self.emit.constant(self.emit.int(count))]))
     }
 
     /// For a nested string-valued INTERVAL (`peek0 == interval`, `peek1 ==

--- a/rust/hogql/parser/src/parse/expr.rs
+++ b/rust/hogql/parser/src/parse/expr.rs
@@ -1410,12 +1410,11 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
     /// top-level combined-string branch of `parse_interval_expr` and the nested
     /// `parse_interval_string_only`.
     ///
-    /// Emulates cpp's `std::stoll` over the count: cpp digit-checks each char (an
-    /// empty count vacuously passes that loop), then converts. ClickHouse stores
-    /// intervals as Int64, so the count is accepted across the full Int64 range;
-    /// an empty string is an `invalid_argument` ("no conversion") and a value past
-    /// Int64 max is `out_of_range`. The unit is matched case-sensitively against
-    /// cpp's literal-lowercase singular / plural set (so `SECOND` rejects).
+    /// The count must be a non-empty run of ASCII digits (cpp digit-checks each
+    /// char). ClickHouse stores intervals as Int64, so the count is accepted
+    /// across the full Int64 range; a digit string past Int64 max is rejected as
+    /// too large. The unit is matched case-sensitively against cpp's
+    /// literal-lowercase singular / plural set (so `SECOND` rejects).
     fn emit_interval_combined_string(
         &mut self,
         count_str: &str,
@@ -1423,29 +1422,21 @@ impl<'a, E: Emitter + Clone> Parser<'a, E> {
         str_tok: Token,
     ) -> Result<E::Value, ParseError> {
         self.bump()?;
-        if !count_str.bytes().all(|b| b.is_ascii_digit()) {
+        if count_str.is_empty() || !count_str.bytes().all(|b| b.is_ascii_digit()) {
             return Err(ParseError::not_implemented_fatal(
-                format!("Unsupported interval count: {count_str}"),
+                format!("Unsupported interval count: '{count_str}' is not a valid integer"),
                 str_tok.start,
                 str_tok.end,
             ));
         }
-        let count: i64 = if count_str.is_empty() {
-            return Err(ParseError::not_implemented_fatal(
-                "Unknown error: stoll: no conversion",
-                str_tok.start,
-                str_tok.end,
-            ));
-        } else {
-            match count_str.parse::<i64>() {
-                Ok(n) => n,
-                Err(_) => {
-                    return Err(ParseError::not_implemented_fatal(
-                        "Unknown error: stoll: out of range",
-                        str_tok.start,
-                        str_tok.end,
-                    ));
-                }
+        let count: i64 = match count_str.parse::<i64>() {
+            Ok(n) => n,
+            Err(_) => {
+                return Err(ParseError::not_implemented_fatal(
+                    format!("Unsupported interval count: '{count_str}' is too large"),
+                    str_tok.start,
+                    str_tok.end,
+                ));
             }
         };
         let Some(unit_name) = interval_call_name_case_sensitive(unit) else {

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.102"
+version = "1.3.103"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/6d/64ac85e6b6f5b0ba67bc6cce8e6c7aae55484f68a971ab23fb71ef5532c1/hogql_parser_rs-1.3.102.tar.gz", hash = "sha256:7a2417ab20435ed0e4d40a75573753a4801308b62b7a226ba0de91008bcb9d3f", size = 301215, upload-time = "2026-06-26T15:40:35.197Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/5f/d316806be977ed47131a1c90d65264d7b1a0f77a70227cfcfa78e71e784e/hogql_parser_rs-1.3.103.tar.gz", hash = "sha256:7396b4276cdd46cf3914730c8bccb7b80f78d22da4d068a3a20104f0d5ead443", size = 301187, upload-time = "2026-06-26T16:05:31.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/11/48/86a378111d34c4c0175115144f12ead5100b41c04e514fe544fa64e870bb/hogql_parser_rs-1.3.102-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:616d99031fb12b96bff2c6340b7879efeb08a2118dfbe8ac682972efb6baae09", size = 741516, upload-time = "2026-06-26T15:40:25.823Z" },
-    { url = "https://files.pythonhosted.org/packages/58/b9/e647677ff90e8239c53bcdc155c97c057edff16d0789a2f29528ca4c2f71/hogql_parser_rs-1.3.102-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:59a1f2701ce8aba2a2c7c469a404e3c0e27b5334526332a6f5a1cbc1e60f8582", size = 699403, upload-time = "2026-06-26T15:40:27.471Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/61/fb2a0fb96efe01d9da6ca24cd6cb3cf1e5b0ca3baddb713706b10556b1d6/hogql_parser_rs-1.3.102-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:cee035952cdccf93fa21110f7459c11ae21d5453d05069aa4c34470b341dafe3", size = 2503731, upload-time = "2026-06-26T15:40:29.089Z" },
-    { url = "https://files.pythonhosted.org/packages/55/2b/53f626bbabe7f20acde77ff9210eedb11dca8d0cbf3f05ad6bcc0c40f83c/hogql_parser_rs-1.3.102-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b8a00f5298bc935bbf6440c112362cc3f40410df21098c6ef5d865da7f559a91", size = 2765194, upload-time = "2026-06-26T15:40:30.647Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/02/38602e1c7bf62608cef860698dff43eaf4ad1c17ac2174ec5489fdb93878/hogql_parser_rs-1.3.102-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:052cb4857c2e1e6538b2daa9ae540537ab725960799bc30d5f3604ca8005a3d3", size = 2677159, upload-time = "2026-06-26T15:40:32.335Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/95/a4c609af74b6437b0d2a093855c41b15ee96367865c6757ba41caeb55d28/hogql_parser_rs-1.3.102-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c946c1b7ca5a464f3f61eb3cda8cad1797d70a475c41afb0a62d764b563bd778", size = 2726518, upload-time = "2026-06-26T15:40:33.762Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/24/2ad2ac64823a014e1f359fe203a539d5480436796ab37795e1f0ae109ea5/hogql_parser_rs-1.3.103-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0ff376a87a97ed55f8f41a2debd5900f1e2ed4d8ed5e29de097b7005885f7d50", size = 741324, upload-time = "2026-06-26T16:05:20.587Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/62/2f9a74fa7c783e42e44b1919778d167d997009cfb7b17780cc094af51651/hogql_parser_rs-1.3.103-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:3e80504359e9df080d025c5e8b6b91510411debdc3333c45f83aff5ae0602acf", size = 699049, upload-time = "2026-06-26T16:05:22.346Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4e/6e0b1d03c76cf4bdd4e8062f2cafec0df6c0dc38a2e3ad97ec87a9ee4ef4/hogql_parser_rs-1.3.103-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1929aeffc59b0f3b4b8cc9eb78f914971774714282deca6ae91dd4f24a6b4528", size = 2502198, upload-time = "2026-06-26T16:05:24.222Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d8/3999d6c080be185486f5be91bc4c16f875b2b6008b28ba4f782875e36cdf/hogql_parser_rs-1.3.103-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:11589561067431a10c5c1521ec7d7dab39982055520ff5e78d949b98a40e42f2", size = 2763599, upload-time = "2026-06-26T16:05:25.851Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/f9/ccaff1586ccf2988e5186849301528d6c8169bc8380f492fc1586f764a44/hogql_parser_rs-1.3.103-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53cf1a6b80501d21d8d495ee7673def52af0666f57f9a435e71b26f4b3cf342a", size = 2675816, upload-time = "2026-06-26T16:05:27.645Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/20/4eb40209d7fa4a2e0344c84ae9ae40afb2760aff769b54a6fc5c0199b10c/hogql_parser_rs-1.3.103-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3dcbfa4c5a169df832bbf78575d862da4eeca3fff96ee7609512c6d4461c37e2", size = 2726144, upload-time = "2026-06-26T16:05:29.421Z" },
 ]
 
 [[package]]
@@ -5878,7 +5878,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.102" },
+    { name = "hogql-parser-rs", specifier = "==1.3.103" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.103"
+version = "1.3.104"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/12/5f/d316806be977ed47131a1c90d65264d7b1a0f77a70227cfcfa78e71e784e/hogql_parser_rs-1.3.103.tar.gz", hash = "sha256:7396b4276cdd46cf3914730c8bccb7b80f78d22da4d068a3a20104f0d5ead443", size = 301187, upload-time = "2026-06-26T16:05:31.043Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/e7/c8a0fb39e0bc66c0ab877683bfb75055252911ef6b774ec73c7803499943/hogql_parser_rs-1.3.104.tar.gz", hash = "sha256:838dbac97b9ed948697de3ce80ba7cd0ecf5cfec95f8f11922cc0c6c3afc01f0", size = 301109, upload-time = "2026-06-26T16:21:40.298Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/24/2ad2ac64823a014e1f359fe203a539d5480436796ab37795e1f0ae109ea5/hogql_parser_rs-1.3.103-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:0ff376a87a97ed55f8f41a2debd5900f1e2ed4d8ed5e29de097b7005885f7d50", size = 741324, upload-time = "2026-06-26T16:05:20.587Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/62/2f9a74fa7c783e42e44b1919778d167d997009cfb7b17780cc094af51651/hogql_parser_rs-1.3.103-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:3e80504359e9df080d025c5e8b6b91510411debdc3333c45f83aff5ae0602acf", size = 699049, upload-time = "2026-06-26T16:05:22.346Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/4e/6e0b1d03c76cf4bdd4e8062f2cafec0df6c0dc38a2e3ad97ec87a9ee4ef4/hogql_parser_rs-1.3.103-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:1929aeffc59b0f3b4b8cc9eb78f914971774714282deca6ae91dd4f24a6b4528", size = 2502198, upload-time = "2026-06-26T16:05:24.222Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/d8/3999d6c080be185486f5be91bc4c16f875b2b6008b28ba4f782875e36cdf/hogql_parser_rs-1.3.103-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:11589561067431a10c5c1521ec7d7dab39982055520ff5e78d949b98a40e42f2", size = 2763599, upload-time = "2026-06-26T16:05:25.851Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/f9/ccaff1586ccf2988e5186849301528d6c8169bc8380f492fc1586f764a44/hogql_parser_rs-1.3.103-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:53cf1a6b80501d21d8d495ee7673def52af0666f57f9a435e71b26f4b3cf342a", size = 2675816, upload-time = "2026-06-26T16:05:27.645Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/20/4eb40209d7fa4a2e0344c84ae9ae40afb2760aff769b54a6fc5c0199b10c/hogql_parser_rs-1.3.103-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3dcbfa4c5a169df832bbf78575d862da4eeca3fff96ee7609512c6d4461c37e2", size = 2726144, upload-time = "2026-06-26T16:05:29.421Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/26/6809a725eb3c7202dc6ba1580a368e4d38dd8d80f4b598851ce83966f4e3/hogql_parser_rs-1.3.104-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:8dc7861d65c6b3cb89cb89144fcfea7e2c4c4f4e396977adc18bb33552f43fad", size = 741269, upload-time = "2026-06-26T16:21:31.534Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6a/09525f13d929b7ce90f427a9619944f825dffc5c8cbb62c23433c4b9cd56/hogql_parser_rs-1.3.104-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:9363210d6f8b45e812c46ae798b6fcaaf656e416b86c91b4fe62c42ec09a987c", size = 698617, upload-time = "2026-06-26T16:21:33.263Z" },
+    { url = "https://files.pythonhosted.org/packages/88/be/bd91222d719e99ba9b410f1bbae6f3efc8293d5e1d1339c8f7877a421c4b/hogql_parser_rs-1.3.104-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:33d05cdb34b3ac5c38ff32ef722c1a9677d04d038d77e547ee18efaad8c29540", size = 2500855, upload-time = "2026-06-26T16:21:34.623Z" },
+    { url = "https://files.pythonhosted.org/packages/28/fe/7e082d94e0917870edbe16d7f6653aba14199b2879e33160e30b95d3eae8/hogql_parser_rs-1.3.104-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ecf1bfde158efaa89365761c70c7759f24707acd6b4b5d1dfd08109021d9728", size = 2763723, upload-time = "2026-06-26T16:21:36.025Z" },
+    { url = "https://files.pythonhosted.org/packages/15/51/22c973ec0493b9f4030b5d244020921d851abb987efe8a9bcbcfaf22c75e/hogql_parser_rs-1.3.104-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ab6b23a788b8d7d416c74404d517e7c47e946d32c4a9d74c844b19b16138f0e2", size = 2675311, upload-time = "2026-06-26T16:21:37.493Z" },
+    { url = "https://files.pythonhosted.org/packages/db/63/660cbfdc58bce5b7567e144d6fd055603989d7772031ddb19b39fb450932/hogql_parser_rs-1.3.104-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:2e403e1771cb3e36021877d512c5d8e5053401adc5b66a9b1a54254916257db8", size = 2724715, upload-time = "2026-06-26T16:21:38.974Z" },
 ]
 
 [[package]]
@@ -5878,7 +5878,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.103" },
+    { name = "hogql-parser-rs", specifier = "==1.3.104" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3133,14 +3133,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.72"
+version = "1.3.74"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/db/4d/75af6a39d54c3b680375351c32514d340f6d458dd2496d693993b34fdd47/hogql_parser-1.3.72.tar.gz", hash = "sha256:e3571e3f53585a9e50ba16d5154926ada9f40ef5c508facc6d5d7decb4c1935c", size = 92397, upload-time = "2026-06-17T16:09:35.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2e/de/0dbfa352455acd57670a085c68b4509d252be7fcb6915f6167d820d8b4b4/hogql_parser-1.3.74.tar.gz", hash = "sha256:777a18d69bd0994b3b0ac1c75ff21eb1779d1a5f8e80945fbfd6c0e1cb88ea7c", size = 92395, upload-time = "2026-06-26T16:33:27.193Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5e/87/e9fac8e518fd7d01d31ad265448b80c6b31f64778329bacf8a45fd13080f/hogql_parser-1.3.72-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:a914a0665db7f1fc81946533ba539b80f890586b6fbd9ef72290448ac0c6425e", size = 655637, upload-time = "2026-06-17T16:09:29.382Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/cd/87894a31170f2bc2c697ff3bf0342c3ff773d5a8c04405f528eecdb9a7f1/hogql_parser-1.3.72-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:c876f1ba0e57ca50f32063249e5cb0040810f47ab8f2e13e3c4e59cd354888fc", size = 664876, upload-time = "2026-06-17T16:09:30.752Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/06/138bd75b093df9d84c01d00312213e6387b9e3bb9356cc37bff1114fac6c/hogql_parser-1.3.72-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:89c99ac6e508bc9178e457cff2bceeb1a61dbde9433277cb90a72eff3623cdd7", size = 5078592, upload-time = "2026-06-17T16:09:32.396Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/8e/d8c49b857c012b290b256c026d6c0815e0f62fdc11e7da4b6e0956e4d74d/hogql_parser-1.3.72-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ab496ef7efc234ca0c0e18953cd8f3333a459061cbe0455db3fd5aa1341b0584", size = 5184443, upload-time = "2026-06-17T16:09:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/74/2350b0f3dab703ab64fb257a7d88969eef005f7862be53f6ec796b4d9fae/hogql_parser-1.3.74-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:93ee57afe7009a5ad7ae2815496685fea9b067b69d50d154ad8238eba3d2df92", size = 655878, upload-time = "2026-06-26T16:33:20.172Z" },
+    { url = "https://files.pythonhosted.org/packages/26/56/eaff7ef52c8c2642fc67fd3fd99dcb986c5c7f7a6d1ea933a4b0b755b7ec/hogql_parser-1.3.74-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:5419734e5738523bde9ea46b0162bf2521a7fa9025f9f31008df856854f1e427", size = 665046, upload-time = "2026-06-26T16:33:21.875Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/5b/971b20903a1a7148a0ee1883f7a0836da023edbe9b0336c9397b7b1a4fc4/hogql_parser-1.3.74-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5725d98bf8af03a2363b8334bb0440cc274bc3b074a2ff636b8411ed4dab7ae7", size = 5084027, upload-time = "2026-06-26T16:33:23.949Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/e9/c9421223e5001505ed07a8264883f5473ba53c3a73e5cceba4649fbb6ff0/hogql_parser-1.3.74-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8bcc4fbdb378bc57ce5c53b213dec9c8c0b286b7ff647a25ed8df4bd542890a0", size = 5190293, upload-time = "2026-06-26T16:33:25.795Z" },
 ]
 
 [[package]]
@@ -5877,7 +5877,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.72" },
+    { name = "hogql-parser", specifier = "==1.3.74" },
     { name = "hogql-parser-rs", specifier = "==1.3.104" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },

--- a/uv.lock
+++ b/uv.lock
@@ -3145,16 +3145,16 @@ wheels = [
 
 [[package]]
 name = "hogql-parser-rs"
-version = "1.3.99"
+version = "1.3.102"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/89/3724e75e34ebcf5309f05ff3d2dd8f85ef84bbc21bd385f98f16689c9ae3/hogql_parser_rs-1.3.99.tar.gz", hash = "sha256:aaf8cbbf3d9e77706b3c8b35f016a3b39da6529f8172b1dccc5a7ed6b5489728", size = 301257, upload-time = "2026-06-23T16:17:47.323Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/6d/64ac85e6b6f5b0ba67bc6cce8e6c7aae55484f68a971ab23fb71ef5532c1/hogql_parser_rs-1.3.102.tar.gz", hash = "sha256:7a2417ab20435ed0e4d40a75573753a4801308b62b7a226ba0de91008bcb9d3f", size = 301215, upload-time = "2026-06-26T15:40:35.197Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/69/b0/7d4d58eea85de62802baaeb32c36b3c6c759966d6bf7d86a7cd0592e19c3/hogql_parser_rs-1.3.99-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:03bc570d3febd063e13619f69630f1ca979a4eeb65648611b0a0636db500fd0a", size = 741679, upload-time = "2026-06-23T16:17:36.031Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/79/ff03eb9dbc1a49eb1ce9798e357d6c70756965d53ab7c0f281871020d7c9/hogql_parser_rs-1.3.99-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:27790a9533636a0cbe00edc62ac1df882a08f503ea35ce01f519a76a7738ad6c", size = 698323, upload-time = "2026-06-23T16:17:37.838Z" },
-    { url = "https://files.pythonhosted.org/packages/60/16/4bd3ef88afdfc9eab8fdb0f50d3f5c28f74c0de034513005aa9dea1be120/hogql_parser_rs-1.3.99-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:211db8cdc9b996b85f945a92ccc2716f4ae39d4bcce4c3b80d76b4a8ddd9ec3b", size = 2501932, upload-time = "2026-06-23T16:17:40.181Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a5/6c26c5af1d47e9be5077149bbf5d67d3d80ea23e766018164b87d9a89353/hogql_parser_rs-1.3.99-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:c8639d89da19b8760e5b89a79ac4b37d52272f45d61c5b7f78f65cecf171f275", size = 2763536, upload-time = "2026-06-23T16:17:42.159Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/38/154333afcab0b24ff9c34e6058ad3d208daa2c9749f463dac8f036cb0f90/hogql_parser_rs-1.3.99-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:334a43a4dd4488e578efa7fc79198399acc8eca8d20b736788eb291108d5888c", size = 2675863, upload-time = "2026-06-23T16:17:43.839Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/a6/e984a79999a15dedb70140ba72a658863927d239bc94052c468656fa1254/hogql_parser_rs-1.3.99-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:0b2f18f897dfd0467980e4e21a5889ccf727fa24d9ec10d8995e280151f16284", size = 2725837, upload-time = "2026-06-23T16:17:45.703Z" },
+    { url = "https://files.pythonhosted.org/packages/11/48/86a378111d34c4c0175115144f12ead5100b41c04e514fe544fa64e870bb/hogql_parser_rs-1.3.102-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:616d99031fb12b96bff2c6340b7879efeb08a2118dfbe8ac682972efb6baae09", size = 741516, upload-time = "2026-06-26T15:40:25.823Z" },
+    { url = "https://files.pythonhosted.org/packages/58/b9/e647677ff90e8239c53bcdc155c97c057edff16d0789a2f29528ca4c2f71/hogql_parser_rs-1.3.102-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:59a1f2701ce8aba2a2c7c469a404e3c0e27b5334526332a6f5a1cbc1e60f8582", size = 699403, upload-time = "2026-06-26T15:40:27.471Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/61/fb2a0fb96efe01d9da6ca24cd6cb3cf1e5b0ca3baddb713706b10556b1d6/hogql_parser_rs-1.3.102-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:cee035952cdccf93fa21110f7459c11ae21d5453d05069aa4c34470b341dafe3", size = 2503731, upload-time = "2026-06-26T15:40:29.089Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2b/53f626bbabe7f20acde77ff9210eedb11dca8d0cbf3f05ad6bcc0c40f83c/hogql_parser_rs-1.3.102-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b8a00f5298bc935bbf6440c112362cc3f40410df21098c6ef5d865da7f559a91", size = 2765194, upload-time = "2026-06-26T15:40:30.647Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/02/38602e1c7bf62608cef860698dff43eaf4ad1c17ac2174ec5489fdb93878/hogql_parser_rs-1.3.102-cp312-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:052cb4857c2e1e6538b2daa9ae540537ab725960799bc30d5f3604ca8005a3d3", size = 2677159, upload-time = "2026-06-26T15:40:32.335Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/95/a4c609af74b6437b0d2a093855c41b15ee96367865c6757ba41caeb55d28/hogql_parser_rs-1.3.102-cp312-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:c946c1b7ca5a464f3f61eb3cda8cad1797d70a475c41afb0a62d764b563bd778", size = 2726518, upload-time = "2026-06-26T15:40:33.762Z" },
 ]
 
 [[package]]
@@ -5878,7 +5878,7 @@ requires-dist = [
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
     { name = "hogql-parser", specifier = "==1.3.72" },
-    { name = "hogql-parser-rs", specifier = "==1.3.99" },
+    { name = "hogql-parser-rs", specifier = "==1.3.102" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },
     { name = "jsonref", specifier = "==1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -3133,14 +3133,14 @@ provides-extras = ["dev"]
 
 [[package]]
 name = "hogql-parser"
-version = "1.3.74"
+version = "1.3.75"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/de/0dbfa352455acd57670a085c68b4509d252be7fcb6915f6167d820d8b4b4/hogql_parser-1.3.74.tar.gz", hash = "sha256:777a18d69bd0994b3b0ac1c75ff21eb1779d1a5f8e80945fbfd6c0e1cb88ea7c", size = 92395, upload-time = "2026-06-26T16:33:27.193Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/10/20388a0121c0c74578ed84dc038234e476c5e02e79bd38e1b8634516cdde/hogql_parser-1.3.75.tar.gz", hash = "sha256:75a0659864276bc32241af6d55e7521654598a5e950265ace095bab239bd6c76", size = 92415, upload-time = "2026-06-29T11:06:56.774Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/74/2350b0f3dab703ab64fb257a7d88969eef005f7862be53f6ec796b4d9fae/hogql_parser-1.3.74-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:93ee57afe7009a5ad7ae2815496685fea9b067b69d50d154ad8238eba3d2df92", size = 655878, upload-time = "2026-06-26T16:33:20.172Z" },
-    { url = "https://files.pythonhosted.org/packages/26/56/eaff7ef52c8c2642fc67fd3fd99dcb986c5c7f7a6d1ea933a4b0b755b7ec/hogql_parser-1.3.74-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:5419734e5738523bde9ea46b0162bf2521a7fa9025f9f31008df856854f1e427", size = 665046, upload-time = "2026-06-26T16:33:21.875Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/5b/971b20903a1a7148a0ee1883f7a0836da023edbe9b0336c9397b7b1a4fc4/hogql_parser-1.3.74-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:5725d98bf8af03a2363b8334bb0440cc274bc3b074a2ff636b8411ed4dab7ae7", size = 5084027, upload-time = "2026-06-26T16:33:23.949Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/e9/c9421223e5001505ed07a8264883f5473ba53c3a73e5cceba4649fbb6ff0/hogql_parser-1.3.74-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8bcc4fbdb378bc57ce5c53b213dec9c8c0b286b7ff647a25ed8df4bd542890a0", size = 5190293, upload-time = "2026-06-26T16:33:25.795Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/27/88e28a44da703c326a4f1ad71bf09adae666e338e3234bec01b7130f90e6/hogql_parser-1.3.75-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:f204115d79eb38f2965aefdeb4b1a4b0f6b49f08443aabe79f3b3ec42512707a", size = 655879, upload-time = "2026-06-29T11:06:50.397Z" },
+    { url = "https://files.pythonhosted.org/packages/df/3a/0acc7ebad37dd6e501396f74b5e75d78d3a3ea4ba04a702b6dad11622505/hogql_parser-1.3.75-cp313-cp313-macosx_15_0_x86_64.whl", hash = "sha256:cf0a41135034813b6b06865ccdd9a421bc3c560abfeb57616cd9f8676ac77a72", size = 665051, upload-time = "2026-06-29T11:06:51.716Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4d/9a2a78a2560866836078813638db3f5f9c5eeaa2e955803eff0b334bc31f/hogql_parser-1.3.75-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:f78e6f013f4d738e3095690c8472837af8f79c49ecb140302ba591df47d89fa9", size = 5084029, upload-time = "2026-06-29T11:06:53.362Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/fb/818cd2e8c34e588651e3a62bac4f60618926b860a03081a9b15f600896f3/hogql_parser-1.3.75-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:7b55c19c4533ee17261d00d9322fdd2b998dfa4af135f885e25db576d7642435", size = 5190293, upload-time = "2026-06-29T11:06:55.334Z" },
 ]
 
 [[package]]
@@ -5877,7 +5877,7 @@ requires-dist = [
     { name = "grimp", specifier = "~=3.14" },
     { name = "grpcio", specifier = "~=1.71.0" },
     { name = "gspread", specifier = "==6.2.1" },
-    { name = "hogql-parser", specifier = "==1.3.74" },
+    { name = "hogql-parser", specifier = "==1.3.75" },
     { name = "hogql-parser-rs", specifier = "==1.3.104" },
     { name = "humanize", specifier = "~=4.12.3" },
     { name = "infi-clickhouse-orm", git = "https://github.com/PostHog/infi.clickhouse_orm?rev=4e3996becf66bf5c26580aff12a80425d9d56fe5" },


### PR DESCRIPTION
## Problem

PostHog runs several HogQL parser backends that must produce identical results: the C++ reference (`cpp-json`), the hand-rolled Rust port (`rust-py` / `rust-json`, now the production default primary), and a legacy `python` backend. The two production parsers diverged from each other and from ClickHouse on several `INTERVAL '<string>'` edge cases, and some invalid-interval errors leaked internal C++ stdlib text. The reported case was `interval ''`.

## Changes

Fixes to `INTERVAL '<count> <unit>'` parsing so the rust and cpp parsers agree with each other and with ClickHouse, plus clearer error messages. Behavior on `master` vs after this PR:

| Input | `master` | After (both parsers) |
|---|---|---|
| `interval ''`, `interval 'x'` (no-space string) | rust: `SyntaxError`; cpp: rejects | rejects `Unsupported interval type: must be in the format '<count> <unit>'` |
| `interval ' '`, `interval ' day'` (empty count) | rust: `Unsupported interval count:`; cpp: `Unknown error: stoll: no conversion` | rejects `Unsupported interval count: '' is not a valid integer` |
| `interval 'twenty days'` (non-numeric count) | `Unsupported interval count: twenty` | `Unsupported interval count: 'twenty' is not a valid integer` |
| `interval '1 dayss'` (doubled-plural unit) | rust: accepted as `toIntervalDay`; cpp: rejects | rejects `Unsupported interval unit: dayss` |
| `interval '3000000000 day'` (int32 < count ≤ Int64 max) | rust: accepts; cpp: rejects (`std::stoi`) | accepts `toIntervalDay(3000000000)` |
| `interval '9223372036854775808 day'` (count > Int64 max) | rust: accepts; cpp: `Unknown error: stoll: out of range` | rejects `Unsupported interval count: '9223372036854775808' is too large` |

Two things worth calling out:

**Count range.** ClickHouse stores intervals as `Int64` (`DataTypeInterval` is `DataTypeNumberBase<Int64>`) and handles the whole Int64 range correctly; past it the value silently overflows to garbage. The cpp parser capped the string-form count at int32 via `std::stoi`, even though the equivalent `INTERVAL <count> <unit>` and `toIntervalX(<count>)` forms already accepted the full range. This change converts the string count with `std::stoll` (cpp) / `i64` (rust) so all three forms accept the same Int64 range and only reject counts past Int64 max.

**Error messages.** Invalid counts used to surface the raw C++ stdlib text (`Unknown error: stoll: out of range` / `no conversion`), which is meaningless to a user. Both parsers now emit `Unsupported interval count: '<count>' is not a valid integer` or `... is too large`. cpp catches `std::out_of_range` from `std::stoll` and throws a clean error instead of letting it propagate to the generic handler, so the message is fully parser-controlled and identical across backends (and the test no longer depends on the libc++/libstdc++ difference in `stoll`'s `what()`).

Other notes:

- The no-space case uses checkpoint/backtracking: it tries the `INTERVAL <expr> <unit>` form first so a no-space string that is only the head of a longer unit-terminated value still parses (`interval 'a' || 'b' hour`), and falls back to the string-form rejection only when no unit closes the value. This mirrors how the C++ ANTLR grammar chooses between `ColumnExprInterval` and `ColumnExprIntervalString`.
- Unit matching lists the singular and single-`s` plural explicitly instead of `trim_end_matches('s')`, which stripped every trailing `s` and over-accepted doubled plurals.
- The combined-string count/unit validation, previously duplicated in two rust functions, is now a single shared helper.
- Bumps both wheels: `hogql-parser` 1.3.72 → 1.3.74 and `hogql-parser-rs` → 1.3.104.

## How did you test this code?

I'm an agent; I did not do manual UI testing. Automated only:

- Built **both** parsers locally and diffed `rust-py` against `cpp-json` across the string, expr+unit, and direct-call forms over the int32 / Int64 boundaries and the empty / non-numeric / doubled-plural / no-space cases. All agree, including the new error messages.
- Ground-truthed the accepted range against the ClickHouse cluster: `toIntervalDay(9223372036854775807)` is correct, `toIntervalDay(9223372036854775808)` silently overflows to a negative value, so Int64 is the meaningful bound.
- Ran the shared cross-backend test `test_interval_combined_string_validates_count_and_unit` against `cpp-json`, `rust-json`, and `rust-py` (3 passed), plus the full `rust-py` + `rust-json` parser suites (943 passed, 504 snapshots). Rust unit tests (20) and `cargo fmt` / `clippy` / `ruff` clean.

The shared regression test asserts both backends raise the same `ExposedHogQLError` message for each reject case, and compares the rust AST to the `cpp-json` AST for accept cases (including the Int64-max boundary). The legacy `python` backend is deferred for this test (it cannot match C++ `std::stoll` because Python ints never overflow) and is not wired to any production parser mode.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Driven by Robbie.

Built with Claude Code (Opus 4.8). Skills invoked: `/qa-team` (multi-agent review of the diff), which independently surfaced the doubled-plural over-acceptance.

Decisions along the way:

- Chose checkpoint/backtracking for the no-space case rather than a static lookahead, so the head-of-longer-value accept path keeps working while bare `interval ''` rejects.
- Aligned the count range to ClickHouse's `Int64` interval type rather than the arbitrary `std::stoi` int32 cap, after confirming against both the ClickHouse source and the live cluster that Int64 is the range it handles correctly. This required changing the cpp reference parser too, not just rust.
- Made the invalid-count error messages clear and identical in both parsers rather than only in rust, to keep the parsers in parity.
- Left the legacy `python` backend untouched and deferred.

Reviewer note on CI: this PR bumps **both** parser wheels. The root `pyproject.toml` / `uv.lock` pins are auto-bumped by `tests-posthog[bot]` after each wheel's `build-hogql-parser*` workflow publishes. Until both bot commits land, Python CI installs the old wheels and the new tests will be transiently red. That is expected, not a real failure.
