### PR TITLE
feat(metrics): anomaly badge from characterize endpoint

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonSegmentedButton, LemonSelect, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect, LemonTag, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
 import { MetricCard, useChartTheme } from '@posthog/quill-charts'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -104,11 +104,21 @@ export const MetricsViewer = (): JSX.Element => {
         sparklineValues,
         sparklineLabels,
         statTotal,
+        anomalyBadge,
         queryResultsLoading,
         hasMetricName,
     } = useValues(logic)
-    const { setMetricName, setAggregation, setDateFrom, setDateTo, setViewMode, setStatSummary, fetchQueryResults } =
-        useActions(logic)
+    const {
+        setMetricName,
+        setAggregation,
+        setDateFrom,
+        setDateTo,
+        setViewMode,
+        setStatSummary,
+        fetchQueryResults,
+        fetchAnomaly,
+        clearAnomaly,
+    } = useActions(logic)
     const { items: pickerItems } = useValues(pickerLogic)
     const chartTheme = useChartTheme()
 
@@ -116,6 +126,15 @@ export const MetricsViewer = (): JSX.Element => {
     useEffect(() => {
         fetchQueryResults({})
     }, [metricName, aggregation, dateFrom, dateTo]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    // Characterize the recent window only while the stat card is visible — the badge is stat-mode only.
+    useEffect(() => {
+        if (viewMode === 'stat' && hasMetricName) {
+            fetchAnomaly({})
+        } else {
+            clearAnomaly()
+        }
+    }, [metricName, aggregation, dateFrom, dateTo, viewMode, hasMetricName]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const selectedMetricType = useMemo(
         () => pickerItems.find((item) => item.name === metricName)?.metric_type,
@@ -219,28 +238,48 @@ export const MetricsViewer = (): JSX.Element => {
                         Pick a metric to see its time series.
                     </div>
                 ) : hasResults && viewMode === 'stat' ? (
-                    <MetricCard
-                        className="h-full"
-                        title={metricName}
-                        restingSubtitle={`${METRIC_SUMMARY_LABELS[statSummary]} · ${aggregation}`}
-                        value={computeMetricSummary(statSummary, statTotal, sparklineValues)}
-                        change={computeMetricSummaryChange(
-                            statSummary,
-                            { total: statTotal, data: sparklineValues },
-                            undefined
+                    <div className="flex flex-col h-full">
+                        {anomalyBadge && (
+                            <div className="flex justify-end">
+                                <Tooltip
+                                    title={`Baseline ${humanFriendlyNumber(anomalyBadge.baselineMean)} → recent ${humanFriendlyNumber(
+                                        anomalyBadge.anomalyMean
+                                    )}${
+                                        anomalyBadge.onsetTime
+                                            ? `, onset ${dayjs(anomalyBadge.onsetTime).format('D MMM HH:mm')}`
+                                            : ''
+                                    }`}
+                                >
+                                    <LemonTag type="warning">
+                                        {anomalyBadge.direction === 'up' ? '▲' : '▼'} {anomalyBadge.percent}% vs
+                                        baseline
+                                    </LemonTag>
+                                </Tooltip>
+                            </div>
                         )}
-                        changeTooltip={getMetricChangeTooltip(statSummary, false, null)}
-                        changeSize="md"
-                        changeInline
-                        hoverChangeFromPreviousPoint
-                        data={sparklineValues}
-                        labels={sparklineLabels.map(renderLabel)}
-                        theme={chartTheme}
-                        sparklineFill
-                        sparklineHeight={140}
-                        formatValue={(value) => humanFriendlyNumber(value)}
-                        dataAttr="metrics-stat-value"
-                    />
+                        <MetricCard
+                            className="flex-1"
+                            title={metricName}
+                            restingSubtitle={`${METRIC_SUMMARY_LABELS[statSummary]} · ${aggregation}`}
+                            value={computeMetricSummary(statSummary, statTotal, sparklineValues)}
+                            change={computeMetricSummaryChange(
+                                statSummary,
+                                { total: statTotal, data: sparklineValues },
+                                undefined
+                            )}
+                            changeTooltip={getMetricChangeTooltip(statSummary, false, null)}
+                            changeSize="md"
+                            changeInline
+                            hoverChangeFromPreviousPoint
+                            data={sparklineValues}
+                            labels={sparklineLabels.map(renderLabel)}
+                            theme={chartTheme}
+                            sparklineFill
+                            sparklineHeight={140}
+                            formatValue={(value) => humanFriendlyNumber(value)}
+                            dataAttr="metrics-stat-value"
+                        />
+                    </div>
                 ) : hasResults ? (
                     <Sparkline
                         type="line"

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -6,8 +6,8 @@ import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 
-import { metricsQueryCreate } from 'products/metrics/frontend/generated/api'
-import type { _MetricSeriesApi } from 'products/metrics/frontend/generated/api.schemas'
+import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
+import type { _MetricAnomalyReportApi, _MetricSeriesApi } from 'products/metrics/frontend/generated/api.schemas'
 
 import type { metricsViewerLogicType } from './metricsViewerLogicType'
 
@@ -21,6 +21,8 @@ export type MetricsViewerSeries = _MetricSeriesApi
 const DEFAULT_AGGREGATION: MetricAggregation = 'sum'
 const DEFAULT_DATE_FROM = '-1h'
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling the previous one'
+// The anomaly badge characterizes the most recent slice of the selected window against the rest.
+const ANOMALY_WINDOW_FRACTION = 0.2
 
 const resolveDate = (value: string | null | undefined): string | null => {
     if (!value) {
@@ -106,6 +108,38 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                 },
             },
         ],
+        anomalyReport: [
+            null as _MetricAnomalyReportApi | null,
+            {
+                clearAnomaly: () => null,
+                fetchAnomaly: async (_, breakpoint) => {
+                    const trimmedName = values.metricName.trim()
+                    const fromISO = resolveDate(values.dateFrom)
+                    if (!trimmedName || !fromISO) {
+                        return null
+                    }
+                    const toISO = resolveDate(values.dateTo) ?? dayjs().toISOString()
+                    const spanMs = dayjs(toISO).diff(dayjs(fromISO))
+                    if (spanMs <= 0) {
+                        return null
+                    }
+                    const anomalyFrom = dayjs(toISO)
+                        .subtract(spanMs * ANOMALY_WINDOW_FRACTION, 'ms')
+                        .toISOString()
+                    await breakpoint(300)
+                    const report = await metricsCharacterizeCreate(String(values.currentTeamId), {
+                        query: {
+                            metricName: trimmedName,
+                            aggregation: values.aggregation,
+                            anomalyFrom,
+                            anomalyTo: toISO,
+                        },
+                    })
+                    breakpoint()
+                    return report
+                },
+            },
+        ],
     })),
     selectors({
         hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
@@ -124,5 +158,19 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // The stat card summarizes the per-bucket `sparklineValues` into one headline value;
         // `statTotal` is the grand total across buckets (the basis for the 'total' summary).
         statTotal: [(s) => [s.sparklineValues], (values: number[]) => values.reduce((sum, v) => sum + v, 0)],
+        // Display shape for the anomaly badge — null when there's no report or the metric is flat.
+        anomalyBadge: [
+            (s) => [s.anomalyReport],
+            (report: _MetricAnomalyReportApi | null) =>
+                report && report.direction !== 'flat'
+                    ? {
+                          direction: report.direction,
+                          percent: Math.abs(Math.round((report.change_ratio - 1) * 100)),
+                          baselineMean: report.baseline_mean,
+                          anomalyMean: report.anomaly_mean,
+                          onsetTime: report.onset_time,
+                      }
+                    : null,
+        ],
     }),
 ])


### PR DESCRIPTION
## Problem

A stat value is more useful with context: is the current window abnormal versus its recent baseline? The Metrics backend already has a `/metrics/characterize/` endpoint that computes baseline mean, anomaly mean and a change ratio — we just weren't surfacing it.

## Changes

- While the stat card is visible, characterize the most recent slice of the selected window (last 20%) against the preceding baseline via the existing `metricsCharacterizeCreate`.
- Show a small "▲/▼ N% vs baseline" badge (warning tone) when the metric isn't flat, with a tooltip giving baseline → recent values and the onset time.
- Fetch is gated to Stat mode and cleared otherwise, so Chart mode does no extra work.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing — this calls a live endpoint that needs a running stack with metrics data. No new tests; the badge is a thin presentational read over an already-tested endpoint.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Part of the Metrics stat-view stack. The characterize endpoint's `baseline_mean` / `anomaly_mean` / `change_ratio` map directly onto a "value vs baseline" badge, so it's reused as-is rather than adding a new endpoint.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
