### PR TITLE
fix(cohorts): exclude JSON null from is_set property filter

### DIFF
--- a/ee/clickhouse/models/test/test_property.py
+++ b/ee/clickhouse/models/test/test_property.py
@@ -1821,6 +1821,51 @@ def test_prop_filter_json_extract_nullable_materialized_is_set_uses_json(
         assert uuids == expected
 
 
+@freeze_time("2021-04-01T01:00:00.000Z")
+def test_prop_filter_json_extract_is_set_excludes_explicit_json_null(clean_up_materialised_columns, team):
+    # Regression test for #29916: a person/event property whose JSON value is explicitly `null`
+    # should be treated as "not set", consistently for both `is_set` and `is_not_set`.
+    events = [
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"email": "test@posthog.com"},
+        ),
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"email": None},
+        ),
+        _create_event(
+            event="$pageview",
+            team=team,
+            distinct_id="whatever",
+            properties={"attr": "unrelated"},
+        ),
+    ]
+
+    cases = [
+        (Property(key="email", operator="is_set", value="is_set"), [0]),
+        (Property(key="email", operator="is_not_set", value="is_not_set"), [1, 2]),
+    ]
+
+    for property, expected_event_indexes in cases:
+        query, params = prop_filter_json_extract(property, 0, allow_denormalized_props=False)
+        uuids = sorted(
+            [
+                str(uuid)
+                for (uuid,) in sync_execute(
+                    f"SELECT uuid FROM events WHERE team_id = %(team_id)s {query}",
+                    {"team_id": team.pk, **params},
+                )
+            ]
+        )
+        expected = sorted([events[index] for index in expected_event_indexes])
+        assert uuids == expected, f"operator={property.operator}"
+
+
 @pytest.mark.parametrize("property,expected_event_indexes", TEST_PROPERTIES)
 @freeze_time("2021-04-01T01:00:00.000Z")
 def test_prop_filter_json_extract_person_on_events_materialized(

--- a/posthog/models/property/util.py
+++ b/posthog/models/property/util.py
@@ -487,15 +487,21 @@ def prop_filter_json_extract(
             "v{}_{}".format(prepend, idx): prop.value,
         }
         if is_denormalized:
+            # `property_expr` is quote-trimmed JSON, so an explicit JSON `null` value comes through
+            # as the literal string "null" rather than SQL NULL. Without excluding it here, "is_set"
+            # would incorrectly match persons whose property value is null (see #29916).
             return (
-                " {property_operator} {left} != ''".format(left=property_expr, property_operator=property_operator),
+                " {property_operator} ({left} != '' AND {left} != 'null')".format(
+                    left=property_expr, property_operator=property_operator
+                ),
                 params,
             )
         return (
-            " {property_operator} JSONHas({prop_var}, %(k{prepend}_{idx})s)".format(
+            " {property_operator} (JSONHas({prop_var}, %(k{prepend}_{idx})s) AND {left} != 'null')".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,
+                left=property_expr,
                 property_operator=property_operator,
             ),
             params,
@@ -506,12 +512,16 @@ def prop_filter_json_extract(
             "v{}_{}".format(prepend, idx): prop.value,
         }
         if is_denormalized:
+            # Mirror the "is_set" fix above: a person with an explicit JSON `null` value should count
+            # as "not set", same as a person missing the key entirely.
             return (
-                " {property_operator} {left} = ''".format(left=property_expr, property_operator=property_operator),
+                " {property_operator} ({left} = '' OR {left} = 'null')".format(
+                    left=property_expr, property_operator=property_operator
+                ),
                 params,
             )
         return (
-            " {property_operator} (isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s))".format(
+            " {property_operator} (isNull({left}) OR NOT JSONHas({prop_var}, %(k{prepend}_{idx})s) OR {left} = 'null')".format(
                 idx=idx,
                 prepend=prepend,
                 prop_var=prop_var,


### PR DESCRIPTION
## Problem

`prop_filter_json_extract()` only checked whether a JSON property key existed, not whether its value was an explicit JSON `null`. So a person/event property explicitly set to `null` showed up as "is set" — and `is_not_set` missed those same rows.

Closes #29916

## Changes

- Updated both the denormalized and JSON-extract branches of `prop_filter_json_extract()` so `is_set` excludes an explicit JSON `null`, and `is_not_set` includes it — consistently on both sides.
- Added a regression test for the change.

## How did you test this code?

Built this with Claude (Cowork). I haven't run the Postgres/ClickHouse suite in this sandbox, so I'm not pasting fabricated pytest output — the new test exists but I haven't executed it myself.

One known gap: the new test only covers the `allow_denormalized_props=False` path. A reviewer on the earlier combined PR (#65069) flagged that the denormalized branch needs its own test too, and I haven't added that yet — calling it out rather than burying it.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude (Cowork) to track down the bug, write the fix, and add the test above. I reviewed the diff and I'm the one submitting and owning this PR.