### PR TITLE
chore(experiments): remove rolled-out experiment-funnel-dwh-support flag

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -302,7 +302,6 @@ export const FEATURE_FLAGS = {
     ERROR_TRACKING_WEEKLY_DIGEST: 'error-tracking-weekly-digest', // owner: #team-error-tracking
     EVENT_MEDIA_PREVIEWS: 'event-media-previews', // owner: @alexlider
     EXPERIMENT_FUNNEL_ACTORS_QUERY: 'experiment-funnel-actors-query', // owner: @rodrigoi #team-experiments
-    EXPERIMENT_FUNNEL_DWH_SUPPORT: 'experiment-funnel-dwh-support', // owner: @rodrigoi #team-experiments
     EXPERIMENT_SESSION_REPLAYS_SKILL: 'experiment-session-replays-skill', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_DW_AA_TEST: 'experiments-dw-aa-test', // owner: @rodrigoi #team-experiments
     EXPERIMENTS_END_MODAL_CONCLUSION_FIRST: 'experiments-end-modal-conclusion-first', // owner: @ruby.c #team-experiments

--- a/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
+++ b/frontend/src/scenes/experiments/ExperimentMetricForm.tsx
@@ -4,7 +4,6 @@ import { IconInfo, IconPencil } from '@posthog/icons'
 import { LemonBanner, LemonInput } from '@posthog/lemon-ui'
 
 import { DataWarehousePopoverField } from 'lib/components/TaxonomicFilter/types'
-import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { IconOpenInNew } from 'lib/lemon-ui/icons'
 import { LemonLabel } from 'lib/lemon-ui/LemonLabel'
 import { LemonRadio } from 'lib/lemon-ui/LemonRadio'
@@ -139,8 +138,6 @@ export function ExperimentMetricForm({
     const [eventCount, setEventCount] = useState<number | null>(null)
     const [isLoading, setIsLoading] = useState(false)
 
-    const isExperimentFunnelDWHSupport = useFeatureFlag('EXPERIMENT_FUNNEL_DWH_SUPPORT')
-
     const getEventTypeLabel = (): string => {
         if (isExperimentMeanMetric(metric)) {
             return metric.source.kind === NodeKind.ActionsNode ? 'actions' : 'events'
@@ -196,23 +193,13 @@ export function ExperimentMetricForm({
             if (newMetricType === ExperimentMetricType.MEAN && isExperimentMeanMetric(newMetric)) {
                 newMetric.source = sources[0]
             } else if (newMetricType === ExperimentMetricType.FUNNEL && isExperimentFunnelMetric(newMetric)) {
-                // Filter sources based on feature flag support
-                if (isExperimentFunnelDWHSupport) {
-                    // Include all supported types including DataWarehouseNode
-                    newMetric.series = sources.filter(
-                        (s): s is ExperimentFunnelMetricStep =>
-                            s &&
-                            (s.kind === NodeKind.EventsNode ||
-                                s.kind === NodeKind.ActionsNode ||
-                                s.kind === NodeKind.ExperimentDataWarehouseNode)
-                    )
-                } else {
-                    // Legacy: only support EventsNode and ActionsNode
-                    newMetric.series = sources.filter(
-                        (s): s is ExperimentFunnelMetricStep =>
-                            s && (s.kind === NodeKind.EventsNode || s.kind === NodeKind.ActionsNode)
-                    )
-                }
+                newMetric.series = sources.filter(
+                    (s): s is ExperimentFunnelMetricStep =>
+                        s &&
+                        (s.kind === NodeKind.EventsNode ||
+                            s.kind === NodeKind.ActionsNode ||
+                            s.kind === NodeKind.ExperimentDataWarehouseNode)
+                )
             } else if (newMetricType === ExperimentMetricType.RATIO && isExperimentRatioMetric(newMetric)) {
                 newMetric.numerator = sources[0]
             } else if (newMetricType === ExperimentMetricType.RETENTION && isExperimentRetentionMetric(newMetric)) {
@@ -410,17 +397,9 @@ export function ExperimentMetricForm({
                         // showNumericalPropsOnly={true}
                         mathAvailability={mathAvailability}
                         allowedMathTypes={allowedMathTypes}
-                        actionsTaxonomicGroupTypes={
-                            isExperimentFunnelDWHSupport
-                                ? commonActionFilterProps.actionsTaxonomicGroupTypes
-                                : commonActionFilterProps.actionsTaxonomicGroupTypes?.filter(
-                                      (type) => type !== 'data_warehouse'
-                                  )
-                        }
+                        actionsTaxonomicGroupTypes={commonActionFilterProps.actionsTaxonomicGroupTypes}
                         propertiesTaxonomicGroupTypes={commonActionFilterProps.propertiesTaxonomicGroupTypes}
-                        dataWarehousePopoverFields={
-                            isExperimentFunnelDWHSupport ? dataWarehousePopoverFields : undefined
-                        }
+                        dataWarehousePopoverFields={dataWarehousePopoverFields}
                     />
                 )}
 


### PR DESCRIPTION
## Problem

The `experiment-funnel-dwh-support` feature flag has been fully rolled out (boolean, 100% to everyone) for ~2 months. A flag with no remaining targeting is equivalent to a hardcoded `true` — the conditional code paths are dead weight and the flag check is the only thing keeping it "alive."

## Changes

Removes the flag and collapses its conditional code to the enabled (data-warehouse) path:

- Drop `EXPERIMENT_FUNNEL_DWH_SUPPORT` from `FEATURE_FLAGS`.
- In `ExperimentMetricForm.tsx`, remove the `useFeatureFlag` check (and now-unused import) in all three spots, keeping the enabled behavior: funnel series accept `ExperimentDataWarehouseNode`, the `data_warehouse` taxonomic group stays, and `dataWarehousePopoverFields` is always passed.

Frontend-only. No backend usages, no experiment attached, no dependent flags.

## How did you test this code?

I'm an agent (PostHog Code). I did not manually test. Ran `oxlint` on the two changed files (clean) and `tsgo --noEmit` — no errors attributable to these files (pre-existing errors elsewhere in the tree are unrelated).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by the repo owner via the `/cleaning-up-stale-feature-flags` skill. Confirmed the flag's state through the PostHog MCP: fully rolled out (`effectively_full_rollout: true`), boolean, empty `experiment_set`, no dependent flags. Classified as `fully_rolled_out`, so the cleanup keeps the enabled branch everywhere and removes the else/legacy branches.

The flag is intentionally **not** disabled in PostHog yet — that should happen only after this merges and deploys, to avoid the old deployed code losing its DWH path mid-flight.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
