### PR TITLE
feat(dashboards): add starring to dashboards list behind A/B test

### DIFF
--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -218,7 +218,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
 
         setLastNewFolder: (folder: string | null) => ({ folder }),
 
-        addShortcutItem: (item: FileSystemEntry) => ({ item }),
+        addShortcutItem: (item: FileSystemEntry, source?: string) => ({ item, source }),
         deleteShortcut: (id: FileSystemEntry['id']) => ({ id }),
         loadShortcuts: true,
         reorderShortcuts: (orderedIds: NonNullable<FileSystemEntry['id']>[]) => ({ orderedIds }),
@@ -485,7 +485,7 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                     )
                     return response.results
                 },
-                addShortcutItem: async ({ item }) => {
+                addShortcutItem: async ({ item, source }) => {
                     const shortcutPath = joinPath([splitPath(item.path).pop() ?? 'Unnamed'])
 
                     const shortcutItem =
@@ -502,7 +502,11 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                                   href: item.href,
                               }
                     const response = await api.fileSystemShortcuts.create(shortcutItem)
-                    eventUsageLogic.actions.reportNavbarStarredItemAdded(shortcutItem.type ?? 'unknown', shortcutPath)
+                    eventUsageLogic.actions.reportNavbarStarredItemAdded(
+                        shortcutItem.type ?? 'unknown',
+                        shortcutPath,
+                        source
+                    )
                     lemonToast.success('Added to starred', {
                         button: {
                             label: 'View',

--- a/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
+++ b/frontend/src/layout/panel-layout/ProjectTree/projectTreeDataLogic.tsx
@@ -862,6 +862,23 @@ export const projectTreeDataLogic = kea<projectTreeDataLogicType>([
                 return keyedByRef
             },
         ],
+        // The user's starred items, keyed by `${type}::${ref}` — the canonical "is this entity
+        // starred, and which shortcut row is it?" lookup. Mirrors `itemsByRef` but over the user's
+        // shortcuts rather than the loaded tree, so callers don't each re-scan `shortcutData`.
+        shortcutByTypeRef: [
+            (s) => [s.shortcutData],
+            (shortcutData): Record<string, FileSystemEntry> => {
+                const keyedByRef: Record<string, FileSystemEntry> = {}
+
+                for (const shortcut of shortcutData) {
+                    if (shortcut.type && shortcut.ref) {
+                        keyedByRef[`${shortcut.type}::${shortcut.ref}`] = shortcut
+                    }
+                }
+
+                return keyedByRef
+            },
+        ],
         itemsByHref: [
             (s) => [s.sortedItems],
             (sortedItems): Record<string, FileSystemEntry> => {

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -174,6 +174,7 @@ export const FEATURE_FLAGS = {
 
     // UX flags, used to control the UX of the app
     CREATE_BUTTON_NAV_EXPERIMENT: 'create-button-nav-experiment', // owner: #team-platform-ux multivariate=control,test — adds a Create dropdown to the top of the Browse tab in the left nav
+    DASHBOARDS_LIST_STARRING: 'dashboards-list-starring', // owner: @matt.p multivariate=control,test — adds a star button + Starred filter to the dashboards list; measuring whether more users favourite dashboards
     STARRED_REORDER: 'starred-reorder', // owner: #team-platform-ux, drag-and-drop reorder of starred shortcuts in the side panel
     UX_HIDE_PROJECT_NOTICE: 'ux-hide-project-notice', // owner: #team-platform-ux, hides the project notice banner across all scenes
 

--- a/frontend/src/lib/utils/eventUsageLogic.ts
+++ b/frontend/src/lib/utils/eventUsageLogic.ts
@@ -1166,9 +1166,10 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
         reportUsageMetricUpdated: () => true,
         reportUsageMetricDeleted: () => true,
         // navbar starred
-        reportNavbarStarredItemAdded: (itemType: string, itemName: string) => ({
+        reportNavbarStarredItemAdded: (itemType: string, itemName: string, source?: string) => ({
             itemType,
             itemName,
+            source,
         }),
         reportNavbarStarredItemRemoved: (itemType: string, itemName: string) => ({
             itemType,
@@ -2680,10 +2681,11 @@ export const eventUsageLogic = kea<eventUsageLogicType>([
             const eventName = delay ? 'person profile analyzed' : 'person profile viewed'
             posthog.capture(eventName, { delay })
         },
-        reportNavbarStarredItemAdded: ({ itemType, itemName }) => {
+        reportNavbarStarredItemAdded: ({ itemType, itemName, source }) => {
             posthog.capture('navbar starred item added', {
                 item_type: itemType,
                 item_name: itemName,
+                source,
             })
         },
         reportNavbarStarredItemRemoved: ({ itemType, itemName }) => {

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsFiltersBar.tsx
@@ -1,10 +1,20 @@
 import { useActions, useValues } from 'kea'
 import { useDebouncedCallback } from 'use-debounce'
 
-import { IconChevronDown, IconFolder, IconPin, IconPinFilled, IconShare, IconX } from '@posthog/icons'
+import {
+    IconChevronDown,
+    IconFolder,
+    IconPin,
+    IconPinFilled,
+    IconShare,
+    IconStar,
+    IconStarFilled,
+    IconX,
+} from '@posthog/icons'
 import { LemonInput, Popover } from '@posthog/lemon-ui'
 
 import { MemberSelectMultiplePopover } from 'lib/components/MemberSelectMultiplePopover'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { DashboardsTab, dashboardsLogic } from 'scenes/dashboard/dashboards/dashboardsLogic'
 
@@ -15,6 +25,7 @@ interface DashboardsFiltersBarProps {
 export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps): JSX.Element {
     const { filters, currentTab, filteredTags, tagSearch, showTagPopover } = useValues(dashboardsLogic)
     const { setFilters, setTagSearch, setShowTagPopover, setSearch } = useActions(dashboardsLogic)
+    const showStarring = useFeatureFlag('DASHBOARDS_LIST_STARRING', 'test')
 
     const createdByIds = filters.createdBy === 'All users' ? [] : filters.createdBy
 
@@ -56,6 +67,19 @@ export function DashboardsFiltersBar({ extraActions }: DashboardsFiltersBarProps
                                 icon={filters.pinned ? <IconPinFilled /> : <IconPin />}
                             >
                                 Pinned
+                            </LemonButton>
+                        </div>
+                    )}
+                    {showStarring && (
+                        <div className="flex items-center gap-2">
+                            <LemonButton
+                                active={filters.starred}
+                                type="secondary"
+                                size="small"
+                                onClick={() => setFilters({ starred: !filters.starred })}
+                                icon={filters.starred ? <IconStarFilled /> : <IconStar />}
+                            >
+                                Starred
                             </LemonButton>
                         </div>
                     )}

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -51,9 +51,9 @@ import { DashboardsFiltersBar } from './DashboardsFiltersBar'
 
 export function DashboardsTableContainer(): JSX.Element {
     const { dashboardsLoading } = useValues(dashboardsModel)
-    const { dashboards } = useValues(dashboardsLogic)
+    const { dashboards, starredFilterPending } = useValues(dashboardsLogic)
 
-    return <DashboardsTable dashboards={dashboards} dashboardsLoading={dashboardsLoading} />
+    return <DashboardsTable dashboards={dashboards} dashboardsLoading={dashboardsLoading || starredFilterPending} />
 }
 
 interface DashboardsTableProps {
@@ -97,7 +97,7 @@ export function DashboardsTable({
                                   const shortcut = shortcutData.find(
                                       (s) => s.type === 'dashboard' && s.ref === String(id)
                                   )
-                                  if (shortcut) {
+                                  if (shortcut?.id) {
                                       deleteShortcut(shortcut.id)
                                   }
                               }

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -1,11 +1,21 @@
 import { useActions, useValues } from 'kea'
 
-import { IconFolder, IconHome, IconLock, IconPin, IconPinFilled, IconShare } from '@posthog/icons'
+import {
+    IconFolder,
+    IconHome,
+    IconLock,
+    IconPin,
+    IconPinFilled,
+    IconShare,
+    IconStar,
+    IconStarFilled,
+} from '@posthog/icons'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { BulkUpdateTagsButton } from 'lib/components/BulkActions/BulkUpdateTagsButton'
 import { moveToLogic } from 'lib/components/FileSystem/MoveTo/moveToLogic'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { More } from 'lib/lemon-ui/LemonButton/More'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
@@ -26,6 +36,7 @@ import { urls } from 'scenes/urls'
 
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { dashboardsModel, nameCompareFunction } from '~/models/dashboardsModel'
+import { FileSystemEntry } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -60,7 +71,8 @@ export function DashboardsTable({
 }: DashboardsTableProps): JSX.Element {
     const { unpinDashboard, pinDashboard } = useActions(dashboardsModel)
     const { tableSortingChanged, setFilters } = useActions(dashboardsLogic)
-    const { tableSorting, filters } = useValues(dashboardsLogic)
+    const { tableSorting, filters, starredDashboardRefs } = useValues(dashboardsLogic)
+    const { addShortcutItem, deleteShortcut } = useActions(projectTreeDataLogic)
     // Server-side fuzzy search ranks results by relevance; re-sorting alphabetically by name
     // would push the exact match below partial matches. Suppress the persisted column sort
     // while the user has an active search term.
@@ -69,7 +81,45 @@ export function DashboardsTable({
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
     const { openMoveToModal } = useActions(moveToLogic)
-    const { itemsByRef } = useValues(projectTreeDataLogic)
+    const { itemsByRef, shortcutData } = useValues(projectTreeDataLogic)
+    const showStarring = useFeatureFlag('DASHBOARDS_LIST_STARRING', 'test')
+
+    const starColumn: LemonTableColumn<DashboardType, keyof DashboardType | undefined> = {
+        width: 0,
+        render: function Render(_, { id, name }) {
+            const isStarred = starredDashboardRefs.has(String(id))
+            return (
+                <LemonButton
+                    size="small"
+                    onClick={
+                        isStarred
+                            ? () => {
+                                  const shortcut = shortcutData.find(
+                                      (s) => s.type === 'dashboard' && s.ref === String(id)
+                                  )
+                                  if (shortcut) {
+                                      deleteShortcut(shortcut.id)
+                                  }
+                              }
+                            : () => {
+                                  // Reuse the file-system "shortcuts" feature for starring. Prefer the real
+                                  // tree entry when it's loaded; otherwise build a minimal one from the row.
+                                  const entry: FileSystemEntry = itemsByRef[`dashboard::${id}`] ?? {
+                                      id: `dashboard::${id}`,
+                                      path: name || 'Untitled',
+                                      type: 'dashboard',
+                                      ref: String(id),
+                                      href: urls.dashboard(id),
+                                  }
+                                  addShortcutItem(entry, 'dashboards_list')
+                              }
+                    }
+                    tooltip={isStarred ? 'Remove from starred' : 'Add to starred'}
+                    icon={isStarred ? <IconStarFilled /> : <IconStar />}
+                />
+            )
+        },
+    }
 
     const columns: LemonTableColumns<DashboardType> = [
         {
@@ -90,6 +140,7 @@ export function DashboardsTable({
                 )
             },
         },
+        ...(showStarring ? [starColumn] : []),
         {
             title: 'Name',
             dataIndex: 'name',

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -36,7 +36,6 @@ import { urls } from 'scenes/urls'
 
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { dashboardsModel, nameCompareFunction } from '~/models/dashboardsModel'
-import { FileSystemEntry } from '~/queries/schema/schema-general'
 import {
     AccessControlLevel,
     AccessControlResourceType,
@@ -70,9 +69,8 @@ export function DashboardsTable({
     hideActions,
 }: DashboardsTableProps): JSX.Element {
     const { unpinDashboard, pinDashboard } = useActions(dashboardsModel)
-    const { tableSortingChanged, setFilters } = useActions(dashboardsLogic)
+    const { tableSortingChanged, setFilters, toggleStarredDashboard } = useActions(dashboardsLogic)
     const { tableSorting, filters, starredDashboardRefs } = useValues(dashboardsLogic)
-    const { addShortcutItem, deleteShortcut } = useActions(projectTreeDataLogic)
     // Server-side fuzzy search ranks results by relevance; re-sorting alphabetically by name
     // would push the exact match below partial matches. Suppress the persisted column sort
     // while the user has an active search term.
@@ -81,26 +79,8 @@ export function DashboardsTable({
     const { showDuplicateDashboardModal } = useActions(duplicateDashboardLogic)
     const { showDeleteDashboardModal } = useActions(deleteDashboardLogic)
     const { openMoveToModal } = useActions(moveToLogic)
-    const { itemsByRef, shortcutData } = useValues(projectTreeDataLogic)
+    const { itemsByRef } = useValues(projectTreeDataLogic)
     const showStarring = useFeatureFlag('DASHBOARDS_LIST_STARRING', 'test')
-
-    // Reuse the file-system "shortcuts" feature for starring. Prefer the real tree entry when it's
-    // loaded; otherwise build a minimal one from the dashboard row.
-    const toggleStarred = (id: number, name: string): void => {
-        const shortcut = shortcutData.find((s) => s.type === 'dashboard' && s.ref === String(id))
-        if (shortcut?.id) {
-            deleteShortcut(shortcut.id)
-            return
-        }
-        const entry: FileSystemEntry = itemsByRef[`dashboard::${id}`] ?? {
-            id: `dashboard::${id}`,
-            path: name || 'Untitled',
-            type: 'dashboard',
-            ref: String(id),
-            href: urls.dashboard(id),
-        }
-        addShortcutItem(entry, 'dashboards_list')
-    }
 
     const columns: LemonTableColumns<DashboardType> = [
         {
@@ -251,7 +231,7 @@ export function DashboardsTable({
 
                                       {showStarring && (
                                           <LemonButton
-                                              onClick={() => toggleStarred(id, name)}
+                                              onClick={() => toggleStarredDashboard(id, name)}
                                               icon={
                                                   isStarred ? (
                                                       <IconStarFilled className="size-4" />

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -252,7 +252,13 @@ export function DashboardsTable({
                                       {showStarring && (
                                           <LemonButton
                                               onClick={() => toggleStarred(id, name)}
-                                              icon={isStarred ? <IconStarFilled /> : <IconStar />}
+                                              icon={
+                                                  isStarred ? (
+                                                      <IconStarFilled className="size-4" />
+                                                  ) : (
+                                                      <IconStar className="size-4" />
+                                                  )
+                                              }
                                               fullWidth
                                           >
                                               {isStarred ? 'Remove from starred' : 'Add to starred'}

--- a/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
+++ b/frontend/src/scenes/dashboard/dashboards/DashboardsTable.tsx
@@ -84,41 +84,22 @@ export function DashboardsTable({
     const { itemsByRef, shortcutData } = useValues(projectTreeDataLogic)
     const showStarring = useFeatureFlag('DASHBOARDS_LIST_STARRING', 'test')
 
-    const starColumn: LemonTableColumn<DashboardType, keyof DashboardType | undefined> = {
-        width: 0,
-        render: function Render(_, { id, name }) {
-            const isStarred = starredDashboardRefs.has(String(id))
-            return (
-                <LemonButton
-                    size="small"
-                    onClick={
-                        isStarred
-                            ? () => {
-                                  const shortcut = shortcutData.find(
-                                      (s) => s.type === 'dashboard' && s.ref === String(id)
-                                  )
-                                  if (shortcut?.id) {
-                                      deleteShortcut(shortcut.id)
-                                  }
-                              }
-                            : () => {
-                                  // Reuse the file-system "shortcuts" feature for starring. Prefer the real
-                                  // tree entry when it's loaded; otherwise build a minimal one from the row.
-                                  const entry: FileSystemEntry = itemsByRef[`dashboard::${id}`] ?? {
-                                      id: `dashboard::${id}`,
-                                      path: name || 'Untitled',
-                                      type: 'dashboard',
-                                      ref: String(id),
-                                      href: urls.dashboard(id),
-                                  }
-                                  addShortcutItem(entry, 'dashboards_list')
-                              }
-                    }
-                    tooltip={isStarred ? 'Remove from starred' : 'Add to starred'}
-                    icon={isStarred ? <IconStarFilled /> : <IconStar />}
-                />
-            )
-        },
+    // Reuse the file-system "shortcuts" feature for starring. Prefer the real tree entry when it's
+    // loaded; otherwise build a minimal one from the dashboard row.
+    const toggleStarred = (id: number, name: string): void => {
+        const shortcut = shortcutData.find((s) => s.type === 'dashboard' && s.ref === String(id))
+        if (shortcut?.id) {
+            deleteShortcut(shortcut.id)
+            return
+        }
+        const entry: FileSystemEntry = itemsByRef[`dashboard::${id}`] ?? {
+            id: `dashboard::${id}`,
+            path: name || 'Untitled',
+            type: 'dashboard',
+            ref: String(id),
+            href: urls.dashboard(id),
+        }
+        addShortcutItem(entry, 'dashboards_list')
     }
 
     const columns: LemonTableColumns<DashboardType> = [
@@ -140,7 +121,6 @@ export function DashboardsTable({
                 )
             },
         },
-        ...(showStarring ? [starColumn] : []),
         {
             title: 'Name',
             dataIndex: 'name',
@@ -221,6 +201,7 @@ export function DashboardsTable({
             : {
                   width: 0,
                   render: function RenderActions(_, { id, name, user_access_level }: DashboardType) {
+                      const isStarred = starredDashboardRefs.has(String(id))
                       return (
                           <More
                               overlay={
@@ -267,6 +248,16 @@ export function DashboardsTable({
                                       >
                                           Duplicate
                                       </LemonButton>
+
+                                      {showStarring && (
+                                          <LemonButton
+                                              onClick={() => toggleStarred(id, name)}
+                                              icon={isStarred ? <IconStarFilled /> : <IconStar />}
+                                              fullWidth
+                                          >
+                                              {isStarred ? 'Remove from starred' : 'Add to starred'}
+                                          </LemonButton>
+                                      )}
 
                                       {itemsByRef[`dashboard::${id}`] && (
                                           <AccessControlAction

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.test.ts
@@ -8,8 +8,10 @@ import { sceneLogic } from 'scenes/sceneLogic'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { useMocks } from '~/mocks/jest'
 import { dashboardsModel } from '~/models/dashboardsModel'
+import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { initKeaTests } from '~/test/init'
 import { AppContext, DashboardType, UserBasicType } from '~/types'
 
@@ -134,6 +136,53 @@ describe('dashboardsLogic', () => {
                     dashboards.length === inFolder.length && dashboards.every((d) => d.folder === 'Marketing/Website')
             ),
         })
+    })
+
+    it('filters to starred dashboards once shortcuts have loaded', async () => {
+        // Starring is backed by file-system shortcuts: a starred dashboard has a shortcut whose
+        // type is 'dashboard' and ref is the dashboard id. Seed one and assert the filter narrows
+        // to exactly that dashboard.
+        const starred = allDashboards[1] as DashboardType
+        projectTreeDataLogic.actions.loadShortcutsSuccess([
+            { id: 'sc-1', path: 'Starred', type: 'dashboard', ref: String(starred.id) } as FileSystemEntry,
+        ])
+
+        await expectLogic(logic, () => {
+            logic.actions.setFilters({ starred: true })
+        }).toMatchValues({
+            dashboards: truth(
+                (dashboards: DashboardType[]) =>
+                    dashboards.length === 1 && String(dashboards[0].id) === String(starred.id)
+            ),
+        })
+    })
+
+    it('toggleStarredDashboard stars an unstarred dashboard and unstars a starred one', async () => {
+        const target = allDashboards[2] as DashboardType
+        useMocks({
+            post: {
+                '/api/environments/:team_id/file_system_shortcut/': {
+                    id: 'sc-new',
+                    path: target.name,
+                    type: 'dashboard',
+                    ref: String(target.id),
+                },
+            },
+            delete: { '/api/environments/:team_id/file_system_shortcut/:id/': { success: true } },
+        })
+
+        // Not starred yet → toggling creates a shortcut.
+        await expectLogic(projectTreeDataLogic, () => {
+            logic.actions.toggleStarredDashboard(target.id, target.name)
+        }).toDispatchActions(['addShortcutItem'])
+
+        // Now that it's starred, toggling removes the shortcut.
+        projectTreeDataLogic.actions.loadShortcutsSuccess([
+            { id: 'sc-new', path: target.name, type: 'dashboard', ref: String(target.id) } as FileSystemEntry,
+        ])
+        await expectLogic(projectTreeDataLogic, () => {
+            logic.actions.toggleStarredDashboard(target.id, target.name)
+        }).toDispatchActions(['deleteShortcut'])
     })
 
     it('shows dashboards from all selected creators when multiple are chosen', async () => {
@@ -342,6 +391,7 @@ describe('dashboardsLogic', () => {
             expected: [2],
         },
         { name: 'pinned', set: { pinned: true }, reset: { pinned: false }, param: 'pinned', expected: true },
+        { name: 'starred', set: { starred: true }, reset: { starred: false }, param: 'starred', expected: true },
         { name: 'shared', set: { shared: true }, reset: { shared: false }, param: 'shared', expected: true },
         { name: 'tags', set: { tags: ['finance'] }, reset: { tags: [] }, param: 'tags', expected: ['finance'] },
     ]
@@ -368,6 +418,7 @@ describe('dashboardsLogic', () => {
     }> = [
         { name: 'created_by', params: { created_by: [2] }, expected: { createdBy: [2] } },
         { name: 'pinned', params: { pinned: true }, expected: { pinned: true } },
+        { name: 'starred', params: { starred: true }, expected: { starred: true } },
         { name: 'shared', params: { shared: true }, expected: { shared: true } },
         { name: 'tags', params: { tags: ['finance', 'q4'] }, expected: { tags: ['finance', 'q4'] } },
     ]

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -11,6 +11,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
+import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { tagsModel } from '~/models/tagsModel'
 import { ActivityScope, Breadcrumb, DashboardBasicType } from '~/types'
@@ -30,6 +31,7 @@ export interface DashboardsFilters {
     search: string
     createdBy: number[] | 'All users'
     pinned: boolean
+    starred: boolean
     shared: boolean
     tags?: string[]
     /** Folder path to filter to, e.g. 'Unfiled/Dashboards' (empty string = project root). null means no folder filter. */
@@ -40,6 +42,7 @@ export const DEFAULT_FILTERS: DashboardsFilters = {
     search: '',
     createdBy: 'All users',
     pinned: false,
+    starred: false,
     shared: false,
     tags: [],
     folder: null,
@@ -177,6 +180,18 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 return (tags || []).filter((tag) => tag.toLowerCase().includes(search.toLowerCase()))
             },
         ],
+        // Starring reuses the file-system "shortcuts" feature: a starred dashboard has a
+        // FileSystemShortcut row (per-user) whose `ref` is the dashboard id. Build the set of
+        // starred dashboard ids so both the list filter and per-row toggle can read it.
+        starredDashboardRefs: [
+            () => [projectTreeDataLogic.selectors.shortcutData],
+            (shortcutData): Set<string> =>
+                new Set(
+                    shortcutData
+                        .filter((shortcut) => shortcut.type === 'dashboard' && shortcut.ref)
+                        .map((shortcut) => shortcut.ref as string)
+                ),
+        ],
         dashboards: [
             (s) => [
                 dashboardsModel.selectors.nameSortedDashboards,
@@ -185,8 +200,9 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 s.filters,
                 s.currentTab,
                 s.user,
+                s.starredDashboardRefs,
             ],
-            (allDashboards, rawDashboards, searchedDashboards, filters, currentTab, user) => {
+            (allDashboards, rawDashboards, searchedDashboards, filters, currentTab, user, starredDashboardRefs) => {
                 // When a search term is active we trust the server's trigram word similarity
                 // ranking; otherwise we use the model's alphabetised list. This keeps the exact
                 // match at the top.
@@ -204,6 +220,9 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 }
                 if (filters.pinned) {
                     haystack = haystack.filter((d) => d.pinned)
+                }
+                if (filters.starred) {
+                    haystack = haystack.filter((d) => starredDashboardRefs.has(String(d.id)))
                 }
                 if (filters.shared) {
                     haystack = haystack.filter((d) => d.is_shared)
@@ -274,7 +293,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             return [router.values.location.pathname, searchParams, router.values.hashParams, { replace: true }]
         },
         setFilters: () => {
-            const { createdBy, pinned, shared, tags } = values.filters
+            const { createdBy, pinned, starred, shared, tags } = values.filters
             const searchParams: Record<string, any> = { ...router.values.searchParams }
 
             if (createdBy !== DEFAULT_FILTERS.createdBy) {
@@ -286,6 +305,11 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 searchParams['pinned'] = true
             } else {
                 delete searchParams['pinned']
+            }
+            if (starred) {
+                searchParams['starred'] = true
+            } else {
+                delete searchParams['starred']
             }
             if (shared) {
                 searchParams['shared'] = true
@@ -334,6 +358,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             const nextFilters = {
                 createdBy: createdByIds.length > 0 ? createdByIds : DEFAULT_FILTERS.createdBy,
                 pinned: searchParams['pinned'] === true || searchParams['pinned'] === 'true',
+                starred: searchParams['starred'] === true || searchParams['starred'] === 'true',
                 shared: searchParams['shared'] === true || searchParams['shared'] === 'true',
                 tags: Array.isArray(searchParams['tags']) ? searchParams['tags'] : DEFAULT_FILTERS.tags,
                 folder: 'folder' in searchParams ? urlSearchParamToString(searchParams['folder']) : null,
@@ -342,6 +367,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             if (
                 !objectsEqual(current.createdBy, nextFilters.createdBy) ||
                 current.pinned !== nextFilters.pinned ||
+                current.starred !== nextFilters.starred ||
                 current.shared !== nextFilters.shared ||
                 !objectsEqual(current.tags ?? [], nextFilters.tags ?? []) ||
                 (current.folder ?? null) !== nextFilters.folder

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -8,12 +8,14 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { objectClean, objectsEqual } from 'lib/utils/objects'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 import { userLogic } from 'scenes/userLogic'
 
 import { SIDE_PANEL_CONTEXT_KEY, SidePanelSceneContext } from '~/layout/navigation-3000/sidepanel/types'
 import { projectTreeDataLogic } from '~/layout/panel-layout/ProjectTree/projectTreeDataLogic'
 import { dashboardsModel } from '~/models/dashboardsModel'
 import { tagsModel } from '~/models/tagsModel'
+import { FileSystemEntry } from '~/queries/schema/schema-general'
 import { ActivityScope, Breadcrumb, DashboardBasicType } from '~/types'
 
 import type { dashboardsLogicType } from './dashboardsLogicType'
@@ -69,6 +71,7 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
         }),
         setTagSearch: (search: string) => ({ search }),
         setShowTagPopover: (visible: boolean) => ({ visible }),
+        toggleStarredDashboard: (id: number, name: string) => ({ id, name }),
     }),
     reducers({
         tableSorting: [
@@ -181,13 +184,14 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
             },
         ],
         // Starring reuses the file-system "shortcuts" feature: a starred dashboard has a
-        // FileSystemShortcut row (per-user) whose `ref` is the dashboard id. Build the set of
-        // starred dashboard ids so both the list filter and per-row toggle can read it.
+        // FileSystemShortcut row (per-user) whose `ref` is the dashboard id. Project the canonical
+        // `shortcutByTypeRef` map down to the set of starred dashboard ids for the list filter and
+        // the per-row star icon.
         starredDashboardRefs: [
-            () => [projectTreeDataLogic.selectors.shortcutData],
-            (shortcutData): Set<string> =>
+            () => [projectTreeDataLogic.selectors.shortcutByTypeRef],
+            (shortcutByTypeRef): Set<string> =>
                 new Set(
-                    shortcutData
+                    Object.values(shortcutByTypeRef)
                         .filter((shortcut) => shortcut.type === 'dashboard' && shortcut.ref)
                         .map((shortcut) => shortcut.ref as string)
                 ),
@@ -419,6 +423,24 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                     folder: values.filters.folder ?? null,
                 })
             }
+        },
+        toggleStarredDashboard: ({ id, name }) => {
+            // Star/unstar a dashboard via the file-system shortcuts feature. If a shortcut already
+            // exists, remove it; otherwise create one — preferring the real tree entry when it's
+            // loaded, falling back to a minimal entry built from the row.
+            const existing = projectTreeDataLogic.values.shortcutByTypeRef[`dashboard::${id}`]
+            if (existing?.id) {
+                projectTreeDataLogic.actions.deleteShortcut(existing.id)
+                return
+            }
+            const entry: FileSystemEntry = projectTreeDataLogic.values.itemsByRef[`dashboard::${id}`] ?? {
+                id: `dashboard::${id}`,
+                path: name || 'Untitled',
+                type: 'dashboard',
+                ref: String(id),
+                href: urls.dashboard(id),
+            }
+            projectTreeDataLogic.actions.addShortcutItem(entry, 'dashboards_list')
         },
     })),
 ])

--- a/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
+++ b/frontend/src/scenes/dashboard/dashboards/dashboardsLogic.ts
@@ -192,6 +192,13 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                         .map((shortcut) => shortcut.ref as string)
                 ),
         ],
+        // True while the user has the Starred filter on but their shortcuts haven't loaded yet.
+        // Without this, a bookmarked `?starred=true` would filter every dashboard out (shortcutData
+        // starts empty and loads async) and look broken — so we hold the table in a loading state instead.
+        starredFilterPending: [
+            (s) => [s.filters, projectTreeDataLogic.selectors.shortcutDataHasLoaded],
+            (filters, shortcutDataHasLoaded): boolean => filters.starred === true && !shortcutDataHasLoaded,
+        ],
         dashboards: [
             (s) => [
                 dashboardsModel.selectors.nameSortedDashboards,
@@ -201,8 +208,18 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 s.currentTab,
                 s.user,
                 s.starredDashboardRefs,
+                projectTreeDataLogic.selectors.shortcutDataHasLoaded,
             ],
-            (allDashboards, rawDashboards, searchedDashboards, filters, currentTab, user, starredDashboardRefs) => {
+            (
+                allDashboards,
+                rawDashboards,
+                searchedDashboards,
+                filters,
+                currentTab,
+                user,
+                starredDashboardRefs,
+                shortcutDataHasLoaded
+            ) => {
                 // When a search term is active we trust the server's trigram word similarity
                 // ranking; otherwise we use the model's alphabetised list. This keeps the exact
                 // match at the top.
@@ -221,7 +238,9 @@ export const dashboardsLogic = kea<dashboardsLogicType>([
                 if (filters.pinned) {
                     haystack = haystack.filter((d) => d.pinned)
                 }
-                if (filters.starred) {
+                // Only narrow to starred once shortcuts have loaded — otherwise the set is still empty
+                // and we'd wrongly hide everything (the table shows a loading state via starredFilterPending).
+                if (filters.starred && shortcutDataHasLoaded) {
                     haystack = haystack.filter((d) => starredDashboardRefs.has(String(d.id)))
                 }
                 if (filters.shared) {


### PR DESCRIPTION
## Problem

Favouriting a dashboard only happens through the project tree's "Add to starred" menu — there's no affordance on the dashboards list, where people actually browse dashboards. We want to test whether putting a star on the list gets more people to favourite dashboards.

## Changes

- Star button per row + a "Starred" filter in the filter bar.
- Reuses the existing file-system shortcuts (`FileSystemShortcut`) feature — per-user, team-scoped favourites shared with the project tree/Shortcuts panel. No new model; the list calls `addShortcutItem`/`deleteShortcut` and reads `shortcutData` from `projectTreeDataLogic`.
- Gated behind the `dashboards-list-starring` experiment flag (`control`/`test`) — only test sees it; reading the flag emits the `$feature_flag_called` exposure.
- Added a `source` property to `navbar starred item added` so list stars are distinguishable from tree stars.

Star is per-user (personal favourite), intentionally distinct from the team-wide pin.

## How did you test this code?

I'm an agent — no manual testing, and I couldn't run typecheck/lint locally (frontend `node_modules` not installed). Before merge, run `pnpm --filter=@posthog/frontend typescript:check` + `format` and smoke-test star/unstar + the Starred filter with the flag on `test`. No automated tests added yet.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Wired the list's star button + filter to the existing `projectTreeDataLogic` shortcut actions/selectors rather than adding a new data model; gated behind a new feature flag via `useFeatureFlag('...', 'test')`. Created the matching draft experiment (flag `dashboards-list-starring`) with a primary funnel metric (exposed users who fire `navbar starred item added`, `item_type=dashboard`) and a secondary un-favouriting guardrail; invoked the `creating-experiments` skill. Note for review: the primary metric counts net favouriting (control can still favourite via the tree), so it measures lift from the new entry point.
