### PR TITLE
fix(insights): resolve warehouse access control in cache warming

### DIFF
--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -84,6 +84,10 @@ def update_cache(caching_state_id: UUID):
                 cast(dict[str, Any], insight.query),
                 dashboard_filters_json=dashboard.filters if dashboard is not None else None,
                 execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                # Warm the cache as the insight owner so HogQL warehouse access control resolves against
+                # their access. Background warming has no requesting user; without this, the userless
+                # context fails closed and denies every warehouse table (insights with no owner -> None).
+                user=insight.created_by,
                 analytics_props={"source": EventSource.CACHE_WARMING},
             )
             # TRICKY: `result` is null, because `process_query` already set the cache. `cache_type` also irrelevant


### PR DESCRIPTION
## Problem

Background insight cache warming (`update_cache`) computes dashboard insight results without a requesting user. Since #61686 added HogQL access control for warehouse tables — fail-closed when there's no user — any dashboard insight that reads a data warehouse table fails during warming with `You don't have access to table ...`, and that error is served from the shared cache to viewers. The interactive path is unaffected (it passes the request user), so this only surfaces in production via the warmed cache and does not reproduce locally, where insights compute on-demand.

## Changes

`update_cache` now passes `user=insight.created_by` to `process_query_dict`, so warehouse access control resolves against the insight owner's access. This mirrors the approach #61686 took for subscription asset rendering. Insights with no owner stay `None` (unchanged, matching that precedent).

## How did you test this code?

I'm an agent (Claude Code). Root-caused by tracing the cache-warming path; the fix mirrors the established #61686 pattern. No automated tests added yet. I did not run manual testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Root-caused with Claude Code: a marketing analytics chart tile failed in production but not locally. Triangulated that warehouse-backed dashboard insights fail only via background cache warming, which ran userless after #61686 (the interactive path, the SQL editor, and the table tile all pass a user and work fine). Chose `user=insight.created_by` over `bypass_warehouse_access_control` to keep RBAC enforced and stay consistent with #61686's subscriptions handling. Suggested reviewer: the #61686 author (Alex Lider), since this touches that access-control surface. No tests included yet — a regression test for warming a warehouse-backed insight is worth discussing on this PR.
