### PR TITLE
fix(experiments): preserve test-account filter when editing exposure criteria

### DIFF
--- a/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
+++ b/frontend/src/scenes/experiments/ExperimentView/ExposureCriteria.tsx
@@ -111,6 +111,7 @@ export function ExposureCriteriaModal({ onSave }: ExposureCriteriaModalProps): J
                             const entity = events?.[0] || actions?.[0]
                             if (entity) {
                                 setExposureCriteria({
+                                    ...exposureCriteria,
                                     exposure_config: filterToExposureConfig(entity),
                                 })
                             }

--- a/frontend/src/scenes/experiments/ExperimentView/exposureCriteriaModalLogic.ts
+++ b/frontend/src/scenes/experiments/ExperimentView/exposureCriteriaModalLogic.ts
@@ -28,7 +28,7 @@ export const exposureCriteriaModalLogic = kea<exposureCriteriaModalLogicType>([
                 openExposureCriteriaModal: (_, { exposureCriteria }) =>
                     (exposureCriteria ?? NEW_EXPERIMENT.exposure_criteria) as ExperimentExposureCriteria,
                 closeExposureCriteriaModal: () => NEW_EXPERIMENT.exposure_criteria as ExperimentExposureCriteria,
-                setExposureCriteria: (_, { exposureCriteria }) => exposureCriteria,
+                setExposureCriteria: (state, { exposureCriteria }) => ({ ...state, ...exposureCriteria }),
             },
         ],
     }),


### PR DESCRIPTION
## Problem

When editing the exposure criteria of a running experiment, toggling the "Filter out internal and test users" switch was being silently reset to disabled whenever the custom exposure event was changed. A customer reported this repeatedly: they'd enable the toggle, change the exposure criteria, and find the toggle back off after saving.

## Changes

The "Edit exposure criteria" modal builds up a single `exposure_criteria` object. Every control in the modal spreads the existing criteria before updating its own field — except the custom-event picker's `setFilters` handler, which called `setExposureCriteria({ exposure_config: ... })` with no spread. Combined with the modal's reducer *replacing* state rather than merging, changing the exposure event wiped out `filterTestAccounts` (and `multiple_variant_handling`).

Two changes:
- `ExposureCriteria.tsx` — spread `...exposureCriteria` in the event-picker handler, matching the modal's four other controls.
- `exposureCriteriaModalLogic.ts` — make the `setExposureCriteria` reducer merge (`{ ...state, ...exposureCriteria }`) instead of replace, hardening against this whole class of partial-update bug.

The draft-experiment form path was unaffected because it routes through a reducer that already merges — which is likely why this only reproduced on running experiments.

## How did you test this code?

I'm the PostHog Slack app (an agent). I have not run the app or added automated tests for this change — it's a two-line frontend fix. The fix was verified by tracing the call sites: the changed handler now matches the four sibling `setExposureCriteria` calls in the same modal, and the reducer now preserves unrelated fields on partial updates. Manual verification (enable the toggle, change the exposure event, save, confirm the toggle persists) is recommended before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and fixed from a Slack thread via the PostHog Slack app (Claude Code harness). Root-caused to an inconsistent partial-update call site in the exposure-criteria modal plus a non-merging kea reducer. Chose to fix both the specific call site (for consistency with neighboring controls) and the reducer (defense-in-depth) rather than only one, since the reducer fix prevents future regressions of the same shape. No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782495306256109?thread_ts=1782495306.256109&cid=C0ACRAMJUAG)*
