### PR TITLE
feat(signals): scout findings aggregation logic + shared helpers

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutEmissionCard.tsx
@@ -11,6 +11,7 @@ import { addProjectIdIfMissing } from 'lib/utils/kea-router'
 import { urls } from 'scenes/urls'
 
 import { LinkedSignalReport, SignalScoutEmission, SignalScoutRunSummary } from '../../../types'
+import { prettifyScoutSkillName } from '../../../utils/scoutRunsWindow'
 import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
 
 /** Truncated mono identifier rendering for the footer finding id. */
@@ -37,6 +38,7 @@ export function ScoutEmissionCard({
     run,
     report,
     isDeepLinked = false,
+    showScout = false,
 }: {
     skillName: string
     emission: SignalScoutEmission
@@ -45,6 +47,8 @@ export function ScoutEmissionCard({
     report: LinkedSignalReport | null
     /** True when this finding is the one the current URL deep-links to. */
     isDeepLinked?: boolean
+    /** Cross-fleet listings set this to surface the scout (name in the header, "View scout" footer link). */
+    showScout?: boolean
 }): JSX.Element {
     const [expanded, setExpanded] = useState(isDeepLinked)
     const confidencePercent = Math.round((emission.confidence ?? 0) * 100)
@@ -86,6 +90,11 @@ export function ScoutEmissionCard({
                         className={`size-4 shrink-0 text-muted transition-transform ${expanded ? '' : '-rotate-90'}`}
                     />
                     <SignalReportPriorityBadge priority={emission.severity} />
+                    {showScout && (
+                        <span className="truncate text-xs font-medium text-default">
+                            {prettifyScoutSkillName(skillName)}
+                        </span>
+                    )}
                     <span className="whitespace-nowrap text-[11px] text-muted tabular-nums">
                         {confidencePercent}% confidence
                     </span>
@@ -125,6 +134,14 @@ export function ScoutEmissionCard({
                 {expanded && (
                     <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
                         <MonoId label="Finding" value={emission.finding_id} />
+                        {showScout && (
+                            <Link
+                                to={urls.inboxScout(skillName)}
+                                className="flex items-center gap-1 font-medium shrink-0"
+                            >
+                                View {prettifyScoutSkillName(skillName)} <IconArrowRight className="size-3" />
+                            </Link>
+                        )}
                         {run.task_url && (
                             <>
                                 <span className="flex-1" />

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -21,6 +21,9 @@ import { scoutFleetLogic } from './scoutFleetLogic'
 // poll, but only while a recently-emitted finding is still unlinked (past this it never will be).
 const REPORT_LINK_RETRY_WINDOW_MINUTES = 30
 
+// Cadence of the page's own runs-window poll (matches the fleet section's); retries cold/failed loads.
+const RUNS_REFETCH_INTERVAL_MS = 60_000
+
 export type FindingsSortKey = 'newest' | 'oldest' | 'severity' | 'confidence'
 export const FINDINGS_SCOUT_FILTER_ALL = 'all'
 export const FINDINGS_SEVERITY_FILTER_ALL = 'all'
@@ -270,13 +273,19 @@ export const findingsLogic = kea<findingsLogicType>([
         },
     })),
 
-    events(() => ({
+    events(({ cache }) => ({
         afterMount: () => {
             // The page can be reached cold (shared URL, or narrow viewport with no rail) when the fleet
-            // section that normally polls isn't mounted, leaving it stuck on a skeleton — so load once.
-            // We don't mirror the section's start/stop polling: it shares one keyed `runsPoll`
-            // disposable, so stopping on this panel's unmount would kill the section's poll too.
+            // section that normally polls the runs window isn't mounted. Own a poll here so the page
+            // loads, *retries* a failed initial load (else `hasLoadedOnce` would never flip), and gives
+            // the report-link retry listener a poll to ride. It lives on this logic's own disposables
+            // under its own key, so it never disposes the section's `runsPoll` — when both are mounted
+            // the overlap just costs one extra capped request, since `loadRunsWindow` is idempotent.
             scoutFleetLogic.actions.loadRunsWindow()
+            cache.disposables.add(() => {
+                const interval = setInterval(() => scoutFleetLogic.actions.loadRunsWindow(), RUNS_REFETCH_INTERVAL_MS)
+                return () => clearInterval(interval)
+            }, 'findingsRunsPoll')
         },
     })),
 ])

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -1,0 +1,282 @@
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
+import { loaders } from 'kea-loaders'
+import { subscriptions } from 'kea-subscriptions'
+
+import api from 'lib/api'
+import { dayjs } from 'lib/dayjs'
+
+import {
+    LinkedSignalReport,
+    SignalReportPriority,
+    SignalScoutEmission,
+    SignalScoutEmissionReportLink,
+    SignalScoutRunSummary,
+} from '../types'
+import { mostRecentEmittedRuns, prettifyScoutSkillName } from '../utils/scoutRunsWindow'
+import type { findingsLogicType } from './findingsLogicType'
+import { ScoutEmissionRow } from './scoutDetailLogic'
+import { scoutFleetLogic } from './scoutFleetLogic'
+
+// Report linkage is eventually consistent, so keep retrying the reverse lookup on the runs-window
+// poll, but only while a recently-emitted finding is still unlinked (past this it never will be).
+const REPORT_LINK_RETRY_WINDOW_MINUTES = 30
+
+export type FindingsSortKey = 'newest' | 'oldest' | 'severity' | 'confidence'
+export const FINDINGS_SCOUT_FILTER_ALL = 'all'
+export const FINDINGS_SEVERITY_FILTER_ALL = 'all'
+
+/** Lowest number = most severe, so the severity sort is a plain ascending compare. Null sinks last. */
+const SEVERITY_RANK: Record<SignalReportPriority, number> = { P0: 0, P1: 1, P2: 2, P3: 3, P4: 4 }
+function severityRank(severity: SignalReportPriority | null): number {
+    return severity == null ? 5 : SEVERITY_RANK[severity]
+}
+
+/**
+ * Fleet-wide findings logic — the cross-troop counterpart of the per-scout `scoutDetailLogic`. Reuses
+ * `scoutFleetLogic`'s polled runs window to find every scout's recent emitted runs, fetches each run's
+ * emissions + report links, and flattens them into one searchable/filterable/sortable list. Singleton,
+ * mounted only by the findings page, so the per-run fan-out stays lazy (the callout reads the cheap
+ * `scoutFleetLogic.emittedFindingsSummary` instead).
+ */
+export const findingsLogic = kea<findingsLogicType>([
+    path(['scenes', 'inbox', 'logics', 'findingsLogic']),
+
+    connect(() => ({
+        values: [scoutFleetLogic, ['runsWindow', 'runsWindowLoadedOnce', 'runsWindowComplete']],
+    })),
+
+    actions({
+        setSearchText: (searchText: string) => ({ searchText }),
+        setScoutFilter: (scoutFilter: string) => ({ scoutFilter }),
+        setSeverityFilter: (severityFilter: string) => ({ severityFilter }),
+        setSortKey: (sortKey: FindingsSortKey) => ({ sortKey }),
+    }),
+
+    loaders(({ values }) => ({
+        emissions: [
+            [] as SignalScoutEmission[],
+            {
+                loadEmissions: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    // allSettled, not all: one failed run's fetch shouldn't discard every other run's
+                    // findings — surface the partial set.
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissions(run.run_id))
+                    )
+                    const fulfilled = settled.filter(
+                        (result): result is PromiseFulfilledResult<SignalScoutEmission[]> =>
+                            result.status === 'fulfilled'
+                    )
+                    // All fetches failed while the runs say these emitted — throw so the page shows an
+                    // error, not a false "no findings".
+                    if (fulfilled.length === 0) {
+                        throw new Error('Failed to load scout findings')
+                    }
+                    return fulfilled.flatMap((result) => result.value)
+                },
+            },
+        ],
+        emissionReports: [
+            [] as SignalScoutEmissionReportLink[],
+            {
+                loadEmissionReports: async () => {
+                    const runs = values.emittedRuns
+                    if (runs.length === 0) {
+                        return []
+                    }
+                    // Retain the prior round's links for a failed run (this re-runs on the poll); its
+                    // links are the ones whose source_id is prefixed `run:<run_id>:`.
+                    const previous = values.emissionReports
+                    const settled = await Promise.allSettled(
+                        runs.map((run) => api.signalScout.runs.emissionReports(run.run_id))
+                    )
+                    return runs.flatMap((run, index) => {
+                        const result = settled[index]
+                        if (result.status === 'fulfilled') {
+                            return result.value
+                        }
+                        const prefix = `run:${run.run_id}:`
+                        return previous.filter((link) => link.source_id.startsWith(prefix))
+                    })
+                },
+            },
+        ],
+    })),
+
+    reducers({
+        searchText: ['', { setSearchText: (_, { searchText }) => searchText }],
+        scoutFilter: [FINDINGS_SCOUT_FILTER_ALL as string, { setScoutFilter: (_, { scoutFilter }) => scoutFilter }],
+        severityFilter: [
+            FINDINGS_SEVERITY_FILTER_ALL as string,
+            { setSeverityFilter: (_, { severityFilter }) => severityFilter },
+        ],
+        sortKey: ['newest' as FindingsSortKey, { setSortKey: (_, { sortKey }) => sortKey }],
+        // True only when the most recent emissions load failed outright (all per-run fetches rejected).
+        emissionsLoadFailed: [
+            false,
+            {
+                loadEmissions: () => false,
+                loadEmissionsSuccess: () => false,
+                loadEmissionsFailure: () => true,
+            },
+        ],
+    }),
+
+    selectors({
+        // Emitted runs newest-first, capped fleet-wide. Shares `mostRecentEmittedRuns` with the callout
+        // summary so the two count the exact same run set.
+        emittedRuns: [
+            (s) => [s.runsWindow],
+            (runsWindow: { runs: SignalScoutRunSummary[]; complete: boolean }): SignalScoutRunSummary[] =>
+                mostRecentEmittedRuns(runsWindow.runs),
+        ],
+        // Stable key over the emitted runs — refetch only when the set changes, not on every poll.
+        // Includes `emitted_count` so an in-progress run that emits more findings retriggers.
+        emittedRunsKey: [
+            (s) => [s.emittedRuns],
+            (emittedRuns: SignalScoutRunSummary[]): string =>
+                emittedRuns
+                    .map((run) => `${run.run_id}:${run.emitted_count ?? 0}`)
+                    .sort()
+                    .join(','),
+        ],
+        reportBySourceId: [
+            (s) => [s.emissionReports],
+            (emissionReports): Map<string, LinkedSignalReport> =>
+                new Map(
+                    emissionReports
+                        .filter((link) => link.report !== null)
+                        .map((link) => [link.source_id, link.report as LinkedSignalReport])
+                ),
+        ],
+        // Join emissions back to their run (for skill_name + task-run link) and the report they grouped into.
+        rows: [
+            (s) => [s.emissions, s.emittedRuns, s.reportBySourceId],
+            (
+                emissions: SignalScoutEmission[],
+                emittedRuns: SignalScoutRunSummary[],
+                reportBySourceId: Map<string, LinkedSignalReport>
+            ): ScoutEmissionRow[] => {
+                const runsById = new Map(emittedRuns.map((run) => [run.run_id, run]))
+                return emissions
+                    .map((emission) => {
+                        const run = runsById.get(emission.run_id)
+                        return run ? { emission, run, report: reportBySourceId.get(emission.source_id) ?? null } : null
+                    })
+                    .filter((row): row is ScoutEmissionRow => row !== null)
+            },
+        ],
+        // Distinct scouts present in the loaded findings, with a per-scout count, for the scout filter.
+        availableScouts: [
+            (s) => [s.rows],
+            (rows): { skillName: string; label: string; count: number }[] => {
+                const counts = new Map<string, number>()
+                for (const row of rows) {
+                    counts.set(row.run.skill_name, (counts.get(row.run.skill_name) ?? 0) + 1)
+                }
+                return [...counts.entries()]
+                    .map(([skillName, count]) => ({ skillName, label: prettifyScoutSkillName(skillName), count }))
+                    .sort((a, b) => a.label.localeCompare(b.label))
+            },
+        ],
+        // Visible set: search (over finding text + prettified scout name) + scout + severity, then sort.
+        filteredRows: [
+            (s) => [s.rows, s.searchText, s.scoutFilter, s.severityFilter, s.sortKey],
+            (rows, searchText, scoutFilter, severityFilter, sortKey): ScoutEmissionRow[] => {
+                const needle = searchText.trim().toLowerCase()
+                const filtered = rows.filter((row) => {
+                    if (scoutFilter !== FINDINGS_SCOUT_FILTER_ALL && row.run.skill_name !== scoutFilter) {
+                        return false
+                    }
+                    if (severityFilter !== FINDINGS_SEVERITY_FILTER_ALL && row.emission.severity !== severityFilter) {
+                        return false
+                    }
+                    if (needle) {
+                        const haystack = `${row.emission.description ?? ''} ${prettifyScoutSkillName(
+                            row.run.skill_name
+                        )}`.toLowerCase()
+                        if (!haystack.includes(needle)) {
+                            return false
+                        }
+                    }
+                    return true
+                })
+                const byNewest = (a: ScoutEmissionRow, b: ScoutEmissionRow): number =>
+                    (b.emission.emitted_at ?? '').localeCompare(a.emission.emitted_at ?? '')
+                return filtered.slice().sort((a, b) => {
+                    if (sortKey === 'oldest') {
+                        return -byNewest(a, b)
+                    }
+                    if (sortKey === 'severity') {
+                        const diff = severityRank(a.emission.severity) - severityRank(b.emission.severity)
+                        return diff !== 0 ? diff : byNewest(a, b)
+                    }
+                    if (sortKey === 'confidence') {
+                        const diff = (b.emission.confidence ?? 0) - (a.emission.confidence ?? 0)
+                        return diff !== 0 ? diff : byNewest(a, b)
+                    }
+                    return byNewest(a, b)
+                })
+            },
+        ],
+        // Page header tallies, from the loaded set (not the cheap window sum the callout uses).
+        totalCount: [(s) => [s.rows], (rows): number => rows.length],
+        scoutCount: [(s) => [s.availableScouts], (availableScouts): number => availableScouts.length],
+        latestEmittedAt: [
+            (s) => [s.rows],
+            (rows): string | null => {
+                let latest: string | null = null
+                for (const row of rows) {
+                    const at = row.emission.emitted_at
+                    if (at && (!latest || at > latest)) {
+                        latest = at
+                    }
+                }
+                return latest
+            },
+        ],
+        // "Loaded once" — distinguishes "not loaded yet" from "loaded, empty" without a skeleton flash.
+        // With no emitted runs there's nothing to fetch, so resolve immediately; otherwise the
+        // `!emissionsLoading` guard suppresses poll flicker once findings are in hand.
+        hasLoadedOnce: [
+            (s) => [s.runsWindowLoadedOnce, s.emittedRuns, s.emissionsLoading, s.emissions],
+            (runsWindowLoadedOnce, emittedRuns: SignalScoutRunSummary[], emissionsLoading, emissions): boolean =>
+                runsWindowLoadedOnce && (emittedRuns.length === 0 || !emissionsLoading || emissions.length > 0),
+        ],
+    }),
+
+    subscriptions(({ actions }) => ({
+        // Fires on mount and whenever the emitted-run set changes; the key holds equal across no-op polls.
+        emittedRunsKey: () => {
+            actions.loadEmissions()
+            actions.loadEmissionReports()
+        },
+    })),
+
+    listeners(({ actions, values }) => ({
+        // Ride the fleet's runs-window poll to refetch report links while a recent finding is unlinked.
+        [scoutFleetLogic.actionTypes.loadRunsWindowSuccess]: () => {
+            const cutoff = dayjs().subtract(REPORT_LINK_RETRY_WINDOW_MINUTES, 'minute')
+            const hasRecentUnlinked = values.rows.some(
+                (row) =>
+                    row.report === null && row.emission.emitted_at && dayjs(row.emission.emitted_at).isAfter(cutoff)
+            )
+            if (hasRecentUnlinked) {
+                actions.loadEmissionReports()
+            }
+        },
+    })),
+
+    events(() => ({
+        afterMount: () => {
+            // The page can be reached cold (shared URL, or narrow viewport with no rail) when the fleet
+            // section that normally polls isn't mounted, leaving it stuck on a skeleton — so load once.
+            // We don't mirror the section's start/stop polling: it shares one keyed `runsPoll`
+            // disposable, so stopping on this panel's unmount would kill the section's poll too.
+            scoutFleetLogic.actions.loadRunsWindow()
+        },
+    })),
+])

--- a/frontend/src/scenes/inbox/logics/findingsLogic.ts
+++ b/frontend/src/scenes/inbox/logics/findingsLogic.ts
@@ -53,9 +53,12 @@ export const findingsLogic = kea<findingsLogicType>([
         setScoutFilter: (scoutFilter: string) => ({ scoutFilter }),
         setSeverityFilter: (severityFilter: string) => ({ severityFilter }),
         setSortKey: (sortKey: FindingsSortKey) => ({ sortKey }),
+        // Some (but not all) per-run emission fetches failed — the list is incomplete. Carries the
+        // failed-run count so the page can warn that findings are missing rather than hiding it.
+        setEmissionsPartialFailure: (failedRuns: number) => ({ failedRuns }),
     }),
 
-    loaders(({ values }) => ({
+    loaders(({ values, actions }) => ({
         emissions: [
             [] as SignalScoutEmission[],
             {
@@ -78,6 +81,9 @@ export const findingsLogic = kea<findingsLogicType>([
                     if (fulfilled.length === 0) {
                         throw new Error('Failed to load scout findings')
                     }
+                    // A partial failure returns the findings that loaded, but flag the gap so the page
+                    // can warn — silently dropping a scout's findings would mislead a triage decision.
+                    actions.setEmissionsPartialFailure(settled.length - fulfilled.length)
                     return fulfilled.flatMap((result) => result.value)
                 },
             },
@@ -124,6 +130,16 @@ export const findingsLogic = kea<findingsLogicType>([
                 loadEmissions: () => false,
                 loadEmissionsSuccess: () => false,
                 loadEmissionsFailure: () => true,
+            },
+        ],
+        // Count of runs whose emission fetch failed while others succeeded — the list is incomplete.
+        // Reset when a fresh load starts; a clean success sets it to 0 via the partial-failure action.
+        emissionsPartialFailedRuns: [
+            0,
+            {
+                loadEmissions: () => 0,
+                loadEmissionsFailure: () => 0,
+                setEmissionsPartialFailure: (_, { failedRuns }) => failedRuns,
             },
         ],
     }),

--- a/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutFleetLogic.ts
@@ -19,6 +19,7 @@ import {
     computeScoutRollups,
     FleetSummary,
     getScoutOrigin,
+    mostRecentEmittedRuns,
     SCOUT_RUNS_WINDOW_HOURS,
     ScoutRollup,
     sortConfigsForDisplay,
@@ -226,6 +227,26 @@ export const scoutFleetLogic = kea<scoutFleetLogicType>([
             },
         ],
         runsWindowComplete: [(s) => [s.runsWindow], (runsWindow): boolean => runsWindow.complete],
+        // Cheap fleet-wide findings tally off the runs window — sums each run's `emitted_count` without
+        // fetching emission bodies, to power the "Scout findings" callout. Tallied over the SAME capped
+        // set the page fetches (`mostRecentEmittedRuns`) so the callout can't over-advertise.
+        emittedFindingsSummary: [
+            (s) => [s.runsWindow],
+            (runsWindow): { count: number; scoutCount: number; latestAt: string | null } => {
+                let count = 0
+                const scouts = new Set<string>()
+                let latestAt: string | null = null
+                for (const run of mostRecentEmittedRuns(runsWindow.runs)) {
+                    count += run.emitted_count ?? 0
+                    scouts.add(run.skill_name)
+                    const at = run.completed_at ?? run.created_at
+                    if (at && (!latestAt || at > latestAt)) {
+                        latestAt = at
+                    }
+                }
+                return { count, scoutCount: scouts.size, latestAt }
+            },
+        ],
         customScoutCount: [
             (s) => [s.scoutConfigs],
             (scoutConfigs): number =>

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -32,6 +32,19 @@ export function scoutRunsWindowLabel(complete: boolean): string {
     return complete ? base : `${base} · truncated`
 }
 
+// Fleet-wide findings views fetch/tally only the most recent N emitted runs, to bound the per-run
+// fan-out. Shared so the page (`findingsLogic`) and the callout summary count the exact same set.
+export const MAX_FLEET_EMITTED_RUNS = 120
+
+/** The most recent emitted runs across the fleet, newest first, capped at `MAX_FLEET_EMITTED_RUNS`. */
+export function mostRecentEmittedRuns(runs: SignalScoutRunSummary[]): SignalScoutRunSummary[] {
+    return runs
+        .filter((run) => (run.emitted_count ?? 0) > 0)
+        .slice()
+        .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
+        .slice(0, MAX_FLEET_EMITTED_RUNS)
+}
+
 // ── Origin classification ────────────────────────────────────────────────────
 
 /**

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -38,11 +38,15 @@ export const MAX_FLEET_EMITTED_RUNS = 120
 
 /** The most recent emitted runs across the fleet, newest first, capped at `MAX_FLEET_EMITTED_RUNS`. */
 export function mostRecentEmittedRuns(runs: SignalScoutRunSummary[]): SignalScoutRunSummary[] {
-    return runs
-        .filter((run) => (run.emitted_count ?? 0) > 0)
-        .slice()
-        .sort((a, b) => (b.created_at ?? '').localeCompare(a.created_at ?? ''))
-        .slice(0, MAX_FLEET_EMITTED_RUNS)
+    return (
+        runs
+            .filter((run) => (run.emitted_count ?? 0) > 0)
+            .slice()
+            // "Most recently emitted" — a run can complete (and emit) later than one created after it, so
+            // order by completion, falling back to creation. Matches `emittedFindingsSummary`'s `latestAt`.
+            .sort((a, b) => (b.completed_at ?? b.created_at ?? '').localeCompare(a.completed_at ?? a.created_at ?? ''))
+            .slice(0, MAX_FLEET_EMITTED_RUNS)
+    )
 }
 
 // ── Origin classification ────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The inbox has no single place to see every finding the scout troop has surfaced recently — you have to click into each scout one by one. This is the **foundation PR** for a cross-fleet "Scout findings" page: the data layer and reusable pieces it needs. The page UI + entry point are stacked on top in the next PR.

## Changes

Pure foundation — no new user-facing surface in this PR. Each piece is consumed by the stacked page PR:

- **`findingsLogic.ts`** — a singleton kea logic that aggregates findings across the whole troop. Reuses `scoutFleetLogic`'s already-polled runs window to find every scout's recent emitted runs, fetches each run's emissions + report links, and exposes one searchable/filterable/sortable list. It's the cross-fleet counterpart of the existing per-scout `scoutDetailLogic` and follows the same fetch/join shape.
- **`scoutRunsWindow.ts`** — `MAX_FLEET_EMITTED_RUNS` (120) + `mostRecentEmittedRuns()`, the shared cap so the page and its callout summary tally the exact same run set.
- **`scoutFleetLogic.ts`** — `emittedFindingsSummary` selector: a cheap count·scouts·recency tally summed straight off the runs window (no emission fetch), so the callout can advertise the page without triggering the per-run fan-out.
- **`ScoutEmissionCard.tsx`** — an opt-in `showScout` prop (scout name in the header, "View scout" footer link) so the existing per-scout card can be reused in a cross-fleet listing.

No backend changes — built on existing `api.signalScout.*` endpoints.

## How did you test this code?

I'm an agent. Automated checks I ran on the changed files: `tsgo` typecheck (clean, after kea typegen regen) and `oxlint` (clean). The logic is exercised end-to-end by the stacked page PR; I also seeded local scout runs/emissions in Postgres to sanity-check the aggregation, but did not personally verify rendered UI (this PR ships no UI). No new automated tests — `findingsLogic` filter/sort selector tests are a sensible follow-up.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus) at the request of @andrewm4894. This is the base of a 2-PR Graphite stack (foundation → page); The split is by layer: this PR is the reusable data/logic, the stacked PR is the page UI + routing + callout that consume it. No repo skills were invoked (no DRF/migrations/generated-types touched). Reviewers: this PR's exports are intentionally unused until the stacked PR lands on top.
