### PR TITLE
fix(stripe): drain all split batcher chunks before batching next item

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/stripe.py
@@ -413,7 +413,10 @@ def get_rows(
                             }
                         )
 
-                        if batcher.should_yield():
+                        # A single batch can split into several ready chunks, so drain them all
+                        # before batching the next item — otherwise the next batch() trips the
+                        # "table already ready" guard.
+                        while batcher.should_yield():
                             py_table = batcher.get_table()
                             yield py_table
 
@@ -437,14 +440,14 @@ def get_rows(
             for obj in stripe_objects.auto_paging_iter():
                 batcher.batch(obj)
 
-                if batcher.should_yield():
+                while batcher.should_yield():
                     py_table = batcher.get_table()
                     yield py_table
 
                     last_cur = py_table.column("id")[-1].as_py()
                     resumable_source_manager.save_state(StripeResumeConfig(starting_after=last_cur))
 
-        if batcher.should_yield(include_incomplete_chunk=True):
+        while batcher.should_yield(include_incomplete_chunk=True):
             py_table = batcher.get_table()
             yield py_table
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -399,6 +399,39 @@ class TestStripeBatcherDrainsSplitChunks:
 
         assert [row["id"] for row in rows] == [f"cbt_{i}" for i in range(6)]
 
+    def test_final_incomplete_chunk_drain_splits(self):
+        # The final drain takes a different path: get_table() flushes the leftover buffer and can
+        # itself produce multiple chunks. A large chunk_size keeps every row in the buffer until the
+        # end, so all rows go through that final drain — which must drain every split chunk.
+        objects = [{"id": f"ch_{i}", "description": "z" * 10} for i in range(4)]
+        resource = StripeResource(method=lambda params: cast(ListObject[Any], _FakeStripeList(objects)))
+
+        resumable_source_manager = MagicMock()
+        resumable_source_manager.can_resume.return_value = False
+
+        splitting_batcher = functools.partial(
+            stripe_module.Batcher, chunk_size=100, max_table_bytes=1, max_column_offset_bytes=1
+        )
+
+        with (
+            patch.object(stripe_module, "StripeClient"),
+            patch.object(stripe_module, "Batcher", splitting_batcher),
+            patch.object(stripe_module, "_build_resources", return_value={"charge": resource}),
+        ):
+            rows: list[dict] = []
+            for table in get_rows(
+                api_key="sk_test_123",
+                endpoint="charge",
+                account_id=None,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                logger=MagicMock(),
+                resumable_source_manager=resumable_source_manager,
+            ):
+                rows.extend(table.to_pylist())
+
+        assert [row["id"] for row in rows] == [f"ch_{i}" for i in range(4)]
+
 
 class TestCustomerMightHaveBalanceTransactions:
     @pytest.mark.parametrize(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/stripe/tests/test_stripe_source.py
@@ -1,3 +1,4 @@
+import functools
 from typing import Any, cast
 
 import pytest
@@ -346,6 +347,57 @@ class TestSubscriptionPageSize:
             )
 
         assert captured["limit"] == SUBSCRIPTION_PAGE_LIMIT
+
+
+class TestStripeBatcherDrainsSplitChunks:
+    def test_flat_resource_drains_all_split_chunks_per_batch(self):
+        # A single batch() can split a flushed buffer into several ready chunks (large rows over the
+        # per-table byte cap). get_rows must drain every chunk before batching the next object,
+        # otherwise the following batch() raises "Batcher already has a table ready to yield."
+        objects = [{"id": f"ch_{i}", "description": "x" * 10} for i in range(6)]
+        resource = StripeResource(method=lambda params: cast(ListObject[Any], _FakeStripeList(objects)))
+
+        resumable_source_manager = MagicMock()
+        resumable_source_manager.can_resume.return_value = False
+
+        # Tiny caps force every 2-row buffer flush to split into single-row chunks.
+        splitting_batcher = functools.partial(
+            stripe_module.Batcher, chunk_size=2, max_table_bytes=1, max_column_offset_bytes=1
+        )
+
+        with (
+            patch.object(stripe_module, "StripeClient"),
+            patch.object(stripe_module, "Batcher", splitting_batcher),
+            patch.object(stripe_module, "_build_resources", return_value={"charge": resource}),
+        ):
+            rows: list[dict] = []
+            for table in get_rows(
+                api_key="sk_test_123",
+                endpoint="charge",
+                account_id=None,
+                db_incremental_field_last_value=None,
+                db_incremental_field_earliest_value=None,
+                logger=MagicMock(),
+                resumable_source_manager=resumable_source_manager,
+            ):
+                rows.extend(table.to_pylist())
+
+        assert [row["id"] for row in rows] == [f"ch_{i}" for i in range(6)]
+
+    def test_nested_resource_drains_all_split_chunks_per_batch(self):
+        nested_objects = [{"id": f"cbt_{i}", "amount": 100, "note": "y" * 10} for i in range(6)]
+
+        def nested_method(customer=None, params=None):
+            return _list_object(nested_objects)
+
+        splitting_batcher = functools.partial(
+            stripe_module.Batcher, chunk_size=2, max_table_bytes=1, max_column_offset_bytes=1
+        )
+
+        with patch.object(stripe_module, "Batcher", splitting_batcher):
+            rows = _run_nested_get_rows(nested_method, parent_objects=[{"id": "cus_1"}])
+
+        assert [row["id"] for row in rows] == [f"cbt_{i}" for i in range(6)]
 
 
 class TestCustomerMightHaveBalanceTransactions:


### PR DESCRIPTION
## Problem

Error tracking surfaced an `Exception` from the Stripe data-warehouse import source ([issue](https://us.posthog.com/project/2/error_tracking/019f0609-f84a-7051-9339-332178b51610)):

```
Exception: Batcher already has a table ready to yield. Call get_table() before batching more items.
```

The stack runs through our own code: `stripe.py:get_rows` → `batcher.py:batch`. This is a fixable bug in our pipeline, not an upstream/user error.

Root cause: `Batcher._set_ready()` runs `_split_table()`, which can place **multiple** chunks into the ready deque when a flushed buffer exceeds the per-table byte/offset cap (the cap that keeps the loader's per-batch merge memory bounded). Each `get_table()` pops only **one** chunk. `get_rows` consumed the batcher with `if batcher.should_yield(): get_table()`, draining a single chunk per object — so after a multi-chunk split, leftover chunks stayed in the deque and the next `batcher.batch()` hit the guard and raised. This only triggers for sources whose rows are large enough to split a buffer flush, which is why it's rare.

## Changes

Drain **all** ready chunks (`while batcher.should_yield()`) before batching the next item, at the three batcher-consume sites in `get_rows` (flat resource loop, nested resource loop, and the final incomplete-chunk drain). Split chunks are ordered row-slices, so yielding them in deque order and saving the resume cursor from each remains correct.

Scoped to the Stripe source — the same `if should_yield()` idiom exists in other sources, but only Stripe is implicated by this issue, so this change stays narrow.

## How did you test this code?

I'm an agent. I added two regression tests in `test_stripe_source.py` (flat and nested resources) that patch the batcher with tiny byte/offset caps to force every buffer flush to split into multiple chunks, then assert `get_rows` yields every row. Both tests fail against the unpatched code with the exact `Batcher already has a table ready to yield` exception and pass with the fix. Ran the full Stripe and batcher suites (84 passed), plus `ruff check`/`ruff format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from the error-tracking issue above. Confirmed the failure originates in `stripe/stripe.py:get_rows` (not just serialized log context), traced it to the `_split_table` multi-chunk behavior in the shared batcher, and chose to fix the consumer idiom in the Stripe source rather than alter the shared batcher contract used by ~20 sources. Checked open PRs (including the maintainer's) for a duplicate — the only other open Stripe import fix targets a different root cause (truncated JSON responses), so this is not a duplicate.
