### PR TITLE
chore(signals): nudge scouts to write scratchpad content as markdown

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -83,6 +83,11 @@ surfaced, defeating the dedupe it was meant to do.
 Good: `dedupe:error_tracking:019de34e`, `pattern:apm:cursor`.
 Bad: `dedupe:error_tracking:019de34e-2026-06-09`, `pattern:apm:scan-2026-06-09-0400`.
 
+Write the `content` as **Markdown** — headings, bullet lists, `inline code` for
+ids/keys, links. Humans read these entries directly, so structured Markdown is far
+easier to skim than a wall of prose; it costs you nothing and reads verbatim into
+future prompts just the same.
+
 # Recency lens
 
 Default to recent windows (~last 72h) when querying — fresh evidence is usually

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -566,8 +566,10 @@ tools:
             Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so
             this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking,
             not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and
-            defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass
-            `run_id` to record which run wrote it.
+            defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Write `content`
+            as Markdown — humans read these entries directly, so structured Markdown (headings, bullets, inline
+            code for ids) is far easier to skim than a wall of prose. Optionally pass `run_id` to record which run
+            wrote it.
     signals-scout-scratchpad-search:
         operation: signals_scout_scratchpad_search
         enabled: true

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -566,10 +566,9 @@ tools:
             Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so
             this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking,
             not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and
-            defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Write `content`
-            as Markdown — humans read these entries directly, so structured Markdown (headings, bullets, inline
-            code for ids) is far easier to skim than a wall of prose. Optionally pass `run_id` to record which run
-            wrote it.
+            defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Write `content` as
+            Markdown — humans read these entries directly, so structured Markdown (headings, bullets, inline code for
+            ids) is far easier to skim than a wall of prose. Optionally pass `run_id` to record which run wrote it.
     signals-scout-scratchpad-search:
         operation: signals_scout_scratchpad_search
         enabled: true

--- a/products/signals/skills/signals-scout-general/references/conventions.md
+++ b/products/signals/skills/signals-scout-general/references/conventions.md
@@ -72,7 +72,9 @@ duplicating entries.
 ## Entry shape that pays off
 
 Good entries are **future-run actionable**. The next scout reads them and
-changes behavior because of them:
+changes behavior because of them. Write `content` as Markdown — humans read these
+entries directly, so structured Markdown (headings, bullets, `inline code` for ids)
+is far easier to skim than a wall of prose:
 
 ```text
 key:     dedupe:error_tracking:019de34e-2026-05-01

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6584,7 +6584,7 @@
         }
     },
     "signals-scout-scratchpad-remember": {
-        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass `run_id` to record which run wrote it.",
+        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Write `content` as Markdown — humans read these entries directly, so structured Markdown (headings, bullets, inline code for ids) is far easier to skim than a wall of prose. Optionally pass `run_id` to record which run wrote it.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Remember a scratchpad entry",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7095,7 +7095,7 @@
         }
     },
     "signals-scout-scratchpad-remember": {
-        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Optionally pass `run_id` to record which run wrote it.",
+        "description": "Upsert a scratchpad entry keyed on `(team, key)` — re-using a key updates the existing entry in place, so this is an upsert rather than a strict create. Keys are stable identities: key off *what* you're tracking, not *when* you saw it — never embed dates, timestamps, or run ids (that mints a new row every run and defeats dedupe). For run state, use one fixed key and keep the timestamp in `content`. Write `content` as Markdown — humans read these entries directly, so structured Markdown (headings, bullets, inline code for ids) is far easier to skim than a wall of prose. Optionally pass `run_id` to record which run wrote it.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Remember a scratchpad entry",


### PR DESCRIPTION
## Problem

Scout scratchpad entries are written by the agent but also read directly by humans. Today the harness gives no formatting guidance, so entries tend to come out as a wall of prose that's hard to skim.

## Changes

Add a markdown nudge to the three surfaces that shape how a scout writes scratchpad `content`:

- **Harness prompt** (`prompt.py`) — the "Scratchpad keys" section now tells scouts to write `content` as markdown (headings, bullets, inline code for ids), noting it costs nothing and still reads verbatim into future prompts.
- **`signals-scout-scratchpad-remember` tool description** (`tools.yaml`) — same nudge in the write tool's own description.
- **General scout conventions reference** (`conventions.md`) — "Entry shape that pays off" now mentions markdown.

Regenerated the two MCP tool-definition schemas (`generated-tool-definitions.json`, `tool-definitions-all.json`) from the updated `tools.yaml` description.

## How did you test this code?

I'm an agent. No automated tests were run — these are prompt/description text changes. I verified the regenerated MCP schema descriptions byte-match the folded `tools.yaml` description with a YAML parse check. The full `hogli build:openapi` codegen wasn't run because it requires a live database that wasn't available in this environment; the changed surfaces don't depend on a serializer schema rebuild.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with the PostHog Slack app from a Slack thread. The ask was to nudge scouts to use markdown in scratchpad entries so humans reading them have an easier time, targeting the harness prompt and the write tool descriptions.

Decision worth flagging: I initially also updated the `content` field `help_text` on the DRF serializer, but reverted it. That field flows through the full OpenAPI → orval → MCP zod → vitest-snapshot codegen chain, which needs a DB-backed `build:openapi` run I couldn't perform here. The tool-level description in `tools.yaml` is the surface the scout actually sees when calling the write tool, and it regenerates deterministically from YAML alone, so the nudge lives there instead. The two `schema/*.json` tool-definition files were hand-updated to match the new folded YAML description exactly (verified via parser).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782582466150949)*
