### PR TITLE
feat(mcp): strip prompt framing from execute-sql tool results

### DIFF
--- a/ee/hogai/context/insight/context.py
+++ b/ee/hogai/context/insight/context.py
@@ -78,6 +78,7 @@ class InsightContext:
         prompt_template: str = INSIGHT_RESULT_TEMPLATE,
         return_exceptions: bool = False,
         truncate_results: bool = True,
+        include_prompt_framing: bool = True,
     ) -> str:
         """Execute query and format results."""
         effective_query = await self._get_effective_query()
@@ -90,6 +91,7 @@ class InsightContext:
                 insight_id=self.insight_model_id,
                 truncate_results=truncate_results,
                 user=self.user,
+                include_prompt_framing=include_prompt_framing,
             )
         except Exception as e:
             error_message = f"Error executing query: {str(e)}"

--- a/ee/hogai/context/insight/query_executor.py
+++ b/ee/hogai/context/insight/query_executor.py
@@ -615,6 +615,7 @@ async def execute_and_format_query(
     insight_id: Optional[int] = None,
     truncate_results: bool = True,
     user: Optional["User"] = None,
+    include_prompt_framing: bool = True,
 ) -> str:
     """
     Executes a supported query and formats the results for the AI assistant:
@@ -630,6 +631,9 @@ async def execute_and_format_query(
         query: The query to execute.
         execution_mode: The execution mode to use.
         insight_id: The insight ID to use.
+        include_prompt_framing: When False, return only the formatted results table without the
+            example-format description and the surrounding `QUERY_RESULTS_PROMPT` system reminder.
+            Used by the MCP `execute_sql` tool, which returns data straight to an external agent.
     Returns:
         The formatted query results.
     """
@@ -640,6 +644,8 @@ async def execute_and_format_query(
     results, used_fallback = await query_runner.arun_and_format_query(
         query, execution_mode, insight_id, truncate_results=truncate_results
     )
+    if not include_prompt_framing:
+        return results
     example_prompt = FALLBACK_EXAMPLE_PROMPT if used_fallback else get_example_prompt(query)
     currency = team.base_currency or CurrencyCode.USD.value
 

--- a/ee/hogai/tools/execute_sql/mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/mcp_tool.py
@@ -83,7 +83,7 @@ class ExecuteSQLMCPTool(HogQLOutputParserMixin, MCPTool[ExecuteSQLMCPToolArgs]):
             user=self._user,
         )
         results = await insight_context.execute_and_format(
-            prompt_template="{{{results}}}", truncate_results=args.truncate
+            prompt_template="{{{results}}}", truncate_results=args.truncate, include_prompt_framing=False
         )
 
         return _prepend_taxonomy_warnings(results, taxonomy_warnings)

--- a/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
+++ b/ee/hogai/tools/execute_sql/test/test_mcp_tool.py
@@ -35,6 +35,19 @@ class TestExecuteSQLMCPTool(ClickhouseTestMixin, NonAtomicBaseTest):
 
         self.assertIn("test_event", content)
 
+    async def test_result_has_no_prompt_framing(self):
+        _create_event(team=self.team, distinct_id="user1", event="test_event")
+
+        content = await self.tool.execute(
+            ExecuteSQLMCPToolArgs(query="SELECT event, count() as cnt FROM events GROUP BY event"),
+        )
+
+        # The MCP tool returns the data table straight to an external agent, so the human-assistant
+        # framing (format description + "Here is the results table of the ... insight:" reminder) is stripped.
+        self.assertIn("test_event", content)
+        self.assertNotIn("You are given a table with the results of a SQL query", content)
+        self.assertNotIn("Here is the results table", content)
+
     async def test_validation_error_for_invalid_query(self):
         with self.assertRaises(MaxToolRetryableError) as ctx:
             await self.tool.execute(


### PR DESCRIPTION
## Problem

The MCP `execute-sql` tool returns its results to an external agent, but it was wrapping them in framing meant for Max (the in-app chat agent):

- a format-description preamble — *"You are given a table with the results of a SQL query. Values are separated by the pipe character…"* plus an example block, and
- the `QUERY_RESULTS_PROMPT` wrapper — *"Here is the results table of the `<kind>` insight:"* with a trailing `<system_reminder>` block.

For an MCP client that just wants the data, that preamble and reminder are pure noise — they inflate every result and read as instructions aimed at the wrong consumer.

## Changes

The framing leaked through because `prompt_template="{{{results}}}"` only stripped the *outer* `INSIGHT_RESULT_TEMPLATE`; the example/results framing is added one layer deeper, inside `execute_and_format_query`.

I threaded an `include_prompt_framing` flag (default `True`, so Max and every other caller are unchanged) down through `execute_and_format_query` → `InsightContext.execute_and_format`. The MCP tool now passes `include_prompt_framing=False` and gets back the bare formatted table.

What stays in the MCP output, because it's data rather than framing: the warehouse-sync warning prefix and the `<taxonomy_warnings>` block.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only — no manual testing:

- Ran the existing `ee/hogai/tools/execute_sql/test/test_mcp_tool.py` suite — all green; none of them asserted on the framing, so they kept passing.
- Added `test_result_has_no_prompt_framing`, which runs a real query through the tool and asserts the data is present while the two framing strings ("You are given a table with the results of a SQL query", "Here is the results table") are absent. It catches a regression the existing tests miss: they only check that the data appears, so re-introducing the wrapper would slip past them.

`ruff check` / `ruff format` and the lint-staged `ty` check pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: Claude Code (Opus 4.8). No repo skills were required for this change; `/writing-tests` conventions were followed by hand when adding the regression test.
- Decision: rather than special-casing the MCP tool by post-stripping the prose (brittle — it would re-break whenever the prompts change), I added a flag at the source so the framing is simply never generated for this path. Default stays `True` so the in-app assistant and all other callers are untouched.
- Scope: deliberately a separate PR from #66308 (SQL schema discovery flag) — different concern, even though both touch the MCP SQL surface.
