### PR TITLE
fix(insights): honor legend position in shared and exported insights

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -2125,9 +2125,9 @@ snapshots:
     exporter-trends--trends-pie-insight-detailed--light:
         hash: v1.k794b7964.4b3dc5c1ac8094d0c48ee7a731279c42e272174094ee092e2ac7779c937aef9c.0NgmX4_0qEgTnWwoI1U6bWc5UH2wqG2HzqQdn6udpv8
     exporter-trends--trends-pie-insight-legend--dark:
-        hash: v1.k794b7964.7c88b9ccf583ff6527b997ac16a63ca9172547b6c56ce9842fc968a4b4fee8a0.3zGT_2mZlZJtpobr6CuQ0q8HeP5vcXPEImGbROHgnd4
+        hash: v1.k794b7964.5ae052d37cb8c02eb89fccc8bb1f5d5f3db4dfd5f3acbb747fbc00947860b21c.DpI8t9Sori5hQblOk_BjR-BB_kFD7PCllrHBgaRV-Ug
     exporter-trends--trends-pie-insight-legend--light:
-        hash: v1.k794b7964.a4aa386a7fccbe94d96d86e259ce76de1080df615b6a3fe3ee14954d39de87ce.ZqMY25Bb78GHUAvNCKmaCt6N9ia-N0U3aTY1QMRGn_w
+        hash: v1.k794b7964.a32d802383ee2bd4dbcdaf895e70eee5674e8d079007c184355ca34e6363d982.CZSGSNjPPbdHQ6MdpqwpC22lTThfTW8RZ1AFIYjSrLk
     exporter-trends--trends-table-breakdown-insight--dark:
         hash: v1.k794b7964.b405c1ec4fac6926a7d94ab64146c3db056e5c5521a9e532dd2cdd663472b24c.ot1LJLLfiQQHdyUE3WZ_LUuEGzLcBYBegDMBTRYNI8s
     exporter-trends--trends-table-breakdown-insight--light:

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.test.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.test.tsx
@@ -43,37 +43,24 @@ function renderExported(legendPosition?: string): HTMLElement {
 }
 
 describe('ExportedInsight legend position', () => {
-    it('places a vertical legend after the chart when position is unset (defaults to right)', () => {
-        const container = renderExported()
+    // position → orientation ('true' = horizontal, for top/bottom) and whether the legend sits
+    // before the chart in document order (top/left) vs after it (bottom/right). Covers all four
+    // positions plus the unset default, which falls back to 'right'.
+    it.each([
+        ['unset (defaults to right)', undefined, 'false', 'after'],
+        ['right', 'right', 'false', 'after'],
+        ['left', 'left', 'false', 'before'],
+        ['bottom', 'bottom', 'true', 'after'],
+        ['top', 'top', 'true', 'before'],
+    ])('places the legend correctly when position is %s', (_desc, position, horizontal, order) => {
+        const container = renderExported(position)
 
         const chart = container.querySelector('[data-testid="chart"]')!
         const legend = container.querySelector('[data-testid="legend"]')!
         expect(chart).not.toBeNull()
         expect(legend).not.toBeNull()
-        // vertical (side) legend
-        expect(legend.getAttribute('data-horizontal')).toBe('false')
-        // legend comes after the chart in document order -> right side
-        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    })
-
-    it('places a horizontal legend below the chart when position is bottom', () => {
-        const container = renderExported('bottom')
-
-        const chart = container.querySelector('[data-testid="chart"]')!
-        const legend = container.querySelector('[data-testid="legend"]')!
-        // horizontal legend
-        expect(legend.getAttribute('data-horizontal')).toBe('true')
-        // legend after the chart -> below
-        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
-    })
-
-    it('places a horizontal legend before the chart when position is top', () => {
-        const container = renderExported('top')
-
-        const chart = container.querySelector('[data-testid="chart"]')!
-        const legend = container.querySelector('[data-testid="legend"]')!
-        expect(legend.getAttribute('data-horizontal')).toBe('true')
-        // legend before the chart -> above
-        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+        expect(legend.getAttribute('data-horizontal')).toBe(horizontal)
+        const relation = order === 'before' ? Node.DOCUMENT_POSITION_PRECEDING : Node.DOCUMENT_POSITION_FOLLOWING
+        expect(chart.compareDocumentPosition(legend) & relation).toBeTruthy()
     })
 })

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.test.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.test.tsx
@@ -1,0 +1,79 @@
+import { render } from '@testing-library/react'
+
+import { ExportedInsight } from '~/exporter/ExportedInsight/ExportedInsight'
+import { SharingConfigurationSettings } from '~/queries/schema/schema-general'
+import { initKeaTests } from '~/test/init'
+import { InsightModel } from '~/types'
+
+// The legend's internal rows need scene/router wiring that the exporter doesn't provide in isolation;
+// we only care here about WHERE the legend lands relative to the chart, so render a marker instead.
+jest.mock('lib/components/InsightLegend/InsightLegend', () => ({
+    InsightLegend: ({ horizontal }: { horizontal?: boolean }) => (
+        <div data-testid="legend" data-horizontal={String(!!horizontal)} />
+    ),
+}))
+// Render the chart as a marker too — the real Query mounts logics we don't need for placement.
+jest.mock('~/queries/Query/Query', () => ({
+    Query: () => <div data-testid="chart" />,
+}))
+
+const trendsLineInsight = require('../../mocks/fixtures/api/projects/team_id/insights/trendsLine.json') as InsightModel
+
+beforeEach(() => {
+    initKeaTests()
+})
+
+function renderExported(legendPosition?: string): HTMLElement {
+    const source = (trendsLineInsight as any).query.source
+    const insight = {
+        ...trendsLineInsight,
+        query: {
+            ...(trendsLineInsight as any).query,
+            source: {
+                ...source,
+                trendsFilter: { ...source.trendsFilter, ...(legendPosition ? { legendPosition } : {}) },
+            },
+        },
+    } as InsightModel
+
+    const exportOptions = { legend: true } as SharingConfigurationSettings
+
+    const { container } = render(<ExportedInsight insight={insight} themes={[]} exportOptions={exportOptions} />)
+    return container
+}
+
+describe('ExportedInsight legend position', () => {
+    it('places a vertical legend after the chart when position is unset (defaults to right)', () => {
+        const container = renderExported()
+
+        const chart = container.querySelector('[data-testid="chart"]')!
+        const legend = container.querySelector('[data-testid="legend"]')!
+        expect(chart).not.toBeNull()
+        expect(legend).not.toBeNull()
+        // vertical (side) legend
+        expect(legend.getAttribute('data-horizontal')).toBe('false')
+        // legend comes after the chart in document order -> right side
+        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('places a horizontal legend below the chart when position is bottom', () => {
+        const container = renderExported('bottom')
+
+        const chart = container.querySelector('[data-testid="chart"]')!
+        const legend = container.querySelector('[data-testid="legend"]')!
+        // horizontal legend
+        expect(legend.getAttribute('data-horizontal')).toBe('true')
+        // legend after the chart -> below
+        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    })
+
+    it('places a horizontal legend before the chart when position is top', () => {
+        const container = renderExported('top')
+
+        const chart = container.querySelector('[data-testid="chart"]')!
+        const legend = container.querySelector('[data-testid="legend"]')!
+        expect(legend.getAttribute('data-horizontal')).toBe('true')
+        // legend before the chart -> above
+        expect(chart.compareDocumentPosition(legend) & Node.DOCUMENT_POSITION_PRECEDING).toBeTruthy()
+    })
+})

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -19,7 +19,7 @@ import { InsightsTable } from 'scenes/insights/views/InsightsTable/InsightsTable
 import { getQueryBasedInsightModel } from '~/queries/nodes/InsightViz/utils'
 import { Query } from '~/queries/Query/Query'
 import { SharingConfigurationSettings } from '~/queries/schema/schema-general'
-import { isDataTableNode, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
+import { getLegendPosition, isDataTableNode, isInsightVizNode, isTrendsQuery } from '~/queries/utils'
 import { ChartDisplayType, DataColorThemeModel, InsightLogicProps, InsightModel } from '~/types'
 
 export function ExportedInsight({
@@ -77,6 +77,21 @@ export function ExportedInsight({
         isTrendsQuery(query.source) &&
         !DISPLAY_TYPES_WITHOUT_DETAILED_RESULTS.includes(query.source.trendsFilter?.display as ChartDisplayType)
 
+    // Match the in-app default fallback of 'right' when the position is unset.
+    const legendPosition = (isInsightVizNode(query) ? getLegendPosition(query.source) : undefined) ?? 'right'
+    const legendIsHorizontal = legendPosition === 'top' || legendPosition === 'bottom'
+    const legendBeforeChart = legendPosition === 'top' || legendPosition === 'left'
+
+    const legendElement = showLegend ? (
+        <div className={clsx(legendIsHorizontal ? 'p-4' : 'p-4 flex items-center')}>
+            {isBoxPlot ? (
+                <BoxPlotLegend horizontal={legendIsHorizontal} />
+            ) : (
+                <InsightLegend horizontal={legendIsHorizontal} readOnly />
+            )}
+        </div>
+    ) : null
+
     return (
         <BindLogic logic={insightLogic} props={insightLogicProps}>
             <div className="ExportedInsight">
@@ -106,19 +121,20 @@ export function ExportedInsight({
                         'ExportedInsight__content--with-watermark': showWatermark,
                     })}
                 >
-                    <Query
-                        query={insight.query}
-                        cachedResults={insight}
-                        readOnly
-                        context={{ insightProps: insightLogicProps }}
-                        embedded
-                        inSharedMode
-                    />
-                    {showLegend && (
-                        <div className="p-4">
-                            {isBoxPlot ? <BoxPlotLegend horizontal /> : <InsightLegend horizontal readOnly />}
+                    <div className={clsx('flex', legendIsHorizontal ? 'flex-col' : 'flex-row items-start')}>
+                        {legendBeforeChart && legendElement}
+                        <div className="flex-1 min-w-0">
+                            <Query
+                                query={insight.query}
+                                cachedResults={insight}
+                                readOnly
+                                context={{ insightProps: insightLogicProps }}
+                                embedded
+                                inSharedMode
+                            />
                         </div>
-                    )}
+                        {!legendBeforeChart && legendElement}
+                    </div>
                     {showDetailedResultsTable && (
                         <div className="border-t mt-2">
                             <InsightsTable filterKey={short_id} isLegend embedded editMode={false} />

--- a/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
+++ b/frontend/src/exporter/ExportedInsight/ExportedInsight.tsx
@@ -92,6 +92,21 @@ export function ExportedInsight({
         </div>
     ) : null
 
+    // Only a left/right legend needs the flex-row + flex-1 wrapper. No legend and top/bottom legends
+    // render exactly as before (chart as a direct child, horizontal legend above/below), so those
+    // exports are visually unchanged.
+    const legendOnSide = showLegend && !legendIsHorizontal
+    const queryElement = (
+        <Query
+            query={insight.query}
+            cachedResults={insight}
+            readOnly
+            context={{ insightProps: insightLogicProps }}
+            embedded
+            inSharedMode
+        />
+    )
+
     return (
         <BindLogic logic={insightLogic} props={insightLogicProps}>
             <div className="ExportedInsight">
@@ -121,20 +136,19 @@ export function ExportedInsight({
                         'ExportedInsight__content--with-watermark': showWatermark,
                     })}
                 >
-                    <div className={clsx('flex', legendIsHorizontal ? 'flex-col' : 'flex-row items-start')}>
-                        {legendBeforeChart && legendElement}
-                        <div className="flex-1 min-w-0">
-                            <Query
-                                query={insight.query}
-                                cachedResults={insight}
-                                readOnly
-                                context={{ insightProps: insightLogicProps }}
-                                embedded
-                                inSharedMode
-                            />
+                    {legendOnSide ? (
+                        <div className="flex flex-row items-start">
+                            {legendBeforeChart && legendElement}
+                            <div className="flex-1 min-w-0">{queryElement}</div>
+                            {!legendBeforeChart && legendElement}
                         </div>
-                        {!legendBeforeChart && legendElement}
-                    </div>
+                    ) : (
+                        <>
+                            {legendBeforeChart && legendElement}
+                            {queryElement}
+                            {!legendBeforeChart && legendElement}
+                        </>
+                    )}
                     {showDetailedResultsTable && (
                         <div className="border-t mt-2">
                             <InsightsTable filterKey={short_id} isLegend embedded editMode={false} />


### PR DESCRIPTION
## Problem

Shared and embedded insights (rendered by the exporter) always drew the legend **horizontally below** the chart, ignoring the insight's configured `legendPosition`. So an insight whose legend sits on the right in-app would show it at the bottom in every shared link / embed — an inconsistency that a heavy-sharing customer notices immediately.

## Changes

`ExportedInsight` now reads `legendPosition` via the existing `getLegendPosition(query.source)` helper (treating unset as `'right'`, matching the in-app fallback) and places the legend accordingly:

- `'bottom'` / `'top'` — horizontal legend below / above the chart (`flex-col`).
- `'right'` / `'left'` — vertical (side) legend after / before the chart (`flex-row items-start`); the chart sits in a `flex-1 min-w-0` wrapper so it keeps its size and the legend takes its natural width.

Presentation-only: the show/hide, detailed-results, watermark, and header gating are all unchanged — only where/how the legend renders when shown.

## How did you test this code?

I'm an agent (PostHog Code). Automated only:

- Added `ExportedInsight.test.tsx` — three render cases asserting placement: unset → vertical legend after the chart (right), `'bottom'` → horizontal legend after the chart, `'top'` → horizontal legend before the chart. One top-level `describe`, no snapshots; `InsightLegend`/`Query` mocked to placement markers. All 3 pass.
- oxlint clean, oxfmt no-op.

⚠️ **Visual review:** the story `TrendsPieInsightLegend` (`ExporterTrends.stories.tsx`) is not `test-skip` and its fixture has no `legendPosition`, so its legend now moves from below the chart to the right — its snapshot will need regenerating/approving in the VR run. (`TrendsLineInsightLegend` is `test-skip`, unaffected.)

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Steven (@slshults) directed the work.

Built with PostHog Code (Claude Opus). Companion to #66484 (which removes the schema default that was contaminating saved `legendPosition`); this PR makes the *shared/embedded* render honor whatever position the insight has, so in-app and shared views match.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
