### PR TITLE
fix(error-tracking): route cymbal rate-limiter app_metrics to warpstream-ingestion

### DIFF
--- a/rust/cymbal/src/modes/processing/app_context.rs
+++ b/rust/cymbal/src/modes/processing/app_context.rs
@@ -32,6 +32,10 @@ pub struct AppContext {
     // Dedicated producer for `cdp_internal_events`. Points at warpstream-cyclotron when
     // `CYMBAL_CYCLOTRON_KAFKA_HOSTS` is set; otherwise falls back to `immediate_producer`.
     pub cyclotron_producer: FutureProducer<KafkaContext>,
+    // Dedicated producer for `clickhouse_app_metrics2`. Points at warpstream-ingestion when
+    // `CYMBAL_APP_METRICS_KAFKA_HOSTS` is set; otherwise falls back to `immediate_producer`.
+    // The primary producer's cluster (warpstream-shared) does not carry that topic.
+    pub app_metrics_producer: FutureProducer<KafkaContext>,
     pub posthog_pool: PgPool,
     pub catalog: Arc<Catalog>,
     pub symbol_resolver: Arc<dyn SymbolResolver>,
@@ -134,6 +138,24 @@ impl AppContext {
             _ => immediate_producer.clone(),
         };
 
+        // Build the app-metrics producer if a separate broker list is configured; otherwise
+        // reuse the primary producer (so local dev, where one cluster carries every topic,
+        // works without extra config).
+        let app_metrics_producer = match config.app_metrics_kafka_hosts.as_deref() {
+            Some(hosts) if !hosts.is_empty() => {
+                let mut app_metrics_config = config.kafka.clone();
+                app_metrics_config.kafka_hosts = hosts.to_string();
+                if let Some(tls) = config.app_metrics_kafka_tls {
+                    app_metrics_config.kafka_tls = tls;
+                }
+                let kafka_app_metrics_liveness = health_registry
+                    .register("app_metrics_kafka".to_string(), Duration::from_secs(30))
+                    .await;
+                create_kafka_producer(&app_metrics_config, kafka_app_metrics_liveness).await?
+            }
+            _ => immediate_producer.clone(),
+        };
+
         s3_client
             .ping_bucket(&config.resolver.object_storage_bucket)
             .await?;
@@ -180,6 +202,7 @@ impl AppContext {
             health_registry,
             immediate_producer,
             cyclotron_producer,
+            app_metrics_producer,
             posthog_pool,
             catalog,
             config: config.clone(),

--- a/rust/cymbal/src/modes/processing/config.rs
+++ b/rust/cymbal/src/modes/processing/config.rs
@@ -46,6 +46,18 @@ pub struct ProcessingConfig {
     #[envconfig(from = "CYMBAL_CYCLOTRON_KAFKA_TLS")]
     pub cyclotron_kafka_tls: Option<bool>,
 
+    // Optional override for the brokers used to produce `clickhouse_app_metrics2`. When set,
+    // cymbal opens a dedicated producer pointed at this host list (the warpstream-ingestion VC,
+    // where ClickHouse consumes app_metrics2). When unset, app metrics go through the primary
+    // `kafka` producer — which only carries that topic where the cluster has it (e.g. local dev).
+    #[envconfig(from = "CYMBAL_APP_METRICS_KAFKA_HOSTS")]
+    pub app_metrics_kafka_hosts: Option<String>,
+
+    // Optional TLS override for the app-metrics producer. When unset, it inherits `KAFKA_TLS`
+    // from the primary kafka config.
+    #[envconfig(from = "CYMBAL_APP_METRICS_KAFKA_TLS")]
+    pub app_metrics_kafka_tls: Option<bool>,
+
     #[envconfig(default = "cdp_internal_events")]
     pub internal_events_topic: String,
 

--- a/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
+++ b/rust/cymbal/src/modes/processing/stages/rate_limiting/mod.rs
@@ -270,7 +270,7 @@ impl RateLimitingStage {
         }
 
         let results = send_iter_to_kafka(
-            &self.ctx.immediate_producer,
+            &self.ctx.app_metrics_producer,
             APP_METRICS2_TOPIC,
             app_metrics,
         )


### PR DESCRIPTION
## Problem

When the cymbal error-tracking rate limiter was enabled in prod, it flooded logs with:

```
WARN cymbal::modes::processing::stages::rate_limiting: failed to emit error-tracking rate-limit app_metric: failed to produce to kafka: Message production error: UnknownTopic (Local: Unknown topic)
```

The rate-limiting stage emits `app_metrics2` rows (the per-team allowed/rate-limited counts that power the product surface) to the `clickhouse_app_metrics2` topic via `immediate_producer`. But `immediate_producer` points at the **warpstream-shared** cluster, which only carries cymbal's issue/embedding topics (`clickhouse_error_tracking_fingerprint_issue_state`, `document_embeddings_input`) — not `clickhouse_app_metrics2`. That topic lives on the **warpstream-ingestion** cluster (and MSK), where ClickHouse actually consumes it. warpstream-shared has topic auto-creation off, so every produce hard-failed with `UnknownTopic`.

The rate limiter is the first cymbal code path to ever produce `app_metrics2`, so this mismatch never surfaced before. Note: the rate limiting itself was unaffected — the Redis decision and event drops happen before metric emission, and the Kafka failure is a swallowed best-effort `WARN`. The only impact was the lost `app_metrics2` rows and the log flood.

## Changes

Add a dedicated `app_metrics_producer` to `AppContext`, built from a new `CYMBAL_APP_METRICS_KAFKA_HOSTS` broker override (with an optional `CYMBAL_APP_METRICS_KAFKA_TLS`), and route the rate-limiter's `app_metrics2` emission through it. This mirrors the existing `cyclotron_producer` pattern exactly:

- When the override is set, cymbal opens a producer pointed at warpstream-ingestion (where ClickHouse consumes `app_metrics2`).
- When unset, it falls back to `immediate_producer`, so local dev (one cluster carrying every topic) needs no extra config.

The matching prod wiring (`CYMBAL_APP_METRICS_KAFKA_HOSTS` → `warpstream-ingestion-v2-…:9092`) is a companion PR in the charts repo.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran:

- `cargo check -p cymbal` — compiles clean on the current master base.
- `cargo fmt -p cymbal` — no formatting changes.

No new unit tests: the change is producer wiring (which cluster a `FutureProducer` targets), exercised only against a real Kafka cluster — there's no existing harness that asserts broker routing, and a mock wouldn't catch the real `UnknownTopic` regression. Behavior is verified end-to-end once the charts override is deployed and the `UnknownTopic` warnings stop.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a prod log report. Traced the failing produce in `rate_limiting/mod.rs` → `APP_METRICS2_TOPIC` (`clickhouse_app_metrics2`) → `immediate_producer` (built from `config.kafka` = warpstream-shared in the chart values), then confirmed via the ClickHouse Kafka engine tables (`posthog/models/app_metrics2/sql.py`, `posthog/clickhouse/kafka_engine.py`) that `app_metrics2` is consumed only from MSK and warpstream-ingestion — never warpstream-shared.

Considered the alternative of provisioning `clickhouse_app_metrics2` on warpstream-shared plus a dedicated ClickHouse consumer (a migration + topic creation), but rejected it: routing cymbal's rows into the existing warpstream-ingestion stream avoids new ClickHouse infra and keeps app_metrics2 in a single consumer, at the cost of one extra producer in cymbal. Chose the cyclotron-producer pattern for consistency with the existing dual-producer setup.
