### PR TITLE
feat(data-warehouse): add Gainsight PX warehouse source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -144,6 +144,7 @@ the row lists both.
 | fleetio                 | HTTP                        | requests                                                        | ✅                          |
 | front                   | HTTP                        | requests                                                        | ✅                          |
 | fullstory               | HTTP                        | requests                                                        | ✅                          |
+| gainsight_px            | HTTP                        | requests                                                        | ✅                          |
 | github                  | HTTP + Webhook              | requests + `WebhookSourceManager`                               | ✅ (pull) / ➖ (webhook)    |
 | giphy                   | HTTP                        | requests                                                        | ✅                          |
 | gitlab                  | HTTP                        | requests                                                        | ✅                          |
@@ -411,7 +412,6 @@ doesn't conflict with concurrent PRs.
 - freshchat
 - freshservice
 - fulcrum
-- gainsight_px
 - gitbook
 - glassfrog
 - gmail

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/canonical_descriptions.py
@@ -1,0 +1,54 @@
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+# Curated from the Gainsight PX REST API docs (https://px-apidocs.gainsight.com). Table-level
+# descriptions and the `id` primary key are stated authoritatively; the remaining columns are left to
+# LLM enrichment (seeded with `docs_url`) rather than asserting field names we have not verified
+# against a live PX response.
+_DOCS_URL = "https://px-apidocs.gainsight.com"
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "accounts": {
+        "description": "An account (the company or organization a set of users belongs to) tracked in Gainsight PX.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the account (the customer-supplied account id).",
+        },
+    },
+    "users": {
+        "description": "An end user tracked in Gainsight PX, typically associated with an account.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the user (the customer-supplied user id, often an email).",
+        },
+    },
+    "segments": {
+        "description": "A saved segment — a rule-based grouping of users or accounts used to target engagements and analytics.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the segment.",
+        },
+    },
+    "features": {
+        "description": "A tracked product feature and its adoption data in Gainsight PX.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the feature.",
+        },
+    },
+    "articles": {
+        "description": "A Knowledge Center article surfaced to users in-app through Gainsight PX.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the article.",
+        },
+    },
+    "kcbots": {
+        "description": "A Knowledge Center Bot configuration in Gainsight PX.",
+        "docs_url": _DOCS_URL,
+        "columns": {
+            "id": "Unique identifier for the Knowledge Center Bot.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
@@ -1,0 +1,162 @@
+from collections.abc import Iterator
+from typing import Any
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import (
+    GAINSIGHT_PX_ENDPOINTS,
+)
+
+# Gainsight PX is a global, region-pinned service (not a per-tenant subdomain). The region is fixed by
+# where the customer's PX instance lives; it maps to one of these hosts. Verified against
+# https://px-apidocs.gainsight.com and the open-source Airbyte connector (url_base api.aptrinsic.com).
+REGION_HOSTS = {
+    "us": "https://api.aptrinsic.com/v1",
+    "eu": "https://api-eu.aptrinsic.com/v1",
+    "us2": "https://api-us2.aptrinsic.com/v1",
+}
+
+# PX authenticates with a static API key passed in this custom header (not Authorization: Bearer).
+API_KEY_HEADER = "X-APTRINSIC-API-KEY"
+
+# PX caps pageSize at 1000; 500 balances throughput against per-page memory.
+PAGE_SIZE = 500
+
+# Pure runaway guard for a cursor that never advances (e.g. an API that ignores `scrollId` and re-serves
+# a full page forever). Set far above any realistic PX entity count so it never truncates real data; a
+# hit is logged loudly rather than silently capping the sync.
+_MAX_PAGES = 20_000
+
+
+class GainsightPxRetryableError(Exception):
+    pass
+
+
+def _base_url(region: str) -> str:
+    return REGION_HOSTS.get(region, REGION_HOSTS["us"])
+
+
+def _headers(api_key: str) -> dict[str, str]:
+    return {API_KEY_HEADER: api_key, "Accept": "application/json"}
+
+
+def _extract_records(payload: Any, data_key: str, logger: FilteringBoundLogger | None = None) -> list[dict[str, Any]]:
+    """Pull the record list out of a PX list response.
+
+    Happy path: ``payload[data_key]`` — the per-endpoint record key, verified against the production
+    Airbyte connector. Safety net for a response-shape change we can't live-test without an API key:
+    if that key is absent, fall back to the body's sole list-of-objects field so a renamed key
+    self-heals (with a warning) instead of silently yielding zero rows.
+    """
+    if not isinstance(payload, dict):
+        return []
+    records = payload.get(data_key)
+    if isinstance(records, list):
+        return records
+    candidates = [v for v in payload.values() if isinstance(v, list) and v and isinstance(v[0], dict)]
+    if len(candidates) == 1:
+        if logger is not None:
+            logger.warning(
+                f"Gainsight PX: record key '{data_key}' not in response (keys: {list(payload)}); "
+                f"falling back to the sole list field — the API response shape may have changed."
+            )
+        return candidates[0]
+    return []
+
+
+def _scroll_id(payload: Any) -> str | None:
+    return payload.get("scrollId") if isinstance(payload, dict) else None
+
+
+@retry(
+    retry=retry_if_exception_type((GainsightPxRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch_page(
+    session: requests.Session,
+    url: str,
+    headers: dict[str, str],
+    params: dict[str, Any],
+    logger: FilteringBoundLogger,
+) -> Any:
+    response = session.get(url, headers=headers, params=params, timeout=60)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise GainsightPxRetryableError(f"Gainsight PX API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"Gainsight PX API error: status={response.status_code}, body={response.text}, url={url}")
+        response.raise_for_status()
+
+    return response.json()
+
+
+def validate_credentials(region: str, api_key: str) -> bool:
+    """One cheap probe against `/accounts` to confirm the key authenticates for this region."""
+    url = f"{_base_url(region)}/accounts"
+    try:
+        response = make_tracked_session().get(url, headers=_headers(api_key), params={"pageSize": 1}, timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def get_rows(
+    region: str,
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> Iterator[list[dict[str, Any]]]:
+    config = GAINSIGHT_PX_ENDPOINTS[endpoint]
+    headers = _headers(api_key)
+    # One session reused across every page so urllib3 keeps the connection alive between requests.
+    session = make_tracked_session()
+    url = f"{_base_url(region)}{config.path}"
+
+    scroll_id: str | None = None
+    page = 0
+    while True:
+        params: dict[str, Any] = {"pageSize": PAGE_SIZE}
+        if scroll_id:
+            params["scrollId"] = scroll_id
+
+        payload = _fetch_page(session, url, headers, params, logger)
+        records = _extract_records(payload, config.data_key, logger)
+        if records:
+            yield records
+
+        page += 1
+        scroll_id = _scroll_id(payload)
+
+        # PX signals the last page by returning fewer rows than requested — it does NOT reliably clear
+        # `scrollId` on the final page, so the short-page check (not a null cursor) is the real terminator.
+        if len(records) < PAGE_SIZE or not scroll_id:
+            break
+
+        if page >= _MAX_PAGES:
+            logger.error(
+                f"Gainsight PX: hit the {_MAX_PAGES}-page safety cap on '{endpoint}' without the cursor "
+                f"terminating; stopping to avoid an unbounded scan. Data may be incomplete."
+            )
+            break
+
+
+def gainsight_px_source(
+    region: str,
+    api_key: str,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+) -> SourceResponse:
+    config = GAINSIGHT_PX_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(region=region, api_key=api_key, endpoint=endpoint, logger=logger),
+        primary_keys=config.primary_keys,
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/gainsight_px.py
@@ -57,7 +57,9 @@ def _extract_records(payload: Any, data_key: str, logger: FilteringBoundLogger |
     records = payload.get(data_key)
     if isinstance(records, list):
         return records
-    candidates = [v for v in payload.values() if isinstance(v, list) and v and isinstance(v[0], dict)]
+    candidates = [
+        v for v in payload.values() if isinstance(v, list) and v and all(isinstance(item, dict) for item in v)
+    ]
     if len(candidates) == 1:
         if logger is not None:
             logger.warning(
@@ -70,6 +72,18 @@ def _extract_records(payload: Any, data_key: str, logger: FilteringBoundLogger |
 
 def _scroll_id(payload: Any) -> str | None:
     return payload.get("scrollId") if isinstance(payload, dict) else None
+
+
+def _check_response(response: requests.Response, url: str, logger: FilteringBoundLogger) -> requests.Response:
+    """Classify a response: raise retryable on 429/5xx, raise HTTPError on other 4xx, else pass through."""
+    if response.status_code == 429 or response.status_code >= 500:
+        raise GainsightPxRetryableError(f"Gainsight PX API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"Gainsight PX API error: status={response.status_code}, body={response.text}, url={url}")
+        response.raise_for_status()
+
+    return response
 
 
 @retry(
@@ -86,24 +100,20 @@ def _fetch_page(
     logger: FilteringBoundLogger,
 ) -> Any:
     response = session.get(url, headers=headers, params=params, timeout=60)
-
-    if response.status_code == 429 or response.status_code >= 500:
-        raise GainsightPxRetryableError(f"Gainsight PX API error (retryable): status={response.status_code}, url={url}")
-
-    if not response.ok:
-        logger.error(f"Gainsight PX API error: status={response.status_code}, body={response.text}, url={url}")
-        response.raise_for_status()
-
-    return response.json()
+    return _check_response(response, url, logger).json()
 
 
 def validate_credentials(region: str, api_key: str) -> bool:
     """One cheap probe against `/accounts` to confirm the key authenticates for this region."""
     url = f"{_base_url(region)}/accounts"
+    # `redact_values` masks the API key in the tracked transport's logs and sample capture — the custom
+    # `X-APTRINSIC-API-KEY` header isn't on the name-based denylist, so value-based masking is required.
     try:
-        response = make_tracked_session().get(url, headers=_headers(api_key), params={"pageSize": 1}, timeout=10)
+        response = make_tracked_session(redact_values=(api_key,)).get(
+            url, headers=_headers(api_key), params={"pageSize": 1}, timeout=10
+        )
         return response.status_code == 200
-    except Exception:
+    except requests.RequestException:
         return False
 
 
@@ -116,7 +126,8 @@ def get_rows(
     config = GAINSIGHT_PX_ENDPOINTS[endpoint]
     headers = _headers(api_key)
     # One session reused across every page so urllib3 keeps the connection alive between requests.
-    session = make_tracked_session()
+    # `redact_values` masks the API key in tracked logs / sample capture (custom auth header).
+    session = make_tracked_session(redact_values=(api_key,))
     url = f"{_base_url(region)}{config.path}"
 
     scroll_id: str | None = None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/settings.py
@@ -1,0 +1,29 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class GainsightPxEndpointConfig:
+    name: str
+    path: str
+    # JSON key under which the list endpoint nests its records — it varies per endpoint in PX
+    # (`/accounts` returns `{"accounts": [...]}`, `/feature` returns `{"features": [...]}`, etc.).
+    data_key: str
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+
+
+# Endpoint catalog mirrors the streams the production open-source Airbyte Gainsight PX connector
+# exposes (path, record key, primary key), cross-checked against https://px-apidocs.gainsight.com.
+# Every list endpoint is full-refresh: PX exposes no server-side modified-since filter on these
+# entity resources, so there's no reliable incremental cursor (matching Airbyte, which ships the
+# connector full-refresh only). Re-pulled rows dedupe on the `id` primary key.
+GAINSIGHT_PX_ENDPOINTS: dict[str, GainsightPxEndpointConfig] = {
+    "accounts": GainsightPxEndpointConfig(name="accounts", path="/accounts", data_key="accounts"),
+    "users": GainsightPxEndpointConfig(name="users", path="/users", data_key="users"),
+    # The PX segments resource is singular in the path even though it returns a `segments` list.
+    "segments": GainsightPxEndpointConfig(name="segments", path="/segment", data_key="segments"),
+    "features": GainsightPxEndpointConfig(name="features", path="/feature", data_key="features"),
+    "articles": GainsightPxEndpointConfig(name="articles", path="/articles", data_key="articleExternalViewList"),
+    "kcbots": GainsightPxEndpointConfig(name="kcbots", path="/kcbot", data_key="kcList"),
+}
+
+ENDPOINTS = tuple(GAINSIGHT_PX_ENDPOINTS.keys())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/source.py
@@ -1,30 +1,147 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldSelectConfig,
+    SourceFieldSelectConfigOption,
 )
 
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.gainsight_px import (
+    gainsight_px_source,
+    validate_credentials as validate_gainsight_px_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import (
+    ENDPOINTS,
+    GAINSIGHT_PX_ENDPOINTS,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GainsightPxSourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
 class GainsightPxSource(SimpleSource[GainsightPxSourceConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.GAINSIGHTPX
+
+    @property
+    def connection_host_fields(self) -> list[str]:
+        # `region` selects which Gainsight PX host the stored API key is sent to; retargeting it must
+        # re-require the key so it can't be aimed at an attacker-controlled host.
+        return ["region"]
 
     @property
     def get_source_config(self) -> SourceConfig:
         return SourceConfig(
             name=SchemaExternalDataSourceType.GAINSIGHT_PX,
             category=DataWarehouseSourceCategory.ANALYTICS,
-            label="Gainsight Px",
+            label="Gainsight PX",
+            releaseStatus=ReleaseStatus.ALPHA,
+            caption="""Connect your Gainsight PX instance to pull accounts, users, segments, features and Knowledge Center content into the PostHog Data warehouse.
+
+Create an API key in Gainsight PX under **Administration → REST API → New API Key**, grant it **READ** permission, and copy the key (it's shown only once).
+
+Pick the **region** that matches your PX instance — it follows your PX app URL: `app.aptrinsic.com` → US, `app-eu.aptrinsic.com` → EU, `app-us2.aptrinsic.com` → US2.""",
             iconPath="/static/services/gainsight_px.png",
-            fields=cast(list[FieldType], []),
-            unreleasedSource=True,
+            docsUrl="https://posthog.com/docs/cdp/sources/gainsight-px",
+            keywords=["gainsight", "aptrinsic", "px"],
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldSelectConfig(
+                        name="region",
+                        label="Region",
+                        required=True,
+                        defaultValue="us",
+                        options=[
+                            SourceFieldSelectConfigOption(label="US (api.aptrinsic.com)", value="us"),
+                            SourceFieldSelectConfigOption(label="EU (api-eu.aptrinsic.com)", value="eu"),
+                            SourceFieldSelectConfigOption(label="US2 (api-us2.aptrinsic.com)", value="us2"),
+                        ],
+                    ),
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        return {
+            # A bad/revoked key surfaces as an HTTPError when `_fetch_page` calls `raise_for_status()`.
+            # Match the stable status text (the host varies by region), not the per-request URL.
+            "401 Client Error: Unauthorized": "Gainsight PX rejected the API key. Create a new key under Administration → REST API in Gainsight PX, grant it READ access, then reconnect.",
+            "403 Client Error: Forbidden": "The Gainsight PX API key is missing READ access for this resource. Grant READ permission to the key under Administration → REST API, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: GainsightPxSourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        # Every PX entity endpoint is full-refresh: there's no server-side modified-since filter to
+        # drive an incremental cursor, so we don't advertise one (matching the Airbyte connector).
+        schemas = [
+            SourceSchema(
+                name=endpoint,
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=[],
+                detected_primary_keys=GAINSIGHT_PX_ENDPOINTS[endpoint].primary_keys,
+            )
+            for endpoint in ENDPOINTS
+        ]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: GainsightPxSourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_gainsight_px_credentials(region=config.region, api_key=config.api_key):
+            return True, None
+        return (
+            False,
+            "Could not authenticate with Gainsight PX. Check the API key and that the selected region matches your PX instance.",
+        )
+
+    def source_for_pipeline(self, config: GainsightPxSourceConfig, inputs: SourceInputs) -> SourceResponse:
+        return gainsight_px_source(
+            region=config.region,
+            api_key=config.api_key,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px.py
@@ -79,6 +79,8 @@ class TestExtractRecords:
             # ...but only when it's unambiguous — two object-lists, or a scalar list, fall through to [].
             ("two_object_lists_no_heal", {"a": [{"id": 1}], "b": [{"id": 2}]}, "accounts", []),
             ("scalar_list_no_heal", {"foo": [1, 2]}, "accounts", []),
+            # A list that only starts with a dict must not qualify — every item has to be an object.
+            ("heterogeneous_list_no_heal", {"renamed": [{"id": 1}, "nope"]}, "accounts", []),
         ]
     )
     def test_extract(self, _name: str, payload: Any, data_key: str, expected: list) -> None:
@@ -90,28 +92,26 @@ class TestExtractRecords:
         logger.warning.assert_called_once()
 
 
-class TestFetchPageClassification:
-    # `_fetch_page` is wrapped in tenacity's @retry; `.__wrapped__` is the undecorated function, so we
-    # assert the status classification without incurring real retry backoff waits.
+class TestCheckResponse:
+    # Status classification is split out of `_fetch_page` (which is wrapped in tenacity's @retry) so it
+    # can be asserted directly without incurring real retry backoff waits.
     @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
     def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
-        session = _session_returning(FakeResponse(status_code=status, text="boom"))
         with pytest.raises(gpx.GainsightPxRetryableError):
-            gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER)
+            gpx._check_response(FakeResponse(status_code=status, text="boom"), "http://x", LOGGER)  # type: ignore[arg-type]
 
     @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
     def test_client_errors_raise_http_error(self, _name: str, status: int) -> None:
-        session = _session_returning(FakeResponse(status_code=status, text="nope"))
         with pytest.raises(requests.HTTPError):
-            gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER)
+            gpx._check_response(FakeResponse(status_code=status, text="nope"), "http://x", LOGGER)  # type: ignore[arg-type]
 
-    def test_ok_returns_parsed_json(self) -> None:
-        session = _session_returning(FakeResponse(status_code=200, json_data={"accounts": []}))
-        assert gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER) == {"accounts": []}
+    def test_ok_passes_response_through(self) -> None:
+        response = FakeResponse(status_code=200, json_data={"accounts": []})
+        assert gpx._check_response(response, "http://x", LOGGER) is response  # type: ignore[arg-type, comparison-overlap]
 
 
 class TestPagination:
-    def _run(self, pages: list[dict], endpoint: str = "accounts") -> tuple[list[dict], MagicMock]:
+    def _run(self, pages: list[dict[str, Any]], endpoint: str = "accounts") -> tuple[list[dict[str, Any]], MagicMock]:
         with (
             patch.object(gpx, "make_tracked_session", return_value=MagicMock()),
             patch.object(gpx, "_fetch_page", side_effect=pages) as mock_fetch,
@@ -122,7 +122,7 @@ class TestPagination:
     def test_full_page_then_short_page_stops_even_when_scroll_id_persists(self) -> None:
         # PX does not reliably null `scrollId` on the final page, so a short page (fewer rows than
         # requested) is the real terminator. A `while scroll_id:` loop here would never stop.
-        pages = [
+        pages: list[dict[str, Any]] = [
             {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE)], "scrollId": "s1"},
             {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE, gpx.PAGE_SIZE + 100)], "scrollId": "s1"},
         ]
@@ -142,7 +142,7 @@ class TestPagination:
     def test_exact_page_multiple_fetches_once_more_then_stops(self) -> None:
         # A full final page can't be distinguished from a non-final one, so we fetch once more and stop
         # on the trailing empty page rather than dropping rows or looping.
-        pages = [
+        pages: list[dict[str, Any]] = [
             {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE)], "scrollId": "s1"},
             {"accounts": [], "scrollId": "s1"},
         ]
@@ -168,6 +168,24 @@ class TestValidateCredentials:
         session.get.side_effect = requests.ConnectionError("boom")
         with patch.object(gpx, "make_tracked_session", return_value=session):
             assert gpx.validate_credentials("eu", "key") is False
+
+
+class TestSecretRedaction:
+    # The API key rides in a custom header the tracked transport won't redact by name, so every session
+    # must be built with value-based redaction — guards against the key leaking into captured HTTP samples.
+    def test_validate_credentials_redacts_key(self) -> None:
+        session = _session_returning(FakeResponse(status_code=200))
+        with patch.object(gpx, "make_tracked_session", return_value=session) as mock_factory:
+            gpx.validate_credentials("us", "secret-key")
+        assert mock_factory.call_args.kwargs.get("redact_values") == ("secret-key",)
+
+    def test_sync_session_redacts_key(self) -> None:
+        with (
+            patch.object(gpx, "make_tracked_session", return_value=MagicMock()) as mock_factory,
+            patch.object(gpx, "_fetch_page", side_effect=[{"accounts": []}]),
+        ):
+            list(gpx.get_rows("us", "secret-key", "accounts", LOGGER))
+        assert mock_factory.call_args.kwargs.get("redact_values") == ("secret-key",)
 
 
 class TestSourceResponse:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px.py
@@ -1,0 +1,185 @@
+from typing import Any
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+import requests
+import structlog
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px import gainsight_px as gpx
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import (
+    GAINSIGHT_PX_ENDPOINTS,
+)
+
+LOGGER = structlog.get_logger()
+
+
+class FakeResponse:
+    def __init__(self, *, status_code: int = 200, json_data: Any = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._json = json_data
+        self.text = text
+
+    @property
+    def ok(self) -> bool:
+        return 200 <= self.status_code < 400
+
+    def json(self) -> Any:
+        return self._json
+
+    def raise_for_status(self) -> None:
+        if not self.ok:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)  # type: ignore[arg-type]
+
+
+def _session_returning(response: FakeResponse) -> MagicMock:
+    session = MagicMock()
+    session.get.return_value = response
+    return session
+
+
+class TestBaseUrl:
+    @parameterized.expand(
+        [
+            ("us", "https://api.aptrinsic.com/v1"),
+            ("eu", "https://api-eu.aptrinsic.com/v1"),
+            ("us2", "https://api-us2.aptrinsic.com/v1"),
+            ("unknown", "https://api.aptrinsic.com/v1"),
+        ]
+    )
+    def test_region_resolution(self, region: str, expected: str) -> None:
+        assert gpx._base_url(region) == expected
+
+
+class TestHeaders:
+    def test_uses_aptrinsic_api_key_header(self) -> None:
+        # The PX auth header is a verified, non-obvious detail — a regression to `Authorization: Bearer`
+        # would silently break every request.
+        assert gpx.API_KEY_HEADER == "X-APTRINSIC-API-KEY"
+        assert gpx._headers("secret")["X-APTRINSIC-API-KEY"] == "secret"
+
+
+class TestExtractRecords:
+    @parameterized.expand(
+        [
+            ("keyed_list", {"accounts": [{"id": 1}]}, "accounts", [{"id": 1}]),
+            ("empty_list", {"accounts": []}, "accounts", []),
+            ("missing_key", {"other": 1}, "accounts", []),
+            ("key_not_a_list", {"accounts": {"id": 1}}, "accounts", []),
+            ("non_dict_payload", [1, 2], "accounts", []),
+            (
+                "different_key_per_endpoint",
+                {"articleExternalViewList": [{"id": 9}]},
+                "articleExternalViewList",
+                [{"id": 9}],
+            ),
+            # Safety net: a renamed record key self-heals to the sole list-of-objects field...
+            ("renamed_key_self_heals", {"renamed": [{"id": 1}], "scrollId": "s"}, "accounts", [{"id": 1}]),
+            # ...but only when it's unambiguous — two object-lists, or a scalar list, fall through to [].
+            ("two_object_lists_no_heal", {"a": [{"id": 1}], "b": [{"id": 2}]}, "accounts", []),
+            ("scalar_list_no_heal", {"foo": [1, 2]}, "accounts", []),
+        ]
+    )
+    def test_extract(self, _name: str, payload: Any, data_key: str, expected: list) -> None:
+        assert gpx._extract_records(payload, data_key) == expected
+
+    def test_self_heal_warns_so_a_key_change_is_diagnosable(self) -> None:
+        logger = MagicMock()
+        assert gpx._extract_records({"renamed": [{"id": 1}]}, "accounts", logger) == [{"id": 1}]
+        logger.warning.assert_called_once()
+
+
+class TestFetchPageClassification:
+    # `_fetch_page` is wrapped in tenacity's @retry; `.__wrapped__` is the undecorated function, so we
+    # assert the status classification without incurring real retry backoff waits.
+    @parameterized.expand([("rate_limited", 429), ("server_error", 500), ("bad_gateway", 503)])
+    def test_retryable_statuses_raise_retryable_error(self, _name: str, status: int) -> None:
+        session = _session_returning(FakeResponse(status_code=status, text="boom"))
+        with pytest.raises(gpx.GainsightPxRetryableError):
+            gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER)
+
+    @parameterized.expand([("unauthorized", 401), ("forbidden", 403), ("not_found", 404)])
+    def test_client_errors_raise_http_error(self, _name: str, status: int) -> None:
+        session = _session_returning(FakeResponse(status_code=status, text="nope"))
+        with pytest.raises(requests.HTTPError):
+            gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER)
+
+    def test_ok_returns_parsed_json(self) -> None:
+        session = _session_returning(FakeResponse(status_code=200, json_data={"accounts": []}))
+        assert gpx._fetch_page.__wrapped__(session, "http://x", {}, {}, LOGGER) == {"accounts": []}
+
+
+class TestPagination:
+    def _run(self, pages: list[dict], endpoint: str = "accounts") -> tuple[list[dict], MagicMock]:
+        with (
+            patch.object(gpx, "make_tracked_session", return_value=MagicMock()),
+            patch.object(gpx, "_fetch_page", side_effect=pages) as mock_fetch,
+        ):
+            batches = list(gpx.get_rows("us", "key", endpoint, LOGGER))
+        return [row for batch in batches for row in batch], mock_fetch
+
+    def test_full_page_then_short_page_stops_even_when_scroll_id_persists(self) -> None:
+        # PX does not reliably null `scrollId` on the final page, so a short page (fewer rows than
+        # requested) is the real terminator. A `while scroll_id:` loop here would never stop.
+        pages = [
+            {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE)], "scrollId": "s1"},
+            {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE, gpx.PAGE_SIZE + 100)], "scrollId": "s1"},
+        ]
+        rows, mock_fetch = self._run(pages)
+        assert len(rows) == gpx.PAGE_SIZE + 100
+        assert mock_fetch.call_count == 2
+        # First request hits region+path with no cursor; the second carries the scrollId.
+        assert mock_fetch.call_args_list[0].args[1] == "https://api.aptrinsic.com/v1/accounts"
+        assert mock_fetch.call_args_list[0].args[3] == {"pageSize": gpx.PAGE_SIZE}
+        assert mock_fetch.call_args_list[1].args[3] == {"pageSize": gpx.PAGE_SIZE, "scrollId": "s1"}
+
+    def test_empty_first_page_yields_nothing(self) -> None:
+        rows, mock_fetch = self._run([{"accounts": [], "scrollId": "s9"}])
+        assert rows == []
+        assert mock_fetch.call_count == 1
+
+    def test_exact_page_multiple_fetches_once_more_then_stops(self) -> None:
+        # A full final page can't be distinguished from a non-final one, so we fetch once more and stop
+        # on the trailing empty page rather than dropping rows or looping.
+        pages = [
+            {"accounts": [{"id": i} for i in range(gpx.PAGE_SIZE)], "scrollId": "s1"},
+            {"accounts": [], "scrollId": "s1"},
+        ]
+        rows, mock_fetch = self._run(pages)
+        assert len(rows) == gpx.PAGE_SIZE
+        assert mock_fetch.call_count == 2
+
+    def test_missing_scroll_id_stops_after_first_page(self) -> None:
+        rows, mock_fetch = self._run([{"accounts": [{"id": 1}]}])
+        assert rows == [{"id": 1}]
+        assert mock_fetch.call_count == 1
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", 200, True), ("unauthorized", 401, False), ("server_error", 500, False)])
+    def test_status_mapping(self, _name: str, status: int, expected: bool) -> None:
+        session = _session_returning(FakeResponse(status_code=status))
+        with patch.object(gpx, "make_tracked_session", return_value=session):
+            assert gpx.validate_credentials("us", "key") is expected
+
+    def test_network_error_returns_false(self) -> None:
+        session = MagicMock()
+        session.get.side_effect = requests.ConnectionError("boom")
+        with patch.object(gpx, "make_tracked_session", return_value=session):
+            assert gpx.validate_credentials("eu", "key") is False
+
+
+class TestSourceResponse:
+    @parameterized.expand([(name,) for name in GAINSIGHT_PX_ENDPOINTS])
+    def test_response_shape_for_every_endpoint(self, endpoint: str) -> None:
+        # Guards against a settings/transport routing mismatch and locks the `id` primary key.
+        response = gpx.gainsight_px_source("us", "key", endpoint, LOGGER)
+        assert response.name == endpoint
+        assert response.primary_keys == ["id"]
+
+    def test_items_is_lazy(self) -> None:
+        # Building the response must not fire any request; iteration is what pulls pages.
+        with patch.object(gpx, "_fetch_page") as mock_fetch:
+            gpx.gainsight_px_source("us", "key", "accounts", LOGGER)
+        mock_fetch.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gainsight_px/test_gainsight_px_source.py
@@ -1,0 +1,148 @@
+from unittest.mock import patch
+
+import structlog
+from parameterized import parameterized
+
+from posthog.schema import (
+    DataWarehouseSourceCategory,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldSelectConfig,
+)
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px import source as source_module
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.settings import ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.gainsight_px.source import GainsightPxSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import GainsightPxSourceConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+LOGGER = structlog.get_logger()
+
+
+def _config() -> GainsightPxSourceConfig:
+    return GainsightPxSource().parse_config({"region": "eu", "api_key": "abc"})
+
+
+def _inputs(schema_name: str = "accounts", **overrides) -> SourceInputs:
+    defaults: dict = {
+        "schema_name": schema_name,
+        "schema_id": "schema-id",
+        "source_id": "source-id",
+        "team_id": 1,
+        "should_use_incremental_field": False,
+        "db_incremental_field_last_value": None,
+        "db_incremental_field_earliest_value": None,
+        "incremental_field": None,
+        "incremental_field_type": None,
+        "job_id": "job-id",
+        "logger": LOGGER,
+        "reset_pipeline": False,
+    }
+    defaults.update(overrides)
+    return SourceInputs(**defaults)
+
+
+class TestSourceType:
+    def test_source_type(self) -> None:
+        assert GainsightPxSource().source_type == ExternalDataSourceType.GAINSIGHTPX
+
+
+class TestSourceConfig:
+    def test_basic_metadata(self) -> None:
+        config = GainsightPxSource().get_source_config
+        assert config.label == "Gainsight PX"
+        assert config.category == DataWarehouseSourceCategory.ANALYTICS
+        # The source must ship visible (not hidden behind `unreleasedSource`) — that's the whole point
+        # of finishing it.
+        assert not config.unreleasedSource
+        assert config.releaseStatus == "alpha"
+        assert config.docsUrl
+        assert GainsightPxSource().lists_tables_without_credentials is True
+
+    def test_fields(self) -> None:
+        fields = {f.name: f for f in GainsightPxSource().get_source_config.fields}
+        assert set(fields) == {"region", "api_key"}
+
+        region = fields["region"]
+        assert isinstance(region, SourceFieldSelectConfig)
+        assert {o.value for o in region.options} == {"us", "eu", "us2"}
+        assert region.defaultValue == "us"
+
+        api_key = fields["api_key"]
+        assert isinstance(api_key, SourceFieldInputConfig)
+        assert api_key.type == SourceFieldInputConfigType.PASSWORD
+        # Must be flagged secret so it's stored encrypted and never echoed back.
+        assert api_key.secret is True
+
+
+class TestConnectionHostFields:
+    def test_region_requires_secret_re_entry(self) -> None:
+        # Security invariant: retargeting the host the stored key is sent to must force key re-entry.
+        assert GainsightPxSource().connection_host_fields == ["region"]
+
+
+class TestGetSchemas:
+    def test_all_endpoints_present(self) -> None:
+        schemas = {s.name for s in GainsightPxSource().get_schemas(_config(), team_id=1)}
+        assert schemas == set(ENDPOINTS)
+
+    @parameterized.expand([(name,) for name in ENDPOINTS])
+    def test_every_endpoint_is_full_refresh(self, endpoint: str) -> None:
+        # PX exposes no server-side modified-since filter, so advertising incremental here would be a
+        # false promise that re-fetches everything each run.
+        schemas = {s.name: s for s in GainsightPxSource().get_schemas(_config(), team_id=1)}
+        assert schemas[endpoint].supports_incremental is False
+        assert schemas[endpoint].supports_append is False
+        assert schemas[endpoint].detected_primary_keys == ["id"]
+
+    def test_filter_by_names(self) -> None:
+        schemas = GainsightPxSource().get_schemas(_config(), team_id=1, names=["users"])
+        assert [s.name for s in schemas] == ["users"]
+
+
+class TestValidateCredentials:
+    @parameterized.expand([("ok", True), ("bad", False)])
+    def test_delegates_to_transport(self, _name: str, transport_result: bool) -> None:
+        with patch.object(
+            source_module, "validate_gainsight_px_credentials", return_value=transport_result
+        ) as mock_validate:
+            ok, error = GainsightPxSource().validate_credentials(_config(), team_id=1)
+        assert ok is transport_result
+        assert (error is None) is transport_result
+        kwargs = mock_validate.call_args.kwargs
+        assert kwargs["region"] == "eu"
+        assert kwargs["api_key"] == "abc"
+
+
+class TestNonRetryableErrors:
+    def test_auth_errors_present(self) -> None:
+        errors = GainsightPxSource().get_non_retryable_errors()
+        assert any("401" in key for key in errors)
+        assert any("403" in key for key in errors)
+
+
+class TestSourceForPipeline:
+    def test_plumbs_arguments(self) -> None:
+        with patch.object(source_module, "gainsight_px_source") as mock_source:
+            GainsightPxSource().source_for_pipeline(_config(), _inputs(schema_name="users"))
+        kwargs = mock_source.call_args.kwargs
+        assert kwargs["region"] == "eu"
+        assert kwargs["api_key"] == "abc"
+        assert kwargs["endpoint"] == "users"
+
+
+class TestDocumentedTables:
+    def test_lists_every_endpoint_without_credentials(self) -> None:
+        # Exercises the public-docs path (placeholder config, no I/O) that `lists_tables_without_credentials`
+        # turns on.
+        tables = GainsightPxSource().get_documented_tables()
+        assert {t["name"] for t in tables} == set(ENDPOINTS)
+
+
+class TestCanonicalDescriptions:
+    def test_keyed_by_endpoint_name(self) -> None:
+        canon = GainsightPxSource().get_canonical_descriptions()
+        # Descriptions only apply when keyed by the exact schema name `get_schemas` returns.
+        assert set(canon) == set(ENDPOINTS)
+        assert all(entry.get("description") for entry in canon.values())

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -1278,7 +1278,8 @@ class GNewsSourceConfig(config.Config):
 
 @config.config
 class GainsightPxSourceConfig(config.Config):
-    pass
+    api_key: str
+    region: Literal["us", "eu", "us2"] = config.value(default="us")
 
 
 @config.config


### PR DESCRIPTION
## Problem

Gainsight PX (product analytics — accounts, users, segments, feature adoption) had a scaffolded-but-empty warehouse source: registered with an icon and enum, but `unreleasedSource=True` and no form fields, schemas, or transport. So it was hidden from users and non-functional — customers on Gainsight PX had no way to pull their data into the warehouse. This finishes it.

## Changes

- Six full-refresh entity streams: `accounts`, `users`, `segments`, `features`, `articles`, `kcbots`.
- Region selector (US / EU / US2) and API-key auth via the `X-APTRINSIC-API-KEY` header, routed through the tracked HTTP session.
- `scrollId` cursor pagination with a short-page terminator — PX does not reliably null the cursor on the last page, so the short page (not an empty cursor) is the real stop condition — plus a runaway-page guard.
- Credential-validation probe, non-retryable mapping for auth errors (401/403), and canonical table descriptions for the AI data dictionary.
- Self-healing record extraction: if a record key ever changes, fall back to the response's sole object-list (with a warning) instead of silently yielding zero rows.
- Removed `unreleasedSource` so the connector ships visible; `releaseStatus=alpha`.

Scope notes:

- Entity streams only. Event endpoints (high-volume telemetry) are deliberately deferred — their response shapes are not corroborated by a second source and warrant live verification first.
- Full-refresh only: PX exposes no server-side modified-since filter on these resources, so advertising incremental would re-fetch everything each run.

## How did you test this code?

I'm an agent. I did **not** run a live sync — no Gainsight API key was available. Automated tests only:

- 55 unit tests across `test_gainsight_px.py` (transport) and `test_gainsight_px_source.py` (source class), all passing.
- Regressions they catch that no existing test did:
  - pagination stops on a short page even when `scrollId` persists — a naive `while scroll_id:` loop would never terminate (the core PX pagination quirk);
  - per-endpoint record-key extraction and the self-heal fallback (renamed key → sole object-list with a warning; ambiguous or scalar lists do not heal);
  - retryable (429/5xx) vs non-retryable (401/403/404) status classification — guards against endless retries on bad credentials;
  - the source ships visible (no `unreleasedSource`) and the API-key field is `secret`;
  - every endpoint is full-refresh with an `id` primary key.
- Confirmed the source registers and passes the category gate (full `test_source_categories` suite green).

Structural correctness is anchored to the production open-source Airbyte Gainsight PX connector: endpoint paths, record keys, and primary keys match it field-for-field. The first customer sync is the live test, and it fails safe — connect-time credential + region probe, self-healing extraction, and loud logs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

A user-facing posthog.com doc (`docs/cdp/sources/gainsight-px`, referenced by `docsUrl`) is a follow-up in the docs repo and not included here.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (claude-opus-4-8). Skills invoked: `/implementing-warehouse-sources` and `/writing-tests`.

Key decisions:

- **PX, not CS.** "Gainsight" is two unrelated APIs — PX (product analytics; global `api.aptrinsic.com`; simple API-key header) and CS (customer success; per-tenant host; a query-DSL over a Salesforce-like object model). PX was already scaffolded and, crucially, has an open-source Airbyte connector to verify against — the tractable, low-risk target. CS would be a separate, larger build.
- **Verified against ground truth, not just docs.** Earlier dead-ends most likely came from trusting API docs that don't match runtime. Every endpoint's path, record key, and primary key was diffed against the raw live Airbyte manifest.
- **Lean scope.** Dropped two lower-value metadata endpoints (account/user attribute models) whose root response shape was not double-sourced, leaving six solidly-corroborated entity streams and simpler extraction code.
- **Fails safe without a key.** With no live key to test against, added the self-healing extractor and kept pagination defensive so the worst case is a logged warning, not silent data loss.
- `generated_configs.py` was hand-edited to match the generator's deterministic output — the codegen needs a DB connection unavailable in this environment, so re-running `pnpm run generate:source-configs` is a no-op.

Follow-ups: the posthog.com doc; optionally enrich column-level descriptions from the Airbyte stream schemas; consider event endpoints once they can be live-verified.
