### PR TITLE
chore(observability): add on-demand memory probe (SIGUSR2)

### DIFF
--- a/posthog/asgi.py
+++ b/posthog/asgi.py
@@ -37,6 +37,7 @@ def _ensure_post_fork_init():
     from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
     from posthog.continuous_profiling import start_continuous_profiling
     from posthog.otel_instrumentation import initialize_otel
+    from posthog.web_memory_probe import install_memory_probe_handler
     from posthog.web_memory_sampler import start_web_memory_sampler
 
     start_continuous_profiling()
@@ -45,6 +46,10 @@ def _ensure_post_fork_init():
     # Production runs ASGI, so the sampler — previously only started from wsgi.py — never
     # ran in prod, leaving posthog_web_worker_rss_mb empty. Start it here, post-fork.
     start_web_memory_sampler()
+    # Register the on-demand SIGUSR2 memory probe here too — not because of fork-unsafe
+    # threads (it starts none), but because signal handlers must be set on the worker's
+    # main thread, which this init runs on. Inert unless WEB_MEMORY_PROBE_ENABLED is set.
+    install_memory_probe_handler()
     _post_fork_initialized = True
 
 

--- a/posthog/web_memory_probe.py
+++ b/posthog/web_memory_probe.py
@@ -1,0 +1,124 @@
+import gc
+import os
+import ctypes
+import signal
+import logging
+from types import FrameType
+
+import structlog
+
+logger = logging.getLogger(__name__)
+
+PROBE_ENABLED_ENV = "WEB_MEMORY_PROBE_ENABLED"
+
+# glibc mallinfo2() layout — all size_t (see `man mallinfo2`). mallinfo2 (glibc >= 2.33)
+# supersedes mallinfo(), whose int fields overflow on the multi-GB heaps we care about.
+# fordblks (free, reclaimable) vs uordblks (in use) vs hblkhd (mmapped) is the breakdown
+# that tells us how much glibc is sitting on without returning to the OS.
+_MALLINFO2_FIELDS = (
+    "arena",
+    "ordblks",
+    "smblks",
+    "hblks",
+    "hblkhd",
+    "usmblks",
+    "fsmblks",
+    "uordblks",
+    "fordblks",
+    "keepcost",
+)
+
+
+class _Mallinfo2(ctypes.Structure):
+    _fields_ = [(name, ctypes.c_size_t) for name in _MALLINFO2_FIELDS]
+
+
+def _read_vmrss_kb() -> int | None:
+    """Resident set size of this process in kB, from /proc/self/status. A process can
+    always read its own status — no CAP_SYS_PTRACE needed, unlike /proc/<pid>/smaps or
+    attaching a profiler. Returns None off Linux (dev machines without /proc)."""
+    try:
+        with open("/proc/self/status") as status:
+            for line in status:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _mallinfo2() -> dict[str, int] | None:
+    """glibc allocator stats: how much the process has taken from the OS and how much is
+    parked on free lists (fordblks) rather than returned. Quantifies reclaimable
+    fragmentation directly, in O(1), without a heap walk. None where libc/mallinfo2 is
+    unavailable (non-glibc, e.g. dev macOS)."""
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+        libc.mallinfo2.restype = _Mallinfo2
+        info = libc.mallinfo2()
+    except (OSError, AttributeError):
+        return None
+    return {name: getattr(info, name) for name in _MALLINFO2_FIELDS}
+
+
+def _handle_probe(signum: int, frame: FrameType | None) -> None:
+    """SIGUSR2 handler — a one-shot memory diagnostic for a single worker. Python delivers
+    signals on the main thread between bytecodes, so ordinary work (logging, ctypes calls)
+    is safe here; logging's RLock is reentrant for the same thread, so interrupting a log
+    call can't self-deadlock.
+
+    Reads RSS at three points — as-is, after gc.collect(), after malloc_trim(0) — which is
+    enough to tell apart the three causes of a high resident set without a GIL-blocking
+    heap walk:
+      after_gc  << before    -> uncollected reference cycles were holding memory (Python-level)
+      after_trim << after_gc -> glibc was sitting on reclaimable freed pages (jemalloc / a trim cron would recover it)
+      all three ~ equal      -> memory is live and referenced (only fetching/retaining less helps)
+
+    The gc.collect() costs a single pause on the one worker that's signalled, which is why
+    this is fired by hand on a chosen pod, never on a schedule."""
+    log = structlog.get_logger("posthog.web_memory_probe")
+    rss_before = _read_vmrss_kb()
+    gc_counts = gc.get_count()
+    collected = gc.collect()
+    rss_after_gc = _read_vmrss_kb()
+    trimmed = False
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+        trimmed = True
+    except (OSError, AttributeError):
+        pass
+    rss_after_trim = _read_vmrss_kb()
+    log.warning(
+        "web_memory_probe",
+        pid=os.getpid(),
+        pod=os.getenv("K8S_POD_NAME") or os.getenv("HOSTNAME"),
+        rss_kb_before=rss_before,
+        rss_kb_after_gc=rss_after_gc,
+        rss_kb_after_trim=rss_after_trim,
+        gc_collected=collected,
+        gc_uncollectable=len(gc.garbage),
+        gc_counts=gc_counts,
+        malloc_trimmed=trimmed,
+        mallinfo2=_mallinfo2(),
+    )
+
+
+def install_memory_probe_handler() -> None:
+    """Register the SIGUSR2 memory-probe handler, gated by WEB_MEMORY_PROBE_ENABLED.
+
+    MUST be called post-fork from inside each worker (see posthog/asgi.py): signal handlers
+    can only be registered from the main thread, and the handler has to live in the worker
+    that serves requests, not the idle Nginx Unit prototype the workers fork from.
+
+    Inert until armed: with the flag unset (default) nothing is registered at all, and even
+    when armed the handler does nothing until a SIGUSR2 actually arrives. So the safe way to
+    use it is to arm the flag fleet-wide and `kill -USR2 <worker_pid>` exactly one hot
+    worker. Best-effort and idempotent — never breaks startup."""
+    if os.getenv(PROBE_ENABLED_ENV, "").lower() not in ("1", "true", "yes"):
+        return
+    try:
+        signal.signal(signal.SIGUSR2, _handle_probe)
+        logger.info("web memory probe handler installed on SIGUSR2")
+    except (ValueError, OSError):
+        # signal.signal raises ValueError off the main thread; stay best-effort.
+        logger.exception("failed to install web memory probe handler")

--- a/posthog/web_memory_probe.py
+++ b/posthog/web_memory_probe.py
@@ -33,6 +33,30 @@ class _Mallinfo2(ctypes.Structure):
     _fields_ = [(name, ctypes.c_size_t) for name in _MALLINFO2_FIELDS]
 
 
+def _open_libc() -> "ctypes.CDLL | None":
+    """dlopen glibc once at import (dlopen is the costly part) and configure return types,
+    so the handler doesn't re-resolve it on every probe. None on non-glibc platforms (dev
+    macOS), where the probe degrades to RSS-only rather than erroring."""
+    try:
+        libc = ctypes.CDLL("libc.so.6")
+    except OSError:
+        return None
+    try:
+        libc.malloc_trim.restype = ctypes.c_int
+        libc.malloc_trim.argtypes = (ctypes.c_size_t,)
+    except AttributeError:
+        pass
+    try:
+        libc.mallinfo2.restype = _Mallinfo2
+    except AttributeError:
+        # glibc < 2.33 lacks mallinfo2; the trim delta still works without the breakdown.
+        pass
+    return libc
+
+
+_LIBC = _open_libc()
+
+
 def _read_vmrss_kb() -> int | None:
     """Resident set size of this process in kB, from /proc/self/status. A process can
     always read its own status — no CAP_SYS_PTRACE needed, unlike /proc/<pid>/smaps or
@@ -52,11 +76,11 @@ def _mallinfo2() -> dict[str, int] | None:
     parked on free lists (fordblks) rather than returned. Quantifies reclaimable
     fragmentation directly, in O(1), without a heap walk. None where libc/mallinfo2 is
     unavailable (non-glibc, e.g. dev macOS)."""
+    if _LIBC is None:
+        return None
     try:
-        libc = ctypes.CDLL("libc.so.6")
-        libc.mallinfo2.restype = _Mallinfo2
-        info = libc.mallinfo2()
-    except (OSError, AttributeError):
+        info = _LIBC.mallinfo2()
+    except AttributeError:
         return None
     return {name: getattr(info, name) for name in _MALLINFO2_FIELDS}
 
@@ -67,26 +91,35 @@ def _handle_probe(signum: int, frame: FrameType | None) -> None:
     is safe here; logging's RLock is reentrant for the same thread, so interrupting a log
     call can't self-deadlock.
 
-    Reads RSS at three points — as-is, after gc.collect(), after malloc_trim(0) — which is
-    enough to tell apart the three causes of a high resident set without a GIL-blocking
-    heap walk:
-      after_gc  << before    -> uncollected reference cycles were holding memory (Python-level)
-      after_trim << after_gc -> glibc was sitting on reclaimable freed pages (jemalloc / a trim cron would recover it)
-      all three ~ equal      -> memory is live and referenced (only fetching/retaining less helps)
+    Captures mallinfo2 *before* gc/trim disturb it (malloc_trim hands back exactly the
+    reclaimable free-list pages, so a post-trim fordblks reads what's left, not what was
+    hoarded), then RSS at three points plus malloc_trim's own return value. Read the verdict
+    as — note gc.collect() frees cycles into glibc's free list, NOT back to the OS, so RSS
+    may not move even when collection happened; key the cycle call off the count, not RSS:
+      gc_collected large                 -> reference cycles are a factor (Python-level / gc tuning),
+                                            independent of whether RSS moved
+      (rss_before - rss_after_trim) large -> glibc was holding reclaimable pages (malloc_released == 1);
+        or malloc_released == 1             jemalloc decay or a periodic trim would recover it -> the jemalloc gate
+      both small                         -> memory is genuinely live (only fetching/retaining less helps)
 
+    mallinfo2_before.fordblks vs uordblks is the free-list-vs-live split before trim runs.
     The gc.collect() costs a single pause on the one worker that's signalled, which is why
     this is fired by hand on a chosen pod, never on a schedule."""
     log = structlog.get_logger("posthog.web_memory_probe")
+    mallinfo_before = _mallinfo2()
     rss_before = _read_vmrss_kb()
     gc_counts = gc.get_count()
     collected = gc.collect()
     rss_after_gc = _read_vmrss_kb()
-    trimmed = False
-    try:
-        ctypes.CDLL("libc.so.6").malloc_trim(0)
-        trimmed = True
-    except (OSError, AttributeError):
-        pass
+    # malloc_trim(0) returns 1 if it actually released pages to the OS, 0 if not — a direct
+    # answer that doesn't depend on a quiet-at-the-instant RSS sample (ctypes drops the GIL
+    # during the call, so the sync threadpool can allocate and add noise to rss_after_trim).
+    released: int | None = None
+    if _LIBC is not None:
+        try:
+            released = int(_LIBC.malloc_trim(0))
+        except (OSError, AttributeError):
+            released = None
     rss_after_trim = _read_vmrss_kb()
     log.warning(
         "web_memory_probe",
@@ -98,17 +131,20 @@ def _handle_probe(signum: int, frame: FrameType | None) -> None:
         gc_collected=collected,
         gc_uncollectable=len(gc.garbage),
         gc_counts=gc_counts,
-        malloc_trimmed=trimmed,
-        mallinfo2=_mallinfo2(),
+        malloc_released=released,
+        mallinfo2_before=mallinfo_before,
+        mallinfo2_after=_mallinfo2(),
     )
 
 
 def install_memory_probe_handler() -> None:
     """Register the SIGUSR2 memory-probe handler, gated by WEB_MEMORY_PROBE_ENABLED.
 
-    MUST be called post-fork from inside each worker (see posthog/asgi.py): signal handlers
-    can only be registered from the main thread, and the handler has to live in the worker
-    that serves requests, not the idle Nginx Unit prototype the workers fork from.
+    MUST be called post-fork from inside each worker (see posthog/asgi.py and posthog/wsgi.py):
+    signal handlers can only be registered from the main thread, and the handler has to live
+    in the worker that serves requests, not the idle Nginx Unit prototype the workers fork
+    from. Registering post-fork also means it isn't clobbered by any signal reset Unit does
+    during worker init.
 
     Inert until armed: with the flag unset (default) nothing is registered at all, and even
     when armed the handler does nothing until a SIGUSR2 actually arrives. So the safe way to

--- a/posthog/wsgi.py
+++ b/posthog/wsgi.py
@@ -17,6 +17,7 @@ import structlog
 from posthog.caching.redis_cluster_connection_factory import prewarm_query_cache_cluster_in_background
 from posthog.continuous_profiling import start_continuous_profiling
 from posthog.otel_instrumentation import initialize_otel
+from posthog.web_memory_probe import install_memory_probe_handler
 from posthog.web_memory_sampler import start_web_memory_sampler
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "posthog.settings")
@@ -99,5 +100,9 @@ def application(environ, start_response):
         # not survive into the worker — starting it on the worker's first call samples the
         # process that actually serves requests and grows toward the OOM limit.
         start_web_memory_sampler()
+        # Register the SIGUSR2 memory probe on the same post-fork path (see asgi.py). On a
+        # single-threaded Unit worker this runs on the main thread; if Unit serves the app
+        # from a worker thread the install no-ops gracefully. Inert unless the env flag is set.
+        install_memory_probe_handler()
         _prewarmed = True
     return _django_application(environ, start_response)


### PR DESCRIPTION
## Problem

Diagnosing a high resident set on the long-lived web ASGI workers is hard in prod: the containers run without `CAP_SYS_PTRACE` and block `/proc/<pid>/smaps`, so py-spy/pyrasite/gdb can't attach, and there's no way to ask a live worker what its memory is actually made of. Pyroscope covers CPU stacks, but nothing answers the allocator-level question — is a worker's RSS genuinely live Python objects, uncollected reference cycles, or freed pages glibc just hasn't returned to the OS? Those have completely different fixes.

## Changes

Adds `posthog/web_memory_probe.py`: an env-gated `SIGUSR2` handler that, when signalled, logs a one-shot diagnostic for that single worker.

- RSS at three points — as-is, after `gc.collect()`, after `malloc_trim(0)` — which pins the cause without a GIL-blocking heap walk:
  - drops after `gc.collect()` → uncollected reference cycles (Python-level)
  - drops after `malloc_trim(0)` → glibc sitting on reclaimable free-list pages (an allocator with proactive decay, or a periodic trim, would recover it)
  - no drop → memory is genuinely live (only fetching/retaining less helps)
- `mallinfo2()` for the free-list vs in-use vs mmapped split (O(1), no walk), plus gc counts.

It reads only `/proc/self/status`, so it needs no elevated capabilities and works on locked-down pods. Registered post-fork in `asgi.py` because signal handlers must be set on the worker's main thread. Inert unless `WEB_MEMORY_PROBE_ENABLED` is set, and even when armed it does nothing until a `SIGUSR2` arrives — so the intended use is to arm the flag fleet-wide and `kill -USR2` exactly one hot worker, then read its `web_memory_probe` log line.

Stacks are deliberately out of scope: Pyroscope already captures those. If off-CPU/blocked stacks are ever needed, the clean path is a Pyroscope wall-mode flag, not a second hook.

## How did you test this code?

Agent-authored (agent-assisted). Automated checks run locally via the flox env:

- `ruff check` clean on both files.
- A standalone smoke test that (1) asserts nothing is registered when `WEB_MEMORY_PROBE_ENABLED` is unset and the handler is registered when it's set, and (2) fires `_handle_probe` directly and confirms it logs the full diagnostic line without raising — off-Linux the libc/`/proc` reads degrade to `None` rather than erroring.

No prod run yet; that's gated behind arming the env flag.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed — internal diagnostic tooling, no user-facing surface.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. No repo skills were needed (no DRF/migration/serializer surface).

Decisions worth flagging for review: this was scoped down from a broader "diagnostic bundle" after checking what already exists — Pyroscope owns stack capture, so a `faulthandler` stack dump was dropped as redundant, and the connection-holding angle is covered by other in-flight work, leaving the allocator question as the genuinely uncovered gap. Chose the `malloc_trim` delta over a `gc.get_objects()`/`sizeof` heap census because the census holds the GIL across a multi-GB walk (stalls the worker, drops requests) and undercounts native payloads. `SIGUSR2` was picked after confirming nothing in the codebase binds USR1/USR2 (only the Temporal worker uses `faulthandler`, on a separate path).
