### PR TITLE
fix(postgres): retry transient Supavisor pool-checkout failures in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -188,15 +188,19 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a
 # libpq/PgBouncer signature — it raises its own pooler-internal error as a generic psycopg
-# InternalError_ (SQLSTATE XX000) carrying the "(EDBHANDLEREXITED)" code. The trailing message
-# varies — both "(EDBHANDLEREXITED) DbHandler exited. Check logs for more information" and
+# InternalError_ (SQLSTATE XX000) carrying a Supavisor error code. The trailing message varies —
+# both "(EDBHANDLEREXITED) DbHandler exited. Check logs for more information" and
 # "(EDBHANDLEREXITED) connection to database closed. Check logs for more information" have been
-# observed for the same condition — but the EDBHANDLEREXITED code is the stable signal: the
-# pooler's per-session DbHandler process exited because its backend connection died (idle cull,
-# backend restart, failover). That's the same transient class as the libpq drops above and
-# recovers on reconnect, so match the code itself rather than any one message wording. Genuine
+# observed for the same condition — but the code is the stable signal, so match the code itself
+# rather than any one message wording.
+#   - EDBHANDLEREXITED: the pooler's per-session DbHandler process exited because its backend
+#     connection died (idle cull, backend restart, failover).
+#   - ECHECKOUTRETRIES ("failed to check out a connection after multiple retries"): the pooler
+#     couldn't hand us a backend connection after retrying internally — its pool was momentarily
+#     exhausted or every backend was busy. A slot frees the moment another session returns one.
+# Both are the same transient class as the libpq drops above and recover on reconnect. Genuine
 # XX000 internal errors (data corruption, etc.) carry a different code and stay non-recoverable.
-_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited",)
+_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited", "echeckoutretries")
 
 # Connect-time capacity errors: the source refuses a *new* connection because it has hit a
 # connection limit, not because anything is misconfigured. PostgreSQL raises "sorry, too many

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1040,7 +1040,8 @@ class TestIsConnectionDroppedError:
             ValueError("server conn crashed?"),
             Exception("server conn crashed?"),
             # A genuine XX000 internal error that isn't the Supavisor pooler drop must stay
-            # non-recoverable — the InternalError_ match is scoped to the "(EDBHANDLEREXITED)" code.
+            # non-recoverable — the InternalError_ match is scoped to the known pooler codes
+            # ("(EDBHANDLEREXITED)" / "(ECHECKOUTRETRIES)"), not every XX000.
             psycopg.errors.InternalError_("XX000: internal error: something went wrong"),
         ],
     )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1011,6 +1011,11 @@ class TestIsConnectionDroppedError:
             psycopg.errors.InternalError_(
                 "(EDBHANDLEREXITED) connection to database closed. Check logs for more information"
             ),
+            # Supavisor also surfaces a transient pool-checkout failure as an XX000 InternalError_
+            # carrying the "(ECHECKOUTRETRIES)" code — it couldn't hand us a backend connection after
+            # retrying internally. Same transient pooler class as EDBHANDLEREXITED; recovers on
+            # reconnect once a session returns a connection to the pool.
+            psycopg.errors.InternalError_("(ECHECKOUTRETRIES) failed to check out a connection after multiple retries"),
             # Supavisor reports a transient timeout reaching the upstream backend as a
             # ConnectionFailure (08006, an OperationalError) carrying the Erlang-tuple reason
             # "{:error, :etimedout}" — a transient drop the in-process recovery must catch.


### PR DESCRIPTION
## Problem

Error tracking surfaced a Postgres data-warehouse source failure during schema discovery:

- **Exception:** `InternalError_` — `(ECHECKOUTRETRIES) failed to check out a connection after multiple retries`
- **Origin:** `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py` (`get_schemas` → `_connect_and_discover` → `_schemas_from_conn`)
- Issue: https://us.posthog.com/project/2/error_tracking/019f07f3-a559-7050-b334-04c0d30d9663

`(ECHECKOUTRETRIES)` is a Supavisor (Supabase's connection pooler) error code: the pooler couldn't hand us a backend connection after retrying internally, because its pool was momentarily exhausted or every backend was busy. A slot frees the moment another session returns a connection — so this is a **transient** condition that recovers on reconnect, the same family as the `(EDBHANDLEREXITED)` pooler drop we already retry, and as `(EMAXCONNSESSION)` pooler saturation.

The gap: `(ECHECKOUTRETRIES)` arrives as a generic XX000 `InternalError_`, and `_is_connection_dropped_error` only matched the pooler `InternalError_` against `(EDBHANDLEREXITED)`. So when this code surfaces as a bare `InternalError_`, the in-process connect-and-discover retry (`_retry_on_connection_dropped`) doesn't fire, and a transient blip fails the discovery activity and shows up as captured error-tracking noise even though the next attempt would succeed.

## Changes

Add `"echeckoutretries"` to `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, alongside the existing `"edbhandlerexited"`, and extend the explaining comment.

This keeps the error **retryable** (it's transient infrastructure, not a user/upstream config error — so it does **not** belong in `NonRetryableErrors`), and makes the in-process reconnect actually trigger for it on both the schema-discovery and read paths, matching the established Supavisor pooler-drop handling.

## How did you test this code?

I'm an agent. I added a regression case to the existing `test_connection_dropped_errors_are_detected` parametrized test asserting an `InternalError_("(ECHECKOUTRETRIES) ...")` is recognised as a connection drop — this fails before the change (the code wasn't in the substring tuple) and passes after. The sibling `test_unrelated_errors_are_not_detected` still asserts a generic XX000 `InternalError_` stays non-recoverable, so the match remains scoped to known pooler codes.

Automated tests run (via the repo venv pytest):

- `test_connection_dropped_errors_are_detected` / `test_unrelated_errors_are_not_detected` and siblings — 28 passed
- Discovery/pooler retry suite (`get_schemas_retries`, pooler, discovery) — 31 passed; 1 unrelated error is a test that requires a live Postgres connection, which isn't available in the sandbox

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the `postgres` warehouse source. Confirmed via the PostHog error-tracking tools that the failure originates in this source's schema-discovery code, then traced the call path and the existing Supavisor pooler-drop handling.

Decision: transient infrastructure error → keep retryable, mirror the existing `EDBHANDLEREXITED` in-process retry rather than adding to `NonRetryableErrors`. Scoped strictly to recognising the new pooler code; no retry-policy or unrelated changes. Checked open PRs (including the maintainer's) for a duplicate — none address this code.