### PR TITLE
fix(tasks): pass MCP Store approvals to sandbox agents

### DIFF
--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -4,10 +4,12 @@ Facade API for mcp_store.
 This is the ONLY module other apps are allowed to import.
 """
 
+from django.db.models import Prefetch
+
 import structlog
 
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
-from products.mcp_store.backend.models import MCPServerInstallation
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, ActiveInstallationToolInfo
+from products.mcp_store.backend.models import MCPServerInstallation, MCPServerInstallationTool
 
 logger = structlog.get_logger(__name__)
 
@@ -63,4 +65,45 @@ def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallat
         )
 
     logger.debug("Found active MCP installations", count=len(results), team_id=team_id)
+    return results
+
+
+def get_active_installation_tools(team_id: int, user_id: int) -> list[ActiveInstallationToolInfo]:
+    """Return approval metadata for live tools on active, ready-to-use installations."""
+    try:
+        installations = (
+            MCPServerInstallation.objects.filter(team_id=team_id, user_id=user_id, is_enabled=True)
+            .select_related("template")
+            .prefetch_related(
+                Prefetch(
+                    "tools",
+                    queryset=MCPServerInstallationTool.objects.filter(removed_at__isnull=True).order_by("tool_name"),
+                )
+            )
+        )
+    except Exception as e:
+        logger.warning("Error fetching MCP installation tools", error=str(e), team_id=team_id)
+        return []
+
+    results: list[ActiveInstallationToolInfo] = []
+    for installation in installations:
+        if not _is_oauth_ready(installation):
+            logger.debug(
+                "Skipping MCP installation tools because installation is not ready",
+                installation_id=str(installation.id),
+            )
+            continue
+
+        installation_name = _resolve_name(installation)
+        for tool in installation.tools.all():
+            results.append(
+                ActiveInstallationToolInfo(
+                    installation_id=str(installation.id),
+                    installation_name=installation_name,
+                    tool_name=tool.tool_name,
+                    approval_state=tool.approval_state,
+                )
+            )
+
+    logger.debug("Found active MCP installation tools", count=len(results), team_id=team_id)
     return results

--- a/products/mcp_store/backend/facade/api.py
+++ b/products/mcp_store/backend/facade/api.py
@@ -39,30 +39,30 @@ def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallat
     Filters out disabled installations and OAuth installations that
     need reauthorization or are still pending token exchange.
     """
+    results: list[ActiveInstallationInfo] = []
     try:
         installations = MCPServerInstallation.objects.filter(
             team_id=team_id, user_id=user_id, is_enabled=True
         ).select_related("template")
+
+        for installation in installations:
+            if not _is_oauth_ready(installation):
+                logger.debug(
+                    "Skipping MCP installation not ready",
+                    installation_id=str(installation.id),
+                )
+                continue
+
+            results.append(
+                ActiveInstallationInfo(
+                    id=str(installation.id),
+                    name=_resolve_name(installation),
+                    proxy_path=f"/api/environments/{team_id}/mcp_server_installations/{installation.id}/proxy/",
+                )
+            )
     except Exception as e:
         logger.warning("Error fetching MCP installations", error=str(e), team_id=team_id)
         return []
-
-    results: list[ActiveInstallationInfo] = []
-    for installation in installations:
-        if not _is_oauth_ready(installation):
-            logger.debug(
-                "Skipping MCP installation not ready",
-                installation_id=str(installation.id),
-            )
-            continue
-
-        results.append(
-            ActiveInstallationInfo(
-                id=str(installation.id),
-                name=_resolve_name(installation),
-                proxy_path=f"/api/environments/{team_id}/mcp_server_installations/{installation.id}/proxy/",
-            )
-        )
 
     logger.debug("Found active MCP installations", count=len(results), team_id=team_id)
     return results
@@ -70,6 +70,7 @@ def get_active_installations(team_id: int, user_id: int) -> list[ActiveInstallat
 
 def get_active_installation_tools(team_id: int, user_id: int) -> list[ActiveInstallationToolInfo]:
     """Return approval metadata for live tools on active, ready-to-use installations."""
+    results: list[ActiveInstallationToolInfo] = []
     try:
         installations = (
             MCPServerInstallation.objects.filter(team_id=team_id, user_id=user_id, is_enabled=True)
@@ -81,29 +82,28 @@ def get_active_installation_tools(team_id: int, user_id: int) -> list[ActiveInst
                 )
             )
         )
+
+        for installation in installations:
+            if not _is_oauth_ready(installation):
+                logger.debug(
+                    "Skipping MCP installation tools because installation is not ready",
+                    installation_id=str(installation.id),
+                )
+                continue
+
+            installation_name = _resolve_name(installation)
+            for tool in installation.tools.all():
+                results.append(
+                    ActiveInstallationToolInfo(
+                        installation_id=str(installation.id),
+                        installation_name=installation_name,
+                        tool_name=tool.tool_name,
+                        approval_state=tool.approval_state,
+                    )
+                )
     except Exception as e:
         logger.warning("Error fetching MCP installation tools", error=str(e), team_id=team_id)
         return []
-
-    results: list[ActiveInstallationToolInfo] = []
-    for installation in installations:
-        if not _is_oauth_ready(installation):
-            logger.debug(
-                "Skipping MCP installation tools because installation is not ready",
-                installation_id=str(installation.id),
-            )
-            continue
-
-        installation_name = _resolve_name(installation)
-        for tool in installation.tools.all():
-            results.append(
-                ActiveInstallationToolInfo(
-                    installation_id=str(installation.id),
-                    installation_name=installation_name,
-                    tool_name=tool.tool_name,
-                    approval_state=tool.approval_state,
-                )
-            )
 
     logger.debug("Found active MCP installation tools", count=len(results), team_id=team_id)
     return results

--- a/products/mcp_store/backend/facade/contracts.py
+++ b/products/mcp_store/backend/facade/contracts.py
@@ -15,3 +15,13 @@ class ActiveInstallationInfo:
     id: str
     name: str
     proxy_path: str
+
+
+@dataclass(frozen=True)
+class ActiveInstallationToolInfo:
+    """Approval metadata for a live tool on an active MCP server installation."""
+
+    installation_id: str
+    installation_name: str
+    tool_name: str
+    approval_state: str

--- a/products/mcp_store/backend/test/test_facade.py
+++ b/products/mcp_store/backend/test/test_facade.py
@@ -1,5 +1,9 @@
-from posthog.test.base import BaseTest
+from collections.abc import Iterator
 
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.db.utils import OperationalError
 from django.utils import timezone
 
 from parameterized import parameterized
@@ -7,6 +11,17 @@ from parameterized import parameterized
 from products.mcp_store.backend.facade.api import get_active_installation_tools, get_active_installations
 from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, ActiveInstallationToolInfo
 from products.mcp_store.backend.models import MCPServerInstallation, MCPServerInstallationTool, MCPServerTemplate
+
+
+class _FailingInstallationQuerySet:
+    def select_related(self, *_fields: str) -> "_FailingInstallationQuerySet":
+        return self
+
+    def prefetch_related(self, *_lookups: object) -> "_FailingInstallationQuerySet":
+        return self
+
+    def __iter__(self) -> Iterator[MCPServerInstallation]:
+        raise OperationalError("database unavailable")
 
 
 class TestGetActiveInstallations(BaseTest):
@@ -34,6 +49,10 @@ class TestGetActiveInstallations(BaseTest):
                 proxy_path=f"/api/environments/{self.team.id}/mcp_server_installations/{installation.id}/proxy/",
             )
         ]
+
+    def test_returns_empty_list_when_installation_query_evaluation_fails(self) -> None:
+        with patch.object(MCPServerInstallation.objects, "filter", return_value=_FailingInstallationQuerySet()):
+            assert get_active_installations(self.team.id, self.user.id) == []
 
     def test_skips_disabled_installations(self) -> None:
         self._create_installation(is_enabled=False)
@@ -180,6 +199,10 @@ class TestGetActiveInstallationTools(BaseTest):
                 approval_state="needs_approval",
             ),
         ]
+
+    def test_returns_empty_list_when_tool_query_evaluation_fails(self) -> None:
+        with patch.object(MCPServerInstallation.objects, "filter", return_value=_FailingInstallationQuerySet()):
+            assert get_active_installation_tools(self.team.id, self.user.id) == []
 
     def test_skips_removed_tools_and_inactive_installations(self) -> None:
         active = self._create_installation(display_name="Active")

--- a/products/mcp_store/backend/test/test_facade.py
+++ b/products/mcp_store/backend/test/test_facade.py
@@ -1,10 +1,12 @@
 from posthog.test.base import BaseTest
 
+from django.utils import timezone
+
 from parameterized import parameterized
 
-from products.mcp_store.backend.facade.api import get_active_installations
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
-from products.mcp_store.backend.models import MCPServerInstallation, MCPServerTemplate
+from products.mcp_store.backend.facade.api import get_active_installation_tools, get_active_installations
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, ActiveInstallationToolInfo
+from products.mcp_store.backend.models import MCPServerInstallation, MCPServerInstallationTool, MCPServerTemplate
 
 
 class TestGetActiveInstallations(BaseTest):
@@ -134,3 +136,57 @@ class TestGetActiveInstallations(BaseTest):
         results = get_active_installations(self.team.id, self.user.id)
 
         assert (len(results) == 1) == expected_included
+
+
+class TestGetActiveInstallationTools(BaseTest):
+    def _create_installation(self, **kwargs) -> MCPServerInstallation:
+        defaults: dict = {
+            "team": self.team,
+            "user": self.user,
+            "display_name": "Linear",
+            "url": "https://mcp.linear.app/mcp",
+            "auth_type": "api_key",
+            "is_enabled": True,
+        }
+        defaults.update(kwargs)
+        return MCPServerInstallation.objects.create(**defaults)
+
+    def _create_tool(self, installation: MCPServerInstallation, **kwargs) -> MCPServerInstallationTool:
+        defaults = {
+            "installation": installation,
+            "tool_name": "search",
+            "approval_state": "needs_approval",
+            "last_seen_at": timezone.now(),
+        }
+        defaults.update(kwargs)
+        return MCPServerInstallationTool.objects.create(**defaults)
+
+    def test_returns_live_tool_approval_metadata_for_active_installations(self) -> None:
+        installation = self._create_installation(display_name="Linear CRM")
+        self._create_tool(installation, tool_name="search", approval_state="needs_approval")
+        self._create_tool(installation, tool_name="create_ticket", approval_state="approved")
+
+        assert get_active_installation_tools(self.team.id, self.user.id) == [
+            ActiveInstallationToolInfo(
+                installation_id=str(installation.id),
+                installation_name="Linear CRM",
+                tool_name="create_ticket",
+                approval_state="approved",
+            ),
+            ActiveInstallationToolInfo(
+                installation_id=str(installation.id),
+                installation_name="Linear CRM",
+                tool_name="search",
+                approval_state="needs_approval",
+            ),
+        ]
+
+    def test_skips_removed_tools_and_inactive_installations(self) -> None:
+        active = self._create_installation(display_name="Active")
+        disabled = self._create_installation(
+            display_name="Disabled", url="https://disabled.example.com", is_enabled=False
+        )
+        self._create_tool(active, removed_at=timezone.now())
+        self._create_tool(disabled, tool_name="disabled_tool")
+
+        assert get_active_installation_tools(self.team.id, self.user.id) == []

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -718,6 +718,8 @@ class DockerSandbox(SandboxBase):
         model: str | None = None,
         reasoning_effort: str | None = None,
         mcp_servers_arg: str = "",
+        mcp_tool_approvals_arg: str = "",
+        mcp_tool_installations_arg: str = "",
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
@@ -748,7 +750,8 @@ class DockerSandbox(SandboxBase):
             f"env {unset_flags}BASH_ENV={shlex.quote(BASH_ENV_SCRIPT)} "
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{mcp_tool_approvals_arg}"
+            f"{mcp_tool_installations_arg}{domains_flag}"
         )
 
         # agentsh injects HTTP_PROXY pointing at a per-session egress proxy port; undici
@@ -795,6 +798,8 @@ class DockerSandbox(SandboxBase):
         model: str | None = None,
         reasoning_effort: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        mcp_tool_approvals: dict[str, str] | None = None,
+        mcp_tool_installations: dict[str, dict[str, str]] | None = None,
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
@@ -828,6 +833,12 @@ class DockerSandbox(SandboxBase):
         if mcp_configs:
             mcp_json = json.dumps([c.to_dict() for c in mcp_configs])
             mcp_servers_arg = f" --mcpServers {shlex.quote(mcp_json)}"
+        mcp_tool_approvals_arg = ""
+        if mcp_tool_approvals:
+            mcp_tool_approvals_arg = f" --mcpToolApprovals {shlex.quote(json.dumps(mcp_tool_approvals))}"
+        mcp_tool_installations_arg = ""
+        if mcp_tool_installations:
+            mcp_tool_installations_arg = f" --mcpToolInstallations {shlex.quote(json.dumps(mcp_tool_installations))}"
 
         command = self._build_agent_server_command(
             repo_path,
@@ -842,6 +853,8 @@ class DockerSandbox(SandboxBase):
             model,
             reasoning_effort,
             mcp_servers_arg,
+            mcp_tool_approvals_arg,
+            mcp_tool_installations_arg,
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -690,6 +690,8 @@ class ModalSandbox(SandboxBase):
         model: str | None = None,
         reasoning_effort: str | None = None,
         mcp_servers_arg: str = "",
+        mcp_tool_approvals_arg: str = "",
+        mcp_tool_installations_arg: str = "",
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
@@ -716,7 +718,8 @@ class ModalSandbox(SandboxBase):
             f"env {unset_flags}BASH_ENV={shlex.quote(BASH_ENV_SCRIPT)} "
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{mcp_tool_approvals_arg}"
+            f"{mcp_tool_installations_arg}{domains_flag}"
         )
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
@@ -797,6 +800,8 @@ class ModalSandbox(SandboxBase):
         model: str | None = None,
         reasoning_effort: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        mcp_tool_approvals: dict[str, str] | None = None,
+        mcp_tool_installations: dict[str, dict[str, str]] | None = None,
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
@@ -829,6 +834,12 @@ class ModalSandbox(SandboxBase):
         if mcp_configs:
             mcp_json = json.dumps([c.to_dict() for c in mcp_configs])
             mcp_servers_arg = f" --mcpServers {shlex.quote(mcp_json)}"
+        mcp_tool_approvals_arg = ""
+        if mcp_tool_approvals:
+            mcp_tool_approvals_arg = f" --mcpToolApprovals {shlex.quote(json.dumps(mcp_tool_approvals))}"
+        mcp_tool_installations_arg = ""
+        if mcp_tool_installations:
+            mcp_tool_installations_arg = f" --mcpToolInstallations {shlex.quote(json.dumps(mcp_tool_installations))}"
 
         command = self._build_agent_server_command(
             repo_path,
@@ -843,6 +854,8 @@ class ModalSandbox(SandboxBase):
             model,
             reasoning_effort,
             mcp_servers_arg,
+            mcp_tool_approvals_arg,
+            mcp_tool_installations_arg,
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -255,6 +255,8 @@ class SandboxBase(ABC):
         model: str | None = None,
         reasoning_effort: str | None = None,
         mcp_configs: list[McpServerConfig] | None = None,
+        mcp_tool_approvals: dict[str, str] | None = None,
+        mcp_tool_installations: dict[str, dict[str, str]] | None = None,
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -518,6 +518,32 @@ class TestDockerSandboxUnit:
         command = _agent_server_launch_command(mock_execute)
         assert expected_flag in command
 
+    def test_start_agent_server_passes_mcp_tool_approval_metadata(self):
+        sandbox = DockerSandbox.__new__(DockerSandbox)
+        sandbox._container_id = "abc123"
+        sandbox.id = "abc123"
+        sandbox.config = SandboxConfig(name="test")
+        sandbox._host_port = 12345
+
+        with patch.object(sandbox, "is_running", return_value=True):
+            with patch.object(sandbox, "execute") as mock_execute:
+                mock_execute.return_value = ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None)
+                sandbox.start_agent_server(
+                    "posthog/posthog",
+                    "task-123",
+                    "run-456",
+                    "background",
+                    mcp_tool_approvals={"mcp__Linear__search": "needs_approval"},
+                    mcp_tool_installations={"mcp__Linear__search": {"installationId": "inst-1", "toolName": "search"}},
+                )
+
+        command = _agent_server_launch_command(mock_execute)
+        assert "--mcpToolApprovals" in command
+        assert "mcp__Linear__search" in command
+        assert "needs_approval" in command
+        assert "--mcpToolInstallations" in command
+        assert "inst-1" in command
+
     def test_start_agent_server_includes_runtime_environment_variables(self):
         sandbox = DockerSandbox.__new__(DockerSandbox)
         sandbox._container_id = "abc123"

--- a/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
+++ b/products/tasks/backend/logic/services/tests/test_modal_sandbox.py
@@ -420,6 +420,27 @@ class TestModalSandboxAgentServer:
         command = _agent_server_launch_command(mock_sandbox.execute)
         assert expected_flag in command
 
+    def test_start_agent_server_passes_mcp_tool_approval_metadata(self, mock_sandbox: Any):
+        mock_sandbox.execute = MagicMock(
+            return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),
+        )
+
+        mock_sandbox.start_agent_server(
+            repository="posthog/posthog",
+            task_id="task-123",
+            run_id="run-456",
+            mode="background",
+            mcp_tool_approvals={"mcp__Linear__search": "needs_approval"},
+            mcp_tool_installations={"mcp__Linear__search": {"installationId": "inst-1", "toolName": "search"}},
+        )
+
+        command = _agent_server_launch_command(mock_sandbox.execute)
+        assert "--mcpToolApprovals" in command
+        assert "mcp__Linear__search" in command
+        assert "needs_approval" in command
+        assert "--mcpToolInstallations" in command
+        assert "inst-1" in command
+
     def test_start_agent_server_includes_runtime_environment_variables(self, mock_sandbox: Any):
         mock_sandbox.execute = MagicMock(
             return_value=ExecutionResult(stdout="ok:1", stderr="", exit_code=0, error=None),

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -24,6 +24,7 @@ from products.tasks.backend.temporal.process_task.utils import (
     format_allowed_domains_for_log,
     get_sandbox_ph_mcp_configs,
     get_user_mcp_server_configs,
+    get_user_mcp_tool_approval_metadata,
     mark_mcp_token_issued,
 )
 
@@ -207,6 +208,8 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
             interaction_origin=ctx.interaction_origin,
             task_id=str(ctx.task_id),
         )
+        mcp_tool_approvals: dict[str, str] | None = None
+        mcp_tool_installations: dict[str, dict[str, str]] | None = None
         if task.created_by_id:
             user_mcp_configs = get_user_mcp_server_configs(
                 token=access_token,
@@ -216,6 +219,10 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
             )
             if user_mcp_configs:
                 mcp_configs = mcp_configs + user_mcp_configs
+                mcp_tool_metadata = get_user_mcp_tool_approval_metadata(ctx.team_id, task.created_by_id)
+                if mcp_tool_metadata.approvals:
+                    mcp_tool_approvals = mcp_tool_metadata.approvals
+                    mcp_tool_installations = mcp_tool_metadata.installations
 
         if mcp_configs:
             emit_agent_log(
@@ -273,6 +280,8 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
                 model=ctx.model,
                 reasoning_effort=ctx.reasoning_effort,
                 mcp_configs=mcp_configs or None,
+                mcp_tool_approvals=mcp_tool_approvals,
+                mcp_tool_installations=mcp_tool_installations,
                 allowed_domains=agentsh_domains,
                 event_ingest_token=event_ingest_token,
                 event_ingest_url=event_ingest_url,

--- a/products/tasks/backend/temporal/process_task/tests/test_utils.py
+++ b/products/tasks/backend/temporal/process_task/tests/test_utils.py
@@ -1,10 +1,10 @@
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import SimpleTestCase, TestCase
 
 from parameterized import parameterized
 
-from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo
+from products.mcp_store.backend.facade.contracts import ActiveInstallationInfo, ActiveInstallationToolInfo
 from products.tasks.backend.models import Task
 from products.tasks.backend.temporal.process_task.utils import (
     GitHubCredentialSource,
@@ -14,6 +14,7 @@ from products.tasks.backend.temporal.process_task.utils import (
     get_sandbox_github_token,
     get_sandbox_ph_mcp_configs,
     get_user_mcp_server_configs,
+    get_user_mcp_tool_approval_metadata,
     is_caller_token_run,
 )
 
@@ -316,6 +317,36 @@ class TestFetchUserMcpServerConfigs(TestCase):
         assert len(configs) == 2
         assert configs[0].name == "Linear"
         assert configs[1].name == "Notion"
+
+
+class TestUserMcpToolApprovalMetadata(SimpleTestCase):
+    @patch("products.tasks.backend.temporal.process_task.utils.get_active_installation_tools")
+    def test_builds_code_tool_keys_and_installation_refs(self, mock_tools) -> None:
+        mock_tools.return_value = [
+            ActiveInstallationToolInfo(
+                installation_id="abc-1",
+                installation_name="Linear CRM",
+                tool_name="search",
+                approval_state="needs_approval",
+            ),
+            ActiveInstallationToolInfo(
+                installation_id="abc-1",
+                installation_name="Linear CRM",
+                tool_name="create_ticket",
+                approval_state="approved",
+            ),
+        ]
+
+        metadata = get_user_mcp_tool_approval_metadata(team_id=42, user_id=7)
+
+        assert metadata.approvals == {
+            "mcp__Linear_CRM__search": "needs_approval",
+            "mcp__Linear_CRM__create_ticket": "approved",
+        }
+        assert metadata.installations == {
+            "mcp__Linear_CRM__search": {"installationId": "abc-1", "toolName": "search"},
+            "mcp__Linear_CRM__create_ticket": {"installationId": "abc-1", "toolName": "create_ticket"},
+        }
 
 
 class TestGetGitIdentityEnvVars(TestCase):

--- a/products/tasks/backend/temporal/process_task/utils.py
+++ b/products/tasks/backend/temporal/process_task/utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 import logging
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -14,7 +15,7 @@ from posthog.models.integration import GitHubIntegration, Integration
 from posthog.models.user_integration import ReauthorizationRequired, UserGitHubIntegration, UserIntegration
 from posthog.temporal.oauth import TOKEN_EXPIRATION_SECONDS, PosthogMcpScopes, has_write_scopes
 
-from products.mcp_store.backend.facade.api import get_active_installations
+from products.mcp_store.backend.facade.api import get_active_installation_tools, get_active_installations
 from products.tasks.backend.constants import InitialPermissionMode, filter_user_sandbox_env_vars
 from products.tasks.backend.redis import get_tasks_cache
 
@@ -262,6 +263,35 @@ class McpServerConfig:
             "url": self.url,
             "headers": self.headers,
         }
+
+
+@dataclass(frozen=True)
+class McpToolApprovalMetadata:
+    """MCP Store approval metadata keyed by ACP-visible tool name."""
+
+    approvals: dict[str, str] = field(default_factory=dict)
+    installations: dict[str, dict[str, str]] = field(default_factory=dict)
+
+
+def sanitize_mcp_server_name(name: str) -> str:
+    """Match PostHog Code's MCP server name normalization."""
+    return re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+
+
+def get_user_mcp_tool_approval_metadata(team_id: int, user_id: int) -> McpToolApprovalMetadata:
+    approvals: dict[str, str] = {}
+    installations: dict[str, dict[str, str]] = {}
+
+    for tool in get_active_installation_tools(team_id, user_id):
+        server_name = sanitize_mcp_server_name(tool.installation_name)
+        tool_key = f"mcp__{server_name}__{tool.tool_name}"
+        approvals[tool_key] = tool.approval_state
+        installations[tool_key] = {
+            "installationId": tool.installation_id,
+            "toolName": tool.tool_name,
+        }
+
+    return McpToolApprovalMetadata(approvals=approvals, installations=installations)
 
 
 def get_sandbox_api_url() -> str:


### PR DESCRIPTION
## Problem

Sandbox tasks weren't sending tool approvals to users. Tools that require approval are failing at execution time instead of flowing through the normal permission flow.

## Changes

- Expose active MCP Store tools and their approval state through the MCP Store facade, filtered to enabled, ready installations and non-removed tools.
- Convert that tool metadata into ACP-visible `mcp__server__tool` keys plus installation references the sandbox agent can use when handling approvals.
- Pass approval and installation maps into both Docker and Modal sandbox `agent-server` startup.
- Attach approval metadata only when user MCP Store servers are included in the sandbox config.
- Add tests for facade filtering, sandbox metadata key generation, and Docker/Modal command wiring so approval metadata is not silently dropped before startup.

## How did you test this code?

I tested locally with Codex and Claude models.

## Docs update

no