### PR TITLE
fix(resend): treat audiences bad request as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/source.py
@@ -115,6 +115,16 @@ Grant the key **full access** or a read-enabled access token so the following re
             "403 Client Error: Forbidden for url: https://api.resend.com": (
                 "Your Resend API key does not have the required permissions. Please check the key permissions and try again."
             ),
+            # Resend rejects the well-formed list request with a 400 when the connected account
+            # can't access the Audiences/Contacts API (the Marketing/Audiences feature isn't enabled,
+            # or the key lacks full access). Retrying the identical request can't fix an account-level
+            # restriction. Scope the match to the audiences path so a 400 from another endpoint (which
+            # could be our bug) stays retryable and visible.
+            "400 Client Error: Bad Request for url: https://api.resend.com/audiences": (
+                "Resend rejected the request to sync your Audiences/Contacts. This usually means the connected "
+                "Resend account can't access the Audiences API — enable Audiences in Resend and grant the API key "
+                "full access, or unselect the Audiences and Contacts tables to keep syncing your other Resend data."
+            ),
         }
 
     def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[ResendResumeConfig]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/resend/tests/test_resend_source.py
@@ -40,6 +40,19 @@ class TestResendSource:
         assert any("401" in key for key in errors)
         assert any("403" in key for key in errors)
 
+    def test_audiences_bad_request_is_non_retryable(self):
+        errors = self.source.get_non_retryable_errors()
+        raised = "400 Client Error: Bad Request for url: https://api.resend.com/audiences"
+
+        matched = [message for key, message in errors.items() if key in raised]
+
+        assert len(matched) == 1
+        assert matched[0] is not None and "Audiences" in matched[0]
+
+        # A 400 from a different endpoint could be our bug, so it must stay retryable.
+        emails_error = "400 Client Error: Bad Request for url: https://api.resend.com/emails"
+        assert not any(key in emails_error for key in errors)
+
     def test_get_schemas(self):
         schemas = self.source.get_schemas(self.config, self.team_id)
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError` from the Resend data warehouse source:

```
400 Client Error: Bad Request for url: https://api.resend.com/audiences
```

Issue: https://us.posthog.com/project/2/error_tracking/019f066d-2c7a-7131-9dcd-af0c967a8cba

The stack confirms the failure originates in our source code: `get_rows` → `_iter_contacts_fanout` fetches the parent `/audiences` list as the first step of the `contacts` fan-out, and `_fetch` raises `raise_for_status()` on the 400. (The same `GET /audiences` call backs a direct `audiences` sync too.)

The request is a well-formed read with no query params we control, so there's nothing in the request shape to fix. Resend returns a 400 here when the connected account can't access the Audiences/Contacts API — the Marketing/Audiences feature isn't enabled, or the API key lacks full access. Retrying the identical request can't fix an account-level restriction, so the pipeline keeps retrying and re-raising the same error.

This mirrors the existing `/broadcasts` case (#66496) — same source, same "well-formed list request rejected because the account can't access the feature" shape, a different endpoint.

## Changes

Add the `/audiences` 400 to `ResendSource.get_non_retryable_errors()` with a message telling the user to enable Audiences and grant the key full access, or unselect the Audiences/Contacts tables to keep syncing the rest of their Resend data.

The match is scoped to the `https://api.resend.com/audiences` path (not a bare 400 from any Resend URL) so a 400 from another endpoint — which could be our bug — stays retryable and visible. The path prefix also covers the contacts sub-endpoint (`/audiences/{id}/contacts`), which belongs to the same feature family.

## How did you test this code?

I'm an agent. I could not run the Python suite in this sandbox (the project's flox/hogli environment with Django/requests installed wasn't available here), so CI will run it. I added a unit test (`test_audiences_bad_request_is_non_retryable`) mirroring the existing `401`/`403` and broadcasts tests, and verified the substring-matching logic in isolation: the observed `/audiences` message (and the `/audiences/{id}/contacts` variant) is recognised as non-retryable, while a 400 on `/emails`, `/broadcasts`, or `/domains` is not. Ran `ruff check` and `ruff format` on the changed files (clean).

This test catches a regression no existing test covers: a `/audiences` 400 silently staying retryable, or an over-broad match swallowing 400s from other endpoints.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to confirm the issue (full stack trace, exception type, frequency) and that the frame genuinely lives in the resend source. Decision was user/upstream error rather than a code bug: the failing request carries no params we construct, so a 400 reflects an account-level restriction, not a malformed request — the safe and correct response is to stop retrying and surface guidance, following the established Stripe/broadcasts `get_non_retryable_errors` pattern. Checked open PRs (including the maintainer's) and confirmed #66496 handles only `/broadcasts`, leaving `/audiences` unaddressed.
