### PR TITLE
fix(hogql): fix column resolution in JOIN USING

### DIFF
--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -708,19 +708,15 @@ class BasePrinter(Visitor[str]):
             raise QueryError(f"Invalid join constraint type: {constraint.constraint_type!r}")
 
         if constraint.constraint_type == "USING":
-            # The resolver binds each USING field to the left table, so the resolved field prints as
-            # `left_alias.col`. SQL requires USING columns to be bare identifiers resolvable from *both*
-            # relations — the qualified form makes ClickHouse raise Code 47 UNKNOWN_IDENTIFIER.
+            # The resolver binds USING fields to the left table, so they'd print qualified (`e.col`) —
+            # but USING columns must be bare identifiers, else ClickHouse raises Code 47.
             fields = self._unwrap_using_fields(constraint.expr)
             if on_clause_guard is None:
-                # No predicate to fold in: keep USING, just strip the resolver's qualification.
-                #   FROM events AS e JOIN persons AS p USING (person_id)  ->  ... USING (person_id)
                 names = ", ".join(self._print_identifier(str(field.chain[-1])) for field in fields)
                 return f"USING ({names})"
             # A LEFT-JOIN guard (team_id / access control) must live in the join condition to preserve
-            # NULL rows, but USING can't carry a boolean predicate — so lower the whole thing to ON:
-            #   ... LEFT JOIN persons AS p USING (person_id)
-            #   -> ... LEFT JOIN persons AS p ON e.person_id = p.person_id AND p.team_id = 2
+            # NULL rows, but USING can't carry a predicate — so lower to ON:
+            #   LEFT JOIN persons AS p USING (person_id)  ->  ... ON e.person_id = p.person_id AND p.team_id = 2
             if not isinstance(
                 node_type, ast.BaseTableType | ast.SelectSetQueryType | ast.SelectQueryType | ast.SelectQueryAliasType
             ):
@@ -741,8 +737,7 @@ class BasePrinter(Visitor[str]):
         columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
         fields: list[ast.Field] = []
         for col in columns:
-            # The resolver wraps each resolved USING field in a hidden Alias; unwrap it so nothing
-            # downstream ever prints `col AS alias` inside a USING or ON clause.
+            # The resolver wraps each resolved field in a hidden Alias; unwrap to the bare Field.
             field = col.expr if isinstance(col, ast.Alias) else col
             if not isinstance(field, ast.Field) or not field.chain:
                 raise QueryError("JOIN USING expects column names")

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -711,51 +711,43 @@ class BasePrinter(Visitor[str]):
             # The resolver binds each USING field to the left table, so the resolved field prints as
             # `left_alias.col`. SQL requires USING columns to be bare identifiers resolvable from *both*
             # relations — the qualified form makes ClickHouse raise Code 47 UNKNOWN_IDENTIFIER.
+            fields = self._unwrap_using_fields(constraint.expr)
             if on_clause_guard is None:
                 # No predicate to fold in: keep USING, just strip the resolver's qualification.
                 #   FROM events AS e JOIN persons AS p USING (person_id)  ->  ... USING (person_id)
-                return f"USING ({self._print_using_columns(constraint.expr)})"
+                names = ", ".join(self._print_identifier(str(field.chain[-1])) for field in fields)
+                return f"USING ({names})"
             # A LEFT-JOIN guard (team_id / access control) must live in the join condition to preserve
             # NULL rows, but USING can't carry a boolean predicate — so lower the whole thing to ON:
             #   ... LEFT JOIN persons AS p USING (person_id)
             #   -> ... LEFT JOIN persons AS p ON e.person_id = p.person_id AND p.team_id = 2
-            on_expr = ast.And(exprs=[on_clause_guard, self._using_constraint_as_on(constraint.expr, node_type)])
-            return f"ON {self.visit(on_expr)}"
+            if not isinstance(
+                node_type, ast.BaseTableType | ast.SelectSetQueryType | ast.SelectQueryType | ast.SelectQueryAliasType
+            ):
+                raise QueryError("JOIN USING requires a table or subquery on the right-hand side")
+            comparisons: list[ast.Expr] = []
+            for field in fields:
+                name = str(field.chain[-1])
+                right = ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=node_type))
+                comparisons.append(ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=field, right=right))
+            return f"ON {self.visit(ast.And(exprs=[on_clause_guard, *comparisons]))}"
 
         if on_clause_guard is not None:
             combined_constraint = ast.And(exprs=[on_clause_guard, constraint.expr])
             return f"{constraint.constraint_type} {self.visit(combined_constraint)}"
         return f"{constraint.constraint_type} {self.visit(constraint)}"
 
-    def _print_using_columns(self, expr: ast.Expr) -> str:
+    def _unwrap_using_fields(self, expr: ast.Expr) -> list[ast.Field]:
         columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
-        names: list[str] = []
+        fields: list[ast.Field] = []
         for col in columns:
-            # The resolver wraps each USING field in an Alias bound to the left table; unwrap for the name.
+            # The resolver wraps each resolved USING field in a hidden Alias; unwrap it so nothing
+            # downstream ever prints `col AS alias` inside a USING or ON clause.
             field = col.expr if isinstance(col, ast.Alias) else col
             if not isinstance(field, ast.Field) or not field.chain:
                 raise QueryError("JOIN USING expects column names")
-            names.append(self._print_identifier(str(field.chain[-1])))
-        return ", ".join(names)
-
-    def _using_constraint_as_on(self, expr: ast.Expr, right_type: ast.Type | None) -> ast.Expr:
-        if not isinstance(
-            right_type, ast.BaseTableType | ast.SelectSetQueryType | ast.SelectQueryType | ast.SelectQueryAliasType
-        ):
-            raise QueryError("JOIN USING requires a table or subquery on the right-hand side")
-        columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
-        comparisons: list[ast.Expr] = []
-        for col in columns:
-            # The resolver wraps each USING field in an Alias bound to the left table; unwrap for the name.
-            field = col.expr if isinstance(col, ast.Alias) else col
-            if not isinstance(field, ast.Field) or not field.chain:
-                raise QueryError("JOIN USING expects column names")
-            name = str(field.chain[-1])
-            right = ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=right_type))
-            # Use the unwrapped `field`, not `col`: a user-supplied alias (`USING (x AS y)`) would
-            # otherwise render as `x AS y` inside the ON clause, which ClickHouse rejects.
-            comparisons.append(ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=field, right=right))
-        return comparisons[0] if len(comparisons) == 1 else ast.And(exprs=comparisons)
+            fields.append(field)
+        return fields
 
     def visit_join_constraint(self, node: ast.JoinConstraint):
         return self.visit(node.expr)

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -696,25 +696,47 @@ class BasePrinter(Visitor[str]):
                 join_strings.append(sample_clause)
 
         if node.constraint is not None:
-            # Allowlist gate against `setattr`-bypass — the printer interpolates `constraint_type` verbatim.
-            if node.constraint.constraint_type not in ast.VALID_JOIN_CONSTRAINT_TYPES:
-                raise QueryError(f"Invalid join constraint type: {node.constraint.constraint_type!r}")
-            if node.constraint.constraint_type == "USING":
-                # ClickHouse's analyzer requires JOIN ... USING columns to be bare identifiers resolvable from
-                # *both* relations. The resolver binds them to the left table, so emitting the resolved field
-                # gives `left_alias.col`, which the right relation can't resolve (Code 47 UNKNOWN_IDENTIFIER).
-                # Lower USING to an explicit ON with both sides qualified — this also folds in the LEFT-JOIN guard.
-                on_expr = self._using_constraint_as_on(node.constraint.expr, node.type)
-                if on_clause_guard is not None:
-                    on_expr = ast.And(exprs=[on_clause_guard, on_expr])
-                join_strings.append(f"ON {self.visit(on_expr)}")
-            elif on_clause_guard is not None:
-                combined_constraint = ast.And(exprs=[on_clause_guard, node.constraint.expr])
-                join_strings.append(f"{node.constraint.constraint_type} {self.visit(combined_constraint)}")
-            else:
-                join_strings.append(f"{node.constraint.constraint_type} {self.visit(node.constraint)}")
+            join_strings.append(self._print_join_constraint(node.constraint, node.type, on_clause_guard))
 
         return JoinExprResponse(printed_sql=" ".join(join_strings), where=extra_where)
+
+    def _print_join_constraint(
+        self, constraint: ast.JoinConstraint, node_type: ast.Type | None, on_clause_guard: ast.Expr | None
+    ) -> str:
+        # Allowlist gate against `setattr`-bypass — the printer interpolates `constraint_type` verbatim.
+        if constraint.constraint_type not in ast.VALID_JOIN_CONSTRAINT_TYPES:
+            raise QueryError(f"Invalid join constraint type: {constraint.constraint_type!r}")
+
+        if constraint.constraint_type == "USING":
+            # The resolver binds each USING field to the left table, so the resolved field prints as
+            # `left_alias.col`. SQL requires USING columns to be bare identifiers resolvable from *both*
+            # relations — the qualified form makes ClickHouse raise Code 47 UNKNOWN_IDENTIFIER.
+            if on_clause_guard is None:
+                # No predicate to fold in: keep USING, just strip the resolver's qualification.
+                #   FROM events AS e JOIN persons AS p USING (person_id)  ->  ... USING (person_id)
+                return f"USING ({self._print_using_columns(constraint.expr)})"
+            # A LEFT-JOIN guard (team_id / access control) must live in the join condition to preserve
+            # NULL rows, but USING can't carry a boolean predicate — so lower the whole thing to ON:
+            #   ... LEFT JOIN persons AS p USING (person_id)
+            #   -> ... LEFT JOIN persons AS p ON e.person_id = p.person_id AND p.team_id = 2
+            on_expr = ast.And(exprs=[on_clause_guard, self._using_constraint_as_on(constraint.expr, node_type)])
+            return f"ON {self.visit(on_expr)}"
+
+        if on_clause_guard is not None:
+            combined_constraint = ast.And(exprs=[on_clause_guard, constraint.expr])
+            return f"{constraint.constraint_type} {self.visit(combined_constraint)}"
+        return f"{constraint.constraint_type} {self.visit(constraint)}"
+
+    def _print_using_columns(self, expr: ast.Expr) -> str:
+        columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
+        names: list[str] = []
+        for col in columns:
+            # The resolver wraps each USING field in an Alias bound to the left table; unwrap for the name.
+            field = col.expr if isinstance(col, ast.Alias) else col
+            if not isinstance(field, ast.Field) or not field.chain:
+                raise QueryError("JOIN USING expects column names")
+            names.append(self._print_identifier(str(field.chain[-1])))
+        return ", ".join(names)
 
     def _using_constraint_as_on(self, expr: ast.Expr, right_type: ast.Type | None) -> ast.Expr:
         if not isinstance(

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -699,13 +699,35 @@ class BasePrinter(Visitor[str]):
             # Allowlist gate against `setattr`-bypass — the printer interpolates `constraint_type` verbatim.
             if node.constraint.constraint_type not in ast.VALID_JOIN_CONSTRAINT_TYPES:
                 raise QueryError(f"Invalid join constraint type: {node.constraint.constraint_type!r}")
-            if on_clause_guard is not None:
+            if node.constraint.constraint_type == "USING":
+                # ClickHouse's analyzer requires JOIN ... USING columns to be bare identifiers resolvable from
+                # *both* relations. The resolver binds them to the left table, so emitting the resolved field
+                # gives `left_alias.col`, which the right relation can't resolve (Code 47 UNKNOWN_IDENTIFIER).
+                # Lower USING to an explicit ON with both sides qualified — this also folds in the LEFT-JOIN guard.
+                on_expr = self._using_constraint_as_on(node.constraint.expr, node.type)
+                if on_clause_guard is not None:
+                    on_expr = ast.And(exprs=[on_clause_guard, on_expr])
+                join_strings.append(f"ON {self.visit(on_expr)}")
+            elif on_clause_guard is not None:
                 combined_constraint = ast.And(exprs=[on_clause_guard, node.constraint.expr])
                 join_strings.append(f"{node.constraint.constraint_type} {self.visit(combined_constraint)}")
             else:
                 join_strings.append(f"{node.constraint.constraint_type} {self.visit(node.constraint)}")
 
         return JoinExprResponse(printed_sql=" ".join(join_strings), where=extra_where)
+
+    def _using_constraint_as_on(self, expr: ast.Expr, right_type: ast.Type | None) -> ast.Expr:
+        columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
+        comparisons: list[ast.Expr] = []
+        for col in columns:
+            # The resolver wraps each USING field in an Alias bound to the left table; unwrap for the name.
+            field = col.expr if isinstance(col, ast.Alias) else col
+            if not isinstance(field, ast.Field) or not field.chain:
+                raise QueryError("JOIN USING expects column names")
+            name = str(field.chain[-1])
+            right = ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=right_type))
+            comparisons.append(ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=col, right=right))
+        return comparisons[0] if len(comparisons) == 1 else ast.And(exprs=comparisons)
 
     def visit_join_constraint(self, node: ast.JoinConstraint):
         return self.visit(node.expr)

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -717,6 +717,10 @@ class BasePrinter(Visitor[str]):
         return JoinExprResponse(printed_sql=" ".join(join_strings), where=extra_where)
 
     def _using_constraint_as_on(self, expr: ast.Expr, right_type: ast.Type | None) -> ast.Expr:
+        if not isinstance(
+            right_type, ast.BaseTableType | ast.SelectSetQueryType | ast.SelectQueryType | ast.SelectQueryAliasType
+        ):
+            raise QueryError("JOIN USING requires a table or subquery on the right-hand side")
         columns = expr.exprs if isinstance(expr, ast.Tuple) else [expr]
         comparisons: list[ast.Expr] = []
         for col in columns:

--- a/posthog/hogql/printer/base.py
+++ b/posthog/hogql/printer/base.py
@@ -730,7 +730,9 @@ class BasePrinter(Visitor[str]):
                 raise QueryError("JOIN USING expects column names")
             name = str(field.chain[-1])
             right = ast.Field(chain=[name], type=ast.FieldType(name=name, table_type=right_type))
-            comparisons.append(ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=col, right=right))
+            # Use the unwrapped `field`, not `col`: a user-supplied alias (`USING (x AS y)`) would
+            # otherwise render as `x AS y` inside the ON clause, which ClickHouse rejects.
+            comparisons.append(ast.CompareOperation(op=ast.CompareOperationOp.Eq, left=field, right=right))
         return comparisons[0] if len(comparisons) == 1 else ast.And(exprs=comparisons)
 
     def visit_join_constraint(self, node: ast.JoinConstraint):

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1769,19 +1769,20 @@ class TestPrinter(BaseTest):
                 "single_column",
                 "SELECT s.platform_group FROM (SELECT 1 AS platform_group) AS s "
                 "LEFT JOIN (SELECT 1 AS platform_group) AS platform USING (platform_group)",
-                "ON equals(s.platform_group, platform.platform_group)",
+                "USING (platform_group)",
             ),
             (
                 "multi_column",
                 "SELECT a.x FROM (SELECT 1 AS x, 2 AS y) AS a INNER JOIN (SELECT 1 AS x, 2 AS y) AS b USING (x, y)",
-                "ON and(equals(a.x, b.x), equals(a.y, b.y))",
+                "USING (x, y)",
             ),
         ],
     )
-    def test_join_using_is_lowered_to_qualified_on(self, _name: str, query: str, expected_on: str):
-        # ClickHouse's analyzer rejects table-qualified columns inside USING (Code 47); the printer must
-        # lower USING to an ON with both sides qualified so the right relation can resolve the column.
-        self.assertIn(expected_on, self._select(query))
+    def test_join_using_prints_bare_identifiers(self, _name: str, query: str, expected_using: str):
+        # ClickHouse's analyzer rejects table-qualified columns inside USING (Code 47). The resolver binds
+        # each USING field to the left table, so the printer must strip that qualification and emit bare
+        # identifiers — not rewrite the join to ON — when there's no guard predicate to fold in.
+        self.assertIn(expected_using, self._select(query))
 
     def test_left_join_using_retains_team_id_guard(self):
         # Lowering USING to ON must still fold the LEFT-JOIN team_id guard into the ON clause, otherwise

--- a/posthog/hogql/printer/test/test_printer.py
+++ b/posthog/hogql/printer/test/test_printer.py
@@ -1765,6 +1765,36 @@ class TestPrinter(BaseTest):
 
     @parameterized.expand(
         [
+            (
+                "single_column",
+                "SELECT s.platform_group FROM (SELECT 1 AS platform_group) AS s "
+                "LEFT JOIN (SELECT 1 AS platform_group) AS platform USING (platform_group)",
+                "ON equals(s.platform_group, platform.platform_group)",
+            ),
+            (
+                "multi_column",
+                "SELECT a.x FROM (SELECT 1 AS x, 2 AS y) AS a INNER JOIN (SELECT 1 AS x, 2 AS y) AS b USING (x, y)",
+                "ON and(equals(a.x, b.x), equals(a.y, b.y))",
+            ),
+        ],
+    )
+    def test_join_using_is_lowered_to_qualified_on(self, _name: str, query: str, expected_on: str):
+        # ClickHouse's analyzer rejects table-qualified columns inside USING (Code 47); the printer must
+        # lower USING to an ON with both sides qualified so the right relation can resolve the column.
+        self.assertIn(expected_on, self._select(query))
+
+    def test_left_join_using_retains_team_id_guard(self):
+        # Lowering USING to ON must still fold the LEFT-JOIN team_id guard into the ON clause, otherwise
+        # the joined table would leak rows across teams.
+        result = self._select("SELECT e.event FROM events AS e LEFT JOIN events AS s USING (event)")
+        on_start = result.find(" ON ")
+        where_start = result.find("WHERE")
+        on_clause = result[on_start:where_start] if on_start != -1 and where_start != -1 else ""
+        self.assertIn(f"equals(s.team_id, {self.team.pk})", on_clause)
+        self.assertIn("equals(e.event, s.event)", on_clause)
+
+    @parameterized.expand(
+        [
             ("gte", ast.CompareOperationOp.GtEq),
             ("gt", ast.CompareOperationOp.Gt),
             ("lte", ast.CompareOperationOp.LtEq),


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

we see a small percentage of data modeling errors attributed to clickhouse code 47. this typically indicates that 
a field or column is unresolvable but in this case it is almost exlusively due to JOIN ... USING clauses being
printed incorrectly using fully qualified field names. for example

select * from table1 a JOIN table2 b USING (column)

would print something like

select * from table1 a JOIN table2 b USING (a.column)

which is invalid -> Code 47

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

reduce JOIN ... USING to a JOIN ... ON with all bare columns fully qualified

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

tests

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->

<!-- gg:stack-start -->
## gg stack

- **#66577 `andrew/fix-code-47-errs` 👈 this PR**
<!-- gg:stack-end -->
