### PR TITLE
feat(cohorts): skip recompute of unchanged person-property cohorts

### DIFF
--- a/posthog/settings/schedules.py
+++ b/posthog/settings/schedules.py
@@ -1,5 +1,5 @@
 from posthog.settings.base_variables import TEST
-from posthog.settings.utils import get_from_env
+from posthog.settings.utils import get_from_env, str_to_bool
 
 USE_PRECALCULATED_CH_COHORT_PEOPLE = not TEST
 
@@ -71,6 +71,15 @@ REALTIME_COHORT_CALCULATION_GLOBAL_PERCENTAGE: float = get_from_env(
     "REALTIME_COHORT_CALCULATION_GLOBAL_PERCENTAGE",
     0.0,
     type_cast=float,
+)
+
+# Kill-switch for skipping the recompute of person-property-only realtime cohorts whose conditions
+# saw no precalculated write since the cohort's last calculation (read from precalc_condition_watermark).
+# Off by default; the skip fails open (recomputes) on any uncertainty.
+REALTIME_COHORT_SKIP_UNCHANGED_ENABLED: bool = get_from_env(
+    "REALTIME_COHORT_SKIP_UNCHANGED_ENABLED",
+    False,
+    type_cast=str_to_bool,
 )
 
 # Realtime cohort calculation schedule intervals (in minutes) based on duration percentiles

--- a/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
+++ b/posthog/temporal/messaging/realtime_cohort_calculation_workflow_coordinator.py
@@ -12,8 +12,11 @@ from django.utils import timezone
 import temporalio.common
 import temporalio.activity
 import temporalio.workflow
+from prometheus_client import Counter
 from temporalio.common import MetricHistogramFloat
 
+from posthog.clickhouse.client import sync_execute
+from posthog.models.precalculated_person_properties.condition_watermark_sql import PRECALC_CONDITION_WATERMARK_TABLE
 from posthog.sync import database_sync_to_async
 from posthog.temporal.common.base import PostHogWorkflow
 from posthog.temporal.common.logger import get_logger
@@ -27,6 +30,121 @@ from posthog.temporal.messaging.realtime_cohort_calculation_workflow import (
 from products.cohorts.backend.models.cohort import Cohort, CohortType
 
 LOGGER = get_logger(__name__)
+
+REALTIME_COHORT_SKIPPED_UNCHANGED_COUNTER = Counter(
+    "realtime_cohort_skipped_unchanged_total",
+    "Number of person-property-only realtime cohorts skipped because no precalculated write landed "
+    "for their conditions since the cohort's last calculation",
+)
+
+# Cohort property types that reference another cohort (a nested dependency). A nested cohort's
+# membership can change with no precalculated write, so these cohorts are not skippable.
+_NESTED_COHORT_PROPERTY_TYPES = {"cohort", "precalculated-cohort", "static-cohort", "dynamic-cohort"}
+
+
+def classify_cohort_composition(cohort: Cohort) -> str:
+    """Classify a realtime cohort by the kinds of conditions it uses.
+
+    Only "pp_only" cohorts are eligible for the watermark skip: behavioral conditions decay with the
+    clock (a leave is not write-driven) and nested-cohort conditions change without a precalculated
+    write. Pure, in-memory read of the cohort's stored filters (no DB access).
+
+    Returns one of: "pp_only", "behavioral", "nested", "other".
+    """
+    leaves = cohort.properties.flat
+    if not leaves:
+        return "other"
+
+    has_behavioral = False
+    has_nested = False
+    all_person = True
+    for prop in leaves:
+        if prop.type == "behavioral":
+            has_behavioral = True
+            all_person = False
+        elif prop.type in _NESTED_COHORT_PROPERTY_TYPES:
+            has_nested = True
+            all_person = False
+        elif prop.type != "person":
+            all_person = False
+
+    if has_behavioral:
+        return "behavioral"
+    if has_nested:
+        return "nested"
+    if all_person:
+        return "pp_only"
+    return "other"
+
+
+def _filter_unchanged_pp_cohorts(cohort_ids: list[int]) -> list[int]:
+    """Drop person-property-only cohorts whose conditions saw no precalculated write since their last
+    calculation, read from the precalc_condition_watermark table.
+
+    Fails open (keeps the cohort) on any uncertainty: a non-pp_only cohort, a never-calculated cohort,
+    a missing conditionHash, a missing watermark row, or a query error. We only skip on positive
+    evidence — a watermark row showing the latest write predates the last calculation. Because the
+    watermark may lag the precalc table slightly, a just-written change can be missed for one tick and
+    picked up on the next; that is within the realtime cohorts' eventual-consistency budget.
+    """
+    if not cohort_ids:
+        return cohort_ids
+
+    try:
+        # team_id, last_calc, and condition hashes per pp_only candidate with a prior calculation.
+        candidates: dict[int, tuple[int, dt.datetime, list[str]]] = {}
+        teams: set[int] = set()
+        conditions: set[str] = set()
+
+        for cohort in Cohort.objects.filter(id__in=cohort_ids):
+            last_calc = cohort.last_realtime_cohort_calculation_at
+            if last_calc is None or classify_cohort_composition(cohort) != "pp_only":
+                continue
+            hashes: list[str] = []
+            missing_hash = False
+            for prop in cohort.properties.flat:
+                condition_hash = getattr(prop, "conditionHash", None)
+                if not condition_hash:
+                    missing_hash = True  # a leaf without a conditionHash → can't reason about it
+                    break
+                hashes.append(condition_hash)
+            if missing_hash or not hashes:
+                continue
+            candidates[cohort.id] = (cohort.team_id, last_calc, hashes)
+            teams.add(cohort.team_id)
+            conditions.update(hashes)
+
+        if not candidates:
+            return cohort_ids
+
+        rows = sync_execute(
+            f"SELECT team_id, condition, max(last_write_at) FROM {PRECALC_CONDITION_WATERMARK_TABLE} "
+            "WHERE team_id IN %(teams)s AND condition IN %(conditions)s GROUP BY team_id, condition",
+            {"teams": list(teams), "conditions": list(conditions)},
+        )
+        # _timestamp/last_write_at come back as naive UTC datetimes.
+        watermark = {(int(team_id), condition): w.replace(tzinfo=dt.UTC) for team_id, condition, w in rows}
+
+        skipped: set[int] = set()
+        for cohort_id, (team_id, last_calc, hashes) in candidates.items():
+            writes = [watermark[(team_id, h)] for h in hashes if (team_id, h) in watermark]
+            # Skip only when every condition has a watermark row and the latest write is strictly
+            # before the last calculation. Strict `<` because the two timestamps come from different
+            # clocks (ClickHouse write time vs. the Django calculation stamp): an equal value is
+            # ambiguous about whether the calculation saw that write, so we keep (fail open). A
+            # missing row → no positive evidence → keep.
+            if len(writes) == len(hashes) and max(writes) < last_calc:
+                skipped.add(cohort_id)
+
+        if not skipped:
+            return cohort_ids
+
+        REALTIME_COHORT_SKIPPED_UNCHANGED_COUNTER.inc(len(skipped))
+        LOGGER.info("Skipped unchanged realtime cohorts", skipped_count=len(skipped), skipped_ids=sorted(skipped))
+        return [cohort_id for cohort_id in cohort_ids if cohort_id not in skipped]
+    except Exception:
+        LOGGER.warning("Watermark skip filter failed; processing all cohorts", exc_info=True)
+        return cohort_ids
 
 
 def get_coordinator_duration_histogram(percentile_bucket: str) -> MetricHistogramFloat:
@@ -350,6 +468,11 @@ async def get_realtime_cohort_selection_activity(
             if cohort_id not in seen_ids:
                 seen_ids.add(cohort_id)
                 unique_cohort_ids.append(cohort_id)
+
+        # Step 3.5: Skip person-property-only cohorts whose conditions saw no precalculated write
+        # since their last calculation (gated; fails open to recomputing everything).
+        if settings.REALTIME_COHORT_SKIP_UNCHANGED_ENABLED:
+            unique_cohort_ids = _filter_unchanged_pp_cohorts(unique_cohort_ids)
 
         # Step 4: Return with duration-based ordering preserved for effective load balancing
         return unique_cohort_ids

--- a/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
+++ b/posthog/temporal/messaging/test/test_realtime_cohort_calculation_workflow.py
@@ -1,4 +1,5 @@
 import os
+import datetime as dt
 
 import pytest
 from unittest.mock import Mock, patch
@@ -14,9 +15,13 @@ from posthog.temporal.messaging.realtime_cohort_calculation_workflow_coordinator
     QueryPercentileThresholdsInput,
     RealtimeCohortCalculationCoordinatorWorkflowInputs,
     _apply_duration_filtering,
+    _filter_unchanged_pp_cohorts,
+    classify_cohort_composition,
     get_query_percentile_thresholds_activity,
     get_realtime_cohort_selection_activity,
 )
+
+from products.cohorts.backend.models.cohort import Cohort
 
 
 class TestFlushKafkaBatch:
@@ -1744,3 +1749,129 @@ class TestFinalQueryMembershipStatuses:
 
         # Unchanged member: present in both → WHERE filters it out entirely
         assert passes_where(pid, pid) is False
+
+
+_COORD = "posthog.temporal.messaging.realtime_cohort_calculation_workflow_coordinator"
+
+
+def _person_leaf(condition_hash=None):
+    leaf = {"key": "promoCodes", "type": "person", "value": ["x"], "operator": "exact"}
+    if condition_hash is not None:
+        leaf["conditionHash"] = condition_hash
+    return leaf
+
+
+def _behavioral_leaf():
+    return {
+        "key": "$pageview",
+        "type": "behavioral",
+        "value": "performed_event",
+        "event_type": "events",
+        "time_value": "30",
+        "time_interval": "day",
+        "conditionHash": "beh1",
+    }
+
+
+def _make_cohort(cohort_id, team_id, last_calc, leaves):
+    return Cohort(
+        id=cohort_id,
+        team_id=team_id,
+        last_realtime_cohort_calculation_at=last_calc,
+        filters={"properties": {"type": "OR", "values": [{"type": "AND", "values": leaves}]}},
+    )
+
+
+_LAST_CALC = dt.datetime(2026, 6, 1, tzinfo=dt.UTC)
+_BEFORE = dt.datetime(2026, 5, 1)  # naive UTC, as returned by ClickHouse
+_AFTER = dt.datetime(2026, 6, 15)
+_EQUAL = dt.datetime(2026, 6, 1)  # exactly _LAST_CALC's instant — ambiguous, must not skip
+
+
+class TestClassifyCohortComposition:
+    """A misclassification would let the skip optimization drop a cohort that can silently change
+    (behavioral decay, nested-cohort cascade), so each non-pp_only kind is pinned."""
+
+    @pytest.mark.parametrize(
+        "leaves,expected",
+        [
+            ([_person_leaf("a")], "pp_only"),
+            ([_person_leaf("a"), _person_leaf("b")], "pp_only"),
+            ([_behavioral_leaf()], "behavioral"),
+            ([{"key": "id", "type": "cohort", "value": 7}], "nested"),
+            # Any behavioral leaf disqualifies, even mixed with person/nested leaves.
+            ([_person_leaf("a"), _behavioral_leaf()], "behavioral"),
+            ([_behavioral_leaf(), {"key": "id", "type": "cohort", "value": 7}], "behavioral"),
+            # Nested without behavioral stays "nested" (child membership can change with no write).
+            ([_person_leaf("a"), {"key": "id", "type": "cohort", "value": 7}], "nested"),
+            ([], "other"),
+        ],
+    )
+    def test_classification(self, leaves, expected):
+        assert classify_cohort_composition(_make_cohort(1, 2, _LAST_CALC, leaves)) == expected
+
+
+class TestFilterUnchangedPpCohorts:
+    """The skip predicate must only drop a cohort on positive evidence (a watermark row predating the
+    last calculation) and otherwise fail open, so a stale/empty watermark never silently freezes a
+    cohort's membership."""
+
+    def _run(self, cohorts, watermark_rows, query_raises=False):
+        with patch(f"{_COORD}.Cohort.objects") as mock_objects, patch(f"{_COORD}.sync_execute") as mock_exec:
+            mock_objects.filter.return_value = cohorts
+            mock_exec.side_effect = RuntimeError("boom") if query_raises else None
+            mock_exec.return_value = watermark_rows
+            result = _filter_unchanged_pp_cohorts([c.id for c in cohorts])
+        return result, mock_exec
+
+    def test_skips_pp_cohort_with_no_write_since_last_calc(self):
+        cohorts = [_make_cohort(1, 2, _LAST_CALC, [_person_leaf("a")])]
+        result, _ = self._run(cohorts, [(2, "a", _BEFORE)])
+        assert result == []
+
+    @pytest.mark.parametrize(
+        "watermark_rows,expected",
+        [
+            ([(2, "a", _BEFORE), (2, "b", _BEFORE)], []),  # every condition predates last calc → skip
+            ([(2, "a", _BEFORE), (2, "b", _AFTER)], [1]),  # one condition written after → keep
+            ([(2, "a", _BEFORE), (2, "b", _EQUAL)], [1]),  # a write exactly at last calc is ambiguous → keep
+        ],
+    )
+    def test_multi_condition_skip_requires_all_strictly_before(self, watermark_rows, expected):
+        cohorts = [_make_cohort(1, 2, _LAST_CALC, [_person_leaf("a"), _person_leaf("b")])]
+        assert self._run(cohorts, watermark_rows)[0] == expected
+
+    def test_keeps_when_a_condition_has_no_watermark_row(self):
+        # No positive evidence for condition "b" → fail open, keep.
+        cohorts = [_make_cohort(1, 2, _LAST_CALC, [_person_leaf("a"), _person_leaf("b")])]
+        result, _ = self._run(cohorts, [(2, "a", _BEFORE)])
+        assert result == [1]
+
+    @pytest.mark.parametrize(
+        "leaves,last_calc",
+        [
+            ([_behavioral_leaf()], _LAST_CALC),  # not pp_only (behavioral)
+            ([_person_leaf("a")], None),  # never calculated
+            ([_person_leaf(None)], _LAST_CALC),  # a leaf is missing its conditionHash
+        ],
+    )
+    def test_keeps_ineligible_cohort_without_querying(self, leaves, last_calc):
+        # Each hits a different early-continue guard, so the watermark is never queried.
+        cohorts = [_make_cohort(1, 2, last_calc, leaves)]
+        result, mock_exec = self._run(cohorts, [])
+        assert result == [1]
+        mock_exec.assert_not_called()
+
+    def test_fails_open_on_query_error(self):
+        cohorts = [_make_cohort(1, 2, _LAST_CALC, [_person_leaf("a")])]
+        result, _ = self._run(cohorts, [], query_raises=True)
+        assert result == [1]
+
+    def test_removes_only_skipped_and_preserves_order(self):
+        cohorts = [
+            _make_cohort(1, 2, _LAST_CALC, [_person_leaf("a")]),  # skippable
+            _make_cohort(2, 2, _LAST_CALC, [_behavioral_leaf()]),  # behavioral, kept
+            _make_cohort(3, 2, _LAST_CALC, [_person_leaf("c")]),  # recent write, kept
+        ]
+        result, _ = self._run(cohorts, [(2, "a", _BEFORE), (2, "c", _AFTER)])
+        assert result == [2, 3]


### PR DESCRIPTION
> **Stacked on #66439** (the `precalc_condition_watermark` migration). Review/merge that first; this PR's diff is against that branch and will retarget to `master` once it lands.

## Problem

The realtime-cohort calculation recomputes every enabled cohort on every scheduled tick, even when nothing about a cohort changed. For **person-property-only** cohorts there's now a cheap, safe signal to skip that wasted work: the `precalc_condition_watermark` table (base PR) records the latest precalculated write time per `(team_id, condition)`. If none of a cohort's conditions saw a write since its last calculation, the recompute is provably a no-op.

## Changes

In the coordinator's selection activity, after the cohort list is assembled, drop the cohorts that can't have changed:

- `classify_cohort_composition` — only `pp_only` cohorts are eligible. Behavioral conditions decay with the clock (a leave isn't write-driven) and nested cohorts change when a *child's* membership changes (no precalc write), so neither is skippable by a write watermark.
- `_filter_unchanged_pp_cohorts` — for eligible cohorts, read each condition's `conditionHash` (already stored on the cohort), query the watermark for `max(last_write_at)`, and skip the cohort iff **every** condition has a watermark row whose latest write predates `last_realtime_cohort_calculation_at`.

Safety:

- **Gated** by `REALTIME_COHORT_SKIP_UNCHANGED_ENABLED` (off by default) — no behavior change until enabled.
- **Fails open** (keeps the cohort) on every uncertainty: not `pp_only`, never calculated, a missing `conditionHash`, a missing watermark row, or any query error. It only ever skips on *positive evidence*, so an empty/broken/lagging watermark can never silently freeze a cohort's membership.
- **Bounded staleness.** The watermark can lag the precalc table slightly, so a just-written change may be missed for one tick and picked up the next — within the realtime cohorts' existing eventual-consistency budget.
- Emits `realtime_cohort_skipped_unchanged_total` for observability.

## How did you test this code?

I'm an agent (Claude Code). Added two pure, mock-based test classes (24 cases total across this and the classifier) and ran them locally — all pass; `ruff` clean:
- `TestClassifyCohortComposition` — pins that behavioral/nested cohorts never read as `pp_only` (the misclassification that would make a skip unsafe).
- `TestFilterUnchangedPpCohorts` — skip only when all conditions predate last-calc; keep on a recent write, a missing watermark row, behavioral/never-calculated/missing-hash cohorts (asserting the watermark isn't even queried then), and query errors; order preserved.

Not exercised here: the live ClickHouse read path (no cluster in the sandbox) — covered by CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Driven by @gustavohstrassburger; the second half of the watermark design, stacked on the migration PR. Key decisions: skip only on positive evidence (never on absence of a watermark row) so the feature is safe against a cold/lagging watermark; gate behind a kill-switch; scope strictly to `pp_only` cohorts. The selection activity already runs once per tier every 7–45 min, so the extra watermark query (over a tiny table) is negligible.

Tooling: Claude Code (Opus 4.8).
