### PR TITLE
chore(alerts): remove alerts-anomaly-detection feature flag

### DIFF
--- a/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
+++ b/frontend/src/lib/components/Alerts/views/EditAlertModal.tsx
@@ -128,7 +128,6 @@ export function EditAlertModal({
 
     const { currentTeam } = useValues(teamLogic)
     const projectTimezone = currentTeam?.timezone ?? 'UTC'
-    const anomalyDetectionEnabled = useFeatureFlag('ALERTS_ANOMALY_DETECTION')
     const inlineNotificationsEnabled = useFeatureFlag('ALERTS_INLINE_NOTIFICATIONS')
     const investigationAgentEnabled = useFeatureFlag('ALERTS_INVESTIGATION_AGENT')
     const alerts15MinuteIntervalEnabled = useFeatureFlag('ALERTS_15_MINUTE_INTERVAL')
@@ -279,9 +278,7 @@ export function EditAlertModal({
                                             valueColumnOptions: hogqlValueColumnOptions,
                                             labelColumnOptions: hogqlLabelColumnOptions,
                                         }}
-                                        anomalyDetectionEnabled={
-                                            anomalyDetectionEnabled && supportsAnomalyDetection(alertForm.config)
-                                        }
+                                        anomalyDetectionEnabled={supportsAnomalyDetection(alertForm.config)}
                                         investigationAgentEnabled={investigationAgentEnabled}
                                         simulationResult={simulationResult}
                                         simulationResultLoading={simulationResultLoading}

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -246,7 +246,6 @@ export const FEATURE_FLAGS = {
     AI_GATEWAY: 'ai-gateway', // owner: #team-ai-gateway, gates the AI gateway UI and llm_gateway:read on project secret API keys
     /** Alert edit modal: check history chart + chart/table toggle (table remains when off). */
     ALERTS_15_MINUTE_INTERVAL: 'alerts-15-minute-interval', // owner: #team-analytics-platform, gates 15-minute insight alert interval
-    ALERTS_ANOMALY_DETECTION: 'alerts-anomaly-detection', // owner: @andrewm4894
     ALERTS_INLINE_NOTIFICATIONS: 'alerts-inline-notifications', // owner: @vdekrijger
     ALERTS_INVESTIGATION_AGENT: 'alerts-investigation-agent', // owner: @andrewm4894, anomaly alerts — investigation agent on firing
     AMPLITUDE_BATCH_IMPORT_OPTIONS: 'amplitude-batch-import-options', // owner: #team-ingestion


### PR DESCRIPTION
## Problem

The `alerts-anomaly-detection` flag has been rolled out to 100% of users for a while now, so the runtime checks gating the anomaly detection UI in the alert edit modal are dead weight. Removing the flag simplifies the code and unblocks retiring the flag in PostHog.

## Changes

- Removed the `ALERTS_ANOMALY_DETECTION` entry from `frontend/src/lib/constants.tsx`.
- Dropped the `useFeatureFlag('ALERTS_ANOMALY_DETECTION')` check in `EditAlertModal`. Anomaly detection now surfaces whenever `supportsAnomalyDetection(alertForm.config)` is true.

## How did you test this code?

I'm an agent (PostHog Slack app). No manual testing. This is a pure flag-removal change — the only behavioral effect is that the anomaly detection section now renders based solely on whether the alert config supports it, which was already the gate alongside the (now-always-true) flag.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack by Radu Raicea / Andy Maguire — the flag is at 100% and they want it gone. Straightforward removal: deleted the constant and the single `useFeatureFlag` consumer, collapsing the `anomalyDetectionEnabled && supportsAnomalyDetection(...)` expression down to just `supportsAnomalyDetection(...)`. The `useFeatureFlag` import stays since the modal still reads other alert flags. No skills were needed.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782498753300209?thread_ts=1782498753.300209&cid=C09SK2PAGKF)*
