### PR TITLE
fix(insights): drop the bottom default for legend position for legacy insights

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -23141,7 +23141,6 @@
                     "default": "vertical"
                 },
                 "legendPosition": {
-                    "default": "bottom",
                     "description": "Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.",
                     "enum": ["top", "bottom", "left", "right"],
                     "type": "string"
@@ -26027,7 +26026,6 @@
             "additionalProperties": false,
             "properties": {
                 "legendPosition": {
-                    "default": "bottom",
                     "description": "Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.",
                     "enum": ["top", "bottom", "left", "right"],
                     "type": "string"
@@ -43166,7 +43164,6 @@
                     "type": "array"
                 },
                 "legendPosition": {
-                    "default": "bottom",
                     "description": "Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.",
                     "enum": ["top", "bottom", "left", "right"],
                     "type": "string"
@@ -45479,7 +45476,6 @@
                     "type": "boolean"
                 },
                 "legendPosition": {
-                    "default": "bottom",
                     "description": "Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.",
                     "enum": ["top", "bottom", "left", "right"],
                     "type": "string"

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -1457,8 +1457,7 @@ export type TrendsFilter = {
     display?: TrendsFilterLegacy['display']
     /** @default false */
     showLegend?: TrendsFilterLegacy['show_legend']
-    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.
-     * @default bottom */
+    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend. */
     legendPosition?: 'top' | 'bottom' | 'left' | 'right'
     /** @default false */
     showAlertThresholdLines?: boolean
@@ -1757,8 +1756,7 @@ export type FunnelsFilter = {
      * @default false
      */
     showLegend?: boolean
-    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.
-     * @default bottom */
+    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend. */
     legendPosition?: 'top' | 'bottom' | 'left' | 'right'
     /** @default false */
     showValuesOnSeries?: boolean
@@ -1963,8 +1961,7 @@ export interface StickinessCriteria {
 export type StickinessFilter = {
     display?: StickinessFilterLegacy['display']
     showLegend?: StickinessFilterLegacy['show_legend']
-    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.
-     * @default bottom */
+    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend. */
     legendPosition?: 'top' | 'bottom' | 'left' | 'right'
     showValuesOnSeries?: StickinessFilterLegacy['show_values_on_series']
     showMultipleYAxes?: StickinessFilterLegacy['show_multiple_y_axes']
@@ -2032,8 +2029,7 @@ export type LifecycleFilter = {
     toggledLifecycles?: LifecycleFilterLegacy['toggledLifecycles']
     /** @default false */
     showLegend?: LifecycleFilterLegacy['show_legend']
-    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend.
-     * @default bottom */
+    /** Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend. */
     legendPosition?: 'top' | 'bottom' | 'left' | 'right'
     /** @default true */
     stacked?: boolean

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -1427,10 +1427,13 @@ class TestFilterToQuery(BaseTest):
         ]
     )
     def test_legend_position_absent_when_not_set(self, insight: str, filter_key: str):
-        query = filter_to_query({"insight": insight})
+        # show_legend yields a non-empty filter section without setting a position, so the absence
+        # check is meaningful (the section must be present, else the assertion would pass vacuously).
+        query = filter_to_query({"insight": insight, "show_legend": True})
 
-        serialized_filter = query.model_dump(exclude_none=True).get(filter_key, {})
-        self.assertNotIn("legendPosition", serialized_filter)
+        serialized = query.model_dump(exclude_none=True)
+        self.assertIn(filter_key, serialized)
+        self.assertNotIn("legendPosition", serialized[filter_key])
 
     def test_funnels_filter(self):
         filter: dict[str, Any] = {

--- a/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
+++ b/posthog/hogql_queries/legacy_compatibility/test/test_filter_to_query.py
@@ -3,6 +3,8 @@ from typing import Any, cast
 import pytest
 from posthog.test.base import BaseTest
 
+from parameterized import parameterized
+
 from posthog.schema import (
     ActionsNode,
     AggregationAxisFormat,
@@ -1415,6 +1417,20 @@ class TestFilterToQuery(BaseTest):
                 showPercentStackView=True,
             ),
         )
+
+    @parameterized.expand(
+        [
+            ("TRENDS", "trendsFilter"),
+            ("STICKINESS", "stickinessFilter"),
+            ("LIFECYCLE", "lifecycleFilter"),
+            ("FUNNELS", "funnelsFilter"),
+        ]
+    )
+    def test_legend_position_absent_when_not_set(self, insight: str, filter_key: str):
+        query = filter_to_query({"insight": insight})
+
+        serialized_filter = query.model_dump(exclude_none=True).get(filter_key, {})
+        self.assertNotIn("legendPosition", serialized_filter)
 
     def test_funnels_filter(self):
         filter: dict[str, Any] = {

--- a/posthog/schema.py
+++ b/posthog/schema.py
@@ -5614,7 +5614,7 @@ class LifecycleFilter(BaseModel):
         extra="forbid",
     )
     legendPosition: LegendPosition | None = Field(
-        default=LegendPosition.BOTTOM,
+        default=None,
         description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
     )
     showLegend: bool | None = False
@@ -7179,7 +7179,7 @@ class StickinessFilter(BaseModel):
     display: ChartDisplayType | None = None
     hiddenLegendIndexes: list[int] | None = None
     legendPosition: LegendPosition | None = Field(
-        default=LegendPosition.BOTTOM,
+        default=None,
         description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
     )
     resultCustomizationBy: ResultCustomizationBy | None = Field(
@@ -7981,7 +7981,7 @@ class TrendsFilter(BaseModel):
     hiddenLegendIndexes: list[int] | None = None
     hideWeekends: bool | None = False
     legendPosition: LegendPosition | None = Field(
-        default=LegendPosition.BOTTOM,
+        default=None,
         description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
     )
     metricChangeDecreaseColor: str | None = Field(
@@ -23110,7 +23110,7 @@ class FunnelsFilter(BaseModel):
     )
     layout: FunnelLayout | None = FunnelLayout.VERTICAL
     legendPosition: LegendPosition | None = Field(
-        default=LegendPosition.BOTTOM,
+        default=None,
         description=("Where the in-chart legend sits relative to the plot. Only applies to the in-chart legend."),
     )
     resultCustomizations: dict[str, ResultCustomizationByValue] | None = Field(


### PR DESCRIPTION
## Problem

Trends/stickiness/lifecycle/funnel insights were silently getting `trendsFilter.legendPosition: "bottom"` baked into their **saved** query, which moved the in-chart legend to the bottom even for users who never chose a position. This surfaced after the configurable in-chart legend shipped: a customer reported nearly all of their existing insights suddenly had the legend on the bottom.

Root cause: the schema gave `legendPosition` a **non-null default of `"bottom"`** on all four chart filter types. When a legacy filters-based insight is converted to a query, `model_dump(exclude_none=True)` can't strip `"bottom"` (it isn't `None`), so the value gets baked into the query and persisted on the next save. The frontend render fallback is `?? 'right'`, but it never applies because the value is already present.

## Changes

Drop the non-null default from the four `legendPosition` fields in `schema-general.ts` and regenerate the derived schema (`posthog/schema.py`, `frontend/src/queries/schema.json`). With the default gone, the field defaults to absent, `exclude_none=True` drops it, and the frontend's existing `?? 'right'` fallback applies — so legacy insights render on the right again.

This is surgical: only the schema default + regenerated files, plus one focused regression test. No frontend render fallbacks or `LegendOptionsFilter.tsx` seed logic were touched.

> **Note:** This fix stops *new* contamination. Insights that already have `"bottom"` persisted in their stored query are corrected separately via an org-scoped data backfill (handled out-of-band), since a code change can't retroactively rewrite saved data.

## How did you test this code?

I'm an agent (PostHog Code). Automated only:

- Added `test_legend_position_absent_when_not_set` to `test_filter_to_query.py` (parameterized over TRENDS/STICKINESS/LIFECYCLE/FUNNELS) asserting `legendPosition` is absent from `model_dump(exclude_none=True)` when never set — the exact path that baked the value in. Verified it fails if the `bottom` default is restored, then passes with the fix.
- `hogli build:schema` regenerated `schema.py`/`schema.json` cleanly; the diff is exactly the four `"default": "bottom"` removals + matching `default=None` changes. ruff + `ty check` pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Steven (@slshults) directed the work; root cause was traced and verified before this change.

Built with PostHog Code (Claude Opus). The root cause was confirmed end-to-end (schema default → `filter_to_query` → `model_dump(exclude_none=True)` → persisted on save) before changing anything.

**Decision for the reviewer (@sampennington):** removing the default means **new** insights now also default to `'right'` (via the frontend fallback), not `'bottom'`. If you want new insights to default to bottom, that should be done explicitly at insight-creation time rather than via a schema default that retroactively rewrites legacy insights — deliberately left to you rather than implemented here.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
