### PR TITLE
fix(oauth): don't authorize the wrong project while a team_id hint is pending

### DIFF
--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
@@ -198,43 +198,76 @@ describe('oauthAuthorizeLogic', () => {
     const HINT_TEAMS = [
         { id: 11, organization: 'org-a', name: 'A project' },
         { id: 22, organization: 'org-b', name: 'B project' },
-    ] as any
+    ]
+    const CURRENT_TEAM = {
+        id: MOCK_DEFAULT_USER.team?.id,
+        organization: MOCK_DEFAULT_USER.organization?.id,
+        name: 'Current project',
+    }
 
-    it('pre-selects the hinted project and its org from the team_id param', () => {
-        logic.actions.setTeamHint(22)
+    // Once teams load, a team_id hint resolves to that project + its org; an
+    // inaccessible hint falls back to the user's current org/team.
+    const hintResolutionCases: {
+        name: string
+        hint: number
+        teams: any[]
+        expectedOrg: string | undefined
+        expectedTeams: (number | undefined)[]
+    }[] = [
+        {
+            name: 'resolves the hinted project and its org from the team_id param',
+            hint: 22,
+            teams: HINT_TEAMS,
+            expectedOrg: 'org-b',
+            expectedTeams: [22],
+        },
+        {
+            name: 'falls back to the current org/team when the hinted team is inaccessible',
+            hint: 999,
+            teams: [...HINT_TEAMS, CURRENT_TEAM],
+            expectedOrg: MOCK_DEFAULT_USER.organization?.id,
+            expectedTeams: [MOCK_DEFAULT_USER.team?.id],
+        },
+    ]
+
+    it.each(hintResolutionCases)('team_id hint $name', ({ hint, teams, expectedOrg, expectedTeams }) => {
+        logic.actions.setTeamHint(hint)
         logic.actions.setRequiredAccessLevel('team')
-        logic.actions.loadAllTeamsSuccess(HINT_TEAMS)
-        expect(logic.values.selectedOrganization).toBe('org-b')
-        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([22])
+        logic.actions.loadAllTeamsSuccess(teams as any)
         expect(logic.values.teamHint).toBeNull()
+        expect(logic.values.selectedOrganization).toBe(expectedOrg)
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual(expectedTeams)
     })
 
-    it('does not pre-select the current project while a team_id hint is pending', () => {
-        // The eager current-org selection is what authorized the wrong project on a
-        // fast CTA click; with a hint pending it must stay empty until teams load.
-        logic.actions.setTeamHint(22)
-        logic.actions.setRequiredAccessLevel('team')
-        expect(logic.values.selectedOrganization).toBeNull()
-        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([])
-    })
+    // Before teams load, a pending hint suppresses the eager current-org selection
+    // (so a fast CTA click can't authorize the wrong project), while the no-hint
+    // path keeps pre-selecting the current org/team.
+    const eagerSelectionCases: {
+        name: string
+        hint: number | null
+        expectedOrg: string | null | undefined
+        expectedTeams: (number | undefined)[]
+    }[] = [
+        {
+            name: 'leaves the selection empty while a team_id hint is pending',
+            hint: 22,
+            expectedOrg: null,
+            expectedTeams: [],
+        },
+        {
+            name: 'pre-selects the current org/team when no team_id hint is given',
+            hint: null,
+            expectedOrg: MOCK_DEFAULT_USER.organization?.id,
+            expectedTeams: [MOCK_DEFAULT_USER.team?.id],
+        },
+    ]
 
-    it('falls back to the current org/team when the hinted team is inaccessible', () => {
-        const currentTeam = {
-            id: MOCK_DEFAULT_USER.team?.id,
-            organization: MOCK_DEFAULT_USER.organization?.id,
-            name: 'Current project',
+    it.each(eagerSelectionCases)('before teams load, $name', ({ hint, expectedOrg, expectedTeams }) => {
+        if (hint !== null) {
+            logic.actions.setTeamHint(hint)
         }
-        logic.actions.setTeamHint(999)
         logic.actions.setRequiredAccessLevel('team')
-        logic.actions.loadAllTeamsSuccess([...HINT_TEAMS, currentTeam] as any)
-        expect(logic.values.teamHint).toBeNull()
-        expect(logic.values.selectedOrganization).toBe(MOCK_DEFAULT_USER.organization?.id)
-        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([MOCK_DEFAULT_USER.team?.id])
-    })
-
-    it('pre-selects the current org/team when no team_id hint is given', () => {
-        logic.actions.setRequiredAccessLevel('team')
-        expect(logic.values.selectedOrganization).toBe(MOCK_DEFAULT_USER.organization?.id)
-        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([MOCK_DEFAULT_USER.team?.id])
+        expect(logic.values.selectedOrganization).toBe(expectedOrg)
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual(expectedTeams)
     })
 })

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.test.ts
@@ -194,4 +194,47 @@ describe('oauthAuthorizeLogic', () => {
         expect(logic.values.deniedScopeObjects).toEqual([])
         expect(logic.values.effectiveScopes).toEqual(['openid', 'insight:write'])
     })
+
+    const HINT_TEAMS = [
+        { id: 11, organization: 'org-a', name: 'A project' },
+        { id: 22, organization: 'org-b', name: 'B project' },
+    ] as any
+
+    it('pre-selects the hinted project and its org from the team_id param', () => {
+        logic.actions.setTeamHint(22)
+        logic.actions.setRequiredAccessLevel('team')
+        logic.actions.loadAllTeamsSuccess(HINT_TEAMS)
+        expect(logic.values.selectedOrganization).toBe('org-b')
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([22])
+        expect(logic.values.teamHint).toBeNull()
+    })
+
+    it('does not pre-select the current project while a team_id hint is pending', () => {
+        // The eager current-org selection is what authorized the wrong project on a
+        // fast CTA click; with a hint pending it must stay empty until teams load.
+        logic.actions.setTeamHint(22)
+        logic.actions.setRequiredAccessLevel('team')
+        expect(logic.values.selectedOrganization).toBeNull()
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([])
+    })
+
+    it('falls back to the current org/team when the hinted team is inaccessible', () => {
+        const currentTeam = {
+            id: MOCK_DEFAULT_USER.team?.id,
+            organization: MOCK_DEFAULT_USER.organization?.id,
+            name: 'Current project',
+        }
+        logic.actions.setTeamHint(999)
+        logic.actions.setRequiredAccessLevel('team')
+        logic.actions.loadAllTeamsSuccess([...HINT_TEAMS, currentTeam] as any)
+        expect(logic.values.teamHint).toBeNull()
+        expect(logic.values.selectedOrganization).toBe(MOCK_DEFAULT_USER.organization?.id)
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([MOCK_DEFAULT_USER.team?.id])
+    })
+
+    it('pre-selects the current org/team when no team_id hint is given', () => {
+        logic.actions.setRequiredAccessLevel('team')
+        expect(logic.values.selectedOrganization).toBe(MOCK_DEFAULT_USER.organization?.id)
+        expect(logic.values.oauthAuthorization.scoped_teams).toEqual([MOCK_DEFAULT_USER.team?.id])
+    })
 })

--- a/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
+++ b/frontend/src/scenes/oauth/oauthAuthorizeLogic.ts
@@ -339,9 +339,15 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
                 actions.setOauthAuthorizationValue('access_type', 'organizations')
             } else if (requiredAccessLevel === 'team') {
                 actions.setOauthAuthorizationValue('access_type', 'teams')
-                const user = userLogic.values.user
-                if (user?.organization?.id) {
-                    actions.setSelectedOrganization(user.organization.id, user?.team?.id)
+                // With a team_id hint pending, let it drive org+project selection once
+                // teams load — don't pre-select the user's current org/team, or a CTA
+                // link could authorize the wrong project before the hint resolves. The
+                // empty project keeps the submit blocked until the hint fills it in.
+                if (!values.teamHint) {
+                    const user = userLogic.values.user
+                    if (user?.organization?.id) {
+                        actions.setSelectedOrganization(user.organization.id, user?.team?.id)
+                    }
                 }
             }
         },
@@ -360,23 +366,36 @@ export const oauthAuthorizeLogic = kea<oauthAuthorizeLogicType>([
         },
         loadAllTeamsSuccess: () => {
             const teams = values.sortedTeams
+            if (!teams) {
+                return
+            }
             // A team_id hint from the authorize URL (e.g. the wizard's --project-id) wins:
             // pre-select that project and its org so the user just clicks Authorize. We only
             // honor it if the user has access to that team (it's in their loaded teams), and
             // consume it once — so it can't override a later manual change or a project the
             // user creates here (both also re-fire this listener).
-            if (values.teamHint && teams && values.requiredAccessLevel === 'team') {
+            if (values.teamHint) {
                 const hinted = teams.find((t) => t.id === values.teamHint)
                 actions.setTeamHint(null)
-                if (hinted) {
+                if (hinted && values.requiredAccessLevel === 'team') {
                     actions.setSelectedOrganization(hinted.organization, hinted.id)
                     return
+                }
+                // Hint didn't resolve (inaccessible team, or not a team-level grant). Fall
+                // back to the user's current org/team — setRequiredAccessLevel skipped this
+                // while the hint was pending, so without it the screen would be left empty.
+                if (values.requiredAccessLevel === 'team' && !values.selectedOrganization) {
+                    const user = userLogic.values.user
+                    if (user?.organization?.id) {
+                        actions.setSelectedOrganization(user.organization.id, user?.team?.id)
+                        return
+                    }
                 }
             }
             // After teams load, auto-select first project if org is set but no project selected
             const orgId = values.selectedOrganization
             const currentTeams = values.oauthAuthorization.scoped_teams
-            if (orgId && (!currentTeams || currentTeams.length === 0) && teams) {
+            if (orgId && (!currentTeams || currentTeams.length === 0)) {
                 const orgTeams = teams.filter((t) => t.organization === orgId)
                 if (orgTeams.length > 0) {
                     actions.setOauthAuthorizationValue('scoped_teams', [orgTeams[0].id])


### PR DESCRIPTION
## Problem

The OAuth consent screen pre-selects a project + org from a `team_id` hint in the authorize URL (the wizard's `--project-id`, [PostHog/wizard#743](https://github.com/PostHog/wizard/pull/743)), so a CTA link can drop the user straight onto "Authorize". But it was producing project mismatches.

Root cause: `setRequiredAccessLevel` eagerly pre-selects the user's **current** org/team. The hint only resolves after `loadAllTeams` returns, so there's a window where `scoped_teams` points at the current project. On a fast CTA click — or whenever the hinted team is in a different org — authorizing in that window granted the wrong project. The wizard then rejects the grant (`--project-id` mismatch) or silently captures into the wrong place.

## Changes

While a `team_id` hint is pending, don't eagerly select the current org/team — let the hint drive selection once teams load. The project stays empty in the meantime, which keeps the form's submit blocked (its "Select at least one project" validation) until the hint fills it in, so the wrong project can't be authorized during the load window. If the hint can't be honored (inaccessible team), fall back to the current org/team as before.

No new URL params or actions — this hardens the existing `team_id` flow.

## How did you test this code?

I'm an agent (PostHog Slack app). Automated only — I did not run a live OAuth flow.

- Added 4 cases to `oauthAuthorizeLogic.test.ts` and ran the suite (21/21 pass): hint pre-selects org + project; nothing is pre-selected while a hint is pending (the regression that authorized the wrong project); fallback to current org/team when the hinted team is inaccessible; unchanged current-org default when no hint is given.
- `oxfmt` clean on the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at Edwin's direction, from a Slack thread where Edwin hit project mismatches testing the wizard's `--project-id` against the consent screen. Pairs with the already-merged [#66383](https://github.com/PostHog/posthog/pull/66383) (which added the `team_id` pre-select) and wizard [#743](https://github.com/PostHog/wizard/pull/743).

Decision: rather than disabling the Authorize button on a timer, the fix leans on the existing form validation — leaving `scoped_teams` empty until the hint resolves naturally blocks submit, which closes the race without new UI state. No skills were invoked; the change is confined to one kea logic file and its test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1782493901839569?thread_ts=1782493901.839569&cid=C09GTQY5RLZ)*
