### PR TITLE
feat(mcp-analytics): expose tool-detail query runners as MCP tools

### DIFF
--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -189,9 +189,11 @@ wrappers:
         title: Top errors for one MCP tool
         description: >
             Return the most common error messages for a single MCP tool, each with the resolved client harness it came
-            from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer "why is tool X
-            failing?" or "what errors does tool X throw, and on which clients?".
-        system_prompt_hint: One MCP tool's top error messages, by harness
+            from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on
+            $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail
+            tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to
+            answer "why is tool X failing?" or "what errors does tool X throw, and on which clients?".
+        system_prompt_hint: One MCP tool's top error messages, by harness (scoped by raw tool name)
         exclude_properties:
             - response
             - modifiers

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -131,3 +131,159 @@ wrappers:
             - version
             - tags
         feature_flag: mcp-analytics
+    query-mcp-tool-stats:
+        schema_ref: MCPToolStatsQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Summarise one MCP tool
+        description: >
+            Return the headline numbers for a single MCP tool over the window: total calls, error count, p50 and p95
+            latency, unique users, unique sessions, and how many calls carried an intent. Pass toolName (the effective
+            tool name — the inner tool is resolved server-side for single-exec wrapper calls, matching the tool-detail
+            UI). Use to answer "how is tool X doing overall?" before drilling into failures, users, or neighbours.
+        system_prompt_hint: One MCP tool's headline stats — calls, errors, p50/p95, users, sessions, intents
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-daily-stats:
+        schema_ref: MCPToolDailyStatsQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Daily trend for one MCP tool
+        description: >
+            Return a day-by-day time series for a single MCP tool: calls, errors, p50/p95 latency, unique users, and
+            unique sessions per day. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to
+            answer "how has tool X trended?" — spotting error spikes, latency regressions, or adoption changes over time.
+        system_prompt_hint: One MCP tool's day-by-day series — calls, errors, p50/p95, users, sessions
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-failures:
+        schema_ref: MCPToolFailuresQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Top errors for one MCP tool
+        description: >
+            Return the most common error messages for a single MCP tool, each with the resolved client harness it came
+            from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer "why is tool X
+            failing?" or "what errors does tool X throw, and on which clients?".
+        system_prompt_hint: One MCP tool's top error messages, by harness
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-top-users:
+        schema_ref: MCPToolTopUsersQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Top callers of one MCP tool
+        description: >
+            Return the top callers of a single MCP tool: per caller, the call count, error rate, resolved harness
+            labels, last-seen time, and the caller's display name and email. Pass toolName (effective tool name,
+            resolved server-side) and a dateRange. Use to answer "who uses tool X the most, and how reliably for them?".
+        system_prompt_hint: One MCP tool's top callers — calls, error rate, harnesses, person email/name
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-neighbors:
+        schema_ref: MCPToolNeighborsQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Tools called alongside one MCP tool
+        description: >
+            Return the tools most often called immediately before or after a single MCP tool within the same
+            conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection
+            ('before' or 'after'). Use to answer "what does an agent call around tool X?" — revealing common tool
+            sequences and which tools pair up.
+        system_prompt_hint: Tools co-occurring before/after one MCP tool in a conversation
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-sample-intents:
+        schema_ref: MCPToolSampleIntentsQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Sample intents for one MCP tool
+        description: >
+            Return recent sample agent intents recorded for a single MCP tool, each with its resolved client harness.
+            Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer "what are agents
+            actually trying to do when they call tool X?" — qualitative context behind the usage numbers.
+        system_prompt_hint: Recent sample agent intents for one MCP tool, with harness
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics
+    query-mcp-tool-descriptions:
+        schema_ref: MCPToolDescriptionsQuery
+        enabled: true
+        scopes:
+            - query:read
+            - mcp_analytics:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Descriptions seen for one MCP tool
+        description: >
+            Return the distinct effective tool-description strings seen for a single MCP tool over the window. Pass
+            toolName (effective tool name, resolved server-side) and a dateRange. Use to spot description drift or a tool
+            registered with more than one description across clients or versions.
+        system_prompt_hint: Distinct effective descriptions seen for one MCP tool
+        exclude_properties:
+            - response
+            - modifiers
+            - version
+            - tags
+        feature_flag: mcp-analytics

--- a/products/mcp_analytics/mcp/tools.yaml
+++ b/products/mcp_analytics/mcp/tools.yaml
@@ -168,7 +168,8 @@ wrappers:
         description: >
             Return a day-by-day time series for a single MCP tool: calls, errors, p50/p95 latency, unique users, and
             unique sessions per day. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to
-            answer "how has tool X trended?" — spotting error spikes, latency regressions, or adoption changes over time.
+            answer "how has tool X trended?" — spotting error spikes, latency regressions, or adoption changes over
+            time.
         system_prompt_hint: One MCP tool's day-by-day series — calls, errors, p50/p95, users, sessions
         exclude_properties:
             - response
@@ -280,8 +281,8 @@ wrappers:
         title: Descriptions seen for one MCP tool
         description: >
             Return the distinct effective tool-description strings seen for a single MCP tool over the window. Pass
-            toolName (effective tool name, resolved server-side) and a dateRange. Use to spot description drift or a tool
-            registered with more than one description across clients or versions.
+            toolName (effective tool name, resolved server-side) and a dateRange. Use to spot description drift or a
+            tool registered with more than one description across clients or versions.
         system_prompt_hint: Distinct effective descriptions seen for one MCP tool
         exclude_properties:
             - response

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5877,7 +5877,7 @@
         "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
     },
     "query-mcp-tool-failures": {
-        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
         "category": "MCP analytics",
         "feature": "mcp_analytics",
         "summary": "Top errors for one MCP tool",
@@ -5890,7 +5890,7 @@
             "readOnlyHint": true
         },
         "feature_flag": "mcp-analytics",
-        "system_prompt_hint": "One MCP tool's top error messages, by harness"
+        "system_prompt_hint": "One MCP tool's top error messages, by harness (scoped by raw tool name)"
     },
     "query-mcp-tool-neighbors": {
         "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5844,6 +5844,118 @@
         "feature_flag": "mcp-analytics",
         "system_prompt_hint": "MCP client/harness breakdown — calls, error rate, sessions per harness"
     },
+    "query-mcp-tool-daily-stats": {
+        "description": "Return a day-by-day time series for a single MCP tool: calls, errors, p50/p95 latency, unique users, and unique sessions per day. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"how has tool X trended?\" — spotting error spikes, latency regressions, or adoption changes over time.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Daily trend for one MCP tool",
+        "title": "Daily trend for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's day-by-day series — calls, errors, p50/p95, users, sessions"
+    },
+    "query-mcp-tool-descriptions": {
+        "description": "Return the distinct effective tool-description strings seen for a single MCP tool over the window. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to spot description drift or a tool registered with more than one description across clients or versions.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Descriptions seen for one MCP tool",
+        "title": "Descriptions seen for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
+    },
+    "query-mcp-tool-failures": {
+        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Top errors for one MCP tool",
+        "title": "Top errors for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's top error messages, by harness"
+    },
+    "query-mcp-tool-neighbors": {
+        "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Tools called alongside one MCP tool",
+        "title": "Tools called alongside one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Tools co-occurring before/after one MCP tool in a conversation"
+    },
+    "query-mcp-tool-sample-intents": {
+        "description": "Return recent sample agent intents recorded for a single MCP tool, each with its resolved client harness. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"what are agents actually trying to do when they call tool X?\" — qualitative context behind the usage numbers.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Sample intents for one MCP tool",
+        "title": "Sample intents for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Recent sample agent intents for one MCP tool, with harness"
+    },
+    "query-mcp-tool-stats": {
+        "description": "Return the headline numbers for a single MCP tool over the window: total calls, error count, p50 and p95 latency, unique users, unique sessions, and how many calls carried an intent. Pass toolName (the effective tool name — the inner tool is resolved server-side for single-exec wrapper calls, matching the tool-detail UI). Use to answer \"how is tool X doing overall?\" before drilling into failures, users, or neighbours.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Summarise one MCP tool",
+        "title": "Summarise one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's headline stats — calls, errors, p50/p95, users, sessions, intents"
+    },
+    "query-mcp-tool-top-users": {
+        "description": "Return the top callers of a single MCP tool: per caller, the call count, error rate, resolved harness labels, last-seen time, and the caller's display name and email. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"who uses tool X the most, and how reliably for them?\".",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Top callers of one MCP tool",
+        "title": "Top callers of one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's top callers — calls, error rate, harnesses, person email/name"
+    },
     "query-metrics": {
         "description": "Query server/infrastructure metrics (OTel- or Prometheus-ingested) as bucketed time series. The response is a list of series — `{labels, points: [{time, value}], metric_name, clause}` — where every series shares one time grid (missing buckets are zero-filled). A single ungrouped query returns exactly one series with empty labels.\n\nAll parameters are nested inside a `query` object. Two request forms:\n\n- **Single metric (shorthand):** set `metricName` (+ `aggregation`, `filters`, `groupBy`).\n- **Multi-clause / formula:** set `clauses: [{name, metricName, aggregation, quantile?, filters?, groupBy?}, ...]` and optionally `formula` (e.g. `\"(a - b) / a\"` over clause names; `+ - * /` and parentheses; division by zero yields 0). With a formula set, only the formula result series are returned.\n\n# Workflow — follow this order every time\n\n1. **Discover names first.** Call `metric-names-list` with a substring (`value`) before querying — metric names must match exactly, and the returned `metric_type` tells you the right aggregation.\n2. **Pick the aggregation by metric type:**\n   - `sum` counters (usually `_total`): use `rate` (per-second) or `increase` — both are counter-reset safe and temporality-aware. Do NOT use `sum`/`avg` on cumulative counters; absolute counter values are meaningless.\n   - `gauge`: `avg` (typical), `p95`, `sum`.\n   - `histogram`: `histogram_quantile` with `quantile` (e.g. 0.95). All selected series must share one bucket layout — narrow with `filters` if you get a bounds-mismatch error.\n3. **Narrow with filters.** `filters: [{key, op, value, scope?}]`, ANDed. Ops: `eq`, `neq`, `regex`, `not_regex` (RE2). Leave `scope` at its default `auto` unless you know whether the attribute is per-target (`resource`) or per-datapoint (`attribute`). Negative ops also match rows lacking the key, like Prometheus negative matchers.\n4. **Split with groupBy.** `groupBy: [{key}]` returns one series per label value (capped at the 100 largest). `service_name` is always available; discover other keys from a sample query's labels or ask the user.\n5. **Control the grid with `interval`.** One of `second, minute, minute_5, minute_15, hour, hour_6, day, week`. Omit to auto-pick (~60 buckets across the range). Use the same interval when comparing windows.\n\n# Investigating an anomaly (\"metric X is rising — why?\")\n\n1. Query the metric over a window that includes the anomaly AND an equal-length healthy baseline before it (one call, auto interval).\n2. Find the onset: the first bucket where the value clearly departs from the baseline range.\n3. Re-query grouped by `service_name` (then by other candidate keys) over the same window to see WHICH series moved — a single label value moving points at the culprit; all moving together points at something shared (upstream dependency, infra).\n4. Use `formula` for normalized comparisons, e.g. error ratio `errors / requests` instead of raw error counts.\n5. Correlate the onset window across signals: query logs (`query-logs`, filtered to the same `service.name` and time window, severity error) and traces (APM span tools, same service/window) to find the cause and its blast radius.\n\nCRITICAL: be minimalist — only include filters/settings essential to the question. Time ranges: `dateFrom` is required, ISO 8601; `dateTo` defaults to now.",
         "category": "Metrics",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6342,7 +6342,7 @@
         "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
     },
     "query-mcp-tool-failures": {
-        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName as the raw $mcp_tool_name (the registered tool name) — failures are matched on $exception events, which don't carry the new-SDK effective-tool markers, so unlike the other tool-detail tools this one does NOT resolve the inner tool of a single-exec wrapper call. Also pass a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
         "category": "MCP analytics",
         "feature": "mcp_analytics",
         "summary": "Top errors for one MCP tool",
@@ -6355,7 +6355,7 @@
             "readOnlyHint": true
         },
         "feature_flag": "mcp-analytics",
-        "system_prompt_hint": "One MCP tool's top error messages, by harness"
+        "system_prompt_hint": "One MCP tool's top error messages, by harness (scoped by raw tool name)"
     },
     "query-mcp-tool-neighbors": {
         "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -6309,6 +6309,118 @@
         "feature_flag": "mcp-analytics",
         "system_prompt_hint": "MCP client/harness breakdown — calls, error rate, sessions per harness"
     },
+    "query-mcp-tool-daily-stats": {
+        "description": "Return a day-by-day time series for a single MCP tool: calls, errors, p50/p95 latency, unique users, and unique sessions per day. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"how has tool X trended?\" — spotting error spikes, latency regressions, or adoption changes over time.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Daily trend for one MCP tool",
+        "title": "Daily trend for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's day-by-day series — calls, errors, p50/p95, users, sessions"
+    },
+    "query-mcp-tool-descriptions": {
+        "description": "Return the distinct effective tool-description strings seen for a single MCP tool over the window. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to spot description drift or a tool registered with more than one description across clients or versions.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Descriptions seen for one MCP tool",
+        "title": "Descriptions seen for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Distinct effective descriptions seen for one MCP tool"
+    },
+    "query-mcp-tool-failures": {
+        "description": "Return the most common error messages for a single MCP tool, each with the resolved client harness it came from. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"why is tool X failing?\" or \"what errors does tool X throw, and on which clients?\".",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Top errors for one MCP tool",
+        "title": "Top errors for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's top error messages, by harness"
+    },
+    "query-mcp-tool-neighbors": {
+        "description": "Return the tools most often called immediately before or after a single MCP tool within the same conversation. Pass toolName (effective tool name, resolved server-side), a dateRange, and neighborDirection ('before' or 'after'). Use to answer \"what does an agent call around tool X?\" — revealing common tool sequences and which tools pair up.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Tools called alongside one MCP tool",
+        "title": "Tools called alongside one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Tools co-occurring before/after one MCP tool in a conversation"
+    },
+    "query-mcp-tool-sample-intents": {
+        "description": "Return recent sample agent intents recorded for a single MCP tool, each with its resolved client harness. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"what are agents actually trying to do when they call tool X?\" — qualitative context behind the usage numbers.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Sample intents for one MCP tool",
+        "title": "Sample intents for one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "Recent sample agent intents for one MCP tool, with harness"
+    },
+    "query-mcp-tool-stats": {
+        "description": "Return the headline numbers for a single MCP tool over the window: total calls, error count, p50 and p95 latency, unique users, unique sessions, and how many calls carried an intent. Pass toolName (the effective tool name — the inner tool is resolved server-side for single-exec wrapper calls, matching the tool-detail UI). Use to answer \"how is tool X doing overall?\" before drilling into failures, users, or neighbours.",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Summarise one MCP tool",
+        "title": "Summarise one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's headline stats — calls, errors, p50/p95, users, sessions, intents"
+    },
+    "query-mcp-tool-top-users": {
+        "description": "Return the top callers of a single MCP tool: per caller, the call count, error rate, resolved harness labels, last-seen time, and the caller's display name and email. Pass toolName (effective tool name, resolved server-side) and a dateRange. Use to answer \"who uses tool X the most, and how reliably for them?\".",
+        "category": "MCP analytics",
+        "feature": "mcp_analytics",
+        "summary": "Top callers of one MCP tool",
+        "title": "Top callers of one MCP tool",
+        "required_scopes": ["query:read", "mcp_analytics:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        },
+        "feature_flag": "mcp-analytics",
+        "system_prompt_hint": "One MCP tool's top callers — calls, error rate, harnesses, person email/name"
+    },
     "query-metrics": {
         "description": "Query server/infrastructure metrics (OTel- or Prometheus-ingested) as bucketed time series. The response is a list of series — `{labels, points: [{time, value}], metric_name, clause}` — where every series shares one time grid (missing buckets are zero-filled). A single ungrouped query returns exactly one series with empty labels.\n\nAll parameters are nested inside a `query` object. Two request forms:\n\n- **Single metric (shorthand):** set `metricName` (+ `aggregation`, `filters`, `groupBy`).\n- **Multi-clause / formula:** set `clauses: [{name, metricName, aggregation, quantile?, filters?, groupBy?}, ...]` and optionally `formula` (e.g. `\"(a - b) / a\"` over clause names; `+ - * /` and parentheses; division by zero yields 0). With a formula set, only the formula result series are returned.\n\n# Workflow — follow this order every time\n\n1. **Discover names first.** Call `metric-names-list` with a substring (`value`) before querying — metric names must match exactly, and the returned `metric_type` tells you the right aggregation.\n2. **Pick the aggregation by metric type:**\n   - `sum` counters (usually `_total`): use `rate` (per-second) or `increase` — both are counter-reset safe and temporality-aware. Do NOT use `sum`/`avg` on cumulative counters; absolute counter values are meaningless.\n   - `gauge`: `avg` (typical), `p95`, `sum`.\n   - `histogram`: `histogram_quantile` with `quantile` (e.g. 0.95). All selected series must share one bucket layout — narrow with `filters` if you get a bounds-mismatch error.\n3. **Narrow with filters.** `filters: [{key, op, value, scope?}]`, ANDed. Ops: `eq`, `neq`, `regex`, `not_regex` (RE2). Leave `scope` at its default `auto` unless you know whether the attribute is per-target (`resource`) or per-datapoint (`attribute`). Negative ops also match rows lacking the key, like Prometheus negative matchers.\n4. **Split with groupBy.** `groupBy: [{key}]` returns one series per label value (capped at the 100 largest). `service_name` is always available; discover other keys from a sample query's labels or ask the user.\n5. **Control the grid with `interval`.** One of `second, minute, minute_5, minute_15, hour, hour_6, day, week`. Omit to auto-pick (~60 buckets across the range). Use the same interval when comparing windows.\n\n# Investigating an anomaly (\"metric X is rising — why?\")\n\n1. Query the metric over a window that includes the anomaly AND an equal-length healthy baseline before it (one call, auto interval).\n2. Find the onset: the first bucket where the value clearly departs from the baseline range.\n3. Re-query grouped by `service_name` (then by other candidate keys) over the same window to see WHICH series moved — a single label value moving points at the culprit; all moving together points at something shared (upstream dependency, infra).\n4. Use `formula` for normalized comparisons, e.g. error ratio `errors / requests` instead of raw error counts.\n5. Correlate the onset window across signals: query logs (`query-logs`, filtered to the same `service.name` and time window, severity error) and traces (APM span tools, same service/window) to find the cause and its blast radius.\n\nCRITICAL: be minimalist — only include filters/settings essential to the question. Time ranges: `dateFrom` is required, ISO 8601; `dateTo` defaults to now.",
         "category": "Metrics",

--- a/services/mcp/src/tools/generated/mcp_analytics.ts
+++ b/services/mcp/src/tools/generated/mcp_analytics.ts
@@ -414,6 +414,63 @@ const MCPHarnessBreakdownQuery = z.object({
         .optional(),
 })
 
+const MCPToolStatsQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolStatsQuery').default('MCPToolStatsQuery'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
+const MCPToolDailyStatsQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolDailyStatsQuery').default('MCPToolDailyStatsQuery'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
+const MCPToolFailuresQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolFailuresQuery').default('MCPToolFailuresQuery'),
+    toolName: z.string().describe('The raw $mcp_tool_name to scope $exception events to.'),
+})
+
+const MCPToolTopUsersQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolTopUsersQuery').default('MCPToolTopUsersQuery'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
+const MCPToolNeighborsQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolNeighborsQuery').default('MCPToolNeighborsQuery'),
+    neighborDirection: z
+        .enum(['before', 'after'])
+        .describe('Whether to count tools called immediately before or after the target tool.'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
+const MCPToolSampleIntentsQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolSampleIntentsQuery').default('MCPToolSampleIntentsQuery'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
+const MCPToolDescriptionsQuery = z.object({
+    dateRange: DateRange.optional(),
+    kind: z.literal('MCPToolDescriptionsQuery').default('MCPToolDescriptionsQuery'),
+    toolName: z
+        .string()
+        .describe('The effective tool name to scope to (matched against the single-exec-resolved tool name).'),
+})
+
 export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'mcp-analytics-intent-clusters-recompute': mcpAnalyticsIntentClustersRecompute,
     'mcp-analytics-intent-clusters-retrieve': mcpAnalyticsIntentClustersRetrieve,
@@ -424,5 +481,40 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
         name: 'query-mcp-harness-breakdown',
         schema: MCPHarnessBreakdownQuery,
         kind: 'MCPHarnessBreakdownQuery',
+    }),
+    'query-mcp-tool-stats': createQueryWrapper({
+        name: 'query-mcp-tool-stats',
+        schema: MCPToolStatsQuery,
+        kind: 'MCPToolStatsQuery',
+    }),
+    'query-mcp-tool-daily-stats': createQueryWrapper({
+        name: 'query-mcp-tool-daily-stats',
+        schema: MCPToolDailyStatsQuery,
+        kind: 'MCPToolDailyStatsQuery',
+    }),
+    'query-mcp-tool-failures': createQueryWrapper({
+        name: 'query-mcp-tool-failures',
+        schema: MCPToolFailuresQuery,
+        kind: 'MCPToolFailuresQuery',
+    }),
+    'query-mcp-tool-top-users': createQueryWrapper({
+        name: 'query-mcp-tool-top-users',
+        schema: MCPToolTopUsersQuery,
+        kind: 'MCPToolTopUsersQuery',
+    }),
+    'query-mcp-tool-neighbors': createQueryWrapper({
+        name: 'query-mcp-tool-neighbors',
+        schema: MCPToolNeighborsQuery,
+        kind: 'MCPToolNeighborsQuery',
+    }),
+    'query-mcp-tool-sample-intents': createQueryWrapper({
+        name: 'query-mcp-tool-sample-intents',
+        schema: MCPToolSampleIntentsQuery,
+        kind: 'MCPToolSampleIntentsQuery',
+    }),
+    'query-mcp-tool-descriptions': createQueryWrapper({
+        name: 'query-mcp-tool-descriptions',
+        schema: MCPToolDescriptionsQuery,
+        kind: 'MCPToolDescriptionsQuery',
     }),
 }


### PR DESCRIPTION
## Problem

The MCP-analytics tool stack added seven per-tool query runners (stats, daily-stats, failures, top-users, neighbors, sample-intents, descriptions), but only the frontend can call them — via `/query`. Agents asking "why is tool X failing?" or "who uses tool X?" have to hand-write the HogQL the runners already encapsulate, duplicating effective-tool-name resolution, harness labelling, p50/p95, and the `lagInFrame`/`leadInFrame` co-occurrence logic.

## Changes

Wraps the seven runners as MCP query tools in `products/mcp_analytics/mcp/tools.yaml`, mirroring the existing `query-mcp-harness-breakdown` wrapper:

| tool | answers |
| --- | --- |
| `query-mcp-tool-stats` | one tool's calls/errors/p50/p95/users/sessions/intents |
| `query-mcp-tool-daily-stats` | day-by-day series for one tool |
| `query-mcp-tool-failures` | top error messages for one tool, by harness |
| `query-mcp-tool-top-users` | top callers of one tool (incl. person email/name) |
| `query-mcp-tool-neighbors` | tools co-occurring before/after one tool |
| `query-mcp-tool-sample-intents` | recent agent intents for one tool |
| `query-mcp-tool-descriptions` | distinct effective descriptions seen for one tool |

Each is gated behind `query:read` + `mcp_analytics:read` and the `mcp-analytics` feature flag, read-only, and resolves the effective tool name + harness server-side so results match the tool-detail UI exactly. No backend runner changes — the runners already exist and are dispatch-registered; this is the YAML wrappers plus the regenerated MCP tool definitions.

`query-mcp-tool-top-users` returns the caller's person email/name — a deliberate choice (matches what the UI already shows), gated behind the same authed scopes.

## How did you test this code?

I'm an agent. Automated only:
- `pnpm --filter=@posthog/mcp lint-tool-names` — all 7 names valid (<=52 chars, kebab-case).
- `pnpm --filter=@posthog/mcp generate-tools` — regenerates the tool definitions; all 7 wrappers + correct Zod input schemas (`toolName` on all, `neighborDirection` enum `before`/`after` on neighbors, optional `dateRange`).
- `pnpm --filter=@posthog/mcp test` — 1957 tests pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code at Paul's direction, as the first of a three-PR sub-stack promoting the tool-detail runners (this PR exposes them; follow-ups point the MCP skills at the typed tools and add a suggested-questions skill). Invoked the `/implementing-mcp-tools` skill — confirmed the `wrappers:`/`schema_ref` pattern (not operation-based) and the `generate-tools` codegen path. The generated `services/mcp` tool definitions are committed here for a self-consistent diff; CI regenerates them identically.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
