### PR TITLE
fix(snowflake): recognise account-not-found 404 during credential validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -1,6 +1,6 @@
 from typing import Optional, cast
 
-from snowflake.connector.errors import DatabaseError, ForbiddenError, ProgrammingError
+from snowflake.connector.errors import DatabaseError, ForbiddenError, HttpError, ProgrammingError
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
@@ -41,6 +41,11 @@ SnowflakeErrors = {
     "This session does not have a current database": "Database specified not found",
     "Verify the account name is correct": "Can't find an account with the specified account ID",
     "Multi-factor authentication is required for this account": "This Snowflake account requires multi-factor authentication enrollment. Connect with a service user that uses key-pair authentication or is exempt from MFA.",
+    # Snowflake error 290404: the login-request endpoint 404s because the account identifier doesn't
+    # resolve to a real deployment (wrong/incomplete account id, missing region/cloud segment). The
+    # connector raises HttpError rather than the "Verify the account name is correct" OperationalError,
+    # so it needs its own entry. The host and port in the message are volatile, so we match "404 Not Found".
+    "404 Not Found": "Can't find a Snowflake account with the specified account ID. Please check your account identifier and try again.",
 }
 
 
@@ -268,7 +273,7 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
 
         try:
             self.get_schemas(config, team_id)
-        except (ProgrammingError, DatabaseError, ForbiddenError) as e:
+        except (ProgrammingError, DatabaseError, ForbiddenError, HttpError) as e:
             error_msg = e.msg or e.raw_msg or ""
             for key, value in SnowflakeErrors.items():
                 if key in error_msg:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
-from snowflake.connector.errors import DatabaseError
+from snowflake.connector.errors import DatabaseError, HttpError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.predicates import (
@@ -854,3 +854,24 @@ class TestSnowflakeValidateCredentials:
 
         assert ok is False
         mock_capture.assert_called_once()
+
+    def test_account_not_found_http_error_returns_friendly_message_without_capture(self, source):
+        # HttpError is a sibling of DatabaseError/ProgrammingError, so a 404 on the login-request
+        # endpoint (a wrong/incomplete account id) must still be recognised as a user config error.
+        http_error = HttpError(
+            msg="404 Not Found: post acme.snowflakecomputing.com:443/session/v1/login-request",
+            errno=290404,
+            sqlstate="08001",
+            send_telemetry=False,
+        )
+        with (
+            patch.object(source, "get_schemas", side_effect=http_error),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source.capture_exception"
+            ) as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("password"), team_id=1)
+
+        assert ok is False
+        assert message is not None and "account ID" in message
+        mock_capture.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -855,15 +855,36 @@ class TestSnowflakeValidateCredentials:
         assert ok is False
         mock_capture.assert_called_once()
 
-    def test_account_not_found_http_error_returns_friendly_message_without_capture(self, source):
-        # HttpError is a sibling of DatabaseError/ProgrammingError, so a 404 on the login-request
-        # endpoint (a wrong/incomplete account id) must still be recognised as a user config error.
-        http_error = HttpError(
-            msg="404 Not Found: post acme.snowflakecomputing.com:443/session/v1/login-request",
-            errno=290404,
-            sqlstate="08001",
-            send_telemetry=False,
-        )
+    @pytest.mark.parametrize(
+        "http_error, expect_capture, message_fragment",
+        [
+            # HttpError is a sibling of DatabaseError/ProgrammingError, so a 404 on the login-request
+            # endpoint (a wrong/incomplete account id) must be recognised as a user config error and
+            # surface a friendly message without capture.
+            (
+                HttpError(
+                    msg="404 Not Found: post acme.snowflakecomputing.com:443/session/v1/login-request",
+                    errno=290404,
+                    sqlstate="08001",
+                    send_telemetry=False,
+                ),
+                False,
+                "account ID",
+            ),
+            # An unknown HttpError falls through the known-error matching and must still be captured.
+            (
+                HttpError(
+                    msg="503 Service Unavailable: post acme.snowflakecomputing.com:443/session/v1/login-request",
+                    errno=290503,
+                    sqlstate="08001",
+                    send_telemetry=False,
+                ),
+                True,
+                None,
+            ),
+        ],
+    )
+    def test_http_error_routing(self, source, http_error, expect_capture, message_fragment):
         with (
             patch.object(source, "get_schemas", side_effect=http_error),
             patch(
@@ -873,5 +894,8 @@ class TestSnowflakeValidateCredentials:
             ok, message = source.validate_credentials(_make_config("password"), team_id=1)
 
         assert ok is False
-        assert message is not None and "account ID" in message
-        mock_capture.assert_not_called()
+        if expect_capture:
+            mock_capture.assert_called_once()
+        else:
+            assert message is not None and message_fragment in message
+            mock_capture.assert_not_called()


### PR DESCRIPTION
## Problem

A Snowflake data-warehouse source set up with a wrong or incomplete account identifier fails credential validation with a connector `HttpError` — a `404 Not Found` from the `…/session/v1/login-request` endpoint, because the account identifier doesn't resolve to a real Snowflake deployment.

`validate_credentials` only caught `ProgrammingError`, `DatabaseError`, and `ForbiddenError`. `HttpError` is a sibling of those (`HttpError(Error)`), not a subclass, so it slipped past the known-error matching, fell into the generic `except Exception` handler, and got sent to error tracking via `capture_exception`. The user also got the unhelpful generic "Could not connect to Snowflake" message instead of an actionable one.

This surfaced from PostHog error tracking as an `HttpError` (`290404 ... 404 Not Found ... /session/v1/login-request`) originating in the Snowflake source's `connect`, reached through `validate_credentials` → `get_schemas` from the `database_schema` setup/validation endpoint — not the Temporal sync path.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f04dc-cd74-7d23-a681-a4104801f9f6

## Changes

- Catch `HttpError` alongside the other connector errors in `validate_credentials`, so it runs through the known-error matching.
- Add a `"404 Not Found"` entry to the source's known-error map returning an actionable account-id message.

A wrong account id now returns a clear "check your account identifier" message and is **not** captured to error tracking. The Temporal sync path already classifies `"404 Not Found"` as non-retryable; this aligns the synchronous validation path. Genuinely unexpected `HttpError`s still match no pattern and are captured as before, so this can't swallow real bugs.

## How did you test this code?

I'm an agent. I added a regression test and ran the Snowflake source test suite locally:

- `test_account_not_found_http_error_returns_friendly_message_without_capture` — an `HttpError` carrying a `404 Not Found` login-request message returns `(False, message)` with an actionable account-id message and is **not** captured. This is the regression the existing tests didn't cover: `HttpError` previously bypassed the known-error matching entirely. Matched on the stable `"404 Not Found"` substring, with the host redacted to a placeholder.
- Full file: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` → 89 passed. `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Snowflake source. Read the full stack trace and confirmed the failure originates in the Snowflake source's `connect`, re-raised through `validate_credentials` → `get_schemas`, reached via the `database_schema` setup/validation endpoint (not the Temporal sync path, which already treats `404 Not Found` as non-retryable).

Decision: this is an expected user/upstream config error (wrong/incomplete account identifier), but `validate_credentials` captured it as an unexpected failure because `HttpError` isn't in the caught exception tuple. Chose to teach the validation path about `HttpError` and add the `404 Not Found` known-error mapping, rather than touch retry policy — scoped strictly to this error.