### PR TITLE
feat(warehouse): route copy imports onto colocated duckgres workers

### DIFF
--- a/duckling_team_scoping_plan.md
+++ b/duckling_team_scoping_plan.md
@@ -1,0 +1,120 @@
+# Duckling team-scoping + per-environment tables — implementation plan
+
+## Context
+
+From the thread (James / Eric, 2026-06-19): weatherstage's warehouse (`DuckgresServer`) was
+provisioned org-scoped with **no `team_id`**, so there's no first-class record of which teams
+belong to a given duckling. Today you'd have to infer it from `posthog_ducklakebackfill`, which is
+"weird" — that's an enablement table, not a membership map.
+
+Two distinct problems:
+
+1. **No team↔duckling link.** `DuckgresServer` / `DuckLakeCatalog` are org-scoped (`team` FK kept
+   nullable + deprecated). A duckling is shared by every team in the org, so the relationship is
+   genuinely `1 org-duckling → n teams`. There is no model expressing that membership.
+2. **Table-name collision across teams.** The Dagster backfill writes every team into the _same_
+   `ducklake.posthog.events` (and `posthog.persons`) table in the org's catalog
+   (`posthog/dags/events_backfill_to_duckling.py`, `EVENTS_TABLE_DDL` / `ensure_events_table_exists`
+   / `register_file_with_duckling`). Two teams in one org both land in `posthog.events`,
+   distinguished only by the `team_id` column. We want per-environment tables.
+
+## Decisions already reached in the thread
+
+- New Django model expressing `team → DuckgresServer` (many teams → one server). It becomes the home
+  for future per-team duckling config, not just this fix.
+- `team_id` should be a real relationship on ducklings (don't read a backfill model to learn membership).
+- Going forward, backfills write to `events_<environment_name>` (and persons equiv), **not** `events`.
+- Use the **environment (Team) name**, normalized + truncated — not the raw team_id (Eric floated
+  team_id; James preferred env name). A `sanitize_ducklake_identifier` helper already exists.
+- Name selection might move into the onboarding flow.
+
+## Proposed implementation
+
+### 1. New model `DuckgresServerTeam`
+
+In `posthog/ducklake/models.py`:
+
+- `server` → `ForeignKey(DuckgresServer, related_name="teams", on_delete=CASCADE)`.
+- `team` → `OneToOneField(Team, related_name="duckgres_server_team")` — a team belongs to exactly one
+  duckling; the OneToOne enforces it and gives the required `team_id`.
+- `table_suffix` → `CharField` storing the normalized environment name used to build
+  `events_<suffix>` / `persons_<suffix>`. **Persist it** (don't recompute from `team.name` each run)
+  so table identity is stable if the env is later renamed, and so collisions are resolved once.
+- Inherit `TeamScopedRootMixin` per `CLAUDE.md` (fail-closed IDOR; the model is tenant-data with a
+  `team_id`). Add the model to the IDOR baseline/coverage as required.
+- `Meta.db_table = "posthog_duckgresserverteam"`; unique on `team` (via OneToOne) and a
+  `unique_together(server, table_suffix)` so two envs in the same duckling can't collide.
+- Migration (`/django-migrations` skill — mandatory).
+
+Re James's open question ("do we want `not null`, i.e. ≥1 team required?"): keep `team_id` **required
+on the link row**, but allow a `DuckgresServer` to exist with zero linked teams transiently (right
+after provision, before the first team is attached). The invariant "a duckling has ≥1 team" is better
+enforced by the provisioning/onboarding flow than by a DB constraint that would break provisioning ordering.
+
+### 2. Write the link at provision time (fix the actual bug)
+
+- `DataWarehouseViewSet.provision` already has `self.team`
+  (`products/data_warehouse/backend/api/data_warehouse.py:847`) but only forwards `organization_id`.
+  Pass the team through to `managed_warehouse.provision(...)`.
+- In `_persist_duckgres_server` (`products/data_warehouse/backend/api/managed_warehouse.py`) /
+  `upsert_duckgres_server_for_org` (`posthog/ducklake/common.py`), after upserting the server, upsert
+  a `DuckgresServerTeam` for the provisioning team, computing `table_suffix` (see §4). Keep it
+  best-effort/idempotent like the existing server upsert.
+- **Backfill existing rows:** data migration that, for every existing `DuckLakeBackfill` (and/or
+  existing `DuckgresServer`), creates the `DuckgresServerTeam` link via `team → org → server` and a
+  computed suffix. This directly repairs weatherstage and any other already-provisioned duckling.
+
+### 3. Per-environment table naming in the Dagster backfill
+
+`posthog/dags/events_backfill_to_duckling.py` currently hardcodes `posthog.events` / `posthog.persons`
+in many places. Parametrize the table name by the team's `table_suffix`:
+
+- Add `events_table` / `persons_table` to `DucklingTarget`; resolve the suffix in
+  `_resolve_duckling_target` (look up `DuckgresServerTeam` by team_id).
+- Thread the table name through: `EVENTS_TABLE_DDL` / `PERSONS_TABLE_DDL` (already `.format()`-templated),
+  `ensure_events_table_exists` / `ensure_persons_table_exists`, `table_exists`, `_set_table_partitioning`,
+  `delete_events_partition_data` / `delete_persons_partition_data`, `validate_duckling_schema` /
+  `validate_duckling_persons_schema`, the `DROP TABLE` paths, and the `ducklake_add_data_files`
+  `'events'` / `'persons'` table argument in `register_file_with_duckling` /
+  `register_persons_file_with_duckling`.
+- Reuse `_validate_identifier` on the suffix before interpolation (it's already SQL-interpolated, not
+  parameterized — keep that safe).
+
+### 4. Environment-name normalization
+
+- Use the existing `sanitize_ducklake_identifier(team.name, default_prefix="events")` from
+  `posthog/ducklake/common.py` (lowercase, alnum+underscore, leading-digit guard, 63-char truncate).
+- Build the suffix once at link creation; resolve in-org collisions deterministically (e.g. append
+  `_<team_id>` when `unique_together(server, table_suffix)` would be violated). The thread floated a
+  tiny model (Haiku) to pick a nicer name — treat that as a later enhancement, not required for correctness.
+- Optionally surface/confirm the name during the managed-warehouse onboarding flow (James's last message).
+
+### 5. Tests
+
+- Model + migration tests (link creation, uniqueness, suffix collision).
+- Provision path creates the link with the right suffix (extend
+  `products/data_warehouse/backend/.../test` around `_persist_duckgres_server`).
+- Dagster backfill: parametrized test that two teams in one org write to distinct
+  `events_<a>` / `events_<b>` tables (extend `posthog/dags/test_events_backfill_to_duckling.py`).
+- Data-migration test: existing `DuckLakeBackfill` rows produce correct links.
+
+## Decisions to confirm before building
+
+1. **Existing data migration.** Already-provisioned ducklings have data in plain `posthog.events`.
+   Options: (a) leave old tables, only new writes go to `events_<suffix>` (risks split data for a
+   team mid-flight); (b) one-time rename `events` → `events_<suffix>` for single-team ducklings as
+   part of the backfill migration. (b) is cleaner where a duckling currently has exactly one team.
+2. **Collision policy** for two environments with identical normalized names in one org — suffix with
+   `_<team_id>`, or fail and require a manual name? Recommend auto-suffix.
+3. **Onboarding scope** — is renaming/choosing the env name in the onboarding flow in scope for this
+   change, or a fast-follow?
+
+## Files touched (summary)
+
+- `posthog/ducklake/models.py` — new `DuckgresServerTeam`.
+- `posthog/migrations/` — schema migration + data backfill migration.
+- `posthog/ducklake/common.py` — link upsert helper + suffix resolution.
+- `products/data_warehouse/backend/api/managed_warehouse.py` + `.../data_warehouse.py` — create link at provision.
+- `posthog/dags/events_backfill_to_duckling.py` — per-env table naming throughout.
+- IDOR baseline / `.github/scripts/check-idor-model-coverage.py` coverage for the new model.
+- Tests across the above.

--- a/posthog/ducklake/storage.py
+++ b/posthog/ducklake/storage.py
@@ -18,6 +18,7 @@ Usage:
 
 from __future__ import annotations
 
+import os
 import re
 import dataclasses
 from typing import TYPE_CHECKING
@@ -678,8 +679,61 @@ def setup_duckgres_session(
         conn.execute(f"LOAD {ext}")
 
 
-def connect_to_duckgres(server: DuckgresServer) -> psycopg.Connection:
-    """Open a psycopg connection to a duckgres server."""
+# Worker-profile control for data-import duckgres connections. When enabled, an
+# import connection asks duckgres for a small COLOCATED (bin-packed) worker via
+# libpq startup options, so a copy bursts into a right-sized pod instead of
+# grabbing one of the big exclusive shared workers (270GB / 46-thread). An import
+# does a streaming `CREATE TABLE AS SELECT * FROM delta_scan(...)` plus a few
+# count/peek verification queries — it has no use for a 360Gi worker, and pinning
+# one per in-flight copy is what lets a single import take over dozens of workers.
+# The server gate (DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE) is on in prod, so
+# this defaults ON; set DUCKGRES_WORKER_PROFILE_ENABLED=0 to fall back to the big
+# exclusive workers. Mirrors the duckling backfill path
+# (posthog/dags/events_backfill_to_duckling.py).
+#
+# Evaluated once at import time, not per connection — toggling it (including
+# rollback) requires redeploying so the process re-reads the env.
+DUCKGRES_WORKER_PROFILE_ENABLED = os.environ.get("DUCKGRES_WORKER_PROFILE_ENABLED", "true").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+# Colocated worker size for the data-moving copy path. Larger than the
+# metadata-only backfill (4/16): a CTAS over a full delta_scan buffers more, so
+# memory is sized generously (DuckDB spills to the colocated node's NVMe beyond
+# its memory_limit rather than OOMing). Stays within the server clamp (≤16 CPU /
+# ≤64Gi). Override per deployment via env.
+DUCKGRES_IMPORT_COLOCATE_CPU = os.environ.get("DUCKGRES_IMPORT_COLOCATE_CPU", "8")
+DUCKGRES_IMPORT_COLOCATE_MEMORY = os.environ.get("DUCKGRES_IMPORT_COLOCATE_MEMORY", "48Gi")
+
+
+def duckgres_import_worker_profile_options() -> str:
+    """libpq startup `options` for a data-import duckgres connection.
+
+    When the worker-profile feature is enabled (the default), requests a small
+    colocated worker shape. Returns a single space-joined `-c key=value` string —
+    psycopg forwards it as the startup `options` parameter, which duckgres parses
+    to size/schedule the worker. Returns "" when disabled, so the connection falls
+    back to the default exclusive worker with no extra startup options.
+    """
+    if not DUCKGRES_WORKER_PROFILE_ENABLED:
+        return ""
+    return " ".join(
+        [
+            "-c duckgres.colocate=true",
+            f"-c duckgres.worker_cpu={DUCKGRES_IMPORT_COLOCATE_CPU}",
+            f"-c duckgres.worker_memory={DUCKGRES_IMPORT_COLOCATE_MEMORY}",
+        ]
+    )
+
+
+def connect_to_duckgres(server: DuckgresServer, *, options: str = "") -> psycopg.Connection:
+    """Open a psycopg connection to a duckgres server.
+
+    Pass ``options`` (libpq startup `options`, e.g. from
+    ``duckgres_import_worker_profile_options()``) to select the worker profile.
+    """
     return psycopg.connect(
         host=server.host,
         port=server.port,
@@ -687,6 +741,7 @@ def connect_to_duckgres(server: DuckgresServer) -> psycopg.Connection:
         user=server.username,
         password=server.password,
         autocommit=True,
+        options=options,
     )
 
 
@@ -698,6 +753,7 @@ __all__ = [
     "configure_connection",
     "configure_cross_account_connection",
     "connect_to_duckgres",
+    "duckgres_import_worker_profile_options",
     "ensure_ducklake_bucket_exists",
     "get_deltalake_storage_options",
     "normalize_endpoint",

--- a/posthog/ducklake/test_storage.py
+++ b/posthog/ducklake/test_storage.py
@@ -6,6 +6,7 @@ from posthog.ducklake.storage import (
     _DELTA_LOG_VERSION_RE,
     DuckLakeStorageConfig,
     _collect_delta_log_keys,
+    duckgres_import_worker_profile_options,
     normalize_endpoint,
 )
 
@@ -517,3 +518,29 @@ class TestStageDeltaTable:
         # version 3 log entry must NOT have been copied
         all_copied = [call.kwargs["Key"] for call in mock_s3.copy_object.call_args_list]
         assert "__posthog_staging/data/table/_delta_log/00000000000000000003.json" not in all_copied
+
+
+class TestDuckgresImportWorkerProfileOptions:
+    @parameterized.expand(
+        [
+            ("enabled", True, "-c duckgres.colocate=true -c duckgres.worker_cpu=8 -c duckgres.worker_memory=48Gi"),
+            ("disabled", False, ""),
+        ]
+    )
+    def test_gating(self, _name, enabled, expected):
+        # Guards the colocated-worker startup options shared by the copy-import
+        # processor and the ducklake copy-data-imports workflow: if the gate
+        # inverts or the GUC keys/size drift, imports silently fall back to the
+        # big exclusive workers (the regression this fixes) or send malformed options.
+        with patch("posthog.ducklake.storage.DUCKGRES_WORKER_PROFILE_ENABLED", enabled):
+            assert duckgres_import_worker_profile_options() == expected
+
+    def test_honors_size_overrides(self):
+        with (
+            patch("posthog.ducklake.storage.DUCKGRES_WORKER_PROFILE_ENABLED", True),
+            patch("posthog.ducklake.storage.DUCKGRES_IMPORT_COLOCATE_CPU", "16"),
+            patch("posthog.ducklake.storage.DUCKGRES_IMPORT_COLOCATE_MEMORY", "64Gi"),
+        ):
+            assert duckgres_import_worker_profile_options() == (
+                "-c duckgres.colocate=true -c duckgres.worker_cpu=16 -c duckgres.worker_memory=64Gi"
+            )

--- a/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
+++ b/posthog/temporal/ducklake/ducklake_copy_data_imports_workflow.py
@@ -29,6 +29,7 @@ from posthog.ducklake.storage import (
     compute_staging_uri,
     configure_connection,
     connect_to_duckgres,
+    duckgres_import_worker_profile_options,
     ensure_ducklake_bucket_exists,
     get_deltalake_storage_options,
     setup_duckgres_session,
@@ -328,7 +329,7 @@ def _copy_data_imports_via_duckgres(inputs: DuckLakeCopyDataImportsActivityInput
     schema = inputs.model.ducklake_schema_name
     table = f"{schema}.{inputs.model.ducklake_table_name}"
 
-    with connect_to_duckgres(server) as conn:
+    with connect_to_duckgres(server, options=duckgres_import_worker_profile_options()) as conn:
         setup_duckgres_session(conn)
         logger.info(
             "Creating DuckLake table from staged Delta snapshot via duckgres",
@@ -485,7 +486,7 @@ def _verify_data_imports_ducklake_copy_via_duckgres(
         inputs=inputs,
     )
 
-    with connect_to_duckgres(server) as conn:
+    with connect_to_duckgres(server, options=duckgres_import_worker_profile_options()) as conn:
         setup_duckgres_session(conn)
         return _run_data_imports_verification_checks(
             conn,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -12,7 +11,7 @@ import structlog
 from psycopg import sql
 
 from posthog.ducklake.common import duckgres_data_imports_schema, get_duckgres_config_for_org
-from posthog.ducklake.storage import setup_duckgres_session
+from posthog.ducklake.storage import duckgres_import_worker_profile_options, setup_duckgres_session
 from posthog.models import Team
 
 from products.warehouse_sources.backend.models import ExternalDataJob, ExternalDataSchema
@@ -85,56 +84,6 @@ def process_batch(batch: PendingBatch) -> None:
             )
 
 
-# Worker-profile control. When enabled, a copy-import connection asks duckgres
-# for a small COLOCATED (bin-packed) worker via libpq startup options, so each
-# batch bursts into a right-sized pod instead of grabbing one of the big
-# exclusive shared workers (270GB / 46-thread). A batch does a streaming
-# `CREATE TABLE AS SELECT * FROM delta_scan(...)` plus a few count/peek
-# verification queries — it has no use for a 360Gi worker, and pinning one per
-# in-flight batch is exactly what lets a single import take over dozens of
-# workers. The server gate (DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE) is on in
-# prod, so this defaults ON; set DUCKGRES_WORKER_PROFILE_ENABLED=0 to put a
-# deployment back on the big exclusive workers. Mirrors the duckling backfill
-# path (posthog/dags/events_backfill_to_duckling.py).
-#
-# Evaluated once at process startup, not per connection/batch — toggling it
-# (including rollback) requires redeploying the Temporal worker so the process
-# restarts and re-reads the env, not just unsetting the variable.
-DUCKGRES_WORKER_PROFILE_ENABLED = os.environ.get("DUCKGRES_WORKER_PROFILE_ENABLED", "true").strip().lower() in (
-    "1",
-    "true",
-    "yes",
-    "on",
-)
-# Colocated worker size for the data-moving copy path. Larger than the
-# metadata-only backfill (4/16): a CTAS over a full delta_scan buffers more, so
-# memory is sized generously (DuckDB spills to the colocated node's NVMe beyond
-# its memory_limit rather than OOMing). Stays within the server clamp (≤16 CPU /
-# ≤64Gi). Override per deployment via env.
-DUCKGRES_IMPORT_COLOCATE_CPU = os.environ.get("DUCKGRES_IMPORT_COLOCATE_CPU", "8")
-DUCKGRES_IMPORT_COLOCATE_MEMORY = os.environ.get("DUCKGRES_IMPORT_COLOCATE_MEMORY", "48Gi")
-
-
-def _duckgres_worker_profile_options() -> str:
-    """libpq startup `options` for a copy-import connection.
-
-    When the worker-profile feature is enabled (the default), requests a small
-    colocated worker shape. Returns a single space-joined `-c key=value` string —
-    psycopg forwards it as the startup `options` parameter, which duckgres parses
-    to size/schedule the worker. Returns "" when disabled, so the connection
-    falls back to the default exclusive worker with no extra startup options.
-    """
-    if not DUCKGRES_WORKER_PROFILE_ENABLED:
-        return ""
-    return " ".join(
-        [
-            "-c duckgres.colocate=true",
-            f"-c duckgres.worker_cpu={DUCKGRES_IMPORT_COLOCATE_CPU}",
-            f"-c duckgres.worker_memory={DUCKGRES_IMPORT_COLOCATE_MEMORY}",
-        ]
-    )
-
-
 def _connect_to_duckgres(team_id: int) -> psycopg.Connection[Any]:
     team = Team.objects.only("organization_id").get(id=team_id)
     config = get_duckgres_config_for_org(str(team.organization_id))
@@ -153,7 +102,10 @@ def _connect_to_duckgres(team_id: int) -> psycopg.Connection[Any]:
         keepalives_idle=60,
         keepalives_interval=15,
         keepalives_count=4,
-        options=_duckgres_worker_profile_options(),
+        # Request a small colocated worker per copy-import batch (vs the big
+        # exclusive default), so a single import stops taking over dozens of
+        # 360Gi workers. Shared with the ducklake copy-data-imports workflow.
+        options=duckgres_import_worker_profile_options(),
     )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/processor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Any, Literal
 
@@ -84,6 +85,56 @@ def process_batch(batch: PendingBatch) -> None:
             )
 
 
+# Worker-profile control. When enabled, a copy-import connection asks duckgres
+# for a small COLOCATED (bin-packed) worker via libpq startup options, so each
+# batch bursts into a right-sized pod instead of grabbing one of the big
+# exclusive shared workers (270GB / 46-thread). A batch does a streaming
+# `CREATE TABLE AS SELECT * FROM delta_scan(...)` plus a few count/peek
+# verification queries — it has no use for a 360Gi worker, and pinning one per
+# in-flight batch is exactly what lets a single import take over dozens of
+# workers. The server gate (DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE) is on in
+# prod, so this defaults ON; set DUCKGRES_WORKER_PROFILE_ENABLED=0 to put a
+# deployment back on the big exclusive workers. Mirrors the duckling backfill
+# path (posthog/dags/events_backfill_to_duckling.py).
+#
+# Evaluated once at process startup, not per connection/batch — toggling it
+# (including rollback) requires redeploying the Temporal worker so the process
+# restarts and re-reads the env, not just unsetting the variable.
+DUCKGRES_WORKER_PROFILE_ENABLED = os.environ.get("DUCKGRES_WORKER_PROFILE_ENABLED", "true").strip().lower() in (
+    "1",
+    "true",
+    "yes",
+    "on",
+)
+# Colocated worker size for the data-moving copy path. Larger than the
+# metadata-only backfill (4/16): a CTAS over a full delta_scan buffers more, so
+# memory is sized generously (DuckDB spills to the colocated node's NVMe beyond
+# its memory_limit rather than OOMing). Stays within the server clamp (≤16 CPU /
+# ≤64Gi). Override per deployment via env.
+DUCKGRES_IMPORT_COLOCATE_CPU = os.environ.get("DUCKGRES_IMPORT_COLOCATE_CPU", "8")
+DUCKGRES_IMPORT_COLOCATE_MEMORY = os.environ.get("DUCKGRES_IMPORT_COLOCATE_MEMORY", "48Gi")
+
+
+def _duckgres_worker_profile_options() -> str:
+    """libpq startup `options` for a copy-import connection.
+
+    When the worker-profile feature is enabled (the default), requests a small
+    colocated worker shape. Returns a single space-joined `-c key=value` string —
+    psycopg forwards it as the startup `options` parameter, which duckgres parses
+    to size/schedule the worker. Returns "" when disabled, so the connection
+    falls back to the default exclusive worker with no extra startup options.
+    """
+    if not DUCKGRES_WORKER_PROFILE_ENABLED:
+        return ""
+    return " ".join(
+        [
+            "-c duckgres.colocate=true",
+            f"-c duckgres.worker_cpu={DUCKGRES_IMPORT_COLOCATE_CPU}",
+            f"-c duckgres.worker_memory={DUCKGRES_IMPORT_COLOCATE_MEMORY}",
+        ]
+    )
+
+
 def _connect_to_duckgres(team_id: int) -> psycopg.Connection[Any]:
     team = Team.objects.only("organization_id").get(id=team_id)
     config = get_duckgres_config_for_org(str(team.organization_id))
@@ -102,6 +153,7 @@ def _connect_to_duckgres(team_id: int) -> psycopg.Connection[Any]:
         keepalives_idle=60,
         keepalives_interval=15,
         keepalives_count=4,
+        options=_duckgres_worker_profile_options(),
     )
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor import (
     DuckgresColumn,
+    _duckgres_worker_profile_options,
     _ensure_duckgres_apply_table,
     _insert_batch,
     _mark_duckgres_batch_applied,
@@ -449,3 +450,32 @@ def test_duckgres_apply_marker_is_scoped_by_schema_id() -> None:
         2,
         "00000000-0000-0000-0000-000000000001",
     ]
+
+
+_PROFILE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor"
+
+
+@pytest.mark.parametrize(
+    "enabled,expected",
+    [
+        (True, "-c duckgres.colocate=true -c duckgres.worker_cpu=8 -c duckgres.worker_memory=48Gi"),
+        (False, ""),
+    ],
+)
+def test_duckgres_worker_profile_options_gating(enabled: bool, expected: str):
+    # Guards the colocated-worker startup options: if the gate inverts or the GUC
+    # keys/size drift, imports silently fall back to the big exclusive workers
+    # (the regression this change fixes) or send malformed options.
+    with patch(f"{_PROFILE_MODULE}.DUCKGRES_WORKER_PROFILE_ENABLED", enabled):
+        assert _duckgres_worker_profile_options() == expected
+
+
+def test_duckgres_worker_profile_options_honors_size_overrides():
+    with (
+        patch(f"{_PROFILE_MODULE}.DUCKGRES_WORKER_PROFILE_ENABLED", True),
+        patch(f"{_PROFILE_MODULE}.DUCKGRES_IMPORT_COLOCATE_CPU", "16"),
+        patch(f"{_PROFILE_MODULE}.DUCKGRES_IMPORT_COLOCATE_MEMORY", "64Gi"),
+    ):
+        assert _duckgres_worker_profile_options() == (
+            "-c duckgres.colocate=true -c duckgres.worker_cpu=16 -c duckgres.worker_memory=64Gi"
+        )

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline_v3/duckgres/test_processor.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, Mock, patch
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor import (
     DuckgresColumn,
-    _duckgres_worker_profile_options,
     _ensure_duckgres_apply_table,
     _insert_batch,
     _mark_duckgres_batch_applied,
@@ -450,32 +449,3 @@ def test_duckgres_apply_marker_is_scoped_by_schema_id() -> None:
         2,
         "00000000-0000-0000-0000-000000000001",
     ]
-
-
-_PROFILE_MODULE = "products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline_v3.duckgres.processor"
-
-
-@pytest.mark.parametrize(
-    "enabled,expected",
-    [
-        (True, "-c duckgres.colocate=true -c duckgres.worker_cpu=8 -c duckgres.worker_memory=48Gi"),
-        (False, ""),
-    ],
-)
-def test_duckgres_worker_profile_options_gating(enabled: bool, expected: str):
-    # Guards the colocated-worker startup options: if the gate inverts or the GUC
-    # keys/size drift, imports silently fall back to the big exclusive workers
-    # (the regression this change fixes) or send malformed options.
-    with patch(f"{_PROFILE_MODULE}.DUCKGRES_WORKER_PROFILE_ENABLED", enabled):
-        assert _duckgres_worker_profile_options() == expected
-
-
-def test_duckgres_worker_profile_options_honors_size_overrides():
-    with (
-        patch(f"{_PROFILE_MODULE}.DUCKGRES_WORKER_PROFILE_ENABLED", True),
-        patch(f"{_PROFILE_MODULE}.DUCKGRES_IMPORT_COLOCATE_CPU", "16"),
-        patch(f"{_PROFILE_MODULE}.DUCKGRES_IMPORT_COLOCATE_MEMORY", "64Gi"),
-    ):
-        assert _duckgres_worker_profile_options() == (
-            "-c duckgres.colocate=true -c duckgres.worker_cpu=16 -c duckgres.worker_memory=64Gi"
-        )


### PR DESCRIPTION
## Problem

A single org's warehouse copy import takes over **dozens of full-size duckgres workers** (270 GB / 46-thread each), most sitting idle on an open connection between bursts. Every import connection runs a streaming `CREATE TABLE AS SELECT * FROM delta_scan(...)` plus a few count/peek verification queries — work that has no use for a 360 GiB exclusive worker — but today it grabs one anyway and pins it for the whole copy. At import concurrency that's the bulk of the `duckgres-workers` nodepool consumed by ~2% actual CPU.

## Changes

Request a small **colocated (bin-packed)** worker for every data-import duckgres connection via libpq startup options, gated by `DUCKGRES_WORKER_PROFILE_ENABLED` (default on). When enabled, the connection sends `-c duckgres.colocate=true -c duckgres.worker_cpu=… -c duckgres.worker_memory=…`.

There are **two** duckgres copy paths, and both are covered:

1. **v3 copy-import processor** (`pipeline_v3/duckgres/processor.py`) — the sink that tails delta batches and applies them.
2. **`ducklake_copy_data_imports_workflow`** (the Temporal copy/verify activities) — `_copy_data_imports_via_duckgres` (the CTAS) and `_verify_data_imports_ducklake_copy_via_duckgres` (count/partition checks), both via `connect_to_duckgres`.

The gated options live in **one shared helper**, `duckgres_import_worker_profile_options()` in `posthog/ducklake/storage.py` — single source of truth for import worker sizing. `connect_to_duckgres` gained an `options` kwarg; the processor uses the same helper.

Sizing: **8 CPU / 48 GiB** for the data-moving copy path (vs the metadata-only duckling backfill's 4/16, `posthog/dags/events_backfill_to_duckling.py`, #61454). A CTAS over a full `delta_scan` buffers more, so memory is generous — DuckDB spills to the colocated node's NVMe past its `memory_limit` rather than OOMing. Within the server clamp (≤16 CPU / ≤64 GiB). Both size and gate are env-overridable (`DUCKGRES_IMPORT_COLOCATE_CPU` / `_MEMORY`).

The server gate (`DUCKGRES_K8S_ALLOW_CLIENT_WORKER_PROFILE`) is already on in prod, and colocated workers already run there for the backfills (they bin-pack onto the existing `duckgres-workers` nodepool — no dedicated nodepool required).

**Scope — what's intentionally untouched:**
- The data-modeling copy workflow (the other `connect_to_duckgres` caller) — same shape, separate concern; easy follow-up if wanted.
- The v3 consumer's own connection (to the batch-queue Postgres, not a duckgres worker).
- Interactive read paths (`execute_ducklake_query` / ducklake shadow) — they want the big warm worker.

## How did you test this code?

I'm an agent; I did not manually test against a live cluster. Automated only:

- `duckgres_import_worker_profile_options` unit tests in `posthog/ducklake/test_storage.py` (parameterized enabled/disabled gating + a size-override case) — catch the realistic regression where the gate inverts or the GUC keys/size drift, which would silently send imports back to the big exclusive workers or emit malformed options. No existing test covered it.
- `hogli test posthog/ducklake/test_storage.py` + `test_processor.py` — pass.
- `posthog/temporal/tests/ducklake/test_ducklake_copy_data_imports_workflow.py` — 30 passed (workflow change is connection-options only).
- `ruff` clean; `ty check` passed via lint-staged.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8) at the request of the assignee, off a live investigation into duckgres worker sprawl on `mw-prod-us` (imports pin dozens of big workers at ~2% CPU). The per-connection worker-profile feature is already shipped + enabled server-side and already used by the duckling backfills (#61454); this routes the import copy paths through it.

Skills invoked: `/writing-tests` (gated the unit tests).

Decisions:
- **Mirrored #61454's gated pattern** — same env flag, same `-c duckgres.*` options shape.
- **Covered both import copy paths** after tracing every duckgres connection in the repo: the v3 processor and the older `ducklake_copy_data_imports_workflow` (copy + verify). Hoisted the options into one shared helper so sizing can't drift between them.
- **Sized up to 8/48** (from the backfill's 4/16) because the copy path moves data via CTAS; memory generous to lean on NVMe spill over OOM. Env-overridable.
- **Default on** to match the reference and take effect on deploy; reversible via `DUCKGRES_WORKER_PROFILE_ENABLED=0` + redeploy.
- **Left data-modeling and interactive readers alone** — only the import copy paths should shrink.

Draft because the size/default-on choices likely warrant a human call, and we may want to validate import memory headroom on a canary team before flipping it on broadly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
