### PR TITLE
chore(scene-menu-bar): add agents guide for scene action surfaces

### DIFF
--- a/frontend/src/AGENTS.md
+++ b/frontend/src/AGENTS.md
@@ -56,9 +56,16 @@ These are slow; run them at the right moment, not after every edit.
 
 Run `pnpm --filter=@posthog/frontend format` (oxlint `--fix` + oxfmt) before finishing. Config: root `.oxlintrc.json`. CSS, spelling, and copy-casing rules live in the root `AGENTS.md` (Code Style).
 
+## Adding actions to a scene
+
+Adding a button/toggle/action to a scene's `ScenePanel`? It must also go in that scene's `SceneMenuBar`
+(create one if the scene has none). See [`layout/scenes/AGENTS.md`](./layout/scenes/AGENTS.md) and the
+`/scene-menu-bar` skill.
+
 ## Deeper references
 
 - Root `AGENTS.md` — full Code Style + architecture rules (authoritative).
+- `layout/scenes/AGENTS.md` (scene action surfaces: `ScenePanel` + `SceneMenuBar` dual-write rule).
 - `packages/quill/packages/primitives/AGENTS.md` — component selection matrix.
 - `docs/published/handbook/engineering/conventions/frontend-coding.md` — frontend conventions.
 - Skills: `/adopting-generated-api-types`, `/writing-kea-logics`, `/using-kea-disposables`, `/writing-tests`.

--- a/frontend/src/layout/scenes/AGENTS.md
+++ b/frontend/src/layout/scenes/AGENTS.md
@@ -1,0 +1,69 @@
+# Scene chrome agent guide (`frontend/src/layout/scenes`)
+
+This directory owns the **scene action surfaces**:
+
+- **`ScenePanel`** (`SceneLayout.tsx`): the per-scene action/info side panel. Scenes fill it with
+  `<ScenePanelActionsSection>`, `<ScenePanelInfoSection>`, `<ScenePanelLabel>`, `<ScenePanelDivider>`.
+  This is the **legacy** action surface.
+- **`SceneMenuBar`** (`components/SceneMenuBar.tsx`): the Mac-style menu bar above `<SceneTitleSection>`
+  that consolidates those actions into File / Edit / View / Metadata / Staff only menus. This is the
+  **new** action surface, gated behind the `SCENE_MENU_BAR` feature flag.
+
+We are mid-migration (`ScenePanel` to `SceneMenuBar`). Until the flag ships everywhere, **both surfaces
+must stay in sync**.
+
+## Rule: every scene action goes in the SceneMenuBar
+
+When you add, edit, or remove any action/feature on a scene's `ScenePanel` (a button, toggle, link,
+destructive op, metadata input; anything in `<ScenePanelActionsSection>` / `<ScenePanelInfoSection>`),
+you **must** make the same change in that scene's `SceneMenuBar`. A feature that only exists on the
+`ScenePanel` is invisible to every user with `SCENE_MENU_BAR` on.
+
+This is a dual-write, not a move: keep the `ScenePanel` entry (flag-off path) **and** add the menu bar
+entry (flag-on path). Don't delete `ScenePanel` actions while the flag is still rolling out.
+
+### If the scene has no SceneMenuBar yet, create one
+
+Scenes get a co-located `<Resource>SceneMenuBar` component (`CohortSceneMenuBar`, `DashboardSceneMenuBar`,
+`NotebookSceneMenuBar`, etc). If the scene you're touching doesn't have one, add it:
+
+1. Create `<Resource>SceneMenuBar.tsx` next to the scene. It returns `null` unless the flag is on:
+
+   ```tsx
+   export function CohortSceneMenuBar({ id }: { id?: CohortType['id'] }): JSX.Element | null {
+     const { featureFlags } = useValues(featureFlagLogic)
+     if (!featureFlags[FEATURE_FLAGS.SCENE_MENU_BAR]) {
+       return null
+     }
+     return <CohortSceneMenuBarInner id={id} />
+   }
+   ```
+
+2. Build the menus with the primitives from `~/layout/scenes/components/SceneMenuBar`, mirroring the
+   actions already on the scene's `ScenePanel` into the canonical menu set (File / Edit / View /
+   Metadata / Staff only).
+
+3. Render it in the scene immediately **above** `<SceneTitleSection>`, alongside the existing
+   `<ScenePanel>`:
+
+   ```tsx
+   <CohortSceneMenuBar id={id} />
+   <ScenePanel>…</ScenePanel>
+   <SceneTitleSection … />
+   ```
+
+Reference implementations: `scenes/cohorts/CohortSceneMenuBar.tsx`,
+`scenes/dashboard/DashboardSceneMenuBar.tsx`, `scenes/notebooks/NotebookSceneMenuBar.tsx`.
+
+## Before you write menu code, read the skill
+
+The component taxonomy, canonical menu order, destructive-action styling, `opensFloatingUi`, rich-input
+(`SceneMenuBarPopover` + `TagsCombobox`) wiring, empty-menu handling, and optimistic-save patterns all
+live in the **`/scene-menu-bar` skill** (`.agents/skills/scene-menu-bar/SKILL.md`). Invoke it before
+adding or moving menu items. This guide is the _when/why_; the skill is the _how_.
+
+## Instrumentation is automatic
+
+`SceneMenuBar.tsx` captures `scene menu bar shown` / `menu opened` / `item clicked` centrally, so you
+don't wire analytics per scene. Just give items a stable `data-attr` (`${RESOURCE_TYPE}-menubar-<action>`)
+so the captured `item` is meaningful.

--- a/frontend/src/layout/scenes/CLAUDE.md
+++ b/frontend/src/layout/scenes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Problem

We're mid-migration from the per-scene `ScenePanel` action side panel to the new `SceneMenuBar` (gated behind `SCENE_MENU_BAR`). During this window a scene action that's only wired into one surface is invisible to half the users. There was no co-located guidance telling contributors (human or agent) to keep the two surfaces in sync, so new scene actions risk landing in `ScenePanel` only.

## Changes

Adds `frontend/src/layout/scenes/AGENTS.md` (with its `CLAUDE.md` symlink), the canonical home of both `ScenePanel` (`SceneLayout.tsx`) and `SceneMenuBar` (`components/SceneMenuBar.tsx`). The guide states the dual-write rule: any action added to a scene's `ScenePanel` must also go in that scene's `SceneMenuBar`, and if the scene has no menu bar yet, create a flag-gated `<Resource>SceneMenuBar`. It points to the existing `/scene-menu-bar` skill for the component taxonomy rather than duplicating it.

Also adds a one-line pointer in the top-level `frontend/src/AGENTS.md` so the rule is discoverable from anywhere under `frontend/src`, not just `layout/scenes/`.

Docs-only; no runtime code changes.

## How did you test this code?

I'm an agent. No automated tests apply (markdown-only). Pre-commit hooks passed: the AGENTS.md/CLAUDE.md symlink check and `bin/hogli format:markdown` (markdownlint + oxfmt) both ran clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Adam directed this: after landing the SceneMenuBar tracking/notebook migration (#65045), he asked for an AGENTS.md that enforces routing new scene features through the menu bar. Investigated the existing surfaces to anchor the guide on real code (`ScenePanel`/`ScenePanelActionsSection` in `SceneLayout.tsx`, the `SceneMenuBar` primitives, and reference per-scene bars for cohort/dashboard/notebook). Chose `frontend/src/layout/scenes/` as the location since both surfaces are defined there, and kept the guide as a when/why pointer to the `/scene-menu-bar` skill (the how) to avoid duplication. No skills invoked for code generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
