### PR TITLE
feat(devenv): add `default_group` so sidebar starts grouped by layer

### DIFF
--- a/bin/mprocs.yaml
+++ b/bin/mprocs.yaml
@@ -571,8 +571,11 @@ procs:
         shell: 'bin/wait-for-docker && bin/wait-for-postgres-tables posthog_featureflag posthog_personalapikey posthog_oauthapplication && bin/ensure-local-setup'
         capability: core_infra
         ready_pattern: 'Local setup complete'
+        # Unlike the other Tools-layer entries (manual `autostart: false` utilities), this one
+        # must run automatically every startup to keep local dev bootstrapped.
+        autostart: true
         groups:
-            layer: Infrastructure
+            layer: Tools
             tech: Setup
 
     migrate-clickhouse:
@@ -705,6 +708,9 @@ procs:
             layer: Tools
             tech: Python
         # no capability - manual start
+
+# Grouping dimension the sidebar starts grouped by (press `g` to cycle/disable).
+default_group: layer
 
 group_order:
     layer: [Application, Processing, Ingestion pipeline, Infrastructure, Product services, Tools]

--- a/tools/hogli-commands/hogli_commands/devenv/generator.py
+++ b/tools/hogli-commands/hogli_commands/devenv/generator.py
@@ -93,6 +93,7 @@ class MprocsConfig(BaseModel):
 
     procs: dict[str, dict[str, Any]]
     group_order: dict[str, list[str]] = {}  # display order per grouping dimension
+    default_group: str = ""  # grouping dimension the sidebar starts grouped by ("" = ungrouped)
     mouse_scroll_speed: int = 1
     scrollback: int = 10000
     posthog_config: DevenvConfig | None = None  # embedded source config
@@ -105,6 +106,8 @@ class MprocsConfig(BaseModel):
         result["procs"] = self.procs
         if self.group_order:
             result["group_order"] = self.group_order
+        if self.default_group:
+            result["default_group"] = self.default_group
         result["mouse_scroll_speed"] = self.mouse_scroll_speed
         result["scrollback"] = self.scrollback
         return result
@@ -212,6 +215,7 @@ class MprocsGenerator(ConfigGenerator):
         return MprocsConfig(
             procs=procs,
             group_order=global_settings.get("group_order", {}),
+            default_group=global_settings.get("default_group", ""),
             mouse_scroll_speed=global_settings.get("mouse_scroll_speed", 1),
             scrollback=global_settings.get("scrollback", 10000),
             posthog_config=source_config,

--- a/tools/hogli-commands/hogli_commands/tests/test_devenv.py
+++ b/tools/hogli-commands/hogli_commands/tests/test_devenv.py
@@ -14,7 +14,7 @@ import pytest
 from unittest import mock
 
 import yaml
-from hogli_commands.devenv.generator import DevenvConfig, MprocsGenerator, load_devenv_config
+from hogli_commands.devenv.generator import DevenvConfig, MprocsConfig, MprocsGenerator, load_devenv_config
 from hogli_commands.devenv.registry import ProcessRegistry, create_mprocs_registry
 from hogli_commands.devenv.resolver import Capability, Intent, IntentMap, IntentResolver, load_intent_map
 from hogli_commands.devenv.wizard import _parse_exclude_input
@@ -521,6 +521,16 @@ class TestMprocsRegistry:
 
         assert not orphans, f"procs declare capabilities not defined in intent-map.yaml: {orphans}"
 
+    def test_default_group_is_an_enabled_grouping_dimension(self) -> None:
+        """The sidebar starts grouped by default, and default_group must name a real dimension."""
+        settings = create_mprocs_registry().get_global_settings()
+
+        default_group = settings.get("default_group")
+        assert default_group, "default_group must be set so the sidebar starts grouped"
+        assert default_group in settings.get("group_order", {}), (
+            "default_group must be a configured group_order dimension"
+        )
+
 
 class TestDevenvConfig:
     """Test DevenvConfig data class."""
@@ -558,6 +568,34 @@ class TestDevenvConfig:
 
         assert restored.intents == original.intents
         assert restored.exclude_units == original.exclude_units
+
+
+class TestMprocsConfigSerialization:
+    """Test MprocsConfig.to_yaml_dict output."""
+
+    def test_default_group_emitted_when_set(self) -> None:
+        result = MprocsConfig(procs={}, default_group="layer").to_yaml_dict()
+        assert result["default_group"] == "layer"
+
+    def test_default_group_omitted_when_empty(self) -> None:
+        result = MprocsConfig(procs={}).to_yaml_dict()
+        assert "default_group" not in result
+
+    def test_generator_propagates_default_group_from_registry(self) -> None:
+        """default_group set in the registry's global settings reaches the generated config."""
+        intent_map = create_test_intent_map()
+        registry = create_test_registry()
+
+        def mock_get_global_settings(self):
+            return {"default_group": "layer", "group_order": {"layer": ["A"]}}
+
+        registry.get_global_settings = mock_get_global_settings.__get__(registry, type(registry))  # type: ignore
+
+        resolved = IntentResolver(intent_map, registry).resolve(["error_tracking"])
+        config = MprocsGenerator(registry).generate(resolved)
+
+        assert config.default_group == "layer"
+        assert config.to_yaml_dict()["default_group"] == "layer"
 
 
 class TestConfigPersistence:

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -119,6 +119,7 @@ Prefers `htop` (tree view + PID filter), falls back to `btop` (unfiltered), then
 
 Press `g` to cycle through grouping dimensions defined in the config.
 Each process can declare a `groups` map and an optional top-level `group_order` controls display order.
+The top-level `default_group` names the dimension the sidebar starts grouped by (omit it to start ungrouped).
 See `bin/mprocs.yaml` for the config format.
 
 Processes without a matching group appear under Ungrouped.

--- a/tools/phrocs/internal/config/config.go
+++ b/tools/phrocs/internal/config/config.go
@@ -38,7 +38,8 @@ func (p ProcConfig) ShouldAutostart() bool {
 type Config struct {
 	Shell            string                `yaml:"shell"`
 	Procs            map[string]ProcConfig `yaml:"procs"`
-	GroupOrder       map[string][]string   `yaml:"group_order"` // display order per dimension
+	GroupOrder       map[string][]string   `yaml:"group_order"`   // display order per dimension
+	DefaultGroup     string                `yaml:"default_group"` // grouping dimension active on startup ("" = ungrouped)
 	HideKeymapWindow bool                  `yaml:"hide_keymap_window"`
 	MouseScrollSpeed int                   `yaml:"mouse_scroll_speed"`
 	ProcListWidth    int                   `yaml:"proc_list_width"`

--- a/tools/phrocs/internal/tui/app.go
+++ b/tools/phrocs/internal/tui/app.go
@@ -144,6 +144,7 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 	h := help.New()
 	h.Styles = helpStyles()
 
+	dims := groupDimensions(cfg)
 	m := Model{
 		mgr:              mgr,
 		services:         mgr.Procs(),
@@ -157,8 +158,8 @@ func New(mgr *process.Manager, cfg *config.Config, configPath string, logger *lo
 		procListWidth:    cfg.ProcListWidth,
 		configPath:       configPath,
 		cfg:              cfg,
-		groupDims:        groupDimensions(cfg),
-		groupDimIndex:    -1,
+		groupDims:        dims,
+		groupDimIndex:    initialGroupDimIndex(dims, cfg.DefaultGroup),
 		keys:             keys,
 		help:             h,
 		spinner:          spinner.New(spinner.WithSpinner(spinner.MiniDot)),

--- a/tools/phrocs/internal/tui/group.go
+++ b/tools/phrocs/internal/tui/group.go
@@ -59,6 +59,21 @@ func groupDimensions(cfg *config.Config) []string {
 	return dims
 }
 
+// initialGroupDimIndex resolves the config's default_group dimension to an
+// index into dims. Returns -1 (no grouping) when default_group is unset or
+// names a dimension that isn't available.
+func initialGroupDimIndex(dims []string, defaultGroup string) int {
+	if defaultGroup == "" {
+		return -1
+	}
+	for i, d := range dims {
+		if d == defaultGroup {
+			return i
+		}
+	}
+	return -1
+}
+
 // groupOrderFor returns the display order for a given dimension.
 // If group_order is configured, uses that. Otherwise discovers groups from
 // processes in the order they first appear.

--- a/tools/phrocs/internal/tui/group_test.go
+++ b/tools/phrocs/internal/tui/group_test.go
@@ -368,6 +368,30 @@ func TestGroupDimensions(t *testing.T) {
 	}
 }
 
+// ── initialGroupDimIndex ─────────────────────────────────────────────────────
+
+func TestInitialGroupDimIndex(t *testing.T) {
+	dims := []string{"layer", "tech", "capability"}
+	cases := []struct {
+		name         string
+		defaultGroup string
+		want         int
+	}{
+		{"unset is ungrouped", "", -1},
+		{"first dimension", "layer", 0},
+		{"middle dimension", "tech", 1},
+		{"last dimension", "capability", 2},
+		{"unknown dimension is ungrouped", "team", -1},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := initialGroupDimIndex(dims, tc.defaultGroup); got != tc.want {
+				t.Errorf("initialGroupDimIndex(%v, %q) = %d, want %d", dims, tc.defaultGroup, got, tc.want)
+			}
+		})
+	}
+}
+
 // ── TUI integration ──────────────────────────────────────────────────────────
 
 func readyGroupModel(t *testing.T) Model {
@@ -411,6 +435,36 @@ func TestGroup_cycleWithG(t *testing.T) {
 	m = update(m, keypress('g'))
 	if m.isGrouped() {
 		t.Errorf("after third g: should be ungrouped, got %q", m.activeGroupDim())
+	}
+}
+
+func TestGroup_defaultGroupStartsGrouped(t *testing.T) {
+	f := false
+	cfg := &config.Config{
+		Procs: map[string]config.ProcConfig{
+			"backend":  {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "Application"}},
+			"capture":  {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "Ingestion"}},
+			"frontend": {Shell: "echo", Autostart: &f, Groups: map[string]string{"layer": "Application"}},
+		},
+		DefaultGroup:     "layer",
+		MouseScrollSpeed: 3,
+		Scrollback:       1000,
+		GroupOrder:       map[string][]string{"layer": {"Application", "Ingestion"}},
+	}
+	mgr := process.NewManager(cfg)
+	m := New(mgr, cfg, "", nil)
+	next, _ := m.Update(tea.WindowSizeMsg{Width: 120, Height: 40})
+	m = next.(Model)
+
+	if !m.isGrouped() {
+		t.Fatal("default_group set: model should start grouped")
+	}
+	if m.activeGroupDim() != "layer" {
+		t.Errorf("default_group: got %q, want layer", m.activeGroupDim())
+	}
+	// Cursor must land on a real process, never a header.
+	if m.sidebarEntries[m.entryCursor].isNonSelectable() {
+		t.Error("entryCursor landed on a non-selectable entry on startup")
 	}
 }
 


### PR DESCRIPTION
Adds a `default_group` config field to phrocs and the mprocs generator so the sidebar starts in a grouped state rather than ungrouped on every launch.

Previously, the sidebar always started ungrouped regardless of any `group_order` configuration, requiring users to manually press `g` to enable grouping. With this change, setting `default_group: layer` (or any configured grouping dimension) in `bin/mprocs.yaml` causes the sidebar to open already grouped by that dimension.

The `ensure-local-setup` process is also moved from the Infrastructure layer to the Tools layer (with `autostart: true` to preserve its automatic startup behavior), and `default_group: layer` is set in `bin/mprocs.yaml` so local dev environments open with processes grouped by layer by default.

**Changes include:**
- New `default_group` YAML field in the phrocs `Config` struct, resolved to an index into the available grouping dimensions at startup via `initialGroupDimIndex`
- `MprocsConfig` model and generator updated to read, store, and emit `default_group`
- A validation test ensuring `default_group` names a real configured dimension
- Serialization tests confirming `default_group` is emitted when set and omitted when empty
- `README.md` updated to document the new field