### PR TITLE
fix(metabase): don't leak raw upstream response body on credential check

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/metabase.py
@@ -202,11 +202,14 @@ def validate_credentials(
             return True, None
         return False, "Metabase credentials lack the required permissions"
 
-    try:
-        body = response.json()
-        return False, body.get("message", response.text)
-    except Exception:
-        return False, response.text
+    # Any other status: the host responded but not in a way we recognise — often it isn't a
+    # Metabase instance at all (e.g. a proxy or hosting-provider error page). Surface the status
+    # only; never echo the raw response body, which can carry arbitrary upstream content.
+    return (
+        False,
+        f"Metabase returned an unexpected response (HTTP {response.status_code}). "
+        "Check that the Instance URL points to your Metabase instance.",
+    )
 
 
 def get_rows(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/metabase/tests/test_metabase.py
@@ -221,6 +221,18 @@ class TestValidateCredentials:
             assert msg is not None
             session.get.assert_not_called()
 
+    def test_unexpected_status_does_not_leak_response_body(self):
+        # When the host isn't a Metabase instance it returns an arbitrary body (e.g. a hosting
+        # provider's error page). That body must never reach the user — only a friendly,
+        # status-coded message that points them back at the Instance URL.
+        leaked_body = '{"error": {"code": "404", "message": "SENTINEL_UPSTREAM_BODY"}}'
+        with self._patch_session(_response(status_code=404, json_data={"error": {"code": "404"}}, text=leaked_body)):
+            valid, msg = validate_credentials("https://x.metabaseapp.com", _api_key_auth())
+            assert valid is False
+            assert msg is not None
+            assert "SENTINEL_UPSTREAM_BODY" not in msg
+            assert "404" in msg
+
 
 class TestMetabaseSourceResponse:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When a user sets up a Metabase data-warehouse source, `validate_credentials` probes `/api/user/current`. For any status it doesn't explicitly handle (not 200/401/403/redirect), it fell back to returning the raw response body (`response.text`) as the user-facing error.

If the Instance URL doesn't point at a Metabase instance at all — a common mistake — the host returns an arbitrary body (a reverse proxy or hosting-provider error page, often JSON). That raw body was echoed verbatim into the setup wizard's error message, which is both unhelpful (it gives the user nothing actionable) and leaks whatever the upstream host happened to return.

## Changes

Replace the body-extraction fallback with a friendly, status-coded message that points the user back at the Instance URL and never includes the upstream response body:

> Metabase returned an unexpected response (HTTP `<status>`). Check that the Instance URL points to your Metabase instance.

This matches the status-code-only pattern the majority of other warehouse sources already use for unexpected responses. The 200/401/403/redirect paths are unchanged, so genuine credential and permission errors still surface their existing messages.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only, no manual testing.

Added one regression test, `test_unexpected_status_does_not_leak_response_body`, which feeds an unexpected status with an arbitrary upstream body and asserts the returned message is friendly and status-coded and does **not** contain the body. No existing test covered the non-200 fallthrough — the closest cases only assert `(False, ...)` without checking the message never echoes the body.

Ran (all green):

- `pytest .../metabase/tests/` → 70 passed
- `ruff check` + `ruff format --check` on the touched files → clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a day's worth of data-warehouse source-creation failures across every source type. Most were clear, actionable user-misconfiguration messages that need no change. This Metabase case was a genuine internal-leak: the fallthrough branch dumped the raw upstream body into the user-facing error.

Decision: surface only the HTTP status and a pointer back to the Instance URL, mirroring the established pattern in sibling sources, rather than trying to parse meaning out of an arbitrary non-Metabase body. Kept the fix scoped to the fallthrough branch; the handled statuses are untouched. Checked open PRs (including the maintainer's) — none touch the Metabase source.

The same body-echoing fallback pattern exists in a couple of other sources (braze, buildkite) that did not show up in this batch of failures; left out of scope to keep this PR minimal and reviewable.
