### PR TITLE
chore(test): shrink capture header-timeout test sleeps

### DIFF
--- a/rust/capture/tests/header_timeout.rs
+++ b/rust/capture/tests/header_timeout.rs
@@ -35,7 +35,7 @@ async fn start_server_with_header_timeout(
     tokio::spawn(async move { serve(listener, components).await });
 
     // Give server time to start
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    tokio::time::sleep(Duration::from_millis(20)).await;
 
     (addr, shutdown_token)
 }
@@ -44,8 +44,8 @@ async fn start_server_with_header_timeout(
 async fn test_header_read_timeout_closes_connection() {
     setup_tracing();
 
-    // Start server with 500ms header read timeout
-    let (addr, _shutdown) = start_server_with_header_timeout(Some(500)).await;
+    // Start server with a 70ms header read timeout
+    let (addr, _shutdown) = start_server_with_header_timeout(Some(70)).await;
 
     // Connect and send partial headers (slow loris style)
     let mut stream = TcpStream::connect(addr).await.unwrap();
@@ -55,7 +55,7 @@ async fn test_header_read_timeout_closes_connection() {
     // Don't send the final \r\n to complete headers - this simulates slow loris
 
     // Wait for longer than the timeout
-    tokio::time::sleep(Duration::from_millis(700)).await;
+    tokio::time::sleep(Duration::from_millis(150)).await;
 
     // Try to read - connection should be closed by server due to timeout
     let mut buf = [0u8; 1024];
@@ -84,8 +84,8 @@ async fn test_header_read_timeout_closes_connection() {
 async fn test_complete_headers_within_timeout_succeeds() {
     setup_tracing();
 
-    // Start server with 2 second header read timeout
-    let (addr, _shutdown) = start_server_with_header_timeout(Some(2000)).await;
+    // Start server with a generous header read timeout
+    let (addr, _shutdown) = start_server_with_header_timeout(Some(300)).await;
 
     // Connect and send complete headers quickly
     let mut stream = TcpStream::connect(addr).await.unwrap();
@@ -132,8 +132,8 @@ async fn test_disabled_header_timeout_allows_slow_headers() {
     // Send partial headers
     stream.write_all(b"GET / HTTP/1.1\r\n").await.unwrap();
 
-    // Wait 500ms (would have timed out if enabled with 500ms timeout)
-    tokio::time::sleep(Duration::from_millis(500)).await;
+    // Wait well past what a 70ms timeout would allow (it is disabled here)
+    tokio::time::sleep(Duration::from_millis(150)).await;
 
     // Now complete the headers
     stream.write_all(b"Host: localhost\r\n\r\n").await.unwrap();


### PR DESCRIPTION
## Problem

`rust/capture/tests/header_timeout.rs` guards capture's configurable slow-loris protection (`http1_header_read_timeout_ms`) — real DoS protection worth keeping. But the three tests slept far longer than needed (a 500ms server timeout + a 700ms client wait, a 500ms wait, plus 50ms server-start sleeps), so the file burned ~1.25s of real time every CI run.

## Changes

Shrink the timings while preserving the timeout-vs-wait margins that make the assertions meaningful:

| Spot | Before | After |
|---|---|---|
| header read timeout (close test) | 500ms | 70ms |
| client wait past timeout | 700ms | 150ms |
| header read timeout (success test) | 2000ms | 300ms |
| client wait (disabled-timeout test) | 500ms | 150ms |
| server-start sleep | 50ms | 20ms |

All three tests are kept; only the durations change. The wait is still comfortably longer than the timeout (150ms vs 70ms), so the slow-loris close path is exercised exactly as before.

## How did you test this code?

I'm an agent. Ran locally:

```
cargo test -p capture --test header_timeout
```

Result: 3 passed in 0.20s (down from ~1.25s of sleeping). Ran it 5 consecutive times to confirm the tighter margins are not flaky — all green.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a monorepo test-suite cleanup targeting high CI-wall-time tests. This file was explicitly flagged as a "fix the timings, do not delete" item — it tests our own DoS protection, not a framework default. Margins are preserved proportionally and the close happens over localhost (sub-ms FIN propagation), so the shrink is safe. Tool: Claude Code (Opus 4.8).

Requesting review from: Ingestion
