### PR TITLE
fix(onboarding): make product introduction close button clickable

### DIFF
--- a/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
+++ b/frontend/src/lib/components/ProductIntroduction/ProductIntroduction.tsx
@@ -107,7 +107,7 @@ export const ProductIntroduction = ({
             data-attr={`product-introduction-${thingName}`}
         >
             {!isEmpty && (
-                <div className="flex justify-end -mb-6 -mt-2 -mr-2">
+                <div className="flex justify-end -mb-6 -mt-2 -mr-2 relative z-10">
                     <div>
                         <LemonButton
                             icon={<IconX />}


### PR DESCRIPTION
## Problem

Clicking the close (X) button on the product introduction empty-state banner does nothing — the dismissal never takes effect. First spotted on the Replay vision scanner intro (`data-attr="product-introduction-scanner"`), but it affects every scene that shows the dismissable welcome variant of `ProductIntroduction`.

The click handler, the `updateHasSeenProductIntroFor` listener, and the server-side persistence are all wired correctly. The problem is purely layout: the close-button row uses a `-mb-6` negative margin to tuck against the content below it, which pulls the **full-width** (`w-full`) content row up and over the button. Since neither element is positioned, the content row paints later in the DOM on top of the button and intercepts the pointer event, so the click lands on the content container instead of the X.

## Changes

Added `relative z-10` to the close-button row so it stacks above the overlapping content row and actually receives the click. No visual change — the negative margins and positioning are preserved.

## How did you test this code?

I'm an agent (PostHog Slack app). I traced the full dismissal path — close button `onClick` → `updateHasSeenProductIntroFor` listener (`userLogic`) → `PATCH api/users/@me/` (`has_seen_product_intro_for` is a writable field) → `loadUser` → visibility gate hides the banner — and confirmed it's all correct, isolating the cause to the CSS stacking overlap. I did not run the app manually to click the button. A reviewer should verify the X dismisses the banner in the browser.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Reported from a Slack thread: the close button on the Replay vision scanner product introduction did nothing. Investigated with the PostHog Slack app (Claude Code). Confirmed the dismissal logic and persistence are sound, then narrowed it to a z-stacking bug where the `-mb-6` negative margin on the close-button row lets the full-width content row overlap and swallow the click. Chose the minimal fix (`relative z-10` on the close-button row) over reworking the margins, since it preserves the exact visual layout. Fix lives in the shared component, so it restores the dismiss button across all product introductions, not just the scanner one. No skills were required for this one-line CSS change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C03PB072FMJ/p1782638834622449)*