### PR TITLE
feat(dashboards): open tile actions menu on right-click

### DIFF
--- a/frontend/src/lib/components/Cards/CardMeta.tsx
+++ b/frontend/src/lib/components/Cards/CardMeta.tsx
@@ -33,6 +33,10 @@ export interface CardMetaProps extends Pick<React.HTMLAttributes<HTMLDivElement>
     moreButtons?: JSX.Element
     /** Tooltip for the editing controls dropdown. */
     moreTooltip?: string
+    /** Controlled visibility of the "more" dropdown (e.g. opened from a tile right-click). */
+    moreDropdownVisible?: boolean
+    /** Called when the "more" dropdown visibility changes. Passing this puts the dropdown in controlled mode. */
+    setMoreDropdownVisible?: (visible: boolean) => void
     /** Tooltip for the details button. */
     detailsTooltip?: string
     topHeading?: JSX.Element | null
@@ -62,6 +66,8 @@ export function CardMeta({
     metaDetails,
     moreButtons,
     moreTooltip,
+    moreDropdownVisible,
+    setMoreDropdownVisible,
     topHeading,
     areDetailsShown,
     setAreDetailsShown,
@@ -105,6 +111,18 @@ export function CardMeta({
         inStorybookTestRunner() ||
         (!!primaryWidth && primaryWidth > 480 && controlsAvailableSpace >= neededWidth)
 
+    const moreButton = (
+        <More
+            overlay={moreButtons}
+            dropdown={
+                setMoreDropdownVisible
+                    ? { visible: moreDropdownVisible, onVisibilityChange: setMoreDropdownVisible }
+                    : undefined
+            }
+        />
+    )
+    const moreButtonWithTooltip = moreTooltip ? <Tooltip title={moreTooltip}>{moreButton}</Tooltip> : moreButton
+
     return (
         <div
             className={clsx(
@@ -129,14 +147,7 @@ export function CardMeta({
                                 <div className="CardMeta__heading">{topHeading}</div>
                                 <div className="CardMeta__controls">
                                     {refreshControl}
-                                    {showEditingControls &&
-                                        (moreTooltip ? (
-                                            <Tooltip title={moreTooltip}>
-                                                <More overlay={moreButtons} />
-                                            </Tooltip>
-                                        ) : (
-                                            <More overlay={moreButtons} />
-                                        ))}
+                                    {showEditingControls && moreButtonWithTooltip}
                                 </div>
                             </div>
                             {meta}
@@ -177,14 +188,7 @@ export function CardMeta({
                                             </LemonButton>
                                         </Tooltip>
                                     )}
-                                    {showEditingControls &&
-                                        (moreTooltip ? (
-                                            <Tooltip title={moreTooltip}>
-                                                <More overlay={moreButtons} />
-                                            </Tooltip>
-                                        ) : (
-                                            <More overlay={moreButtons} />
-                                        ))}
+                                    {showEditingControls && moreButtonWithTooltip}
                                 </div>
                             </div>
                             {meta}

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -177,6 +177,9 @@ function InsightCardInternal(
     const canEditInsight = insight.user_access_level
         ? accessLevelSatisfied(AccessControlResourceType.Insight, insight.user_access_level, AccessControlLevel.Editor)
         : true
+    const canViewInsight = insight.user_access_level
+        ? accessLevelSatisfied(AccessControlResourceType.Insight, insight.user_access_level, AccessControlLevel.Viewer)
+        : true
     const canPersistDisplayOptions = !!dashboardId && canEditInsight
 
     // Base props without setQuery — used to mount insightDataLogic and retrieve the
@@ -211,7 +214,18 @@ function InsightCardInternal(
     }
 
     const [areDetailsShown, setAreDetailsShown] = useState(false)
+    const [moreDropdownVisible, setMoreDropdownVisible] = useState(false)
     const hasResults = !!insight?.result || !!(insight as any)?.results
+
+    // Right-clicking anywhere on the tile opens the same "⋯" actions menu instead of the browser's
+    // native context menu. Only when the editing controls (and therefore the menu) are present.
+    const canOpenMoreMenu = showEditingControls !== false && canViewInsight
+    const onContextMenu = canOpenMoreMenu
+        ? (event: React.MouseEvent<HTMLDivElement>): void => {
+              event.preventDefault()
+              setMoreDropdownVisible(true)
+          }
+        : undefined
 
     // Empty states that completely replace the Query component.
     const BlockingEmptyState = (() => {
@@ -306,6 +320,7 @@ function InsightCardInternal(
             )}
             data-attr="insight-card"
             {...divProps}
+            onContextMenu={onContextMenu}
             // eslint-disable-next-line react/forbid-dom-props
             style={{ ...divProps?.style, ...theme?.boxStyle }}
             ref={mergedRefs}
@@ -340,6 +355,8 @@ function InsightCardInternal(
                         placement={placement}
                         surveyOpportunity={surveyOpportunity}
                         onDragHandleMouseDown={onDragHandleMouseDown}
+                        moreDropdownVisible={moreDropdownVisible}
+                        setMoreDropdownVisible={setMoreDropdownVisible}
                     />
                     {vizContent}
                 </BindLogic>

--- a/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightCard.tsx
@@ -229,15 +229,6 @@ function InsightCardInternal(
 
     // Empty states that completely replace the Query component.
     const BlockingEmptyState = (() => {
-        // Check for access denied - use the same logic as other components
-        const canViewInsight = insight?.user_access_level
-            ? accessLevelSatisfied(
-                  AccessControlResourceType.Insight,
-                  insight.user_access_level,
-                  AccessControlLevel.Viewer
-              )
-            : true
-
         if (!canViewInsight) {
             const errorMessage = getAccessControlDisabledReason(
                 AccessControlResourceType.Insight,

--- a/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
+++ b/frontend/src/lib/components/Cards/InsightCard/InsightMeta.tsx
@@ -93,6 +93,9 @@ interface InsightMetaProps extends Pick<
     areDetailsShown?: boolean
     setAreDetailsShown?: React.Dispatch<React.SetStateAction<boolean>>
     persistDisplayOptions?: (node: Node) => void
+    /** Controlled visibility of the "more" dropdown (e.g. opened from a tile right-click). */
+    moreDropdownVisible?: boolean
+    setMoreDropdownVisible?: (visible: boolean) => void
 }
 
 export function InsightMeta({
@@ -123,6 +126,8 @@ export function InsightMeta({
     surveyOpportunity,
     onDragHandleMouseDown,
     persistDisplayOptions,
+    moreDropdownVisible,
+    setMoreDropdownVisible,
 }: InsightMetaProps): JSX.Element {
     const { short_id, name, next_allowed_client_refresh: nextAllowedClientRefresh } = insight
     const tileFiltersOverride = tile?.filters_overrides
@@ -602,6 +607,8 @@ export function InsightMeta({
                         ? 'Rename, duplicate, export, refresh and more…'
                         : 'Duplicate, export, refresh and more…'
                 }
+                moreDropdownVisible={moreDropdownVisible}
+                setMoreDropdownVisible={setMoreDropdownVisible}
                 extraControls={surveyOpportunityButton ?? feedbackButtons}
                 refreshControl={refreshControl}
             />

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.test.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.test.tsx
@@ -1,6 +1,6 @@
 import '@testing-library/jest-dom'
 
-import { fireEvent, render } from '@testing-library/react'
+import { fireEvent, render, within } from '@testing-library/react'
 
 import { DashboardPlacement, DashboardTile, QueryBasedInsightModel } from '~/types'
 
@@ -36,7 +36,7 @@ describe('TextCard', () => {
     })
 
     it('opens the more menu on right-click and suppresses the native context menu', () => {
-        const { container, getByText, queryByText } = render(
+        const { container } = render(
             <TextCard
                 textTile={makeTextTile()}
                 placement={DashboardPlacement.Dashboard}
@@ -44,18 +44,21 @@ describe('TextCard', () => {
             />
         )
 
-        expect(queryByText('more overlay')).not.toBeInTheDocument()
+        // The overlay mounts into a portal on document.body, so we observe the menu's open state via the
+        // trigger button's active class (scoped to this render's container) rather than querying the overlay text.
+        const moreButton = within(container).getByLabelText('more')
+        expect(moreButton).not.toHaveClass('LemonButton--active')
 
         const card = container.querySelector('[data-attr="text-card"]') as HTMLElement
         const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
         fireEvent(card, event)
 
         expect(event.defaultPrevented).toBe(true)
-        expect(getByText('more overlay')).toBeInTheDocument()
+        expect(moreButton).toHaveClass('LemonButton--active')
     })
 
     it('does not hijack right-click when the more menu is hidden (Public placement)', () => {
-        const { container, queryByText } = render(
+        const { container } = render(
             <TextCard
                 textTile={makeTextTile()}
                 placement={DashboardPlacement.Public}
@@ -63,12 +66,13 @@ describe('TextCard', () => {
             />
         )
 
+        expect(within(container).queryByLabelText('more')).not.toBeInTheDocument()
+
         const card = container.querySelector('[data-attr="text-card"]') as HTMLElement
         const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
         fireEvent(card, event)
 
         expect(event.defaultPrevented).toBe(false)
-        expect(queryByText('more overlay')).not.toBeInTheDocument()
     })
 
     it('renders edit-mode edge overlay when enabled and not resizing', () => {

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.test.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.test.tsx
@@ -35,6 +35,42 @@ describe('TextCard', () => {
         expect(getByText('more overlay')).toBeInTheDocument()
     })
 
+    it('opens the more menu on right-click and suppresses the native context menu', () => {
+        const { container, getByText, queryByText } = render(
+            <TextCard
+                textTile={makeTextTile()}
+                placement={DashboardPlacement.Dashboard}
+                moreButtonOverlay={<div>more overlay</div>}
+            />
+        )
+
+        expect(queryByText('more overlay')).not.toBeInTheDocument()
+
+        const card = container.querySelector('[data-attr="text-card"]') as HTMLElement
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+        fireEvent(card, event)
+
+        expect(event.defaultPrevented).toBe(true)
+        expect(getByText('more overlay')).toBeInTheDocument()
+    })
+
+    it('does not hijack right-click when the more menu is hidden (Public placement)', () => {
+        const { container, queryByText } = render(
+            <TextCard
+                textTile={makeTextTile()}
+                placement={DashboardPlacement.Public}
+                moreButtonOverlay={<div>more overlay</div>}
+            />
+        )
+
+        const card = container.querySelector('[data-attr="text-card"]') as HTMLElement
+        const event = new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+        fireEvent(card, event)
+
+        expect(event.defaultPrevented).toBe(false)
+        expect(queryByText('more overlay')).not.toBeInTheDocument()
+    })
+
     it('renders edit-mode edge overlay when enabled and not resizing', () => {
         const onEnterEditModeFromEdge = jest.fn()
 

--- a/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
+++ b/frontend/src/lib/components/Cards/TextCard/TextCard.tsx
@@ -2,7 +2,7 @@ import './TextCard.scss'
 
 import { EditorContent } from '@tiptap/react'
 import clsx from 'clsx'
-import React, { memo, useEffect, useMemo } from 'react'
+import React, { memo, useEffect, useMemo, useState } from 'react'
 
 import 'lib/components/Cards/CardMeta.scss'
 import 'lib/components/MarkdownEditor/shared/RichMarkdownEditor.scss'
@@ -96,6 +96,17 @@ function TextCardInternal(
 
     const isTransparent = textTile.transparent_background
 
+    const [moreDropdownVisible, setMoreDropdownVisible] = useState(false)
+    const canOpenMoreMenu = !!moreButtonOverlay && !shouldHideMoreButton
+    // Right-clicking anywhere on the tile opens the same "⋯" actions menu instead of the browser's
+    // native context menu. Only when the editing controls (and therefore the menu) are present.
+    const onContextMenu = canOpenMoreMenu
+        ? (event: React.MouseEvent<HTMLDivElement>): void => {
+              event.preventDefault()
+              setMoreDropdownVisible(true)
+          }
+        : undefined
+
     return (
         <div
             className={clsx(
@@ -106,11 +117,15 @@ function TextCardInternal(
             )}
             data-attr="text-card"
             {...divProps}
+            onContextMenu={onContextMenu}
             ref={ref}
         >
-            {moreButtonOverlay && !shouldHideMoreButton && (
+            {canOpenMoreMenu && (
                 <div className="absolute right-4 top-4">
-                    <More overlay={moreButtonOverlay} />
+                    <More
+                        overlay={moreButtonOverlay}
+                        dropdown={{ visible: moreDropdownVisible, onVisibilityChange: setMoreDropdownVisible }}
+                    />
                 </div>
             )}
 


### PR DESCRIPTION
## Problem

The "more actions" (`⋯`) menu on dashboard tiles is only reachable by hunting for the small button in the top-right corner. Right-clicking a tile just pops the browser's native context menu, which is rarely what you want on a dashboard.

## Changes

Right-clicking anywhere on a dashboard tile now opens the existing `⋯` more-actions dropdown and suppresses the native context menu.

Rather than build a parallel context menu (which would mean re-authoring every menu item), this reuses the existing dropdown by making its visibility controllable:

- **`CardMeta`** — added `moreDropdownVisible` / `setMoreDropdownVisible` props, wired into the `More` button via its existing `dropdown` prop (`LemonDropdown` already supports controlled mode). Collapsed the four duplicated `<More>` render sites into one shared element.
- **`InsightMeta`** — threads the two props through to `CardMeta`.
- **`InsightCard`** — owns the open state and attaches `onContextMenu` to the root tile div. Calls `preventDefault()` and opens the menu, gated on `showEditingControls !== false && canViewInsight` so it's inert on public/export/access-denied tiles.
- **`TextCard`** — same treatment for consistency, gated on the existing more-button visibility condition.

The menu anchors to the `⋯` button (top-right), consistent with a left-click. Normal left-click, click-outside-to-close, and click-inside-to-close all keep working through controlled mode.

Tradeoff: suppressing the native context menu on the tile body means you lose right-click → "open insight link in new tab" on the tile itself (the title link still supports it).

## How did you test this code?

I'm an agent (Claude Code). I did not manually test in a browser. Automated coverage I actually ran:

- `pnpm typescript:check` — passes with zero errors.
- Added two tests in `TextCard.test.tsx`:
  - Right-click opens the menu **and** prevents the native context menu.
  - Right-click on a `Public` tile (no menu) does **not** preventDefault and shows nothing — guards against hijacking right-click where there is no menu to show.

  (I could not execute jest in this environment — `node_modules` for jest isn't installed in the checkout — but the tests mirror the existing passing test in that file.)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). No repo skills were strictly required for this change (pure `.tsx` UI work); `/adopting-generated-api-types` was not triggered since no API types or `lib/api` calls were touched.

Key decision: chose to make the existing `More`/`LemonDropdown` controllable and drive it from a tile-level `onContextMenu` handler, rather than wrapping tiles in the Radix `ContextMenu` primitive. The Radix route would have required duplicating the entire menu structure (View/Edit/Rename/Duplicate/Alerts/colors/export/…) as `ContextMenuItem`s and keeping it in sync with the dropdown — far more surface area for the same outcome. Gating was added after noticing `InsightMeta` forces `showEditingControls={false}` on access-denied tiles, where preventing the native menu with nothing to show would be a regression.
