### PR TITLE
fix(impersonation): only proceed after confirmed admin OAuth2

### DIFF
--- a/frontend/src/layout/navigation/ImpersonationNotice/adminLoginAs.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/adminLoginAs.ts
@@ -26,16 +26,25 @@ async function ensureAdminOAuth2(): Promise<void> {
         throw new Error('Popup blocked. Please allow popups for this site and try again.')
     }
 
-    await new Promise<void>((resolve) => {
+    // Resolve ONLY once the popup confirms success via `oauth2_complete`. A popup that closes
+    // without sending it means the admin session was never established — proceeding anyway would
+    // fire the impersonation POST against a stale session, which silently fails and forces a retry.
+    await new Promise<void>((resolve, reject) => {
         let checkClosed: ReturnType<typeof setInterval>
+        let completed = false
+
+        const cleanup = (): void => {
+            clearInterval(checkClosed)
+            window.removeEventListener('message', handleMessage)
+        }
 
         const handleMessage = (event: MessageEvent): void => {
             if (event.origin !== window.location.origin) {
                 return
             }
             if (event.data?.type === 'oauth2_complete') {
-                clearInterval(checkClosed)
-                window.removeEventListener('message', handleMessage)
+                completed = true
+                cleanup()
                 resolve()
             }
         }
@@ -44,8 +53,14 @@ async function ensureAdminOAuth2(): Promise<void> {
         checkClosed = setInterval(() => {
             if (authWindow.closed) {
                 clearInterval(checkClosed)
-                window.removeEventListener('message', handleMessage)
-                resolve()
+                // The success message can land a tick after the popup closes — give it a brief
+                // grace period before deciding this was a cancellation.
+                setTimeout(() => {
+                    window.removeEventListener('message', handleMessage)
+                    if (!completed) {
+                        reject(new Error('Admin authentication was cancelled. Please try impersonating again.'))
+                    }
+                }, 500)
             }
         }, 500)
     })

--- a/frontend/src/layout/navigation/ImpersonationNotice/adminLoginAs.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/adminLoginAs.ts
@@ -31,10 +31,14 @@ async function ensureAdminOAuth2(): Promise<void> {
     // fire the impersonation POST against a stale session, which silently fails and forces a retry.
     await new Promise<void>((resolve, reject) => {
         let checkClosed: ReturnType<typeof setInterval>
+        let gracePeriodTimeout: ReturnType<typeof setTimeout> | null = null
         let completed = false
 
         const cleanup = (): void => {
             clearInterval(checkClosed)
+            if (gracePeriodTimeout) {
+                clearTimeout(gracePeriodTimeout)
+            }
             window.removeEventListener('message', handleMessage)
         }
 
@@ -55,9 +59,9 @@ async function ensureAdminOAuth2(): Promise<void> {
                 clearInterval(checkClosed)
                 // The success message can land a tick after the popup closes — give it a brief
                 // grace period before deciding this was a cancellation.
-                setTimeout(() => {
-                    window.removeEventListener('message', handleMessage)
+                gracePeriodTimeout = setTimeout(() => {
                     if (!completed) {
+                        cleanup()
                         reject(new Error('Admin authentication was cancelled. Please try impersonating again.'))
                     }
                 }, 500)

--- a/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
+++ b/frontend/src/layout/navigation/ImpersonationNotice/impersonationNoticeLogic.test.ts
@@ -252,20 +252,12 @@ describe('impersonationNoticeLogic', () => {
             openSpy.mockRestore()
         })
 
-        it('opens OAuth2 popup when auth check fails and proceeds after window closes', async () => {
+        it('opens OAuth2 popup when auth check fails and proceeds once the popup confirms success', async () => {
             logic.actions.setSessionExpired({ email: 'test@example.com', userId: 123, isImpersonatedUntil: null })
 
-            let authCheckCallCount = 0
             useMocks({
                 get: {
-                    '/admin/auth_check': () => {
-                        authCheckCallCount++
-                        // First call fails (triggers popup), but the login will succeed after
-                        if (authCheckCallCount === 1) {
-                            return [401, {}]
-                        }
-                        return [200, {}]
-                    },
+                    '/admin/auth_check': () => [401, {}],
                     '/api/users/@me/': () => [200, MOCK_IMPERSONATED_USER],
                 },
                 post: {
@@ -273,7 +265,6 @@ describe('impersonationNoticeLogic', () => {
                 },
             })
 
-            // Mock window.open to return a window that closes immediately
             const mockWindow = { closed: false } as Window
             const openSpy = jest.spyOn(window, 'open').mockReturnValue(mockWindow)
 
@@ -281,9 +272,14 @@ describe('impersonationNoticeLogic', () => {
                 logic.actions.reImpersonate('reason', true)
             })
 
-            // Simulate the popup window closing (which resolves the promise)
+            // The popup signals a successful admin OAuth2 grant — only then may the flow proceed
             await new Promise((resolve) => setTimeout(resolve, 100))
-            ;(mockWindow as any).closed = true
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: window.location.origin,
+                    data: { type: 'oauth2_complete' },
+                })
+            )
 
             await reImpersonatePromise.toDispatchActions(['reImpersonate', 'loadUser']).toFinishAllListeners()
 
@@ -292,6 +288,40 @@ describe('impersonationNoticeLogic', () => {
                 'admin_oauth2',
                 expect.stringContaining('width=600')
             )
+            openSpy.mockRestore()
+        })
+
+        it('fails without impersonating when the OAuth2 popup closes before confirming', async () => {
+            logic.actions.setSessionExpired({ email: 'test@example.com', userId: 123, isImpersonatedUntil: null })
+
+            useMocks({
+                get: {
+                    '/admin/auth_check': () => [401, {}],
+                    '/api/users/@me/': () => [200, MOCK_IMPERSONATED_USER],
+                },
+                post: {
+                    '/admin/login/user/:id/': () => [200, {}],
+                },
+            })
+
+            const mockWindow = { closed: false } as Window
+            const openSpy = jest.spyOn(window, 'open').mockReturnValue(mockWindow)
+
+            const reImpersonatePromise = expectLogic(logic, () => {
+                logic.actions.reImpersonate('reason', true)
+            })
+
+            // Popup closes without ever posting `oauth2_complete` — the admin session was never
+            // established, so the flow must surface a failure rather than fire the login-as POST.
+            await new Promise((resolve) => setTimeout(resolve, 100))
+            ;(mockWindow as any).closed = true
+
+            await reImpersonatePromise
+                .toDispatchActions(['reImpersonate', 'reImpersonateFailure'])
+                .toNotHaveDispatchedActions(['loadUser'])
+                .toFinishAllListeners()
+
+            expect(lemonToast.error).toHaveBeenCalled()
             openSpy.mockRestore()
         })
     })
@@ -537,10 +567,14 @@ describe('impersonationNoticeLogic', () => {
             // Give the listener time to (incorrectly) process the message
             await new Promise((resolve) => setTimeout(resolve, 100))
 
-            // The login-as POST should NOT have been sent yet because the
-            // cross-origin message was correctly ignored. Closing the popup
-            // is what actually unblocks the flow.
-            ;(mockWindow as any).closed = true
+            // The cross-origin message was correctly ignored, so the flow is still blocked.
+            // Only a legitimate same-origin `oauth2_complete` unblocks it.
+            window.dispatchEvent(
+                new MessageEvent('message', {
+                    origin: window.location.origin,
+                    data: { type: 'oauth2_complete' },
+                })
+            )
 
             await promise.toDispatchActions(['loadUser']).toFinishAllListeners()
 


### PR DESCRIPTION
## Problem

Fixes GROW-78

Staff repeatedly hit "impersonate a customer → land on the login screen instead of the app → log in → access denied → re-impersonate and it works the second time."

The new paper-desk auth pages got the blame, but that variant is cosmetic-only and sits downstream of the auth decision — it just changes how the login screen looks once you're already deemed logged out. The real culprit is the impersonation start path, which the redesign didn't touch.

`ensureAdminOAuth2` (in `adminLoginAs.ts`) resolved its promise as soon as the admin OAuth2 popup _closed_, even if the popup never sent the `oauth2_complete` confirmation. On a fresh impersonation where the admin session isn't established yet, the `POST /admin/login/user/{id}/` could fire before the session cookie was set — the impersonation silently doesn't take, you land back on `/` unauthenticated (login screen), and the second attempt works because OAuth is now valid.

## Changes

`ensureAdminOAuth2` now resolves **only** on a confirmed `oauth2_complete` message. A popup that closes without it is treated as a cancellation and rejects, with a short grace window so a success message that lands a tick after the popup closes still counts as success (avoids flipping the race the other way).

Both callers (`impersonationNoticeLogic.reImpersonate` and `NotFound`'s `LogInAsSuggestions`) already wrap `adminLoginAs` in try/catch with a toast, so the rejection surfaces as a clear error instead of silently proceeding to a failing POST.

No backend or session-flow changes.

## How did you test this code?

I'm an agent. I did not run manual testing, and the frontend lint/typecheck tooling isn't installed in this environment, so I couldn't run it here. The change is a small, self-contained edit to the popup-handshake promise; both call sites already handle a thrown error. Worth a manual impersonation smoke test (including the cancel-the-popup path) before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread asking whether the paper-desk auth redesign broke impersonation. Compared the legacy vs paper-desk `Login` variants and confirmed they share `loginLogic`/`userLogic`/`sceneLogic` and differ only presentationally — so the variant can't be what decides you land on a login page. Traced the actual failure to the OAuth2 popup race in `adminLoginAs.ts` and hardened the handshake. No skills were required for this single-file frontend change.