### PR TITLE
fix(temporalio): retry transient gRPC deadline timeouts in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/temporalio.py
@@ -55,19 +55,22 @@ class TemporalIOResumeConfig:
 
 T = TypeVar("T")
 
-# Temporal Cloud throttles per-namespace RPCs (RPS / concurrency / overload) with a gRPC
-# RESOURCE_EXHAUSTED status — e.g. "namespace rate limit exceeded". It's transient: a short backoff
-# usually clears the window. Riding it out in-process keeps a brief throttle from failing the whole
-# import activity (which would rebuild the client and restart pagination) and avoids error-tracking
-# noise. Persistent throttling re-raises so Temporal's activity retry still applies.
-_MAX_RATE_LIMIT_ATTEMPTS = 6
+# Temporal Cloud surfaces transient server-side conditions as gRPC errors that a short backoff
+# usually clears: per-namespace throttling (RESOURCE_EXHAUSTED — e.g. "namespace rate limit
+# exceeded") and request deadlines on the visibility/history services (DEADLINE_EXCEEDED — e.g.
+# "downstream duration timeout"). Riding these out in-process keeps a brief blip from failing the
+# whole import activity (which would rebuild the client and restart pagination) and avoids
+# error-tracking noise. Persistent failures re-raise so Temporal's activity retry still applies.
+_MAX_TRANSIENT_RPC_ATTEMPTS = 6
+
+_RETRYABLE_RPC_STATUSES = frozenset({RPCStatusCode.RESOURCE_EXHAUSTED, RPCStatusCode.DEADLINE_EXCEEDED})
 
 
-async def _with_rate_limit_retry(
+async def _with_transient_rpc_retry(
     operation: Callable[[], Awaitable[T]],
     logger: FilteringBoundLogger,
     *,
-    max_attempts: int = _MAX_RATE_LIMIT_ATTEMPTS,
+    max_attempts: int = _MAX_TRANSIENT_RPC_ATTEMPTS,
 ) -> T:
     attempt = 0
     while True:
@@ -75,10 +78,15 @@ async def _with_rate_limit_retry(
             return await operation()
         except RPCError as e:
             attempt += 1
-            if attempt >= max_attempts or e.status != RPCStatusCode.RESOURCE_EXHAUSTED:
+            if attempt >= max_attempts or e.status not in _RETRYABLE_RPC_STATUSES:
                 raise
             backoff = min(2 * attempt, 30)
-            logger.debug("TemporalIO: namespace rate limited", backoff_seconds=backoff, attempt=attempt)
+            logger.debug(
+                "TemporalIO: transient RPC error, backing off",
+                status=e.status,
+                backoff_seconds=backoff,
+                attempt=attempt,
+            )
             await asyncio.sleep(backoff)
 
 
@@ -206,7 +214,7 @@ async def _get_workflows(
         # Save the token that will be used to fetch this page *before* fetching.
         # On resume we re-fetch this same page — duplicates are safe thanks to primary keys.
         pre_fetch_token = workflows.next_page_token
-        await _with_rate_limit_retry(workflows.fetch_next_page, logger)
+        await _with_transient_rpc_retry(workflows.fetch_next_page, logger)
         page = workflows.current_page
         if not page:
             break
@@ -257,7 +265,7 @@ async def _get_workflow_histories(
         # Save the token that will be used to fetch this page *before* fetching.
         # On resume we re-fetch this same page — duplicates are safe thanks to primary keys.
         pre_fetch_token = workflows.next_page_token
-        await _with_rate_limit_retry(workflows.fetch_next_page, logger)
+        await _with_transient_rpc_retry(workflows.fetch_next_page, logger)
         page = workflows.current_page
         if not page:
             break
@@ -274,7 +282,7 @@ async def _get_workflow_histories(
         for item in page:
             try:
                 handle = client.get_workflow_handle(item.id, run_id=item.run_id)
-                history = await _with_rate_limit_retry(handle.fetch_history, logger)
+                history = await _with_transient_rpc_retry(handle.fetch_history, logger)
                 history_dict = history.to_json_dict()
                 events = history_dict["events"]
                 for event in events:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/temporalio/test_temporalio.py
@@ -11,7 +11,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.temporalio
 from products.warehouse_sources.backend.temporal.data_imports.sources.temporalio.temporalio import (
     FakeSettings,
     _get_temporal_client,
-    _with_rate_limit_retry,
+    _with_transient_rpc_retry,
 )
 
 
@@ -105,37 +105,51 @@ class TestTemporalIONonRetryableErrors:
         )
 
 
-class TestRateLimitRetry:
+class TestTransientRPCRetry:
+    @pytest.mark.parametrize(
+        "message,status",
+        [
+            ("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED),
+            ("downstream duration timeout", RPCStatusCode.DEADLINE_EXCEEDED),
+        ],
+    )
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep",
         new_callable=AsyncMock,
     )
-    async def test_rides_out_transient_rate_limit(self, sleep):
+    async def test_rides_out_transient_error(self, sleep, message, status):
         calls = {"n": 0}
 
         async def operation():
             calls["n"] += 1
             if calls["n"] <= 2:
-                raise _rpc_error("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED)
+                raise _rpc_error(message, status)
             return "ok"
 
-        result = await _with_rate_limit_retry(operation, MagicMock())
+        result = await _with_transient_rpc_retry(operation, MagicMock())
 
         assert result == "ok"
         assert calls["n"] == 3
         # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
         assert sleep.await_args_list == [call(2), call(4)]
 
+    @pytest.mark.parametrize(
+        "message,status",
+        [
+            ("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED),
+            ("downstream duration timeout", RPCStatusCode.DEADLINE_EXCEEDED),
+        ],
+    )
     @patch(
         "products.warehouse_sources.backend.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep",
         new_callable=AsyncMock,
     )
-    async def test_persistent_rate_limit_is_reraised(self, sleep):
+    async def test_persistent_transient_error_is_reraised(self, sleep, message, status):
         async def operation():
-            raise _rpc_error("namespace rate limit exceeded", RPCStatusCode.RESOURCE_EXHAUSTED)
+            raise _rpc_error(message, status)
 
         with pytest.raises(RPCError):
-            await _with_rate_limit_retry(operation, MagicMock(), max_attempts=4)
+            await _with_transient_rpc_retry(operation, MagicMock(), max_attempts=4)
 
         # Bounded attempts leave Temporal to retry; backs off between attempts but not after the last.
         assert sleep.await_args_list == [call(2), call(4), call(6)]
@@ -144,11 +158,11 @@ class TestRateLimitRetry:
         "products.warehouse_sources.backend.temporal.data_imports.sources.temporalio.temporalio.asyncio.sleep",
         new_callable=AsyncMock,
     )
-    async def test_non_rate_limit_rpc_error_is_not_retried(self, sleep):
+    async def test_non_transient_rpc_error_is_not_retried(self, sleep):
         async def operation():
             raise _rpc_error("workflow execution not found for", RPCStatusCode.NOT_FOUND)
 
         with pytest.raises(RPCError):
-            await _with_rate_limit_retry(operation, MagicMock())
+            await _with_transient_rpc_retry(operation, MagicMock())
 
         assert sleep.await_count == 0


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring failure on the Temporal.io import source: `RPCError: (4, 'downstream duration timeout', b'')` raised from `_get_workflow_histories` → `fetch_history` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f059f-aa59-7dd3-b1ce-fde34630f0af)).

gRPC status code `4` is `DEADLINE_EXCEEDED`. Temporal Cloud returns "downstream duration timeout" when a visibility/history RPC exceeds the server-side deadline — a transient, server-side condition, not a credential or config problem. It was propagating straight out of the import activity, failing the whole run and restarting pagination, and generating error-tracking noise.

## Changes

The source already has a purpose-built in-process retry helper that rides out transient gRPC `RESOURCE_EXHAUSTED` (namespace rate limiting) with bounded backoff so a brief blip doesn't fail the activity. `DEADLINE_EXCEEDED` is the same class of transient server-side condition.

- Generalize `_with_rate_limit_retry` → `_with_transient_rpc_retry`, retrying a set of transient statuses (`RESOURCE_EXHAUSTED` and `DEADLINE_EXCEEDED`) instead of only rate limits.
- Both pagination (`fetch_next_page`) and per-workflow history fetches (`fetch_history`) go through it, as before.
- Behavior is otherwise unchanged: bounded attempts with `min(2 * attempt, 30)` backoff, then re-raise so Temporal's activity retry still applies. This is **not** treated as non-retryable — a transient timeout should stay retryable.

This deliberately does **not** touch `NonRetryableErrors` or the global retry policy. The scope is strictly the one transient timeout.

## How did you test this code?

I'm an agent. The repo's Python env wasn't runnable in my sandbox (no Django), so I could not execute the full pytest suite locally — CI will. I did verify the retry logic in isolation against the real `temporalio` `RPCError`/`RPCStatusCode` types, confirming: transient `DEADLINE_EXCEEDED` is ridden out, persistent `DEADLINE_EXCEEDED` re-raises after the bounded budget, `RESOURCE_EXHAUSTED` is still retried (regression), and non-transient statuses (`NOT_FOUND`) are never retried. Also confirmed `RPCStatusCode.DEADLINE_EXCEEDED.value == 4`, matching the observed error.

Updated `TestTransientRPCRetry` (was `TestRateLimitRetry`): the ride-out and persistent-reraise cases are now parameterized over both `RESOURCE_EXHAUSTED` and `DEADLINE_EXCEEDED`, so the new tests catch a regression where a transient deadline timeout fails the activity instead of being retried in-process.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Read the full stack trace and confirmed the failure originates in the source's own code (`temporalio.py`), then read the implementation to understand the call path. Classified the error as transient infrastructure (a gRPC `DEADLINE_EXCEEDED` server timeout) rather than a user/upstream credential error, so the right move is in-process backoff + retry, not `NonRetryableErrors`. This matches the existing `RESOURCE_EXHAUSTED` handling in the same helper and the maintainer's recent pattern of backing off transient errors elsewhere in data imports. Checked open PRs (including the maintainer's) for an existing fix and found none.