### PR TITLE
fix(snowflake): treat MFA-enrollment-required login as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/source.py
@@ -40,6 +40,7 @@ SnowflakeErrors = {
     "Incorrect username or password was specified": "Incorrect username or password was specified",
     "This session does not have a current database": "Database specified not found",
     "Verify the account name is correct": "Can't find an account with the specified account ID",
+    "Multi-factor authentication is required for this account": "This Snowflake account requires multi-factor authentication enrollment. Connect with a service user that uses key-pair authentication or is exempt from MFA.",
 }
 
 
@@ -205,6 +206,11 @@ class SnowflakeSource(SQLSource[SnowflakeSourceConfig]):
             # connector's login is rejected (250001 / 08001). An unattended sync can't answer a
             # Duo push, so retrying never succeeds — surface an actionable message instead.
             "Duo Security authentication is denied": "Snowflake rejected the login because multi-factor authentication (Duo Security) is enforced for this user. Automated syncs can't answer an MFA prompt — connect with a service user that uses key-pair authentication or is exempt from MFA.",
+            # Snowflake error 250001 (08001): the account requires MFA enrollment, so the login is
+            # rejected until the user enrolls via Snowsight. An unattended sync can't complete MFA, so
+            # retrying never succeeds. The codes and host in the message are volatile, so we match the
+            # stable phrase.
+            "Multi-factor authentication is required for this account": "Snowflake rejected the login because this account requires multi-factor authentication enrollment. Automated syncs can't complete MFA — connect with a service user that uses key-pair authentication or is exempt from MFA, then resync.",
             "invalid credentials": "Snowflake authentication failed. Please check your username, password, and account details.",
             "authentication failed": "Snowflake authentication failed. Please check your username, password, and account details.",
             # Snowflake error 250001 (08001): the supplied username or password is wrong, so the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, patch
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
+from snowflake.connector.errors import DatabaseError
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.predicates import (
@@ -644,6 +645,20 @@ class TestSnowflakeSourceNonRetryableErrors:
     @pytest.mark.parametrize(
         "error_msg",
         [
+            "Multi-factor authentication is required for this account",
+            # The real shape from production: codes + host vary, but the MFA substring is stable.
+            "250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "Multi-factor authentication is required for this account. Log in to Snowsight to enroll.",
+        ],
+    )
+    def test_mfa_enrollment_required_is_non_retryable(self, source, error_msg):
+        non_retryable = source.get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable, f"MFA-enrollment error should be non-retryable: {error_msg}"
+
+    @pytest.mark.parametrize(
+        "error_msg",
+        [
             "No active warehouse selected in the current session.  Select an active warehouse with the 'use warehouse' command.",
             # The real shape from production: the query id varies, but the warehouse substring is stable.
             "000606 (57P03): 01c51211-0105-f139-0002-113a46e58fba: No active warehouse selected in the current "
@@ -805,6 +820,27 @@ class TestSnowflakeValidateCredentials:
 
         assert ok is False
         assert message is not None and "PEM private key" in message
+        mock_capture.assert_not_called()
+
+    def test_mfa_enrollment_required_returns_friendly_message_without_capture(self, source):
+        # The account enforces MFA enrollment, so validate_credentials must surface an actionable
+        # message instead of capturing it as an unexpected failure.
+        mfa_error = DatabaseError(
+            msg="250001 (08001): None: Failed to connect to DB: acme-xy123.snowflakecomputing.com:443. "
+            "Multi-factor authentication is required for this account. Log in to Snowsight to enroll.",
+            errno=250001,
+            sqlstate="08001",
+        )
+        with (
+            patch.object(source, "get_schemas", side_effect=mfa_error),
+            patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.snowflake.source.capture_exception"
+            ) as mock_capture,
+        ):
+            ok, message = source.validate_credentials(_make_config("password"), team_id=1)
+
+        assert ok is False
+        assert message is not None and "multi-factor authentication" in message
         mock_capture.assert_not_called()
 
     def test_unexpected_value_error_is_still_captured(self, source):


### PR DESCRIPTION
## Problem

A Snowflake data-warehouse source on an account that **requires multi-factor authentication enrollment** fails to connect. The connector raises a `250001 (08001)` `DatabaseError` whose message ends with `Multi-factor authentication is required for this account. Log in to Snowsight to enroll.`

This is a customer-side account-policy issue: the connecting user hasn't enrolled in MFA, and Snowflake refuses the login until they do. An unattended PostHog sync can't answer or complete an MFA enrollment flow, so retrying can never succeed.

Two existing entries already cover other MFA shapes — `MFA authentication is required` and `Duo Security authentication is denied` — but neither substring matches this `Multi-factor authentication is required for this account` wording, so it slipped through:
- On the credential-validation path (`validate_credentials` → `get_schemas` → `connect`, reached from the `database_schema` setup endpoint), the message matched no known error and got sent to error tracking via `capture_exception`, with the user shown the generic "Could not connect to Snowflake" message.
- On the Temporal sync path it wouldn't be classified as non-retryable.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f04e0-8c48-7901-828d-66babfe279f7

This is a sibling of #66408 (which handled the wrong-account-id `404 Not Found` on the same validation path) — same source, different root cause and message.

## Changes

- Add `Multi-factor authentication is required for this account` to `get_non_retryable_errors`, so the Temporal sync stops retrying and surfaces an actionable message (consistent with the existing Duo/MFA entries).
- Add the same stable phrase to the `SnowflakeErrors` validation map, so `validate_credentials` returns a clear "connect with a service user that uses key-pair auth or is exempt from MFA" message and no longer captures it as an unexpected failure.

Matched on the stable phrase only — the error codes and host in the connector message are volatile and are not part of the match, so this can't false-positive on transient errors and won't swallow real bugs.

## How did you test this code?

I'm an agent. I added regression tests and ran the Snowflake source suite locally:

- `test_mfa_enrollment_required_is_non_retryable` — asserts the new phrase (bare and in the full production-shaped message with a redacted host) is recognised as non-retryable.
- `test_mfa_enrollment_required_returns_friendly_message_without_capture` — asserts `validate_credentials` returns `(False, message)` with an actionable MFA message and does **not** call `capture_exception`. This is the regression the existing tests didn't cover: the message previously matched no known error and was captured.
- `pytest products/warehouse_sources/backend/temporal/data_imports/sources/snowflake/tests/test_snowflake.py` → 91 passed. `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Snowflake source. Confirmed the failure originates in the source's `connect` (`snowflake.py`), re-raised through `validate_credentials` → `get_schemas`, reached from the `database_schema` setup/validation endpoint.

Decision: this is an expected user/upstream account-policy error (MFA enrollment required), not a code bug — there's nothing sensible to do but stop retrying and tell the customer how to fix it. Extended the non-retryable map (sync path) and the validation error map (which is what actually fired) rather than touching retry policy or catching new exception types. Scoped strictly to this message; matched the stable phrase, not the volatile codes/host. Verified against open PRs (including the maintainer's own) that this exact message isn't already handled — #66408 covers the distinct `404 Not Found` case on the same path.