### PR TITLE
feat(metrics): total/average/latest summary selector

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -29,9 +29,12 @@ const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
     { value: 'stat', label: 'Stat' },
 ]
 
-// The stat card shows a single headline value. 'latest' (the most recent bucket) is the natural
-// default for a live metric; the user can switch total/average/latest in a later PR.
-const STAT_SUMMARY: MetricSummary = 'latest'
+// How the stat card summarizes the series into one headline value.
+const SUMMARY_OPTIONS: { value: MetricSummary; label: string }[] = [
+    { value: 'latest', label: 'Latest' },
+    { value: 'average', label: 'Average' },
+    { value: 'total', label: 'Total' },
+]
 
 const AGGREGATION_OPTIONS: { value: MetricAggregation; label: string }[] = [
     { value: 'sum', label: 'Sum' },
@@ -97,13 +100,15 @@ export const MetricsViewer = (): JSX.Element => {
         dateFrom,
         dateTo,
         viewMode,
+        statSummary,
         sparklineValues,
         sparklineLabels,
         statTotal,
         queryResultsLoading,
         hasMetricName,
     } = useValues(logic)
-    const { setMetricName, setAggregation, setDateFrom, setDateTo, setViewMode, fetchQueryResults } = useActions(logic)
+    const { setMetricName, setAggregation, setDateFrom, setDateTo, setViewMode, setStatSummary, fetchQueryResults } =
+        useActions(logic)
     const { items: pickerItems } = useValues(pickerLogic)
     const chartTheme = useChartTheme()
 
@@ -199,6 +204,14 @@ export const MetricsViewer = (): JSX.Element => {
                     options={VIEW_MODE_OPTIONS}
                     onChange={(value) => setViewMode(value)}
                 />
+                {viewMode === 'stat' && (
+                    <LemonSelect
+                        size="small"
+                        value={statSummary}
+                        options={SUMMARY_OPTIONS}
+                        onChange={(value) => setStatSummary(value)}
+                    />
+                )}
             </div>
             <div className="relative h-[360px] border rounded p-3">
                 {!hasMetricName ? (
@@ -209,14 +222,14 @@ export const MetricsViewer = (): JSX.Element => {
                     <MetricCard
                         className="h-full"
                         title={metricName}
-                        restingSubtitle={`${METRIC_SUMMARY_LABELS[STAT_SUMMARY]} · ${aggregation}`}
-                        value={computeMetricSummary(STAT_SUMMARY, statTotal, sparklineValues)}
+                        restingSubtitle={`${METRIC_SUMMARY_LABELS[statSummary]} · ${aggregation}`}
+                        value={computeMetricSummary(statSummary, statTotal, sparklineValues)}
                         change={computeMetricSummaryChange(
-                            STAT_SUMMARY,
+                            statSummary,
                             { total: statTotal, data: sparklineValues },
                             undefined
                         )}
-                        changeTooltip={getMetricChangeTooltip(STAT_SUMMARY, false, null)}
+                        changeTooltip={getMetricChangeTooltip(statSummary, false, null)}
                         changeSize="md"
                         changeInline
                         hoverChangeFromPreviousPoint

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -1,6 +1,7 @@
 import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
+import { type MetricSummary } from 'lib/components/Metric/metricSummary'
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
@@ -40,6 +41,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setDateFrom: (dateFrom: string | null) => ({ dateFrom }),
         setDateTo: (dateTo: string | null) => ({ dateTo }),
         setViewMode: (viewMode: MetricsViewMode) => ({ viewMode }),
+        setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -54,6 +56,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         dateFrom: [DEFAULT_DATE_FROM as string | null, { setDateFrom: (_, { dateFrom }) => dateFrom }],
         dateTo: [null as string | null, { setDateTo: (_, { dateTo }) => dateTo }],
         viewMode: ['chart' as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
+        // 'latest' (current value) is the natural default for a live single-metric stat.
+        statSummary: ['latest' as MetricSummary, { setStatSummary: (_, { statSummary }) => statSummary }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },


### PR DESCRIPTION
## Problem

The stat card (previous PR) hardcodes its headline to the latest bucket value. Different metrics call for different summaries — a counter reads best as a total, a gauge as an average or its current value.

## Changes

- Add a total/average/latest selector, shown only in Stat mode, wired through `metricsViewerLogic`.
- The change pill and its tooltip follow the chosen summary (total/average compare period-over-period; latest compares first→last point).
- Default stays `latest`.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing. No new tests — the summary/change computation is already covered by `Metric.utils.test.ts`; this PR only wires the selection into the logic.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Part of the Metrics stat-view stack.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
