### PR TITLE
chore(migrations): document safe product/app teardown

### DIFF
--- a/.agents/skills/django-migrations/SKILL.md
+++ b/.agents/skills/django-migrations/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: django-migrations
-description: Django migration patterns and safety workflow for PostHog. Use when creating, adjusting, or reviewing Django/Postgres migrations, including non-blocking index/constraint changes, multi-phase schema changes, data backfills, migration conflict rebasing, and product model moves that require SeparateDatabaseAndState.
+description: Django migration patterns and safety workflow for PostHog. Use when creating, adjusting, or reviewing Django/Postgres migrations, including non-blocking index/constraint changes, multi-phase schema changes, data backfills, migration conflict rebasing, and product model moves that require SeparateDatabaseAndState. Also use for any deletion or removal of a model, table, column, product, or app — including deleting migration files or retiring a feature — even when no migration is written.
 ---
 
 # Django migrations

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,7 +162,7 @@ ALWAYS invoke the matching skill **before** writing or reviewing code in these a
 **Always invoke:**
 
 - `/improving-drf-endpoints` — any DRF viewset or serializer change
-- `/django-migrations` — any Django migration
+- `/django-migrations` — any Django migration, including deleting a model, table, column, or whole product/app (even when no migration file is written, e.g. removing a product folder)
 - `/clickhouse-migrations` — any ClickHouse migration
 - `/adopting-generated-api-types` — any frontend file using `lib/api`, `api.get<`, `api.create<`, or handwritten API types
 - `/writing-tests` — adding or substantially changing any test (pytest, Jest, or Playwright)

--- a/docs/published/handbook/engineering/safe-django-migrations.md
+++ b/docs/published/handbook/engineering/safe-django-migrations.md
@@ -208,6 +208,25 @@ class Migration(migrations.Migration):
     ]
 ```
 
+### Removing a whole product or app
+
+Removing a product (`products/<name>/`) is the phased table drop above — once per model — plus app teardown. It is **not** a folder delete.
+
+**Do not "remove" a table by deleting its migration file.** Deleting the file drops nothing:
+
+- The table and its FK constraints stay in every database where the migration already ran.
+- The `django_migrations` rows linger as orphans — harmless (Django ignores migrations for apps not in `INSTALLED_APPS`) but never cleaned up.
+- Fresh databases never create the table, so production and CI diverge.
+- The migration risk analyzer rebuilds master's schema, then checks out each open PR's tree, so any in-flight branch that predates the deletion still carries the file and gets it re-analyzed as a brand-new migration — a phantom "blocked" flag that only clears once that branch merges master.
+
+Safe order:
+
+1. Strip all usage and the model classes, and drop the tables via the [phased approach](#dropping-tables) (state-only `DeleteModel`, wait a deploy cycle, then `DROP TABLE`). Keep the app in `INSTALLED_APPS` so its migrations still run.
+2. Only after the drop migration has deployed everywhere, remove the app from `INSTALLED_APPS` and delete the `products/<name>/` folder.
+3. Optionally `DELETE FROM django_migrations WHERE app = '<app_label>'` to clear the orphan rows.
+
+Leaving the table in place — code gone, table dropped in a follow-up — is a legitimate shortcut for a small retired product: it dodges the rolling-deploy window where in-flight requests hit a dropped table. Just make the leftover table a tracked follow-up, not an accident.
+
 ## Dropping Columns
 
 **Problem:** `RemoveField` operations drop columns immediately. This breaks backwards compatibility during deployment and **cannot be rolled back** - once data is deleted, any rollback deployment will fail because the column no longer exists.


### PR DESCRIPTION
## Problem

Removing a Django product by deleting its migration files looks clean but drops nothing. The table, its FK constraints, and the `django_migrations` rows stay behind on every database that already ran the migration, while fresh databases never create them — so prod and CI drift apart. It also resurrects the deleted migration as a phantom "blocked" flag on any open PR that branched before the removal: the migration risk analyzer rebuilds master's schema, then analyzes each branch's working tree, so a migration that's deleted on master but still present on a stale branch reads as brand new.

This bit a real PR — an unrelated warehouse fix that branched ~13 min before a product removal landed got a "Migration Risk Analysis → Blocked" comment for a model it never touched. The handbook already covers dropping a single table well, but says nothing about removing a whole product, and the trigger that should have caught the original teardown never fired, because that teardown wrote no migration at all.

## Changes

- **`safe-django-migrations.md`** — new "Removing a whole product or app" subsection under Dropping Tables. Names the delete-the-file anti-pattern and its four consequences (orphan table + FKs, orphan `django_migrations` rows, prod/CI drift, phantom analyzer flag), then the safe order: drop tables via the phased pattern with the app still in `INSTALLED_APPS`, remove the app only after that deploys, optionally clear orphan rows. Endorses leaving the table as a *tracked* follow-up for small retired products.
- **`django-migrations` skill + `AGENTS.md`** — widen the trigger to fire on deleting a model, table, column, or whole product/app, "even when no migration is written." The dangerous teardown path is exactly the one that doesn't read as a migration task, so the old description (framed around authoring migrations) skipped it.

Docs and agent-instructions only — no code or runtime change.

## How did you test this code?

I'm an agent (Claude, via Claude Code), working under Julian's direction. No code changed, so no tests to run. Verified the doc's Table of Contents lists only `##` sections (so the new `###` subsection correctly needs no TOC entry) and that the three edits render as intended.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from Julian asking why a "Migration Risk Analysis → Blocked" comment showed up on a PR that touched no migrations. Traced it to the analyzer's master-schema-vs-branch-tree method surfacing a migration that master had deleted but a stale branch still carried, then to the gap that let the original file-only teardown skip the `/django-migrations` skill entirely. Chose to document the product/app teardown case and widen the skill trigger rather than build a CI guard on deleted migration files — the guard is the more robust backstop and is noted as a deferred follow-up, but it's a bigger lift and wasn't needed to close the immediate gap.
