### PR TITLE
chore(test): make preview-stats authz test actually test the guard

### DIFF
--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth.models import Group
+from django.contrib.messages import get_messages
 from django.contrib.messages.storage.fallback import FallbackStorage
 from django.test import RequestFactory, override_settings
 
@@ -720,7 +721,7 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
         # The guard must short-circuit before any preview is computed or stashed in the session, and
         # surface the rejection — otherwise removing the authz check would still pass this test.
         self.assertNotIn("data_deletion_preview_stats", http_request.session)
-        self.assertIn("Only ClickHouse Team members can preview stats.", [str(m) for m in http_request._messages])
+        self.assertIn("Only ClickHouse Team members can preview stats.", [str(m) for m in get_messages(http_request)])
 
 
 @override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})

--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -690,11 +690,11 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
         http_request.user = user or self.user
         _attach_messages(http_request)
         with patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse):
-            return view(http_request, str(request.pk))
+            return view(http_request, str(request.pk)), http_request
 
     def test_fetch_stats_redirects_to_change_page(self):
         request = self._person_request()
-        response = self._call(self.admin.fetch_stats_view, request)
+        response, _ = self._call(self.admin.fetch_stats_view, request)
         self.assertEqual(response.status_code, 302)
         self.assertIn("posthog_datadeletionrequest_change", response.url)
         request.refresh_from_db()
@@ -702,7 +702,7 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
 
     def test_preview_stats_redirects_to_change_page(self):
         request = self._person_request()
-        response = self._call(self.admin.preview_stats_view, request)
+        response, _ = self._call(self.admin.preview_stats_view, request)
         self.assertEqual(response.status_code, 302)
         self.assertIn("posthog_datadeletionrequest_change", response.url)
 
@@ -710,11 +710,7 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
         request = self._person_request()
         self.user.groups.clear()
 
-        http_request = self.factory.post(f"/admin/posthog/datadeletionrequest/{request.pk}/x/")
-        http_request.user = self.user
-        _attach_messages(http_request)
-        with patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse):
-            response = self.admin.preview_stats_view(http_request, str(request.pk))
+        response, http_request = self._call(self.admin.preview_stats_view, request)
 
         self.assertEqual(response.status_code, 302)
         self.assertIn("posthog_datadeletionrequest_change", response.url)

--- a/posthog/admin/test_data_deletion_request_admin.py
+++ b/posthog/admin/test_data_deletion_request_admin.py
@@ -708,9 +708,19 @@ class TestDataDeletionRequestAdminStatsViewRedirects(BaseTest):
     def test_preview_stats_rejects_non_clickhouse_team(self):
         request = self._person_request()
         self.user.groups.clear()
-        response = self._call(self.admin.preview_stats_view, request)
+
+        http_request = self.factory.post(f"/admin/posthog/datadeletionrequest/{request.pk}/x/")
+        http_request.user = self.user
+        _attach_messages(http_request)
+        with patch("posthog.admin.admins.data_deletion_request_admin.reverse", side_effect=_fake_reverse):
+            response = self.admin.preview_stats_view(http_request, str(request.pk))
+
         self.assertEqual(response.status_code, 302)
         self.assertIn("posthog_datadeletionrequest_change", response.url)
+        # The guard must short-circuit before any preview is computed or stashed in the session, and
+        # surface the rejection — otherwise removing the authz check would still pass this test.
+        self.assertNotIn("data_deletion_preview_stats", http_request.session)
+        self.assertIn("Only ClickHouse Team members can preview stats.", [str(m) for m in http_request._messages])
 
 
 @override_settings(STORAGES={"staticfiles": {"BACKEND": "django.contrib.staticfiles.storage.StaticFilesStorage"}})


### PR DESCRIPTION
## Problem

`test_preview_stats_rejects_non_clickhouse_team` asserted only the `302 → change page` redirect — which is exactly what the **success** path (`test_preview_stats_redirects_to_change_page`) asserts too. So the test passed whether or not the ClickHouse-Team authz guard in `preview_stats_view` was present. A security-adjacent guard test that can't detect its guard being removed gives false confidence.

## Changes

Strengthen the rejection test to assert the guard's observable effect, not just the redirect:

- No preview is computed/stashed: `"data_deletion_preview_stats"` is absent from the request session (the success path writes it).
- The rejection is surfaced: the `"Only ClickHouse Team members can preview stats."` error message is added.

The request is now built inline (instead of via the `_call` helper) so the test can inspect the session and messages.

## How did you test this code?

I'm an agent. Ran locally with `SANDBOX_PROVIDER=modal` (to match CI on this devbox):

```
hogli test "posthog/admin/test_data_deletion_request_admin.py::TestDataDeletionRequestAdminStatsViewRedirects"
```

Result: 3 passed with the guard in place. I then temporarily removed the `CLICKHOUSE_TEAM_GROUP` guard from `preview_stats_view` and re-ran — the strengthened test **failed** (proving it now catches guard removal) — then restored the guard (production code unchanged in this PR).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Part of a monorepo test-suite cleanup; this is one of the worklist's "flawed-but-valuable" FIX items (a test whose assertions pass even when the guard it claims to test is removed). Only the test changed; verified the negative case by neutering the production guard locally and confirming the failure, then reverting. No CODEOWNERS entry covers `posthog/admin/` data-deletion, so routing to Platform as the closest owner of core admin tooling.

Requesting review from: Platform
