### PR TITLE
chore(signals): document how scouts resolve suggested_reviewers

### DIFF
--- a/products/signals/skills/authoring-signals-scouts/references/report-contract.md
+++ b/products/signals/skills/authoring-signals-scouts/references/report-contract.md
@@ -98,28 +98,38 @@ human even when **no PR** is involved. **Set it whenever you can name a plausibl
 including on informational `requires_human_input` reports**, not only PR-bound ones. A report
 with no reviewer just sits in the shared inbox hoping someone grabs it.
 
-Each entry must be a **GitHub login** (the backend maps it to the PostHog user to do the
-assignment). You rarely know the login outright — resolve it, cheapest source first:
+Each entry must be a **bare, lowercase GitHub login** — no `@`, no display name (e.g. `octocat`,
+not `@OctoCat`). Internal assignment matches the login against each user's linked GitHub login by
+exact, lowercased comparison, so a mis-cased handle, an `@`-prefix, a display name, a CODEOWNERS
+**team** slug, or an email won't set `is_suggested_reviewer` for anyone (autostart's PR-selection
+path is more lenient, but the assignment path is not). You rarely know the login outright —
+resolve it, cheapest source first:
 
 1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a sibling run) recorded
-   before — reuse it. Fastest path, and the reason the caching step below exists.
+   before — reuse it. Fastest path, and the reason the caching step at the end of this list exists.
 2. **Inbox precedent.** `inbox-reports-list` for a similar/related report on the same surface
    (same `source_product`, plus a free-text `search` for the area), then `inbox-reports-retrieve`
    / `inbox-report-artefacts-list` to see who comparable reports were routed to. Reuse that
    reviewer for the same area — the safest general recipe, available to every scout.
 3. **CODEOWNERS / git** (only if the scout has a repo checkout). `.github/CODEOWNERS` for the
-   owning path, or the last `git log` author for the file → their GitHub login. Authoritative.
-4. **`org-members-list`** confirms a person exists and gives their canonical name + PostHog
-   email — useful to **disambiguate or spell** a name. But it does **not** return a GitHub
-   login, so treat it as a corroboration aid, never as the source of the handle.
+   owning path, or the last `git log` author for the file. Neither usually hands you a usable
+   login directly: CODEOWNERS entries are often **team** slugs (`@your-org/team-name`) and `git log`
+   gives a name + email — both must be resolved to an **individual** GitHub login before you write
+   the reviewer (a team slug or an email won't match any user).
+4. **`org-members-list`** — only where the run has organization scope. It needs
+   `organization_member:read`, which **headless scout runs scoped to a single team don't have**, so
+   the tool is typically **absent from a scout's toolset**; don't build a scout's reviewer recipe
+   around it. Where it _is_ available it confirms a person exists and gives their canonical name +
+   account email (useful to **disambiguate or spell** a name) — but it still does **not** return a
+   GitHub login, so treat it as a corroboration aid, never as the source of the handle.
 
 **If you can't resolve a confident login, leave `suggested_reviewers` empty** — the report still
 surfaces for a human to grab. **Never guess a handle**: a wrong login mis-assigns the report (or
 silently fails to assign), which is worse than leaving it open.
 
-**After** you confidently tie an area to an owner, write a `reviewer:<domain>:<area>` scratchpad
-entry with the GitHub login so the next run — and sibling scouts — route faster. The fleet's
-reviewer map should compound over time.
+**Cache for next time.** After you confidently tie an area to an owner, write a
+`reviewer:<domain>:<area>` scratchpad entry with the bare lowercase login so the next run — and
+sibling scouts — route faster. The fleet's reviewer map should compound over time.
 
 ## `edit_report` — update an existing report
 

--- a/products/signals/skills/authoring-signals-scouts/references/report-contract.md
+++ b/products/signals/skills/authoring-signals-scouts/references/report-contract.md
@@ -89,6 +89,38 @@ sandbox, no PR). Autostart itself still no-ops unless the report is `immediately
 repo + priority, and a reviewer qualifies — so these fields are safe to omit for an informational
 report.
 
+## Choosing `suggested_reviewers` — how a report gets assigned to a human
+
+`suggested_reviewers` is **not just a PR gate** — it is the **primary way a report gets routed
+to the right person internally**. The inbox orders by `is_suggested_reviewer`, so a reviewer's
+own reports float to the top of _their_ inbox; a report with the right reviewer reaches that
+human even when **no PR** is involved. **Set it whenever you can name a plausible owner —
+including on informational `requires_human_input` reports**, not only PR-bound ones. A report
+with no reviewer just sits in the shared inbox hoping someone grabs it.
+
+Each entry must be a **GitHub login** (the backend maps it to the PostHog user to do the
+assignment). You rarely know the login outright — resolve it, cheapest source first:
+
+1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a sibling run) recorded
+   before — reuse it. Fastest path, and the reason step 5 exists.
+2. **Inbox precedent.** `inbox-reports-list` for a similar/related report on the same surface
+   (same `source_product`, plus a free-text `search` for the area), then `inbox-reports-retrieve`
+   / `inbox-report-artefacts-list` to see who comparable reports were routed to. Reuse that
+   reviewer for the same area — the safest general recipe, available to every scout.
+3. **CODEOWNERS / git** (only if the scout has a repo checkout). `.github/CODEOWNERS` for the
+   owning path, or the last `git log` author for the file → their GitHub login. Authoritative.
+4. **`org-members-list`** confirms a person exists and gives their canonical name + PostHog
+   email — useful to **disambiguate or spell** a name. But it does **not** return a GitHub
+   login, so treat it as a corroboration aid, never as the source of the handle.
+
+**If you can't resolve a confident login, leave `suggested_reviewers` empty** — the report still
+surfaces for a human to grab. **Never guess a handle**: a wrong login mis-assigns the report (or
+silently fails to assign), which is worse than leaving it open.
+
+**After** you confidently tie an area to an owner, write a `reviewer:<domain>:<area>` scratchpad
+entry with the GitHub login so the next run — and sibling scouts — route faster. The fleet's
+reviewer map should compound over time.
+
 ## `edit_report` — update an existing report
 
 Rewrite `title`/`summary` and/or append a note to a report that already exists. Pass `run_id`

--- a/products/signals/skills/authoring-signals-scouts/references/report-contract.md
+++ b/products/signals/skills/authoring-signals-scouts/references/report-contract.md
@@ -102,7 +102,7 @@ Each entry must be a **GitHub login** (the backend maps it to the PostHog user t
 assignment). You rarely know the login outright — resolve it, cheapest source first:
 
 1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a sibling run) recorded
-   before — reuse it. Fastest path, and the reason step 5 exists.
+   before — reuse it. Fastest path, and the reason the caching step below exists.
 2. **Inbox precedent.** `inbox-reports-list` for a similar/related report on the same surface
    (same `source_product`, plus a free-text `search` for the area), then `inbox-reports-retrieve`
    / `inbox-report-artefacts-list` to see who comparable reports were routed to. Reuse that


### PR DESCRIPTION
## Problem

`suggested_reviewers` on an emitted report is the primary way a Signals report gets assigned/routed to the right person internally (the inbox orders by `is_suggested_reviewer`), yet the report-channel contract only described it as a PR-autostart gate. Scouts had no guidance on *how* to resolve a GitHub login, so they tended to leave it empty and reports landed in the shared inbox unassigned.

## Changes

Adds a "Choosing `suggested_reviewers`" section to `authoring-signals-scouts/references/report-contract.md` — the shared field contract every report-channel scout references. It makes two points concrete:

- Reviewers drive internal assignment, not just PRs — set one even on informational `requires_human_input` reports.
- A cheapest-first recipe to resolve a GitHub login: scratchpad `reviewer:` cache → inbox precedent (how similar past reports were routed) → CODEOWNERS/git → `org-members-list` (confirm/spell only — it does **not** return a GitHub login). Leave it empty rather than guess, and cache the area→owner once resolved.

Docs-only; no code paths touched. The per-team dogfood scouts on team 2 already carry matching nudges in their bodies — this lands the canonical guidance so it stays in sync and reaches every enrolled team via `lazy_seed`.

## How did you test this code?

I'm an agent (Claude Code). No automated tests apply — this is a single markdown reference file with no code changes. Verified the rendered markdown and that the new section sits between the autostart and `edit_report` sections.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this work. Tooling: Claude Code, plus the PostHog MCP skills-store tools to inspect the live team-2 dogfood scouts and their shared report-contract reference. The same guidance was applied to the per-team scout bodies and the team-2 store copy of this reference via MCP; this PR is the canonical repo counterpart so the two don't diverge. The recipe is shaped around a verified constraint: `org-members-list` returns names + PostHog emails but not GitHub logins, so the doc routes login resolution through CODEOWNERS/git, inbox precedent, and a cached `reviewer:<domain>:<area>` scratchpad key instead.
