### PR TITLE
feat(oauth): pre-select project on consent screen via team_id hint

### DIFF
--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -122,6 +122,7 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
         setReadOnlyMode: (readOnly: boolean) => ({ readOnly }),
         toggleDeniedScope: (scopeObject: string) => ({ scopeObject }),
         setRequiredAccessLevel: (requiredAccessLevel: 'organization' | 'team' | null) => ({ requiredAccessLevel }),
+        setTeamHint: (teamId: number | null) => ({ teamId }),
         setScopesWereDefaulted: (scopesWereDefaulted: boolean) => ({ scopesWereDefaulted }),
         setIsMcpResource: (isMcpResource: boolean) => ({ isMcpResource }),
         loadResourceScopes: (resourceUrl: string) => ({ resourceUrl }),
@@ -313,6 +314,12 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
                 setSelectedOrganization: (_, { organizationId }) => organizationId,
             },
         ],
+        teamHint: [
+            null as number | null,
+            {
+                setTeamHint: (_, { teamId }) => teamId,
+            },
+        ],
         showCreateProject: [
             false,
             {
@@ -352,6 +359,18 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
             }
         },
         loadAllTeamsSuccess: () => {
+            // A team_id hint from the authorize URL (e.g. the wizard's --project-id) wins:
+            // pre-select that project and its org so the user just clicks Authorize. We only
+            // honor it if the user actually has access to that team (it's in their loaded
+            // teams); otherwise fall through to the normal default.
+            const teams = values.sortedTeams
+            if (values.teamHint && teams && values.requiredAccessLevel === 'team') {
+                const hinted = teams.find((t) => t.id === values.teamHint)
+                if (hinted) {
+                    actions.setSelectedOrganization(hinted.organization, hinted.id)
+                    return
+                }
+            }
             // After teams load, auto-select first project if org is set but no project selected
             const orgId = values.selectedOrganization
             const currentTeams = values.oauthAuthorization.scoped_teams
@@ -665,8 +684,14 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
             const rawRequiredAccessLevel = searchParams['required_access_level'] as 'organization' | 'project' | null
             const requiredAccessLevel = rawRequiredAccessLevel === 'project' ? 'team' : rawRequiredAccessLevel
 
+            // Optional project to pre-select on the consent screen (e.g. the wizard's
+            // `--project-id`). Honored only when the user has access to it; otherwise ignored.
+            const teamIdParam = Number(searchParams['team_id'])
+            const teamHint = Number.isInteger(teamIdParam) && teamIdParam > 0 ? teamIdParam : null
+
             actions.setScopesWereDefaulted(scopesWereDefaulted)
             actions.setIsMcpResource(isMcpResource)
+            actions.setTeamHint(teamHint)
             actions.setRequiredAccessLevel(requiredAccessLevel || null)
             actions.loadOAuthApplication()
             actions.loadAllTeams()

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -359,13 +359,15 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
             }
         },
         loadAllTeamsSuccess: () => {
+            const teams = values.sortedTeams
             // A team_id hint from the authorize URL (e.g. the wizard's --project-id) wins:
             // pre-select that project and its org so the user just clicks Authorize. We only
-            // honor it if the user actually has access to that team (it's in their loaded
-            // teams); otherwise fall through to the normal default.
-            const teams = values.sortedTeams
+            // honor it if the user has access to that team (it's in their loaded teams), and
+            // consume it once — so it can't override a later manual change or a project the
+            // user creates here (both also re-fire this listener).
             if (values.teamHint && teams && values.requiredAccessLevel === 'team') {
                 const hinted = teams.find((t) => t.id === values.teamHint)
+                actions.setTeamHint(null)
                 if (hinted) {
                     actions.setSelectedOrganization(hinted.organization, hinted.id)
                     return
@@ -374,13 +376,10 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
             // After teams load, auto-select first project if org is set but no project selected
             const orgId = values.selectedOrganization
             const currentTeams = values.oauthAuthorization.scoped_teams
-            if (orgId && (!currentTeams || currentTeams.length === 0)) {
-                const teams = values.sortedTeams
-                if (teams) {
-                    const orgTeams = teams.filter((t) => t.organization === orgId)
-                    if (orgTeams.length > 0) {
-                        actions.setOauthAuthorizationValue('scoped_teams', [orgTeams[0].id])
-                    }
+            if (orgId && (!currentTeams || currentTeams.length === 0) && teams) {
+                const orgTeams = teams.filter((t) => t.organization === orgId)
+                if (orgTeams.length > 0) {
+                    actions.setOauthAuthorizationValue('scoped_teams', [orgTeams[0].id])
                 }
             }
         },


### PR DESCRIPTION
## Problem

When a CLI like the `@posthog/wizard` kicks off OAuth to instrument a specific project, it can pass `--project-id`, but the OAuth consent screen ignores it — the user has to manually pick the right project from a dropdown. That's the main friction point in the MCP analytics "magical onboarding": we tell the user which project to choose instead of just pre-selecting it.

## Changes

Lets an authorize URL carry an optional `team_id` query param. Once the user's teams load on the consent screen, we pre-select that project (and its org) so the user just clicks **Authorize**.

Guardrails:
- Honored **only** for project-level consent (`required_access_level=project`).
- Honored **only** when the team is in the user's loaded teams — an id they can't access is silently ignored and we fall back to the normal default.
- No auto-submit — the user still explicitly authorizes, and team membership is enforced server-side on POST (`validate_scoped_teams`), which is unchanged.

The mechanism reuses the existing `setSelectedOrganization(orgId, preferredTeamId)` path that already auto-selects a preferred team; the only new wiring is reading the URL hint and holding it across the async team load.

This is additive and safe to ship alone: it does nothing unless an authorize URL includes `team_id`, which only an updated wizard sends.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks run:
- `oxlint` clean on the changed file.
- Regenerated the kea type for `oauthAuthorizeLogic` (`typegen:file`, `--show-ts-errors`) with no type errors, confirming the new `setTeamHint` action / `teamHint` reducer wiring is consistent.

Not manually tested in a browser. Suggested manual check: open `/oauth/authorize?...&required_access_level=project&team_id=<a project you belong to>` and confirm that project is pre-selected; confirm a `team_id` you don't belong to is ignored.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code at Lucas's direction, as part of the MCP analytics onboarding work. An exploration agent mapped the OAuth consent flow (`posthog/api/oauth/views.py`, `oauthAuthorizeLogic.ts`, `OAuthAuthorize.tsx`) and confirmed the `preferredTeamId` machinery already existed, so the change is small and frontend-only — no backend/serializer/token changes needed.

Decisions: chose pure pre-selection over "locking" the picker (simpler, and the user can still see/change the project before authorizing); gated the hint to project-level consent to avoid side effects on org-level grants; relied on the existing server-side membership validation rather than adding a redundant check.

Pairs with a wizard change that sends `team_id` and honors `--project-id` post-OAuth (separate PR), and the MCP analytics install command now emits `--project-id` (#66237).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*