### PR TITLE
feat(mcp-analytics): personalized first-look card on onboard

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5977,9 +5977,9 @@ snapshots:
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
     scenes-app-mcp-analytics--dashboard--dark:
-        hash: v1.k794b7964.2d41908d00a1ff34a9d2853a1b93497981dd9e3ee468f606f4be9375a8a5b02e.LYY0_XMZs7Wx5rQQCLr8NKzyEwYYPAXGebZpVUIsmHw
+        hash: v1.k794b7964.0ea60752a844fdeb315a7097c3dbec54b88c65e83e0754a0493a3e298caa8798.l4Fy_Gv11GiegC6l-OJGVfUoSpP__Xhx41X5GRc8uWA
     scenes-app-mcp-analytics--dashboard--light:
-        hash: v1.k794b7964.4fb6af8da91a3be359b14faaa2f6a4f179715cffd4c8a6d600ddb02c819cd0bd.HSLNfvQM5TDHs7XhOcAfkPCfZp_Znxe9VPRwjznA-dk
+        hash: v1.k794b7964.5ff783bc949d516121e4b3bcbe22dea0272ea1d06b96faf5fdbb195430420b79.QpMgijOyn69H-BXNJHXYY-maOdflsXoQAwcO7bYmzHY
     scenes-app-mcp-analytics--intent-clustering--dark:
         hash: v1.k794b7964.4bf359b5089b714711c176bdbd5e454857e35935027ca46c161215957bcdff63.tuUCfVazgJFLRYPnMr4rBr_bdCHDOR4WINf5P7PHyCU
     scenes-app-mcp-analytics--intent-clustering--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -18,6 +18,7 @@ import { KpiTiles } from './dashboard/KpiTiles'
 import { NotableSessionsTable } from './dashboard/NotableSessionsTable'
 import { ToolErrorRateChart } from './dashboard/ToolErrorRateChart'
 import { ToolUsageChart } from './dashboard/ToolUsageChart'
+import { MCPAnalyticsFirstLook } from './firstLook/MCPAnalyticsFirstLook'
 import { mcpDashboardOverviewLogic } from './mcpDashboardOverviewLogic'
 
 export function MCPAnalyticsDashboardOverview(): JSX.Element {
@@ -30,7 +31,6 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         harnessRows,
         harnessRowsLoading,
         dailyActivity,
-        activityIncompleteTail,
         activityRowsLoading,
         toolDailySeries,
         toolDailyRowsLoading,
@@ -51,6 +51,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
 
     return (
         <div className="flex flex-col gap-4">
+            <MCPAnalyticsFirstLook />
             <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="flex flex-wrap items-center gap-3">
                     <McpDateFilter
@@ -94,7 +95,6 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                                 theme={theme}
                                 timezone={timezone}
                                 interval={interval}
-                                incompleteTail={activityIncompleteTail}
                             />
                         </div>
                         <HarnessDonut rows={harnessRows} loading={harnessRowsLoading} theme={theme} />

--- a/products/mcp_analytics/frontend/firstLook/MCPAnalyticsFirstLook.tsx
+++ b/products/mcp_analytics/frontend/firstLook/MCPAnalyticsFirstLook.tsx
@@ -1,0 +1,120 @@
+import { useActions, useValues } from 'kea'
+import { useEffect, useRef } from 'react'
+
+import { IconBolt, IconChevronDown, IconChevronRight, IconClock, IconSparkles, IconWarning } from '@posthog/icons'
+import { LemonButton, LemonCard } from '@posthog/lemon-ui'
+
+import { CopyToClipboardInline } from 'lib/components/CopyToClipboard'
+import { Link } from 'lib/lemon-ui/Link/Link'
+import posthog from 'lib/posthog-typed'
+import { cn } from 'lib/utils/css-classes'
+
+import { harnessLogo } from '../dashboard/harnessRegistry'
+import type { FirstLookChip } from './firstLookCopy'
+import { mcpFirstLookLogic } from './mcpFirstLookLogic'
+
+const CHIP_ICON: Record<string, JSX.Element> = {
+    'top-tool': <IconBolt />,
+    'worst-error': <IconWarning />,
+    p95: <IconClock />,
+}
+
+function Chip({ chip }: { chip: FirstLookChip }): JSX.Element {
+    const logo = chip.harness ? harnessLogo(chip.harness) : undefined
+    return (
+        <span
+            className={cn(
+                'inline-flex items-center gap-1.5 rounded-full bg-surface-secondary px-2.5 py-1 text-xs',
+                chip.tone === 'danger' ? 'text-danger' : 'text-secondary'
+            )}
+        >
+            <span className="flex items-center text-xs leading-none">
+                {logo ? <img src={logo.src} alt={logo.alt} className="size-3.5" /> : CHIP_ICON[chip.key]}
+            </span>
+            <span className="text-muted">{chip.label}</span>
+            <span className="font-medium text-primary">{chip.value}</span>
+        </span>
+    )
+}
+
+/**
+ * Personalized "first look" shown once when a project's first MCP tool calls land — turns the
+ * bare dashboard into "here's what we already see" plus two ways to dig deeper. Self-gates via
+ * `shouldShow`; renders `null` otherwise.
+ */
+export function MCPAnalyticsFirstLook(): JSX.Element | null {
+    const { shouldShow, headline, chips, editorPrompt, editorExpanded, eventProperties } = useValues(mcpFirstLookLogic)
+    const { dismiss, dismissAndAskMax, toggleEditor } = useActions(mcpFirstLookLogic)
+
+    // Fire once when the card first becomes visible — for replay filtering + impact.
+    const shownRef = useRef(false)
+    useEffect(() => {
+        if (shouldShow && !shownRef.current) {
+            shownRef.current = true
+            posthog.captureRaw('mcp analytics first look shown', eventProperties)
+        }
+    }, [shouldShow, eventProperties])
+
+    if (!shouldShow) {
+        return null
+    }
+
+    return (
+        <LemonCard
+            hoverEffect={false}
+            closeable
+            onClose={dismiss}
+            className="bg-gradient-to-br from-accent/15 via-accent/5 to-surface-primary"
+        >
+            <div className="flex flex-col gap-4 pr-6">
+                <div className="flex items-center gap-2 text-accent">
+                    <IconSparkles className="text-lg" />
+                    <span className="text-xs font-semibold uppercase tracking-wide">Your first look</span>
+                </div>
+                <h2 className="m-0 text-lg font-semibold text-primary">{headline}</h2>
+                {chips.length > 0 && (
+                    <div className="flex flex-wrap gap-2">
+                        {chips.map((chip) => (
+                            <Chip key={chip.key} chip={chip} />
+                        ))}
+                    </div>
+                )}
+                <div className="flex flex-wrap items-center gap-2">
+                    <LemonButton type="primary" icon={<IconSparkles />} onClick={dismissAndAskMax}>
+                        Ask PostHog AI
+                    </LemonButton>
+                    <LemonButton
+                        type="tertiary"
+                        size="small"
+                        icon={editorExpanded ? <IconChevronDown /> : <IconChevronRight />}
+                        onClick={toggleEditor}
+                        data-attr="mcp-first-look-editor-toggle"
+                    >
+                        Prefer your editor?
+                    </LemonButton>
+                </div>
+                {editorExpanded && (
+                    <div className="flex flex-col gap-2 rounded border border-border bg-surface-primary p-3">
+                        <p className="m-0 text-xs text-muted">
+                            {editorPrompt.label}, or any agent with the PostHog MCP installed:
+                        </p>
+                        <div className="flex items-start gap-2 rounded bg-surface-secondary px-2.5 py-1.5">
+                            <span className="flex-1 font-mono text-xs text-primary">{editorPrompt.prompt}</span>
+                            <CopyToClipboardInline
+                                explicitValue={editorPrompt.prompt}
+                                description="prompt"
+                                iconSize="small"
+                            />
+                        </div>
+                        <p className="m-0 text-xs text-muted">
+                            Needs the PostHog MCP in your editor.{' '}
+                            <Link to="https://posthog.com/docs/model-context-protocol" target="_blank">
+                                Set it up
+                            </Link>
+                        </p>
+                    </div>
+                )}
+            </div>
+        </LemonCard>
+    )
+}

--- a/products/mcp_analytics/frontend/firstLook/MCPAnalyticsFirstLook.tsx
+++ b/products/mcp_analytics/frontend/firstLook/MCPAnalyticsFirstLook.tsx
@@ -17,6 +17,8 @@ const CHIP_ICON: Record<string, JSX.Element> = {
     'top-tool': <IconBolt />,
     'worst-error': <IconWarning />,
     p95: <IconClock />,
+    // Fallback for the client chip when the harness has no logo (e.g. "Other").
+    client: <IconSparkles />,
 }
 
 function Chip({ chip }: { chip: FirstLookChip }): JSX.Element {

--- a/products/mcp_analytics/frontend/firstLook/firstLookCopy.test.ts
+++ b/products/mcp_analytics/frontend/firstLook/firstLookCopy.test.ts
@@ -108,6 +108,16 @@ describe('firstLookCopy', () => {
             ).toEqual([])
         })
 
+        it('drops the flakiest chip when it is the same tool as the busiest', () => {
+            const chips = buildChips({
+                topTool: tool({ tool: 'execute-sql' }),
+                worstErrorTool: tool({ tool: 'execute-sql', error_rate_pct: 12 }),
+                kpis: KPIS,
+                client: null,
+            })
+            expect(chips.map((c) => c.key)).toEqual(['top-tool', 'p95'])
+        })
+
         it('includes all four when data is present, in order', () => {
             const chips = buildChips({
                 topTool: tool(),

--- a/products/mcp_analytics/frontend/firstLook/firstLookCopy.test.ts
+++ b/products/mcp_analytics/frontend/firstLook/firstLookCopy.test.ts
@@ -1,0 +1,123 @@
+import type { KPIData, ToolRow } from '../mcpDashboardOverviewLogic'
+import { buildChips, buildEditorPrompt, buildHeadline, buildMaxPrompt } from './firstLookCopy'
+
+const metric = (value: number): KPIData['sessions'] => ({
+    value,
+    previousValue: 0,
+    deltaPct: null,
+    sparkline: [],
+    goodDirection: 'up',
+})
+
+const KPIS: KPIData = {
+    sessions: metric(120),
+    toolCalls: metric(1480),
+    errorRatePct: metric(9),
+    p95LatencyMs: metric(3525),
+}
+
+const tool = (over: Partial<ToolRow> = {}): ToolRow => ({
+    tool: 'execute-sql',
+    total_calls: 1480,
+    errors: 144,
+    error_rate_pct: 9.7,
+    p95_duration_ms: 3525,
+    ...over,
+})
+
+describe('firstLookCopy', () => {
+    describe('buildHeadline', () => {
+        it('names the company, dominant client, busiest tool, and flags a flaky one', () => {
+            const headline = buildHeadline({
+                company: 'Acme',
+                project: 'prod',
+                topTool: tool(),
+                client: 'Claude Code',
+                kpis: KPIS,
+            })
+            expect(headline).toContain("Acme's MCP server is live")
+            expect(headline).toContain('Claude Code agents')
+            expect(headline).toContain('execute-sql')
+            expect(headline).toContain('errors 9.7% of the time')
+        })
+
+        it('omits the client phrase and the flaky clause when not warranted', () => {
+            const headline = buildHeadline({
+                company: null,
+                project: 'prod',
+                topTool: tool({ error_rate_pct: 1 }),
+                client: null,
+                kpis: KPIS,
+            })
+            expect(headline).toContain("prod's MCP server is live")
+            expect(headline).toContain('Agents leaned on')
+            expect(headline).not.toContain('agents leaned on') // no client prefix
+            expect(headline).not.toContain('errors')
+        })
+
+        it('falls back to top-line counts when no per-tool rows resolved', () => {
+            const headline = buildHeadline({ company: null, project: null, topTool: null, client: null, kpis: KPIS })
+            expect(headline).toContain('Your MCP server is live')
+            expect(headline).toContain('tool calls across')
+            expect(headline).toContain('sessions so far')
+        })
+    })
+
+    describe('buildMaxPrompt', () => {
+        it('references the worst error tool and its rate', () => {
+            const prompt = buildMaxPrompt({
+                worstErrorTool: tool({ tool: 'cohort-create', error_rate_pct: 6.3 }),
+                topTool: tool(),
+            })
+            expect(prompt).toContain('cohort-create')
+            expect(prompt).toContain('6.3%')
+            expect(prompt).toContain('$mcp_tool_call')
+        })
+
+        it('asks a trend question on the busiest tool when nothing errors', () => {
+            const prompt = buildMaxPrompt({
+                worstErrorTool: tool({ error_rate_pct: 0 }),
+                topTool: tool({ tool: 'read-data-schema' }),
+            })
+            expect(prompt).toContain('read-data-schema')
+            expect(prompt).toContain('trended')
+        })
+    })
+
+    describe('buildEditorPrompt', () => {
+        it('targets the detected client', () => {
+            expect(buildEditorPrompt({ client: 'Cursor' }).label).toBe('Paste this into Cursor')
+            expect(buildEditorPrompt({ client: 'OpenAI Codex' }).label).toBe('Paste this into Codex')
+        })
+
+        it('falls back to a generic target for unknown or missing clients', () => {
+            expect(buildEditorPrompt({ client: null }).label).toBe('Paste this into your agent')
+            expect(buildEditorPrompt({ client: 'Some New Agent' }).label).toBe('Paste this into your agent')
+        })
+    })
+
+    describe('buildChips', () => {
+        it('drops chips whose data is missing', () => {
+            expect(
+                buildChips({
+                    topTool: null,
+                    worstErrorTool: null,
+                    kpis: { ...KPIS, p95LatencyMs: metric(0) },
+                    client: null,
+                })
+            ).toEqual([])
+        })
+
+        it('includes all four when data is present, in order', () => {
+            const chips = buildChips({
+                topTool: tool(),
+                worstErrorTool: tool({ tool: 'cohort-create', error_rate_pct: 12 }),
+                kpis: KPIS,
+                client: 'Cursor',
+            })
+            expect(chips.map((c) => c.key)).toEqual(['top-tool', 'worst-error', 'p95', 'client'])
+            expect(chips.find((c) => c.key === 'worst-error')?.tone).toBe('danger')
+            expect(chips.find((c) => c.key === 'client')?.harness).toBe('Cursor')
+        })
+    })
+})

--- a/products/mcp_analytics/frontend/firstLook/firstLookCopy.ts
+++ b/products/mcp_analytics/frontend/firstLook/firstLookCopy.ts
@@ -96,7 +96,9 @@ export function buildChips({
     if (topTool) {
         chips.push({ key: 'top-tool', label: 'Busiest tool', value: topTool.tool })
     }
-    if (worstErrorTool && worstErrorTool.error_rate_pct > 0) {
+    // Skip the flakiest chip when it's the same tool as the busiest one — the busiest chip
+    // and the headline's flaky clause already name it; a third mention reads as noise.
+    if (worstErrorTool && worstErrorTool.error_rate_pct > 0 && worstErrorTool.tool !== topTool?.tool) {
         chips.push({
             key: 'worst-error',
             label: 'Flakiest tool',

--- a/products/mcp_analytics/frontend/firstLook/firstLookCopy.ts
+++ b/products/mcp_analytics/frontend/firstLook/firstLookCopy.ts
@@ -1,0 +1,114 @@
+import { formatMs, formatNumber } from '../dashboard/formatters'
+import type { KPIData, ToolRow } from '../mcpDashboardOverviewLogic'
+
+// At/above this error rate we call the tool out as flaky in the headline.
+const FLAKY_ERROR_RATE_PCT = 5
+
+export interface FirstLookChip {
+    key: string
+    label: string
+    value: string
+    tone?: 'danger'
+    /** When set, render this harness's logo in place of an icon. */
+    harness?: string
+}
+
+const possessive = (company?: string | null, project?: string | null): string =>
+    company ? `${company}'s` : project ? `${project}'s` : 'Your'
+
+/** One-line, personalized "your server is live" headline derived from real metrics. */
+export function buildHeadline({
+    company,
+    project,
+    topTool,
+    client,
+    kpis,
+}: {
+    company?: string | null
+    project?: string | null
+    topTool: ToolRow | null
+    client: string | null
+    kpis: KPIData
+}): string {
+    const who = possessive(company, project)
+    if (topTool) {
+        const agents = client ? `${client} agents` : 'Agents'
+        const flaky =
+            topTool.error_rate_pct >= FLAKY_ERROR_RATE_PCT
+                ? `, though it errors ${topTool.error_rate_pct}% of the time`
+                : ''
+        return `${who} MCP server is live — ${agents} leaned on ${topTool.tool} ${formatNumber(topTool.total_calls)} times, your busiest tool${flaky}.`
+    }
+    // No per-tool rows resolved yet — fall back to top-line counts.
+    return `${who} MCP server is live — ${formatNumber(kpis.toolCalls.value)} tool calls across ${formatNumber(kpis.sessions.value)} sessions so far.`
+}
+
+/** A concrete question for PostHog AI, tied to their actual worst tool so the answer is useful. */
+export function buildMaxPrompt({
+    worstErrorTool,
+    topTool,
+}: {
+    worstErrorTool: ToolRow | null
+    topTool: ToolRow | null
+}): string {
+    if (worstErrorTool && worstErrorTool.error_rate_pct > 0) {
+        return `My MCP server's ${worstErrorTool.tool} tool errors ${worstErrorTool.error_rate_pct}% of the time over ${formatNumber(worstErrorTool.total_calls)} $mcp_tool_call events. Show me the most common errors and what's causing them.`
+    }
+    if (topTool) {
+        return `My busiest MCP tool is ${topTool.tool}. Show me how its usage and latency have trended over the last 7 days and whether anything looks anomalous.`
+    }
+    return `Summarize how agents are using my MCP server from $mcp_tool_call events — top tools, error rates, and what they're trying to do.`
+}
+
+// Friendly harness label → where to paste the prompt. Falls back to "your agent".
+const HARNESS_PASTE_TARGET: Record<string, string> = {
+    'Claude Code': 'Claude Code',
+    'Claude Desktop': 'Claude Desktop',
+    'Claude Code (VS Code)': 'Claude Code',
+    Cursor: 'Cursor',
+    'OpenAI Codex': 'Codex',
+    'VS Code': 'VS Code',
+    Windsurf: 'Windsurf',
+}
+
+/** A copy-paste prompt for the customer's own coding agent, framed for their dominant client. */
+export function buildEditorPrompt({ client }: { client: string | null }): { label: string; prompt: string } {
+    const where = (client && HARNESS_PASTE_TARGET[client]) || 'your agent'
+    return {
+        label: `Paste this into ${where}`,
+        prompt: 'Using the PostHog MCP, pull my $mcp_tool_call events and tell me which tools error most and why.',
+    }
+}
+
+/** Metric highlight chips; any chip whose data is missing is dropped. */
+export function buildChips({
+    topTool,
+    worstErrorTool,
+    kpis,
+    client,
+}: {
+    topTool: ToolRow | null
+    worstErrorTool: ToolRow | null
+    kpis: KPIData
+    client: string | null
+}): FirstLookChip[] {
+    const chips: FirstLookChip[] = []
+    if (topTool) {
+        chips.push({ key: 'top-tool', label: 'Busiest tool', value: topTool.tool })
+    }
+    if (worstErrorTool && worstErrorTool.error_rate_pct > 0) {
+        chips.push({
+            key: 'worst-error',
+            label: 'Flakiest tool',
+            value: `${worstErrorTool.tool} · ${worstErrorTool.error_rate_pct}%`,
+            tone: 'danger',
+        })
+    }
+    if (kpis.p95LatencyMs.value > 0) {
+        chips.push({ key: 'p95', label: 'p95 latency', value: formatMs(kpis.p95LatencyMs.value) })
+    }
+    if (client) {
+        chips.push({ key: 'client', label: 'Top client', value: client, harness: client })
+    }
+    return chips
+}

--- a/products/mcp_analytics/frontend/firstLook/mcpFirstLookLogic.ts
+++ b/products/mcp_analytics/frontend/firstLook/mcpFirstLookLogic.ts
@@ -1,0 +1,123 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+
+import posthog from 'lib/posthog-typed'
+import { organizationLogic } from 'scenes/organizationLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { ProductKey } from '~/queries/schema/schema-general'
+import { SidePanelTab } from '~/types'
+
+import { mcpAnalyticsOnboardingLogic } from '../mcpAnalyticsOnboardingLogic'
+import type { HarnessRow, KPIData, ToolRow } from '../mcpDashboardOverviewLogic'
+import { mcpDashboardOverviewLogic } from '../mcpDashboardOverviewLogic'
+import { buildChips, buildEditorPrompt, buildHeadline, buildMaxPrompt, type FirstLookChip } from './firstLookCopy'
+import type { mcpFirstLookLogicType } from './mcpFirstLookLogicType'
+
+export const mcpFirstLookLogic = kea<mcpFirstLookLogicType>([
+    path(['products', 'mcp_analytics', 'frontend', 'firstLook', 'mcpFirstLookLogic']),
+    connect(() => ({
+        values: [
+            mcpDashboardOverviewLogic,
+            ['kpis', 'toolRows', 'harnessRows'],
+            mcpAnalyticsOnboardingLogic,
+            ['isOnboarded'],
+            userLogic,
+            ['user'],
+            teamLogic,
+            ['currentTeam'],
+            organizationLogic,
+            ['currentOrganization'],
+        ],
+        actions: [userLogic, ['updateHasSeenProductIntroFor']],
+    })),
+    actions({
+        dismiss: true,
+        askMax: true,
+        dismissAndAskMax: true,
+        toggleEditor: true,
+    }),
+    reducers({
+        // Secondary path; collapsed by default to keep the hero tight.
+        editorExpanded: [false, { toggleEditor: (state) => !state }],
+    }),
+    selectors({
+        // Once per user, never on demo, and only after data loads (avoids an empty-flash).
+        shouldShow: [
+            (s) => [s.isOnboarded, s.user, s.currentTeam, s.kpis, s.toolRows],
+            (isOnboarded, user, currentTeam, kpis: KPIData, toolRows: ToolRow[]): boolean => {
+                const hasData = toolRows.length > 0 || kpis.toolCalls.value > 0
+                return (
+                    Boolean(isOnboarded) &&
+                    hasData &&
+                    !user?.has_seen_product_intro_for?.[ProductKey.MCP_ANALYTICS] &&
+                    !currentTeam?.is_demo
+                )
+            },
+        ],
+        topTool: [(s) => [s.toolRows], (toolRows: ToolRow[]): ToolRow | null => toolRows[0] ?? null],
+        worstErrorTool: [
+            (s) => [s.toolRows],
+            (toolRows: ToolRow[]): ToolRow | null =>
+                toolRows.length ? [...toolRows].sort((a, b) => b.error_rate_pct - a.error_rate_pct)[0] : null,
+        ],
+        dominantClient: [
+            (s) => [s.harnessRows],
+            (harnessRows: HarnessRow[]): string | null => harnessRows[0]?.category ?? null,
+        ],
+        headline: [
+            (s) => [s.currentOrganization, s.currentTeam, s.topTool, s.dominantClient, s.kpis],
+            (currentOrganization, currentTeam, topTool, dominantClient, kpis: KPIData): string =>
+                buildHeadline({
+                    company: currentOrganization?.name,
+                    project: currentTeam?.name,
+                    topTool,
+                    client: dominantClient,
+                    kpis,
+                }),
+        ],
+        maxPrompt: [
+            (s) => [s.worstErrorTool, s.topTool],
+            (worstErrorTool, topTool): string => buildMaxPrompt({ worstErrorTool, topTool }),
+        ],
+        editorPrompt: [
+            (s) => [s.dominantClient],
+            (dominantClient): { label: string; prompt: string } => buildEditorPrompt({ client: dominantClient }),
+        ],
+        chips: [
+            (s) => [s.topTool, s.worstErrorTool, s.kpis, s.dominantClient],
+            (topTool, worstErrorTool, kpis: KPIData, dominantClient): FirstLookChip[] =>
+                buildChips({ topTool, worstErrorTool, kpis, client: dominantClient }),
+        ],
+        eventProperties: [
+            (s) => [s.dominantClient, s.topTool, s.worstErrorTool],
+            (dominantClient, topTool: ToolRow | null, worstErrorTool: ToolRow | null): Record<string, unknown> => ({
+                client: dominantClient,
+                busiest_tool: topTool?.tool ?? null,
+                flakiest_tool: worstErrorTool?.tool ?? null,
+            }),
+        ],
+    }),
+    listeners(({ values, actions }) => ({
+        dismiss: () => {
+            posthog.captureRaw('mcp analytics first look dismissed', values.eventProperties)
+            actions.updateHasSeenProductIntroFor(ProductKey.MCP_ANALYTICS)
+        },
+        askMax: () => {
+            posthog.captureRaw('mcp analytics first look ask ai clicked', values.eventProperties)
+            // The `!` prefix opens the (app-shell-mounted) panel and auto-submits.
+            sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Max, '!' + values.maxPrompt)
+        },
+        dismissAndAskMax: () => {
+            actions.askMax()
+            actions.dismiss()
+        },
+        toggleEditor: () => {
+            // Capture the expand only, not the collapse.
+            if (values.editorExpanded) {
+                posthog.captureRaw('mcp analytics first look editor expanded', values.eventProperties)
+            }
+        },
+    })),
+])

--- a/products/mcp_analytics/frontend/firstLook/mcpFirstLookLogic.ts
+++ b/products/mcp_analytics/frontend/firstLook/mcpFirstLookLogic.ts
@@ -106,8 +106,10 @@ export const mcpFirstLookLogic = kea<mcpFirstLookLogicType>([
         },
         askMax: () => {
             posthog.captureRaw('mcp analytics first look ask ai clicked', values.eventProperties)
-            // The `!` prefix opens the (app-shell-mounted) panel and auto-submits.
-            sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Max, '!' + values.maxPrompt)
+            // Prefill, don't auto-submit: the prompt embeds tool names from `$mcp_tool_call`
+            // events, which anyone with the project token can set — auto-running it would let a
+            // seeded tool name reach PostHog AI as an instruction. The user reviews, then sends.
+            sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Max, values.maxPrompt)
         },
         dismissAndAskMax: () => {
             actions.askMax()


### PR DESCRIPTION
## Problem

The moment a customer's first MCP tool calls land, we drop them into a generic dashboard instead of saying "here's something useful." That's where the onboarding "aha" is won or lost — the data is already there, we just weren't surfacing it.

## Changes

A one-time, per-user **first-look card** at the top of the dashboard, shown the first time a project is onboarded. Everything is personalized from data we already query:

- **Headline** built from their real metrics — e.g. *"Acme's MCP server is live — Claude Code agents leaned on `execute-sql` 1,480 times, your busiest tool, though it errors 9.7% of the time."*
- **Metric chips** — busiest tool, flakiest tool (danger-toned), p95 latency, and dominant client with its logo.
- **"Ask PostHog AI"** — opens the side panel auto-submitting a question about their *actual* worst tool.
- **Editor prompt** — a copy-paste prompt framed for their detected coding agent (Claude Code / Cursor / Codex) plus an `mcp add` nudge.

Self-gates: shows once per user (`has_seen_product_intro_for`), skips demo projects, and waits for real data so it never flashes an empty "0 tool calls" card.

Frontend-only. Reuses `mcpDashboardOverviewLogic` selectors (no new HogQL) and the existing harness normalizer. All copy lives in pure, unit-tested builders. This is Phase 1; a backend AI-written narrative is a planned fast-follow.

<img width="2088" height="1080" alt="CleanShot 2026-06-30 at 19 01 33@2x" src="https://github.com/user-attachments/assets/80097efb-0807-47b4-a74a-1955a36f9918" />

## How did you test this code?

Agent-authored (PostHog Code). Automated: 9 unit tests on the copy builders (degraded headlines, harness-tailored prompts, chip drop-on-missing), oxlint clean, and a typecheck pass. Cross-checked the metrics against live data to confirm the personalized copy reads sensibly. The existing `MCPAnalyticsDashboard` Storybook story now renders this card (mocks make it onboarded with data), so it picks up visual-regression coverage — its baseline will change and needs the usual Visual Review approval.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code at Lucas's direction as the next step in making MCP analytics onboarding "magical" (after the wizard install + project-pinning + live-detection work). Plan-mode research mapped the reusable overview selectors, the PostHog AI open-with-prompt path (`maxGlobalLogic`/`sidePanelStateLogic`), the client→harness normalizer, and the show-once gate. Decisions: keep all copy in pure builders so the personalization is testable in isolation; gate on real data to avoid a mid-load empty flash; open PostHog AI in the side panel (auto-submit) to stay in-context. The cross-tenant boundary is respected — the card only ever reads the requesting team's own events.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*