### PR TITLE
fix(ws): cap V3 batcher output by real Arrow bytes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/batcher.py
@@ -11,31 +11,26 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 DEFAULT_CHUNK_SIZE_BYTES: int = 200 * 1024 * 1024  # 200 MiB
 DEFAULT_CHUNK_SIZE: int = 5000
 
-# pyarrow `string`/`binary`/`list` columns use 32-bit offsets, so a single column in
-# one batch overflows once its offsets cross 2^31 (~2.1e9). delta-rs concatenates a
-# merge source's chunks into one contiguous array, which is where this surfaces in
-# prod as "Offset overflow error: <bytes>". Casting the source to large_string does
-# NOT help — delta-rs coerces back to the target's 32-bit `string` during the merge —
-# so the only reliable fix is to keep each yielded table's worst column under the
-# limit, splitting by rows when needed. The margin below 2^31 leaves room for the
-# offset buffer itself and any target-side rows pulled into a matched-update merge.
-DEFAULT_MAX_COLUMN_OFFSET_BYTES: int = 1_500_000_000  # ~1.4 GiB
+# string/binary/list use 32-bit offsets and overflow ("Offset overflow error") once a column's
+# offsets cross 2^31 (~2.1 GB); delta-rs hits this when it concatenates merge-source chunks.
+DEFAULT_MAX_COLUMN_OFFSET_BYTES: int = 1_500_000_000  # ~1.4 GiB, safely under the 2 GB (2^31) limit
+
+# Cap each yielded table's real Arrow payload: wide rows / large cells can materialize a multi-GiB
+# table from a few thousand rows, which becomes the loader's per-batch merge memory and OOMs the pod.
+DEFAULT_MAX_TABLE_BYTES: int = 256 * 1024 * 1024  # 256 MiB of Arrow payload
 
 
 def _column_offset_pressure(col: pa.ChunkedArray) -> int:
-    """Return the 32-bit-offset quantity that would overflow for this column.
+    """32-bit-offset pressure: value bytes (string/binary) or child element count (list); 0 otherwise.
 
-    For `string`/`binary` it's the total value bytes (the final offset). For `list`
-    it's the total child element count (the final list offset). 64-bit (`large_*`)
-    variants can't overflow, so they contribute nothing. Computed via `pc.sum` over
-    per-row lengths, which is slice-accurate (unlike `Array.nbytes`, which reports the
-    full shared buffer for a zero-copy slice and would break the recursion below).
+    Slice-accurate via `pc.sum` over per-row lengths (not `Array.nbytes`, which reports the full
+    shared buffer for a zero-copy slice and would break the recursive split).
     """
-    t = col.type
-    if pa.types.is_string(t) or pa.types.is_binary(t):
+    col_type = col.type
+    if pa.types.is_string(col_type) or pa.types.is_binary(col_type):
         total = pc.sum(pc.binary_length(col)).as_py()
         return int(total or 0)
-    if pa.types.is_list(t):
+    if pa.types.is_list(col_type):
         total = pc.sum(pc.list_value_length(col)).as_py()
         return int(total or 0)
     return 0
@@ -45,20 +40,48 @@ def _max_offset_pressure(table: pa.Table) -> int:
     return max((_column_offset_pressure(table.column(name)) for name in table.column_names), default=0)
 
 
-def _split_to_offset_limit(table: pa.Table, limit: int) -> list[pa.Table]:
-    """Recursively row-halve `table` until every slice's worst column is under `limit`.
+def _column_payload_bytes(col: pa.ChunkedArray) -> int:
+    """Slice-accurate in-memory payload bytes: value bytes + offset buffer (string/binary/list)
+    or col_length * byte_width (fixed-width); nested/other types return 0. Avoids `.nbytes` (wrong for slices)."""
+    col_type = col.type
+    col_length = len(col)
+    if pa.types.is_string(col_type) or pa.types.is_binary(col_type):
+        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
+        return payload + col_length * 4  # value bytes + 32-bit offsets
+    if pa.types.is_large_string(col_type) or pa.types.is_large_binary(col_type):
+        # 64-bit offsets can't overflow (the offset guard skips them) but still hold real payload.
+        payload = int(pc.sum(pc.binary_length(col)).as_py() or 0)
+        return payload + col_length * 8
+    if pa.types.is_list(col_type):
+        elements = int(pc.sum(pc.list_value_length(col)).as_py() or 0)
+        return elements + col_length * 4
+    # Fixed-width primitives expose bit_width; variable-length / nested types raise -> 0.
+    # Known limitation: deeply-nested struct/map and sub-byte bool columns undercount to 0 (we only bound large string/JSON payloads, the actual OOM driver).
+    try:
+        bit_width = col_type.bit_width
+    except (ValueError, AttributeError):
+        return 0
+    return col_length * (bit_width // 8)
 
-    Slices are zero-copy views, so this doesn't duplicate the data. A single row can
-    never overflow (a string value can't itself exceed 2^31), so the `num_rows <= 1`
-    base case guarantees termination.
-    """
-    if table.num_rows <= 1 or _max_offset_pressure(table) <= limit:
+
+def _table_payload_bytes(table: pa.Table) -> int:
+    return sum(_column_payload_bytes(table.column(name)) for name in table.column_names)
+
+
+def _split_table(table: pa.Table, *, offset_limit: int, bytes_limit: int) -> list[pa.Table]:
+    """Row-halve `table` (zero-copy slices) until every slice is under both the per-column offset limit
+    and the total-bytes limit. `num_rows <= 1` is the base case, so a lone oversized row is yielded as-is."""
+    if table.num_rows <= 1:
+        return [table]
+    if _max_offset_pressure(table) <= offset_limit and _table_payload_bytes(table) <= bytes_limit:
         return [table]
 
     mid = table.num_rows // 2
     left = table.slice(0, mid)
     right = table.slice(mid, table.num_rows - mid)
-    return _split_to_offset_limit(left, limit) + _split_to_offset_limit(right, limit)
+    return _split_table(left, offset_limit=offset_limit, bytes_limit=bytes_limit) + _split_table(
+        right, offset_limit=offset_limit, bytes_limit=bytes_limit
+    )
 
 
 class Batcher:
@@ -69,6 +92,7 @@ class Batcher:
     _chunk_size: int
     _chunk_size_bytes: int
     _max_column_offset_bytes: int
+    _max_table_bytes: int
 
     def __init__(
         self,
@@ -76,20 +100,34 @@ class Batcher:
         chunk_size: Optional[int] = None,
         chunk_size_bytes: Optional[int] = None,
         max_column_offset_bytes: Optional[int] = None,
+        max_table_bytes: Optional[int] = None,
     ) -> None:
         self._logger = logger
 
         self._chunk_size = chunk_size or DEFAULT_CHUNK_SIZE
         self._chunk_size_bytes = chunk_size_bytes or DEFAULT_CHUNK_SIZE_BYTES
         self._max_column_offset_bytes = max_column_offset_bytes or DEFAULT_MAX_COLUMN_OFFSET_BYTES
+        self._max_table_bytes = max_table_bytes or DEFAULT_MAX_TABLE_BYTES
 
         self._buffer = []
         self._buffer_size_bytes = 0
         self._ready = deque()
 
     def _set_ready(self, table: pa.Table) -> None:
-        """Split `table` so no yielded chunk can overflow a 32-bit offset column."""
-        self._ready = deque(_split_to_offset_limit(table, self._max_column_offset_bytes))
+        """Split `table` so no yielded chunk overflows a 32-bit offset column or exceeds
+        the per-table Arrow-payload cap (keeping the loader's per-batch merge bounded)."""
+        chunks = _split_table(table, offset_limit=self._max_column_offset_bytes, bytes_limit=self._max_table_bytes)
+        if len(chunks) > 1:
+            payload_bytes = _table_payload_bytes(table)
+            if payload_bytes > self._max_table_bytes:
+                self._logger.info(
+                    "batcher_split_by_bytes",
+                    payload_bytes=payload_bytes,
+                    bytes_limit=self._max_table_bytes,
+                    chunk_count=len(chunks),
+                    row_count=table.num_rows,
+                )
+        self._ready = deque(chunks)
 
     def _estimate_size(self, obj: Any) -> int:
         if isinstance(obj, dict):

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_batcher.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_batcher.py
@@ -7,9 +7,16 @@ from parameterized import parameterized
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.batcher import (
     Batcher,
     _column_offset_pressure,
+    _column_payload_bytes,
     _max_offset_pressure,
-    _split_to_offset_limit,
+    _split_table,
+    _table_payload_bytes,
 )
+
+
+def _split_to_offset_limit(table: pa.Table, *, limit: int) -> list[pa.Table]:
+    """Offset-only split shim for the existing tests below (byte cap effectively off)."""
+    return _split_table(table, offset_limit=limit, bytes_limit=2**62)
 
 
 def _drain(batcher: Batcher) -> list[pa.Table]:
@@ -185,6 +192,120 @@ def test_batcher_splits_buffered_list_items():
     assert len(drained) > 1
     combined = pa.concat_tables(drained)
     assert combined.column("val").to_pylist() == ["aa", "bb", "cc", "dd"]
+
+
+@parameterized.expand(
+    [
+        # value bytes + 32-bit offset buffer (n * 4): 4 + 8 = 12
+        ("string", pa.array(["aa", "bb"], type=pa.string()), 12),
+        ("binary", pa.array([b"aa", b"bb"], type=pa.binary()), 12),
+        # value bytes + 64-bit offset buffer (n * 8): 4 + 16 = 20
+        ("large_string_counted", pa.array(["aa", "bb"], type=pa.large_string()), 20),
+        ("large_binary_counted", pa.array([b"aa", b"bb"], type=pa.large_binary()), 20),
+        # child element count + 32-bit offset buffer (n * 4): 3 + 8 = 11
+        ("list", pa.array([[1, 2], [3]], type=pa.list_(pa.int64())), 11),
+        ("int64", pa.array([1, 2, 3], type=pa.int64()), 24),
+        ("bool_subbyte_is_zero", pa.array([True, False, True], type=pa.bool_()), 0),
+        ("nulls_counted_as_zero_payload", pa.array([None, "abc"], type=pa.string()), 3 + 8),
+        ("unsupported_nested_is_zero", pa.array([{"x": 1}], type=pa.struct([("x", pa.int64())])), 0),
+    ]
+)
+def test_column_payload_bytes(_name: str, array: pa.Array, expected: int):
+    assert _column_payload_bytes(pa.chunked_array([array])) == expected
+
+
+def test_table_payload_bytes_is_slice_accurate():
+    # Guards against a refactor reintroducing Array.nbytes, which reports the full shared
+    # buffer for a zero-copy slice and would make the byte-driven split non-converging.
+    table = pa.table({"val": ["aaaa", "bbbb", "cccc", "dddd"]})
+
+    full = _table_payload_bytes(table)
+    first_half = _table_payload_bytes(table.slice(0, 2))
+    second_half = _table_payload_bytes(table.slice(2, 2))
+
+    assert first_half < full
+    assert first_half == second_half  # equal-sized rows here
+
+
+def test_split_table_splits_on_bytes_when_offset_is_under_limit():
+    # Offset limit is huge, so only the byte cap can drive the split.
+    table = pa.table({"val": ["aa", "bb", "cc", "dd"]})
+
+    result = _split_table(table, offset_limit=1_000_000, bytes_limit=14)
+
+    assert len(result) > 1
+    for slice_table in result:
+        assert _table_payload_bytes(slice_table) <= 14 or slice_table.num_rows <= 1
+    assert pa.concat_tables(result).equals(table)
+
+
+def test_split_table_byte_cap_sums_across_columns():
+    # Each column's payload (16) is under the limit, but their sum (32) exceeds it, so it must
+    # still split. Guards against measuring the worst column (like the offset guard) instead of the total.
+    table = pa.table({"a": ["aaaa", "bbbb"], "b": ["cccc", "dddd"]})
+
+    result = _split_table(table, offset_limit=1_000_000, bytes_limit=20)
+
+    assert len(result) > 1
+    assert pa.concat_tables(result).equals(table)
+
+
+def test_split_table_single_oversized_row_terminates():
+    table = pa.table({"val": ["a-very-long-value"]})
+
+    result = _split_table(table, offset_limit=1, bytes_limit=1)
+
+    assert len(result) == 1
+    assert result[0].equals(table)
+
+
+def test_batcher_splits_oversized_pa_table_by_bytes_on_yield():
+    batcher = Batcher(logger=mock.MagicMock(), max_table_bytes=14, max_column_offset_bytes=1_000_000)
+    table = pa.table({"val": ["aa", "bb", "cc", "dd"]})
+
+    batcher.batch(table)
+
+    drained = _drain(batcher)
+
+    assert len(drained) > 1
+    assert pa.concat_tables(drained).equals(table)
+
+
+def test_batcher_logs_when_splitting_by_bytes():
+    logger = mock.MagicMock()
+    batcher = Batcher(logger=logger, max_table_bytes=14, max_column_offset_bytes=1_000_000)
+
+    batcher.batch(pa.table({"val": ["aa", "bb", "cc", "dd"]}))
+    _drain(batcher)
+
+    logger.info.assert_called_once()
+    assert logger.info.call_args.args[0] == "batcher_split_by_bytes"
+
+
+def test_batcher_does_not_log_byte_split_for_offset_only_split():
+    # An offset-driven split (byte cap effectively off) must not emit the byte-split signal.
+    logger = mock.MagicMock()
+    batcher = Batcher(logger=logger, max_column_offset_bytes=3, max_table_bytes=10**12)
+
+    batcher.batch(pa.table({"val": ["aa", "bb", "cc", "dd"]}))
+    drained = _drain(batcher)
+
+    assert len(drained) > 1  # it did split, by offset
+    byte_events = [c for c in logger.info.call_args_list if c.args and c.args[0] == "batcher_split_by_bytes"]
+    assert byte_events == []
+
+
+def test_batcher_does_not_split_small_table_under_byte_cap():
+    # Default byte cap (256 MiB) and offset cap; a tiny table stays a single chunk.
+    batcher = Batcher(logger=mock.MagicMock())
+    table = pa.table({"id": [0, 1, 2, 3], "val": ["aa", "bb", "cc", "dd"]})
+
+    batcher.batch(table)
+
+    drained = _drain(batcher)
+
+    assert len(drained) == 1
+    assert drained[0].equals(table)
 
 
 def test_batching_should_not_yield_when_buffer_not_full():


### PR DESCRIPTION
## Problem

The V3 warehouse loader (`warehouse-sources-load`) OOMs on a small tail of imports. An overnight health check found V3 healthy overall (~99.6% success) except for a loader-specific OOM class: pods get SIGKILLed (exit 137) writing tiny-by-row-count batches (1–1,078 rows) that are heavy by **width / cell size** — Convex JSON documents, wide ad-platform stat schemas, large Postgres JSON/text columns.

Root cause: the extract batcher bounds each batch only by row count and a Python `sys.getsizeof` estimate, neither of which reflects the materialized Arrow table's memory. A wide batch can materialize into a multi-GiB Arrow table from a few thousand rows, which becomes the loader's per-batch Delta merge working set and blows past the pod memory limit.

## Changes

Generalize the batcher's existing post-materialization splitter so each yielded table is bounded by **real, slice-accurate Arrow payload bytes** (256 MiB default), reusing the proven row-halving recursion already used for the 32-bit offset-overflow guard.

- New `_column_payload_bytes` / `_table_payload_bytes` — sum value bytes + offset buffers (string/binary/large_string/large_binary/list) and fixed-width columns, deliberately avoiding `Array.nbytes` (which reports the full shared buffer for a zero-copy slice and would stop the recursion from converging).
- `_split_table` now row-halves while **either** a column's offset pressure exceeds the offset limit **or** the table's total payload exceeds the byte limit. `num_rows <= 1` base case preserved.
- New `max_table_bytes` knob on `Batcher` (defaults apply, so `PipelineV3` needs no change).
- A `batcher_split_by_bytes` log line when the byte cap drives a split, so we can confirm it firing in production logs.

The batcher runs on the extract worker but is the single point that sets each batch's size for the S3 Parquet **and** (transitively) the loader's per-batch merge. Since `loader_peak ≈ per_batch × concurrency`, this shrinks the `per_batch` term without touching the consumer's 16-way concurrency model.

Per-column string/binary/list payloads stay under ~1.4 GiB (< 2 GiB / 2³¹), so no column can hit the Arrow offset overflow either.

## How did you test this code?

I'm an agent (PostHog Code, with the `investigating-warehouse-sources-load` skill for the diagnosis). I did not do manual/prod testing. Automated only:

- Extended `test_batcher.py` — **36 tests pass**, `ruff check` + `ruff format` clean.
- New test groups and the regression each catches that existing tests did not:
  - `test_split_table_byte_cap_sums_across_columns` — the byte cap measures the **total across columns**, not the worst column (guards a `sum`→`max` regression that every single-column test would miss).
  - `test_table_payload_bytes_is_slice_accurate` — guards against a refactor reintroducing `.nbytes`, which would silently break the recursion on zero-copy slices.
  - `test_column_payload_bytes` (parameterized) — per-type byte accounting incl. binary, large_binary, list, bool (sub-byte→0), nulls, nested struct→0.
  - `test_batcher_logs_when_splitting_by_bytes` / `test_batcher_does_not_log_byte_split_for_offset_only_split` — the observability signal fires on a byte split and **not** on an offset-only split.
  - `test_split_table_single_oversized_row_terminates` — termination on a lone oversized row.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosis-first: used the `investigating-warehouse-sources-load` skill to triage the overnight V3 run health (Loki, VictoriaMetrics, federated Postgres via `execute-sql`), which isolated the OOM tail to 5 teams / wide tables and confirmed real SIGKILLs (exit 137) rather than native delta-rs crashes.

Scope was deliberately narrowed to this one change. Two alternatives were considered and **rejected for this PR**: a byte-budget concurrency semaphore (riskier concurrency-primitive change), and passing `max_rows_per_group` / `target_file_size` to delta-rs (complementary, separate). The byte cap was chosen because it cuts the per-batch memory term safely and is self-contained to one file + tests.

One honest limitation, documented inline at the fallback: deeply-nested struct/map and sub-byte bool columns undercount to 0 — acceptable because the OOM driver is large string/JSON payloads, which are counted.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
