### PR TITLE
fix(stripe): reduce subscription page size to avoid truncated responses

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -56,6 +56,14 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.set
 
 LOGGER = get_logger(__name__)
 DEFAULT_LIMIT = 100
+# Subscriptions are fetched with two levels of `expand` (subscription discounts and per-line-item
+# discounts), so each object is far larger than a typical Stripe resource. A full page of 100 such
+# objects can grow past the size that reliably transfers intact, and the response then arrives
+# truncated mid-stream — the SDK only discovers the bad body while JSON-decoding it, after its retry
+# loop, and re-fetching the identical oversized page just truncates again. A smaller page keeps each
+# response well within transferable size; _is_truncated_stripe_list_response stays as a backstop for
+# genuinely transient cuts.
+SUBSCRIPTION_PAGE_LIMIT = 20
 
 _JSON_WHITESPACE = frozenset(b" \t\n\r\f\v")
 _OPEN_BRACE = ord("{")
@@ -292,6 +300,9 @@ def _build_resources(
             method=client.subscriptions.list,
             params={
                 "status": "all",
+                # Smaller page than DEFAULT_LIMIT because the expansions below bloat each object; see
+                # SUBSCRIPTION_PAGE_LIMIT. Overrides the default `limit` in the merged params.
+                "limit": SUBSCRIPTION_PAGE_LIMIT,
                 # Expand discount objects so coupon details (amount_off, percent_off, duration) are inline.
                 # Without expansion Stripe returns only discount IDs, which prevents revenue projection.
                 # Key must be "expand" (not "expand[]") for a list value: the SDK encodes it as

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -17,9 +17,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.con
     CUSTOMER_PAYMENT_METHOD_RESOURCE_NAME,
     CUSTOMER_RESOURCE_NAME,
     RESOURCE_TO_STRIPE_WEBHOOK_EVENT,
+    SUBSCRIPTION_RESOURCE_NAME,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.source import StripeSource
 from products.warehouse_sources.backend.temporal.data_imports.sources.stripe.stripe import (
+    SUBSCRIPTION_PAGE_LIMIT,
     StripeAuthenticationError,
     StripeNestedResource,
     StripeResource,
@@ -304,6 +306,46 @@ class TestStripeNestedResourceGetRows:
         # cus_zero is skipped entirely — no API call, no rows.
         assert called_for == ["cus_credit", "cus_owed"]
         assert {row["customer"] for row in rows} == {"cus_credit", "cus_owed"}
+
+
+class TestSubscriptionPageSize:
+    def test_build_resources_caps_subscription_page_size(self):
+        # Subscriptions expand discounts at two levels, so a full DEFAULT_LIMIT page can grow past the
+        # size that transfers intact and arrives truncated mid-stream. The endpoint must request a
+        # smaller page than the default to keep each response transferable.
+        resources = stripe_module._build_resources(MagicMock(), logger=None)
+
+        subscription = resources[SUBSCRIPTION_RESOURCE_NAME]
+        assert subscription.params["limit"] == SUBSCRIPTION_PAGE_LIMIT
+        assert SUBSCRIPTION_PAGE_LIMIT < stripe_module.DEFAULT_LIMIT
+
+    def test_get_rows_sends_resource_limit_over_default(self):
+        # A resource's own `limit` must win over DEFAULT_LIMIT in the merged params — otherwise the
+        # reduced subscription page size would be clobbered back up to 100.
+        captured: dict = {}
+
+        def capturing_list(params):
+            captured.update(params)
+            return _FakeStripeList([])
+
+        resource = StripeResource(method=capturing_list, params={"limit": SUBSCRIPTION_PAGE_LIMIT})
+        resumable_source_manager = MagicMock()
+        resumable_source_manager.can_resume.return_value = False
+
+        with patch.object(stripe_module, "_build_resources", return_value={SUBSCRIPTION_RESOURCE_NAME: resource}):
+            list(
+                get_rows(
+                    api_key="sk_test_123",
+                    endpoint=SUBSCRIPTION_RESOURCE_NAME,
+                    account_id=None,
+                    db_incremental_field_last_value=None,
+                    db_incremental_field_earliest_value=None,
+                    logger=MagicMock(),
+                    resumable_source_manager=resumable_source_manager,
+                )
+            )
+
+        assert captured["limit"] == SUBSCRIPTION_PAGE_LIMIT
 
 
 class TestCustomerMightHaveBalanceTransactions:


### PR DESCRIPTION
## Problem

Error tracking surfaced a `JSONDecodeError` / `APIError` from the Stripe data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f056c-7a4d-74b3-9ad5-8113315f54fd)):

```
JSONDecodeError: Expecting property name enclosed in double quotes: line 4147 column 1 (char 131072)
APIError: Invalid response body from API: { "object": "list", "data": [ ...subscription... <cut off> }
```

The stack runs through our own code — `stripe.py:get_rows` → `auto_paging_iter()` → into the Stripe SDK, where `_interpret_response` fails to JSON-decode the response body. Stripe returned a **2xx with a `subscription` list page truncated mid-stream** at exactly `131072` bytes (128 KiB, a power-of-two boundary).

A prior fix ([#64916](https://github.com/PostHog/posthog/pull/64916)) already added an in-process retry for truncated list pages, treating truncation as a transient blip. But this recurred a few hours later, and the page size here is the tell: the `subscriptions` resource is fetched with **two levels of `expand`** (`data.discounts` and `data.items.data.discounts`) to inline coupon details for revenue projection, so each object is much larger than a typical Stripe resource. For a customer with complex subscriptions, a full page of 100 such objects grows past the size that reliably transfers intact and gets cut off mid-stream. Retrying just re-fetches the same oversized page, so it truncates again every time and the existing retry can't recover it — the import crashes.

This is not a credential, config, or permission problem (so `NonRetryableErrors` is wrong — it would permanently fail syncs and silently drop data), and it's not a plain transient cut the existing retry handles. It's our request asking for too much data per page on a heavily-expanded endpoint.

## Changes

Request a smaller page (`limit`) for the `subscriptions` endpoint via a new `SUBSCRIPTION_PAGE_LIMIT`, so each response stays well within transferable size. The reduced `limit` lives in the resource's own params and overrides the default in the merged params, covering the full-refresh, incremental, and resume call paths uniformly. The existing `_is_truncated_stripe_list_response` retry stays in place as a backstop for genuinely transient cuts on any endpoint.

Scoped strictly to the subscriptions endpoint — the one whose expansions bloat each object. Other endpoints keep `DEFAULT_LIMIT`.

## How did you test this code?

I'm an agent (Claude Code). I added and ran automated unit tests; I did not perform manual testing.

- `test_build_resources_caps_subscription_page_size` — the subscriptions resource is configured with a `limit` below `DEFAULT_LIMIT`. Catches a regression where the cap is dropped and pages grow back to 100.
- `test_get_rows_sends_resource_limit_over_default` — `get_rows` forwards a resource's own `limit` to the Stripe call, overriding `DEFAULT_LIMIT`. Catches a regression in the param-merge order that would clobber the reduced page size back up to 100.

Full stripe source test file passes (`48 passed`); `ruff check` / `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Tool: Claude Code, with the PostHog error-tracking MCP (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to pull the stack trace, a representative event, and frequency. Confirmed the failure originates in the source's own call path (`stripe.py:get_rows`), not just serialized log context.
- Decision: classified as a fixable bug, not a user/upstream error. Rejected `NonRetryableErrors` (it would permanently fail syncs and drop data on a recoverable condition). Verified the existing truncated-list retry ([#64916](https://github.com/PostHog/posthog/pull/64916)) is already on `master` and confirmed it can't recover this case, because the SDK retry re-fetches the same oversized page — the body cut at exactly 128 KiB indicates the page is intrinsically too large to transfer, not a random network drop. Chose to shrink the page on the one endpoint whose double `expand` bloats each object, rather than touch global retry policy or page size for all endpoints.
- Checked open PRs (including the maintainer's) for the exception type, the stable message phrase, and the source module path — no existing PR addresses this.
