### PR TITLE
fix(ws): per-group connection ownership to prevent shared-connection deadlock in v3 batch consumer

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/batch_consumer.py
@@ -35,6 +35,8 @@ RECONCILE_INTERVAL_SECONDS = 300.0
 RECONCILE_GRACE_SECONDS = 120  # don't race a _fail_run that is still in flight
 RECONCILE_LOOKBACK_SECONDS = 24 * 60 * 60  # wide enough to catch jobs orphaned by consumer outages
 
+SHUTDOWN_DRAIN_TIMEOUT_SECONDS = 30.0
+
 
 class OwnershipLostError(Exception):
     """Raised when the advisory lock for a (team_id, schema_id) group is no longer held."""
@@ -84,13 +86,29 @@ class BatchConsumerAdapter(Protocol):
     succeeded_state: str
     waiting_retry_state: str
 
-    async def fetch_and_lock(
+    async def fetch_candidates(
         self,
         conn: psycopg.AsyncConnection[Any],
         *,
         limit: int,
         retry_backoff_base_seconds: int,
     ) -> list[PendingBatch]: ...
+
+    async def try_lock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> bool: ...
+
+    async def unlock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None: ...
 
     async def unlock(
         self,
@@ -171,15 +189,14 @@ class BatchConsumer:
         self._adapter = adapter
         self._health_reporter = health_reporter
         self._metrics = metrics or DELTA_CONSUMER_METRICS
-        self._semaphore = asyncio.Semaphore(config.max_concurrency)
         self._shutdown = asyncio.Event()
-        self._conn: psycopg.AsyncConnection[Any] | None = None
+        self._poll_conn: psycopg.AsyncConnection[Any] | None = None
         self._recovery_conn: psycopg.AsyncConnection[Any] | None = None
-        # Serialize reconnects: concurrent groups all hit _ensure_*_conn on a bounce; without a lock each would dial its own connection and orphan all but the last.
-        self._main_conn_lock = asyncio.Lock()
+        self._poll_conn_lock = asyncio.Lock()
         self._recovery_conn_lock = asyncio.Lock()
         self._recovery_task: asyncio.Task[None] | None = None
         self._heartbeat_task: asyncio.Task[None] | None = None
+        self._in_flight: dict[tuple[int, str], asyncio.Task[None]] = {}
         # Monotonic stamp of the last reconcile sweep; runs inside the recovery loop so both share one connection.
         self._last_reconcile_monotonic = 0.0
         # batch_id -> monotonic start, for the stuck-batch watchdog.
@@ -192,16 +209,15 @@ class BatchConsumer:
             autocommit=True,
         )
 
-    async def _ensure_main_conn(self) -> psycopg.AsyncConnection[Any]:
-        """Return the main queue connection, reconnecting if a failover/pgbouncer bounce dropped it."""
-        if self._conn is not None and not self._conn.closed and not self._conn.broken:
-            return self._conn
-        async with self._main_conn_lock:
-            # Re-check under the lock: another coroutine may have already reconnected while we waited.
-            if self._conn is None or self._conn.closed or self._conn.broken:
-                logger.warning(self._event("queue_db_main_connection_reconnecting"))
-                self._conn = await self._connect()
-            return self._conn
+    async def _ensure_poll_conn(self) -> psycopg.AsyncConnection[Any]:
+        """Return the poll connection, reconnecting if a failover/pgbouncer bounce dropped it."""
+        if self._poll_conn is not None and not self._poll_conn.closed and not self._poll_conn.broken:
+            return self._poll_conn
+        async with self._poll_conn_lock:
+            if self._poll_conn is None or self._poll_conn.closed or self._poll_conn.broken:
+                logger.warning(self._event("queue_db_poll_connection_reconnecting"))
+                self._poll_conn = await self._connect()
+            return self._poll_conn
 
     async def _ensure_recovery_conn(self) -> psycopg.AsyncConnection[Any]:
         """Return the recovery/reconcile connection, reconnecting so a dropped one can't disable the sweeps forever."""
@@ -222,7 +238,7 @@ class BatchConsumer:
     async def run(self) -> None:
         self._install_signal_handlers()
 
-        self._conn = await self._connect()
+        self._poll_conn = await self._connect()
         self._recovery_conn = await self._connect()
 
         logger.info(
@@ -240,16 +256,22 @@ class BatchConsumer:
             while not self._shutdown.is_set():
                 self._report_health()
 
+                self._reap_finished_tasks()
+
+                available = self._config.max_concurrency - len(self._in_flight)
+                if available <= 0:
+                    await self._wait_or_shutdown(self._config.poll_interval_seconds)
+                    continue
+
                 poll_start = time.monotonic()
                 try:
-                    conn = await self._ensure_main_conn()
-                    batches = await self._adapter.fetch_and_lock(
+                    conn = await self._ensure_poll_conn()
+                    batches = await self._adapter.fetch_candidates(
                         conn,
                         limit=self._config.poll_limit,
                         retry_backoff_base_seconds=self._config.retry_backoff_base_seconds,
                     )
                 except psycopg.OperationalError as e:
-                    # Queue DB unreachable — keep the pod alive; the next iteration reconnects.
                     logger.exception(self._event("poll_failed_queue_db_unreachable"))
                     capture_exception(e)
                     await self._wait_or_shutdown(self._config.poll_interval_seconds)
@@ -269,22 +291,60 @@ class BatchConsumer:
                     group_count=len(groups),
                 )
 
-                self._metrics.active_groups.inc(len(groups))
-                try:
-                    await asyncio.gather(
-                        *[self._process_group(key, group_batches) for key, group_batches in groups.items()]
-                    )
-                finally:
-                    self._metrics.active_groups.dec(len(groups))
+                for key, group_batches in groups.items():
+                    if key in self._in_flight:
+                        continue
+                    if len(self._in_flight) >= self._config.max_concurrency:
+                        break
+                    task = asyncio.create_task(self._process_group_tracked(key, group_batches))
+                    self._in_flight[key] = task
+                    self._metrics.active_groups.inc()
+
+                await self._wait_or_shutdown(self._config.poll_interval_seconds)
         finally:
             await self._close()
 
+    def _reap_finished_tasks(self) -> None:
+        """Remove completed group tasks from the in-flight registry and log exceptions."""
+        finished = [key for key, task in self._in_flight.items() if task.done()]
+        for key in finished:
+            task = self._in_flight.pop(key)
+            self._metrics.active_groups.dec()
+            exc = task.exception() if not task.cancelled() else None
+            if exc is not None:
+                logger.exception(
+                    self._event("group_task_unhandled_exception"),
+                    team_id=key[0],
+                    schema_id=key[1],
+                    exc_info=exc,
+                )
+                capture_exception(exc)
+
+    async def _process_group_tracked(self, key: tuple[int, str], batches: list[PendingBatch]) -> None:
+        """Wrapper that ensures the group task is self-contained (never propagates exceptions to the event loop)."""
+        try:
+            await self._process_group(key, batches)
+        except Exception as e:
+            logger.exception(
+                self._event("process_group_unhandled_error"),
+                team_id=key[0],
+                schema_id=key[1],
+            )
+            capture_exception(e)
+
     async def _process_group(self, key: tuple[int, str], batches: list[PendingBatch]) -> None:
         team_id, schema_id = key
-        # Pin the connection that holds the advisory locks so status writes stay on the same session.
-        lock_conn = self._conn
-        await self._semaphore.acquire()
+        group_conn = await self._connect()
         try:
+            locked = await self._adapter.try_lock_group(group_conn, team_id=team_id, schema_id=schema_id)
+            if not locked:
+                logger.debug(
+                    self._event("group_lock_not_acquired"),
+                    team_id=team_id,
+                    schema_id=schema_id,
+                )
+                return
+
             for batch in batches:
                 if self._shutdown.is_set():
                     logger.info(
@@ -295,7 +355,7 @@ class BatchConsumer:
                     )
                     break
                 try:
-                    succeeded = await self._process_single(batch, lock_conn=lock_conn)
+                    succeeded = await self._process_single(batch, lock_conn=group_conn)
                 except OwnershipLostError:
                     logger.warning(
                         self._event("ownership_lost_abandoning_group"),
@@ -304,7 +364,6 @@ class BatchConsumer:
                     )
                     break
                 except Exception as e:
-                    # A queue-DB write failing mid-batch (e.g. stale conn after a bounce) must cost this group, not the pod.
                     logger.exception(
                         self._event("process_single_unhandled_error"),
                         team_id=team_id,
@@ -315,8 +374,6 @@ class BatchConsumer:
                     capture_exception(e)
                     succeeded = False
                 if not succeeded:
-                    # Stop processing sibling batches in this run once one fails or
-                    # enters waiting_retry -- later batches depend on earlier ones.
                     logger.info(
                         self._event("group_halted_by_non_success"),
                         team_id=team_id,
@@ -326,18 +383,19 @@ class BatchConsumer:
                     )
                     break
         finally:
-            self._semaphore.release()
             try:
-                assert lock_conn is not None
-                await self._adapter.unlock(lock_conn, batches=batches)
+                await self._adapter.unlock_group(group_conn, team_id=team_id, schema_id=schema_id)
             except Exception as e:
-                # A dead session already released its locks server-side; don't crash every concurrent group.
                 logger.exception(
-                    self._event("unlock_for_batches_failed"),
+                    self._event("unlock_group_failed"),
                     team_id=team_id,
                     external_data_schema_id=schema_id,
                 )
                 capture_exception(e)
+            try:
+                await group_conn.close()
+            except Exception:
+                pass
 
     async def _get_status_conn(self, lock_conn: psycopg.AsyncConnection[Any] | None) -> psycopg.AsyncConnection[Any]:
         """Return the connection to use for status writes, preferring the lock session."""
@@ -345,7 +403,7 @@ class BatchConsumer:
             if lock_conn.closed or lock_conn.broken:
                 raise OwnershipLostError("lock session is dead")
             return lock_conn
-        return await self._ensure_main_conn()
+        return await self._ensure_poll_conn()
 
     async def _verify_ownership(self, lock_conn: psycopg.AsyncConnection[Any] | None, batch: PendingBatch) -> None:
         """Raise OwnershipLostError if this session no longer holds the advisory lock."""
@@ -444,7 +502,7 @@ class BatchConsumer:
                 run_uuid=batch.run_uuid,
                 attempt=attempt,
             )
-            await self._fail_run(batch, reason=f"max retries exceeded (attempt {attempt})")
+            await self._fail_run(batch, reason=f"max retries exceeded (attempt {attempt})", conn=lock_conn)
             return False
 
         status_conn = await self._get_status_conn(lock_conn)
@@ -470,12 +528,24 @@ class BatchConsumer:
         heartbeat_task: asyncio.Task[None] | None = None
         try:
             start = time.monotonic()
-            should_process = await self._adapter.should_process_batch(await self._ensure_main_conn(), batch=batch)
+            should_process = await self._adapter.should_process_batch(status_conn, batch=batch)
             if should_process:
                 if lock_conn is not None:
                     heartbeat_task = asyncio.create_task(self._batch_heartbeat(lock_conn, batch, attempt))
                 await self._process_batch(batch)
-                await self._adapter.after_batch_processed(await self._ensure_main_conn(), batch=batch)
+
+                # Cancel heartbeat before any post-processing DB writes to avoid
+                # concurrent use of lock_conn (psycopg async connections are not
+                # safe for concurrent coroutine access).
+                if heartbeat_task is not None:
+                    heartbeat_task.cancel()
+                    try:
+                        await heartbeat_task
+                    except asyncio.CancelledError:
+                        pass
+                    heartbeat_task = None
+
+                await self._adapter.after_batch_processed(status_conn, batch=batch)
 
             duration = time.monotonic() - start
             self._metrics.batch_processing_duration_seconds.labels(team_id=team_id, schema_id=schema_id).observe(
@@ -513,7 +583,7 @@ class BatchConsumer:
                     attempt=attempt,
                 )
                 capture_exception(err)
-                await self._fail_run(batch, reason=f"max retries exceeded: {err}")
+                await self._fail_run(batch, reason=f"max retries exceeded: {err}", conn=lock_conn)
             else:
                 logger.warning(
                     self._event("batch_failed_will_retry"),
@@ -544,13 +614,11 @@ class BatchConsumer:
         conn: psycopg.AsyncConnection[Any] | None = None,
     ) -> None:
         """Fail the run via the adapter; the adapter isolates each step so a failure can't crash the consumer."""
-        conn = conn or await self._ensure_main_conn()
+        conn = conn or await self._ensure_poll_conn()
 
         try:
             await self._adapter.fail_run(conn, batch=batch, reason=reason)
         except Exception as e:
-            # Adapters are documented no-raise; this is the engine's backstop so a
-            # buggy adapter cannot crash _recovery_sweep or _process_single_inner.
             logger.exception(self._event("adapter_fail_run_raised"), batch_id=batch.id, run_uuid=batch.run_uuid)
             capture_exception(e)
         self._metrics.runs_failed_total.inc()
@@ -686,7 +754,6 @@ class BatchConsumer:
                 finally:
                     structlog.contextvars.unbind_contextvars(*recovery_bound_keys)
         finally:
-            # Release probe locks acquired by keep_locks=True.
             try:
                 await self._adapter.unlock(conn, batches=stale)
             except Exception:
@@ -698,6 +765,8 @@ class BatchConsumer:
             loop.add_signal_handler(sig, self._shutdown.set)
 
     async def _close(self) -> None:
+        self._shutdown.set()
+
         for task in (self._recovery_task, self._heartbeat_task):
             if task is not None:
                 task.cancel()
@@ -706,17 +775,22 @@ class BatchConsumer:
                 except asyncio.CancelledError:
                     pass
 
+        # Drain in-flight group tasks; each task releases its own advisory lock and closes its connection.
+        if self._in_flight:
+            logger.info(self._event("draining_in_flight_groups"), count=len(self._in_flight))
+            tasks = list(self._in_flight.values())
+            done, pending = await asyncio.wait(tasks, timeout=SHUTDOWN_DRAIN_TIMEOUT_SECONDS)
+            for task in pending:
+                task.cancel()
+            if pending:
+                await asyncio.wait(pending, timeout=5.0)
+            self._in_flight.clear()
+
         if self._recovery_conn is not None and not self._recovery_conn.closed:
             await self._recovery_conn.close()
 
-        if self._conn is not None and not self._conn.closed:
-            try:
-                await self._conn.execute("SELECT pg_advisory_unlock_all()")
-            except Exception as e:
-                # A broken session already lost its advisory locks; still close below.
-                logger.exception(self._event("advisory_unlock_all_failed_on_shutdown"))
-                capture_exception(e)
-            await self._conn.close()
+        if self._poll_conn is not None and not self._poll_conn.closed:
+            await self._poll_conn.close()
 
         logger.info(self._event("batch_consumer_stopped"))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/consumer.py
@@ -105,7 +105,7 @@ class DuckgresBatchConsumerAdapter:
         SINK_ELIGIBLE_BACKLOG.set(backlog)
         SINK_OLDEST_ELIGIBLE_AGE_SECONDS.set(oldest_age or 0.0)
 
-    async def fetch_and_lock(
+    async def fetch_candidates(
         self,
         conn: psycopg.AsyncConnection[Any],
         *,
@@ -118,12 +118,30 @@ class DuckgresBatchConsumerAdapter:
 
         await self._run_maintenance(conn, team_ids)
 
-        return await DuckgresBatchQueue.get_delta_succeeded_and_lock(
+        return await DuckgresBatchQueue.get_delta_succeeded_candidates(
             conn,
             limit=limit,
             retry_backoff_base_seconds=retry_backoff_base_seconds,
             team_ids=team_ids,
         )
+
+    async def try_lock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> bool:
+        return await DuckgresBatchQueue.try_lock_group(conn, team_id=team_id, schema_id=schema_id)
+
+    async def unlock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        await DuckgresBatchQueue.unlock_group(conn, team_id=team_id, schema_id=schema_id)
 
     async def unlock(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/jobs_db.py
@@ -481,6 +481,125 @@ class DuckgresBatchQueue:
         return result
 
     @staticmethod
+    async def get_delta_succeeded_candidates(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        limit: int = 50,
+        retry_backoff_base_seconds: int = 0,
+        team_ids: list[int] | None = None,
+    ) -> list[PendingBatch]:
+        """Fetch Duckgres-eligible batches without acquiring advisory locks.
+
+        Same candidate selection as ``get_delta_succeeded_and_lock`` but the outer
+        query does NOT call ``pg_try_advisory_lock``.  Callers acquire the lock
+        per-group on a dedicated connection via ``try_lock_group``.
+        """
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                f"""
+                WITH {ELIGIBILITY_CTES}
+                candidates AS MATERIALIZED (
+                    SELECT
+                        {pending_batch_select_columns("dgs")}
+                    FROM {BATCH_TABLE} b
+                    JOIN {DELTA_STATUS_VIEW} ds ON b.id = ds.batch_id
+                    JOIN run_starts rs_b ON rs_b.run_uuid = b.run_uuid
+                    LEFT JOIN {DUCKGRES_STATUS_VIEW} dgs ON b.id = dgs.batch_id
+                    WHERE
+                        b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                        AND (%(team_ids)s::bigint[] IS NULL OR b.team_id = ANY(%(team_ids)s))
+                        AND ds.job_state = 'succeeded'
+                        AND (
+                            dgs.batch_id IS NULL
+                            OR (
+                                dgs.job_state = 'waiting_retry'
+                                AND dgs.created_at <= now() - make_interval(
+                                    secs => %(backoff)s * GREATEST(COALESCE(dgs.attempt, 1), 1)
+                                )
+                            )
+                        )
+                        AND (
+                            b.is_final_batch = true
+                            OR dgs.batch_id IS NOT NULL
+                            OR NOT EXISTS (
+                                SELECT 1
+                                FROM {DUCKGRES_APPLY_TABLE} current_apply
+                                WHERE current_apply.team_id = b.team_id
+                                    AND current_apply.schema_id = b.schema_id
+                                    AND current_apply.run_uuid = b.run_uuid
+                                    AND current_apply.batch_index = b.batch_index
+                            )
+                        )
+                        AND b.run_uuid NOT IN (SELECT run_uuid FROM failed_runs)
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM {BATCH_TABLE} prev
+                            LEFT JOIN {DUCKGRES_APPLY_TABLE} a
+                                ON a.team_id = prev.team_id
+                                AND a.schema_id = prev.schema_id
+                                AND a.run_uuid = prev.run_uuid
+                                AND a.batch_index = prev.batch_index
+                            WHERE prev.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                                AND prev.team_id = b.team_id
+                                AND prev.schema_id = b.schema_id
+                                AND prev.run_uuid = b.run_uuid
+                                AND prev.is_final_batch = false
+                                AND (
+                                    prev.batch_index < b.batch_index
+                                    OR (b.is_final_batch = true AND prev.batch_index <= b.batch_index)
+                                )
+                                AND a.id IS NULL
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM incomplete_runs ir
+                            WHERE ir.team_id = b.team_id
+                                AND ir.schema_id = b.schema_id
+                                AND ir.run_uuid <> b.run_uuid
+                                AND (ir.started_at, ir.run_uuid) < (rs_b.started_at, b.run_uuid)
+                        )
+                    ORDER BY b.created_at ASC, b.batch_index ASC, b.is_final_batch ASC
+                    LIMIT %(limit)s
+                )
+                SELECT c.*
+                FROM candidates c
+                ORDER BY c.created_at ASC, c.batch_index ASC, c.is_final_batch ASC
+                """,
+                {"limit": limit, "backoff": retry_backoff_base_seconds, "team_ids": team_ids},
+            )
+            rows = await cur.fetchall()
+        return [PendingBatch(**row) for row in rows]
+
+    @staticmethod
+    async def try_lock_group(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> bool:
+        """Acquire the advisory lock for a (team_id, schema_id) group. Returns True if acquired."""
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"SELECT pg_try_advisory_lock({DUCKGRES_ADVISORY_LOCK_NAMESPACE}, hashtext(%(key)s))",
+                {"key": f"{team_id}:{schema_id}"},
+            )
+            row = await cur.fetchone()
+            return bool(row and row[0])
+
+    @staticmethod
+    async def unlock_group(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        """Release the advisory lock for a (team_id, schema_id) group (depth 1)."""
+        await conn.execute(
+            f"SELECT pg_advisory_unlock({DUCKGRES_ADVISORY_LOCK_NAMESPACE}, hashtext(%(key)s))",
+            {"key": f"{team_id}:{schema_id}"},
+        )
+
+    @staticmethod
     async def unlock_for_batches(
         conn: psycopg.AsyncConnection[Any],
         *,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_consumer.py
@@ -49,7 +49,7 @@ def _make_consumer(max_attempts: int = 3, **kwargs) -> DuckgresBatchConsumer:
         **kwargs,
     )
     consumer = DuckgresBatchConsumer(config=config, process_batch=AsyncMock())
-    consumer._conn = _make_healthy_conn()
+    consumer._poll_conn = _make_healthy_conn()
     consumer._recovery_conn = _make_healthy_conn()
     return consumer
 
@@ -183,10 +183,10 @@ class TestDuckgresEnablementGating:
         conn = _make_healthy_conn()
 
         with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.get_delta_succeeded_and_lock",
+            "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.get_delta_succeeded_candidates",
             new_callable=AsyncMock,
         ) as mock_fetch:
-            batches = await adapter.fetch_and_lock(conn, limit=50, retry_backoff_base_seconds=0)
+            batches = await adapter.fetch_candidates(conn, limit=50, retry_backoff_base_seconds=0)
 
         assert batches == []
         mock_fetch.assert_not_called()
@@ -200,7 +200,7 @@ class TestDuckgresEnablementGating:
 
         with (
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.get_delta_succeeded_and_lock",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.consumer.DuckgresBatchQueue.get_delta_succeeded_candidates",
                 new_callable=AsyncMock,
                 return_value=[],
             ) as mock_fetch,
@@ -215,7 +215,7 @@ class TestDuckgresEnablementGating:
                 return_value=(0, None),
             ) as mock_backlog,
         ):
-            await adapter.fetch_and_lock(conn, limit=50, retry_backoff_base_seconds=30)
+            await adapter.fetch_candidates(conn, limit=50, retry_backoff_base_seconds=30)
 
         assert mock_fetch.call_args[1]["team_ids"] == [1, 2]
         assert mock_fetch.call_args[1]["retry_backoff_base_seconds"] == 30

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_jobs_db.py
@@ -251,6 +251,45 @@ class TestDuckgresBatchQueueEligibility:
         assert batches == []
 
 
+@pytest.fixture
+async def conn_b(_db_url: str):
+    async with await psycopg.AsyncConnection.connect(_db_url, autocommit=True) as c:
+        yield c
+
+
+@pytest.mark.django_db(transaction=True)
+class TestDuckgresBatchQueueGetCandidates:
+    @pytest.mark.asyncio
+    async def test_returns_delta_succeeded_candidates_without_locks(self, conn, conn_b):
+        batch_id = await _insert_batch(conn, team_id=1, schema_id="s1")
+        await BatchQueue.update_status(conn, batch_id=batch_id, job_state="succeeded", attempt=1)
+
+        candidates_a = await DuckgresBatchQueue.get_delta_succeeded_candidates(conn)
+        assert len(candidates_a) == 1
+
+        candidates_b = await DuckgresBatchQueue.get_delta_succeeded_candidates(conn_b)
+        assert len(candidates_b) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+class TestDuckgresGroupLock:
+    @pytest.mark.asyncio
+    async def test_try_lock_group_exclusive_across_connections(self, conn, conn_b):
+        locked_a = await DuckgresBatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+        assert locked_a is True
+
+        locked_b = await DuckgresBatchQueue.try_lock_group(conn_b, team_id=1, schema_id="s1")
+        assert locked_b is False
+
+    @pytest.mark.asyncio
+    async def test_unlock_group_releases_lock(self, conn, conn_b):
+        await DuckgresBatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+        await DuckgresBatchQueue.unlock_group(conn, team_id=1, schema_id="s1")
+
+        locked_b = await DuckgresBatchQueue.try_lock_group(conn_b, team_id=1, schema_id="s1")
+        assert locked_b is True
+
+
 async def _mark_applied_raw(
     conn: psycopg.AsyncConnection[Any],
     *,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/consumer.py
@@ -55,18 +55,36 @@ class DeltaBatchConsumerAdapter:
     succeeded_state: str = SourceBatchStatus.State.SUCCEEDED.value
     waiting_retry_state: str = SourceBatchStatus.State.WAITING_RETRY.value
 
-    async def fetch_and_lock(
+    async def fetch_candidates(
         self,
         conn: psycopg.AsyncConnection[Any],
         *,
         limit: int,
         retry_backoff_base_seconds: int,
     ) -> list[PendingBatch]:
-        return await BatchQueue.get_unprocessed_and_lock(
+        return await BatchQueue.get_candidates(
             conn,
             limit=limit,
             retry_backoff_base_seconds=retry_backoff_base_seconds,
         )
+
+    async def try_lock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> bool:
+        return await BatchQueue.try_lock_group(conn, team_id=team_id, schema_id=schema_id)
+
+    async def unlock_group(
+        self,
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        await BatchQueue.unlock_group(conn, team_id=team_id, schema_id=schema_id)
 
     async def unlock(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/jobs_db.py
@@ -514,6 +514,112 @@ class BatchQueue:
         ]
 
     @staticmethod
+    async def get_candidates(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        limit: int = 50,
+        retry_backoff_base_seconds: int = 0,
+    ) -> list[PendingBatch]:
+        """Fetch unprocessed batches without acquiring advisory locks.
+
+        Same candidate selection as ``get_unprocessed_and_lock`` but the outer
+        query does NOT call ``pg_try_advisory_lock``.  Callers acquire the lock
+        per-group on a dedicated connection via ``try_lock_group``.
+        """
+        async with conn.cursor(row_factory=dict_row) as cur:
+            await cur.execute(
+                f"""
+                WITH candidates AS MATERIALIZED (
+                    SELECT
+                        {pending_batch_select_columns("s")}
+                    FROM {BATCH_TABLE} b
+                    LEFT JOIN {STATUS_VIEW} s ON b.id = s.batch_id
+                    WHERE
+                        b.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                        AND (
+                            s.batch_id IS NULL
+                            OR (
+                                s.job_state = 'waiting_retry'
+                                AND s.created_at <= now() - make_interval(
+                                    secs => %(backoff)s * GREATEST(COALESCE(s.attempt, 1), 1)
+                                )
+                            )
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM {BATCH_TABLE} b_prev
+                            LEFT JOIN {STATUS_VIEW} s_prev ON b_prev.id = s_prev.batch_id
+                            WHERE b_prev.run_uuid = b.run_uuid
+                                AND b_prev.batch_index < b.batch_index
+                                AND b_prev.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                                AND (
+                                    s_prev.job_state = 'executing'
+                                    OR (
+                                        s_prev.job_state = 'waiting_retry'
+                                        AND s_prev.created_at > now() - make_interval(
+                                            secs => %(backoff)s * GREATEST(COALESCE(s_prev.attempt, 1), 1)
+                                        )
+                                    )
+                                )
+                        )
+                        AND b.run_uuid NOT IN (
+                            SELECT DISTINCT b2.run_uuid
+                            FROM {BATCH_TABLE} b2
+                            JOIN {STATUS_VIEW} s2 ON b2.id = s2.batch_id
+                            WHERE b2.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                                AND s2.job_state = 'failed'
+                        )
+                        AND NOT EXISTS (
+                            SELECT 1
+                            FROM {BATCH_TABLE} b_busy
+                            JOIN {STATUS_VIEW} s_busy ON b_busy.id = s_busy.batch_id
+                            WHERE b_busy.team_id = b.team_id
+                                AND b_busy.schema_id = b.schema_id
+                                AND b_busy.created_at > now() - interval '{PARTITION_PRUNING_INTERVAL}'
+                                AND s_busy.job_state = 'executing'
+                        )
+                    ORDER BY b.created_at ASC, b.batch_index ASC
+                    LIMIT %(limit)s
+                )
+                SELECT c.*
+                FROM candidates c
+                ORDER BY c.created_at ASC, c.batch_index ASC
+                """,
+                {"limit": limit, "backoff": retry_backoff_base_seconds},
+            )
+            rows = await cur.fetchall()
+        return [PendingBatch(**row) for row in rows]
+
+    @staticmethod
+    async def try_lock_group(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> bool:
+        """Acquire the advisory lock for a (team_id, schema_id) group. Returns True if acquired."""
+        async with conn.cursor() as cur:
+            await cur.execute(
+                f"SELECT pg_try_advisory_lock({ADVISORY_LOCK_NAMESPACE}, hashtext(%(key)s))",
+                {"key": f"{team_id}:{schema_id}"},
+            )
+            row = await cur.fetchone()
+            return bool(row and row[0])
+
+    @staticmethod
+    async def unlock_group(
+        conn: psycopg.AsyncConnection[Any],
+        *,
+        team_id: int,
+        schema_id: str,
+    ) -> None:
+        """Release the advisory lock for a (team_id, schema_id) group (depth 1)."""
+        await conn.execute(
+            f"SELECT pg_advisory_unlock({ADVISORY_LOCK_NAMESPACE}, hashtext(%(key)s))",
+            {"key": f"{team_id}:{schema_id}"},
+        )
+
+    @staticmethod
     async def unlock_for_batches(
         conn: psycopg.AsyncConnection[Any],
         *,
@@ -521,9 +627,8 @@ class BatchQueue:
     ) -> None:
         """Release advisory locks once per returned batch row.
 
-        The MATERIALIZED CTE in get_unprocessed_and_lock ensures locks are
-        only acquired on rows that actually appear in the result set, so
-        one unlock per row balances the depth exactly.
+        The MATERIALIZED CTE in get_unprocessed_and_lock / get_stale_executing
+        acquires locks per row, so one unlock per row balances the depth exactly.
         """
         await unlock_advisory_locks(conn, batches=batches, namespace=ADVISORY_LOCK_NAMESPACE)
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_consumer.py
@@ -71,13 +71,12 @@ def _make_consumer(max_attempts: int = 3, **kwargs) -> BatchConsumer:
     )
     mock_process = AsyncMock()
     consumer = BatchConsumer(config=config, process_batch=mock_process)
-    consumer._conn = _make_healthy_conn()
+    consumer._poll_conn = _make_healthy_conn()
     consumer._recovery_conn = _make_healthy_conn()
     return consumer
 
 
 def _make_healthy_conn(closed: bool = False, broken: bool = False) -> AsyncMock:
-    # closed/broken must be real booleans, otherwise _ensure_*_conn sees a dead conn and dials the fake database_url.
     conn = AsyncMock()
     conn.closed = closed
     conn.broken = broken
@@ -160,16 +159,23 @@ class TestProcessGroup:
             order.append(batch.batch_index)
 
         consumer._process_batch = track_batch
+        group_conn = _make_healthy_conn()
 
         batches = [_make_batch(batch_index=i, id=f"00000000-0000-0000-0000-{i + 1:012d}") for i in range(3)]
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ) as mock_unlock,
             patch(
@@ -181,22 +187,29 @@ class TestProcessGroup:
             await consumer._process_group((1, "schema-1"), batches)
 
         assert order == [0, 1, 2]
-        mock_unlock.assert_called_once()
+        mock_unlock.assert_called_once_with(group_conn, team_id=1, schema_id="schema-1")
 
     @pytest.mark.asyncio
     async def test_unlocks_even_on_error(self):
         consumer = _make_consumer()
         consumer._process_batch = AsyncMock(side_effect=RuntimeError("crash"))
+        group_conn = _make_healthy_conn()
 
         batches = [_make_batch()]
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ) as mock_unlock,
             patch(
@@ -221,16 +234,23 @@ class TestProcessGroup:
                 raise RuntimeError("boom")
 
         consumer._process_batch = fail_on_one
+        group_conn = _make_healthy_conn()
 
         batches = [_make_batch(batch_index=i, id=f"00000000-0000-0000-0000-{i + 1:012d}") for i in range(3)]
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ),
             patch(
@@ -241,7 +261,6 @@ class TestProcessGroup:
         ):
             await consumer._process_group((1, "schema-1"), batches)
 
-        # batch 2 must not be processed once batch 1 enters waiting_retry
         assert processed == [0, 1]
 
     @pytest.mark.asyncio
@@ -255,16 +274,23 @@ class TestProcessGroup:
                 consumer._shutdown.set()
 
         consumer._process_batch = track_and_shutdown
+        group_conn = _make_healthy_conn()
 
         batches = [_make_batch(batch_index=i, id=f"00000000-0000-0000-0000-{i + 1:012d}") for i in range(3)]
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ),
             patch(
@@ -276,6 +302,136 @@ class TestProcessGroup:
             await consumer._process_group((1, "schema-1"), batches)
 
         assert processed == [0]
+
+    @pytest.mark.asyncio
+    async def test_skips_group_when_lock_not_acquired(self):
+        consumer = _make_consumer()
+        consumer._process_batch = AsyncMock()
+        group_conn = _make_healthy_conn()
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            await consumer._process_group((1, "schema-1"), [_make_batch()])
+
+        consumer._process_batch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_closes_connection_on_exit(self):
+        consumer = _make_consumer()
+        consumer._process_batch = AsyncMock()
+        group_conn = _make_healthy_conn()
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_advisory_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await consumer._process_group((1, "schema-1"), [_make_batch()])
+
+        group_conn.close.assert_awaited_once()
+
+
+class TestPerGroupConnectionIsolation:
+    """Regression tests for the shared-connection deadlock (PR #65181 incident).
+
+    Each group task must own a dedicated connection for its full lifecycle.
+    No two coroutines should ever touch the same psycopg async connection.
+    """
+
+    @pytest.mark.asyncio
+    async def test_each_group_gets_distinct_connection(self):
+        consumer = _make_consumer()
+        consumer._process_batch = AsyncMock()
+        connections_used: dict[tuple[int, str], Any] = {}
+
+        conn_a = _make_healthy_conn()
+        conn_b = _make_healthy_conn()
+        connect_returns = iter([conn_a, conn_b])
+
+        async def mock_connect():
+            return next(connect_returns)
+
+        original_process_single = consumer._process_single
+
+        async def capture_conn(batch: Any, lock_conn: Any = None) -> Any:
+            key = (batch.team_id, batch.schema_id)
+            connections_used[key] = lock_conn
+            return await original_process_single(batch, lock_conn=lock_conn)
+
+        with (
+            patch.object(consumer, "_connect", side_effect=mock_connect),
+            patch.object(consumer, "_process_single", side_effect=capture_conn),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await asyncio.gather(
+                consumer._process_group((1, "schema-a"), [_make_batch(team_id=1, schema_id="schema-a")]),
+                consumer._process_group((1, "schema-b"), [_make_batch(team_id=1, schema_id="schema-b")]),
+            )
+
+        assert connections_used[(1, "schema-a")] is conn_a
+        assert connections_used[(1, "schema-b")] is conn_b
+        assert conn_a is not conn_b
+
+    @pytest.mark.asyncio
+    async def test_group_connection_not_shared_with_poll(self):
+        consumer = _make_consumer()
+        consumer._process_batch = AsyncMock()
+        group_conn = _make_healthy_conn()
+
+        with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.verify_advisory_lock",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            await consumer._process_group((1, "schema-1"), [_make_batch()])
+
+        assert group_conn is not consumer._poll_conn
 
 
 class TestRecoverySweep:
@@ -363,7 +519,6 @@ class TestRecoverySweep:
 class TestFailRun:
     @pytest.mark.asyncio
     async def test_does_not_raise_when_job_status_update_fails(self):
-        # A dropped app-DB connection while marking the job Failed must not propagate out of _fail_run.
         consumer = _make_consumer()
         batch = _make_batch()
 
@@ -379,7 +534,7 @@ class TestFailRun:
         ):
             await consumer._fail_run(batch, reason="max retries exceeded: the connection is closed")
 
-        mock_fail_run.assert_called_once()  # queue batches still marked failed
+        mock_fail_run.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_attempts_job_status_update_even_when_queue_update_fails(self):
@@ -447,8 +602,8 @@ class TestReconcileFailedRuns:
         ):
             await consumer._reconcile_failed_runs()
 
-        mock_mark.assert_called_once()  # no-op for an already-terminal job, no error
-        mock_release.assert_not_called()  # don't release the lock for a job we didn't reconcile
+        mock_mark.assert_called_once()
+        mock_release.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_continues_after_error_on_one_ref(self):
@@ -472,7 +627,7 @@ class TestReconcileFailedRuns:
         ):
             await consumer._reconcile_failed_runs()
 
-        assert mock_mark.call_count == 2  # error on the first ref does not abort the sweep
+        assert mock_mark.call_count == 2
 
 
 class TestConnectionRecovery:
@@ -486,14 +641,14 @@ class TestConnectionRecovery:
         ids=["healthy", "closed", "broken"],
     )
     @pytest.mark.asyncio
-    async def test_ensure_main_conn_reconnects_only_when_dead(self, closed, broken, expect_reconnect):
+    async def test_ensure_poll_conn_reconnects_only_when_dead(self, closed, broken, expect_reconnect):
         consumer = _make_consumer()
         original = _make_healthy_conn(closed=closed, broken=broken)
-        consumer._conn = original
+        consumer._poll_conn = original
         fresh = _make_healthy_conn()
 
         with patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=fresh) as mock_connect:
-            conn = await consumer._ensure_main_conn()
+            conn = await consumer._ensure_poll_conn()
 
         if expect_reconnect:
             mock_connect.assert_awaited_once()
@@ -501,23 +656,6 @@ class TestConnectionRecovery:
         else:
             mock_connect.assert_not_awaited()
             assert conn is original
-
-    @pytest.mark.asyncio
-    async def test_concurrent_ensure_main_conn_dials_only_once(self):
-        # All concurrent groups hitting a dead conn must share one reconnect, not dial N connections.
-        consumer = _make_consumer()
-        consumer._conn = _make_healthy_conn(closed=True)
-        fresh = _make_healthy_conn()
-
-        async def slow_connect() -> AsyncMock:
-            await asyncio.sleep(0)  # yield so the other coroutines reach the check while we're "dialing"
-            return fresh
-
-        with patch.object(consumer, "_connect", side_effect=slow_connect) as mock_connect:
-            conns = await asyncio.gather(*[consumer._ensure_main_conn() for _ in range(5)])
-
-        assert mock_connect.call_count == 1
-        assert all(conn is fresh for conn in conns)
 
     @pytest.mark.asyncio
     async def test_ensure_recovery_conn_reconnects_when_dead(self):
@@ -533,17 +671,23 @@ class TestConnectionRecovery:
 
     @pytest.mark.asyncio
     async def test_process_group_does_not_raise_when_unlock_fails(self):
-        # An unlock failure must not crash the gather() running every concurrent group.
         consumer = _make_consumer()
         consumer._process_batch = AsyncMock()
+        group_conn = _make_healthy_conn()
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
                 side_effect=Exception("the connection is closed"),
             ),
@@ -558,8 +702,10 @@ class TestConnectionRecovery:
     @pytest.mark.asyncio
     async def test_process_group_does_not_raise_when_process_single_raises(self):
         consumer = _make_consumer()
+        group_conn = _make_healthy_conn()
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch.object(
                 consumer,
                 "_process_single",
@@ -567,13 +713,18 @@ class TestConnectionRecovery:
                 side_effect=psycopg.OperationalError("the connection is closed"),
             ) as mock_single,
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ) as mock_unlock,
         ):
             await consumer._process_group((1, "schema-1"), [_make_batch(), _make_batch(batch_index=1)])
 
-        mock_single.assert_awaited_once()  # group halts after the failed batch
+        mock_single.assert_awaited_once()
         mock_unlock.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -628,14 +779,6 @@ class TestGroupByKey:
 
 
 class TestLogContextBinding:
-    """Verify the consumer binds the structlog contextvars `LogMessagesRenderer` needs.
-
-    The CDC Syncs UI panel queries log_entries by `(log_source='external_data_jobs',
-    log_source_id=schema_id, instance_id=workflow_run_id)`. The renderer in
-    `posthog.temporal.common.logger` reads these from the structlog event_dict, so they
-    must be bound via contextvars BEFORE downstream loggers fire.
-    """
-
     @pytest.mark.asyncio
     async def test_process_single_binds_log_context_for_syncs_panel(self):
         consumer = _make_consumer()
@@ -664,12 +807,10 @@ class TestLogContextBinding:
         assert seen.get("external_data_schema_id") == batch.schema_id
         assert seen.get("attempt") == 1
 
-        # Cleared after the batch returns so context doesn't leak across batches.
         assert structlog.contextvars.get_contextvars().get("batch_id") is None
 
     @pytest.mark.asyncio
     async def test_process_single_binds_external_data_job_workflow_type_for_non_cdc(self):
-        """Consumer also runs non-CDC syncs (`external-data-job` workflow_id prefix)."""
         consumer = _make_consumer()
         batch = _make_batch(
             latest_attempt=0,
@@ -695,7 +836,6 @@ class TestLogContextBinding:
 
     @pytest.mark.asyncio
     async def test_process_single_handles_missing_workflow_ids_in_metadata(self):
-        """Old batches enqueued before this change have no workflow ids in metadata — must not crash."""
         consumer = _make_consumer()
         consumer._process_batch = AsyncMock()
 
@@ -743,21 +883,17 @@ class TestHeartbeatLoop:
 
     @pytest.mark.asyncio
     async def test_keeps_liveness_healthy_through_long_batch(self):
-        # A poll cycle (large final-batch compaction) can run far longer than the
-        # health timeout; the dedicated heartbeat must keep liveness green so
-        # kubelet doesn't SIGTERM the pod mid-batch.
         health = HealthState(timeout_seconds=0.1)
         consumer = _make_consumer(heartbeat_interval_seconds=0.02)
         consumer._health_reporter = health.report_healthy
 
         task = asyncio.create_task(consumer._heartbeat_loop())
-        await asyncio.sleep(0.3)  # simulate a batch ~3x the health timeout
+        await asyncio.sleep(0.3)
         assert health.is_healthy() is True
 
         consumer._shutdown.set()
         await asyncio.wait_for(task, timeout=1.0)
 
-        # Once the heartbeat stops, liveness correctly goes stale again.
         await asyncio.sleep(0.2)
         assert health.is_healthy() is False
 
@@ -772,16 +908,23 @@ class TestOwnershipVerification:
             processed.append(batch.batch_index)
 
         consumer._process_batch = track_and_lose_lock
+        group_conn = _make_healthy_conn()
 
         batches = [_make_batch(batch_index=i, id=f"00000000-0000-0000-0000-{i + 1:012d}") for i in range(3)]
 
         with (
+            patch.object(consumer, "_connect", new_callable=AsyncMock, return_value=group_conn),
             patch(
                 "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.update_status",
                 new_callable=AsyncMock,
             ),
             patch(
-                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_for_batches",
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.try_lock_group",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.postgres_queue.consumer.BatchQueue.unlock_group",
                 new_callable=AsyncMock,
             ) as mock_unlock,
             patch(
@@ -792,8 +935,6 @@ class TestOwnershipVerification:
         ):
             await consumer._process_group((1, "schema-1"), batches)
 
-        # Batch 0 processes (verify returns True before batch 0, True before succeeded write),
-        # batch 1 fails on verify (returns False) and the group is abandoned.
         assert len(processed) <= 2
         mock_unlock.assert_called_once()
 
@@ -803,7 +944,6 @@ class TestOwnershipVerification:
         batch = _make_batch(latest_attempt=0)
 
         dead_conn = _make_healthy_conn(closed=True)
-        consumer._conn = dead_conn
 
         with (
             patch(
@@ -834,3 +974,34 @@ class TestOwnershipVerification:
 
         assert result is True
         mock_verify.assert_not_called()
+
+
+class TestInFlightTaskRegistry:
+    @pytest.mark.asyncio
+    async def test_reap_finished_tasks_removes_completed(self):
+        consumer = _make_consumer()
+
+        done_task = asyncio.create_task(asyncio.sleep(0))
+        await done_task
+        running_task = asyncio.ensure_future(asyncio.sleep(100))
+
+        consumer._in_flight = {(1, "done"): done_task, (2, "running"): running_task}
+        consumer._metrics.active_groups.inc(2)
+
+        consumer._reap_finished_tasks()
+
+        assert (1, "done") not in consumer._in_flight
+        assert (2, "running") in consumer._in_flight
+
+        running_task.cancel()
+        try:
+            await running_task
+        except asyncio.CancelledError:
+            pass
+
+    @pytest.mark.asyncio
+    async def test_process_group_tracked_swallows_exceptions(self):
+        consumer = _make_consumer()
+
+        with patch.object(consumer, "_process_group", new_callable=AsyncMock, side_effect=RuntimeError("boom")):
+            await consumer._process_group_tracked((1, "schema-1"), [_make_batch()])

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/postgres_queue/test_jobs_db.py
@@ -422,6 +422,72 @@ class TestBatchQueueRetryBackoff:
         await BatchQueue.unlock_for_batches(conn, batches=batches)
 
 
+@pytest.mark.django_db(transaction=True)
+class TestBatchQueueGetCandidates:
+    @pytest.mark.asyncio
+    async def test_returns_same_batches_as_get_unprocessed(self, conn):
+        await _insert_batch(conn, batch_index=0)
+        await _insert_batch(conn, batch_index=1)
+
+        candidates = await BatchQueue.get_candidates(conn)
+
+        assert len(candidates) == 2
+        assert sorted(b.batch_index for b in candidates) == [0, 1]
+
+    @pytest.mark.asyncio
+    async def test_does_not_acquire_advisory_locks(self, conn, conn_b):
+        await _insert_batch(conn, team_id=1, schema_id="s1")
+
+        candidates_a = await BatchQueue.get_candidates(conn)
+        assert len(candidates_a) == 1
+
+        candidates_b = await BatchQueue.get_candidates(conn_b)
+        assert len(candidates_b) == 1
+
+    @pytest.mark.asyncio
+    async def test_skips_succeeded_batches(self, conn):
+        bid = await _insert_batch(conn)
+        await BatchQueue.update_status(conn, batch_id=bid, job_state="succeeded", attempt=1)
+
+        assert await BatchQueue.get_candidates(conn) == []
+
+
+@pytest.mark.django_db(transaction=True)
+class TestBatchQueueGroupLock:
+    @pytest.mark.asyncio
+    async def test_try_lock_group_acquires_lock(self, conn):
+        locked = await BatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+        assert locked is True
+
+    @pytest.mark.asyncio
+    async def test_try_lock_group_exclusive_across_connections(self, conn, conn_b):
+        locked_a = await BatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+        assert locked_a is True
+
+        locked_b = await BatchQueue.try_lock_group(conn_b, team_id=1, schema_id="s1")
+        assert locked_b is False
+
+    @pytest.mark.asyncio
+    async def test_try_lock_group_different_keys_independent(self, conn, conn_b):
+        locked_a = await BatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+        locked_b = await BatchQueue.try_lock_group(conn_b, team_id=2, schema_id="s2")
+
+        assert locked_a is True
+        assert locked_b is True
+
+    @pytest.mark.asyncio
+    async def test_unlock_group_releases_lock(self, conn, conn_b):
+        await BatchQueue.try_lock_group(conn, team_id=1, schema_id="s1")
+
+        locked_b = await BatchQueue.try_lock_group(conn_b, team_id=1, schema_id="s1")
+        assert locked_b is False
+
+        await BatchQueue.unlock_group(conn, team_id=1, schema_id="s1")
+
+        locked_b = await BatchQueue.try_lock_group(conn_b, team_id=1, schema_id="s1")
+        assert locked_b is True
+
+
 class TestPendingBatchToExportSignal:
     def test_maps_all_fields(self):
         batch = PendingBatch(


### PR DESCRIPTION
## Problem

The V3 batch consumer uses `psycopg` async connections, which are not safe for concurrent coroutine access. After #65181 replaced the `asyncio.gather()` barrier with fire-and-forget tasks, all concurrent group tasks, heartbeats, and the poll loop shared a single connection (`self._conn`). Under load, this caused the connection to wedge silently - pods stayed Running but stopped processing batches entirely.

The root cause is connection ownership: Postgres advisory locks are session-scoped, so all operations for a `(team_id, schema_id)` group must happen on the same connection. But concurrent coroutines on the same `psycopg` async connection causes undefined behavior.

## Changes

Gives each in-flight group its own dedicated connection while preserving the fire-and-forget parallelism from #65181.

**Connection model:**

| Connection | Owner | Purpose |
|---|---|---|
| `_poll_conn` (was `_conn`) | poll loop only | `fetch_candidates` (no locks acquired) |
| `_recovery_conn` | recovery loop only | stale-batch sweeps, reconcile |
| per-group connection | group task | advisory lock, status writes, heartbeat, unlock |

Total max connections per pod: `max_concurrency` (16) + 2 = 18.

**SQL change - split fetch-and-lock:**

The old `get_unprocessed_and_lock` combined candidate selection with lock acquisition in one query. This is split into:
- `get_candidates` / `get_delta_succeeded_candidates` - same MATERIALIZED CTE, returns all candidates without calling `pg_try_advisory_lock`
- `try_lock_group(conn, team_id, schema_id)` - acquires the advisory lock on the group's dedicated connection
- `unlock_group(conn, team_id, schema_id)` - releases the lock (depth 1, matching `try_lock_group`)

The old per-row lock methods (`get_unprocessed_and_lock`, `unlock_for_batches`) are preserved for the recovery sweep path.

**Other fixes included:**
- Heartbeat race: heartbeat task is now cancelled *before* post-processing writes (`_verify_ownership`, `update_status(succeeded)`), not after. The `finally` block remains as a safety net.
- Connection routing: `should_process_batch` and `after_batch_processed` now use the group connection instead of `_ensure_main_conn()`, which matters for the Duckgres adapter (real DB work).
- `_fail_run` calls in `_process_single_inner` now pass `conn=lock_conn` explicitly.
- Graceful shutdown drains in-flight tasks with a 30s timeout before cancelling stragglers.

## How did you test this code?

Agent-authored. Ran the full consumer test suite (50 tests across Delta and Duckgres consumers, all passing).

**New regression tests:**
- `TestPerGroupConnectionIsolation.test_each_group_gets_distinct_connection` - verifies each group task receives a unique connection object from `_connect()`. Fails against the old `lock_conn = self._conn` code.
- `TestPerGroupConnectionIsolation.test_group_connection_not_shared_with_poll` - verifies group connections are distinct from `_poll_conn`.
- `TestProcessGroup.test_skips_group_when_lock_not_acquired` - verifies `try_lock_group` returning `False` causes the group to be skipped without processing.
- `TestProcessGroup.test_closes_connection_on_exit` - verifies group connection is closed in the finally block.
- `TestInFlightTaskRegistry.test_reap_finished_tasks_removes_completed` - verifies completed tasks are cleaned from `_in_flight`.
- `TestInFlightTaskRegistry.test_process_group_tracked_swallows_exceptions` - verifies unhandled exceptions don't propagate to the event loop.
- `TestBatchQueueGetCandidates` - integration tests verifying candidates returned without acquiring advisory locks.
- `TestBatchQueueGroupLock` - integration tests for `try_lock_group` exclusion across connections and `unlock_group` release.
- Equivalent Duckgres integration tests for `get_delta_succeeded_candidates`, `try_lock_group`, `unlock_group`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code (Opus). The human provided detailed root cause analysis of the shared-connection deadlock, design constraints (advisory locks are session-scoped, psycopg async connections not safe for concurrent
use), and the per-group connection approach. Key design decisions during implementation:
- Chose per-group dedicated connections over a connection pool for simplicity (18 connections per pod is acceptable)
- Split `fetch_and_lock` into `fetch_candidates` + `try_lock_group` to keep the poll connection lock-free
- Added `unlock_group` (single unlock, depth 1) alongside existing `unlock_for_batches` (per-row unlock for recovery sweep compatibility)
- Fixed the heartbeat race by cancelling the heartbeat task between `_process_batch` and post-processing writes, rather than only in the `finally` block

Skills invoked: none (changes are to internal async infrastructure, not DRF/Django/frontend).
