### PR TITLE
fix(mcp-analytics): force-refresh the onboarding poll so it flips instantly

### DIFF
--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.test.ts
@@ -1,0 +1,51 @@
+import { expectLogic } from 'kea-test-utils'
+
+import api from 'lib/api'
+
+import { initKeaTests } from '~/test/init'
+
+import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
+
+jest.mock('lib/api')
+
+const mockApi = api as jest.Mocked<typeof api>
+
+describe('mcpAnalyticsOnboardingLogic', () => {
+    beforeEach(() => {
+        jest.clearAllMocks()
+        initKeaTests()
+    })
+
+    function mountWith(results: unknown[][]): ReturnType<typeof mcpAnalyticsOnboardingLogic.build> {
+        jest.spyOn(mockApi, 'query').mockResolvedValue({ results } as any)
+        const logic = mcpAnalyticsOnboardingLogic()
+        logic.mount()
+        return logic
+    }
+
+    it('forces a fresh calculation so an ingestion-gap cached [0,0] never sticks', async () => {
+        const logic = mountWith([[1, 1]])
+        await expectLogic(logic).toFinishAllListeners()
+        // The onboarding poll must bypass the cache (force_blocking). Otherwise a
+        // pre-ingestion [0,0] cached during the capture->queryable gap keeps the page
+        // on "not onboarded" for a full cache cycle after events actually land.
+        expect(mockApi.query).toHaveBeenCalledWith(expect.anything(), { refresh: 'force_blocking' })
+    })
+
+    it.each([
+        [[[1, 1]], 'onboarded'],
+        [[[1, 0]], 'connected-no-calls'],
+        [[[0, 0]], 'not-instrumented'],
+    ])('maps signal row %j to state %s', async (results, expected) => {
+        const logic = mountWith(results)
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.onboardingState).toBe(expected)
+        expect(logic.values.isOnboarded).toBe(expected === 'onboarded')
+    })
+
+    it('treats a stringified "0" as false (no false-positive onboarding)', async () => {
+        const logic = mountWith([['0', '0']])
+        await expectLogic(logic).toFinishAllListeners()
+        expect(logic.values.onboardingState).toBe('not-instrumented')
+    })
+})

--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
@@ -40,10 +40,21 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
         signals: {
             __default: null as MCPOnboardingSignals | null,
             loadSignals: async (_: void, breakpoint): Promise<MCPOnboardingSignals> => {
-                const response = (await api.query({
-                    kind: NodeKind.HogQLQuery,
-                    query: ONBOARDING_SIGNAL_QUERY,
-                })) as HogQLQueryResponse
+                // Force a fresh calculation instead of reading a cached result. The first
+                // events on a new project land a beat after capture returns 200, so a poll
+                // during that gap caches `[0,0]` — and with the default cache TTL the page
+                // would then keep serving that stale "not onboarded" answer for up to a
+                // minute after the data is actually queryable, dulling the "you're connected!"
+                // moment. Forcing keeps the flip near-instant. Polling stops as soon as we're
+                // onboarded (see loadSignalsSuccess), so this is bounded to the onboarding
+                // window, and the query itself is cheap (two event-name counts on the sort key).
+                const response = (await api.query(
+                    {
+                        kind: NodeKind.HogQLQuery,
+                        query: ONBOARDING_SIGNAL_QUERY,
+                    },
+                    { refresh: 'force_blocking' }
+                )) as HogQLQueryResponse
                 breakpoint()
                 const row = (response?.results?.[0] as unknown[] | undefined) ?? []
                 // ClickHouse returns the `> 0` comparisons as 0/1; coerce numerically so a


### PR DESCRIPTION
## Problem

The event-gated MCP-analytics onboarding poll (`mcpAnalyticsOnboardingLogic`) read a **cached** HogQL result. The first events on a brand-new project become queryable a beat after the capture endpoint returns `200`, so a poll landing in that gap caches `[0, 0]` — and with the default cache TTL the page then keeps serving that stale *"not onboarded"* answer for up to a cache cycle after the data is actually there.

Caught it live while testing the wizard end-to-end: events were visible in the Activity tab, but the onboarding query came back `"is_cached": true`, `results: [[0, 0]]`, with `next_allowed_client_refresh` a minute out. So the "you're connected!" flip lagged ~a minute behind reality — exactly the moment we want to feel instant.

## Fix

Pass `refresh: 'force_blocking'` on the poll so each check recomputes against fresh data instead of reading the cache.

It's safe and cheap:
- Polling **stops the moment we're onboarded** (`loadSignalsSuccess` disposes the timer), so the forced recompute is bounded to the onboarding window.
- The query is two event-name counts filtered on the events sort key.

## Tests

Adds `mcpAnalyticsOnboardingLogic.test.ts` (the logic had none): asserts the poll is forced (`{ refresh: 'force_blocking' }`), the signal→state mapping (`onboarded` / `connected-no-calls` / `not-instrumented`), and the stringified-`"0"` coercion guard. 5/5 pass.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*