### PR TITLE
fix(experiments): add conclusion to sort allowlist

### DIFF
--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -488,6 +488,8 @@ class ExperimentService:
         "-duration",
         "status",
         "-status",
+        "conclusion",
+        "-conclusion",
     }
 
     ELIGIBLE_FLAGS_ORDER_ALLOWLIST = {
@@ -2565,6 +2567,13 @@ class ExperimentService:
                         F("created_by__email"),
                     )
                 ).order_by(f"{prefix}created_by_display")
+            elif order_value in ["conclusion", "-conclusion"]:
+                # Sort by conclusion label; experiments with no conclusion (null) always
+                # sort last so the "active / in-progress" rows don't get buried.
+                descending = order_value.startswith("-")
+                queryset = queryset.order_by(
+                    F("conclusion").desc(nulls_last=True) if descending else F("conclusion").asc(nulls_last=True)
+                )
             else:
                 queryset = queryset.order_by(order_value)
         else:


### PR DESCRIPTION
## Problem

Closes #63621

Clicking the **Result** column header in the experiments list throws:

> Load experiments failed: Invalid order field: 'conclusion'

The column sends `?order=conclusion` to the API, but `conclusion` wasn't in `EXPERIMENT_ORDER_ALLOWLIST`, so the backend rejected it immediately with a `ValidationError`.

## Changes

Added `conclusion` / `-conclusion` to `EXPERIMENT_ORDER_ALLOWLIST` and wired up the ordering logic. Experiments with no conclusion (null — most in-progress ones) always sort last via `nulls_last=True` so they don't flood the top of the list when sorting ascending.

The `created_by` server error mentioned in the same issue already has backend handling (the `Coalesce` annotation branch added earlier) so that part should be fine.

## How did you test this code?

Traced the code path: `filter_experiments_queryset` checks `order_value` against the allowlist before doing anything else. Adding `conclusion`/`-conclusion` to the set lets it fall through to the new `elif` branch. `F('conclusion').asc(nulls_last=True)` is standard Django ORM — no migration needed since `conclusion` is an existing model field.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Traced from the error message to `EXPERIMENT_ORDER_ALLOWLIST` in `experiment_service.py`. The fix is a two-part addition: allow the field name through the guard, then order with `nulls_last` so rows without a conclusion don't pollute the sort.