### PR TITLE
feat(metrics): filter a metric by attribute

### DIFF
--- a/products/metrics/frontend/components/MetricsViewer.tsx
+++ b/products/metrics/frontend/components/MetricsViewer.tsx
@@ -95,6 +95,7 @@ export const MetricsViewer = (): JSX.Element => {
         viewMode,
         statSummary,
         groupByKeys,
+        filterStrings,
         chartSeries,
         sparklineValues,
         sparklineLabels,
@@ -112,6 +113,7 @@ export const MetricsViewer = (): JSX.Element => {
         setViewMode,
         setStatSummary,
         setGroupByKeys,
+        setFilterStrings,
         setLiveRefresh,
         fetchQueryResults,
         fetchAnomaly,
@@ -122,7 +124,7 @@ export const MetricsViewer = (): JSX.Element => {
     // Refetch the chart whenever any filter changes — the loader breakpoint debounces input.
     useEffect(() => {
         fetchQueryResults({})
-    }, [metricName, aggregation, dateFrom, dateTo, groupByKeys]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [metricName, aggregation, dateFrom, dateTo, groupByKeys, filterStrings]) // eslint-disable-line react-hooks/exhaustive-deps
 
     // Characterize the recent window only while the stat card is visible — the badge is stat-mode only.
     useEffect(() => {
@@ -131,7 +133,7 @@ export const MetricsViewer = (): JSX.Element => {
         } else {
             clearAnomaly()
         }
-    }, [metricName, aggregation, dateFrom, dateTo, viewMode, hasMetricName]) // eslint-disable-line react-hooks/exhaustive-deps
+    }, [metricName, aggregation, dateFrom, dateTo, viewMode, hasMetricName, filterStrings]) // eslint-disable-line react-hooks/exhaustive-deps
 
     const selectedMetricType = useMemo(
         () => pickerItems.find((item) => item.name === metricName)?.metric_type,
@@ -209,6 +211,16 @@ export const MetricsViewer = (): JSX.Element => {
                     options={[]}
                     placeholder="Group by attribute…"
                     className="min-w-[12rem]"
+                />
+                <LemonInputSelect
+                    mode="multiple"
+                    size="small"
+                    allowCustomValues
+                    value={filterStrings}
+                    onChange={setFilterStrings}
+                    options={[]}
+                    placeholder="Filter attribute=value…"
+                    className="min-w-[14rem]"
                 />
                 <DateFilter
                     size="small"

--- a/products/metrics/frontend/components/metricsViewerLogic.tsx
+++ b/products/metrics/frontend/components/metricsViewerLogic.tsx
@@ -10,6 +10,7 @@ import { teamLogic } from 'scenes/teamLogic'
 import { metricsCharacterizeCreate, metricsQueryCreate } from 'products/metrics/frontend/generated/api'
 import type {
     _MetricAnomalyReportApi,
+    _MetricFilterApi,
     _MetricSeriesApi,
     MetricAnomalyDirectionEnumApi,
 } from 'products/metrics/frontend/generated/api.schemas'
@@ -41,6 +42,15 @@ const ANOMALY_WINDOW_FRACTION = 0.2
 export const LIVE_REFRESH_MS = 15_000
 const LIVE_REFRESH_KEY = 'metricsLiveRefresh'
 
+// Parse a "key=value" chip into an equality filter. Returns null for malformed input (no key before '=').
+const parseFilter = (raw: string): _MetricFilterApi | null => {
+    const eq = raw.indexOf('=')
+    if (eq <= 0) {
+        return null
+    }
+    return { key: raw.slice(0, eq).trim(), op: 'eq', value: raw.slice(eq + 1).trim() }
+}
+
 const resolveDate = (value: string | null | undefined): string | null => {
     if (!value) {
         return null
@@ -63,6 +73,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         setStatSummary: (statSummary: MetricSummary) => ({ statSummary }),
         setLiveRefresh: (liveRefresh: boolean) => ({ liveRefresh }),
         setGroupByKeys: (groupByKeys: string[]) => ({ groupByKeys }),
+        setFilterStrings: (filterStrings: string[]) => ({ filterStrings }),
         // AbortController plumbing mirrors logsViewerDataLogic: a `cancelInProgress`
         // action aborts the previous controller before storing the new one.
         setQueryAbortController: (controller: AbortController | null) => ({ controller }),
@@ -82,6 +93,8 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
         liveRefresh: [false, { setLiveRefresh: (_, { liveRefresh }) => liveRefresh }],
         // Attribute keys to split the metric into one series each (e.g. ['service.name', 'env']).
         groupByKeys: [[] as string[], { setGroupByKeys: (_, { groupByKeys }) => groupByKeys }],
+        // Raw "key=value" filter chips; parsed into query filters by the `queryFilters` selector.
+        filterStrings: [[] as string[], { setFilterStrings: (_, { filterStrings }) => filterStrings }],
         queryAbortController: [
             null as AbortController | null,
             { setQueryAbortController: (_, { controller }) => controller },
@@ -139,6 +152,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                                 ...(values.groupByKeys.length
                                     ? { groupBy: values.groupByKeys.map((key) => ({ key })) }
                                     : {}),
+                                ...(values.queryFilters.length ? { filters: values.queryFilters } : {}),
                             },
                         },
                         { signal: controller.signal }
@@ -174,6 +188,7 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
                             aggregation: values.aggregation,
                             anomalyFrom,
                             anomalyTo: toISO,
+                            ...(values.queryFilters.length ? { filters: values.queryFilters } : {}),
                         },
                     })
                     breakpoint()
@@ -184,6 +199,11 @@ export const metricsViewerLogic = kea<metricsViewerLogicType>([
     })),
     selectors({
         hasMetricName: [(s) => [s.metricName], (metricName) => metricName.trim().length > 0],
+        queryFilters: [
+            (s) => [s.filterStrings],
+            (filterStrings: string[]): _MetricFilterApi[] =>
+                filterStrings.map(parseFilter).filter((f): f is _MetricFilterApi => f !== null),
+        ],
         // The viewer renders the first series only for now; group-by lands
         // multi-series rendering in a later PR.
         // Metrics has no compare/previous-series concept, so "current" is simply the first series.


### PR DESCRIPTION
## Problem

No way to narrow a metric to a subset — e.g. just `service.name=checkout` in `env=prod`. This is also the basis for the "my team's metrics" scoping the vision calls for.

## Changes

- Add an attribute filter input: `key=value` chips are parsed into equality filters and passed to both the metric query and the anomaly characterization, so chart, stat card and badge all reflect the filtered series.
- Reuses `LemonInputSelect`. Equality only for now; non-equality operators (neq/regex, which the backend supports) can follow.

## How did you test this code?

Agent-authored. Ran the frontend `typescript:check` (clean for the changed files). No manual testing — needs a running stack with metric data. No new tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Top of the Stack 2 run. Equality-only `key=value` parsing was chosen as the minimal functional filter; a key/op/value builder with autocomplete is the natural next step.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
