### PR TITLE
fix(data-warehouse): skip error capture for expected schema-discovery errors

### DIFF
--- a/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
+++ b/posthog/temporal/tests/product_analytics/__snapshots__/test_upgrade_queries_workflow.ambr
@@ -13,14 +13,6 @@
       (!exists(@.version) || @.version == null || @.version < 4)
   )'
          OR query @? '$.** ? (
-      @.kind == "RetentionQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
-      @.kind == "StickinessQuery" &&
-      (!exists(@.version) || @.version == null || @.version < 2)
-  )'
-         OR query @? '$.** ? (
       @.kind == "TrendsQuery" &&
       (!exists(@.version) || @.version == null || @.version < 6)
   )')

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -2456,9 +2456,6 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         try:
             schemas = source.get_schemas(source_config, self.team_id)
         except Exception as e:
-            # Don't capture errors the source already classifies as expected (e.g. a missing
-            # BigQuery dataset, rejected credentials) — they're actionable user-config problems
-            # surfaced to the wizard, not bugs, and capturing them just spams error tracking.
             _, is_expected_source_error = _classify_refresh_schemas_error(source, e)
             if not is_expected_source_error:
                 capture_exception(e, {"source_type": source_type, "team_id": self.team_id})

--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -2456,7 +2456,12 @@ class ExternalDataSourceViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixi
         try:
             schemas = source.get_schemas(source_config, self.team_id)
         except Exception as e:
-            capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
+            # Don't capture errors the source already classifies as expected (e.g. a missing
+            # BigQuery dataset, rejected credentials) — they're actionable user-config problems
+            # surfaced to the wizard, not bugs, and capturing them just spams error tracking.
+            _, is_expected_source_error = _classify_refresh_schemas_error(source, e)
+            if not is_expected_source_error:
+                capture_exception(e, {"source_type": source_type, "team_id": self.team_id})
             return Response(
                 status=status.HTTP_400_BAD_REQUEST,
                 data={"message": str(e)},

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -3996,43 +3996,30 @@ class TestExternalDataSource(APIBaseTest):
             assert response.status_code == 400
             assert "Stripe credentials lack permissions for Account, Invoice" in response.json()["message"]
 
+    @parameterized.expand(
+        [
+            ("expected_source_error", False),
+            ("unexpected_source_error", True),
+        ]
+    )
     @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
     @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
-    def test_database_schema_does_not_capture_expected_source_error(self, mock_get_source, mock_capture_exception):
+    def test_database_schema_captures_only_unexpected_source_errors(
+        self, _name, expect_capture, mock_get_source, mock_capture_exception
+    ):
         from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
             BIGQUERY_DATASET_NOT_FOUND_ERROR,
             BigQueryDatasetNotFoundError,
         )
         from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
 
+        error: Exception = (
+            RuntimeError("schema discovery exploded")
+            if expect_capture
+            else BigQueryDatasetNotFoundError(BIGQUERY_DATASET_NOT_FOUND_ERROR)
+        )
         source = BigQuerySource()
         mock_get_source.return_value = source
-
-        with (
-            patch.object(source, "validate_config", return_value=(True, [])),
-            patch.object(source, "parse_config", return_value=None),
-            patch.object(source, "validate_credentials", return_value=(True, None)),
-            patch.object(
-                source, "get_schemas", side_effect=BigQueryDatasetNotFoundError(BIGQUERY_DATASET_NOT_FOUND_ERROR)
-            ),
-        ):
-            response = self.client.post(
-                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
-                data={"source_type": "BigQuery"},
-            )
-
-        assert response.status_code == 400
-        assert response.json()["message"] == BIGQUERY_DATASET_NOT_FOUND_ERROR
-        mock_capture_exception.assert_not_called()
-
-    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
-    @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
-    def test_database_schema_captures_unexpected_source_error(self, mock_get_source, mock_capture_exception):
-        from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
-
-        source = BigQuerySource()
-        mock_get_source.return_value = source
-        error = RuntimeError("schema discovery exploded")
 
         with (
             patch.object(source, "validate_config", return_value=(True, [])),
@@ -4046,7 +4033,11 @@ class TestExternalDataSource(APIBaseTest):
             )
 
         assert response.status_code == 400
-        mock_capture_exception.assert_called_once_with(error, {"source_type": "BigQuery", "team_id": self.team.pk})
+        assert response.json()["message"] == str(error)
+        if expect_capture:
+            mock_capture_exception.assert_called_once_with(error, {"source_type": "BigQuery", "team_id": self.team.pk})
+        else:
+            mock_capture_exception.assert_not_called()
 
     def test_database_schema_stripe_surfaces_per_endpoint_permission_errors(self):
         """Schema-selection step calls get_endpoint_permissions and merges the per-endpoint

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -3996,6 +3996,58 @@ class TestExternalDataSource(APIBaseTest):
             assert response.status_code == 400
             assert "Stripe credentials lack permissions for Account, Invoice" in response.json()["message"]
 
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
+    def test_database_schema_does_not_capture_expected_source_error(self, mock_get_source, mock_capture_exception):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
+            BIGQUERY_DATASET_NOT_FOUND_ERROR,
+            BigQueryDatasetNotFoundError,
+        )
+        from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
+
+        source = BigQuerySource()
+        mock_get_source.return_value = source
+
+        with (
+            patch.object(source, "validate_config", return_value=(True, [])),
+            patch.object(source, "parse_config", return_value=None),
+            patch.object(source, "validate_credentials", return_value=(True, None)),
+            patch.object(
+                source, "get_schemas", side_effect=BigQueryDatasetNotFoundError(BIGQUERY_DATASET_NOT_FOUND_ERROR)
+            ),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+                data={"source_type": "BigQuery"},
+            )
+
+        assert response.status_code == 400
+        assert response.json()["message"] == BIGQUERY_DATASET_NOT_FOUND_ERROR
+        mock_capture_exception.assert_not_called()
+
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.SourceRegistry.get_source")
+    def test_database_schema_captures_unexpected_source_error(self, mock_get_source, mock_capture_exception):
+        from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.source import BigQuerySource
+
+        source = BigQuerySource()
+        mock_get_source.return_value = source
+        error = RuntimeError("schema discovery exploded")
+
+        with (
+            patch.object(source, "validate_config", return_value=(True, [])),
+            patch.object(source, "parse_config", return_value=None),
+            patch.object(source, "validate_credentials", return_value=(True, None)),
+            patch.object(source, "get_schemas", side_effect=error),
+        ):
+            response = self.client.post(
+                f"/api/environments/{self.team.pk}/external_data_sources/database_schema/",
+                data={"source_type": "BigQuery"},
+            )
+
+        assert response.status_code == 400
+        mock_capture_exception.assert_called_once_with(error, {"source_type": "BigQuery", "team_id": self.team.pk})
+
     def test_database_schema_stripe_surfaces_per_endpoint_permission_errors(self):
         """Schema-selection step calls get_endpoint_permissions and merges the per-endpoint
         result into each schema row so the UI can disable tables the credentials can't reach."""


### PR DESCRIPTION
## Problem

When a user sets up or validates a BigQuery data-warehouse source with a dataset that doesn't exist (or lives in a different region), schema discovery raises an actionable error that's already surfaced to the setup wizard as a 400. But the `database_schema` endpoint captured **every** exception from `get_schemas` to error tracking — including these expected, user-config errors — so each misconfigured setup attempt generated an error-tracking issue with no action for us to take.

This surfaced from PostHog error tracking as a `NotFound` / `BigQueryDatasetNotFoundError` originating in `bigquery.py`'s `get_columns`, raised through `get_schemas` from the `database_schema` endpoint. The dataset is already classified as a known non-retryable error by the source, yet it was still captured.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f04ae-672d-7701-85ff-cfa13af0978a

## Changes

`database_schema` now classifies the exception via the source's own `get_non_retryable_errors()` (using the existing `_classify_refresh_schemas_error` helper) and only calls `capture_exception` when the error is **not** an expected source error. This mirrors what `refresh_schemas` already does. The user-facing 400 message is unchanged, and genuinely unexpected errors are still captured.

This is scoped to error-tracking noise only — no retry policy, no pipeline behavior, no message changes. It applies to any source, gated by that source's own expected-error classification, so it can't swallow real bugs (unexpected errors that match no pattern are still captured).

## How did you test this code?

I'm an agent. I added two regression tests in `test_external_data_source.py` and could not run the Python suite in this sandbox (the test runner wasn't available), but the edited files compile and pass `ruff check` / `ruff format`:

- `test_database_schema_does_not_capture_expected_source_error` — a `BigQueryDatasetNotFoundError` (matched by the real `BigQuerySource.get_non_retryable_errors()`) returns a 400 with its actionable message and is **not** captured. This is the regression the existing tests didn't cover: previously every expected schema-discovery error was captured.
- `test_database_schema_captures_unexpected_source_error` — an unmatched `RuntimeError` is still captured, so real bugs are not silently dropped.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the BigQuery source. Read the full stack trace and confirmed the failure originates in `bigquery.py` `get_columns` (re-raising a BigQuery `NotFound` as the actionable `BigQueryDatasetNotFoundError`), reached via the `database_schema` setup/validation endpoint — not the Temporal sync path (which already treats this as non-retryable).

Decision: this is an expected user/upstream config error (dataset missing or wrong region), already surfaced correctly to the user. The only defect is that the `database_schema` endpoint captured it to error tracking, unlike `refresh_schemas`, which already suppresses capture for expected source errors. Chose to align the two paths rather than extend BigQuery's `NonRetryableErrors` (which already contains the relevant patterns and wouldn't change this synchronous endpoint's behavior). Kept the fix minimal: preserve the existing `str(e)` user message, only gate the capture.
