### PR TITLE
fix: Fix Field error in Web analytics achivements notification

### DIFF
--- a/products/notifications/backend/resolvers.py
+++ b/products/notifications/backend/resolvers.py
@@ -20,7 +20,7 @@ class RecipientsResolver:
 
             return list(
                 OrganizationMembership.objects.filter(
-                    organization__teams__id=int(target_id),
+                    organization__team=int(target_id),
                 ).values_list("user_id", flat=True)
             )
         elif target_type == TargetType.ORGANIZATION:

--- a/products/notifications/backend/resolvers.py
+++ b/products/notifications/backend/resolvers.py
@@ -16,13 +16,10 @@ class RecipientsResolver:
         if target_type == TargetType.USER:
             return [int(target_id)]
         elif target_type == TargetType.TEAM:
-            from posthog.models import OrganizationMembership
-
-            return list(
-                OrganizationMembership.objects.filter(
-                    organization__team=int(target_id),
-                ).values_list("user_id", flat=True)
-            )
+            team = Team.objects.filter(id=int(target_id)).first()
+            if team is None:
+                return []
+            return list(team.all_users_with_access().values_list("id", flat=True))
         elif target_type == TargetType.ORGANIZATION:
             from posthog.models import OrganizationMembership
 

--- a/products/notifications/backend/tests/test_logic.py
+++ b/products/notifications/backend/tests/test_logic.py
@@ -86,6 +86,40 @@ class TestCreateNotification(BaseTest):
         assert event is not None
         assert set(event.resolved_user_ids) == {self.user.id, user2.id}
 
+    def test_resolve_team_excludes_org_members_without_project_access(self):
+        from posthog.models import OrganizationMembership
+
+        from ee.models.rbac.access_control import AccessControl
+
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL}
+        ]
+        self.organization.save()
+
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=None,
+            role=None,
+            access_level="none",
+        )
+
+        allowed_user = User.objects.create_and_join(self.organization, "allowed@test.com", "password")
+        AccessControl.objects.create(
+            team=self.team,
+            resource="project",
+            resource_id=str(self.team.id),
+            organization_member=OrganizationMembership.objects.get(organization=self.organization, user=allowed_user),
+            access_level="member",
+        )
+        denied_user = User.objects.create_and_join(self.organization, "denied@test.com", "password")
+
+        result = RecipientsResolver().resolve(TargetType.TEAM, str(self.team.id), self.team.id)
+
+        assert allowed_user.id in result
+        assert denied_user.id not in result
+
     def test_resolve_unknown_target_type_raises(self):
         resolver = RecipientsResolver()
         with pytest.raises(ValueError, match="Unknown target type"):

--- a/products/notifications/backend/tests/test_logic.py
+++ b/products/notifications/backend/tests/test_logic.py
@@ -68,6 +68,24 @@ class TestCreateNotification(BaseTest):
         assert event is not None
         assert set(event.resolved_user_ids) == {self.user.id, user2.id}
 
+    @patch("products.notifications.backend.logic.posthoganalytics.feature_enabled", return_value=True)
+    @patch("products.notifications.backend.logic._publish_to_kafka")
+    def test_create_notification_for_team(self, mock_publish, mock_ff):
+        user2 = User.objects.create_and_join(self.organization, "team_test@test.com", "password")
+
+        data = NotificationData(
+            team_id=self.team.id,
+            notification_type=NotificationType.COMMENT_MENTION,
+            title="Team alert",
+            body="Something happened",
+            target_type=TargetType.TEAM,
+            target_id=str(self.team.id),
+        )
+        event = create_notification(data)
+
+        assert event is not None
+        assert set(event.resolved_user_ids) == {self.user.id, user2.id}
+
     def test_resolve_unknown_target_type_raises(self):
         resolver = RecipientsResolver()
         with pytest.raises(ValueError, match="Unknown target type"):


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem
The team-scoped notification resolver is throwing a FieldError as Web analytics achievements roll out 

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes
changed `organization__teams__id=int(target_id)` to `organization__team=int(target_id)`

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?
Locally, new test
<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
