### PR TITLE
fix(clickhouse): treat unsupported Arrow column type as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/source.py
@@ -213,6 +213,13 @@ class ClickHouseSource(SimpleSource[ClickHouseSourceConfig], SSHTunnelMixin, Val
             # replays the identical failure, so stop and tell the customer to fix the schema.
             # We match the stable suffix, not the volatile `<database>.<table>` prefix.
             "not found or has no columns": "We couldn't find this table in your ClickHouse database — it may have been dropped or renamed. If you were syncing a materialized view, sync it by its own name rather than its internal `.inner_id.<uuid>` table (those names change whenever the view is recreated). Remove or re-point this table in your source, then resync.",
+            # UNKNOWN_TYPE (code 50) raised while ClickHouse streams our extraction
+            # query as Arrow: a selected column has a type ClickHouse can't serialize
+            # to Arrow (e.g. an `AggregateFunction(...)` state column on an aggregating
+            # materialized view). The column type is fixed, so retrying replays the
+            # identical failure. We match the stable Arrow-conversion phrase, not the
+            # volatile column name or type in the message.
+            "is not supported for conversion into Arrow data format": "One of the columns in this table has a type ClickHouse can't export (for example an `AggregateFunction` state column on an aggregating materialized view). Deselect that column in this schema's column settings, or sync a view that finalizes it, then resync.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/clickhouse/test_clickhouse.py
@@ -640,6 +640,11 @@ class TestClickHouseSourceNonRetryableErrors:
             # view's `.inner_id.<uuid>` inner table whose UUID changed when the view was recreated.
             "Table soax_stage..inner_id.8c612ff0-b72c-4b20-8ea5-405ed002c2f6 not found or has no columns",
             "Table default.some_dropped_table not found or has no columns",
+            # UNKNOWN_TYPE (code 50) — a column type ClickHouse can't serialize to Arrow,
+            # e.g. an AggregateFunction state column on an aggregating materialized view.
+            "HTTPDriver for https://host:8443 received ClickHouse error code 50\n Code: 50. "
+            "DB::Exception: The type 'AggregateFunction(uniq, String)' of a column 'profile_id' "
+            "is not supported for conversion into Arrow data format: While executing Arrow. (UNKNOWN_TYPE)",
         ],
     )
     def test_permanent_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A ClickHouse data-warehouse import keeps retrying — and re-failing — when the source table contains a column ClickHouse can't serialize to Arrow. We stream extraction queries in Arrow format, and ClickHouse rejects certain column types at export time with `UNKNOWN_TYPE` (code 50):

```
Code: 50. DB::Exception: The type 'AggregateFunction(...)' of a column '<name>'
is not supported for conversion into Arrow data format: While executing Arrow. (UNKNOWN_TYPE)
```

This shows up most often on aggregating materialized views, whose state columns are `AggregateFunction(...)` and hold binary intermediate aggregation states. The column type is fixed, so every retry replays the identical failure — the import burned its full retry budget before surfacing.

Observed via error tracking: [issue 019f04d6-e2b4-7933-af05-7c9ca31221cc](https://us.posthog.com/project/2/error_tracking/019f04d6-e2b4-7933-af05-7c9ca31221cc). The failing frame is in `clickhouse.py:get_rows`, at the `query_arrow_stream` call inside our source.

## Changes

Treat this as a non-retryable, user-actionable error. Added the stable Arrow-conversion phrase to `ClickHouseSource.get_non_retryable_errors()` with a message telling the user to deselect the offending column (column selection is already supported for this source) or sync a view that finalizes it.

The match is on the stable substring `is not supported for conversion into Arrow data format` — not the volatile column name or type in the message, and not the broad `Code: 50` (which would risk matching unrelated `UNKNOWN_TYPE` cases). This mirrors the existing ClickHouse error-code mappings in the same method (e.g. memory/disk/table-missing).

## How did you test this code?

I'm an agent. I did not manually run an import. I added a parameterized case to `TestClickHouseSourceNonRetryableErrors::test_permanent_errors_are_non_retryable` covering the real Arrow-conversion error string, and verified the new substring matches that case while matching none of the existing transient cases in `test_transient_errors_are_retryable`. The regression this guards: an unsupported-Arrow-type failure being retried instead of failing fast with guidance. `ruff check` and `ruff format --check` pass on both changed files. The full pytest suite couldn't run in this environment (no Django/pytest installed); the new test is a pure substring-matching case in the same shape as the existing passing ones.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the ClickHouse warehouse source. Confirmed the stack originates in our `clickhouse.py:get_rows` (not just serialized log context), traced it to ClickHouse refusing to export an `AggregateFunction` column to Arrow.

Decision — non-retryable vs code fix: the alternative was auto-wrapping `AggregateFunction` columns with `finalizeAggregation()` in our SELECT. Rejected as out of scope and risky — it changes data semantics (approximate finalized values), needs to handle arbitrary inner aggregate types, and the source already supports column selection so the user can opt out per-column. The conservative, in-pattern fix is a non-retryable mapping, matching how this method already handles other fixed-state ClickHouse failures.

Checked for duplicates across open PRs (Arrow/conversion/non-retryable searches and the maintainer's own open PRs) — none address this root cause.