### PR TITLE
fix(marketing-analytics): pair compare periods with cross join in aggregated cards

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -216,17 +216,16 @@ class MarketingAnalyticsAggregatedQueryRunner(
         previous_period_query = previous_runner.to_query()
         current_period_query = self.to_query()
 
+        # Both sides are a single aggregated row, so pair them with a CROSS JOIN. A LEFT JOIN on a
+        # constant condition does not match in ClickHouse (the previous columns fall back to defaults),
+        # which silently zeroed every previous-period value in the compare.
         join_expr = ast.JoinExpr(
             table=current_period_query,
             alias="current_period",
             next_join=ast.JoinExpr(
                 table=previous_period_query,
                 alias="previous_period",
-                join_type="LEFT JOIN",
-                constraint=ast.JoinConstraint(
-                    expr=ast.Constant(value=1),  # Always join since there's only one row each
-                    constraint_type="ON",
-                ),
+                join_type="CROSS JOIN",
             ),
         )
 

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
@@ -3,7 +3,7 @@ from typing import Optional
 from posthog.test.base import BaseTest, ClickhouseTestMixin
 from unittest.mock import Mock, patch
 
-from posthog.schema import BaseMathType, DateRange, MarketingAnalyticsAggregatedQuery, NodeKind
+from posthog.schema import BaseMathType, CompareFilter, DateRange, MarketingAnalyticsAggregatedQuery, NodeKind
 
 from posthog.hogql.parser import parse_select
 from posthog.hogql.test.utils import pretty_print_in_tests
@@ -78,3 +78,32 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
 
         # Snapshot the query
         assert pretty_print_in_tests(hogql, self.team.pk) == self.snapshot
+
+    def test_compare_pairs_periods_with_cross_join(self):
+        # The two single-row periods must be paired with a CROSS JOIN. A LEFT JOIN on a constant
+        # condition does not match in ClickHouse, which silently zeroed every previous-period value
+        # in the compare. (The prod ClickHouse can't be reproduced locally — it joins `ON 1` fine —
+        # so this guards the SQL structure, which is the contract.)
+        query = MarketingAnalyticsAggregatedQuery(
+            dateRange=self.default_date_range,
+            compareFilter=CompareFilter(compare=True),
+            properties=[],
+        )
+        runner = self._create_query_runner(query)
+
+        mock_adapter = Mock()
+        mock_adapter.get_source_id.return_value = "test_source"
+        mock_adapter.supports_level.return_value = True
+        mock_adapter.build_query.return_value = parse_select(
+            "SELECT 'Campaign' as campaign, 'id1' as id, 'google' as source, "
+            "100 as impressions, 10 as clicks, 50.0 as cost, 5 as reported_conversion, "
+            "25.0 as reported_conversion_value, 'Campaign' as match_key"
+        )
+
+        # Patch on the class so the previous-period runner (a fresh instance) is mocked too.
+        with patch.object(
+            MarketingAnalyticsAggregatedQueryRunner, "_get_marketing_source_adapters", return_value=[mock_adapter]
+        ):
+            hogql = runner.calculate_with_compare().to_hogql()
+
+        assert "CROSS JOIN" in hogql, f"compare must pair the periods with a CROSS JOIN. Got: {hogql}"


### PR DESCRIPTION
## Problem

In the marketing-analytics summary cards (the aggregated totals), comparing with the previous period shows every previous-period value as empty / "–" — Cost, Clicks, Impressions, conversions, all of them. The per-campaign table compare works correctly; only the aggregated cards are affected.

Root cause: `MarketingAnalyticsAggregatedQueryRunner.calculate_with_compare` pairs the current- and previous-period aggregates with `LEFT JOIN previous_period ON <constant 1>`. ClickHouse does not treat a constant join condition as an always-true match, so the join produces no match and (with `join_use_nulls=0`) every `previous_period` column falls back to its default `0`. The previous-period query itself is correct — run standalone it returns real totals — it's only the join that drops the data. The per-campaign table runner avoids this by pairing periods with a `UNION ALL` pivot; the aggregated runner was left on the constant-condition join.

## Changes

Pair the two single-row period aggregates with a `CROSS JOIN` instead of a `LEFT JOIN` on a constant. Both sides are guaranteed to be exactly one row (an aggregate with no `GROUP BY`), so the cross product is exactly one row carrying both periods' columns — which is what the downstream `tuple(current, previous)` select expects.

## How did you test this code?

I'm an agent (Claude Code). Automated test via `hogli test`:
- New case `test_compare_pairs_periods_with_cross_join`: builds the aggregated compare query and asserts it pairs the periods with a `CROSS JOIN`. It **fails on master** (the query emits the constant-condition `LEFT JOIN`) and **passes with this change**.
- Note: this guards the SQL structure rather than executing, on purpose — the local ClickHouse matches a constant-condition `LEFT JOIN` fine (returns the previous values), so an execution test cannot reproduce the prod behavior. The empty-previous regression was confirmed against the production cluster (previous-period values came back `0`, while the same window queried without compare returned real totals).
- Existing aggregated-runner suite (join-structure snapshot test) still passes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @jabahamondes after noticing the previous-period compare was blank on the summary cards. Skills invoked: `/writing-tests`.

Localized by reproducing against prod: the table compare worked, the aggregated compare returned `0` for every previous value, and the aggregated previous window queried standalone returned real data — isolating the constant-condition join as the cause. Chose `CROSS JOIN` (both sides are single-row aggregates) over `ON 1=1`, since a constant-only join condition is exactly the construct ClickHouse mishandles here.
