### PR TITLE
fix(taxonomic-filter): recent feature flags not selectable in match criteria

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -821,15 +821,15 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
             getName: (featureFlag: FeatureFlagType) => {
                 const name = featureFlag.key || featureFlag.name
-                const isInactive = !featureFlag.active
+                const isInactive = featureFlag.active === false
                 return isInactive ? `${name} (disabled)` : name
             },
             getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
             getPopoverHeader: () => `Feature Flags`,
             getIcon: (featureFlag: FeatureFlagType) => (
-                <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
+                <IconFlag className={clsx('size-4', featureFlag.active === false && 'text-muted-alt opacity-50')} />
             ),
-            getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
+            getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
             localItemsSearch: (items: TaxonomicDefinitionTypes[], query: string): TaxonomicDefinitionTypes[] => {
                 // Note: This function doesn't have direct access to the current value
                 // The actual filtering logic needs to be implemented in the infinite list logic


### PR DESCRIPTION
## Problem

Closes #66492

When searching for a feature flag to use in match criteria, flags that appear under the "Feature Flags - recent" section can't be selected. Clicking them does nothing. The same flags work fine when they appear under the regular "Feature Flags" section.

## Changes

Recent items in the taxonomic filter are stored with minimal data — just `name` and `id`. The `active` field isn't persisted. The feature flags group had `getIsDisabled: (ff) => !ff.active`, and `!undefined` evaluates to `true`, so every recently-used flag gets marked as disabled regardless of its actual state.

Fixed by switching to `ff.active === false` in `getIsDisabled`, `getName`, and `getIcon` — this way a flag is only treated as inactive when `active` is explicitly false, not when it's missing from a stripped recent-item object.

## How did you test this code?

Traced the code path: `InfiniteList` calls `itemGroup.getIsDisabled(item)` using the source group's definition. For recent items, the object is `{ name, id }` with no `active` field, so the old `!featureFlag.active` check always returns true and the click handler bails early. The fix is confirmed by reading both paths.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Traced the bug from the issue report to `buildTaxonomicGroups.tsx` where three checks all used `!featureFlag.active`. Recent items are stripped down to `{ name, id }` when saved (see `taxonomicFilterLogic.tsx`), so `active` is `undefined` and the negation flips it to disabled. Changed all three to `=== false` so only explicitly inactive flags are treated as such.