### PR TITLE
chore(subscriptions): remove rolled-out hackathons_subscriptions flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1653,37 +1653,37 @@ snapshots:
     components-sso-select--sso-select--light:
         hash: v1.k794b7964.ae3ecf63f33e98350bb2cc9aa9b9458e0985c910f97b3251d837ee30b97a3c48.HKoN2BOvJoiBCjXKNt17mEo4yuzNnN3XmyVO9nAwgjc
     components-subscriptions--subscription-at-ai-summary-limit--dark:
-        hash: v1.k794b7964.642f0909654a4ba972a7d47559deff803020e6496421eabaf2b4028efc6c1738.AWNEfZukSS_IDQcY4JONenfhREk5rBhqcEDs5qI77RA
+        hash: v1.k794b7964.156fcfd3acd09553669f21cf0eed2f0b74e811115028d5b3616cc25929461e13.rCqYVhYGsHS-I0v1V4Ql1UT7Rk82Bfk5DXcfwQQdqiE
     components-subscriptions--subscription-at-ai-summary-limit--light:
-        hash: v1.k794b7964.47116a1253902261d402ee08a4906936b11200f2448ca225c4b8b38540b1e156.j5S2L8s3M08hPSFGAffBTNbv9HIYdtddElWCvGBTK2w
+        hash: v1.k794b7964.84894ff2c579c37bfc8dd80e9a7fe66133e8f37100c1faa4a0eba06b577d228c._JlKB55oauByI2QKThK5F_P0iYeY6ropuckxiIo5AnM
     components-subscriptions--subscription-no-integrations--dark:
-        hash: v1.k794b7964.642f0909654a4ba972a7d47559deff803020e6496421eabaf2b4028efc6c1738.6Khaj5CugcRss_yDiewqbHhBjP6fz0TQ-V3A099dPds
+        hash: v1.k794b7964.156fcfd3acd09553669f21cf0eed2f0b74e811115028d5b3616cc25929461e13.BZrbU6sA08zPACj6BafIxNfNrCTo4m-F4hdzzrBChNI
     components-subscriptions--subscription-no-integrations--light:
-        hash: v1.k794b7964.47116a1253902261d402ee08a4906936b11200f2448ca225c4b8b38540b1e156.GuBX6IYBJWMUZFEMWM9DLwGPT66p1lrKSBiFZSCkBcE
+        hash: v1.k794b7964.84894ff2c579c37bfc8dd80e9a7fe66133e8f37100c1faa4a0eba06b577d228c.xUlmAMPwEw0v38iknYf5eZL7f3pHZdfPGfNElRbNDT4
     components-subscriptions--subscriptions--dark:
         hash: v1.k794b7964.fc400fe330eaa6daa5c385a93b7db81b07b3056333c2622a758ae9d38d6a776e.m0LtVH-8u07XdEa0ONbCgF6d5d1X_8u9hUAc82PTOqk
     components-subscriptions--subscriptions--light:
         hash: v1.k794b7964.517d82cde2df377e32f848aa936b5f28feb7cd8c3d8c66dbbf0eb411550fed47.eXkZSld2uMIDekRRgYU7ZqBXck0f2Lx8IRfnyiVVsvg
     components-subscriptions--subscriptions-edit--dark:
-        hash: v1.k794b7964.4e1ee828d437569050391360bc2558b20607184ea1d598615aba7174cead55e0.tY6ID-dXxnh09jIhNfDD7kFP6XZlUToL239uSJDqcu4
+        hash: v1.k794b7964.70ac57bb1ea7ebd4db6f2d2e744e0a8e7c8f6188c937424f96f6a9c491971be2.e5BPPcxlrmkoPXisD7IuiAgwad_8RhCr120jMuHC4BA
     components-subscriptions--subscriptions-edit--light:
-        hash: v1.k794b7964.82bef30a8f265520b6707e2d7023f73b527a4e296653f81d84a921f251a6bf2a.ysxTpIREp6XBhSldR_rRCa4cxdWVVmApPYhNEsl834U
+        hash: v1.k794b7964.360957697af8f82c1e8eb0941e3f7d1fbab4c32ace207a5c8abd26e9371acb75.uwhJT1FZEwkRINc6RppFyQDBGuXvu06RcwW1dQmzYQE
     components-subscriptions--subscriptions-empty--dark:
         hash: v1.k794b7964.f005758ea36c0529486769ea8bb9e3bdec6b57e890e7a169b2f4e2f61cb5d19f.nG4DohzDpxMs7gbyl4P5UWO96tI5c5qFojY1XERmlqk
     components-subscriptions--subscriptions-empty--light:
         hash: v1.k794b7964.d331fc9b42100507ac4e0f5762bbf0b6b01a83dc29051c691c6a7840fc0c523c.CFIX34yvj3C-ut2blBB5gzLMYfpbxEDaJhDhUuqDszg
     components-subscriptions--subscriptions-new--dark:
-        hash: v1.k794b7964.642f0909654a4ba972a7d47559deff803020e6496421eabaf2b4028efc6c1738.wgN_ZZUOjsz7j2YLMUmJ1Bl5FmxadrRe_iu0lww-9gY
+        hash: v1.k794b7964.156fcfd3acd09553669f21cf0eed2f0b74e811115028d5b3616cc25929461e13.G4g6wjnsO6lG9WlBT9wk6QrwTMpAq8E75cp2XZgUmEU
     components-subscriptions--subscriptions-new--light:
-        hash: v1.k794b7964.47116a1253902261d402ee08a4906936b11200f2448ca225c4b8b38540b1e156.beV4TjCs3E204PRfl7WUhxr50DHXDYFIEGQKEEenz5I
+        hash: v1.k794b7964.84894ff2c579c37bfc8dd80e9a7fe66133e8f37100c1faa4a0eba06b577d228c.3sAUnEVwLL7g7quJccHet9YO9NlGfFFuxUhxurkFHI0
     components-subscriptions--subscriptions-new-free-at-limit--dark:
         hash: v1.k794b7964.41ac7d4533d1b27f2afeb40fb2aae1ad0337b6fd9037e6c9a26c6e037a4d432c.4FVzozovgeZAbGFWqwOnm1eLexeusHDUMflLwLeWNyk
     components-subscriptions--subscriptions-new-free-at-limit--light:
         hash: v1.k794b7964.a971f902aa7f51449fe3f86373c7693d285ec211c6df31dfcf9f7deac9f1955c.n4woUv2PvQAXSynjnG-79LJbeacQzqRzluNJ6VoviJg
     components-subscriptions--subscriptions-new-free-under-limit--dark:
-        hash: v1.k794b7964.642f0909654a4ba972a7d47559deff803020e6496421eabaf2b4028efc6c1738.YEexCHtwSJmepbKiQKay00KyCNKzpso0sGcDVcY5Nso
+        hash: v1.k794b7964.156fcfd3acd09553669f21cf0eed2f0b74e811115028d5b3616cc25929461e13.G-O9rtNMIDfqm1p3GDgDt6snE8IDQhM4jdGA1N1WS1I
     components-subscriptions--subscriptions-new-free-under-limit--light:
-        hash: v1.k794b7964.47116a1253902261d402ee08a4906936b11200f2448ca225c4b8b38540b1e156.DVRBl2oKCZDfgTmIkYnKrA0fDFQ9AxJKBXLNpZDKRu0
+        hash: v1.k794b7964.84894ff2c579c37bfc8dd80e9a7fe66133e8f37100c1faa4a0eba06b577d228c.ChxfwytyQqy9fw82b_ghndTIv1g2TqN5EmqSKm8F2o4
     components-table-preview--default--dark:
         hash: v1.k794b7964.f2fdf6780b196f98bfabf47545246e3c519b55183a6ffa604b42bc81b3ca3c79.VWTXfGIsY8N8ABdW7hszyLHqOZUjS8ik06JS8eU9yHE
     components-table-preview--default--light:

--- a/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
+++ b/frontend/src/lib/components/Subscriptions/SubscriptionsModal.stories.tsx
@@ -1,11 +1,9 @@
 import { MOCK_DEFAULT_ORGANIZATION } from 'lib/api.mock'
 
 import { Meta, StoryObj } from '@storybook/react'
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 
-import { FEATURE_FLAGS } from 'lib/constants'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { uuid } from 'lib/utils/dom'
 
 import { useStorybookMocks } from '~/mocks/browser'
@@ -34,23 +32,6 @@ const meta: Meta<StoryArgs> = {
         const { noIntegrations = false, aiSummaryAtLimit = false, freeTierSubscriptionCount, ...props } = args
         const insightShortIdRef = useRef(props.insightShortId || (uuid() as InsightShortId))
         const [modalOpen, setModalOpen] = useState(false)
-
-        useEffect(() => {
-            if (!aiSummaryAtLimit) {
-                return
-            }
-            featureFlagLogic.mount()
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS], {
-                [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
-            })
-            // Reset on unmount so the flag doesn't leak into other stories
-            // rendered later in the same Storybook session.
-            return () => {
-                featureFlagLogic.actions.setFeatureFlags([], {
-                    [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: false,
-                })
-            }
-        }, [aiSummaryAtLimit])
 
         useStorybookMocks({
             get: {

--- a/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
+++ b/frontend/src/lib/components/Subscriptions/views/EditSubscription.tsx
@@ -659,7 +659,7 @@ function EditSubscriptionForm({
                          * a summary of a summary. Hide the toggle entirely for AI subs.
                          */}
                         {!isAiPrompt && (
-                            <FlaggedFeature flag={FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS}>
+                            <>
                                 <LemonField name="summary_enabled">
                                     {({ value, onChange }) => (
                                         <AIConsentPopoverWrapper>
@@ -707,7 +707,7 @@ function EditSubscriptionForm({
                                         </LemonField>
                                     </FlaggedFeature>
                                 )}
-                            </FlaggedFeature>
+                            </>
                         )}
 
                         {insightShortId && !isAiPrompt && (

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -322,7 +322,6 @@ export const FEATURE_FLAGS = {
     FLAGGED_FEATURE_INDICATOR: 'flagged-feature-indicator', // owner: @benjackwhite
     FUNNEL_INSIGHT_ALERTS: 'funnel-insight-alerts', // owner: @vdekrijger, gates alerts on funnel insights (conversion rate)
     GROUP_PROFILE_EXPERIMENT: 'group-profile-experiment', // owner: @arthurdedeus #team-customer-analytics
-    HACKATHONS_SUBSCRIPTIONS: 'hackathons_subscriptions', // owner: #team-analytics-platform, gates listing subscription delivery history and AI change summaries
     HEALTH_ASK_AI: 'health-ask-ai', // owner: @jordanm-posthog #team-web-analytics, gates the "Ask PostHog AI" buttons on the Health overview
     HOGQL_INSIGHT_ALERTS: 'hogql-insight-alerts', // owner: @vdekrijger, gates alerts on SQL-backed (HogQL) insights
     HOGQL_WAREHOUSE_ACCESS_CONTROL: 'hogql-warehouse-access-control', // owner: @a-lider #team-platform-features, gates per-object access control for warehouse tables and views

--- a/frontend/src/scenes/subscriptions/SubscriptionScene.tsx
+++ b/frontend/src/scenes/subscriptions/SubscriptionScene.tsx
@@ -76,7 +76,6 @@ export function SubscriptionScene(): JSX.Element {
     const {
         subscription,
         subscriptionLoading,
-        deliveriesEnabled,
         deliveriesPage,
         deliveriesPageLoading,
         deliveringSubscriptionId,
@@ -109,24 +108,22 @@ export function SubscriptionScene(): JSX.Element {
                             <SubscriptionSummary sub={subscription} />
                         </div>
                     ) : null}
-                    {deliveriesEnabled ? (
-                        <SubscriptionDeliveryHistory
-                            deliveriesPage={deliveriesPage}
-                            deliveriesPageLoading={deliveriesPageLoading}
-                            loadDeliveriesPage={loadDeliveriesPage}
-                            deliveryStatusFilter={deliveryStatusFilter}
-                            onDeliveryStatusFilterChange={setDeliveryStatusFilter}
-                            onTestDelivery={subscription ? () => deliverSubscription(subscription.id) : undefined}
-                            testDeliveryLoading={Boolean(subscription && deliveringSubscriptionId === subscription.id)}
-                            onDeliveryFeedback={
-                                subscription?.resource_type === ResourceTypeEnumApi.AiPrompt
-                                    ? (deliveryId, feedback) => submitDeliveryFeedback(deliveryId, feedback, 'in_app')
-                                    : undefined
-                            }
-                            deliveryFeedback={deliveryFeedback}
-                            recentlyThankedDeliveries={recentlyThankedDeliveries}
-                        />
-                    ) : null}
+                    <SubscriptionDeliveryHistory
+                        deliveriesPage={deliveriesPage}
+                        deliveriesPageLoading={deliveriesPageLoading}
+                        loadDeliveriesPage={loadDeliveriesPage}
+                        deliveryStatusFilter={deliveryStatusFilter}
+                        onDeliveryStatusFilterChange={setDeliveryStatusFilter}
+                        onTestDelivery={subscription ? () => deliverSubscription(subscription.id) : undefined}
+                        testDeliveryLoading={Boolean(subscription && deliveringSubscriptionId === subscription.id)}
+                        onDeliveryFeedback={
+                            subscription?.resource_type === ResourceTypeEnumApi.AiPrompt
+                                ? (deliveryId, feedback) => submitDeliveryFeedback(deliveryId, feedback, 'in_app')
+                                : undefined
+                        }
+                        deliveryFeedback={deliveryFeedback}
+                        recentlyThankedDeliveries={recentlyThankedDeliveries}
+                    />
                 </div>
             )}
         </SceneContent>

--- a/frontend/src/scenes/subscriptions/subscriptionSceneLogic.test.ts
+++ b/frontend/src/scenes/subscriptions/subscriptionSceneLogic.test.ts
@@ -12,9 +12,6 @@ import {
 } from '@posthog/products-subscriptions/frontend/generated/api.schemas'
 import type { SubscriptionApi } from '@posthog/products-subscriptions/frontend/generated/api.schemas'
 
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -96,10 +93,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS], {
-            [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
-        })
 
         const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
@@ -114,10 +107,9 @@ describe('subscriptionSceneLogic', () => {
         expect(deliveriesRequestUrls).toHaveLength(2)
         expect(deliveriesRequestUrls[1]).toContain('status=failed')
         logic.unmount()
-        featureFlagLogic.unmount()
     })
 
-    it('does not request deliveries when the hackathons_subscriptions flag is off', async () => {
+    it('loads delivery history once the subscription has loaded', async () => {
         useMocks({
             get: {
                 [`/api/projects/${MOCK_TEAM_ID}/subscriptions/1/`]: [200, MOCK_SUBSCRIPTION],
@@ -128,33 +120,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
-
-        const logic = subscriptionSceneLogic({ id: '1' })
-        logic.mount()
-
-        await expectLogic(logic).toDispatchActions(['loadSubscriptionSuccess'])
-        expect(deliveriesRequestUrls).toHaveLength(0)
-        logic.unmount()
-        featureFlagLogic.unmount()
-    })
-
-    it('loads delivery history when the hackathons_subscriptions flag is on', async () => {
-        useMocks({
-            get: {
-                [`/api/projects/${MOCK_TEAM_ID}/subscriptions/1/`]: [200, MOCK_SUBSCRIPTION],
-                [`/api/projects/${MOCK_TEAM_ID}/subscriptions/1/deliveries/`]: () => {
-                    deliveriesRequestUrls.push('deliveries')
-                    return [200, { results: [], next: null, previous: null }]
-                },
-            },
-        })
-        initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS], {
-            [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
-        })
 
         const logic = subscriptionSceneLogic({ id: '1' })
         logic.mount()
@@ -162,40 +127,9 @@ describe('subscriptionSceneLogic', () => {
         await expectLogic(logic).toFinishAllListeners()
         expect(deliveriesRequestUrls).toHaveLength(1)
         logic.unmount()
-        featureFlagLogic.unmount()
     })
 
-    it('refetches deliveries after subscription loads when the flag turns on', async () => {
-        useMocks({
-            get: {
-                [`/api/projects/${MOCK_TEAM_ID}/subscriptions/1/`]: [200, MOCK_SUBSCRIPTION],
-                [`/api/projects/${MOCK_TEAM_ID}/subscriptions/1/deliveries/`]: () => {
-                    deliveriesRequestUrls.push('deliveries')
-                    return [200, { results: [], next: null, previous: null }]
-                },
-            },
-        })
-        initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
-
-        const logic = subscriptionSceneLogic({ id: '1' })
-        logic.mount()
-        await expectLogic(logic).toDispatchActions(['loadSubscriptionSuccess'])
-        expect(deliveriesRequestUrls).toHaveLength(0)
-
-        await expectLogic(logic, () => {
-            featureFlagLogic.actions.setFeatureFlags([FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS], {
-                [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
-            })
-        }).toFinishAllListeners()
-
-        expect(deliveriesRequestUrls).toHaveLength(1)
-        logic.unmount()
-        featureFlagLogic.unmount()
-    })
-
-    it('loads an AI prompt subscription and its deliveries when the flag is on', async () => {
+    it('loads an AI prompt subscription and its deliveries', async () => {
         useMocks({
             get: {
                 // Function form, not the `[200, body]` shorthand: useMocks serializes a bare array as
@@ -208,16 +142,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        // HACKATHONS_SUBSCRIPTIONS gates the delivery history this test asserts; SUBSCRIPTION_AI_PROMPT
-        // is what makes AI prompt subscriptions exist in the first place, so both are on in a realistic run.
-        featureFlagLogic.actions.setFeatureFlags(
-            [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS, FEATURE_FLAGS.SUBSCRIPTION_AI_PROMPT],
-            {
-                [FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]: true,
-                [FEATURE_FLAGS.SUBSCRIPTION_AI_PROMPT]: true,
-            }
-        )
 
         const logic = subscriptionSceneLogic({ id: '2' })
         logic.mount()
@@ -227,7 +151,6 @@ describe('subscriptionSceneLogic', () => {
         expect(logic.values.subscription?.prompt).toBeTruthy()
         expect(deliveriesRequestUrls).toHaveLength(1)
         logic.unmount()
-        featureFlagLogic.unmount()
     })
 
     it.each([
@@ -240,8 +163,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
         const captureSpy = jest.spyOn(posthog, 'capture')
 
         const logic = subscriptionSceneLogic({ id: '2' })
@@ -266,7 +187,6 @@ describe('subscriptionSceneLogic', () => {
         expect(captureSpy.mock.calls.filter(([event]) => event === 'ai_report_feedback')).toHaveLength(1)
 
         logic.unmount()
-        featureFlagLogic.unmount()
         captureSpy.mockRestore()
     })
 
@@ -277,8 +197,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
         const captureSpy = jest.spyOn(posthog, 'capture')
 
         const logic = subscriptionSceneLogic({ id: '2' })
@@ -302,7 +220,6 @@ describe('subscriptionSceneLogic', () => {
         expect(logic.values.deliveryFeedback).toEqual({ 'd-123': 'positive' })
 
         logic.unmount()
-        featureFlagLogic.unmount()
         captureSpy.mockRestore()
     })
 
@@ -313,8 +230,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
 
         let logic = subscriptionSceneLogic({ id: '2' })
         logic.mount()
@@ -330,7 +245,6 @@ describe('subscriptionSceneLogic', () => {
         expect(logic.values.recentlyThankedDeliveries).toEqual({})
 
         logic.unmount()
-        featureFlagLogic.unmount()
     })
 
     it('captures in-app thumbs feedback and records it per delivery', async () => {
@@ -340,8 +254,6 @@ describe('subscriptionSceneLogic', () => {
             },
         })
         initKeaTests()
-        featureFlagLogic.mount()
-        featureFlagLogic.actions.setFeatureFlags([], {})
         const captureSpy = jest.spyOn(posthog, 'capture')
 
         const logic = subscriptionSceneLogic({ id: '2' })
@@ -380,7 +292,6 @@ describe('subscriptionSceneLogic', () => {
         expect(logic.values.deliveryFeedback).toEqual({ 'd-9': 'positive' })
 
         logic.unmount()
-        featureFlagLogic.unmount()
         captureSpy.mockRestore()
     })
 })

--- a/frontend/src/scenes/subscriptions/subscriptionSceneLogic.tsx
+++ b/frontend/src/scenes/subscriptions/subscriptionSceneLogic.tsx
@@ -1,7 +1,6 @@
-import { actions, afterMount, connect, kea, key, listeners, path, props, reducers, selectors } from 'kea'
+import { actions, afterMount, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { router, urlToAction } from 'kea-router'
-import { subscriptions } from 'kea-subscriptions'
 import posthog from 'posthog-js'
 
 import {
@@ -17,9 +16,7 @@ import type {
 } from '@posthog/products-subscriptions/frontend/generated/api.schemas'
 
 import { runSubscriptionTestDelivery } from 'lib/components/Subscriptions/runSubscriptionTestDelivery'
-import { FEATURE_FLAGS } from 'lib/constants'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { getCurrentTeamId } from 'lib/utils/getAppContext'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
@@ -56,9 +53,6 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
     props({} as SubscriptionSceneLogicProps),
     key(({ id }) => id),
     path((key) => ['scenes', 'subscriptions', 'subscriptionSceneLogic', key]),
-    connect(() => ({
-        values: [featureFlagLogic, ['featureFlags']],
-    })),
     actions({
         deliverSubscription: (id: number) => ({ id }),
         deliverSubscriptionSuccess: true,
@@ -135,9 +129,6 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
             null as PaginatedSubscriptionDeliveryListApi | null,
             {
                 loadDeliveriesPage: async (targetUrl: string | null) => {
-                    if (!values.deliveriesEnabled) {
-                        return null
-                    }
                     const numericId = parseInt(props.id, 10)
                     if (!Number.isFinite(numericId)) {
                         return null
@@ -157,10 +148,6 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
         ],
     })),
     selectors({
-        deliveriesEnabled: [
-            (s) => [s.featureFlags],
-            (featureFlags): boolean => Boolean(featureFlags[FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS]),
-        ],
         breadcrumbs: [
             (s) => [s.subscription],
             (subscription): Breadcrumb[] => {
@@ -184,20 +171,6 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
             },
         ],
     }),
-    subscriptions(({ actions, values }) => ({
-        featureFlags: (featureFlags, oldFeatureFlags) => {
-            const enabled = Boolean(featureFlags[FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS])
-            const wasEnabled = Boolean(oldFeatureFlags?.[FEATURE_FLAGS.HACKATHONS_SUBSCRIPTIONS])
-            if (enabled === wasEnabled) {
-                return
-            }
-            if (!enabled) {
-                actions.loadDeliveriesPageSuccess(null, null)
-            } else if (values.subscription) {
-                void actions.loadDeliveriesPage(null)
-            }
-        },
-    })),
     listeners(({ actions, values, props, cache, selectors }) => ({
         submitDeliveryFeedback: ({ deliveryId, feedback, source }, _breakpoint, _action, previousState) => {
             posthog.capture('ai_report_feedback', {
@@ -220,12 +193,12 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
             }, `deliveryThanks-${deliveryId}`)
         },
         setDeliveryStatusFilter: () => {
-            if (values.deliveriesEnabled && values.subscription) {
+            if (values.subscription) {
                 void actions.loadDeliveriesPage(null)
             }
         },
         loadSubscriptionSuccess: () => {
-            if (values.deliveriesEnabled && values.subscription) {
+            if (values.subscription) {
                 void actions.loadDeliveriesPage(null)
             }
         },
@@ -242,9 +215,6 @@ export const subscriptionSceneLogic = kea<subscriptionSceneLogicType>([
         // Test delivery returns 202 before Temporal persists the delivery row. Refetch now (fast path) and
         // again after a short delay so the list usually shows the new row without manual refresh.
         deliverSubscriptionSuccess: async (_, breakpoint) => {
-            if (!values.deliveriesEnabled) {
-                return
-            }
             void actions.loadDeliveriesPage(null)
             await breakpoint(2000)
             void actions.loadDeliveriesPage(null)

--- a/posthog/constants.py
+++ b/posthog/constants.py
@@ -319,7 +319,6 @@ SURVEY_TARGETING_FLAG_PREFIX = "survey-targeting-"
 PRODUCT_TOUR_TARGETING_FLAG_PREFIX = "product-tour-targeting-"
 
 # Server-side evaluation via posthoganalytics; keep in sync with frontend FEATURE_FLAGS.
-HACKATHONS_SUBSCRIPTIONS_FEATURE_FLAG_KEY = "hackathons_subscriptions"
 SUBSCRIPTION_AI_SUMMARY_PROMPT_GUIDE_FEATURE_FLAG_KEY = "subscription-ai-summary-prompt-guide"
 SUBSCRIPTION_AI_PROMPT_FEATURE_FLAG_KEY = "ai-subscriptions"
 ALERTS_15_MINUTE_INTERVAL_FEATURE_FLAG_KEY = "alerts-15-minute-interval"


### PR DESCRIPTION
## Problem

`hackathons_subscriptions` is fully rolled out, so the flag is dead weight.

## Changes

Removed the flag and made its two gated bits unconditional: the delivery history list on the subscription scene, and the AI summary toggle in the edit form. Dropped the now-dead `featureFlagLogic` plumbing, the two flag-toggle tests, and the flag setup in the story.

> [!NOTE]
> The flag still needs archiving in the PostHog app once this merges.

## How did you test this code?

Agent-run automated checks only, no manual testing:
- `subscriptionSceneLogic.test.ts` — 8/8 pass
- tsgo clean for subscription files; oxfmt/oxlint/ruff clean

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

PostHog Code (Claude Opus 4.8). Matt asked to remove the rolled-out flag. No repo skills triggered (pure removal — no migrations/serializers/API types).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
