### PR TITLE
fix(mcp): attach org/project groups to $mcp_tool_call events

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4404,8 +4404,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/mcp-analytics':
-        specifier: npm:@posthog/mcp@0.4.0
-        version: '@posthog/mcp@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
+        specifier: npm:@posthog/mcp@0.4.4
+        version: '@posthog/mcp@0.4.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
@@ -9883,11 +9883,11 @@ packages:
   '@posthog/core@1.23.1':
     resolution: {integrity: sha512-GViD5mOv/mcbZcyzz3z9CS0R79JzxVaqEz4sP5Dsea178M/j3ZWe6gaHDZB9yuyGfcmIMQ/8K14yv+7QrK4sQQ==}
 
-  '@posthog/core@1.35.1':
-    resolution: {integrity: sha512-2a9JgJgR+Ow8lrUQHVZYXH9EgXskYDlpbgNW6UvtsVxp8pEEFD8PxjZMnzq73Dx3NhAwNUrnVpb8KeZzHAtoSA==}
-
   '@posthog/core@1.37.2':
     resolution: {integrity: sha512-qq9ASrhqxEcfzMQ/kc7dC00pibIcSbQ57FwVHxOGQOeSHr+uN18LA01ESsQX+UcgJ1beFvM6goa8SMxW99OLUw==}
+
+  '@posthog/core@1.38.0':
+    resolution: {integrity: sha512-QLrJh0hMVpEJXHNyiJR9YhvIO5tzLDedw4UHdvB+ub4fXHMtHCA8H44qgl11HWR3ajpjxtJ8hs3HyOGVF3Zc1w==}
 
   '@posthog/core@1.7.1':
     resolution: {integrity: sha512-kjK0eFMIpKo9GXIbts8VtAknsoZ18oZorANdtuTj1CbgS28t4ZVq//HAWhnxEuXRTrtkd+SUJ6Ux3j2Af8NCuA==}
@@ -9929,8 +9929,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/mcp@0.4.0':
-    resolution: {integrity: sha512-5k5q4On86ISHKczYUgHC4KxA3XNIN/6mbgXHEaF1cNo2xI+gxBJxivDVlzcU1h2F++WYJP5AGEj3lxffjLXG7Q==}
+  '@posthog/mcp@0.4.4':
+    resolution: {integrity: sha512-wN+5K2fnP0z6dNAi02fWYU39GrQpcPcSGtom+WttM8Yl9hLenrJ+XDu2fNt9xUAtKHquKNpZAv+rSUy/p7Ef9Q==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.29.0
@@ -30333,11 +30333,11 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@posthog/core@1.35.1':
+  '@posthog/core@1.37.2':
     dependencies:
       '@posthog/types': 1.391.1
 
-  '@posthog/core@1.37.2':
+  '@posthog/core@1.38.0':
     dependencies:
       '@posthog/types': 1.391.1
 
@@ -30383,10 +30383,10 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/mcp@0.4.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
+  '@posthog/mcp@0.4.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
-      '@posthog/core': 1.35.1
+      '@posthog/core': 1.38.0
       posthog-node: 5.25.0
 
   '@posthog/react@1.9.0(@types/react@18.3.27)(posthog-js@1.393.4)(react@18.3.1)':

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4404,8 +4404,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/mcp-analytics':
-        specifier: npm:@posthog/mcp@0.4.4
-        version: '@posthog/mcp@0.4.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
+        specifier: npm:@posthog/mcp@0.5.0
+        version: '@posthog/mcp@0.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)'
       '@posthog/quill':
         specifier: workspace:*
         version: link:../../packages/quill/packages/quill
@@ -9929,8 +9929,8 @@ packages:
       react: 18.3.1
       react-dom: 18.3.1
 
-  '@posthog/mcp@0.4.4':
-    resolution: {integrity: sha512-wN+5K2fnP0z6dNAi02fWYU39GrQpcPcSGtom+WttM8Yl9hLenrJ+XDu2fNt9xUAtKHquKNpZAv+rSUy/p7Ef9Q==}
+  '@posthog/mcp@0.5.0':
+    resolution: {integrity: sha512-0XtnLb860ktC7/U5bw97WHhLbUhWbyw+8kXYDp4zIi9YrbLJQvjiuLz8FGOvJcgyO6s5bNUts5rgMoSlDMhCcQ==}
     engines: {node: ^20.20.0 || >=22.22.0}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.29.0
@@ -30383,7 +30383,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@posthog/mcp@0.4.4(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
+  '@posthog/mcp@0.5.0(@modelcontextprotocol/sdk@1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6))(posthog-node@5.25.0)':
     dependencies:
       '@modelcontextprotocol/sdk': 1.29.0(@cfworker/json-schema@4.1.1)(zod@4.3.6)
       '@posthog/core': 1.38.0

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -45,7 +45,7 @@
         "@hono/node-server": "^2.0.2",
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.4",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.5.0",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
         "@toon-format/toon": "^2.1.0",

--- a/services/mcp/package.json
+++ b/services/mcp/package.json
@@ -45,7 +45,7 @@
         "@hono/node-server": "^2.0.2",
         "@modelcontextprotocol/ext-apps": "^1.5.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
-        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.0",
+        "@posthog/mcp-analytics": "npm:@posthog/mcp@0.4.4",
         "@posthog/quill": "workspace:*",
         "@posthog/quill-charts": "workspace:*",
         "@toon-format/toon": "^2.1.0",


### PR DESCRIPTION
## Problem

`$mcp_tool_call` events can't be broken down by unique organizations the way the legacy `mcp_tool_call` events can. In practice the `organization` group is present on nearly all `mcp_tool_call` events but absent from `$mcp_tool_call`.

Root cause is a three-layer interaction:

1. `$mcp_tool_call` is emitted via the `@posthog/mcp` SDK (`captureToolCall`), which places groups into `properties.$groups`.
2. The SDK's event sink in **0.4.0** called posthog-node's `capture()` **without** the top-level `groups` option.
3. posthog-node's `capture()` does `$groups: eventMessage.groups || groups`, which **overwrites** any `$groups` already in `properties` with the (absent) `groups` arg.

So the `organization` and `project` groups were silently wiped on every SDK-emitted event. The legacy `mcp_tool_call` dual-emit avoids this because it passes posthog-node's native `groups` option directly.

## Changes

Bump `@posthog/mcp-analytics` from `npm:@posthog/mcp@0.4.0` → `0.5.0`. The fix landed upstream in 0.4.4 (the sink now lifts `$groups` into posthog-node's native `groups` option); 0.5.0 is the latest release and carries the same fix. Across 0.4.0 → 0.5.0 the `engines`/`peerDependencies` are unchanged and the only public-API change is an additive `instrumentMutator` export we don't use; transitive `@posthog/core` 1.35.1 → 1.38.0 comes along.

Once deployed, `$mcp_tool_call` will carry the `organization` and `project` groups, enabling unique-org breakdowns identical to `mcp_tool_call`.

## How did you test this code?

I'm an agent. No automated tests were added — this is a dependency version bump. Verification was empirical:

- Confirmed the `organization` group is present on `mcp_tool_call` but absent from `$mcp_tool_call`, including for the most recent events (ruling out deploy lag).
- Traced the drop through the SDK source (`McpEventSink.capture` in 0.4.0 vs the fixed 0.4.4/0.5.0) and posthog-node 5.25.0's `prepareEventMessage`, confirming the fixed sink passes `groups` as the native capture option.
- Verified 0.4.0 → 0.5.0 has identical `engines`/`peerDependencies` and an additive-only public type surface, so the bump is low risk.

`pnpm install --lockfile-only` validated the lockfile is self-consistent.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by @Radu-Raicea via a Slack thread.

Authored by the PostHog Slack app (Claude Code). The ask was to make `$mcp_tool_call` selectable by unique org, like `mcp_tool_call`. I confirmed the group was missing, then root-caused it to the SDK/posthog-node `$groups` overwrite rather than anything in this repo's emit code (which already passes `groups` correctly). The fix is an upstream SDK bump; landed on 0.5.0 (latest) at the reviewer's request — 0.4.4 was the first release containing the sink fix. Kept the lockfile diff surgical (only the mcp + transitive core entries) rather than letting a full re-resolve pull in unrelated drift. No repo skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B3E1Y576X/p1782493608104769?thread_ts=1782493608.104769&cid=C0B3E1Y576X)*
