### PR TITLE
feat(llma): compact a conversation's checkpoints on demand from Django admin

### DIFF
--- a/posthog/admin/admins/conversation_admin.py
+++ b/posthog/admin/admins/conversation_admin.py
@@ -1,0 +1,52 @@
+from django.contrib import admin, messages
+from django.urls import reverse
+from django.utils.html import format_html
+
+from products.posthog_ai.backend.models.assistant import Conversation
+
+from ee.hogai.django_checkpoint.compaction import compact_thread
+
+
+@admin.register(Conversation)
+class ConversationAdmin(admin.ModelAdmin):
+    list_display = ("id", "team_link", "user", "status", "type", "title", "updated_at")
+    list_select_related = ("team", "user")
+    list_filter = ("status", "type")
+    search_fields = ("id", "team__name", "user__email")
+    autocomplete_fields = ("team", "user")
+    ordering = ("-updated_at",)
+    actions = ["compact_checkpoints"]
+
+    def has_add_permission(self, request) -> bool:
+        return False
+
+    @admin.display(description="Team")
+    def team_link(self, conversation: Conversation):
+        return format_html(
+            '<a href="{}">{}</a>',
+            reverse("admin:posthog_team_change", args=[conversation.team_id]),
+            conversation.team.name,
+        )
+
+    @admin.action(description="Compact checkpoints (keep latest, reclaim storage)")
+    def compact_checkpoints(self, request, queryset) -> None:
+        """On-demand single-conversation compaction for staff.
+
+        Deliberately bypasses the rollout allowlist (that gates only the automated sweep). The
+        primitive's own safety guards still apply, so a conversation that is mid-run, awaiting an
+        approval interrupt, or carrying a pending interrupt is skipped rather than corrupted."""
+        compacted = skipped = checkpoints = blobs = 0
+        for conversation in queryset:
+            result = compact_thread(str(conversation.id))
+            if result.compacted:
+                compacted += 1
+                checkpoints += result.checkpoints_deleted
+                blobs += result.blobs_deleted
+            else:
+                skipped += 1
+        self.message_user(
+            request,
+            f"Compacted {compacted} conversation(s) — reclaimed {checkpoints} checkpoints "
+            f"and {blobs} blobs. Skipped {skipped} (not idle, awaiting approval, or nothing to compact).",
+            messages.SUCCESS if compacted else messages.WARNING,
+        )


### PR DESCRIPTION
## Problem

Before the automated daily sweep rolls out, we want to validate compaction against specific conversations on demand — and to have an ops tool to compact a single conversation when needed. Builds on #66320 (the primitive).

## Changes

Adds a `Conversation` Django admin (staff-only) with a **"Compact checkpoints"** action over the selected rows. It calls the `compact_thread` primitive and reports a per-batch summary (compacted / skipped / checkpoints + blobs reclaimed).

The action deliberately **bypasses the rollout allowlist** — that allowlist gates only the automated daily sweep (at selection). A staff member explicitly selecting a conversation is an authorized override and can compact any team's conversation. The primitive's own safety guards still apply, so a conversation that is mid-run, awaiting an approval interrupt, or carrying a pending interrupt is skipped (never corrupted).

To support this cleanly, `compact_thread` is a **pure primitive** (no team awareness); the allowlist is enforced only at sweep selection (`select_compactable_conversation_ids` in #66321) and the self-hosted safeguard is the Cloud-gated schedule (#66323).

## How did you test this code?

I'm an agent (Claude). The admin action is thin glue over `compact_thread`, which is covered by the primitive's tests in #66320 (load + resume + idempotency + null-placeholder tip + pending-Sends skip + unsafe-skip). No standalone admin test — it's a loop over the tested primitive with a message summary. (Local dev DB was down; CI is the authoritative run.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @pauldambra, built with Claude (PostHog Code). Placed early in the stack (right after the primitive) since it only needs `compact_thread`. The bypass-allowlist behavior was a deliberate product choice confirmed with @pauldambra: the allowlist is a rollout control for the automated sweep, not a restriction on manual staff ops. Making `compact_thread` pure (moving the team gate out of the primitive and into sweep selection) was the enabling refactor.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
