### PR TITLE
feat(mcp-analytics): add exploring-mcp-tool-usage suggested-questions skill

### DIFF
--- a/products/mcp_analytics/skills/exploring-mcp-tool-usage/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-tool-usage/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: exploring-mcp-tool-usage
+description: >
+  Starting point for exploring how a PostHog MCP server's tools are used —
+  routes a broad question to the typed tool that answers it. Use when the user
+  asks "how is my MCP doing?", "what should I look at?", "explore my tool
+  calls", "who uses my MCP tools?", "what are agents doing with the MCP?", or
+  pastes an MCP analytics URL without a specific question. Offers a menu of
+  questions, each backed by a query tool, then hands off to the focused skill.
+---
+
+# Exploring MCP tool usage
+
+Any MCP server instrumented with the `@posthog/mcp` SDK emits a `$mcp_tool_call`
+event every time an agent invokes a tool. This skill is the **front door** for a
+user who knows they want to look at their MCP tool usage but hasn't picked a
+specific question. Offer the menu below, then route to the tool — or the focused
+skill — that answers what they choose.
+
+Every per-tool tool here is gated behind the `mcp-analytics` flag, takes a
+`toolName` (the effective tool name — resolved server-side, so pass the name the
+agent actually invokes) plus a `dateRange`, and runs the same query runner the
+tool-detail UI uses. So results match the UI, and you never hand-write the HogQL.
+
+## Suggested questions
+
+Lead with these when the user is unsure what to ask:
+
+| Ask the user…                                     | Answered by                                                                             |
+| ------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| "Which tools fail most, or are slowest?"          | `exploring-mcp-tool-quality` (ranks all tools), then `query-mcp-tool-stats` to drill in |
+| "How is tool X doing overall?"                    | `query-mcp-tool-stats` — calls, errors, p50/p95, users, sessions, intents               |
+| "How has tool X trended?"                         | `query-mcp-tool-daily-stats` — day-by-day series                                        |
+| "Why is tool X failing?"                          | `query-mcp-tool-failures` — top error messages, by harness                              |
+| "Who uses tool X the most?"                       | `query-mcp-tool-top-users` — top callers (incl. person email/name)                      |
+| "What gets called right before/after tool X?"     | `query-mcp-tool-neighbors` (`neighborDirection: before`/`after`)                        |
+| "What are agents trying to do with tool X?"       | `query-mcp-tool-sample-intents` — recent agent intents                                  |
+| "What description is tool X registered with?"     | `query-mcp-tool-descriptions` — distinct descriptions seen                              |
+| "Which harnesses use my MCP, how reliably?"       | `query-mcp-harness-breakdown` — calls/errors/sessions per client                        |
+| "What are agents trying to do, across all tools?" | `exploring-mcp-intent-clusters` — semantic goal clusters                                |
+| "What did this one session do?"                   | `exploring-mcp-sessions` — a single agent run's tool sequence                           |
+
+## Finding the tool name
+
+The per-tool tools need a `toolName`. If the user named a tool, pass it. If they
+asked a broad "which tool…" question, start with `exploring-mcp-tool-quality` to
+rank the tools, pick the one that stands out, then drill in with the per-tool
+tools above. The name to pass is the **effective** tool name (the inner tool for
+single-exec wrapper calls) — the same string the tool-quality ranking returns.
+
+## How to use a per-tool tool
+
+Call it with the tool name and a window, e.g. for the headline numbers of a tool:
+
+```text
+query-mcp-tool-stats  { "toolName": "<tool>", "dateRange": { "date_from": "-7d" } }
+```
+
+Then offer a natural follow-up from the menu — e.g. after `stats` shows a high
+error rate, reach for `query-mcp-tool-failures`; after it shows broad reach, reach
+for `query-mcp-tool-top-users` or `query-mcp-tool-neighbors`.
+
+## When to drop to SQL
+
+The tools cover the per-tool drill-downs and the harness cut. For cross-tool
+rankings (the tool-quality matrix), custom breakdowns, session listing, or
+per-session tool calls, query `$mcp_tool_call` directly with `posthog:execute-sql`
+— the schema and recipes are in
+[`models-mcp.md`](../../../posthog_ai/skills/querying-posthog-data/references/models-mcp.md).
+
+## Related skills
+
+- [`exploring-mcp-tool-quality`](../exploring-mcp-tool-quality/SKILL.md) — rank
+  tools by error rate / latency / reach, then drill in
+- [`exploring-mcp-sessions`](../exploring-mcp-sessions/SKILL.md) — a single agent
+  run and its tool sequence
+- [`exploring-mcp-intent-clusters`](../exploring-mcp-intent-clusters/SKILL.md) —
+  agent goals grouped by semantic similarity

--- a/products/mcp_analytics/skills/exploring-mcp-tool-usage/SKILL.md
+++ b/products/mcp_analytics/skills/exploring-mcp-tool-usage/SKILL.md
@@ -19,26 +19,28 @@ skill — that answers what they choose.
 
 Every per-tool tool here is gated behind the `mcp-analytics` flag, takes a
 `toolName` (the effective tool name — resolved server-side, so pass the name the
-agent actually invokes) plus a `dateRange`, and runs the same query runner the
-tool-detail UI uses. So results match the UI, and you never hand-write the HogQL.
+agent actually invokes — **except `posthog:query-mcp-tool-failures`**, which
+matches `$exception` events and so takes the raw registered `$mcp_tool_name`)
+plus a `dateRange`, and runs the same query runner the tool-detail UI uses. So
+results match the UI, and you never hand-write the HogQL.
 
 ## Suggested questions
 
 Lead with these when the user is unsure what to ask:
 
-| Ask the user…                                     | Answered by                                                                             |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| "Which tools fail most, or are slowest?"          | `exploring-mcp-tool-quality` (ranks all tools), then `query-mcp-tool-stats` to drill in |
-| "How is tool X doing overall?"                    | `query-mcp-tool-stats` — calls, errors, p50/p95, users, sessions, intents               |
-| "How has tool X trended?"                         | `query-mcp-tool-daily-stats` — day-by-day series                                        |
-| "Why is tool X failing?"                          | `query-mcp-tool-failures` — top error messages, by harness                              |
-| "Who uses tool X the most?"                       | `query-mcp-tool-top-users` — top callers (incl. person email/name)                      |
-| "What gets called right before/after tool X?"     | `query-mcp-tool-neighbors` (`neighborDirection: before`/`after`)                        |
-| "What are agents trying to do with tool X?"       | `query-mcp-tool-sample-intents` — recent agent intents                                  |
-| "What description is tool X registered with?"     | `query-mcp-tool-descriptions` — distinct descriptions seen                              |
-| "Which harnesses use my MCP, how reliably?"       | `query-mcp-harness-breakdown` — calls/errors/sessions per client                        |
-| "What are agents trying to do, across all tools?" | `exploring-mcp-intent-clusters` — semantic goal clusters                                |
-| "What did this one session do?"                   | `exploring-mcp-sessions` — a single agent run's tool sequence                           |
+| Ask the user…                                     | Answered by                                                                                     |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
+| "Which tools fail most, or are slowest?"          | `exploring-mcp-tool-quality` (ranks all tools), then `posthog:query-mcp-tool-stats` to drill in |
+| "How is tool X doing overall?"                    | `posthog:query-mcp-tool-stats` — calls, errors, p50/p95, users, sessions, intents               |
+| "How has tool X trended?"                         | `posthog:query-mcp-tool-daily-stats` — day-by-day series                                        |
+| "Why is tool X failing?"                          | `posthog:query-mcp-tool-failures` — top error messages, by harness (raw tool name)              |
+| "Who uses tool X the most?"                       | `posthog:query-mcp-tool-top-users` — top callers (incl. person email/name)                      |
+| "What gets called right before/after tool X?"     | `posthog:query-mcp-tool-neighbors` (`neighborDirection: before`/`after`)                        |
+| "What are agents trying to do with tool X?"       | `posthog:query-mcp-tool-sample-intents` — recent agent intents                                  |
+| "What description is tool X registered with?"     | `posthog:query-mcp-tool-descriptions` — distinct descriptions seen                              |
+| "Which harnesses use my MCP, how reliably?"       | `posthog:query-mcp-harness-breakdown` — calls/errors/sessions per client                        |
+| "What are agents trying to do, across all tools?" | `exploring-mcp-intent-clusters` — semantic goal clusters                                        |
+| "What did this one session do?"                   | `exploring-mcp-sessions` — a single agent run's tool sequence                                   |
 
 ## Finding the tool name
 
@@ -47,18 +49,20 @@ asked a broad "which tool…" question, start with `exploring-mcp-tool-quality` 
 rank the tools, pick the one that stands out, then drill in with the per-tool
 tools above. The name to pass is the **effective** tool name (the inner tool for
 single-exec wrapper calls) — the same string the tool-quality ranking returns.
+The one exception is `posthog:query-mcp-tool-failures`, which matches `$exception`
+events by the raw registered `$mcp_tool_name`, not the effective inner tool.
 
 ## How to use a per-tool tool
 
 Call it with the tool name and a window, e.g. for the headline numbers of a tool:
 
 ```text
-query-mcp-tool-stats  { "toolName": "<tool>", "dateRange": { "date_from": "-7d" } }
+posthog:query-mcp-tool-stats  { "toolName": "<tool>", "dateRange": { "date_from": "-7d" } }
 ```
 
 Then offer a natural follow-up from the menu — e.g. after `stats` shows a high
-error rate, reach for `query-mcp-tool-failures`; after it shows broad reach, reach
-for `query-mcp-tool-top-users` or `query-mcp-tool-neighbors`.
+error rate, reach for `posthog:query-mcp-tool-failures`; after it shows broad reach, reach
+for `posthog:query-mcp-tool-top-users` or `posthog:query-mcp-tool-neighbors`.
 
 ## When to drop to SQL
 


### PR DESCRIPTION
## Problem

A user who knows they want to explore their MCP tool usage but hasn't picked a specific question has no front door. The existing `exploring-mcp-*` skills each answer a narrow question; nothing greets a broad "how is my MCP doing?" and routes it to the right tool.

## Changes

Adds `exploring-mcp-tool-usage` — a broad-trigger entry-point skill. It offers a menu of suggested questions, each mapped to the query tool (or focused skill) that answers it, then hands off:

| Ask the user | Answered by |
| --- | --- |
| "How is tool X doing?" | `query-mcp-tool-stats` |
| "Why is tool X failing?" | `query-mcp-tool-failures` |
| "Who uses tool X?" | `query-mcp-tool-top-users` |
| "What's called around tool X?" | `query-mcp-tool-neighbors` |
| "What are agents doing with tool X?" | `query-mcp-tool-sample-intents` |
| "Which tools fail most?" | `exploring-mcp-tool-quality` |
| …and the harness / intent-cluster / session cuts | their tools/skills |

This turns the tool-detail query tools (added earlier in the stack) into the worked examples behind a starter question set, and cross-links the three existing `exploring-mcp-*` skills. SQL-only questions defer to `models-mcp.md`.

## How did you test this code?

I'm an agent. New skill markdown only:
- `build_skills.py --lint` passes (96 skills OK; the one advisory warning is in an unrelated signals skill).
- `bin/hogli format:markdown` passes (0 errors) after tagging the example fence.
- Verified every `query-mcp-*` tool referenced exists in `tools.yaml` and every linked sibling skill exists.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code at Paul's direction — third of the three-PR sub-stack (runners exposed as MCP tools → skills point at them → this adds the suggested-questions front door). Invoked `/writing-skills` conventions: gerund name matching the sibling trio, trigger `description` enumerating concrete utterances.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
