### PR TITLE
feat(platform): add org-member-get-github-login mcp tool

### DIFF
--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -274,7 +274,7 @@ class OrganizationMemberViewSet(
         instance.user.leave(organization=instance.organization)
 
     @extend_schema(responses=OrganizationMemberGithubLoginSerializer)
-    @action(detail=True, methods=["get"], url_path="github_login")
+    @action(detail=True, methods=["get"], url_path="github_login", required_scopes=["organization_member:read"])
     def github_login(self, request: Request, *args: Any, **kwargs: Any) -> Response:
         instance = cast(OrganizationMembership, self.get_object())
         return Response({"github_login": instance.user.get_github_login()})

--- a/posthog/api/organization_member.py
+++ b/posthog/api/organization_member.py
@@ -130,6 +130,16 @@ class OrganizationMemberSerializer(SearchMatchTypeSerializerMixin, serializers.M
         return updated_membership
 
 
+class OrganizationMemberGithubLoginSerializer(serializers.Serializer):
+    github_login = serializers.CharField(
+        allow_null=True,
+        help_text=(
+            "The member's GitHub username (login), resolved from their linked GitHub integration or OAuth "
+            "identity. Null when the member has no GitHub identity linked."
+        ),
+    )
+
+
 @extend_schema(extensions={"x-product": "platform_features"})
 @extend_schema_view(
     list=extend_schema(
@@ -262,6 +272,12 @@ class OrganizationMemberViewSet(
         )
 
         instance.user.leave(organization=instance.organization)
+
+    @extend_schema(responses=OrganizationMemberGithubLoginSerializer)
+    @action(detail=True, methods=["get"], url_path="github_login")
+    def github_login(self, request: Request, *args: Any, **kwargs: Any) -> Response:
+        instance = cast(OrganizationMembership, self.get_object())
+        return Response({"github_login": instance.user.get_github_login()})
 
     @action(detail=True, methods=["get"])
     def scoped_api_keys(self, request, *args, **kwargs):

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -108,6 +108,13 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json(), {"github_login": "octocat"})
 
+        # `@me` resolves the requesting user via a separate branch in safely_get_object
+        UserSocialAuth.objects.create(user=self.user, provider="github", uid="456", extra_data={"login": "hedgehog"})
+
+        response = self.client.get("/api/organizations/@current/members/@me/github_login/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"github_login": "hedgehog"})
+
     def test_scoped_api_keys_endpoint(self):
         # Create a user who is a member of the organization
         user = User.objects.create_and_join(self.organization, "test@x.com", None, "X")

--- a/posthog/api/test/test_organization_members.py
+++ b/posthog/api/test/test_organization_members.py
@@ -8,6 +8,7 @@ from django.test import override_settings
 from django_otp.plugins.otp_totp.models import TOTPDevice
 from parameterized import parameterized
 from rest_framework import status
+from social_django.models import UserSocialAuth
 
 from posthog.models.organization import Organization, OrganizationMembership
 from posthog.models.user import User
@@ -92,6 +93,20 @@ class TestOrganizationMembersAPI(APIBaseTest, QueryMatchingTest):
             groups={"instance": "http://localhost:8010", "organization": str(self.organization.id)},
         )
         mock_sync_delay.assert_called_once_with(str(self.organization.id))
+
+    def test_github_login_endpoint(self):
+        # A different member than the requester — proves the lookup is org-scoped, not self-only
+        member = User.objects.create_and_join(self.organization, "gh@x.com", None, "X")
+
+        response = self.client.get(f"/api/organizations/@current/members/{member.uuid}/github_login/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"github_login": None})
+
+        UserSocialAuth.objects.create(user=member, provider="github", uid="123", extra_data={"login": "octocat"})
+
+        response = self.client.get(f"/api/organizations/@current/members/{member.uuid}/github_login/")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"github_login": "octocat"})
 
     def test_scoped_api_keys_endpoint(self):
         # Create a user who is a member of the organization

--- a/products/platform_features/frontend/generated/api.schemas.ts
+++ b/products/platform_features/frontend/generated/api.schemas.ts
@@ -342,6 +342,14 @@ export interface PatchedOrganizationMemberApi {
     readonly search_match_type?: SearchMatchTypeEnumApi | null
 }
 
+export interface OrganizationMemberGithubLoginApi {
+    /**
+     * The member's GitHub username (login), resolved from their linked GitHub integration or OAuth identity. Null when the member has no GitHub identity linked.
+     * @nullable
+     */
+    github_login: string | null
+}
+
 export interface OrganizationPersonalAPIKeyOwnerApi {
     /** First name of the key's owner. */
     readonly first_name: string

--- a/products/platform_features/frontend/generated/api.ts
+++ b/products/platform_features/frontend/generated/api.ts
@@ -24,6 +24,7 @@ import type {
     OrganizationAIAccessRequestResponseApi,
     OrganizationApi,
     OrganizationMemberApi,
+    OrganizationMemberGithubLoginApi,
     PaginatedActivityLogListApi,
     PaginatedApprovalPolicyListApi,
     PaginatedChangeRequestListApi,
@@ -250,6 +251,21 @@ export const membersDestroy = async (
     return apiMutator<void>(getMembersDestroyUrl(organizationId, userUuid), {
         ...options,
         method: 'DELETE',
+    })
+}
+
+export const getMembersGithubLoginRetrieveUrl = (organizationId: string, userUuid: string) => {
+    return `/api/organizations/${organizationId}/members/${userUuid}/github_login/`
+}
+
+export const membersGithubLoginRetrieve = async (
+    organizationId: string,
+    userUuid: string,
+    options?: RequestInit
+): Promise<OrganizationMemberGithubLoginApi> => {
+    return apiMutator<OrganizationMemberGithubLoginApi>(getMembersGithubLoginRetrieveUrl(organizationId, userUuid), {
+        ...options,
+        method: 'GET',
     })
 }
 

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -247,6 +247,26 @@ tools:
     members-update:
         operation: members_update
         enabled: false
+    org-member-get-github-login:
+        operation: members_github_login_retrieve
+        enabled: true
+        scopes:
+            - organization_member:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get an organization member's GitHub username.
+        description: >
+            Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID
+            (obtainable from org-members-list, or "@me" for the current user). Returns null if the member has no GitHub
+            identity linked. Use this when you know which member you want and need their GitHub handle — for example to
+            set suggested reviewers.
+        param_overrides:
+            user__uuid:
+                description: |
+                    The PostHog user UUID of the organization member, as returned by org-members-list. Pass "@me"
+                    for the current user.
     org-members-list:
         operation: members_list
         enabled: true
@@ -260,26 +280,6 @@ tools:
         description: >
             List all members of the current organization with their names, emails, membership levels (member, admin,
             owner), and last login times.
-    org-member-get-github-login:
-        operation: members_github_login_retrieve
-        enabled: true
-        scopes:
-            - organization_member:read
-        annotations:
-            readOnly: true
-            destructive: false
-            idempotent: true
-        title: Get an organization member's GitHub username.
-        description: >
-            Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID
-            (obtainable from org-members-list, or "@me" for the current user). Returns null if the member has no
-            GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for
-            example to set suggested reviewers.
-        param_overrides:
-            user__uuid:
-                description: |
-                    The PostHog user UUID of the organization member, as returned by org-members-list. Pass "@me"
-                    for the current user.
     organization-get:
         operation: retrieve
         enabled: true

--- a/products/platform_features/mcp/tools.yaml
+++ b/products/platform_features/mcp/tools.yaml
@@ -260,6 +260,26 @@ tools:
         description: >
             List all members of the current organization with their names, emails, membership levels (member, admin,
             owner), and last login times.
+    org-member-get-github-login:
+        operation: members_github_login_retrieve
+        enabled: true
+        scopes:
+            - organization_member:read
+        annotations:
+            readOnly: true
+            destructive: false
+            idempotent: true
+        title: Get an organization member's GitHub username.
+        description: >
+            Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID
+            (obtainable from org-members-list, or "@me" for the current user). Returns null if the member has no
+            GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for
+            example to set suggested reviewers.
+        param_overrides:
+            user__uuid:
+                description: |
+                    The PostHog user UUID of the organization member, as returned by org-members-list. Pass "@me"
+                    for the current user.
     organization-get:
         operation: retrieve
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -5383,6 +5383,20 @@
             "readOnlyHint": true
         }
     },
+    "org-member-get-github-login": {
+        "description": "Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID (obtainable from org-members-list, or \"@me\" for the current user). Returns null if the member has no GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for example to set suggested reviewers.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Get an organization member's GitHub username.",
+        "title": "Get an organization member's GitHub username.",
+        "required_scopes": ["organization_member:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "org-members-list": {
         "description": "List all members of the current organization with their names, emails, membership levels (member, admin, owner), and last login times.",
         "category": "Platform Features",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -5834,6 +5834,20 @@
             "readOnlyHint": true
         }
     },
+    "org-member-get-github-login": {
+        "description": "Resolve the GitHub username (login) for a single organization member, given their PostHog user UUID (obtainable from org-members-list, or \"@me\" for the current user). Returns null if the member has no GitHub identity linked. Use this when you know which member you want and need their GitHub handle — for example to set suggested reviewers.",
+        "category": "Platform Features",
+        "feature": "platform_features",
+        "summary": "Get an organization member's GitHub username.",
+        "title": "Get an organization member's GitHub username.",
+        "required_scopes": ["organization_member:read"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": true,
+            "readOnlyHint": true
+        }
+    },
     "org-members-list": {
         "description": "List all members of the current organization with their names, emails, membership levels (member, admin, owner), and last login times.",
         "category": "Platform Features",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -30441,6 +30441,14 @@ export namespace Schemas {
       readonly search_match_type: SearchMatchTypeEnum | null;
     }
 
+    export interface OrganizationMemberGithubLogin {
+      /**
+         * The member's GitHub username (login), resolved from their linked GitHub integration or OAuth identity. Null when the member has no GitHub identity linked.
+         * @nullable
+         */
+      github_login: string | null;
+    }
+
     /**
      * Serializer for organization-scoped OAuth applications (read-only).
      */

--- a/services/mcp/src/generated/platform_features/api.ts
+++ b/services/mcp/src/generated/platform_features/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 19 enabled ops
+ * PostHog API - MCP 20 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -35,6 +35,15 @@ export const MembersListQueryParams = /* @__PURE__ */ zod.object({
         .describe(
             "Match against member `first_name`, `last_name`, and `email`. Returns case-insensitive substring matches and fuzzy trigram matches (typos, prefix-as-you-type) together, ordered exact-first; each result's `search_match_type` is `exact` or `similar`. Capped at 200 characters."
         ),
+})
+
+export const MembersGithubLoginRetrieveParams = /* @__PURE__ */ zod.object({
+    organization_id: zod
+        .string()
+        .describe(
+            "ID of the organization you're trying to access. To find the ID of the organization, make a call to /api/organizations/."
+        ),
+    user__uuid: zod.string(),
 })
 
 export const RolesListParams = /* @__PURE__ */ zod.object({

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -298,27 +298,6 @@ const commentsList = (): ToolBase<typeof CommentsListSchema, Schemas.PaginatedCo
     },
 })
 
-const OrgMembersListSchema = MembersListQueryParams
-
-const orgMembersList = (): ToolBase<typeof OrgMembersListSchema, Schemas.PaginatedOrganizationMemberList> => ({
-    name: 'org-members-list',
-    schema: OrgMembersListSchema,
-    handler: async (context: Context, params: z.infer<typeof OrgMembersListSchema>) => {
-        const orgId = await context.stateManager.getOrgID()
-        const result = await context.api.request<Schemas.PaginatedOrganizationMemberList>({
-            method: 'GET',
-            path: `/api/organizations/${encodeURIComponent(String(orgId))}/members/`,
-            query: {
-                limit: params.limit,
-                offset: params.offset,
-                order: params.order,
-                search: params.search,
-            },
-        })
-        return result
-    },
-})
-
 const OrgMemberGetGithubLoginSchema = MembersGithubLoginRetrieveParams.omit({ organization_id: true }).extend({
     user__uuid: MembersGithubLoginRetrieveParams.shape['user__uuid'].describe(
         'The PostHog user UUID of the organization member, as returned by org-members-list. Pass "@me" for the current user.'
@@ -336,6 +315,27 @@ const orgMemberGetGithubLogin = (): ToolBase<
         const result = await context.api.request<Schemas.OrganizationMemberGithubLogin>({
             method: 'GET',
             path: `/api/organizations/${encodeURIComponent(String(orgId))}/members/${encodeURIComponent(String(params.user__uuid))}/github_login/`,
+        })
+        return result
+    },
+})
+
+const OrgMembersListSchema = MembersListQueryParams
+
+const orgMembersList = (): ToolBase<typeof OrgMembersListSchema, Schemas.PaginatedOrganizationMemberList> => ({
+    name: 'org-members-list',
+    schema: OrgMembersListSchema,
+    handler: async (context: Context, params: z.infer<typeof OrgMembersListSchema>) => {
+        const orgId = await context.stateManager.getOrgID()
+        const result = await context.api.request<Schemas.PaginatedOrganizationMemberList>({
+            method: 'GET',
+            path: `/api/organizations/${encodeURIComponent(String(orgId))}/members/`,
+            query: {
+                limit: params.limit,
+                offset: params.offset,
+                order: params.order,
+                search: params.search,
+            },
         })
         return result
     },
@@ -515,8 +515,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'comment-get': commentGet,
     'comment-thread': commentThread,
     'comments-list': commentsList,
-    'org-members-list': orgMembersList,
     'org-member-get-github-login': orgMemberGetGithubLogin,
+    'org-members-list': orgMembersList,
     'organization-get': organizationGet,
     'organizations-list': organizationsList,
     'role-get': roleGet,

--- a/services/mcp/src/tools/generated/platform_features.ts
+++ b/services/mcp/src/tools/generated/platform_features.ts
@@ -13,6 +13,7 @@ import {
     CommentsRetrieveParams,
     CommentsThreadRetrieveParams,
     ListQueryParams,
+    MembersGithubLoginRetrieveParams,
     MembersListQueryParams,
     RetrieveParams,
     RolesListQueryParams,
@@ -318,6 +319,28 @@ const orgMembersList = (): ToolBase<typeof OrgMembersListSchema, Schemas.Paginat
     },
 })
 
+const OrgMemberGetGithubLoginSchema = MembersGithubLoginRetrieveParams.omit({ organization_id: true }).extend({
+    user__uuid: MembersGithubLoginRetrieveParams.shape['user__uuid'].describe(
+        'The PostHog user UUID of the organization member, as returned by org-members-list. Pass "@me" for the current user.'
+    ),
+})
+
+const orgMemberGetGithubLogin = (): ToolBase<
+    typeof OrgMemberGetGithubLoginSchema,
+    Schemas.OrganizationMemberGithubLogin
+> => ({
+    name: 'org-member-get-github-login',
+    schema: OrgMemberGetGithubLoginSchema,
+    handler: async (context: Context, params: z.infer<typeof OrgMemberGetGithubLoginSchema>) => {
+        const orgId = await context.stateManager.getOrgID()
+        const result = await context.api.request<Schemas.OrganizationMemberGithubLogin>({
+            method: 'GET',
+            path: `/api/organizations/${encodeURIComponent(String(orgId))}/members/${encodeURIComponent(String(params.user__uuid))}/github_login/`,
+        })
+        return result
+    },
+})
+
 const OrganizationGetSchema = RetrieveParams.extend({
     id: RetrieveParams.shape['id'].describe('Organization ID. If omitted, uses the active organization.').optional(),
 })
@@ -493,6 +516,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'comment-thread': commentThread,
     'comments-list': commentsList,
     'org-members-list': orgMembersList,
+    'org-member-get-github-login': orgMemberGetGithubLogin,
     'organization-get': organizationGet,
     'organizations-list': organizationsList,
     'role-get': roleGet,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/org-member-get-github-login.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/org-member-get-github-login.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "user__uuid": {
+            "description": "The PostHog user UUID of the organization member, as returned by org-members-list. Pass \"@me\" for the current user.",
+            "type": "string"
+        }
+    },
+    "required": ["user__uuid"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Agents — Signals scouts in particular — can suggest reviewers on a report via `emit_report(suggested_reviewers=[...])`, but that field takes **GitHub logins**, and there was no agent-accessible way to resolve a known organization member to their GitHub handle.

The existing `/api/users/{uuid}/github_login/` endpoint is self-only (its queryset filters to the requesting user unless staff), so it can never return another member's login. `org-members-list` returns names, emails, and UUIDs — but not GitHub logins.

## Changes

Adds a dedicated, narrowly-scoped capability rather than widening anything shared:

- New `github_login` detail action on `OrganizationMemberViewSet` (org-scoped, `organization_member:read`, looked up by `user__uuid`, supports `@me`). It just wraps the existing `User.get_github_login()`, which already resolves from the user's GitHub integration, OAuth identity, or the team-level integration.
- New `org-member-get-github-login` MCP tool mapping to that operation, with a typed `OrganizationMemberGithubLoginSerializer` response so the generated Zod schema and TS types are correct.
- Regenerated MCP tool defs and frontend types via `hogli build:openapi`.

Deliberately did **not** add the field to `UserBasicSerializer` (used across dozens of endpoints) — that would add cost and N+1 surface everywhere. A single-object detail action keeps the blast radius to this one tool.

Agent flow: `org-members-list` (find member → UUID) → `org-member-get-github-login` (resolve handle) → `emit_report(suggested_reviewers=[...])`.

Note: scout skills still need `org-member-get-github-login` added to their `allowed_tools` to use it — not done here.

## How did you test this code?

I'm an agent. Automated only — no manual testing claimed.

- Added `test_github_login_endpoint` (`posthog/api/test/test_organization_members.py`), which passes. It catches a regression no existing test covers: that the lookup resolves a GitHub login for **a different member than the requester** (proving it's org-scoped, unlike the self-only user endpoint) and returns `null` when no GitHub identity is linked.
- Ran `hogli build:openapi`, MCP tool-name lint, and `ruff` — all clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked: `/implementing-mcp-tools` (tool YAML + codegen workflow). The DRF rule file for this area also flagged `/improving-drf-endpoints` conventions (explicit serializer field types + `help_text`), which shaped the typed response serializer.

Key decision: scope the lookup to the org-members viewset instead of the user viewset. Investigation showed the existing user-level `github_login` endpoint is self-only, so reusing it would have failed the actual use case; an org-scoped detail action reuses the same scope and lookup semantics as `org-members-list` with minimal new surface.
