### PR TITLE
feat(metrics): group a metric into series by attribute

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -1,7 +1,7 @@
 import { useActions, useMountedLogic, useValues } from 'kea'
 import { useCallback, useEffect, useMemo } from 'react'
 
-import { LemonSegmentedButton, LemonSelect, LemonSwitch, SpinnerOverlay } from '@posthog/lemon-ui'
+import { LemonInputSelect, LemonSegmentedButton, LemonSelect, LemonSwitch, SpinnerOverlay } from '@posthog/lemon-ui'
 
 import { DateFilter } from 'lib/components/DateFilter/DateFilter'
 import { CUSTOM_OPTION_KEY } from 'lib/components/DateFilter/types'
@@ -94,6 +94,7 @@ export const MetricsViewer = (): JSX.Element => {
         dateTo,
         viewMode,
         statSummary,
+        groupByKeys,
         chartSeries,
         sparklineValues,
         sparklineLabels,
@@ -110,6 +111,7 @@ export const MetricsViewer = (): JSX.Element => {
         setDateTo,
         setViewMode,
         setStatSummary,
+        setGroupByKeys,
         setLiveRefresh,
         fetchQueryResults,
         fetchAnomaly,
@@ -120,7 +122,7 @@ export const MetricsViewer = (): JSX.Element => {
     // Refetch the chart whenever any filter changes — the loader breakpoint debounces input.
     useEffect(() => {
         fetchQueryResults({})
-    }, [metricName, aggregation, dateFrom, dateTo]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [metricName, aggregation, dateFrom, dateTo, groupByKeys]) // eslint-disable-line react-hooks/exhaustive-deps
 
     // Characterize the recent window only while the stat card is visible — the badge is stat-mode only.
     useEffect(() => {
@@ -197,6 +199,16 @@ export const MetricsViewer = (): JSX.Element => {
                     value={aggregation}
                     options={AGGREGATION_OPTIONS}
                     onChange={(value) => setAggregation(value as MetricAggregation)}
+                />
+                <LemonInputSelect
+                    mode="multiple"
+                    size="small"
+                    allowCustomValues
+                    value={groupByKeys}
+                    onChange={setGroupByKeys}
+                    options={[]}
+                    placeholder="Group by attribute…"
+                    className="min-w-[12rem]"
                 />
                 <DateFilter
                     size="small"

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -62,6 +62,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setViewMode: (viewMode: MetricsViewMode) => ({ viewMode }),
         setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
         setLiveRefresh: (liveRefresh: boolean) => ({ liveRefresh }),
+        setGroupByKeys: (groupByKeys: string[]) => ({ groupByKeys }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -79,6 +80,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         // 'latest' (current value) is the natural default for a live single-metric stat.
         statSummary: ['latest' as MetricSummary, { setStatSummary: (_, { statSummary }) => statSummary }],
         liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
+        // Attribute keys to split the metric into one series each (e.g. ['service.name', 'env']).
+        groupByKeys: [[] as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
@@ -133,6 +136,9 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                                 aggregation: values.aggregation,
                                 dateFrom: dateFromISO,
                                 ...(dateToISO ? { dateTo: dateToISO } : {}),
+                                ...(values.groupByKeys.length
+                                    ? { groupBy: values.groupByKeys.map((key) => ({ key })) }
+                                    : {}),
                             },
                         },
                         { signal: controller.signal }


### PR DESCRIPTION
## Problem

Multi-series rendering only ever drew one line, because the viewer never sent a group-by — there was no way to split a metric by `service.name`, `k8s.pod`, etc.

## Changes

- Add a group-by input whose keys flow into the query body's `groupBy`, so the metric splits into one series per attribute value and the multi-series renderer draws each.
- Reuses `LemonInputSelect` with custom values. The values endpoint can power key autocomplete in a follow-up.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing — exercising it needs a running stack with grouped metric data. No new tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Makes the earlier multi-series PR functional.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
