### PR TITLE
feat(metrics): render all series in chart mode

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -101,6 +101,7 @@ export const MetricsViewer = (): JSX.Element => {
         dateTo,
         viewMode,
         statSummary,
+        chartSeries,
         sparklineValues,
         sparklineLabels,
         statTotal,
@@ -292,7 +293,7 @@ export const MetricsViewer = (): JSX.Element => {
                 ) : hasResults ? (
                     <Sparkline
                         type="line"
-                        data={[{ name: aggregation, values: sparklineValues, color: 'data-color-1' }]}
+                        data={chartSeries}
                         labels={sparklineLabels}
                         className="w-full h-full"
                         withXScale={withXScale}

--- a/products/metrics/frontend/components/metricsSeries.ts
+++ b/products/metrics/frontend/components/metricsSeries.ts
@@ -1,0 +1,16 @@
+import type { _MetricSeriesApi } from 'products/metrics/frontend/generated/api.schemas'
+
+// PostHog defines data-color-1..15 in vars.scss; cycle through them so each series gets a distinct line.
+const SERIES_COLOR_COUNT = 15
+
+export const seriesColor = (index: number): string => `data-color-${(index % SERIES_COLOR_COUNT) + 1}`
+
+// Human-readable series name from its label map (e.g. "service.name=checkout, env=prod"),
+// falling back to the metric name then a provided default for ungrouped/unlabelled series.
+export const formatSeriesName = (series: _MetricSeriesApi, fallback: string): string => {
+    const entries = Object.entries(series.labels ?? {})
+    if (entries.length > 0) {
+        return entries.map(([key, value]) => `${key}=${value}`).join(', ')
+    }
+    return series.metric_name ?? fallback
+}

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -2,6 +2,7 @@ import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea
 import { loaders } from 'kea-loaders'
 
 import { type MetricSummary } from 'lib/components/Metric/metricSummary'
+import { type SparklineTimeSeries } from 'lib/components/Sparkline'
 import { dayjs } from 'lib/dayjs'
 import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
@@ -9,6 +10,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
 import type { _MetricAnomalyReportApi, _MetricSeriesApi } from 'products/metrics/frontend/generated/api.schemas'
 
+import { formatSeriesName, seriesColor } from './metricsSeries'
 import type { metricsViewerLogicType } from './metricsViewerLogicType'
 
 export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95'
@@ -167,6 +169,17 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // multi-series rendering in a later PR.
         // Metrics has no compare/previous-series concept, so "current" is simply the first series.
         currentSeries: [(s) => [s.queryResults], (results): MetricsViewerSeries | undefined => results[0]],
+        // All series rendered as chart lines (a group-by query returns one series per label combination).
+        // The x-axis labels come from `sparklineLabels` (the backend grids every series onto one time axis).
+        chartSeries: [
+            (s) => [s.queryResults, s.metricName],
+            (results: MetricsViewerSeries[], metricName: string): SparklineTimeSeries[] =>
+                results.map((series, index) => ({
+                    name: formatSeriesName(series, metricName),
+                    values: series.points.map((p) => p.value),
+                    color: seriesColor(index),
+                })),
+        ],
         sparklineValues: [
             (s) => [s.currentSeries],
             (series: MetricsViewerSeries | undefined) => (series?.points ?? []).map((p) => p.value),


### PR DESCRIPTION
## Problem

A group-by metrics query returns one series per label combination, but the viewer only drew `results[0]` — so any split metric silently showed a single line.

## Changes

- Render every series as its own line, named from its label map (e.g. `service.name=checkout`) and coloured from the data palette, reusing `Sparkline`'s native multi-series support and tooltip.
- Naming/colour helpers live in a small `metricsSeries` module so the group-by selector and future correlation links can reuse them.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing. No new tests — presentational wiring over the existing query path.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). First of a "Stack 2" run extending the metrics viewer toward the Grafana-replacement vision (multi-series → group-by → filters).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
