### PR TITLE
feat(mcp-analytics): context-aware Ask PostHog AI button in scene header

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5977,9 +5977,9 @@ snapshots:
     scenes-app-marketing-analytics-cell-actions--source-cell-action-unmapped--light:
         hash: v1.k794b7964.4ebf2f848b10c8b2859630215a9be1ff91fb825fc334005207556310261d3a5c.UcqJY3dqyJNbi3x7oYaZ2rEu95LAEdbGmMyEpI-Wlgc
     scenes-app-mcp-analytics--dashboard--dark:
-        hash: v1.k794b7964.4292b8f6b3204ee0b10809e9db9cff5678c8bee801ba569fb9d22dd452b8a8bb.kgliIkb6GeE4lfxM9ZvokOg9m-DDDV-fpILZFytqWuE
+        hash: v1.k794b7964.2d41908d00a1ff34a9d2853a1b93497981dd9e3ee468f606f4be9375a8a5b02e.LYY0_XMZs7Wx5rQQCLr8NKzyEwYYPAXGebZpVUIsmHw
     scenes-app-mcp-analytics--dashboard--light:
-        hash: v1.k794b7964.49dd989e2726543d470320570c24c2f9b0a50e90d4129741eed06500f183d36d.YbgjXggvlwzgtDVKbyXNS2m6w3TuGQKGF4dq91VGQqQ
+        hash: v1.k794b7964.4fb6af8da91a3be359b14faaa2f6a4f179715cffd4c8a6d600ddb02c819cd0bd.HSLNfvQM5TDHs7XhOcAfkPCfZp_Znxe9VPRwjznA-dk
     scenes-app-mcp-analytics--intent-clustering--dark:
         hash: v1.k794b7964.4bf359b5089b714711c176bdbd5e454857e35935027ca46c161215957bcdff63.tuUCfVazgJFLRYPnMr4rBr_bdCHDOR4WINf5P7PHyCU
     scenes-app-mcp-analytics--intent-clustering--light:

--- a/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsScene.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 import { router, combineUrl } from 'kea-router'
 
+import { IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonTab, LemonTabs } from '@posthog/lemon-ui'
 
 import { urls } from 'scenes/urls'
@@ -9,11 +10,12 @@ import { SceneContent } from '~/layout/scenes/components/SceneContent'
 import { SceneTitleSection } from '~/layout/scenes/components/SceneTitleSection'
 import { SceneExport } from '~/scenes/sceneTypes'
 
+import { askPostHogAI } from './askPostHogAI'
 import { MCPAnalyticsClustering } from './clustering/MCPAnalyticsClustering'
 import { MCPAnalyticsDashboard } from './MCPAnalyticsDashboard'
 import { MCPAnalyticsLoading, MCPAnalyticsOnboarding } from './MCPAnalyticsOnboarding'
 import { mcpAnalyticsOnboardingLogic } from './mcpAnalyticsOnboardingLogic'
-import { MCPAnalyticsTab, TAB_DESCRIPTIONS, mcpAnalyticsSceneLogic } from './mcpAnalyticsSceneLogic'
+import { MCPAnalyticsTab, TAB_AI_PROMPTS, TAB_DESCRIPTIONS, mcpAnalyticsSceneLogic } from './mcpAnalyticsSceneLogic'
 import { MCPAnalyticsToolQuality } from './MCPAnalyticsToolQuality'
 import { MCPSessionsPlaylist } from './sessions/MCPSessionsPlaylist'
 
@@ -67,9 +69,22 @@ export function MCPAnalyticsScene(): JSX.Element {
                 description={onboardingState === 'onboarded' ? TAB_DESCRIPTIONS[activeTab] : null}
                 resourceType={{ type: 'llm_analytics' }}
                 actions={
-                    <LemonButton to={DEFAULT_DOCS_URL} type="secondary" targetBlank size="small">
-                        Documentation
-                    </LemonButton>
+                    <>
+                        {onboardingState === 'onboarded' && (
+                            <LemonButton
+                                type="secondary"
+                                size="small"
+                                icon={<IconSparkles />}
+                                onClick={() => askPostHogAI(TAB_AI_PROMPTS[activeTab])}
+                                data-attr="mcp-analytics-ask-ai"
+                            >
+                                Ask PostHog AI
+                            </LemonButton>
+                        )}
+                        <LemonButton to={DEFAULT_DOCS_URL} type="secondary" targetBlank size="small">
+                            Documentation
+                        </LemonButton>
+                    </>
                 }
             />
             {/* `signals === null` means we don't know yet — still loading, or a transient

--- a/products/mcp_analytics/frontend/askPostHogAI.ts
+++ b/products/mcp_analytics/frontend/askPostHogAI.ts
@@ -1,0 +1,11 @@
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { SidePanelTab } from '~/types'
+
+/**
+ * Open PostHog AI in the side panel with a question pre-filled and auto-submitted — the `!`
+ * prefix runs it immediately. The side-panel logic is mounted by the app shell, so we reach
+ * for the mounted instance rather than mounting it eagerly.
+ */
+export function askPostHogAI(prompt: string): void {
+    sidePanelStateLogic.findMounted()?.actions.openSidePanel(SidePanelTab.Max, '!' + prompt)
+}

--- a/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsSceneLogic.ts
@@ -21,6 +21,18 @@ export const TAB_DESCRIPTIONS: Record<MCPAnalyticsTab, string> = {
         'Cluster semantically similar user intents and see which tools each cluster routes to. Highlights inconsistent routing.',
 }
 
+// Per-tab question seeded into PostHog AI so the answer is grounded in what the user is looking at.
+export const TAB_AI_PROMPTS: Record<MCPAnalyticsTab, string> = {
+    dashboard:
+        "Summarize how agents are using my MCP server from $mcp_tool_call events — top tools, error rates, and what they're trying to do.",
+    sessions:
+        'What are agents actually trying to do across my MCP sessions? Group the $mcp_intent values on $mcp_tool_call events into themes.',
+    'tool-quality':
+        'Which of my MCP tools are least reliable? Break down $mcp_tool_call error rate and p95 $mcp_duration_ms by $mcp_tool_name.',
+    'intent-clustering':
+        "What's the biggest unmet need agents have that my MCP tools don't cover? Look at $mcp_missing_capability and $mcp_intent.",
+}
+
 const SCENE_KEY_TO_TAB: Record<string, MCPAnalyticsTab> = {
     mcpAnalyticsDashboard: 'dashboard',
     mcpAnalyticsSessions: 'sessions',


### PR DESCRIPTION
## Problem

PostHog AI can already answer questions over a customer's `$mcp_tool_call` events, but the MCP analytics scene gives no obvious way in. The first-look card has an "Ask PostHog AI" CTA; the rest of the product doesn't.

## Changes

A single **"Ask PostHog AI" button in the scene header** (next to Documentation) that opens PostHog AI with a question tailored to the active tab:

- **Tool quality** → "which of my MCP tools are least reliable?" (error rate + p95 by tool)
- **Sessions** → "what are agents actually trying to do?" (theme the `$mcp_intent` values)
- **Intent clustering** → "what's the biggest unmet need my tools don't cover?" (`$mcp_missing_capability` + `$mcp_intent`)
- **Dashboard** → the overview question

Shown only once the project is onboarded (no point before there's data). The question is pre-filled and auto-submitted (the side panel `!` convention). Extracts a tiny shared `askPostHogAI(prompt)` helper for the open-and-submit, which the first-look card can adopt once both land.

## How did you test this code?

Agent-authored (PostHog Code). Automated: oxlint + typecheck clean. The prompt strings are static per tab and the open path reuses the existing `sidePanelStateLogic.openSidePanel(Max, '!'+prompt)` convention. Not manually run (local backend was down); the button gates on `onboardingState === 'onboarded'` and the per-tab mapping is a plain `Record`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Follow-up to the first-look card (#66447), at Lucas's request to surface PostHog AI across the whole product rather than just on onboard. Kept as a separate PR since it's a scene-wide change distinct from the first-look card. The `askPostHogAI` helper is intentionally shared so the first-look card's inline open can be deduped onto it after both merge.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*