### PR TITLE
chore(devex): record x-github-request-id on rate-limit samples

### DIFF
--- a/.github/scripts/monitor-github-rate-limit.js
+++ b/.github/scripts/monitor-github-rate-limit.js
@@ -57,7 +57,7 @@ function buildTrigger(context) {
 // per-repo default GITHUB_TOKEN, or a dedicated GitHub App installation bucket
 // (e.g. posthog-devex-general, the setup-action offload bucket). The two are
 // separate 15k buckets, so downstream they're a per-bucket time series.
-function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger, source = DEFAULT_SOURCE }) {
+function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger, source = DEFAULT_SOURCE, requestId = null }) {
     const used = typeof snapshot.used === 'number' ? snapshot.used : snapshot.limit - snapshot.remaining
     const utilization = snapshot.limit > 0 ? used / snapshot.limit : 0
     return {
@@ -72,6 +72,9 @@ function buildProperties({ resource, snapshot, observedAt, observedAtSeconds, re
         source,
         observed_at: observedAt,
         workflow_run_id: runId || null,
+        // x-github-request-id of the /rate_limit call: lets GitHub Support trace
+        // the exact request and confirm which bucket enforced the limit.
+        request_id: requestId,
         ...trigger,
     }
 }
@@ -94,15 +97,17 @@ module.exports = async ({ github, context, core }, { now: _now, fetch: _fetch, s
         return
     }
 
-    const { data } = await github.rest.rateLimit.get()
+    const response = await github.rest.rateLimit.get()
+    const data = response.data
+    const requestId = response.headers?.['x-github-request-id'] ?? null
     const resources = data?.resources || {}
 
     let emitted = 0
     let failures = 0
     for (const [resource, snapshot] of Object.entries(resources)) {
         if (!snapshot || typeof snapshot.limit !== 'number' || typeof snapshot.remaining !== 'number') continue
-        const properties = buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger, source })
-        core.info(`[${source}] ${resource}: ${properties.remaining}/${properties.limit} remaining (resets ${properties.reset_at})`)
+        const properties = buildProperties({ resource, snapshot, observedAt, observedAtSeconds, repo, runId, trigger, source, requestId })
+        core.info(`[${source}] ${resource}: ${properties.remaining}/${properties.limit} remaining (resets ${properties.reset_at}, req ${requestId})`)
         try {
             await captureEvent({
                 fetchImpl,

--- a/.github/scripts/monitor-github-rate-limit.test.js
+++ b/.github/scripts/monitor-github-rate-limit.test.js
@@ -92,6 +92,46 @@ describe('monitor-github-rate-limit', () => {
         assert.ok(calledWith(core.setOutput, 'emitted', '2'))
     })
 
+    it('records the x-github-request-id of the /rate_limit call on each sample', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const captured = []
+        const fetchMock = recordingFn((_url, opts) => {
+            captured.push(JSON.parse(opts.body))
+            return fetchOk()
+        })
+        const github = {
+            rest: {
+                rateLimit: {
+                    get: () =>
+                        Promise.resolve({
+                            data: { resources: { core: snapshot({ remaining: 3000, limit: 15000 }) } },
+                            headers: { 'x-github-request-id': 'ABCD:1234:5678:90AB:DEADBEEF' },
+                        }),
+                },
+            },
+        }
+        const core = createCore()
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        assert.equal(captured[0].properties.request_id, 'ABCD:1234:5678:90AB:DEADBEEF')
+    })
+
+    it('emits request_id null when the response carries no request-id header', async () => {
+        process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
+        const captured = []
+        const fetchMock = recordingFn((_url, opts) => {
+            captured.push(JSON.parse(opts.body))
+            return fetchOk()
+        })
+        const github = createGithubMock({ core: snapshot({ remaining: 3000, limit: 15000 }) })
+        const core = createCore()
+
+        await monitor({ github, context, core }, { now: () => T_BASE, fetch: fetchMock })
+
+        assert.equal(captured[0].properties.request_id, null)
+    })
+
     it('tags emissions with the offload bucket source when overridden', async () => {
         process.env.POSTHOG_DEVEX_PROJECT_API_TOKEN = 'devex-key'
         const captured = []


### PR DESCRIPTION
## Problem

The GitHub rate-limit monitor records utilization numbers but drops the `x-github-request-id` of each `GET /rate_limit` call. GitHub Support needs those IDs to trace which bucket enforced a given limit, and we couldn't supply them on demand — they only exist inside an Actions run and were never persisted. This is a throwaway/diagnostic PR to close that gap.

## Changes

- Read `response.headers['x-github-request-id']` from the `/rate_limit` call and emit it as a `request_id` property on every `github_rate_limit_observed` event.
- Surface the same ID in the job log line.

Result: every sample is GitHub-traceable directly from PostHog, no hand-harvesting.

## How did you test this code?

Agent-authored (Claude Code). Ran the script's node:test suite locally — 10/10 pass, including two new cases: `request_id` captured from the header, and `null` when the header is absent (subset-match keeps the existing assertions intact).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built while investigating a near-90% GITHUB_TOKEN rate-limit spike. Root cause of the gap: the monitor only read the `/rate_limit` response body, never the response headers, so the request ID was discarded. Fix is a two-line capture plus a property add, with two new node:test cases. No repo skills were needed (plain JS, `node --test`).
