### PR TITLE
fix(resend): treat broadcasts bad request as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
@@ -125,6 +125,16 @@ Grant the key **full access** or a read-enabled access token so the following re
                 "Resend account can't access the Audiences API — enable Audiences in Resend and grant the API key "
                 "full access, or unselect the Audiences and Contacts tables to keep syncing your other Resend data."
             ),
+            # Resend rejects the well-formed list request with a 400 when the connected account
+            # can't access the Broadcasts API (the Marketing/Audiences feature isn't enabled, or
+            # the key lacks full access to broadcasts). Retrying the identical request can't fix an
+            # account-level restriction. Scope the match to the broadcasts path so a 400 from another
+            # endpoint (which could be our bug) stays retryable and visible.
+            "400 Client Error: Bad Request for url: https://api.resend.com/broadcasts": (
+                "Resend rejected the request to sync your Broadcasts. This usually means the connected Resend "
+                "account can't access the Broadcasts API — enable Broadcasts in Resend and grant the API key full "
+                "access, or unselect the Broadcasts table to keep syncing your other Resend data."
+            ),
         }
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ResendResumeConfig]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
@@ -49,9 +49,20 @@ class TestResendSource:
         assert len(matched) == 1
         assert matched[0] is not None and "Audiences" in matched[0]
 
-        # A 400 from a different endpoint could be our bug, so it must stay retryable.
-        emails_error = "400 Client Error: Bad Request for url: https://api.resend.com/emails"
-        assert not any(key in emails_error for key in errors)
+    def test_broadcasts_bad_request_is_non_retryable(self):
+        errors = self.source.get_non_retryable_errors()
+        raised = "400 Client Error: Bad Request for url: https://api.resend.com/broadcasts"
+
+        matched = [message for key, message in errors.items() if key in raised]
+
+        assert len(matched) == 1
+        assert matched[0] is not None and "Broadcasts" in matched[0]
+
+    def test_bad_request_on_other_endpoint_stays_retryable(self):
+        errors = self.source.get_non_retryable_errors()
+        raised = "400 Client Error: Bad Request for url: https://api.resend.com/emails"
+
+        assert not any(key in raised for key in errors)
 
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
@@ -1,5 +1,7 @@
 from unittest import mock
 
+from parameterized import parameterized
+
 from posthog.schema import SourceFieldInputConfig, SourceFieldInputConfigType
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
@@ -49,20 +51,23 @@ class TestResendSource:
         assert len(matched) == 1
         assert matched[0] is not None and "Audiences" in matched[0]
 
-    def test_broadcasts_bad_request_is_non_retryable(self):
+    @parameterized.expand(
+        [
+            ("broadcasts_matches", "https://api.resend.com/broadcasts", True),
+            ("other_endpoint_stays_retryable", "https://api.resend.com/emails", False),
+        ]
+    )
+    def test_broadcasts_bad_request_retryability(self, _name: str, url: str, should_match: bool):
         errors = self.source.get_non_retryable_errors()
-        raised = "400 Client Error: Bad Request for url: https://api.resend.com/broadcasts"
+        raised = f"400 Client Error: Bad Request for url: {url}"
 
         matched = [message for key, message in errors.items() if key in raised]
 
-        assert len(matched) == 1
-        assert matched[0] is not None and "Broadcasts" in matched[0]
-
-    def test_bad_request_on_other_endpoint_stays_retryable(self):
-        errors = self.source.get_non_retryable_errors()
-        raised = "400 Client Error: Bad Request for url: https://api.resend.com/emails"
-
-        assert not any(key in raised for key in errors)
+        if should_match:
+            assert len(matched) == 1
+            assert matched[0] is not None and "Broadcasts" in matched[0]
+        else:
+            assert not matched
 
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a new `HTTPError: 400 Client Error: Bad Request for url: https://api.resend.com/broadcasts` originating in the Resend warehouse source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f064d-1c44-75a2-8385-120b7fad1366)). The stack is unambiguously ours: `get_rows` → `_iter_flat_endpoint` → `_fetch` → `raise_for_status`, hitting several distinct accounts on the broadcasts endpoint specifically.

The `GET /broadcasts` list request takes no query parameters or body and uses valid bearer auth, so the request we send is well-formed. Resend deliberately rejects it with a 400 when the connected account can't access the Broadcasts API (the Marketing/Audiences feature isn't enabled, or the key lacks full access to broadcasts). The send-only-key case is already a 401 (handled); this 400 reflects an account-level restriction.

A 400 is a client-error rejection rather than a transient 5xx/timeout, and retrying the identical well-formed request can never succeed. Today the broadcasts 400 isn't classified as non-retryable, so the activity keeps re-running the whole sync and surfaces an opaque `HTTPError 400` to the user.

## Changes

Add the broadcasts 400 to `ResendSource.get_non_retryable_errors()` with an actionable message telling the user to enable Broadcasts / grant the key full access, or unselect the Broadcasts table to keep syncing their other Resend data. Mirrors the Stripe source's pattern.

The match is scoped to the broadcasts path (`.../broadcasts`), which is stable — the endpoint is parameterless, so the error string carries no ids, cursors, or query args. Scoping to broadcasts means a 400 from another Resend endpoint (which could be our own bug) stays retryable and visible rather than being silently swallowed.

## How did you test this code?

I'm an agent. I added unit tests and ran them — no manual testing.

- `test_broadcasts_bad_request_is_non_retryable` — the raised broadcasts 400 string matches exactly one non-retryable entry, with a non-null Broadcasts-specific message. Catches a regression where the match string drifts from what `requests.raise_for_status()` actually produces, or the message is dropped.
- `test_bad_request_on_other_endpoint_stays_retryable` — a 400 on `/emails` matches no non-retryable entry. Guards the scoping: prevents a future broadening of the rule from swallowing 400s on other endpoints that may be our bug.

Ran the full resend source test directory (35 passed) plus ruff check/format (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the full stack trace and representative events via the PostHog error-tracking MCP tools to confirm the failure originates in `resend.py` (not just serialized log context), then read the Resend errors reference to map the 400 to an account-level Broadcasts-access restriction rather than a malformed request.

Decision: user/upstream condition → extend `NonRetryableErrors` rather than change request shape, since our request is already correct and retrying can't help. Considered a silent graceful-skip but rejected it — the user explicitly selected the Broadcasts table, so a clear surfaced message beats an empty table. Checked open PRs (including the maintainer's own) for a duplicate before opening; none found.
