### PR TITLE
fix(marketing-analytics): refresh recent cost precompute windows more often

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -229,7 +229,17 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             )
             return None
 
-        ttl_seconds = {"0d": 6 * 60 * 60, "1d": 24 * 60 * 60, "default": 7 * 24 * 60 * 60}
+        # Ad platforms revise historical cost downward for days-to-weeks after the fact (invalid-traffic
+        # credits, currency settlement), so a cached cost row drifts above the live figure until it is
+        # re-materialized. Refresh the volatile recent window often and cap older-day staleness, instead
+        # of letting everything sit on a 7-day TTL. Values are a freshness/recompute-load tradeoff.
+        ttl_seconds = {
+            "0d": 1 * 60 * 60,  # today: hourly
+            "1d": 3 * 60 * 60,  # yesterday
+            "7d": 12 * 60 * 60,  # last week
+            "30d": 24 * 60 * 60,  # last month (still being revised)
+            "default": 3 * 24 * 60 * 60,  # older: mostly settled, cap drift at 3 days
+        }
         job_ids: list = []
         for adapter in mat_adapters:
             insert_query = adapter.build_materialization_query(adapter.get_source_id())


### PR DESCRIPTION
## Problem

Ad platforms revise historical cost figures **downward** for days to weeks after the fact (invalid-traffic credits, currency settlement). The cost precompute caches a cost row at materialization time; until that row is re-materialized, it drifts **above** the live source figure. The cost precompute TTL kept anything older than a week on a single 7-day band, so recently-revised days could sit stale for up to a week, and the precomputed dashboard read ran consistently above the live (flag-off) path.

## Changes

Replace the cost TTL `{0d: 6h, 1d: 24h, default: 7d}` with a graduated schedule that refreshes the volatile recent window often and caps older-day staleness:

```
0d   → 1h    (today: hourly)
1d   → 3h    (yesterday)
7d   → 12h   (last week)
30d  → 24h   (last month — still being revised)
default → 3d (older: mostly settled, cap drift at ~3 days)
```

This only affects the cost precompute (`marketing_costs_preaggregated`); conversions/touchpoints keep their own schedule. The values are a freshness-vs-recompute-load tradeoff — they trade more frequent re-materialization of recent days for a smaller gap against the live figures, and are easy to tune.

## How did you test this code?

I'm an agent (Claude Code). This is a TTL-schedule constant change; the existing cost-precompute suite still passes (`hogli test test_marketing_costs_precompute.py`). I did not add a test that asserts the literal schedule — that would be a change-detector test with no behavioral value. The staleness it addresses was observed by comparing the precomputed cost against the live ad-source figures over a multi-week range.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @jabahamondes while auditing the marketing-analytics precompute paths. This is the freshness half of the cost-accuracy work; the read-side dedup (latest-job-per-cell) is a separate PR. The exact TTL bands are the reviewable decision here — they balance how aggressively recent cost re-materializes against extra ClickHouse load, and a reviewer with prod load context may want to tune them.
