### PR TITLE
feat(signals): surface scout report-channel activity in the inbox UI

### DIFF
--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutDetailView.tsx
@@ -11,6 +11,7 @@ import { scoutDetailLogic } from '../../../logics/scoutDetailLogic'
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { SCOUT_RUNS_WINDOW_SPAN, scoutRunsWindowLabel } from '../../../utils/scoutRunsWindow'
 import { ScoutEmissionCard } from './ScoutEmissionCard'
+import { ScoutReportCard } from './ScoutReportCard'
 import { ScoutRowCard } from './ScoutRowCard'
 import { ScoutRunHistorySection } from './ScoutRunHistorySection'
 
@@ -71,6 +72,12 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
                                 <>
                                     {pluralize(rollup.runCount, 'run')} · {rollup.completedCount} completed ·{' '}
                                     {rollup.failedCount} failed · {pluralize(rollup.emittedCount, 'signal')} emitted
+                                    {rollup.authoredReportIds.size > 0 && (
+                                        <> · {pluralize(rollup.authoredReportIds.size, 'report')} authored</>
+                                    )}
+                                    {rollup.editedReportIds.size > 0 && (
+                                        <> · {pluralize(rollup.editedReportIds.size, 'report')} edited</>
+                                    )}
                                 </>
                             ) : (
                                 'No runs in this window.'
@@ -81,10 +88,49 @@ export function ScoutDetailView({ skillName }: { skillName: string }): JSX.Eleme
                         </span>
                     </div>
 
+                    <ScoutReportsSection skillName={skillName} />
+
                     <ScoutSignalsSection skillName={skillName} />
 
                     <ScoutRunHistorySection skillName={skillName} />
                 </>
+            )}
+        </div>
+    )
+}
+
+/**
+ * The Reports section: the inbox reports this scout authored or edited directly via the report
+ * channel (`emit_report` / `edit_report`) in the recent window, newest-updated first. Distinct from
+ * the Signals section, which lists weak `emit_signal` findings. Hidden entirely for the common scout
+ * that never authors a report, so it only appears for report-channel scouts.
+ */
+function ScoutReportsSection({ skillName }: { skillName: string }): JSX.Element | null {
+    const { reportRows, touchedReports, scoutReportsLoading, runsWindowLoadedOnce } = useValues(
+        scoutDetailLogic({ skillName })
+    )
+
+    // Most scouts never author a report — keep the section out entirely rather than show an empty box.
+    if (touchedReports.length === 0) {
+        return null
+    }
+
+    const loading = !runsWindowLoadedOnce || (scoutReportsLoading && reportRows.length === 0)
+
+    return (
+        <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium text-default uppercase tracking-wide">Reports</span>
+            {loading ? (
+                <LemonSkeleton className="h-12 w-full rounded" />
+            ) : reportRows.length === 0 ? (
+                // Touched ids exist but none resolved — the reports were deleted, or the fetch failed.
+                <div className="rounded border border-dashed border-primary bg-bg-light px-4 py-6 text-center text-sm text-muted">
+                    Couldn’t load the reports this scout authored.
+                </div>
+            ) : (
+                reportRows.map(({ report, action }) => (
+                    <ScoutReportCard key={report.id} report={report} action={action} />
+                ))
             )}
         </div>
     )

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutReportCard.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutReportCard.tsx
@@ -1,0 +1,39 @@
+import { IconArrowRight } from '@posthog/icons'
+import { LemonTag, Link } from '@posthog/lemon-ui'
+
+import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
+import { urls } from 'scenes/urls'
+
+import { ScoutReportAction } from '../../../logics/scoutDetailLogic'
+import { SignalReport } from '../../../types'
+import { SignalReportPriorityBadge } from '../../badges/SignalReportPriorityBadge'
+import { SignalReportStatusBadge } from '../../badges/SignalReportStatusBadge'
+
+/**
+ * One report this scout touched through the report channel (`emit_report` / `edit_report`), in the
+ * detail Reports section. Unlike a finding's "In report" chip, the run carries the report id directly,
+ * so this links straight to the inbox report — the whole card is the link. An "Authored" vs "Edited"
+ * tag records how the scout touched it; priority/status come from the live report.
+ */
+export function ScoutReportCard({ report, action }: { report: SignalReport; action: ScoutReportAction }): JSX.Element {
+    return (
+        <Link
+            to={urls.inboxReport('reports', report.id)}
+            className="flex flex-col gap-1 rounded border border-primary bg-bg-light px-3 py-2 hover:border-accent"
+        >
+            <div className="flex items-center gap-2">
+                <LemonTag size="small" type={action === 'authored' ? 'success' : 'default'}>
+                    {action === 'authored' ? 'Authored' : 'Edited'}
+                </LemonTag>
+                <SignalReportPriorityBadge priority={report.priority} />
+                <SignalReportStatusBadge status={report.status} />
+                <span className="flex-1" />
+                <span className="whitespace-nowrap text-[11px] text-muted">
+                    {humanFriendlyDetailedTime(report.updated_at)}
+                </span>
+                <IconArrowRight className="size-3 shrink-0 text-muted" />
+            </div>
+            <span className="line-clamp-2 text-sm font-medium text-primary">{report.title || 'Untitled report'}</span>
+        </Link>
+    )
+}

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRunBoxes.tsx
@@ -18,6 +18,8 @@ import {
 // (not the orange brand primary) keeps this in step with the desktop Code app.
 const OUTCOME_BOX_CLASS: Record<ScoutRunOutcome, string> = {
     emitted: 'bg-brand-blue',
+    // A report-channel run produced output too — same payoff blue as an emitting run.
+    reported: 'bg-brand-blue',
     quiet: 'bg-border-bold',
     error: 'bg-danger',
     timed_out: 'bg-warning',

--- a/frontend/src/scenes/inbox/components/config/scouts/ScoutRunHistorySection.tsx
+++ b/frontend/src/scenes/inbox/components/config/scouts/ScoutRunHistorySection.tsx
@@ -1,12 +1,13 @@
 import { useValues } from 'kea'
 import { useMemo, useState } from 'react'
 
-import { IconChevronDown, IconExternal } from '@posthog/icons'
+import { IconArrowRight, IconChevronDown, IconExternal } from '@posthog/icons'
 import { LemonButton, LemonSkeleton, Link } from '@posthog/lemon-ui'
 
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
 import { pluralize } from 'lib/utils/strings'
+import { urls } from 'scenes/urls'
 
 import { scoutFleetLogic } from '../../../logics/scoutFleetLogic'
 import { SignalScoutRunSummary } from '../../../types'
@@ -16,7 +17,10 @@ import {
     normalizeRunStatus,
     runDurationSeconds,
     runMatchesFilter,
+    runProducedOutput,
+    runReportActivity,
     ScoutRunFilter,
+    scoutReportActivityLabel,
     SCOUT_RUNS_WINDOW_SPAN,
 } from '../../../utils/scoutRunsWindow'
 
@@ -32,7 +36,8 @@ function truncateId(value: string): string {
     return value.length > 12 ? `${value.slice(0, 12)}…` : value
 }
 
-/** A compact status glyph: ✗ failed · pulsing dot running/queued · ◆ emitted · · quiet. */
+/** A compact status glyph: ✗ failed · pulsing dot running/queued · ◆ produced output (finding or
+ * report) · · quiet. */
 function RunGlyph({ run }: { run: SignalScoutRunSummary }): JSX.Element {
     const status = normalizeRunStatus(run.status)
     if (status === 'failed') {
@@ -41,7 +46,7 @@ function RunGlyph({ run }: { run: SignalScoutRunSummary }): JSX.Element {
     if (status === 'running' || status === 'queued') {
         return <span className="inline-block size-2 shrink-0 rounded-full bg-primary animate-pulse" />
     }
-    if ((run.emitted_count ?? 0) > 0) {
+    if (runProducedOutput(run)) {
         return <span className="text-primary-3000 text-sm font-medium leading-none">◆</span>
     }
     return <span className="text-muted text-sm leading-none">·</span>
@@ -59,6 +64,8 @@ function ScoutRunRow({ run }: { run: SignalScoutRunSummary }): JSX.Element {
     const failureKind = deriveRunFailureKind(run, now)
     const duration = formatRunDuration(runDurationSeconds(run, now))
     const emitted = run.emitted_count ?? 0
+    const reportActivityLabel = scoutReportActivityLabel(run)
+    const { authored: authoredReportIds, edited: editedReportIds } = runReportActivity(run)
     const hasBody = Boolean(run.summary) || status === 'failed' || expanded
 
     return (
@@ -87,6 +94,10 @@ function ScoutRunRow({ run }: { run: SignalScoutRunSummary }): JSX.Element {
                     <span className="whitespace-nowrap rounded bg-primary-highlight px-1.5 py-0.5 text-[11px] font-medium text-primary-3000">
                         {pluralize(emitted, 'signal')} emitted
                     </span>
+                ) : reportActivityLabel ? (
+                    <span className="whitespace-nowrap rounded bg-primary-highlight px-1.5 py-0.5 text-[11px] font-medium text-primary-3000">
+                        {reportActivityLabel}
+                    </span>
                 ) : status === 'completed' ? (
                     <span className="whitespace-nowrap text-[11px] text-muted">0 signals emitted</span>
                 ) : null}
@@ -111,6 +122,24 @@ function ScoutRunRow({ run }: { run: SignalScoutRunSummary }): JSX.Element {
                     {expanded && (
                         <div className="flex items-center flex-wrap gap-x-3 gap-y-1 border-t pt-2 mt-2 text-xs text-tertiary">
                             <span className="font-mono">{truncateId(run.run_id)}</span>
+                            {authoredReportIds.map((reportId) => (
+                                <Link
+                                    key={reportId}
+                                    to={urls.inboxReport('reports', reportId)}
+                                    className="flex items-center gap-1 font-medium shrink-0"
+                                >
+                                    Authored report <IconArrowRight className="size-3" />
+                                </Link>
+                            ))}
+                            {editedReportIds.map((reportId) => (
+                                <Link
+                                    key={reportId}
+                                    to={urls.inboxReport('reports', reportId)}
+                                    className="flex items-center gap-1 font-medium shrink-0"
+                                >
+                                    Edited report <IconArrowRight className="size-3" />
+                                </Link>
+                            ))}
                             {run.task_url && (
                                 <>
                                     <span className="flex-1" />

--- a/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
+++ b/frontend/src/scenes/inbox/logics/scoutDetailLogic.ts
@@ -5,13 +5,33 @@ import { subscriptions } from 'kea-subscriptions'
 import api from 'lib/api'
 import { dayjs } from 'lib/dayjs'
 
-import { LinkedSignalReport, SignalScoutEmission, SignalScoutEmissionReportLink, SignalScoutRunSummary } from '../types'
+import {
+    LinkedSignalReport,
+    SignalReport,
+    SignalScoutEmission,
+    SignalScoutEmissionReportLink,
+    SignalScoutRunSummary,
+} from '../types'
 import type { scoutDetailLogicType } from './scoutDetailLogicType'
 import { scoutFleetLogic } from './scoutFleetLogic'
 
 export interface ScoutDetailLogicProps {
     skillName: string
 }
+
+/** How a scout touched a report through the report channel: authored it (`emit_report`) or only edited
+ * an existing one (`edit_report`). Authoring supersedes a later edit of the same report. */
+export type ScoutReportAction = 'authored' | 'edited'
+
+/** A report this scout authored or edited in the window, paired with how it touched it. */
+export interface ScoutReportRow {
+    report: SignalReport
+    action: ScoutReportAction
+}
+
+// A report-authoring scout could in theory touch many reports across the window; bound the per-report
+// fetch fan-out the same way emissions are bounded.
+const MAX_TOUCHED_REPORTS = 50
 
 // A noisy scout on the 30-minute floor can rack up hundreds of emitted runs across the window;
 // fetching emissions for all of them at once would fan out hundreds of concurrent requests and
@@ -112,6 +132,27 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                 },
             },
         ],
+        // The reports this scout authored/edited directly via the report channel. Unlike findings, the run
+        // already carries the report id (no async grouping), so this fetches each report straight by id to
+        // resolve its title + live status for the Reports section. Best-effort: a deleted/inaccessible
+        // report drops out (its `get` rejects) rather than erroring the section.
+        scoutReports: [
+            [] as SignalReport[],
+            {
+                loadScoutReports: async () => {
+                    const touched = values.touchedReports.slice(0, MAX_TOUCHED_REPORTS)
+                    if (touched.length === 0) {
+                        return []
+                    }
+                    const settled = await Promise.allSettled(touched.map(({ id }) => api.signalReports.get(id)))
+                    return settled
+                        .filter(
+                            (result): result is PromiseFulfilledResult<SignalReport> => result.status === 'fulfilled'
+                        )
+                        .map((result) => result.value)
+                },
+            },
+        ],
     })),
 
     reducers({
@@ -163,6 +204,51 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
                         .map((link) => [link.source_id, link.report as LinkedSignalReport])
                 ),
         ],
+        // The distinct reports this scout touched via the report channel in the window, each tagged with
+        // how it touched it. Read off the rollup's deduped id sets; authoring supersedes a later edit of
+        // the same report, so a report in both sets reads as "authored".
+        touchedReports: [
+            (s) => [s.rollups, (_, props) => props.skillName],
+            (rollups, skillName): { id: string; action: ScoutReportAction }[] => {
+                const rollup = rollups.get(skillName)
+                if (!rollup) {
+                    return []
+                }
+                const byId = new Map<string, ScoutReportAction>()
+                for (const id of rollup.editedReportIds) {
+                    byId.set(id, 'edited')
+                }
+                for (const id of rollup.authoredReportIds) {
+                    byId.set(id, 'authored')
+                }
+                return [...byId.entries()].map(([id, action]) => ({ id, action }))
+            },
+        ],
+        // Stable key over the touched report set — refetch the reports only when the set actually changes,
+        // not on every runs-window poll that returns the same runs.
+        touchedReportsKey: [
+            (s) => [s.touchedReports],
+            (touchedReports): string =>
+                touchedReports
+                    .map(({ id, action }) => `${id}:${action}`)
+                    .sort()
+                    .join(','),
+        ],
+        // Join the fetched reports back to how the scout touched each, newest-updated first. A touched id
+        // whose report fetch failed (deleted/inaccessible) is skipped.
+        reportRows: [
+            (s) => [s.scoutReports, s.touchedReports],
+            (scoutReports, touchedReports): ScoutReportRow[] => {
+                const actionById = new Map(touchedReports.map(({ id, action }) => [id, action]))
+                return scoutReports
+                    .map((report) => {
+                        const action = actionById.get(report.id)
+                        return action ? { report, action } : null
+                    })
+                    .filter((row): row is ScoutReportRow => row !== null)
+                    .sort((a, b) => (b.report.updated_at ?? '').localeCompare(a.report.updated_at ?? ''))
+            },
+        ],
         // Join fetched emissions back to their run (for the per-row task-run link) and to the inbox
         // report they grouped into (for the "In report" chip), newest first.
         emissionRows: [
@@ -186,6 +272,11 @@ export const scoutDetailLogic = kea<scoutDetailLogicType>([
         emittedRunsKey: () => {
             actions.loadEmissions()
             actions.loadEmissionReports()
+        },
+        // Fires on mount (empty → real ids once the runs window loads) and whenever the set of touched
+        // reports changes; the key holds equal across no-op polls so we don't refetch.
+        touchedReportsKey: () => {
+            actions.loadScoutReports()
         },
     })),
 

--- a/frontend/src/scenes/inbox/types.ts
+++ b/frontend/src/scenes/inbox/types.ts
@@ -245,6 +245,12 @@ export interface SignalScoutRunSummary {
     summary: string
     emitted_count: number
     emitted_finding_ids: string[]
+    /** Reports this run authored directly via the `emit_report` channel. Distinct from `emitted_count`
+     * (weak `emit_signal` findings): a report-authoring run writes a full report instead of a finding. */
+    emitted_report_ids: string[]
+    /** Reports this run mutated via the `edit_report` channel (retitled/resummarized and/or appended a
+     * note), deduped. Can target any inbox report, so these are generally not reports the run authored. */
+    edited_report_ids: string[]
 }
 
 /** One finding a scout run emitted to the inbox. */

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.test.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.test.ts
@@ -2,6 +2,7 @@ import { pluralize } from 'lib/utils/strings'
 
 import { SignalScoutRunSummary } from '../types'
 import {
+    computeFleetSummary,
     computeScoutRollups,
     deriveRunOutcome,
     runMatchesFilter,
@@ -91,6 +92,15 @@ describe('scoutRunsWindow report channel', () => {
             const rollup = computeScoutRollups(runs).get(skill)!
             expect([...rollup.authoredReportIds]).toEqual(['r-1'])
             expect([...rollup.editedReportIds].sort()).toEqual(['r-1', 'r-2'])
+        })
+    })
+
+    describe('computeFleetSummary', () => {
+        it('counts a report-only run toward emit rate, matching the Emitted filter', () => {
+            // Guards the divergence where the fleet emit rate counted only `emitted_count > 0` while the
+            // per-scout "Emitted" chip counts report-channel output too — the two surfaces must agree.
+            const rollups = computeScoutRollups([makeRun({ emitted_report_ids: ['r-1'] })])
+            expect(computeFleetSummary([], rollups).emitRate).toEqual(1)
         })
     })
 })

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.test.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.test.ts
@@ -1,0 +1,96 @@
+import { pluralize } from 'lib/utils/strings'
+
+import { SignalScoutRunSummary } from '../types'
+import {
+    computeScoutRollups,
+    deriveRunOutcome,
+    runMatchesFilter,
+    ScoutRunOutcome,
+    scoutReportActivityLabel,
+} from './scoutRunsWindow'
+
+const NOW = new Date('2026-06-27T22:00:00Z')
+
+function makeRun(overrides: Partial<SignalScoutRunSummary> = {}): SignalScoutRunSummary {
+    return {
+        run_id: 'run-1',
+        skill_name: 'signals-scout-dev-report-probe',
+        skill_version: 1,
+        status: 'completed',
+        created_at: '2026-06-27T21:00:00Z',
+        started_at: '2026-06-27T21:00:00Z',
+        completed_at: '2026-06-27T21:02:00Z',
+        summary: '',
+        emitted_count: 0,
+        emitted_finding_ids: [],
+        emitted_report_ids: [],
+        edited_report_ids: [],
+        ...overrides,
+    }
+}
+
+describe('scoutRunsWindow report channel', () => {
+    // The report channel (emit_report/edit_report) is invisible to emitted_count, so a report-authoring
+    // run used to read as "quiet / 0 signals emitted". These lock in that report activity counts as output.
+    describe('deriveRunOutcome', () => {
+        it.each<[string, Partial<SignalScoutRunSummary>, ScoutRunOutcome]>([
+            ['authored a report, no findings → reported', { emitted_report_ids: ['r-1'] }, 'reported'],
+            ['only edited a report, no findings → reported', { edited_report_ids: ['r-2'] }, 'reported'],
+            ['no findings and no reports → quiet', {}, 'quiet'],
+            [
+                'findings win over report activity → emitted',
+                { emitted_count: 2, emitted_finding_ids: ['f-1', 'f-2'], emitted_report_ids: ['r-1'] },
+                'emitted',
+            ],
+        ])('%s', (_name, overrides, expected) => {
+            expect(deriveRunOutcome(makeRun(overrides), NOW)).toEqual(expected)
+        })
+    })
+
+    describe('runMatchesFilter', () => {
+        it('keeps a report-authoring run out of Quiet and inside Emitted', () => {
+            const run = makeRun({ emitted_report_ids: ['r-1'] })
+            expect(runMatchesFilter(run, 'quiet')).toBe(false)
+            expect(runMatchesFilter(run, 'emitted')).toBe(true)
+        })
+
+        it('keeps a genuinely quiet run inside Quiet and out of Emitted', () => {
+            const run = makeRun()
+            expect(runMatchesFilter(run, 'quiet')).toBe(true)
+            expect(runMatchesFilter(run, 'emitted')).toBe(false)
+        })
+    })
+
+    describe('scoutReportActivityLabel', () => {
+        // Expected built via `pluralize` so the count↔word non-breaking space matches without hardcoding
+        // an invisible character in the literal. The ` · ` separator uses normal spaces.
+        it.each<[string, Partial<SignalScoutRunSummary>, string | null]>([
+            ['authored only', { emitted_report_ids: ['r-1'] }, `${pluralize(1, 'report')} authored`],
+            ['edited only (pluralized)', { edited_report_ids: ['r-1', 'r-2'] }, `${pluralize(2, 'report')} edited`],
+            [
+                'both authored and edited',
+                { emitted_report_ids: ['r-1'], edited_report_ids: ['r-2'] },
+                `${pluralize(1, 'report')} authored · ${pluralize(1, 'report')} edited`,
+            ],
+            ['no report activity', {}, null],
+        ])('%s', (_name, overrides, expected) => {
+            expect(scoutReportActivityLabel(makeRun(overrides))).toEqual(expected)
+        })
+    })
+
+    describe('computeScoutRollups', () => {
+        it('dedupes report ids across runs into the authored/edited sets', () => {
+            const skill = 'signals-scout-dev-report-probe'
+            const runs = [
+                makeRun({ run_id: 'run-1', skill_name: skill, emitted_report_ids: ['r-1'] }),
+                // The same report is edited by a later run — must not double-count, and stays distinct
+                // from the authored set.
+                makeRun({ run_id: 'run-2', skill_name: skill, edited_report_ids: ['r-1'] }),
+                makeRun({ run_id: 'run-3', skill_name: skill, edited_report_ids: ['r-2'] }),
+            ]
+            const rollup = computeScoutRollups(runs).get(skill)!
+            expect([...rollup.authoredReportIds]).toEqual(['r-1'])
+            expect([...rollup.editedReportIds].sort()).toEqual(['r-1', 'r-2'])
+        })
+    })
+})

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -358,7 +358,8 @@ export interface FleetSummary {
     emittedCount: number
     /** Completed / (completed + failed) over the window, or null when no finished runs. */
     successRate: number | null
-    /** Share of runs in the window that emitted at least one signal, or null when no runs. */
+    /** Share of runs in the window that produced output — a signal OR report-channel activity — or null
+     * when no runs. Mirrors the per-scout "Emitted" filter so the two surfaces agree. */
     emitRate: number | null
 }
 
@@ -378,7 +379,9 @@ export function computeFleetSummary(configs: SignalScoutConfig[], rollups: Map<s
         failedCount += rollup.failedCount
         runCount += rollup.runCount
         for (const run of rollup.runs) {
-            if ((run.emitted_count ?? 0) > 0) {
+            // Output = a weak finding OR report-channel activity, consistent with `runMatchesFilter('emitted')`
+            // so the fleet emit rate and the per-scout "Emitted" chip never disagree about the same runs.
+            if (runProducedOutput(run)) {
                 emittedRunCount += 1
             }
         }

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -248,7 +248,10 @@ export function scoutRunOutcomeLabel(run: SignalScoutRunSummary, now: Date): str
             return `${pluralize(count, 'signal')} emitted`
         }
         case 'reported':
-            return scoutReportActivityLabel(run) ?? '0 signals emitted'
+            // `reported` is only produced when the run touched a report, so the label is always present.
+            // The `?? ''` is an unreachable type guard (the helper is `string | null`) — keeps the string
+            // return without an unsafe `as` cast; never rendered.
+            return scoutReportActivityLabel(run) ?? ''
         case 'quiet':
             return '0 signals emitted'
         case 'error':

--- a/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
+++ b/frontend/src/scenes/inbox/utils/scoutRunsWindow.ts
@@ -149,12 +149,62 @@ export function isRunStuck(run: SignalScoutRunSummary, now: Date): boolean {
     return duration !== null && duration >= STUCK_THRESHOLD_SECONDS
 }
 
-export type ScoutRunOutcome = 'emitted' | 'quiet' | 'error' | 'timed_out' | 'running' | 'stuck' | 'queued' | 'unknown'
+// ── Report channel (emit_report / edit_report) ───────────────────────────────
+// A second emit channel: instead of a weak `emit_signal` finding (which drives `emitted_count`), an
+// opted-in scout authors a full inbox report directly (`emitted_report_ids`) or edits an existing one
+// (`edited_report_ids`). This activity is invisible to `emitted_count`, so it's tracked separately here
+// and folded into the run-outcome model so a report-authoring run never reads as "quiet".
+
+/** The reports a single run touched via the report channel — authored (emit_report) and edited (edit_report). */
+export function runReportActivity(run: SignalScoutRunSummary): { authored: string[]; edited: string[] } {
+    return { authored: run.emitted_report_ids ?? [], edited: run.edited_report_ids ?? [] }
+}
+
+/** Whether a run produced any report-channel output (authored or edited at least one report). */
+export function runTouchedReports(run: SignalScoutRunSummary): boolean {
+    const { authored, edited } = runReportActivity(run)
+    return authored.length > 0 || edited.length > 0
+}
+
+/** Whether a completed run produced any output at all — a weak finding OR report-channel activity. */
+export function runProducedOutput(run: SignalScoutRunSummary): boolean {
+    return (run.emitted_count ?? 0) > 0 || runTouchedReports(run)
+}
+
+/** A short label for a run's report-channel activity, e.g. "1 report authored · 2 reports edited", or
+ * null when the run touched no report. */
+export function scoutReportActivityLabel(run: SignalScoutRunSummary): string | null {
+    const { authored, edited } = runReportActivity(run)
+    const parts: string[] = []
+    if (authored.length > 0) {
+        parts.push(`${pluralize(authored.length, 'report')} authored`)
+    }
+    if (edited.length > 0) {
+        parts.push(`${pluralize(edited.length, 'report')} edited`)
+    }
+    return parts.length > 0 ? parts.join(' · ') : null
+}
+
+export type ScoutRunOutcome =
+    | 'emitted'
+    | 'reported'
+    | 'quiet'
+    | 'error'
+    | 'timed_out'
+    | 'running'
+    | 'stuck'
+    | 'queued'
+    | 'unknown'
 
 export function deriveRunOutcome(run: SignalScoutRunSummary, now: Date): ScoutRunOutcome {
     const status = normalizeRunStatus(run.status)
     if (status === 'completed') {
-        return (run.emitted_count ?? 0) > 0 ? 'emitted' : 'quiet'
+        if ((run.emitted_count ?? 0) > 0) {
+            return 'emitted'
+        }
+        // A run that emitted no finding but authored/edited a report is not quiet — it produced output
+        // through the report channel.
+        return runTouchedReports(run) ? 'reported' : 'quiet'
     }
     if (status === 'failed') {
         return deriveRunFailureKind(run, now) === 'timed_out' ? 'timed_out' : 'error'
@@ -172,9 +222,10 @@ export function deriveRunOutcome(run: SignalScoutRunSummary, now: Date): ScoutRu
 export type ScoutRunFilter = 'all' | 'emitted' | 'quiet' | 'failed'
 
 /**
- * Whether a run belongs under a given filter chip. Emitted/Quiet split completed runs by
- * whether they wrote findings; Failed is any failed/cancelled run. There is no server-side
- * `status` filter yet (api gap 1), so the detail view filters its window client-side.
+ * Whether a run belongs under a given filter chip. Emitted/Quiet split completed runs by whether they
+ * produced any output — a weak finding OR report-channel activity (authored/edited a report); Failed is
+ * any failed/cancelled run. There is no server-side `status` filter yet (api gap 1), so the detail view
+ * filters its window client-side.
  */
 export function runMatchesFilter(run: SignalScoutRunSummary, filter: ScoutRunFilter): boolean {
     const status = normalizeRunStatus(run.status)
@@ -182,9 +233,9 @@ export function runMatchesFilter(run: SignalScoutRunSummary, filter: ScoutRunFil
         case 'all':
             return true
         case 'emitted':
-            return (run.emitted_count ?? 0) > 0
+            return runProducedOutput(run)
         case 'quiet':
-            return status === 'completed' && (run.emitted_count ?? 0) === 0
+            return status === 'completed' && !runProducedOutput(run)
         case 'failed':
             return status === 'failed'
     }
@@ -196,6 +247,8 @@ export function scoutRunOutcomeLabel(run: SignalScoutRunSummary, now: Date): str
             const count = run.emitted_count ?? 0
             return `${pluralize(count, 'signal')} emitted`
         }
+        case 'reported':
+            return scoutReportActivityLabel(run) ?? '0 signals emitted'
         case 'quiet':
             return '0 signals emitted'
         case 'error':
@@ -220,6 +273,11 @@ export interface ScoutRollup {
     completedCount: number
     failedCount: number
     emittedCount: number
+    /** Distinct reports authored via `emit_report` across the window (a report authored once, even if
+     * later edited, counts here). Deduped across runs since the same report can recur run-to-run. */
+    authoredReportIds: Set<string>
+    /** Distinct reports edited via `edit_report` across the window, deduped across runs. */
+    editedReportIds: Set<string>
     latestRun: SignalScoutRunSummary | null
     runningRun: SignalScoutRunSummary | null
     /** This scout's runs in the window, oldest first (timeline order). */
@@ -232,6 +290,8 @@ function emptyRollup(): ScoutRollup {
         completedCount: 0,
         failedCount: 0,
         emittedCount: 0,
+        authoredReportIds: new Set(),
+        editedReportIds: new Set(),
         latestRun: null,
         runningRun: null,
         runs: [],
@@ -260,6 +320,12 @@ export function computeScoutRollups(runs: SignalScoutRunSummary[]): Map<string, 
             rollup.failedCount += 1
         }
         rollup.emittedCount += run.emitted_count ?? 0
+        for (const reportId of run.emitted_report_ids ?? []) {
+            rollup.authoredReportIds.add(reportId)
+        }
+        for (const reportId of run.edited_report_ids ?? []) {
+            rollup.editedReportIds.add(reportId)
+        }
         rollup.runs.push(run)
         const startedAt = run.started_at ? new Date(run.started_at).getTime() : 0
         const latestStartedAt = rollup.latestRun?.started_at ? new Date(rollup.latestRun.started_at).getTime() : -1


### PR DESCRIPTION
## Problem

The scout detail page (`/inbox/scouts/<skill>`) is keyed entirely on the `emit_signal` finding channel — `emitted_count` / `emitted_finding_ids`. The second emit channel, where a scout authors or edits a full inbox report directly via `emit_report` / `edit_report`, was invisible to it: a report-authoring run showed "0 signals emitted", read as **Quiet**, and surfaced no link to the report it produced.

PostHog/posthog#66539 (merged) closed the backend half — runs now carry `emitted_report_ids` and `edited_report_ids`. This PR is the frontend follow-on that consumes them, so report-channel scouts (e.g. the `dev-report-probe`) actually show their output.

## Changes

All under `frontend/src/scenes/inbox`:

- **New Reports section** on the scout detail page. Lists the inbox reports this scout authored or edited in the window, newest-updated first, each a link straight to the report with its live title + status + priority and an "Authored" / "Edited" tag (`ScoutReportCard`). Hidden entirely for the common scout that never authors a report, so it only appears for report-channel scouts. Report titles/status are fetched by id (the run already carries the id — no async grouping like findings), best-effort.
- **Run outcome model** now treats report activity as output. A completed run that emitted no finding but authored/edited a report reads as **reported**, not **quiet** — it gets the payoff glyph/box color, a "1 report authored · 1 report edited" badge instead of "0 signals emitted", and falls under the **Emitted** filter rather than **Quiet**. Expanding the run row links out to each report it touched.
- **Rollup line** appends "N reports authored / M reports edited" when present (deduped across runs).
- **Types**: `emitted_report_ids` / `edited_report_ids` added to the handwritten `SignalScoutRunSummary` (consistent with the existing handwritten scout types in this scene; the merged backend serializer now returns both).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated only — no manual browser testing.

- Added `scoutRunsWindow.test.ts` (11 cases, all pass) over the new pure helpers.
- Typecheck (`tsgo --noEmit`) clean for all changed files; oxlint/oxfmt clean.

New tests and the regression each catches (this file had no prior tests):
- `deriveRunOutcome` → **reported** for a completed run that authored/edited a report with zero findings — guards the core regression where report-authoring runs read as "quiet".
- `runMatchesFilter` keeps a report-authoring run out of **Quiet** and inside **Emitted** — guards the filter bucketing.
- `scoutReportActivityLabel` pluralization + authored/edited combination.
- `computeScoutRollups` dedupes report ids across runs into the authored/edited sets.

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude Code (Opus 4.8) at Andy's direction. Started from a debugging question about the `dev-report-probe` scout — its two runs authored/edited a real report (`pending_input`) but the detail page showed "0 signals emitted" and no report link, because the page only knew the finding channel. The fix surfaces the report channel the merged #66539 began exposing.

Skills invoked: `/exploring-signals-scouts` (to trace the probe's runs → report), `/writing-tests` (gated the new tests to behavior-level assertions that each catch a named regression).

Design decisions: report activity is modeled as a distinct **reported** run outcome (not folded into the signal count) so a report-only run stops reading as quiet without muddying the "N signals emitted" framing; the Reports section fetches titles by id rather than re-deriving via grouping, since the report channel carries the id directly. Report fetches refresh on the touched-id set changing, not on every poll — a known minor staleness tradeoff for a `pending_input` report whose status later transitions.
