### PR TITLE
feat(signals): add cross-fleet scout findings page to inbox

### DIFF
--- a/frontend/src/scenes/inbox/InboxScene.tsx
+++ b/frontend/src/scenes/inbox/InboxScene.tsx
@@ -14,6 +14,7 @@ import { ScoutDetailView } from './components/config/scouts/ScoutDetailView'
 import { AgentRunDetail } from './components/detail/AgentRunDetail'
 import { InboxDetailHeader } from './components/detail/InboxDetailHeader'
 import { ReportDetail, ReportDetailSkeleton } from './components/detail/ReportDetail'
+import { FindingsPanel } from './components/findings/FindingsPanel'
 import { InboxOnboardingBanner, InboxOnboardingTakeover } from './components/onboarding/InboxOnboarding'
 import { ScratchpadPanel } from './components/scratchpad/ScratchpadPanel'
 import { AgentSetupColumn } from './components/shell/AgentSetupColumn'
@@ -162,6 +163,31 @@ function InboxScratchpadView(): JSX.Element {
     )
 }
 
+/**
+ * Cross-fleet findings detail surface: the findings browse/search panel under a back link, rendered
+ * full-width over the list like the scratchpad. Reached from the scout-findings callout.
+ */
+function InboxFindingsView(): JSX.Element {
+    const { setFindingsOpen } = useActions(inboxSceneLogic)
+
+    return (
+        <div className="flex flex-col min-h-0 flex-1 overflow-auto">
+            <div className="px-4 pt-3">
+                <LemonButton
+                    type="tertiary"
+                    size="small"
+                    icon={<IconArrowLeft />}
+                    onClick={() => setFindingsOpen(false)}
+                    className="self-start"
+                >
+                    Scouts
+                </LemonButton>
+            </div>
+            <FindingsPanel />
+        </div>
+    )
+}
+
 export function InboxScene(): JSX.Element {
     const {
         isRunningSessionAnalysis,
@@ -170,6 +196,7 @@ export function InboxScene(): JSX.Element {
         selectedReportLoading,
         selectedScoutSkillName,
         isScratchpadOpen,
+        isFindingsOpen,
     } = useValues(inboxSceneLogic)
     const { runSessionAnalysis } = useActions(inboxSceneLogic)
     const { onboardingMode } = useValues(inboxOnboardingLogic)
@@ -179,7 +206,7 @@ export function InboxScene(): JSX.Element {
     // stays *mounted* (just hidden) rather than being unmounted. That keeps `reportListLogic` and the scroll
     // container alive, so clicking "back" lands on the same scroll position with the same loaded pages —
     // instead of remounting and resetting to the first page at the top.
-    const showDetail = !!selectedReportId || !!selectedScoutSkillName || isScratchpadOpen
+    const showDetail = !!selectedReportId || !!selectedScoutSkillName || isScratchpadOpen || isFindingsOpen
 
     return (
         <SceneContent className="gap-y-0 border-b-0 flex-1 min-h-0">
@@ -220,7 +247,9 @@ export function InboxScene(): JSX.Element {
 
             {showDetail && (
                 <div className="flex flex-col -mx-4 flex-1 min-h-0">
-                    {isScratchpadOpen ? (
+                    {isFindingsOpen ? (
+                        <InboxFindingsView />
+                    ) : isScratchpadOpen ? (
                         <InboxScratchpadView />
                     ) : selectedScoutSkillName ? (
                         <ScoutDetailView skillName={selectedScoutSkillName} />

--- a/frontend/src/scenes/inbox/components/config/scouts/FleetFindingsCallout.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/FleetFindingsCallout.tsx
@@ -8,11 +8,10 @@ import { pluralize } from 'lib/utils/strings'
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 
 /**
- * Findings stat card for the scout troop list, sitting above the scratchpad callout. Advertises how
- * many findings the troop has emitted recently (count · scouts · recency) and links into the full
- * cross-fleet findings page. Reads the cheap `emittedFindingsSummary` (summed off the runs window) so
- * it never triggers the per-run emission fetch the page does on open. Renders nothing until there's
- * at least one finding, so a fresh project isn't nudged toward an empty page.
+ * Findings stat card for the scout troop list, above the scratchpad callout. Advertises the troop's
+ * recent findings (count · scouts · recency) and links into the cross-fleet findings page. Reads the
+ * cheap `emittedFindingsSummary` so it never triggers the per-run fetch the page does on open. Renders
+ * nothing until there's at least one finding.
  */
 export function FleetFindingsCallout({ onOpen }: { onOpen: () => void }): JSX.Element | null {
     const { emittedFindingsSummary, runsWindowLoadedOnce } = useValues(scoutFleetLogic)

--- a/frontend/src/scenes/inbox/components/config/scouts/FleetFindingsCallout.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/FleetFindingsCallout.tsx
@@ -1,0 +1,49 @@
+import { useValues } from 'kea'
+
+import { IconArrowRight, IconSparkles } from '@posthog/icons'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { pluralize } from 'lib/utils/strings'
+
+import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
+
+/**
+ * Findings stat card for the scout troop list, sitting above the scratchpad callout. Advertises how
+ * many findings the troop has emitted recently (count · scouts · recency) and links into the full
+ * cross-fleet findings page. Reads the cheap `emittedFindingsSummary` (summed off the runs window) so
+ * it never triggers the per-run emission fetch the page does on open. Renders nothing until there's
+ * at least one finding, so a fresh project isn't nudged toward an empty page.
+ */
+export function FleetFindingsCallout({ onOpen }: { onOpen: () => void }): JSX.Element | null {
+    const { emittedFindingsSummary, runsWindowLoadedOnce } = useValues(scoutFleetLogic)
+
+    // Hold until the first runs-window load settles, then only show when there's something to read.
+    if (!runsWindowLoadedOnce || emittedFindingsSummary.count === 0) {
+        return null
+    }
+
+    return (
+        <button
+            type="button"
+            onClick={onOpen}
+            className="flex w-full items-center gap-3 rounded border border-primary bg-bg-light px-4 py-3.5 text-left transition-colors hover:border-primary-3000 hover:bg-bg-3000"
+        >
+            <IconSparkles className="size-5 shrink-0 text-primary-3000" />
+            <div className="flex min-w-0 flex-col">
+                <span className="text-sm font-medium text-default">Scout findings</span>
+                <span className="truncate text-xs text-secondary leading-snug">
+                    {pluralize(emittedFindingsSummary.count, 'finding')} across{' '}
+                    {pluralize(emittedFindingsSummary.scoutCount, 'scout')}
+                    {emittedFindingsSummary.latestAt ? (
+                        <>
+                            {' · latest '}
+                            <TZLabel time={emittedFindingsSummary.latestAt} />
+                        </>
+                    ) : null}
+                </span>
+            </div>
+            <span className="flex-1" />
+            <IconArrowRight className="size-4 shrink-0 text-muted" />
+        </button>
+    )
+}

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -47,8 +47,7 @@ export function ScoutEmissionCard({
     report: LinkedSignalReport | null
     /** True when this finding is the one the current URL deep-links to. */
     isDeepLinked?: boolean
-    /** Cross-fleet listings set this to surface which scout emitted the finding (name in the header,
-     * "View scout" link in the footer). The per-scout page leaves it off — the scout is implied. */
+    /** Cross-fleet listings set this to surface the scout (name in the header, "View scout" footer link). */
     showScout?: boolean
 }): JSX.Element {
     const [expanded, setExpanded] = useState(isDeepLinked)

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -11,6 +11,7 @@ import { addProjectIdIfMissing } from 'lib/utils/kea-router'
 import { urls } from 'scenes/urls'
 
 import { LinkedSignalReport, SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
+import { prettifyScoutSkillName } from '../../../utils/scoutRunsWindow'
 import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
 
 /** Truncated mono identifier rendering for the footer finding id. */
@@ -37,6 +38,7 @@ export function ScoutEmissionCard({
     run,
     report,
     isDeepLinked = false,
+    showScout = false,
 }: {
     skillName: string
     emission: SignalScoutEmission
@@ -45,6 +47,9 @@ export function ScoutEmissionCard({
     report: LinkedSignalReport | null
     /** True when this finding is the one the current URL deep-links to. */
     isDeepLinked?: boolean
+    /** Cross-fleet listings set this to surface which scout emitted the finding (name in the header,
+     * "View scout" link in the footer). The per-scout page leaves it off — the scout is implied. */
+    showScout?: boolean
 }): JSX.Element {
     const [expanded, setExpanded] = useState(isDeepLinked)
     const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
@@ -86,6 +91,11 @@ export function ScoutEmissionCard({
                         className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
                     />
                     <SignalReportPriorityBadge priority={emission.severity} />
+                    {showScout && (
+                        <span className="truncate text-xs font-medium text-default">
+                            {prettifyScoutSkillName(skillName)}
+                        </span>
+                    )}
                     <span className="whitespace-nowrap text-[11px] text-muted tabular-nums">
                         {confidencePercent}% confidence
                     </span>
@@ -125,6 +135,14 @@ export function ScoutEmissionCard({
                 {expanded && (
                     <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
                         <MonoId label="Finding" value={emission.finding_id} />
+                        {showScout && (
+                            <Link
+                                to={urls.inboxScout(skillName)}
+                                className="flex items-center gap-1 font-medium shrink-0"
+                            >
+                                View {prettifyScoutSkillName(skillName)} <IconArrowRight className="size-3" />
+                            </Link>
+                        )}
                         {run.task_url && (
                             <>
                                 <span className="flex-1" />

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutsFleetSection.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutsFleetSection.tsx
@@ -20,6 +20,7 @@ import {
     scoutRunsWindowLabel,
 } from '../../../utils/scoutRunsWindow'
 import { agentSetupModalLogic } from '../../shell/agentSetupModalLogic'
+import { FleetFindingsCallout } from './FleetFindingsCallout'
 import { FleetMemoryCallout } from './FleetMemoryCallout'
 import { ScoutHelperSkillLinks } from './ScoutHelperSkillLinks'
 import { ScoutRowCard } from './ScoutRowCard'
@@ -33,7 +34,7 @@ import { ScoutRowCard } from './ScoutRowCard'
 export function ScoutsFleetSection(): JSX.Element {
     const { scoutConfigs, scoutConfigsLoading } = useValues(scoutFleetLogic)
     const { loadScoutConfigs, startRunsPolling, stopRunsPolling } = useActions(scoutFleetLogic)
-    const { setScratchpadOpen } = useActions(inboxSceneLogic)
+    const { setScratchpadOpen, setFindingsOpen } = useActions(inboxSceneLogic)
     const { closeSetupModal } = useActions(agentSetupModalLogic)
 
     // Poll the runs window only while the fleet list is open — the always-mounted setup
@@ -76,6 +77,14 @@ export function ScoutsFleetSection(): JSX.Element {
         <div className="flex flex-col gap-3">
             <ScoutAlphaBanner />
             <FleetStatsHeader />
+            <FleetFindingsCallout
+                onOpen={() => {
+                    // This section can render inside the scout-troop setup modal; dismiss it so the
+                    // findings view isn't left hidden behind the portal'd modal. No-op outside a modal.
+                    closeSetupModal()
+                    setFindingsOpen(true)
+                }}
+            />
             <FleetMemoryCallout
                 onOpen={() => {
                     // This section can render inside the scout-troop setup modal; dismiss it so the

--- a/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
+++ b/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
@@ -110,7 +110,9 @@ export function FindingsPanel(): JSX.Element {
                 <div className="flex flex-col gap-2">
                     {filteredRows.map((row) => (
                         <ScoutEmissionCard
-                            key={row.emission.source_id}
+                            // emission.id (unique per row), not source_id — a run can emit the same
+                            // finding_id twice, and those siblings share a source_id.
+                            key={row.emission.id}
                             skillName={row.run.skill_name}
                             emission={row.emission}
                             run={row.run}

--- a/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
+++ b/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
@@ -25,10 +25,9 @@ const SORT_OPTIONS: { value: FindingsSortKey; label: string }[] = [
 ]
 
 /**
- * Cross-fleet findings browser. Surfaces every finding the troop has emitted recently in one place —
- * newest first by default, searchable, and filterable by scout/severity with a sort toggle. Reuses
- * the per-scout `ScoutEmissionCard` (with `showScout` on, so each card names + links its scout).
- * Read-only: the page reflects what scouts emitted; acting on a finding happens in its inbox report.
+ * Cross-fleet findings browser — every finding the troop emitted recently in one place, newest first,
+ * searchable and filterable by scout/severity with a sort toggle. Reuses the per-scout
+ * `ScoutEmissionCard` with `showScout` on. Read-only; acting on a finding happens in its inbox report.
  */
 export function FindingsPanel(): JSX.Element {
     const {
@@ -110,8 +109,7 @@ export function FindingsPanel(): JSX.Element {
                 <div className="flex flex-col gap-2">
                     {filteredRows.map((row) => (
                         <ScoutEmissionCard
-                            // emission.id (unique per row), not source_id — a run can emit the same
-                            // finding_id twice, and those siblings share a source_id.
+                            // emission.id, not source_id — a run can re-emit a finding_id, sharing source_id.
                             key={row.emission.id}
                             skillName={row.run.skill_name}
                             emission={row.emission}

--- a/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
+++ b/frontend/src/scenes/inbox/components/findings/FindingsPanel.tsx
@@ -1,0 +1,186 @@
+import { useActions, useValues } from 'kea'
+
+import { IconSparkles } from '@posthog/icons'
+import { LemonButton, LemonInput, LemonSelect, LemonSkeleton } from '@posthog/lemon-ui'
+
+import { TZLabel } from 'lib/components/TZLabel'
+import { pluralize } from 'lib/utils/strings'
+
+import {
+    FINDINGS_SCOUT_FILTER_ALL,
+    FINDINGS_SEVERITY_FILTER_ALL,
+    findingsLogic,
+    FindingsSortKey,
+} from '../../logics/findingsLogic'
+import { SignalReportPriority } from '../../types'
+import { SCOUT_RUNS_WINDOW_SPAN } from '../../utils/scoutRunsWindow'
+import { ScoutEmissionCard } from '../config/scouts/ScoutEmissionCard'
+
+const SEVERITY_OPTIONS: SignalReportPriority[] = ['P0', 'P1', 'P2', 'P3', 'P4']
+const SORT_OPTIONS: { value: FindingsSortKey; label: string }[] = [
+    { value: 'newest', label: 'Newest' },
+    { value: 'oldest', label: 'Oldest' },
+    { value: 'severity', label: 'Severity' },
+    { value: 'confidence', label: 'Confidence' },
+]
+
+/**
+ * Cross-fleet findings browser. Surfaces every finding the troop has emitted recently in one place —
+ * newest first by default, searchable, and filterable by scout/severity with a sort toggle. Reuses
+ * the per-scout `ScoutEmissionCard` (with `showScout` on, so each card names + links its scout).
+ * Read-only: the page reflects what scouts emitted; acting on a finding happens in its inbox report.
+ */
+export function FindingsPanel(): JSX.Element {
+    const {
+        filteredRows,
+        availableScouts,
+        totalCount,
+        scoutCount,
+        latestEmittedAt,
+        searchText,
+        scoutFilter,
+        severityFilter,
+        sortKey,
+        hasLoadedOnce,
+        emissionsLoadFailed,
+        emissionsLoading,
+    } = useValues(findingsLogic)
+    const { setSearchText, setScoutFilter, setSeverityFilter, setSortKey, loadEmissions } = useActions(findingsLogic)
+
+    const isFiltering =
+        searchText.trim().length > 0 ||
+        scoutFilter !== FINDINGS_SCOUT_FILTER_ALL ||
+        severityFilter !== FINDINGS_SEVERITY_FILTER_ALL
+
+    return (
+        <div className="flex flex-col gap-4 px-4 py-3">
+            <FindingsHeader totalCount={totalCount} scoutCount={scoutCount} latestEmittedAt={latestEmittedAt} />
+
+            <div className="flex flex-wrap items-center gap-2">
+                <LemonInput
+                    type="search"
+                    placeholder="Search findings…"
+                    value={searchText}
+                    onChange={setSearchText}
+                    className="flex-1 min-w-[12rem]"
+                    allowClear
+                />
+                <LemonSelect
+                    size="small"
+                    value={scoutFilter}
+                    onChange={setScoutFilter}
+                    options={[
+                        { value: FINDINGS_SCOUT_FILTER_ALL, label: 'All scouts' },
+                        ...availableScouts.map((scout) => ({
+                            value: scout.skillName,
+                            label: `${scout.label} (${scout.count})`,
+                        })),
+                    ]}
+                />
+                <LemonSelect
+                    size="small"
+                    value={severityFilter}
+                    onChange={setSeverityFilter}
+                    options={[
+                        { value: FINDINGS_SEVERITY_FILTER_ALL, label: 'All severities' },
+                        ...SEVERITY_OPTIONS.map((severity) => ({ value: severity, label: severity })),
+                    ]}
+                />
+                <LemonSelect
+                    size="small"
+                    value={sortKey}
+                    onChange={setSortKey}
+                    options={SORT_OPTIONS}
+                    // Prefix so the dropdown reads "Sort: Newest" rather than a bare value.
+                    renderButtonContent={(label) => `Sort: ${label ?? ''}`}
+                />
+            </div>
+
+            {!hasLoadedOnce ? (
+                <div className="flex flex-col gap-2">
+                    <LemonSkeleton className="h-14 w-full rounded" />
+                    <LemonSkeleton className="h-14 w-full rounded" />
+                    <LemonSkeleton className="h-14 w-full rounded" />
+                </div>
+            ) : emissionsLoadFailed && totalCount === 0 ? (
+                <FindingsErrorState onRetry={() => loadEmissions()} loading={emissionsLoading} />
+            ) : filteredRows.length === 0 ? (
+                <FindingsEmptyState isFiltering={isFiltering} />
+            ) : (
+                <div className="flex flex-col gap-2">
+                    {filteredRows.map((row) => (
+                        <ScoutEmissionCard
+                            key={row.emission.source_id}
+                            skillName={row.run.skill_name}
+                            emission={row.emission}
+                            run={row.run}
+                            report={row.report}
+                            showScout
+                        />
+                    ))}
+                </div>
+            )}
+        </div>
+    )
+}
+
+function FindingsHeader({
+    totalCount,
+    scoutCount,
+    latestEmittedAt,
+}: {
+    totalCount: number
+    scoutCount: number
+    latestEmittedAt: string | null
+}): JSX.Element {
+    return (
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+                <IconSparkles className="size-5 text-primary-3000" />
+                <span className="text-base font-semibold text-default">Scout findings</span>
+            </div>
+            <p className="mb-0 text-sm text-secondary">
+                Every signal your scouts have emitted recently, in one place — newest first. See what's been surfaced
+                across the whole troop, which scout found it, and the inbox report it fed into.
+            </p>
+            {totalCount > 0 && (
+                <span className="text-xs text-muted">
+                    {pluralize(totalCount, 'finding')} · {pluralize(scoutCount, 'scout')}
+                    {latestEmittedAt ? (
+                        <>
+                            {' · latest '}
+                            <TZLabel time={latestEmittedAt} />
+                        </>
+                    ) : null}
+                </span>
+            )}
+            <span className="text-xs text-muted">
+                Covers findings from the most recent {SCOUT_RUNS_WINDOW_SPAN} of troop runs. Older findings live on in
+                the inbox reports they produced.
+            </span>
+        </div>
+    )
+}
+
+function FindingsErrorState({ onRetry, loading }: { onRetry: () => void; loading: boolean }): JSX.Element {
+    return (
+        <div className="flex flex-col items-center gap-2 rounded border border-dashed border-primary bg-bg-light px-4 py-8 text-center text-sm text-muted">
+            <span>
+                Couldn't load findings. The scout API may be unavailable or this project may not be enrolled yet.
+            </span>
+            <LemonButton type="secondary" size="small" onClick={onRetry} loading={loading}>
+                Retry
+            </LemonButton>
+        </div>
+    )
+}
+
+function FindingsEmptyState({ isFiltering }: { isFiltering: boolean }): JSX.Element {
+    return (
+        <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-8 text-center text-sm text-muted">
+            {isFiltering
+                ? 'No findings match your search and filters.'
+                : "Your scouts haven't emitted any findings yet. As they scan your project, what they surface shows up here."}
+        </div>
+    )
+}

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -97,6 +97,34 @@ function findReportRank(
     return { rank: null, listSize: null }
 }
 
+/**
+ * The URL for whichever full-width inbox surface is currently open, or the list otherwise. The four
+ * surfaces (report, scout detail, scratchpad, findings) are mutually exclusive — opening one closes
+ * the others via reducers/listeners — so a fixed priority order resolves them unambiguously.
+ */
+function inboxSurfaceUrl(values: {
+    selectedReportId: string | null
+    activeTab: InboxTabKey
+    selectedScoutSkillName: string | null
+    selectedScoutFindingId: string | null
+    isScratchpadOpen: boolean
+    isFindingsOpen: boolean
+}): string {
+    if (values.selectedReportId) {
+        return urls.inboxReport(values.activeTab, values.selectedReportId)
+    }
+    if (values.selectedScoutSkillName) {
+        return urls.inboxScout(values.selectedScoutSkillName, values.selectedScoutFindingId ?? undefined)
+    }
+    if (values.isScratchpadOpen) {
+        return urls.inboxScratchpad()
+    }
+    if (values.isFindingsOpen) {
+        return urls.inboxFindings()
+    }
+    return urls.inbox(values.activeTab)
+}
+
 /** Open-report engagement tracking state, kept on the logic's `cache` (not reactive). */
 interface InboxOpenTracking {
     report: SignalReport
@@ -136,6 +164,10 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         // Scout fleet-memory (scratchpad) surface: a full-width browse/search view over the list,
         // mutually exclusive with the report and scout-detail views. Reached from the fleet-memory callout.
         setScratchpadOpen: (open: boolean) => ({ open }),
+        // Cross-fleet findings surface: a full-width browse/search/filter view of every finding the
+        // troop emitted recently, mutually exclusive with the other full-width views. Reached from the
+        // scout-findings callout.
+        setFindingsOpen: (open: boolean) => ({ open }),
         runSessionAnalysis: true,
         runSessionAnalysisSuccess: true,
         runSessionAnalysisFailure: (error: string) => ({ error }),
@@ -197,9 +229,20 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             false,
             {
                 setScratchpadOpen: (_, { open }) => open,
-                // Opening a report or a scout closes the memory view.
+                // Opening a report, a scout, or the findings view closes the memory view.
                 setSelectedReportId: (state, { id }) => (id ? false : state),
                 setSelectedScoutSkillName: (state, { skillName }) => (skillName ? false : state),
+                setFindingsOpen: (state, { open }) => (open ? false : state),
+            },
+        ],
+        isFindingsOpen: [
+            false,
+            {
+                setFindingsOpen: (_, { open }) => open,
+                // Opening a report, a scout, or the memory view closes the findings view.
+                setSelectedReportId: (state, { id }) => (id ? false : state),
+                setSelectedScoutSkillName: (state, { skillName }) => (skillName ? false : state),
+                setScratchpadOpen: (state, { open }) => (open ? false : state),
             },
         ],
         // The finding deep-linked within the selected scout, if any. Cleared whenever a scout is
@@ -329,6 +372,20 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 clearScratchpadSearch()
             }
         },
+        setFindingsOpen: ({ open }) => {
+            if (open) {
+                // Same dwell-tracking-preserving close as the scratchpad path. The scratchpad itself is
+                // closed by its reducer; clear its transient search so the memory callout isn't left
+                // hidden behind a stale no-match filter when the user heads back.
+                clearScratchpadSearch()
+                if (values.selectedReportId !== null) {
+                    actions.setSelectedReportId(null)
+                }
+                if (values.selectedScoutSkillName !== null) {
+                    actions.setSelectedScoutSkillName(null)
+                }
+            }
+        },
         loadSourceConfigsSuccess: () => {
             clearInterval(cache.sessionAnalysisPollInterval)
             if (values.isSessionAnalysisRunning) {
@@ -380,34 +437,29 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             router.values.hashParams,
             { replace: false },
         ],
+        // Each surface toggle resolves to whichever full-width view is left open (or the list). When a
+        // report is cleared because a scout / memory / findings view was just opened (mutually
+        // exclusive), this honors that surface's URL rather than bouncing to the list.
         setSelectedReportId: () => [
-            // When a report is cleared because a scout or the memory view was just opened (mutually
-            // exclusive views), honor that surface's URL rather than bouncing to the list.
-            values.selectedReportId
-                ? urls.inboxReport(values.activeTab, values.selectedReportId)
-                : values.isScratchpadOpen
-                  ? urls.inboxScratchpad()
-                  : values.selectedScoutSkillName
-                    ? urls.inboxScout(values.selectedScoutSkillName, values.selectedScoutFindingId ?? undefined)
-                    : urls.inbox(values.activeTab),
+            inboxSurfaceUrl(values),
             router.values.searchParams,
             router.values.hashParams,
             { replace: false },
         ],
         setSelectedScoutSkillName: () => [
-            values.selectedScoutSkillName
-                ? urls.inboxScout(values.selectedScoutSkillName, values.selectedScoutFindingId ?? undefined)
-                : values.isScratchpadOpen
-                  ? urls.inboxScratchpad()
-                  : values.selectedReportId
-                    ? urls.inboxReport(values.activeTab, values.selectedReportId)
-                    : urls.inbox(values.activeTab),
+            inboxSurfaceUrl(values),
             router.values.searchParams,
             router.values.hashParams,
             { replace: false },
         ],
         setScratchpadOpen: () => [
-            values.isScratchpadOpen ? urls.inboxScratchpad() : urls.inbox(values.activeTab),
+            inboxSurfaceUrl(values),
+            router.values.searchParams,
+            router.values.hashParams,
+            { replace: false },
+        ],
+        setFindingsOpen: () => [
+            inboxSurfaceUrl(values),
             router.values.searchParams,
             router.values.hashParams,
             { replace: false },
@@ -420,6 +472,11 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
                 actions.setScratchpadOpen(true)
             }
         },
+        [urls.inboxFindings()]: () => {
+            if (!values.isFindingsOpen) {
+                actions.setFindingsOpen(true)
+            }
+        },
         [urls.inbox()]: () => {
             cache.inboxListVisited = true
             if (values.selectedReportId !== null) {
@@ -430,6 +487,9 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             }
             if (values.isScratchpadOpen) {
                 actions.setScratchpadOpen(false)
+            }
+            if (values.isFindingsOpen) {
+                actions.setFindingsOpen(false)
             }
         },
         [urls.inbox(':tab')]: ({ tab }: { tab?: string }) => {
@@ -462,10 +522,14 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             if (values.isScratchpadOpen) {
                 actions.setScratchpadOpen(false)
             }
+            if (values.isFindingsOpen) {
+                actions.setFindingsOpen(false)
+            }
         },
         [urls.inboxScout(':skillName')]: ({ skillName }: { skillName?: string }) => {
-            // `/inbox/scouts/scratchpad` also matches this pattern; the memory handler owns that path.
-            if (skillName === 'scratchpad') {
+            // `/inbox/scouts/scratchpad` and `/inbox/scouts/findings` also match this pattern; their own
+            // handlers own those paths (no real scout skill_name collides — they're `signals-scout-*`).
+            if (skillName === 'scratchpad' || skillName === 'findings') {
                 return
             }
             const name = skillName ?? null

--- a/frontend/src/scenes/inbox/inboxSceneLogic.ts
+++ b/frontend/src/scenes/inbox/inboxSceneLogic.ts
@@ -98,9 +98,8 @@ function findReportRank(
 }
 
 /**
- * The URL for whichever full-width inbox surface is currently open, or the list otherwise. The four
- * surfaces (report, scout detail, scratchpad, findings) are mutually exclusive — opening one closes
- * the others via reducers/listeners — so a fixed priority order resolves them unambiguously.
+ * The URL for whichever full-width inbox surface is open, or the list otherwise. The four (report,
+ * scout detail, scratchpad, findings) are mutually exclusive, so a fixed priority order resolves them.
  */
 function inboxSurfaceUrl(values: {
     selectedReportId: string | null
@@ -164,9 +163,8 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         // Scout fleet-memory (scratchpad) surface: a full-width browse/search view over the list,
         // mutually exclusive with the report and scout-detail views. Reached from the fleet-memory callout.
         setScratchpadOpen: (open: boolean) => ({ open }),
-        // Cross-fleet findings surface: a full-width browse/search/filter view of every finding the
-        // troop emitted recently, mutually exclusive with the other full-width views. Reached from the
-        // scout-findings callout.
+        // Cross-fleet findings surface: full-width browse/search/filter of every finding the troop
+        // emitted recently, mutually exclusive with the other full-width views.
         setFindingsOpen: (open: boolean) => ({ open }),
         runSessionAnalysis: true,
         runSessionAnalysisSuccess: true,
@@ -374,9 +372,8 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
         },
         setFindingsOpen: ({ open }) => {
             if (open) {
-                // Same dwell-tracking-preserving close as the scratchpad path. The scratchpad itself is
-                // closed by its reducer; clear its transient search so the memory callout isn't left
-                // hidden behind a stale no-match filter when the user heads back.
+                // Same dwell-tracking-preserving close as the scratchpad path; clear its transient
+                // search so the memory callout isn't left hidden behind a stale filter on the way back.
                 clearScratchpadSearch()
                 if (values.selectedReportId !== null) {
                     actions.setSelectedReportId(null)
@@ -437,9 +434,8 @@ export const inboxSceneLogic = kea<inboxSceneLogicType>([
             router.values.hashParams,
             { replace: false },
         ],
-        // Each surface toggle resolves to whichever full-width view is left open (or the list). When a
-        // report is cleared because a scout / memory / findings view was just opened (mutually
-        // exclusive), this honors that surface's URL rather than bouncing to the list.
+        // Each toggle resolves to whichever full-width view is left open (or the list), so clearing one
+        // because another opened honors that surface's URL rather than bouncing to the list.
         setSelectedReportId: () => [
             inboxSurfaceUrl(values),
             router.values.searchParams,

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -254,11 +254,14 @@ export const findingsLogic = kea<findingsLogicType>([
             },
         ],
         // "Loaded once" so the page tells "not loaded yet" from "loaded, genuinely empty" without
-        // flickering a skeleton on the 60s poll.
+        // flickering a skeleton on the 60s poll. When the window loaded but no run emitted anything
+        // there's nothing to fetch, so we're done immediately — otherwise the no-op `loadEmissions([])`
+        // would flash skeletons for a tick before the empty state. The `!emissionsLoading` guard then
+        // only governs the has-emissions case (suppressing poll flicker once findings are in hand).
         hasLoadedOnce: [
-            (s) => [s.runsWindowLoadedOnce, s.emissionsLoading, s.emissions],
-            (runsWindowLoadedOnce, emissionsLoading, emissions): boolean =>
-                runsWindowLoadedOnce && (!emissionsLoading || emissions.length > 0),
+            (s) => [s.runsWindowLoadedOnce, s.emittedRuns, s.emissionsLoading, s.emissions],
+            (runsWindowLoadedOnce, emittedRuns: SignalScoutRunSummary[], emissionsLoading, emissions): boolean =>
+                runsWindowLoadedOnce && (emittedRuns.length === 0 || !emissionsLoading || emissions.length > 0),
         ],
     }),
 

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 import { subscriptions } from 'kea-subscriptions'
 
@@ -12,15 +12,10 @@ import {
     SignalScoutEmissionReportLink,
     SignalScoutRunSummary,
 } from '../types'
-import { prettifyScoutSkillName } from '../utils/scoutRunsWindow'
+import { mostRecentEmittedRuns, prettifyScoutSkillName } from '../utils/scoutRunsWindow'
 import type { findingsLogicType } from './findingsLogicType'
 import { ScoutEmissionRow } from './scoutDetailLogic'
 import { scoutFleetLogic } from './scoutFleetLogic'
-
-// Fleet-wide the fan-out is larger than a single scout's page, so bound the fetched window harder:
-// the most recent emitted runs across the whole troop. Older findings live on in the inbox reports
-// they produced. Sized to keep the concurrent emission fetches (and rendered cards) reasonable.
-const MAX_FLEET_EMITTED_RUNS = 120
 
 // Report linkage is eventually consistent (a finding's signal groups into a report asynchronously),
 // so keep retrying the reverse lookup on the fleet's runs-window poll, but only while a *recent*
@@ -135,15 +130,12 @@ export const findingsLogic = kea<findingsLogicType>([
     }),
 
     selectors({
-        // Every scout's runs that emitted at least one finding, newest first, capped fleet-wide.
+        // Every scout's runs that emitted at least one finding, newest first, capped fleet-wide. Shares
+        // `mostRecentEmittedRuns` with the callout's summary so the two count the exact same run set.
         emittedRuns: [
             (s) => [s.runsWindow],
             (runsWindow: { runs: SignalScoutRunSummary[]; complete: boolean }): SignalScoutRunSummary[] =>
-                runsWindow.runs
-                    .filter((run) => (run.emitted_count ?? 0) > 0)
-                    .slice()
-                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
-                    .slice(0, MAX_FLEET_EMITTED_RUNS),
+                mostRecentEmittedRuns(runsWindow.runs),
         ],
         // Stable string key over the emitted runs — refetch only when the set actually changes, not on
         // every 60s runs-window poll. Includes `emitted_count` so an in-progress run that emits more
@@ -286,6 +278,18 @@ export const findingsLogic = kea<findingsLogicType>([
             if (hasRecentUnlinked) {
                 actions.loadEmissionReports()
             }
+        },
+    })),
+
+    events(() => ({
+        afterMount: () => {
+            // The fleet section's `startRunsPolling` normally loads the runs window, but this page can be
+            // reached cold (a shared `/inbox/scouts/findings` URL, or a narrow viewport with no setup
+            // rail) when that section isn't mounted — which would leave the page stuck on a skeleton.
+            // Trigger one load so it resolves. We deliberately don't mirror the section's start/stop
+            // polling: it shares a single keyed `runsPoll` disposable, so a stop on this panel's unmount
+            // would also kill the section's poll. Live refresh still comes from the section when mounted.
+            scoutFleetLogic.actions.loadRunsWindow()
         },
     })),
 ])

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -17,9 +17,8 @@ import type { findingsLogicType } from './findingsLogicType'
 import { ScoutEmissionRow } from './scoutDetailLogic'
 import { scoutFleetLogic } from './scoutFleetLogic'
 
-// Report linkage is eventually consistent (a finding's signal groups into a report asynchronously),
-// so keep retrying the reverse lookup on the fleet's runs-window poll, but only while a *recent*
-// finding is still unlinked — past this it'll never group (deduped, deleted, below threshold).
+// Report linkage is eventually consistent, so keep retrying the reverse lookup on the runs-window
+// poll, but only while a recently-emitted finding is still unlinked (past this it never will be).
 const REPORT_LINK_RETRY_WINDOW_MINUTES = 30
 
 export type FindingsSortKey = 'newest' | 'oldest' | 'severity' | 'confidence'
@@ -34,11 +33,10 @@ function severityRank(severity: SignalReportPriority | null): number {
 
 /**
  * Fleet-wide findings logic — the cross-troop counterpart of the per-scout `scoutDetailLogic`. Reuses
- * the singleton `scoutFleetLogic`'s already-polled runs window to find every scout's recent emitted
- * runs, fetches each run's emissions + report links, and flattens them into one searchable,
- * filterable, sortable list. Singleton (not keyed): mounted only by the findings page, so the per-run
- * emission fan-out stays lazy — the fleet section's callout reads the cheap
- * `scoutFleetLogic.emittedFindingsSummary` instead.
+ * `scoutFleetLogic`'s polled runs window to find every scout's recent emitted runs, fetches each run's
+ * emissions + report links, and flattens them into one searchable/filterable/sortable list. Singleton,
+ * mounted only by the findings page, so the per-run fan-out stays lazy (the callout reads the cheap
+ * `scoutFleetLogic.emittedFindingsSummary` instead).
  */
 export const findingsLogic = kea<findingsLogicType>([
     path(['scenes', 'inbox', 'logics', 'findingsLogic']),
@@ -63,8 +61,8 @@ export const findingsLogic = kea<findingsLogicType>([
                     if (runs.length === 0) {
                         return []
                     }
-                    // allSettled, not all: one failed run's fetch (transient 500, deleted run) shouldn't
-                    // discard every other run's findings — surface the partial set.
+                    // allSettled, not all: one failed run's fetch shouldn't discard every other run's
+                    // findings — surface the partial set.
                     const settled = await Promise.allSettled(
                         runs.map((run) => api.signalScout.runs.emissions(run.run_id))
                     )
@@ -72,9 +70,8 @@ export const findingsLogic = kea<findingsLogicType>([
                         (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
                             result.status === 'fulfilled'
                     )
-                    // Every fetch failed (outage / auth / scope) while the runs say these emitted —
-                    // throw so the page shows an error, not a false "no findings". A partial failure
-                    // still returns the findings that did load.
+                    // All fetches failed while the runs say these emitted — throw so the page shows an
+                    // error, not a false "no findings".
                     if (fulfilled.length === 0) {
                         throw new Error('Failed to load scout findings')
                     }
@@ -90,9 +87,8 @@ export const findingsLogic = kea<findingsLogicType>([
                     if (runs.length === 0) {
                         return []
                     }
-                    // Retain the prior round's links per run on failure (this loader re-runs on the poll):
-                    // source_id is `run:<run_id>:finding:<id>`, so a failed run's already-resolved chips
-                    // are the ones prefixed with its run_id.
+                    // Retain the prior round's links for a failed run (this re-runs on the poll); its
+                    // links are the ones whose source_id is prefixed `run:<run_id>:`.
                     const previous = values.emissionReports
                     const settled = await Promise.allSettled(
                         runs.map((run) => api.signalScout.runs.emissionReports(run.run_id))
@@ -130,16 +126,15 @@ export const findingsLogic = kea<findingsLogicType>([
     }),
 
     selectors({
-        // Every scout's runs that emitted at least one finding, newest first, capped fleet-wide. Shares
-        // `mostRecentEmittedRuns` with the callout's summary so the two count the exact same run set.
+        // Emitted runs newest-first, capped fleet-wide. Shares `mostRecentEmittedRuns` with the callout
+        // summary so the two count the exact same run set.
         emittedRuns: [
             (s) => [s.runsWindow],
             (runsWindow: { runs: SignalScoutRunSummary[]; complete: boolean }): SignalScoutRunSummary[] =>
                 mostRecentEmittedRuns(runsWindow.runs),
         ],
-        // Stable string key over the emitted runs — refetch only when the set actually changes, not on
-        // every 60s runs-window poll. Includes `emitted_count` so an in-progress run that emits more
-        // findings retriggers.
+        // Stable key over the emitted runs — refetch only when the set changes, not on every poll.
+        // Includes `emitted_count` so an in-progress run that emits more findings retriggers.
         emittedRunsKey: [
             (s) => [s.emittedRuns],
             (emittedRuns: SignalScoutRunSummary[]): string =>
@@ -157,8 +152,7 @@ export const findingsLogic = kea<findingsLogicType>([
                         .map((link) => [link.source_id, link.report as LinkedSignalReport])
                 ),
         ],
-        // Join fetched emissions back to their run (carries skill_name + the task-run link) and to the
-        // inbox report they grouped into.
+        // Join emissions back to their run (for skill_name + task-run link) and the report they grouped into.
         rows: [
             (s) => [s.emissions, s.emittedRuns, s.reportBySourceId],
             (
@@ -188,8 +182,7 @@ export const findingsLogic = kea<findingsLogicType>([
                     .sort((a, b) => a.label.localeCompare(b.label))
             },
         ],
-        // The visible set: search + scout + severity filters, then the chosen sort. Search matches the
-        // finding text and the (prettified) scout name, so typing a scout name narrows too.
+        // Visible set: search (over finding text + prettified scout name) + scout + severity, then sort.
         filteredRows: [
             (s) => [s.rows, s.searchText, s.scoutFilter, s.severityFilter, s.sortKey],
             (rows, searchText, scoutFilter, severityFilter, sortKey): ScoutEmissionRow[] => {
@@ -245,11 +238,9 @@ export const findingsLogic = kea<findingsLogicType>([
                 return latest
             },
         ],
-        // "Loaded once" so the page tells "not loaded yet" from "loaded, genuinely empty" without
-        // flickering a skeleton on the 60s poll. When the window loaded but no run emitted anything
-        // there's nothing to fetch, so we're done immediately — otherwise the no-op `loadEmissions([])`
-        // would flash skeletons for a tick before the empty state. The `!emissionsLoading` guard then
-        // only governs the has-emissions case (suppressing poll flicker once findings are in hand).
+        // "Loaded once" — distinguishes "not loaded yet" from "loaded, empty" without a skeleton flash.
+        // With no emitted runs there's nothing to fetch, so resolve immediately; otherwise the
+        // `!emissionsLoading` guard suppresses poll flicker once findings are in hand.
         hasLoadedOnce: [
             (s) => [s.runsWindowLoadedOnce, s.emittedRuns, s.emissionsLoading, s.emissions],
             (runsWindowLoadedOnce, emittedRuns: SignalScoutRunSummary[], emissionsLoading, emissions): boolean =>
@@ -258,8 +249,7 @@ export const findingsLogic = kea<findingsLogicType>([
     }),
 
     subscriptions(({ actions }) => ({
-        // Fires on mount (empty → real ids once the runs window loads) and whenever the emitted-run set
-        // changes; the string key holds equal across no-op polls so we don't refetch.
+        // Fires on mount and whenever the emitted-run set changes; the key holds equal across no-op polls.
         emittedRunsKey: () => {
             actions.loadEmissions()
             actions.loadEmissionReports()
@@ -267,8 +257,7 @@ export const findingsLogic = kea<findingsLogicType>([
     })),
 
     listeners(({ actions, values }) => ({
-        // Report grouping resolves asynchronously, so ride the fleet's 60s runs-window poll to keep
-        // refetching the links — but only while a recently-emitted finding is still unlinked.
+        // Ride the fleet's runs-window poll to refetch report links while a recent finding is unlinked.
         [scoutFleetLogic.actionTypes.loadRunsWindowSuccess]: () => {
             const cutoff = dayjs().subtract(REPORT_LINK_RETRY_WINDOW_MINUTES, 'minute')
             const hasRecentUnlinked = values.rows.some(
@@ -283,12 +272,10 @@ export const findingsLogic = kea<findingsLogicType>([
 
     events(() => ({
         afterMount: () => {
-            // The fleet section's `startRunsPolling` normally loads the runs window, but this page can be
-            // reached cold (a shared `/inbox/scouts/findings` URL, or a narrow viewport with no setup
-            // rail) when that section isn't mounted — which would leave the page stuck on a skeleton.
-            // Trigger one load so it resolves. We deliberately don't mirror the section's start/stop
-            // polling: it shares a single keyed `runsPoll` disposable, so a stop on this panel's unmount
-            // would also kill the section's poll. Live refresh still comes from the section when mounted.
+            // The page can be reached cold (shared URL, or narrow viewport with no rail) when the fleet
+            // section that normally polls isn't mounted, leaving it stuck on a skeleton — so load once.
+            // We don't mirror the section's start/stop polling: it shares one keyed `runsPoll`
+            // disposable, so stopping on this panel's unmount would kill the section's poll too.
             scoutFleetLogic.actions.loadRunsWindow()
         },
     })),

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -1,0 +1,288 @@
+import { actions, connect, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+
+import {
+    LinkedSignalReport,
+    SignalReportPriority,
+    SignalScoutEmission,
+    SignalScoutEmissionReportLink,
+    SignalScoutRunSummary,
+} from '../types'
+import { prettifyScoutSkillName } from '../utils/scoutRunsWindow'
+import type { findingsLogicType } from './findingsLogicType'
+import { ScoutEmissionRow } from './scoutDetailLogic'
+import { scoutFleetLogic } from './scoutFleetLogic'
+
+// Fleet-wide the fan-out is larger than a single scout's page, so bound the fetched window harder:
+// the most recent emitted runs across the whole troop. Older findings live on in the inbox reports
+// they produced. Sized to keep the concurrent emission fetches (and rendered cards) reasonable.
+const MAX_FLEET_EMITTED_RUNS = 120
+
+// Report linkage is eventually consistent (a finding's signal groups into a report asynchronously),
+// so keep retrying the reverse lookup on the fleet's runs-window poll, but only while a *recent*
+// finding is still unlinked — past this it'll never group (deduped, deleted, below threshold).
+const REPORT_LINK_RETRY_WINDOW_MINUTES = 30
+
+export type FindingsSortKey = 'newest' | 'oldest' | 'severity' | 'confidence'
+export const FINDINGS_SCOUT_FILTER_ALL = 'all'
+export const FINDINGS_SEVERITY_FILTER_ALL = 'all'
+
+/** Lowest number = most severe, so the severity sort is a plain ascending compare. Null sinks last. */
+const SEVERITY_RANK: Record<SignalReportPriority, number> = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 }
+function severityRank(severity: SignalReportPriority | null): number {
+    return severity == null ? 5 : SEVERITY_RANK[severity]
+}
+
+/**
+ * Fleet-wide findings logic — the cross-troop counterpart of the per-scout `scoutDetailLogic`. Reuses
+ * the singleton `scoutFleetLogic`'s already-polled runs window to find every scout's recent emitted
+ * runs, fetches each run's emissions + report links, and flattens them into one searchable,
+ * filterable, sortable list. Singleton (not keyed): mounted only by the findings page, so the per-run
+ * emission fan-out stays lazy — the fleet section's callout reads the cheap
+ * `scoutFleetLogic.emittedFindingsSummary` instead.
+ */
+export const findingsLogic = kea<findingsLogicType>([
+    path(['scenes', 'inbox', 'logics', 'findingsLogic']),
+
+    connect(() => ({
+        values: [scoutFleetLogic, ['runsWindow', 'runsWindowLoadedOnce', 'runsWindowComplete']],
+    })),
+
+    actions({
+        setSearchText: (searchText: string) => ({ searchText }),
+        setScoutFilter: (scoutFilter: string) => ({ scoutFilter }),
+        setSeverityFilter: (severityFilter: string) => ({ severityFilter }),
+        setSortKey: (sortKey: FindingsSortKey) => ({ sortKey }),
+    }),
+
+    loaders(({ values }) => ({
+        emissions: [
+            [] as SignalScoutEmission[],
+            {
+                loadEmissions: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    // allSettled, not all: one failed run's fetch (transient 500, deleted run) shouldn't
+                    // discard every other run's findings — surface the partial set.
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissions(run.run_id))
+                    )
+                    const fulfilled = settled.filter(
+                        (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
+                            result.status === 'fulfilled'
+                    )
+                    // Every fetch failed (outage / auth / scope) while the runs say these emitted —
+                    // throw so the page shows an error, not a false "no findings". A partial failure
+                    // still returns the findings that did load.
+                    if (fulfilled.length === 0) {
+                        throw new Error('Failed to load scout findings')
+                    }
+                    return fulfilled.flatMap((result) => result.value)
+                },
+            },
+        ],
+        emissionReports: [
+            [] as SignalScoutEmissionReportLink[],
+            {
+                loadEmissionReports: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    // Retain the prior round's links per run on failure (this loader re-runs on the poll):
+                    // source_id is `run:<run_id>:finding:<id>`, so a failed run's already-resolved chips
+                    // are the ones prefixed with its run_id.
+                    const previous = values.emissionReports
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissionReports(run.run_id))
+                    )
+                    return runs.flatMap((run, index) => {
+                        const result = settled[index]
+                        if (result.status === 'fulfilled') {
+                            return result.value
+                        }
+                        const prefix = `run:${run.run_id}:`
+                        return previous.filter((link) => link.source_id.startsWith(prefix))
+                    })
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        searchText: ['', { setSearchText: (_, { searchText }) => searchText }],
+        scoutFilter: [FINDINGS_SCOUT_FILTER_ALL as string, { setScoutFilter: (_, { scoutFilter }) => scoutFilter }],
+        severityFilter: [
+            FINDINGS_SEVERITY_FILTER_ALL as string,
+            { setSeverityFilter: (_, { severityFilter }) => severityFilter },
+        ],
+        sortKey: ['newest' as FindingsSortKey, { setSortKey: (_, { sortKey }) => sortKey }],
+        // True only when the most recent emissions load failed outright (all per-run fetches rejected).
+        emissionsLoadFailed: [
+            false,
+            {
+                loadEmissions: () => false,
+                loadEmissionsSuccess: () => false,
+                loadEmissionsFailure: () => true,
+            },
+        ],
+    }),
+
+    selectors({
+        // Every scout's runs that emitted at least one finding, newest first, capped fleet-wide.
+        emittedRuns: [
+            (s) => [s.runsWindow],
+            (runsWindow: { runs: SignalScoutRunSummary[]; complete: boolean }): SignalScoutRunSummary[] =>
+                runsWindow.runs
+                    .filter((run) => (run.emitted_count ?? 0) > 0)
+                    .slice()
+                    .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+                    .slice(0, MAX_FLEET_EMITTED_RUNS),
+        ],
+        // Stable string key over the emitted runs — refetch only when the set actually changes, not on
+        // every 60s runs-window poll. Includes `emitted_count` so an in-progress run that emits more
+        // findings retriggers.
+        emittedRunsKey: [
+            (s) => [s.emittedRuns],
+            (emittedRuns: SignalScoutRunSummary[]): string =>
+                emittedRuns
+                    .map((run) => `${run.run_id}:${run.emitted_count ?? 0}`)
+                    .sort()
+                    .join(','),
+        ],
+        reportBySourceId: [
+            (s) => [s.emissionReports],
+            (emissionReports): Map<string, LinkedSignalReport> =>
+                new Map(
+                    emissionReports
+                        .filter((link) => link.report !== null)
+                        .map((link) => [link.source_id, link.report as LinkedSignalReport])
+                ),
+        ],
+        // Join fetched emissions back to their run (carries skill_name + the task-run link) and to the
+        // inbox report they grouped into.
+        rows: [
+            (s) => [s.emissions, s.emittedRuns, s.reportBySourceId],
+            (
+                emissions: SignalScoutEmission[],
+                emittedRuns: SignalScoutRunSummary[],
+                reportBySourceId: Map<string, LinkedSignalReport>
+            ): ScoutEmissionRow[] => {
+                const runsById = new Map(emittedRuns.map((run) => [run.run_id, run]))
+                return emissions
+                    .map((emission) => {
+                        const run = runsById.get(emission.run_id)
+                        return run ? { emission, run, report: reportBySourceId.get(emission.source_id) ?? null } : null
+                    })
+                    .filter((row): row is ScoutEmissionRow => row !== null)
+            },
+        ],
+        // Distinct scouts present in the loaded findings, with a per-scout count, for the scout filter.
+        availableScouts: [
+            (s) => [s.rows],
+            (rows): { skillName: string; label: string; count: number }[] => {
+                const counts = new Map<string, number>()
+                for (const row of rows) {
+                    counts.set(row.run.skill_name, (counts.get(row.run.skill_name) ?? 0) + 1)
+                }
+                return [...counts.entries()]
+                    .map(([skillName, count]) => ({ skillName, label: prettifyScoutSkillName(skillName), count }))
+                    .sort((a, b) => a.label.localeCompare(b.label))
+            },
+        ],
+        // The visible set: search + scout + severity filters, then the chosen sort. Search matches the
+        // finding text and the (prettified) scout name, so typing a scout name narrows too.
+        filteredRows: [
+            (s) => [s.rows, s.searchText, s.scoutFilter, s.severityFilter, s.sortKey],
+            (rows, searchText, scoutFilter, severityFilter, sortKey): ScoutEmissionRow[] => {
+                const needle = searchText.trim().toLowerCase()
+                const filtered = rows.filter((row) => {
+                    if (scoutFilter !== FINDINGS_SCOUT_FILTER_ALL && row.run.skill_name !== scoutFilter) {
+                        return false
+                    }
+                    if (severityFilter !== FINDINGS_SEVERITY_FILTER_ALL && row.emission.severity !== severityFilter) {
+                        return false
+                    }
+                    if (needle) {
+                        const haystack = `${row.emission.description ?? ''} ${prettifyScoutSkillName(
+                            row.run.skill_name
+                        )}`.toLowerCase()
+                        if (!haystack.includes(needle)) {
+                            return false
+                        }
+                    }
+                    return true
+                })
+                const byNewest = (a: ScoutEmissionRow, b: ScoutEmissionRow): number =>
+                    (b.emission.emitted_at ?? '').localeCompare(a.emission.emitted_at ?? '')
+                return filtered.slice().sort((a, b) => {
+                    if (sortKey === 'oldest') {
+                        return -byNewest(a, b)
+                    }
+                    if (sortKey === 'severity') {
+                        const diff = severityRank(a.emission.severity) - severityRank(b.emission.severity)
+                        return diff !== 0 ? diff : byNewest(a, b)
+                    }
+                    if (sortKey === 'confidence') {
+                        const diff = (b.emission.confidence ?? 0) - (a.emission.confidence ?? 0)
+                        return diff !== 0 ? diff : byNewest(a, b)
+                    }
+                    return byNewest(a, b)
+                })
+            },
+        ],
+        // Page header tallies, from the loaded set (not the cheap window sum the callout uses).
+        totalCount: [(s) => [s.rows], (rows): number => rows.length],
+        scoutCount: [(s) => [s.availableScouts], (availableScouts): number => availableScouts.length],
+        latestEmittedAt: [
+            (s) => [s.rows],
+            (rows): string | null => {
+                let latest: string | null = null
+                for (const row of rows) {
+                    const at = row.emission.emitted_at
+                    if (at && (!latest || at > latest)) {
+                        latest = at
+                    }
+                }
+                return latest
+            },
+        ],
+        // "Loaded once" so the page tells "not loaded yet" from "loaded, genuinely empty" without
+        // flickering a skeleton on the 60s poll.
+        hasLoadedOnce: [
+            (s) => [s.runsWindowLoadedOnce, s.emissionsLoading, s.emissions],
+            (runsWindowLoadedOnce, emissionsLoading, emissions): boolean =>
+                runsWindowLoadedOnce && (!emissionsLoading || emissions.length > 0),
+        ],
+    }),
+
+    subscriptions(({ actions }) => ({
+        // Fires on mount (empty → real ids once the runs window loads) and whenever the emitted-run set
+        // changes; the string key holds equal across no-op polls so we don't refetch.
+        emittedRunsKey: () => {
+            actions.loadEmissions()
+            actions.loadEmissionReports()
+        },
+    })),
+
+    listeners(({ actions, values }) => ({
+        // Report grouping resolves asynchronously, so ride the fleet's 60s runs-window poll to keep
+        // refetching the links — but only while a recently-emitted finding is still unlinked.
+        [scoutFleetLogic.actionTypes.loadRunsWindowSuccess]: () => {
+            const cutoff = dayjs().subtract(REPORT_LINK_RETRY_WINDOW_MINUTES, 'minute')
+            const hasRecentUnlinked = values.rows.some(
+                (row) =>
+                    row.report === null && row.emission.emitted_at && dayjs(row.emission.emitted_at).isAfter(cutoff)
+            )
+            if (hasRecentUnlinked) {
+                actions.loadEmissionReports()
+            }
+        },
+    })),
+])

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -19,6 +19,7 @@ import {
     computeScoutRollups,
     FleetSummary,
     getScoutOrigin,
+    mostRecentEmittedRuns,
     SCOUT_RUNS_WINDOW_HOURS,
     ScoutRollup,
     sortConfigsForDisplay,
@@ -229,19 +230,17 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
         // Cheap fleet-wide findings tally straight off the runs window — sums each run's `emitted_count`
         // without fetching any emission bodies. Powers the "Scout findings" callout (count + scouts +
         // recency) so the fleet section can advertise the page without the per-run emission fan-out the
-        // page itself does on open. `latestAt` uses each emitted run's completion (or creation) time.
+        // page itself does on open. Tallied over the SAME capped emitted-run set the page fetches
+        // (`mostRecentEmittedRuns`), so the callout can't advertise more than the page can show.
+        // `latestAt` uses each emitted run's completion (or creation) time.
         emittedFindingsSummary: [
             (s) => [s.runsWindow],
             (runsWindow): { count: number; scoutCount: number; latestAt: string | null } => {
                 let count = 0
                 const scouts = new Set<string>()
                 let latestAt: string | null = null
-                for (const run of runsWindow.runs) {
-                    const emitted = run.emitted_count ?? 0
-                    if (emitted <= 0) {
-                        continue
-                    }
-                    count += emitted
+                for (const run of mostRecentEmittedRuns(runsWindow.runs)) {
+                    count += run.emitted_count ?? 0
                     scouts.add(run.skill_name)
                     const at = run.completed_at ?? run.created_at
                     if (at && (!latestAt || at > latestAt)) {

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -227,12 +227,9 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
             },
         ],
         runsWindowComplete: [(s) => [s.runsWindow], (runsWindow): boolean => runsWindow.complete],
-        // Cheap fleet-wide findings tally straight off the runs window — sums each run's `emitted_count`
-        // without fetching any emission bodies. Powers the "Scout findings" callout (count + scouts +
-        // recency) so the fleet section can advertise the page without the per-run emission fan-out the
-        // page itself does on open. Tallied over the SAME capped emitted-run set the page fetches
-        // (`mostRecentEmittedRuns`), so the callout can't advertise more than the page can show.
-        // `latestAt` uses each emitted run's completion (or creation) time.
+        // Cheap fleet-wide findings tally off the runs window — sums each run's `emitted_count` without
+        // fetching emission bodies, to power the "Scout findings" callout. Tallied over the SAME capped
+        // set the page fetches (`mostRecentEmittedRuns`) so the callout can't over-advertise.
         emittedFindingsSummary: [
             (s) => [s.runsWindow],
             (runsWindow): { count: number; scoutCount: number; latestAt: string | null } => {

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -226,6 +226,31 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
             },
         ],
         runsWindowComplete: [(s) => [s.runsWindow], (runsWindow): boolean => runsWindow.complete],
+        // Cheap fleet-wide findings tally straight off the runs window — sums each run's `emitted_count`
+        // without fetching any emission bodies. Powers the "Scout findings" callout (count + scouts +
+        // recency) so the fleet section can advertise the page without the per-run emission fan-out the
+        // page itself does on open. `latestAt` uses each emitted run's completion (or creation) time.
+        emittedFindingsSummary: [
+            (s) => [s.runsWindow],
+            (runsWindow): { count: number; scoutCount: number; latestAt: string | null } => {
+                let count = 0
+                const scouts = new Set<string>()
+                let latestAt: string | null = null
+                for (const run of runsWindow.runs) {
+                    const emitted = run.emitted_count ?? 0
+                    if (emitted <= 0) {
+                        continue
+                    }
+                    count += emitted
+                    scouts.add(run.skill_name)
+                    const at = run.completed_at ?? run.created_at
+                    if (at && (!latestAt || at > latestAt)) {
+                        latestAt = at
+                    }
+                }
+                return { count, scoutCount: scouts.size, latestAt }
+            },
+        ],
         customScoutCount: [
             (s) => [s.scoutConfigs],
             (scoutConfigs): number =>

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -32,12 +32,8 @@ export function scoutRunsWindowLabel(complete: boolean): string {
     return complete ? base : `${base} · truncated`
 }
 
-/**
- * Fleet-wide findings views fetch (and tally) only the most recent N emitted runs across the whole
- * troop, to bound the per-run emission fan-out. Shared so the findings page (`findingsLogic`) and the
- * teaser summary (`scoutFleetLogic.emittedFindingsSummary`) agree on exactly which runs count — else
- * the callout could advertise more findings than the page can show.
- */
+// Fleet-wide findings views fetch/tally only the most recent N emitted runs, to bound the per-run
+// fan-out. Shared so the page (`findingsLogic`) and the callout summary count the exact same set.
 export const MAX_FLEET_EMITTED_RUNS = 120
 
 /** The most recent emitted runs across the fleet, newest first, capped at `MAX_FLEET_EMITTED_RUNS`. */

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -32,6 +32,23 @@ export function scoutRunsWindowLabel(complete: boolean): string {
     return complete ? base : `${base} · truncated`
 }
 
+/**
+ * Fleet-wide findings views fetch (and tally) only the most recent N emitted runs across the whole
+ * troop, to bound the per-run emission fan-out. Shared so the findings page (`findingsLogic`) and the
+ * teaser summary (`scoutFleetLogic.emittedFindingsSummary`) agree on exactly which runs count — else
+ * the callout could advertise more findings than the page can show.
+ */
+export const MAX_FLEET_EMITTED_RUNS = 120
+
+/** The most recent emitted runs across the fleet, newest first, capped at `MAX_FLEET_EMITTED_RUNS`. */
+export function mostRecentEmittedRuns(runs: SignalScoutRunSummary[]): SignalScoutRunSummary[] {
+    return runs
+        .filter((run) => (run.emitted_count ?? 0) > 0)
+        .slice()
+        .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+        .slice(0, MAX_FLEET_EMITTED_RUNS)
+}
+
 // ── Origin classification ────────────────────────────────────────────────────
 
 /**

--- a/frontend/src/scenes/urls.ts
+++ b/frontend/src/scenes/urls.ts
@@ -309,6 +309,8 @@ export const urls = {
     },
     // Scout fleet memory (scratchpad) browse/search surface, reached from the fleet-memory callout.
     inboxScratchpad: (): string => '/inbox/scouts/scratchpad',
+    // Cross-fleet findings browse/search surface, reached from the scout-findings callout.
+    inboxFindings: (): string => '/inbox/scouts/findings',
     webAnalyticsBotAnalytics: (): string => '/web/bots',
     webAnalyticsHealth: (): string => '/web/health',
     pipelineStatus: (): string => '/health/pipeline-status',


### PR DESCRIPTION
## Problem

The inbox surfaces scout findings two ways today: at the top of each individual scout's detail page, and indirectly once a finding groups into a report. There's no single place to see **everything the whole scout troop has surfaced recently**. To answer "what have my scouts found lately?" you have to click into each scout one by one.

## Changes

<img width="1662" height="1044" alt="image" src="https://github.com/user-attachments/assets/d68a7da9-9210-43d0-b01c-663b3b43e65b" />

<img width="2618" height="1404" alt="image" src="https://github.com/user-attachments/assets/3a0ed747-258e-408f-a3a1-f6f62ad79b29" />


A new **Scout findings** page — a full-width browse/search surface over the inbox list, mounted in the same slot the Scout scratchpad uses. It lists every finding the troop emitted in the recent runs window, newest first, with:

- **Search** across finding text and scout name
- **Filter** by scout and by severity (P0–P4)
- **Sort** by newest / oldest / severity / confidence
- Each card names the scout that emitted it and links through to that scout's page; the existing "In report" chip is preserved

It's reached from a new **Scout findings** callout in the Scout troop section, sitting just above the existing scratchpad callout (same button grammar).

Implementation notes:

- The page reuses the per-scout `ScoutEmissionCard` with a new opt-in `showScout` prop (scout name in the header, "View scout" link in the footer) rather than forking a second card.
- There's no fleet-wide findings endpoint, so a new singleton `findingsLogic` aggregates client-side: it reads `scoutFleetLogic`'s already-polled runs window, fetches emissions per emitted run (capped at the 120 most recent emitted runs troop-wide), and flattens them into one searchable/sortable list. This mirrors how the per-scout `scoutDetailLogic` already works.
- The callout summary (count · scouts · recency) is computed cheaply from the runs window (`emittedFindingsSummary` selector sums each run's `emitted_count`) so advertising the page costs **zero** extra requests — the per-run emission fan-out only happens when the page is opened.
- The page is the fourth mutually-exclusive full-width inbox surface (report / scout detail / scratchpad / findings); routing and the open/close bookkeeping follow the scratchpad pattern, with a shared `inboxSurfaceUrl` helper to keep the four-way URL resolution readable. New route: `/inbox/scouts/findings`.

No backend changes — this is built entirely on existing scout endpoints.

_No screenshots: I'm an agent and the local browser session wasn't authenticated, so I couldn't capture an authenticated view. Layout follows the existing scratchpad/emission-card components._

## How did you test this code?

I'm an agent. Automated checks I actually ran on the changed files:

- `tsgo` type check (via `typescript:check`) — clean for all changed/added files (after kea typegen regen for the new/changed logics)
- `oxlint` — clean for all changed/added files

I also brought up the local stack and seeded a few test runs/emissions in Postgres to exercise the page with data, but I did **not** personally verify the rendered UI in a browser (the local session was unauthenticated). No new automated tests were added — the change is UI aggregation over existing endpoints; `findingsLogic` filter/sort selectors would be a sensible follow-up to cover.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus) at the request of @andrewm4894, who chose the design direction and approved the approach.

- **Design:** I sketched several ASCII layout options (card stream, dense table, grouped table). The card-stream option was chosen for fastest path to ship and visual consistency with the existing per-scout findings section; the table options were rejected as more work for filtering/scale we don't need yet.
- **Data sourcing:** chose client-side aggregation over a new backend endpoint to avoid a DRF/codegen round-trip, accepting the cap on the recent runs window (older findings live on in their reports). A dedicated fleet-wide emissions endpoint is the natural follow-up if this proves useful and the window cap bites.
- **No skills were invoked** — no DRF endpoints, migrations, or generated API types were touched (the page rides existing `api.signalScout.*` endpoints), so the mandatory-skill triggers didn't apply.
- Reviewers: the riskiest bit is the four-way mutual exclusivity of the full-width inbox surfaces in `inboxSceneLogic` (reducers + listeners + `actionToUrl`/`urlToAction`) — worth a close look that opening findings cleanly closes report/scout/scratchpad and vice versa.
