### PR TITLE
fix(data-warehouse): handle arro3 RecordBatch in table statistics aggregation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/compute_table_statistics.py
@@ -17,7 +17,7 @@ import json
 import uuid
 import dataclasses
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from django.utils import timezone
 
@@ -37,9 +37,6 @@ from products.warehouse_sources.backend.models.external_data_job import External
 from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 from products.warehouse_sources.backend.models.table import DataWarehouseTable
 from products.warehouse_sources.backend.models.util import clean_type
-
-if TYPE_CHECKING:
-    import pyarrow as pa
 
 logger = structlog.get_logger(__name__)
 
@@ -119,14 +116,18 @@ class _ColumnStat:
     has_min_max: bool
 
 
-def _aggregate_add_action_stats(add_actions: "pa.Table", columns: dict[str, Any]) -> tuple[int, dict[str, _ColumnStat]]:
+def _aggregate_add_action_stats(add_actions: Any, columns: dict[str, Any]) -> tuple[int, dict[str, _ColumnStat]]:
     """Aggregate the Delta log's per-file stats into per-column whole-table stats.
 
     `add_actions` is `DeltaTable.get_add_actions(flatten=True)` — one row per live file, with
     `num_records` and (where the log carries stats) `null_count.<col>`, `min.<col>`, `max.<col>`.
     Returns `(row_count, {column_name: _ColumnStat})`. Columns with no log stats get `has_min_max=False`.
     """
-    data = add_actions.to_pydict()
+    import pyarrow as pa  # noqa: PLC0415 — heavy dep kept off this module's flag-check import path
+
+    # deltalake>=1.x returns an arro3 RecordBatch (no `to_pydict`); pa.table() normalizes both that
+    # (via the Arrow C interface) and an already-pyarrow input to a pyarrow Table we can read as a dict.
+    data = pa.table(add_actions).to_pydict()
     row_count = sum(n for n in data.get("num_records", []) if n is not None)
 
     result: dict[str, _ColumnStat] = {}

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_compute_table_statistics.py
@@ -53,6 +53,19 @@ class TestAggregateAddActionStats:
         assert stats["amount"].max_value == "15"
         assert stats["amount"].has_min_max is True
 
+    def test_accepts_arro3_record_batch_from_deltalake(self) -> None:
+        # deltalake>=1.x returns an arro3 RecordBatch (no `to_pydict`) from get_add_actions; the helper
+        # must normalize it to pyarrow rather than crash with AttributeError.
+        from arro3.core import RecordBatch
+
+        pa_table = pa.table({"num_records": [10, 20], "null_count.amount": [1, 2], "min.amount": [5, 3]})
+        arro3_batch = RecordBatch.from_arrow(pa_table.to_batches()[0])
+
+        row_count, stats = _aggregate_add_action_stats(arro3_batch, {"amount": "Int64"})
+        assert row_count == 30
+        assert stats["amount"].null_count == 3
+        assert stats["amount"].min_value == "3"
+
     def test_column_without_log_stats_marks_has_min_max_false(self) -> None:
         # A column present in the table but with no min/max/null in the Delta log (e.g. nested type).
         add_actions = pa.table({"num_records": [5]})


### PR DESCRIPTION
## Problem

`compute_table_statistics_activity` was failing on every run with:

```
AttributeError: 'arro3.core._core.RecordBatch' object has no attribute 'to_pydict'
```

`deltalake` 1.x changed the return type of `DeltaTable.get_add_actions()` from a pyarrow object to an `arro3.core.RecordBatch`. The statistics aggregator (`_aggregate_add_action_stats`) called `add_actions.to_pydict()`, which is a pyarrow API that arro3 doesn't expose — so the activity threw before writing any column stats, and Temporal retried it into a hot error loop.

This is the fire-and-forget child workflow that profiles each warehouse table (null counts, min/max, row count) so the AI agent writes better queries. It isn't on the sync hot path, but it was erroring continuously across many teams.

## Changes

Normalize the add-actions batch to a pyarrow `Table` via `pa.table(...)` before reading it as a dict. `pa.table()` accepts both an arro3 `RecordBatch` (via the Arrow C data interface) and an already-pyarrow input, so the fix is robust across deltalake versions. The pyarrow import stays lazy inside the helper to keep it off this module's flag-check import path (the module is imported elsewhere just for `statistics_enabled`, and deliberately keeps deltalake/pyarrow lazy).

`get_add_actions(...).num_rows` (the earlier zero-files guard) already works on arro3, so only the `to_pydict()` call needed normalizing.

## How did you test this code?

I'm an agent (Claude, via Claude Code), working agent-assisted under Tom's direction.

- Added `test_accepts_arro3_record_batch_from_deltalake`, which feeds an actual `arro3.core.RecordBatch` (the production type) through `_aggregate_add_action_stats` and asserts correct aggregation. It reproduces the exact `AttributeError` without the fix and passes with it — a regression the existing pyarrow-only tests didn't catch.
- Ran the full `TestAggregateAddActionStats` suite locally: 13 passed.
- Ran `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom shared a stream of production `AttributeError` logs from `compute_table_statistics_activity`. Confirmed the installed `deltalake` (1.4.0) returns an arro3 `RecordBatch` from `get_add_actions`, verified `arro3.core.RecordBatch` lacks `to_pydict` but implements `__arrow_c_array__`, and confirmed `pa.table()` round-trips it correctly before applying the fix.

Chose to normalize inside the helper (rather than at the call site) so the function is self-contained regardless of the Arrow flavor it's handed, and so the regression test can exercise it directly as a cheap unit test.
