### PR TITLE
feat(insights): add filter to hide insights already on a dashboard

### DIFF
--- a/frontend/src/scenes/saved-insights/SavedInsights.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsights.tsx
@@ -1069,7 +1069,7 @@ export function SavedInsights(): JSX.Element {
                         setFilters={setSavedInsightsFilters}
                         quickFilters={
                             tab === SavedInsightsTabs.Yours
-                                ? ['insightType', 'tags', 'favorites', 'featureFlags']
+                                ? ['insightType', 'tags', 'favorites', 'featureFlags', 'notOnAnyDashboard']
                                 : undefined
                         }
                     />

--- a/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
+++ b/frontend/src/scenes/saved-insights/SavedInsightsFilters.tsx
@@ -1,6 +1,6 @@
 import posthog from 'posthog-js'
 
-import { IconFlag, IconHeart, IconHeartFilled } from '@posthog/icons'
+import { IconDashboard, IconFlag, IconHeart, IconHeartFilled } from '@posthog/icons'
 
 import { MemberSelectMultiplePopover } from 'lib/components/MemberSelectMultiplePopover'
 import { TagSelect } from 'lib/components/TagSelect'
@@ -13,8 +13,15 @@ import { cn } from 'lib/utils/css-classes'
 import { INSIGHT_TYPE_OPTIONS } from 'scenes/saved-insights/SavedInsights'
 import { SavedInsightFilters } from 'scenes/saved-insights/savedInsightsLogic'
 
-export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags'
-const ALL_QUICK_FILTERS: QuickFilterKind[] = ['insightType', 'tags', 'createdBy', 'favorites', 'featureFlags']
+export type QuickFilterKind = 'insightType' | 'tags' | 'createdBy' | 'favorites' | 'featureFlags' | 'notOnAnyDashboard'
+const ALL_QUICK_FILTERS: QuickFilterKind[] = [
+    'insightType',
+    'tags',
+    'createdBy',
+    'favorites',
+    'featureFlags',
+    'notOnAnyDashboard',
+]
 
 export function SavedInsightsFilters({
     filters,
@@ -28,7 +35,7 @@ export function SavedInsightsFilters({
     /** When true, inactive filters appear borderless. */
     borderless?: boolean
 }): JSX.Element {
-    const { search, hideFeatureFlagInsights, favorited, tags, insightType, createdBy } = filters
+    const { search, hideFeatureFlagInsights, notOnAnyDashboard, favorited, tags, insightType, createdBy } = filters
     const quickFilterSet = new Set(quickFilters)
     const hasInsightTypeSelection = !!insightType && insightType !== 'All types'
 
@@ -116,9 +123,36 @@ export function SavedInsightsFilters({
                             onToggle={(checked) => setFilters({ hideFeatureFlagInsights: checked })}
                         />
                     )}
+                    {quickFilterSet.has('notOnAnyDashboard') && (
+                        <NotOnAnyDashboardToggle
+                            notOnAnyDashboard={notOnAnyDashboard ?? undefined}
+                            onToggle={(checked) => setFilters({ notOnAnyDashboard: checked })}
+                        />
+                    )}
                 </div>
             )}
         </div>
+    )
+}
+
+const NotOnAnyDashboardToggle = ({
+    notOnAnyDashboard,
+    onToggle,
+}: {
+    notOnAnyDashboard?: boolean
+    onToggle: (checked: boolean) => void
+}): JSX.Element => {
+    return (
+        <Tooltip title="Only show insights that aren't added to any dashboard yet." placement="top">
+            <LemonButton
+                icon={<IconDashboard />}
+                onClick={() => onToggle(!notOnAnyDashboard)}
+                type="tertiary"
+                size="small"
+            >
+                Not on any dashboard: <LemonSwitch checked={notOnAnyDashboard || false} className="ml-1" />
+            </LemonButton>
+        </Tooltip>
     )
 }
 

--- a/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
+++ b/frontend/src/scenes/saved-insights/savedInsightsLogic.ts
@@ -58,6 +58,7 @@ export interface SavedInsightFilters {
     dashboardId: number | undefined | null
     events: string[] | undefined | null
     hideFeatureFlagInsights: boolean | undefined | null
+    notOnAnyDashboard: boolean | undefined | null
     favorited: boolean | undefined | null
 }
 
@@ -79,6 +80,7 @@ export function cleanFilters(values: Partial<SavedInsightFilters>): SavedInsight
         dashboardId: values.dashboardId,
         events: values.events,
         hideFeatureFlagInsights: values.hideFeatureFlagInsights || false,
+        notOnAnyDashboard: values.notOnAnyDashboard || false,
         favorited: values.favorited || false,
     }
 }
@@ -281,6 +283,7 @@ export const savedInsightsLogic = kea<savedInsightsLogicType>([
                     dashboards: [filters.dashboardId],
                 }),
                 ...(filters.hideFeatureFlagInsights && { hide_feature_flag_insights: true }),
+                ...(filters.notOnAnyDashboard && { not_on_any_dashboard: true }),
             }),
         ],
         pagination: [

--- a/products/product_analytics/backend/api/insight.py
+++ b/products/product_analytics/backend/api/insight.py
@@ -1348,6 +1348,11 @@ Background calculation can be tracked using the `query_status` response field.""
                 description="JSON-encoded array of dashboard IDs. Returns insights attached to every listed dashboard (AND).",
             ),
             OpenApiParameter(
+                name="not_on_any_dashboard",
+                type=OpenApiTypes.BOOL,
+                description="When truthy, restricts results to insights that aren't tiled on any dashboard.",
+            ),
+            OpenApiParameter(
                 name="tags",
                 type=OpenApiTypes.STR,
                 description="JSON-encoded array of tag names. Returns insights with any of the listed tags.",
@@ -1709,6 +1714,11 @@ class InsightViewSet(
                     queryset = queryset.exclude(
                         name__in=[FEATURE_FLAG_TOTAL_VOLUME_INSIGHT_NAME, FEATURE_FLAG_UNIQUE_USERS_INSIGHT_NAME]
                     )
+            elif key == "not_on_any_dashboard":
+                if str_to_bool(request.GET["not_on_any_dashboard"]):
+                    # Only keep insights that aren't tiled on any (non-deleted) dashboard. See #26621.
+                    on_any_dashboard = DashboardTile.objects.filter(insight=OuterRef("pk"))
+                    queryset = queryset.filter(~Exists(on_any_dashboard))
             elif key == "date_from":
                 queryset = queryset.filter(
                     last_modified_at__gt=relative_date_parse(request.GET["date_from"], self.team.timezone_info)

--- a/products/product_analytics/backend/api/test/test_insight.py
+++ b/products/product_analytics/backend/api/test/test_insight.py
@@ -475,6 +475,44 @@ class TestInsight(ClickhouseTestMixin, APIBaseTest, QueryMatchingTest):
         self.assertEqual(len(response.json()["results"]), 1)
         self.assertEqual(response.json()["results"][0]["name"], "Regular Insight")
 
+    def test_not_on_any_dashboard_filter(self) -> None:
+        # See #26621: let users filter the saved insights list down to insights that aren't
+        # tiled on any dashboard yet.
+        filter_dict = {
+            "events": [{"id": "$pageview"}],
+            "properties": [{"key": "$browser", "value": "Mac OS X"}],
+        }
+
+        dashboard = Dashboard.objects.create(team=self.team, name="A dashboard", created_by=self.user)
+
+        insight_on_dashboard = Insight.objects.create(
+            name="On a dashboard",
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
+        )
+        DashboardTile.objects.create(dashboard=dashboard, insight=insight_on_dashboard)
+
+        insight_not_on_dashboard = Insight.objects.create(
+            name="Not on a dashboard",
+            filters=Filter(data=filter_dict).to_dict(),
+            saved=True,
+            team=self.team,
+            created_by=self.user,
+        )
+
+        # Without the filter, both insights are returned
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 2)
+
+        # With the filter, only the insight that isn't on any dashboard is returned
+        response = self.client.get(f"/api/projects/{self.team.id}/insights/?saved=true&not_on_any_dashboard=true")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.json()["results"]), 1)
+        self.assertEqual(response.json()["results"][0]["name"], insight_not_on_dashboard.name)
+
     def test_get_insight_in_dashboard_context(self) -> None:
         filter_dict = {
             "events": [{"id": "$pageview"}],


### PR DESCRIPTION
## Problem

There's no way to filter the Saved Insights list down to insights that aren't on any dashboard yet — you have to scroll past everything that's already been added to find them.

Closes #26621

## Changes

- Added a `not_on_any_dashboard` query param to the insights list API.
- Added a matching "Not on any dashboard" quick-filter toggle on the Saved Insights page.

<!-- screenshot of the toggle goes here -->

## How did you test this code?

Built this with Claude (Cowork). Added a unit test covering the new filter:

- `products/product_analytics/backend/api/test/test_insight.py::test_not_on_any_dashboard_filter`

I checked the toggle renders correctly via Storybook (screenshot above). I haven't run the full Django/ClickHouse suite in this environment, so I'm not pasting test output I didn't actually generate — happy to run it before merge if asked.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude (Cowork) to find the issue, write the fix, and add the test above. I reviewed the diff and I'm the one submitting and owning this PR.