### PR TITLE
refactor(integrations): update GitHub/Slack integration URLs from settings to dedicated routes

### DIFF
--- a/docs/internal/sandboxes-setup-guide.md
+++ b/docs/internal/sandboxes-setup-guide.md
@@ -51,7 +51,7 @@ Steps:
    this is required (added a couple of releases back). If your local setup
    stopped working recently, this is most likely what's missing.
 7. Generate a private key
-8. Install the app on your test repositories by going to `http://localhost:8010/project/1/settings/project-integrations` and installing the GitHub Integration
+8. Install the app on your test repositories by going to `http://localhost:8010/project/1/integrations/github` and installing the GitHub Integration
 9. Add to your `.env`:
 
 ```bash

--- a/posthog/api/github_callback/README.md
+++ b/posthog/api/github_callback/README.md
@@ -77,7 +77,7 @@ newlines. `GITHUB_APP_SLUG` and `GITHUB_WEBHOOK_SECRET` are instance settings
 Env vars alone create nothing — you must complete the install flow:
 
 1. Start the stack via `bin/start` / `hogli start`.
-2. Go to `http://localhost:8010/project/<id>/settings/project-integrations`.
+2. Go to `http://localhost:8010/project/<id>/integrations/github`.
 3. Connect **GitHub Integration** → you're sent to
    `github.com/apps/<slug>/installations/new`.
 4. Install the App on the account/org that owns your target repos.

--- a/posthog/api/github_callback/redirects.py
+++ b/posthog/api/github_callback/redirects.py
@@ -34,7 +34,7 @@ def landing_url(next_url: str | None, team_id: int | None) -> str:
         return next_url
     if team_id is not None:
         return f"/project/{team_id}/integrations/github"
-    return "/integrationg/github"
+    return "/integrations/github"
 
 
 def redirect_from_finish_result(result: FinishResult) -> HttpResponseRedirect:

--- a/posthog/api/github_callback/redirects.py
+++ b/posthog/api/github_callback/redirects.py
@@ -33,8 +33,8 @@ def landing_url(next_url: str | None, team_id: int | None) -> str:
     if next_url and is_relative_url(next_url):
         return next_url
     if team_id is not None:
-        return f"/project/{team_id}/settings/project-integrations"
-    return "/settings/environment-integrations"
+        return f"/project/{team_id}/integrations/github"
+    return "/integrationg/github"
 
 
 def redirect_from_finish_result(result: FinishResult) -> HttpResponseRedirect:

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -2150,14 +2150,14 @@ class TestGitHubTeamIntegrationComplete:
 
     def test_github_error_redirects_with_setup_error(self, client: HttpClient):
         client.force_login(self.user)
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         store_unified_authorize_state(
             GitHubAuthorizeState(
                 token="t",
                 flow=FlowKind.TEAM_INSTALL,
                 user_id=self.user.id,
                 team_id=self.team.pk,
-                next_url=next_path or None,
+                next_url=next_path,
             ),
         )
 
@@ -2165,7 +2165,7 @@ class TestGitHubTeamIntegrationComplete:
 
         assert response.status_code == status.HTTP_302_FOUND
         assert "github_setup_error=access_denied" in response["Location"]
-        assert f"project/{self.team.pk}/settings/project-integrations" in response["Location"]
+        assert next_path in response["Location"]
 
     @override_settings(GITHUB_APP_CLIENT_ID="client_id", SITE_URL="https://us.posthog.com")
     def test_team_install_via_oauth_callback_routes_to_team_not_personal(self, client: HttpClient):
@@ -2203,14 +2203,14 @@ class TestGitHubTeamIntegrationComplete:
 
     def test_missing_installation_id_redirects_pending(self, client: HttpClient):
         client.force_login(self.user)
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         store_unified_authorize_state(
             GitHubAuthorizeState(
                 token="t",
                 flow=FlowKind.TEAM_INSTALL,
                 user_id=self.user.id,
                 team_id=self.team.pk,
-                next_url=next_path or None,
+                next_url=next_path,
             ),
         )
 
@@ -2271,7 +2271,7 @@ class TestGitHubTeamIntegrationComplete:
 
         # No valid authorize state — the member supplies the team via the user-controlled `state` `next`,
         # which resolves team_id purely from the path. Membership alone must not let them complete it.
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         response = client.get(
             "/integrations/github/callback/",
             {
@@ -2385,9 +2385,7 @@ class TestGitHubTeamIntegrationComplete:
         # flow-based routing the forged `next` would otherwise reach team setup and pass its admin gate.
         client.force_login(self.user)
         state_token = "personal-install-token"
-        forged_state = urlencode(
-            {"token": state_token, "next": f"/project/{self.team.pk}/settings/project-integrations"}
-        )
+        forged_state = urlencode({"token": state_token, "next": f"/project/{self.team.pk}/integrations/github"})
         store_unified_authorize_state(
             GitHubAuthorizeState(token=state_token, flow=FlowKind.PERSONAL_INSTALL, user_id=self.user.id),
         )
@@ -2479,7 +2477,7 @@ class TestGitHubTeamIntegrationComplete:
         )
 
         assert response.status_code == status.HTTP_302_FOUND
-        assert f"project/{self.team.pk}/settings/project-integrations" in response["Location"]
+        assert f"project/{self.team.pk}/integrations/github" in response["Location"]
         assert "integration_id=" in response["Location"]
         assert "github_setup_error" not in response["Location"]
         mock_refresh.assert_called_once_with("12345", self.team.pk, self.user)
@@ -2576,14 +2574,14 @@ class TestGitHubTeamIntegrationComplete:
 
     def test_install_callback_without_state_redirects_invalid_state(self, client: HttpClient):
         client.force_login(self.user)
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         store_unified_authorize_state(
             GitHubAuthorizeState(
                 token="valid-token",
                 flow=FlowKind.TEAM_INSTALL,
                 user_id=self.user.id,
                 team_id=self.team.pk,
-                next_url=next_path or None,
+                next_url=next_path,
             ),
         )
 
@@ -2599,7 +2597,7 @@ class TestGitHubTeamIntegrationComplete:
     def test_orphan_installation_update_redirects_to_oauth(self, mock_build_oauth_url, client: HttpClient):
         mock_build_oauth_url.return_value = "https://github.com/login/oauth/authorize?client_id=test"
         client.force_login(self.user)
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         state_token = "orphan-token"
         store_unified_authorize_state(
             GitHubAuthorizeState(
@@ -2607,7 +2605,7 @@ class TestGitHubTeamIntegrationComplete:
                 flow=FlowKind.TEAM_INSTALL,
                 user_id=self.user.id,
                 team_id=self.team.pk,
-                next_url=next_path or None,
+                next_url=next_path,
             ),
         )
 
@@ -2631,7 +2629,7 @@ class TestGitHubTeamIntegrationComplete:
         attacker = User.objects.create_and_join(
             self.organization, "attacker@posthog.com", "test", level=OrganizationMembership.Level.ADMIN
         )
-        next_path = f"/project/{self.team.pk}/settings/project-integrations"
+        next_path = f"/project/{self.team.pk}/integrations/github"
         state_token = "victim-token"
         store_unified_authorize_state(
             GitHubAuthorizeState(
@@ -2639,7 +2637,7 @@ class TestGitHubTeamIntegrationComplete:
                 flow=FlowKind.TEAM_INSTALL,
                 user_id=self.user.id,
                 team_id=self.team.pk,
-                next_url=next_path or None,
+                next_url=next_path,
             ),
         )
 

--- a/posthog/api/test/test_user_integration.py
+++ b/posthog/api/test/test_user_integration.py
@@ -739,7 +739,7 @@ class TestUserIntegrationEndpoints(APIBaseTest):
                 user_id=self.user.id,
                 team_id=self.team.pk,
                 installation_id="12345",
-                next_url="/project/{}/settings/project-integrations".format(self.team.pk),
+                next_url="/project/{}/integrations/github".format(self.team.pk),
             ),
         )
 
@@ -756,7 +756,7 @@ class TestUserIntegrationEndpoints(APIBaseTest):
         mock_integration_from_install.assert_called_once_with("12345", self.team.pk, self.user)
         # Redirected back to the requested ``next`` URL with the install/integration ids appended.
         location = response["Location"]
-        self.assertIn(f"/project/{self.team.pk}/settings/project-integrations", location)
+        self.assertIn(f"/project/{self.team.pk}/integrations/github", location)
         self.assertIn("installation_id=12345", location)
         self.assertIn(f"integration_id={team_integration.id}", location)
 

--- a/products/conversations/frontend/scenes/settings/GithubSection.tsx
+++ b/products/conversations/frontend/scenes/settings/GithubSection.tsx
@@ -47,9 +47,9 @@ function GithubConnectionSection(): JSX.Element {
                         First, install the PostHog GitHub App from the integrations page, then come back here to select
                         which repositories to monitor.
                     </p>
-                    <Link to="/settings/project-integrations" className="mt-1">
+                    <Link to="/integrations/github" className="mt-1">
                         <LemonButton type="primary" size="small" disabledReason={adminRestrictionReason}>
-                            Go to integrations
+                            Go to GitHub integration
                         </LemonButton>
                     </Link>
                 </div>

--- a/products/signals/backend/management/commands/create_github_app.py
+++ b/products/signals/backend/management/commands/create_github_app.py
@@ -329,7 +329,7 @@ class Command(BaseCommand):
         self.stdout.write("")
         self.stdout.write("Next steps:")
         self.stdout.write(f"  1. Install it on your test repos: https://github.com/apps/{slug}/installations/new")
-        self.stdout.write(f"     (or via PostHog: {base_url.rstrip('/')}/project/1/settings/project-integrations)")
+        self.stdout.write(f"     (or via PostHog: {base_url.rstrip('/')}/project/1/integrations/github)")
         self.stdout.write("  2. Restart your dev server so it picks up the new .env values.")
 
     def _verify_key(self, client_id: str, pem: str) -> None:

--- a/products/slack_app/backend/api.py
+++ b/products/slack_app/backend/api.py
@@ -1208,7 +1208,7 @@ def _notify_missing_slack_scopes(
     if not channel or not thread_ts or not slack_user_id:
         return
 
-    settings_url = f"{settings.SITE_URL}/settings/project-integrations"
+    settings_url = f"{settings.SITE_URL}/integrations/slack"
     text = (
         ":warning: PostHog can't reply because the Slack integration is missing required "
         f"permissions: `{', '.join(sorted(missing))}`.\n"

--- a/products/tasks/backend/max_tools.py
+++ b/products/tasks/backend/max_tools.py
@@ -525,7 +525,7 @@ Use this tool when the user wants to:
         if not repos:
             if search:
                 return f"No repositories found matching '{search}'", {"repositories": []}
-            settings_url = "/settings/project-integrations"
+            settings_url = "/integrations/github"
             return (
                 f"No GitHub repositories available. Please connect a GitHub integration in Settings: {settings_url}",
                 {"repositories": [], "settings_url": settings_url},

--- a/products/tasks/backend/tests/test_max_tools.py
+++ b/products/tasks/backend/tests/test_max_tools.py
@@ -807,9 +807,9 @@ class TestListRepositoriesTool(BaseTaskToolTest):
         content, artifact = await tool._arun_impl()
 
         assert "No GitHub repositories available" in content
-        assert "/settings/project-integrations" in content
+        assert "/integrations/github" in content
         assert artifact["repositories"] == []
-        assert artifact["settings_url"] == "/settings/project-integrations"
+        assert artifact["settings_url"] == "/integrations/github"
 
     @patch("posthog.models.integration.GitHubIntegration")
     @pytest.mark.django_db
@@ -963,9 +963,9 @@ class TestListRepositoriesTool(BaseTaskToolTest):
         content, artifact = await tool._arun_impl()
 
         assert "No GitHub repositories available" in content
-        assert "/settings/project-integrations" in content
+        assert "/integrations/github" in content
         assert artifact["repositories"] == []
-        assert artifact["settings_url"] == "/settings/project-integrations"
+        assert artifact["settings_url"] == "/integrations/github"
 
     @patch("posthog.models.integration.GitHubIntegration")
     @pytest.mark.django_db
@@ -992,6 +992,6 @@ class TestListRepositoriesTool(BaseTaskToolTest):
         content, artifact = await tool._arun_impl()
 
         assert "No GitHub repositories available" in content
-        assert "/settings/project-integrations" in content
+        assert "/integrations/github" in content
         assert artifact["repositories"] == []
-        assert artifact["settings_url"] == "/settings/project-integrations"
+        assert artifact["settings_url"] == "/integrations/github"


### PR DESCRIPTION
Updates all references to the old `/settings/project-integrations` path to use the new dedicated integration-specific routes (`/integrations/github` and `/integrations/slack`). This affects redirect targets in the GitHub OAuth callback flow, documentation, management command output, the Conversations GitHub section link and button label, the Max tools GitHub repository listing, and the Slack missing-scopes notification URL. Also cleans up redundant `or None` expressions in test state construction.
