### PR TITLE
fix(mongodb): handle non-ObjectId _id incremental cursor

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
@@ -197,11 +197,21 @@ def _build_query(
         db_incremental_field_last_value = incremental_type_to_initial_value(incremental_field_type)
 
     if incremental_field_type == IncrementalFieldType.ObjectID:
-        query = {incremental_field: {"$gt": ObjectId(str(db_incremental_field_last_value)), "$exists": True}}
+        query = {incremental_field: {"$gt": _coerce_object_id_cursor(db_incremental_field_last_value), "$exists": True}}
     else:
         query = {incremental_field: {"$gt": db_incremental_field_last_value, "$exists": True}}
 
     return query
+
+
+def _coerce_object_id_cursor(last_value: Any) -> Any:
+    """`_id` is offered as an ObjectID incremental cursor, but MongoDB `_id` values aren't
+    always ObjectIds — collections frequently key on UUIDs or other strings. Only wrap the
+    cursor in ObjectId when it's a valid 24-char hex id; otherwise compare the raw string so
+    a non-ObjectId `_id` doesn't raise InvalidId and permanently break every incremental sync.
+    """
+    value = str(last_value)
+    return ObjectId(value) if ObjectId.is_valid(value) else value
 
 
 def _make_safe_server_selector(team_id: int) -> Callable[[list[ServerDescription]], list[ServerDescription]]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -328,17 +328,21 @@ class TestBuildQuery(SimpleTestCase):
     """`_id` is offered as an ObjectID incremental cursor, but MongoDB `_id` values aren't
     always ObjectIds — a non-ObjectId cursor must not crash query construction."""
 
-    def test_object_id_cursor_is_wrapped(self):
-        oid = ObjectId()
-        query = _build_query(True, "_id", IncrementalFieldType.ObjectID, str(oid))
-        assert query == {"_id": {"$gt": oid, "$exists": True}}
+    _OID_HEX = "507f1f77bcf86cd799439011"
+    _UUID = "fffdb62e-4704-4671-984c-ffcff3a8dd52"
 
-    def test_uuid_id_cursor_compares_as_string(self):
-        # Regression: a UUID-string `_id` previously raised bson.errors.InvalidId here,
-        # permanently breaking every incremental sync for collections that key on UUIDs.
-        uuid_id = "fffdb62e-4704-4671-984c-ffcff3a8dd52"
-        query = _build_query(True, "_id", IncrementalFieldType.ObjectID, uuid_id)
-        assert query == {"_id": {"$gt": uuid_id, "$exists": True}}
+    @parameterized.expand(
+        [
+            # A valid 24-char hex cursor stays an ObjectId so native ordered comparison is preserved.
+            ("objectid_cursor_is_wrapped", _OID_HEX, ObjectId(_OID_HEX)),
+            # Regression: a UUID-string `_id` previously raised bson.errors.InvalidId here,
+            # permanently breaking every incremental sync for collections that key on UUIDs.
+            ("uuid_cursor_compares_as_string", _UUID, _UUID),
+        ]
+    )
+    def test_cursor_coercion(self, _name: str, cursor: str, expected_gt):
+        query = _build_query(True, "_id", IncrementalFieldType.ObjectID, cursor)
+        assert query == {"_id": {"$gt": expected_gt, "$exists": True}}
 
 
 class TestMongoDBNonRetryableErrors(SimpleTestCase):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -13,12 +13,14 @@ from pymongo.errors import ServerSelectionTimeoutError
 from pymongo.server_description import ServerDescription
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
+    _build_query,
     _get_rows_to_sync,
     _make_safe_server_selector,
     _process_doc_with_field_logging,
     _process_nested_value,
     get_leading_index_keys,
 )
+from products.warehouse_sources.backend.types import IncrementalFieldType
 
 
 class TestSafeServerSelector(SimpleTestCase):
@@ -320,6 +322,23 @@ class TestGetLeadingIndexKeys(SimpleTestCase):
     def test_returns_empty_set_for_collection_with_no_indexes(self):
         coll = self._collection_with_indexes([])
         assert get_leading_index_keys(coll) == set()
+
+
+class TestBuildQuery(SimpleTestCase):
+    """`_id` is offered as an ObjectID incremental cursor, but MongoDB `_id` values aren't
+    always ObjectIds — a non-ObjectId cursor must not crash query construction."""
+
+    def test_object_id_cursor_is_wrapped(self):
+        oid = ObjectId()
+        query = _build_query(True, "_id", IncrementalFieldType.ObjectID, str(oid))
+        assert query == {"_id": {"$gt": oid, "$exists": True}}
+
+    def test_uuid_id_cursor_compares_as_string(self):
+        # Regression: a UUID-string `_id` previously raised bson.errors.InvalidId here,
+        # permanently breaking every incremental sync for collections that key on UUIDs.
+        uuid_id = "fffdb62e-4704-4671-984c-ffcff3a8dd52"
+        query = _build_query(True, "_id", IncrementalFieldType.ObjectID, uuid_id)
+        assert query == {"_id": {"$gt": uuid_id, "$exists": True}}
 
 
 class TestMongoDBNonRetryableErrors(SimpleTestCase):


### PR DESCRIPTION
## Problem

The MongoDB import source surfaced an `InvalidId` crash in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f0526-a5b5-7a11-852b-45ddd723bd72)):

```
InvalidId: '<redacted-uuid>' is not a valid ObjectId, it must be a 12-byte input or a 24-character hex string
```

The stack originates in our code: `mongo._build_query` (line 200) ← `mongo_source` ← `mongodb/source.py:source_for_pipeline`.

Root cause: `filter_mongo_incremental_fields` always offers a string-typed `_id` as an `ObjectID` incremental field. But MongoDB `_id` values aren't always ObjectIds — collections frequently key on UUIDs or other strings. The first sync runs fine (the initial cursor is the all-zeros ObjectId), but once it stores a real non-ObjectId `_id` as the cursor, the next incremental run hits `ObjectId(str(last_value))` and raises `bson.errors.InvalidId`. From then on **every** incremental sync of that collection fails the same way — it never recovers on retry.

This is our bug, not a user/config error: we generated an incremental field config that our own query builder can't consume.

## Changes

`_build_query` now wraps the cursor in `ObjectId` only when it's a valid 24-char hex id (`ObjectId.is_valid`); otherwise it compares the raw string. A genuine ObjectId `_id` keeps its native ordered comparison; a UUID/string `_id` degrades to a string `$gt` comparison instead of crashing.

Scoped strictly to the cursor coercion — no change to schema inference, retry policy, or anything else.

## How did you test this code?

I'm an agent. I added unit tests at the same layer as the fix (`TestBuildQuery`) and ran the MongoDB source test suite:

- `test_object_id_cursor_is_wrapped` — a valid ObjectId hex cursor is still wrapped in `ObjectId` (preserves native ordering; nothing regressed).
- `test_uuid_id_cursor_compares_as_string` — a UUID-string cursor builds a query instead of raising `InvalidId`. This is the regression the existing suite did not catch.

`59 passed` for `products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py`. `ruff check` and `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in error tracking (6 occurrences, real in-app frame at `mongo.py:_build_query`), traced the call path, and read the source to find the wrong assumption that any string `_id` is an ObjectId. Classified as a fixable bug rather than a user/upstream error — the failing config is one we generate ourselves, and it crashes permanently rather than being a transient or credential issue, so `NonRetryableErrors` would be the wrong tool. Checked open PRs (including the maintainer's) for an existing fix; none addresses this. Fix kept minimal and verified with targeted regression tests.
