### PR TITLE
fix(bing_ads): surface SOAP fault detail from campaigns fetch

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/client.py
@@ -130,14 +130,17 @@ class BingAdsClient:
         self.authorization_data.account_id = account_id
         self.authorization_data.customer_id = customer_id
 
-        service_client = ServiceClient(
-            service="CampaignManagementService",
-            version=13,
-            authorization_data=self.authorization_data,
-            environment=ENVIRONMENT,
-        )
+        try:
+            service_client = ServiceClient(
+                service="CampaignManagementService",
+                version=13,
+                authorization_data=self.authorization_data,
+                environment=ENVIRONMENT,
+            )
 
-        campaigns = service_client.GetCampaignsByAccountId(AccountId=account_id)
+            campaigns = service_client.GetCampaignsByAccountId(AccountId=account_id)
+        except Exception as e:
+            raise _wrap_with_fault_detail(e, "Failed to fetch campaigns") from e
 
         result = []
         if campaigns and campaigns.Campaign:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bing_ads/tests/test_bing_ads_client.py
@@ -217,3 +217,47 @@ class TestBingAdsClient:
         assert campaign_data["Name"] == "Test Campaign"
         assert campaign_data["Status"] == "Active"
         assert campaign_data["Languages"] == ["English"]
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.client.ServiceClient")
+    def test_get_campaigns_surfaces_soap_fault_detail(self, mock_service_client):
+        """GetCampaignsByAccountId raises the same generic 'Invalid client data' WebFault as GetUser when
+        the configured account is unusable. get_campaigns must funnel it through _wrap_with_fault_detail
+        so the real error code in the SOAP detail reaches the retry framework instead of a raw WebFault.
+        """
+        webfault = _make_webfault(
+            "Invalid client data. Check the SOAP fault details for more information. TrackingId: abc-123.",
+            _ad_api_fault_detail("AuthenticationTokenExpired", "The authentication token has expired."),
+        )
+        mock_client_instance = mock_service_client.return_value
+        mock_client_instance.GetCampaignsByAccountId.side_effect = webfault
+
+        client = BingAdsClient(self.access_token, self.refresh_token, self.developer_token)
+        with pytest.raises(ValueError) as exc_info:
+            list(client.get_campaigns(self.account_id, self.customer_id))
+
+        message = str(exc_info.value)
+        assert "Failed to fetch campaigns" in message
+        assert "AuthenticationTokenExpired" in message
+        assert "Invalid client data" in message
+        non_retryable_patterns = BingAdsSource().get_non_retryable_errors()
+        assert any(pattern in message for pattern in non_retryable_patterns)
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.bing_ads.client.ServiceClient")
+    def test_get_campaigns_transient_failure_stays_retryable(self, mock_service_client):
+        """A network/timeout failure from GetCampaignsByAccountId must keep its original signature and
+        not coincidentally match a non-retryable auth pattern.
+        """
+        mock_client_instance = mock_service_client.return_value
+        mock_client_instance.GetCampaignsByAccountId.side_effect = ConnectionError(
+            "HTTPSConnectionPool(host='bingads.microsoft.com', port=443): Max retries exceeded"
+        )
+
+        client = BingAdsClient(self.access_token, self.refresh_token, self.developer_token)
+        with pytest.raises(ValueError) as exc_info:
+            list(client.get_campaigns(self.account_id, self.customer_id))
+
+        message = str(exc_info.value)
+        assert "Failed to fetch campaigns" in message
+        assert "ConnectionError" in message
+        non_retryable_patterns = BingAdsSource().get_non_retryable_errors()
+        assert not any(pattern in message for pattern in non_retryable_patterns)


### PR DESCRIPTION
## Problem

Error tracking surfaced a `WebFault` raised at `bing_ads/client.py:140` in `get_campaigns` (`Server raised fault: 'Invalid client data. Check the SOAP fault details for more information.'`). Multiple teams hit it.

`get_campaigns` was the only Bing Ads SOAP-calling method that did **not** funnel its errors through `_wrap_with_fault_detail` — `get_customer_id` and `get_performance_report` both do. As a result, a `GetCampaignsByAccountId` failure propagated as a raw suds `WebFault` carrying only the generic top-level faultstring (`Invalid client data...`). The actual, stable error code lives in the SOAP fault detail (e.g. `AuthenticationTokenExpired`, `InvalidCredentials`, `CampaignServiceInvalidAccountId`), and it was being thrown away — hiding the real cause from operators and from the non-retryable error classifier, which matches on substrings of the error message.

The umbrella `Invalid client data` phrase is already classified non-retryable, but because the detail was never extracted on this path, any campaigns-endpoint auth/credential fault whose top-level faultstring is *not* that generic phrase would keep retrying instead of being recognised, and every such failure reached error tracking as an opaque raw `WebFault` instead of a contextual error.

## Changes

Wrap the `ServiceClient` creation and `GetCampaignsByAccountId` call in `get_campaigns` in a `try/except` that re-raises through `_wrap_with_fault_detail`, mirroring the two other SOAP methods. The helper extracts and logs the SOAP fault detail and preserves the original exception type and message, so transient errors (network, timeouts) keep their signature and stay retryable while auth/config codes become matchable.

This is a scoped robustness fix — no change to retry policy or to the shared helper.

## How did you test this code?

I'm an agent. I added two regression tests in `test_bing_ads_client.py` and ran them with the existing suite (`pytest` over `test_bing_ads_client.py`, 12 passed):

- `test_get_campaigns_surfaces_soap_fault_detail` — a `WebFault` with the generic `Invalid client data` faultstring and an `AuthenticationTokenExpired` detail is wrapped into a `ValueError` that surfaces the detail code and matches a non-retryable pattern.
- `test_get_campaigns_transient_failure_stays_retryable` — a `ConnectionError` keeps its signature and does **not** coincidentally match any non-retryable auth pattern.

I confirmed both fail on `master` (raw `WebFault`/`ConnectionError` propagate) and pass with the fix. These catch the regression no existing test did: the prior `get_campaigns` tests only covered the success path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `bing_ads` import source. Investigated the issue (raw `WebFault` originating in `get_campaigns`), confirmed the frame is genuinely in this source's code, and compared the three SOAP-calling methods. Decision: this is a fixable fragility bug (one SOAP path skips the established `_wrap_with_fault_detail` convention) rather than a new non-retryable string — the generic phrase is already classified, so the right fix is to surface the underlying detail consistently. Kept the change minimal and added tests at the client layer mirroring the existing `get_customer_id` fault-detail tests. Checked open PRs (including the maintainer's) for duplicates — none touch this path.