### PR TITLE
feat(metrics): live auto-refresh toggle

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonSegmentedButton, LemonSelect, LemonTag, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
+import { LemonSegmentedButton, LemonSelect, LemonSwitch, LemonTag, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
 import { MetricCard, useChartTheme } from '@posthog/quill-charts'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
@@ -22,7 +22,7 @@ import { DateMappingOption } from '~/types'
 
 import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
-import { MetricAggregation, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
+import { LIVE_REFRESH_MS, MetricAggregation, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
 
 const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
     { value: 'chart', label: 'Chart' },
@@ -105,6 +105,7 @@ export const MetricsViewer = (): JSX.Element => {
         sparklineLabels,
         statTotal,
         anomalyBadge,
+        liveRefresh,
         queryResultsLoading,
         hasMetricName,
     } = useValues(logic)
@@ -115,6 +116,7 @@ export const MetricsViewer = (): JSX.Element => {
         setDateTo,
         setViewMode,
         setStatSummary,
+        setLiveRefresh,
         fetchQueryResults,
         fetchAnomaly,
         clearAnomaly,
@@ -231,6 +233,13 @@ export const MetricsViewer = (): JSX.Element => {
                         onChange={(value) => setStatSummary(value)}
                     />
                 )}
+                <LemonSwitch
+                    label="Live"
+                    checked={liveRefresh}
+                    onChange={setLiveRefresh}
+                    tooltip={`Auto-refresh every ${LIVE_REFRESH_MS / 1000}s`}
+                    bordered
+                />
             </div>
             <div className="relative h-[360px] border rounded p-3">
                 {!hasMetricName ? (

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -23,6 +23,8 @@ const DEFAULT_DATE_FROM = '-1h'
 const NEW_QUERY_STARTED_ERROR_MESSAGE = 'A new metrics query started, cancelling the previous one'
 // The anomaly badge characterizes the most recent slice of the selected window against the rest.
 const ANOMALY_WINDOW_FRACTION = 0.2
+export const LIVE_REFRESH_MS = 15_000
+const LIVE_REFRESH_KEY = 'metricsLiveRefresh'
 
 const resolveDate = (value: string | null | undefined): string | null => {
     if (!value) {
@@ -44,6 +46,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setDateTo: (dateTo: string | null) => ({ dateTo }),
         setViewMode: (viewMode: MetricsViewMode) => ({ viewMode }),
         setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
+        setLiveRefresh: (liveRefresh: boolean) => ({ liveRefresh }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -60,17 +63,34 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         viewMode: ['chart' as MetricsViewMode, { setViewMode: (_, { viewMode }) => viewMode }],
         // 'latest' (current value) is the natural default for a live single-metric stat.
         statSummary: ['latest' as MetricSummary, { setStatSummary: (_, { statSummary }) => statSummary }],
+        liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
         ],
     }),
-    listeners(({ actions, values }) => ({
+    listeners(({ actions, values, cache }) => ({
         cancelInProgressQuery: ({ controller }) => {
             if (values.queryAbortController !== null) {
                 values.queryAbortController.abort(NEW_QUERY_STARTED_ERROR_MESSAGE)
             }
             actions.setQueryAbortController(controller)
+        },
+        setLiveRefresh: ({ liveRefresh }) => {
+            if (!liveRefresh) {
+                cache.disposables.dispose(LIVE_REFRESH_KEY)
+                return
+            }
+            // pauseOnPageHidden (default) stops polling on a hidden tab and resumes on focus.
+            cache.disposables.add(() => {
+                const intervalId = setInterval(() => {
+                    actions.fetchQueryResults({})
+                    if (values.viewMode === 'stat') {
+                        actions.fetchAnomaly({})
+                    }
+                }, LIVE_REFRESH_MS)
+                return () => clearInterval(intervalId)
+            }, LIVE_REFRESH_KEY)
         },
     })),
     loaders(({ values, actions }) => ({


### PR DESCRIPTION
## Problem

Metrics is most useful when it stays current without a manual refresh — a live dashboard you can leave open.

## Changes

- Add a "Live" switch that re-runs the metrics query every 15s (and the anomaly characterization while in Stat mode).
- The interval is registered through `cache.disposables`, so it tears down on unmount and auto-pauses on a hidden tab (no background polling cost).

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing. No new tests — disposables teardown/pause is provided and covered by the shared `kea-disposables` plugin; this PR only registers an interval through it.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Top of the Metrics stat-view stack. Invoked the repo `/using-kea-disposables` skill and followed its pattern (`cache.disposables.add` returning a cleanup, keyed for early `dispose`) rather than a bare `setInterval` + `beforeUnmount`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
