### PR TITLE
refactor(metrics): extract MetricStatPanel component

### DIFF
--- a/products/metrics/frontend/components/MetricStatPanel.tsx
+++ b/products/metrics/frontend/components/MetricStatPanel.tsx
@@ -1,0 +1,79 @@
+import { LemonTag, Tooltip } from '@posthog/lemon-ui'
+import { MetricCard, useChartTheme } from '@posthog/quill-charts'
+
+import {
+    computeMetricSummary,
+    computeMetricSummaryChange,
+    getMetricChangeTooltip,
+    type MetricSummary,
+    METRIC_SUMMARY_LABELS,
+} from 'lib/components/Metric/metricSummary'
+import { dayjs } from 'lib/dayjs'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import { MetricAggregation, MetricsAnomalyBadge } from './metricsViewerLogic'
+
+export interface MetricStatPanelProps {
+    /** Headline title — the metric name. */
+    title: string
+    /** How the series is summarized into one value. */
+    summary: MetricSummary
+    /** The bucket aggregation, shown in the subtitle for context. */
+    aggregation: MetricAggregation
+    /** Grand total across buckets (basis for the 'total' summary). */
+    total: number
+    /** Per-bucket values the summary and sparkline are computed from. */
+    values: number[]
+    /** Pre-formatted bucket labels for the sparkline hover. */
+    labels: string[]
+    /** "vs baseline" anomaly badge, or null when the metric is flat / not characterized. */
+    anomaly: MetricsAnomalyBadge | null
+}
+
+/** A Grafana-style "stat" panel: one headline value + change pill + sparkline, with an optional anomaly badge. */
+export function MetricStatPanel({
+    title,
+    summary,
+    aggregation,
+    total,
+    values,
+    labels,
+    anomaly,
+}: MetricStatPanelProps): JSX.Element {
+    const theme = useChartTheme()
+    return (
+        <div className="flex flex-col h-full">
+            {anomaly && (
+                <div className="flex justify-end">
+                    <Tooltip
+                        title={`Baseline ${humanFriendlyNumber(anomaly.baselineMean)} → recent ${humanFriendlyNumber(
+                            anomaly.anomalyMean
+                        )}${anomaly.onsetTime ? `, onset ${dayjs(anomaly.onsetTime).format('D MMM HH:mm')}` : ''}`}
+                    >
+                        <LemonTag type="warning">
+                            {anomaly.direction === 'up' ? '▲' : '▼'} {anomaly.percent}% vs baseline
+                        </LemonTag>
+                    </Tooltip>
+                </div>
+            )}
+            <MetricCard
+                className="flex-1"
+                title={title}
+                restingSubtitle={`${METRIC_SUMMARY_LABELS[summary]} · ${aggregation}`}
+                value={computeMetricSummary(summary, total, values)}
+                change={computeMetricSummaryChange(summary, { total, data: values }, undefined)}
+                changeTooltip={getMetricChangeTooltip(summary, false, null)}
+                changeSize="md"
+                changeInline
+                hoverChangeFromPreviousPoint
+                data={values}
+                labels={labels}
+                theme={theme}
+                sparklineFill
+                sparklineHeight={140}
+                formatValue={(value) => humanFriendlyNumber(value)}
+                dataAttr="metrics-stat-value"
+            />
+        </div>
+    )
+}

--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,27 +1,20 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonSegmentedButton, LemonSelect, LemonSwitch, LemonTag, SpinnerOverlay, Tooltip } from '@posthog/lemon-ui'
-import { MetricCard, useChartTheme } from '@posthog/quill-charts'
+import { LemonSegmentedButton, LemonSelect, LemonSwitch, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
-import {
-    computeMetricSummary,
-    computeMetricSummaryChange,
-    getMetricChangeTooltip,
-    type MetricSummary,
-    METRIC_SUMMARY_LABELS,
-} from 'lib/components/Metric/metricSummary'
+import { type MetricSummary } from 'lib/components/Metric/metricSummary'
 import { AnyScaleOptions, Sparkline } from 'lib/components/Sparkline'
 import { dayjs } from 'lib/dayjs'
 import { DATE_TIME_FORMAT, formatDateRange } from 'lib/utils/datetime'
-import { humanFriendlyNumber } from 'lib/utils/numbers'
 
 import { DateMappingOption } from '~/types'
 
 import { MetricNameFilter } from './MetricNameFilter'
 import { metricNamePickerLogic } from './metricNamePickerLogic'
+import { MetricStatPanel } from './MetricStatPanel'
 import { LIVE_REFRESH_MS, MetricAggregation, metricsViewerLogic, MetricsViewMode } from './metricsViewerLogic'
 
 const VIEW_MODE_OPTIONS: { value: MetricsViewMode; label: string }[] = [
@@ -123,7 +116,6 @@ export const MetricsViewer = (): JSX.Element => {
         clearAnomaly,
     } = useActions(logic)
     const { items: pickerItems } = useValues(pickerLogic)
-    const chartTheme = useChartTheme()
 
     // Refetch the chart whenever any filter changes — the loader breakpoint debounces input.
     useEffect(() => {
@@ -248,48 +240,15 @@ export const MetricsViewer = (): JSX.Element => {
                         Pick a metric to see its time series.
                     </div>
                 ) : hasResults && viewMode === 'stat' ? (
-                    <div className="flex flex-col h-full">
-                        {anomalyBadge && (
-                            <div className="flex justify-end">
-                                <Tooltip
-                                    title={`Baseline ${humanFriendlyNumber(anomalyBadge.baselineMean)} → recent ${humanFriendlyNumber(
-                                        anomalyBadge.anomalyMean
-                                    )}${
-                                        anomalyBadge.onsetTime
-                                            ? `, onset ${dayjs(anomalyBadge.onsetTime).format('D MMM HH:mm')}`
-                                            : ''
-                                    }`}
-                                >
-                                    <LemonTag type="warning">
-                                        {anomalyBadge.direction === 'up' ? '▲' : '▼'} {anomalyBadge.percent}% vs
-                                        baseline
-                                    </LemonTag>
-                                </Tooltip>
-                            </div>
-                        )}
-                        <MetricCard
-                            className="flex-1"
-                            title={metricName}
-                            restingSubtitle={`${METRIC_SUMMARY_LABELS[statSummary]} · ${aggregation}`}
-                            value={computeMetricSummary(statSummary, statTotal, sparklineValues)}
-                            change={computeMetricSummaryChange(
-                                statSummary,
-                                { total: statTotal, data: sparklineValues },
-                                undefined
-                            )}
-                            changeTooltip={getMetricChangeTooltip(statSummary, false, null)}
-                            changeSize="md"
-                            changeInline
-                            hoverChangeFromPreviousPoint
-                            data={sparklineValues}
-                            labels={sparklineLabels.map(renderLabel)}
-                            theme={chartTheme}
-                            sparklineFill
-                            sparklineHeight={140}
-                            formatValue={(value) => humanFriendlyNumber(value)}
-                            dataAttr="metrics-stat-value"
-                        />
-                    </div>
+                    <MetricStatPanel
+                        title={metricName}
+                        summary={statSummary}
+                        aggregation={aggregation}
+                        total={statTotal}
+                        values={sparklineValues}
+                        labels={sparklineLabels.map(renderLabel)}
+                        anomaly={anomalyBadge}
+                    />
                 ) : hasResults ? (
                     <Sparkline
                         type="line"

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -8,7 +8,11 @@ import { dateStringToDayJs } from 'lib/utils/dateFilters'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
-import type { _MetricAnomalyReportApi, _MetricSeriesApi } from 'products/metrics/frontend/generated/api.schemas'
+import type {
+    _MetricAnomalyReportApi,
+    _MetricSeriesApi,
+    MetricAnomalyDirectionEnumApi,
+} from 'products/metrics/frontend/generated/api.schemas'
 
 import { formatSeriesName, seriesColor } from './metricsSeries'
 import type { metricsViewerLogicType } from './metricsViewerLogicType'
@@ -19,6 +23,15 @@ export type MetricAggregation = 'sum' | 'avg' | 'count' | 'p95'
 export type MetricsViewMode = 'chart' | 'stat'
 
 export type MetricsViewerSeries = _MetricSeriesApi
+
+// Display shape for the stat card's "vs baseline" anomaly badge (null = no anomaly / flat metric).
+export interface MetricsAnomalyBadge {
+    direction: MetricAnomalyDirectionEnumApi
+    percent: number
+    baselineMean: number
+    anomalyMean: number
+    onsetTime: string | null
+}
 
 const DEFAULT_AGGREGATION: MetricAggregation = 'sum'
 const DEFAULT_DATE_FROM = '-1h'
@@ -194,7 +207,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // Display shape for the anomaly badge — null when there's no report or the metric is flat.
         anomalyBadge: [
             (s) => [s.anomalyReport],
-            (report: _MetricAnomalyReportApi | null) =>
+            (report: _MetricAnomalyReportApi | null): MetricsAnomalyBadge | null =>
                 report && report.direction !== 'flat'
                     ? {
                           direction: report.direction,


### PR DESCRIPTION
## Problem

The stat-mode block (anomaly badge + `MetricCard`) had grown large inline in `MetricsViewer`, and the vision calls for a *row* of these cards (golden signals) — which needs the panel as a reusable unit.

## Changes

- Extract a self-contained `MetricStatPanel` that takes the metric, summary, values and anomaly as props.
- Export a named `MetricsAnomalyBadge` type from the logic for the prop.
- No behaviour change — pure refactor that slims the viewer and unblocks the golden-signals grid.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing. No new tests — behaviour-preserving extraction.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). DRY step in the Stack 2 run.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
