### PR TITLE
fix(google_ads): back off and retry transient DB pool timeouts when fetching integration

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -75,6 +75,11 @@ def _ensure_grpc_receive_limit() -> None:
     options.append((_GRPC_MAX_RECEIVE_MESSAGE_LENGTH_KEY, GRPC_MAX_RECEIVE_MESSAGE_LENGTH))
 
 
+def _backoff_sleep(attempt: int) -> None:
+    """Sleep before the next retry: linear growth capped at 30s (2s, 4s, 6s, ...)."""
+    time.sleep(min(2 * attempt, 30))
+
+
 # ``GoogleAdsClient`` performs an OAuth token refresh at construction, reaching Google's token
 # endpoint over the network. Two failure shapes on that hop are transient and usually clear on a
 # short backoff: a connection-level hiccup (e.g. a proxy timeout) surfaces as
@@ -126,7 +131,7 @@ def _load_client_with_transient_retry(
             attempt += 1
             if attempt >= max_attempts or not _is_transient_client_init_error(e):
                 raise
-            time.sleep(min(2 * attempt, 30))
+            _backoff_sleep(attempt)
 
 
 _MAX_INTEGRATION_FETCH_ATTEMPTS = 4
@@ -154,7 +159,7 @@ def _get_integration(integration_id: int, team_id: int) -> Integration:
             attempt += 1
             if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
                 raise
-            time.sleep(min(2 * attempt, 30))
+            _backoff_sleep(attempt)
 
 
 def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> GoogleAdsClient:
@@ -577,7 +582,7 @@ def _call_with_transient_retry(
             attempt += 1
             if attempt >= max_attempts or not _is_transient_grpc_error(e):
                 raise
-            time.sleep(min(2 * attempt, 30))
+            _backoff_sleep(attempt)
 
 
 def _search_with_transient_retry(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -129,23 +129,32 @@ def _load_client_with_transient_retry(
             time.sleep(min(2 * attempt, 30))
 
 
+_MAX_INTEGRATION_FETCH_ATTEMPTS = 4
+
+
 def _get_integration(integration_id: int, team_id: int) -> Integration:
-    """Fetch the OAuth ``Integration`` row, retrying once if the DB connection was dropped.
+    """Fetch the OAuth ``Integration`` row, retrying a transient DB failure with backoff.
 
     Temporal activities run in a long-lived worker that never goes through Django's request
-    cycle, so a pooled Postgres connection can be closed server-side while it sits idle.
-    ``close_old_connections()`` evicts connections already known to be stale, but one can still
-    die in the window before the query runs and surface as a transient ``OperationalError``
-    ("server closed the connection unexpectedly"). The failed query marks the connection
-    unusable, so a second eviction drops it and the retry runs on a fresh connection. This read
-    is idempotent, so it is safe to repeat. ``Integration.DoesNotExist`` is left to propagate.
+    cycle, so a pooled Postgres connection can be closed server-side while it sits idle, or the
+    connection pooler can reject the query with a wait timeout when the pool is saturated. Both
+    surface as a transient ``OperationalError`` and both clear once a healthy connection is used.
+    ``close_old_connections()`` evicts connections already known to be stale (and, after a failed
+    query marks one unusable, drops it), so each attempt runs on a fresh connection; the short
+    backoff also gives a saturated pool time to drain rather than retrying straight back into the
+    same wait timeout. This read is idempotent, so it is safe to repeat. Mirrors the backoff shape
+    of the client-init and search retries. ``Integration.DoesNotExist`` is left to propagate.
     """
-    close_old_connections()
-    try:
-        return Integration.objects.get(id=integration_id, team_id=team_id)
-    except OperationalError:
+    attempt = 0
+    while True:
         close_old_connections()
-        return Integration.objects.get(id=integration_id, team_id=team_id)
+        try:
+            return Integration.objects.get(id=integration_id, team_id=team_id)
+        except OperationalError:
+            attempt += 1
+            if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
+                raise
+            time.sleep(min(2 * attempt, 30))
 
 
 def google_ads_client(config: GoogleAdsSourceConfigUnion, team_id: int) -> GoogleAdsClient:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -866,7 +866,11 @@ class TestGetIntegrationDbResilience:
         integration = object()
         get = mock.Mock(side_effect=[OperationalError("server closed the connection unexpectedly"), integration])
 
-        with mock.patch(_INTEGRATION_GET_PATH, get), mock.patch(_CLOSE_CONNECTIONS_PATH) as close:
+        with (
+            mock.patch(_INTEGRATION_GET_PATH, get),
+            mock.patch(_CLOSE_CONNECTIONS_PATH) as close,
+            mock.patch(_SLEEP_PATH),
+        ):
             result = _get_integration(integration_id=1, team_id=2)
 
         assert result is integration
@@ -874,15 +878,46 @@ class TestGetIntegrationDbResilience:
         # Evicted up front, then again after the failed query marked the connection unusable.
         assert close.call_count == 2
 
-    def test_reraises_when_retry_also_fails(self):
-        get = mock.Mock(side_effect=OperationalError("server closed the connection unexpectedly"))
+    def test_rides_out_pool_wait_timeout_then_succeeds(self):
+        integration = object()
+        # A saturated connection pooler rejects the query with a wait timeout (surfaced as an
+        # OperationalError); the previous immediate single retry hit the same saturation, so we
+        # back off and retry a few times before giving up.
+        get = mock.Mock(
+            side_effect=[
+                OperationalError("query_wait_timeout"),
+                OperationalError("query_wait_timeout"),
+                integration,
+            ]
+        )
 
-        with mock.patch(_INTEGRATION_GET_PATH, get), mock.patch(_CLOSE_CONNECTIONS_PATH):
+        with (
+            mock.patch(_INTEGRATION_GET_PATH, get),
+            mock.patch(_CLOSE_CONNECTIONS_PATH),
+            mock.patch(_SLEEP_PATH) as sleep,
+        ):
+            result = _get_integration(integration_id=1, team_id=2)
+
+        assert result is integration
+        assert get.call_count == 3
+        # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_reraises_after_exhausting_attempts(self):
+        get = mock.Mock(side_effect=OperationalError("query_wait_timeout"))
+
+        with (
+            mock.patch(_INTEGRATION_GET_PATH, get),
+            mock.patch(_CLOSE_CONNECTIONS_PATH),
+            mock.patch(_SLEEP_PATH) as sleep,
+        ):
             with pytest.raises(OperationalError):
                 _get_integration(integration_id=1, team_id=2)
 
-        # One retry only — the second failure propagates so Temporal still retries the activity.
-        assert get.call_count == 2
+        # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry.
+        assert get.call_count == 4
+        # Backed off between each attempt (2s, 4s, 6s) but not after the final attempt that re-raises.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4), mock.call(6)]
 
     def test_missing_integration_is_not_retried(self):
         get = mock.Mock(side_effect=Integration.DoesNotExist())


### PR DESCRIPTION
## Problem

Error tracking surfaced a transient DB failure in the Google Ads import source: a connection-pooler **wait timeout** (`query_wait_timeout`, surfaced as a psycopg `ProtocolViolation` / `OperationalError`) raised while fetching the OAuth integration row in `_get_integration`. The top in-app frame is `_get_integration` at `google_ads.py` — first the initial query, then the immediate retry, both timing out.

Issue: https://us.posthog.com/project/2/error_tracking/019f054e-8a75-7543-b784-7597afa26e35

This is a **transient infrastructure error**, not a credential/config problem — so it must stay retryable (not added to `NonRetryableErrors`). The fragility is in our retry shape: `_get_integration` already retried transient `OperationalError`s, but **immediately and only once**. That works for a stale pooled connection ("server closed the connection unexpectedly"), but against a saturated pool the immediate retry hits the same wait timeout and fails again — exactly what the stack shows.

## Changes

Give `_get_integration` bounded exponential backoff (up to 4 attempts, `min(2 * attempt, 30)`s between them) instead of a single immediate retry. This matches the backoff shape already used by the two sibling retry helpers in the same module (`_load_client_with_transient_retry`, `_search_with_transient_retry`) — `_get_integration` was the outlier. The short backoff gives a saturated pool time to drain rather than retrying straight back into the timeout.

Behavior preserved:
- `Integration.DoesNotExist` still propagates immediately (it's non-retryable elsewhere).
- If every attempt is exhausted the error still propagates, so Temporal's activity-level retry continues to apply.

## How did you test this code?

I'm an agent. I added/updated unit tests and ran them — no manual testing.

- `test_rides_out_pool_wait_timeout_then_succeeds` — new: two `query_wait_timeout` `OperationalError`s are ridden out with backoff, then the read succeeds. Catches the regression that the previous single immediate retry could not absorb a pool-saturation timeout.
- `test_reraises_after_exhausting_attempts` — replaces the old single-retry assertion: bounded at 4 attempts with `[2, 4, 6]`s backoff, then re-raises for Temporal.
- Existing `test_retries_once_on_dropped_connection_then_succeeds`, `test_missing_integration_is_not_retried`, `test_no_retry_on_success` still pass.

Ran the full `test_google_ads_source.py` suite (86 passed) plus `ruff check`/`format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue in PostHog error tracking (pulled the full stack trace and a representative event via the error-tracking MCP tools), traced the failing frame into `_get_integration`, and classified `query_wait_timeout` as a transient pool timeout rather than a user/upstream error. Rejected extending `NonRetryableErrors` (that would swallow a recoverable infra blip); chose to harden the existing retry to back off, consistent with the module's two other retry helpers. Scoped strictly to this read — no change to global retry policy.
