### PR TITLE
fix(middleware): skip session metadata sync for streaming responses

### DIFF
--- a/posthog/session/middleware.py
+++ b/posthog/session/middleware.py
@@ -15,6 +15,10 @@ class UserAuthSessionActivityMiddleware:
         response = self.get_response(request)
         # Same gate as KnownLoginDeviceCookieMiddleware: only session-authenticated requests. The
         # helper itself skips impersonation.
-        if isinstance(request.user, User) and BACKEND_SESSION_KEY in request.session:
+        if (
+            isinstance(request.user, User)
+            and BACKEND_SESSION_KEY in request.session
+            and not getattr(response, "streaming", False)
+        ):
             sync_current_session_metadata(request)
         return response

--- a/posthog/session/test/test_middleware.py
+++ b/posthog/session/test/test_middleware.py
@@ -16,7 +16,7 @@ class TestUserAuthSessionActivityMiddleware(BaseTest):
         request.user = self.user
         session = MagicMock()
         session.__contains__ = MagicMock(return_value=True)
-        request.session = session  # type: ignore[assignment]
+        request.session = session
         return request
 
     def test_syncs_metadata_for_normal_responses(self):

--- a/posthog/session/test/test_middleware.py
+++ b/posthog/session/test/test_middleware.py
@@ -1,0 +1,37 @@
+from posthog.test.base import BaseTest
+from unittest.mock import MagicMock, patch
+
+from django.http import HttpResponse, StreamingHttpResponse
+from django.test import RequestFactory
+
+from posthog.session.middleware import UserAuthSessionActivityMiddleware
+
+
+class TestUserAuthSessionActivityMiddleware(BaseTest):
+    def _make_middleware(self, response):
+        return UserAuthSessionActivityMiddleware(lambda r: response)
+
+    def _authed_request(self):
+        request = RequestFactory().get("/")
+        request.user = self.user
+        session = MagicMock()
+        session.__contains__ = MagicMock(return_value=True)
+        request.session = session  # type: ignore[assignment]
+        return request
+
+    def test_syncs_metadata_for_normal_responses(self):
+        response = HttpResponse("ok")
+        middleware = self._make_middleware(response)
+        with patch("posthog.session.middleware.sync_current_session_metadata") as mock_sync:
+            middleware(self._authed_request())
+        mock_sync.assert_called_once()
+
+    def test_skips_metadata_sync_for_streaming_responses(self):
+        # Regression: streaming responses must not open a DB connection in the response phase.
+        # sync_current_session_metadata uses transaction.on_commit which runs immediately in
+        # autocommit mode, opening a new connection that stays pinned for the stream lifetime.
+        response = StreamingHttpResponse(iter([b"data: hello\n\n"]))
+        middleware = self._make_middleware(response)
+        with patch("posthog.session.middleware.sync_current_session_metadata") as mock_sync:
+            middleware(self._authed_request())
+        mock_sync.assert_not_called()


### PR DESCRIPTION
## Problem

`UserAuthSessionActivityMiddleware` calls `sync_current_session_metadata` in the response phase. In autocommit mode `transaction.on_commit` fires immediately, opening a new DB connection that gets held open for the full SSE stream lifetime — one connection per active stream per session per 5-minute throttle window. This was contributing to pgbouncer cloud-write pool saturation on posthog-web-django after the primary streaming fix in #66282.

## Changes

- Add `and not getattr(response, "streaming", False)` to the sync condition in `UserAuthSessionActivityMiddleware` — skips the DB write when the response is a `StreamingHttpResponse`
- Add `posthog/session/test/test_middleware.py` with two cases: normal responses still trigger the sync, streaming responses skip it

## How did you test this code?

Agent-authored. Ran `hogli test posthog/session/test/test_middleware.py` — 2 passed.

The streaming test is the regression guard: if the `not getattr(response, "streaming", False)` condition is removed, `sync_current_session_metadata` fires for streaming responses again and the test fails.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated pgbouncer cloud-write pool saturation on posthog-web-django using Grafana/VictoriaMetrics + Loki diagnostic logs. PR #66282 added `_release_request_connections()` to the main SSE endpoints, but `stream_with_held_connections` logs continued firing at a lower rate afterward. Traced the residual to `UserAuthSessionActivityMiddleware`: `sync_current_session_metadata` uses `transaction.on_commit` which in autocommit mode runs immediately, opening a new connection in the response phase after `_release_request_connections()` already ran in the view. The connection then stays pinned to pgbouncer for the stream lifetime. `last_activity`/`ip`/`user_agent` are display-only metadata, throttled to once per session per 5 minutes, so skipping the write for streaming responses loses nothing meaningful.

Skills invoked: `/writing-tests`.