### PR TITLE
fix(data-imports): treat empty REST response body as no data

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/rest_client.py
@@ -211,6 +211,13 @@ class RESTClient:
         try:
             body = response.json()
         except RequestsJSONDecodeError as e:
+            # An empty body on an otherwise-successful response is a complete "no data"
+            # answer (e.g. an endpoint with nothing to return), not a truncated page —
+            # retrying can't conjure rows, so treat it as an empty page and let the
+            # paginator stop. A non-empty body that fails to parse is a partial/truncated
+            # read, which stays retryable.
+            if not response.content or not response.content.strip():
+                return response, None
             raise RESTClientRetryableError(f"Malformed JSON response from {response.url}: {e}") from e
 
         return response, body

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/rest_source/tests/test_rest_client.py
@@ -32,6 +32,18 @@ def _make_response(json_body: Any, status_code: int = 200) -> Response:
     return resp
 
 
+def _make_empty_response(content: bytes = b"", status_code: int = 200) -> Response:
+    # A successful response whose body is empty (or whitespace-only) — `response.json()`
+    # raises "Expecting value: line 1 column 1 (char 0)", the shape an endpoint returns
+    # when it has nothing to send back.
+    resp = Response()
+    resp.status_code = status_code
+    resp._content = content
+    resp.headers["Content-Type"] = "application/json"
+    resp.url = "https://api.example.com/items"
+    return resp
+
+
 def _make_truncated_response(status_code: int = 200) -> Response:
     # Simulates a body cut off mid-stream — `response.json()` raises a JSONDecodeError
     # ("Unterminated string"), the same shape we see when an upstream truncates a large page.
@@ -330,6 +342,26 @@ class TestRESTClient:
             list(client.paginate(path="/items", paginator=SinglePagePaginator()))
 
         assert mock_session.send.call_count == 5
+
+    @pytest.mark.parametrize("content", [b"", b"   \n\t"], ids=["empty", "whitespace_only"])
+    @patch("tenacity.nap.time.sleep")
+    @patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.common.rest_source.rest_client.make_tracked_session"
+    )
+    def test_empty_response_body_yields_empty_page_without_retrying(self, MockSession, mock_sleep, content) -> None:
+        # A successful response with an empty/whitespace-only body is a complete "no data"
+        # answer, not a truncated page: yield an empty page and stop, never retrying.
+        mock_session = MockSession.return_value
+        mock_session.headers = {}
+        mock_session.prepare_request.return_value = MagicMock()
+        mock_session.send.return_value = _make_empty_response(content)
+
+        client = RESTClient(base_url="https://api.example.com")
+        pages = list(client.paginate(path="/items", data_selector="results", paginator=SinglePagePaginator()))
+
+        assert pages == [[]]
+        assert mock_session.send.call_count == 1
+        mock_sleep.assert_not_called()
 
     @patch("tenacity.nap.time.sleep")
     @patch(


### PR DESCRIPTION
## Problem

A data-warehouse import surfaced a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` from the shared REST source client, raised at `rest_client.py` `_send_request` when calling `response.json()`. Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f0562-bef7-70e3-b581-4f52d2448078

The `char 0` position means the response body was completely **empty**. The response had already passed `raise_for_status()`, so this was a **successful (2xx) response with an empty body** — not an auth/4xx/5xx failure.

`_send_request` already wraps `response.json()` and converts a parse failure into a `RESTClientRetryableError` so that a *truncated/partial* page gets reissued like a 429/5xx. But an empty body is a complete "no data" answer, so the retry just looped to the cap (5 attempts) and the import failed every time.

## Changes

In `_send_request`, when `response.json()` fails to decode, check whether the body is empty or whitespace-only:

- **Empty / whitespace-only body** → treat it as an empty page (`return response, None`, which flows to `[]`), letting the paginator stop naturally. This matches how every paginator already treats an empty data page as the end of results.
- **Non-empty body that fails to parse** → unchanged; still raised as `RESTClientRetryableError` so a genuinely truncated/partial read is retried.

This is scoped to the empty-body case only. A connection dropped mid-stream still surfaces as `ChunkedEncodingError` and stays retryable, and 429/5xx handling is untouched.

### Why a code fix and not `NonRetryableErrors`

The body came back on a successful HTTP status, so this isn't a credential/permission/upstream-down condition to stop-and-report — it's a response shape the client should handle gracefully. An empty successful response is semantically an empty page, which the paginators are already designed to terminate on.

## How did you test this code?

I'm an agent. I added an automated regression test and ran the suite — no manual testing.

- New parametrized test `test_empty_response_body_yields_empty_page_without_retrying` (`empty` and `whitespace_only`): asserts a 2xx empty/whitespace body yields one empty page (`[[]]`), issues exactly **one** request (no retries), and never sleeps. Before the fix this looped to the retry cap and raised. The existing `truncated_json` cases (non-empty partial body) still assert retry-then-succeed / retry-to-cap, confirming the partial-page path is preserved.
- `uv run pytest .../rest_source/tests/test_rest_client.py` — 26 passed.
- `ruff check` + `ruff format --check` on both changed files — clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Pulled the full stack trace, confirmed the exception originated at `response.json()` inside `_send_request` on a 2xx response with a zero-length body, and traced the call path from the import pipeline through `paginate` / `paginate_resource`. Verified the empty-body path flows cleanly to an empty page (`find_values` on `None` yields `[]`; all paginators terminate on empty data / absent next-page link). Checked open PRs (including the maintainer's) for a duplicate — none touch empty-body handling in the shared `rest_source` client.

Tooling: Claude Code with PostHog error-tracking MCP tools. No repo skills were required for this change.
