### PR TITLE
feat(metrics): single-value stat card view

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3665,6 +3665,9 @@ importers:
       '@posthog/products-error-tracking':
         specifier: workspace:*
         version: link:../error_tracking
+      '@posthog/quill-charts':
+        specifier: workspace:*
+        version: link:../../packages/quill/packages/charts
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,19 +1,37 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonSelect, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect, SpinnerOverlay } from '@posthog/lemon-ui'
+import { MetricCard, useChartTheme } from '@posthog/quill-charts'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
+import {
+    computeMetricSummary,
+    computeMetricSummaryChange,
+    getMetricChangeTooltip,
+    type MetricSummary,
+    METRIC_SUMMARY_LABELS,
+} from 'lib/components/Metric/metricSummary'
 import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
 import { dayjs } from 'lib/dayjs'
 import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils/datetime'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { DateMappingOption } from '~/types'
 
 import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
-import { MetricAggregation, metricsViewerLogic } from './metricsViewerLogic'
+import { MetricAggregation, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
+
+const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
+    { value: 'chart', label: 'Chart' },
+    { value: 'stat', label: 'Stat' },
+]
+
+// The stat card shows a single headline value. 'latest' (the most recent bucket) is the natural
+// default for a live metric; the user can switch total/average/latest in a later PR.
+const STAT_SUMMARY: MetricSummary = 'latest'
 
 const AGGREGATION_OPTIONS: { value: MetricAggregation; label: string }[] = [
     { value: 'sum', label: 'Sum' },
@@ -78,13 +96,16 @@ export const MetricsViewer = (): JSX.Element => {
         aggregation,
         dateFrom,
         dateTo,
+        viewMode,
         sparklineValues,
         sparklineLabels,
+        statTotal,
         queryResultsLoading,
         hasMetricName,
     } = useValues(logic)
-    const { setMetricName, setAggregation, setDateFrom, setDateTo, fetchQueryResults } = useActions(logic)
+    const { setMetricName, setAggregation, setDateFrom, setDateTo, setViewMode, fetchQueryResults } = useActions(logic)
     const { items: pickerItems } = useValues(pickerLogic)
+    const chartTheme = useChartTheme()
 
     // Refetch the chart whenever any filter changes — the loader breakpoint debounces input.
     useEffect(() => {
@@ -172,12 +193,41 @@ export const MetricsViewer = (): JSX.Element => {
                     allowedRollingDateOptions={['minutes', 'hours', 'days', 'weeks']}
                     use24HourFormat
                 />
+                <LemonSegmentedButton
+                    size="small"
+                    value={viewMode}
+                    options={VIEW_MODE_OPTIONS}
+                    onChange={(value) => setViewMode(value)}
+                />
             </div>
             <div className="relative h-[360px] border rounded p-3">
                 {!hasMetricName ? (
                     <div className="h-full flex items-center justify-center text-secondary text-sm">
                         Pick a metric to see its time series.
                     </div>
+                ) : hasResults && viewMode === 'stat' ? (
+                    <MetricCard
+                        className="h-full"
+                        title={metricName}
+                        restingSubtitle={`${METRIC_SUMMARY_LABELS[STAT_SUMMARY]} · ${aggregation}`}
+                        value={computeMetricSummary(STAT_SUMMARY, statTotal, sparklineValues)}
+                        change={computeMetricSummaryChange(
+                            STAT_SUMMARY,
+                            { total: statTotal, data: sparklineValues },
+                            undefined
+                        )}
+                        changeTooltip={getMetricChangeTooltip(STAT_SUMMARY, false, null)}
+                        changeSize="md"
+                        changeInline
+                        hoverChangeFromPreviousPoint
+                        data={sparklineValues}
+                        labels={sparklineLabels.map(renderLabel)}
+                        theme={chartTheme}
+                        sparklineFill
+                        sparklineHeight={140}
+                        formatValue={(value) => humanFriendlyNumber(value)}
+                        dataAttr="metrics-stat-value"
+                    />
                 ) : hasResults ? (
                     <Sparkline
                         type="line"

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -12,6 +12,9 @@ import type { metricsViewerLogicType } from './metricsViewerLogicType'
 
 export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95'
 
+// `chart` shows the time series; `stat` shows a single headline value + change pill (a Grafana "stat" panel).
+export type MetricsViewMode = 'chart' | 'stat'
+
 export type MetricsViewerSeries = _MetricSeriesApi
 
 const DEFAULT_AGGREGATION: MetricAggregation = 'sum'
@@ -36,6 +39,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setAggregation: (aggregation: MetricAggregation) => ({ aggregation }),
         setDateFrom: (dateFrom: string | null) => ({ dateFrom }),
         setDateTo: (dateTo: string | null) => ({ dateTo }),
+        setViewMode: (viewMode: MetricsViewMode) => ({ viewMode }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -49,6 +53,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         ],
         dateFrom: [DEFAULT_DATE_FROM as string | null, { setDateFrom: (_, { dateFrom }) => dateFrom }],
         dateTo: [null as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
+        viewMode: ['chart' as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
@@ -102,7 +107,18 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
         // The viewer renders the first series only for now; group-by lands
         // multi-series rendering in a later PR.
-        sparklineValues: [(s) => [s.queryResults], (results) => (results[0]?.points ?? []).map((p) => p.value)],
-        sparklineLabels: [(s) => [s.queryResults], (results) => (results[0]?.points ?? []).map((p) => p.time)],
+        // Metrics has no compare/previous-series concept, so "current" is simply the first series.
+        currentSeries: [(s) => [s.queryResults], (results): MetricsViewerSeries | undefined => results[0]],
+        sparklineValues: [
+            (s) => [s.currentSeries],
+            (series: MetricsViewerSeries | undefined) => (series?.points ?? []).map((p) => p.value),
+        ],
+        sparklineLabels: [
+            (s) => [s.currentSeries],
+            (series: MetricsViewerSeries | undefined) => (series?.points ?? []).map((p) => p.time),
+        ],
+        // The stat card summarizes the per-bucket `sparklineValues` into one headline value;
+        // `statTotal` is the grand total across buckets (the basis for the 'total' summary).
+        statTotal: [(s) => [s.sparklineValues], (values: number[]) => values.reduce((sum, v) => sum + v, 0)],
     }),
 ])

--- a/products/metrics/package.json
+++ b/products/metrics/package.json
@@ -5,6 +5,7 @@
         "backend:contract-check": "echo 'Contract files unchanged'"
     },
     "dependencies": {
+        "@posthog/quill-charts": "workspace:*",
         "kea": "catalog:",
         "kea-loaders": "catalog:",
         "kea-router": "catalog:",


### PR DESCRIPTION
## Problem

The Metrics viewer only renders a time-series line chart. For "is this metric healthy right now?" at-a-glance reading we want a single headline value — the Grafana "stat" panel — reusing the same `MetricCard` the Metric insight uses, so the two surfaces look identical.

## Changes

- Add a Chart/Stat toggle to the viewer.
- In Stat mode, render the current series as a `@posthog/quill-charts` `MetricCard`: headline value + change pill + sparkline, computed via the shared summary math.
- Headline defaults to the latest bucket value (the natural "current value" for a live metric). The user-facing total/average/latest selector lands in the next PR.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing performed. No new tests — this is presentational wiring over the existing query path, and the summary math it relies on is already unit-tested.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Part of a stack reusing the recently-merged Metric insight in the Metrics product. Chose to inline "current series = first series" rather than reuse the insights `selectCurrentSeries` helper, since Metrics has no compare/previous-series concept and the generic helper mis-inferred under `tsgo`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
