### PR TITLE
fix(marketing-analytics): share hogql database with previous-period compare runner

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -212,6 +212,12 @@ class MarketingAnalyticsAggregatedQueryRunner(
             modifiers=self.modifiers,
             limit_context=self.limit_context,
         )
+        # Share the prebuilt HogQL database (built for the current request, with the user) across both
+        # periods. Besides paying Database.create_for once instead of twice, this is a correctness fix:
+        # the previous runner has no user, so building its own database would resolve warehouse tables
+        # without the user's access — the marketing source adapters come back empty and every
+        # previous-period value silently falls back to 0. The table runners already do this.
+        previous_runner.__dict__["_shared_hogql_database"] = self._shared_hogql_database
 
         previous_period_query = previous_runner.to_query()
         current_period_query = self.to_query()

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -204,10 +204,7 @@ class MarketingAnalyticsAggregatedQueryRunner(
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Run the previous period as the same user. Without it the previous runner is user-less, which
-        # (a) resolves warehouse tables without the user's access, so the marketing source adapters come
-        # back empty and every previous-period value silently falls back to 0, and (b) runs the conversion
-        # goals' property-level RBAC user-less. Passing the user fixes both.
+        # user= is required: a user-less previous runner loses warehouse access (empties the cost) and runs RBAC user-less.
         previous_runner = MarketingAnalyticsAggregatedQueryRunner(
             query=previous_query,
             team=self.team,
@@ -216,8 +213,6 @@ class MarketingAnalyticsAggregatedQueryRunner(
             limit_context=self.limit_context,
             user=self.user,
         )
-        # Reuse the current request's prebuilt HogQL database so the compare pays Database.create_for
-        # once, not twice.
         previous_runner.__dict__["_shared_hogql_database"] = self._shared_hogql_database
 
         previous_period_query = previous_runner.to_query()

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_aggregated_query_runner.py
@@ -204,19 +204,20 @@ class MarketingAnalyticsAggregatedQueryRunner(
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Create a new runner for the previous period
+        # Run the previous period as the same user. Without it the previous runner is user-less, which
+        # (a) resolves warehouse tables without the user's access, so the marketing source adapters come
+        # back empty and every previous-period value silently falls back to 0, and (b) runs the conversion
+        # goals' property-level RBAC user-less. Passing the user fixes both.
         previous_runner = MarketingAnalyticsAggregatedQueryRunner(
             query=previous_query,
             team=self.team,
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            user=self.user,
         )
-        # Share the prebuilt HogQL database (built for the current request, with the user) across both
-        # periods. Besides paying Database.create_for once instead of twice, this is a correctness fix:
-        # the previous runner has no user, so building its own database would resolve warehouse tables
-        # without the user's access — the marketing source adapters come back empty and every
-        # previous-period value silently falls back to 0. The table runners already do this.
+        # Reuse the current request's prebuilt HogQL database so the compare pays Database.create_for
+        # once, not twice.
         previous_runner.__dict__["_shared_hogql_database"] = self._shared_hogql_database
 
         previous_period_query = previous_runner.to_query()

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -191,13 +191,15 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Create a new runner for the previous period
+        # Create a new runner for the previous period, as the same user — a user-less runner resolves
+        # warehouse tables and conversion-goal property RBAC without the user's access.
         previous_runner = MarketingAnalyticsTableQueryRunner(
             query=previous_query,
             team=self.team,
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            user=self.user,
         )
         # Share the prebuilt HogQL database across both periods so the compare query pays the ~1s
         # Database.create_for once, not twice. Pre-populates the previous runner's cached_property.

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_table_query_runner.py
@@ -191,8 +191,7 @@ class MarketingAnalyticsTableQueryRunner(MarketingAnalyticsBaseQueryRunner[Marke
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Create a new runner for the previous period, as the same user — a user-less runner resolves
-        # warehouse tables and conversion-goal property RBAC without the user's access.
+        # user= is required: a user-less previous runner loses warehouse access and runs RBAC user-less.
         previous_runner = MarketingAnalyticsTableQueryRunner(
             query=previous_query,
             team=self.team,

--- a/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
@@ -194,12 +194,15 @@ class NonIntegratedConversionsTableQueryRunner(
             date_to=previous_date_range.date_to().isoformat(),
         )
 
+        # Same user as the current period — a user-less runner resolves warehouse tables and
+        # conversion-goal property RBAC without the user's access.
         previous_runner = NonIntegratedConversionsTableQueryRunner(
             query=previous_query,
             team=self.team,
             timings=self.timings,
             modifiers=self.modifiers,
             limit_context=self.limit_context,
+            user=self.user,
         )
         # Share the prebuilt HogQL database across both periods so the compare query pays the ~1s
         # Database.create_for once, not twice. Pre-populates the previous runner's cached_property.

--- a/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/non_integrated_conversions_table_query_runner.py
@@ -194,8 +194,7 @@ class NonIntegratedConversionsTableQueryRunner(
             date_to=previous_date_range.date_to().isoformat(),
         )
 
-        # Same user as the current period — a user-less runner resolves warehouse tables and
-        # conversion-goal property RBAC without the user's access.
+        # user= is required: a user-less previous runner loses warehouse access and runs RBAC user-less.
         previous_runner = NonIntegratedConversionsTableQueryRunner(
             query=previous_query,
             team=self.team,

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
@@ -115,3 +115,38 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
             f"both periods must share one HogQL database (the previous runner has no user); "
             f"Database.create_for ran {create_for_spy.call_count} times"
         )
+
+    def test_compare_previous_period_not_zeroed_under_user_scoped_adapters(self):
+        # Reproduces the symptom: warehouse adapters resolve only for a user-scoped runner (warehouse
+        # RBAC). A user-less previous runner gets no adapters -> empty cost fallback -> previous = 0.
+        # Passing the user to the previous runner fixes it.
+        query = MarketingAnalyticsAggregatedQuery(
+            dateRange=self.default_date_range,
+            compareFilter=CompareFilter(compare=True),
+            properties=[],
+        )
+        runner = MarketingAnalyticsAggregatedQueryRunner(query=query, team=self.team, user=self.user)
+
+        mock_adapter = Mock()
+        mock_adapter.get_source_id.return_value = "test_source"
+        mock_adapter.supports_level.return_value = True
+        mock_adapter.build_query.return_value = parse_select(
+            "SELECT 'Campaign' as campaign, 'id1' as id, 'google' as source, "
+            "100 as impressions, 10 as clicks, 50.0 as cost, 5 as reported_conversion, "
+            "25.0 as reported_conversion_value, 'Campaign' as match_key"
+        )
+
+        def rbac_adapters(runner_self, date_range):
+            return [mock_adapter] if runner_self.user is not None else []
+
+        with patch.object(
+            MarketingAnalyticsAggregatedQueryRunner,
+            "_get_marketing_source_adapters",
+            autospec=True,
+            side_effect=rbac_adapters,
+        ):
+            response = runner.calculate()
+
+        cost = response.results["Cost"]
+        assert cost.value == 50.0
+        assert cost.previous == 50.0, f"previous fell back to the empty cost source (user-less runner): {cost.previous}"

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
@@ -3,8 +3,9 @@ from typing import Optional
 from posthog.test.base import BaseTest, ClickhouseTestMixin
 from unittest.mock import Mock, patch
 
-from posthog.schema import BaseMathType, DateRange, MarketingAnalyticsAggregatedQuery, NodeKind
+from posthog.schema import BaseMathType, CompareFilter, DateRange, MarketingAnalyticsAggregatedQuery, NodeKind
 
+from posthog.hogql.database.database import Database
 from posthog.hogql.parser import parse_select
 from posthog.hogql.test.utils import pretty_print_in_tests
 
@@ -78,3 +79,39 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
 
         # Snapshot the query
         assert pretty_print_in_tests(hogql, self.team.pk) == self.snapshot
+
+    def test_compare_shares_database_across_periods(self):
+        # The previous-period runner has no user; if it builds its own HogQL database it resolves
+        # warehouse tables without the user's access, the marketing source adapters come back empty,
+        # and every previous value silently falls back to 0. Sharing the current period's database
+        # (built with the user) fixes that — observable as Database.create_for running once, not twice.
+        query = MarketingAnalyticsAggregatedQuery(
+            dateRange=self.default_date_range,
+            compareFilter=CompareFilter(compare=True),
+            properties=[],
+        )
+        runner = self._create_query_runner(query)
+
+        mock_adapter = Mock()
+        mock_adapter.get_source_id.return_value = "test_source"
+        mock_adapter.supports_level.return_value = True
+        mock_adapter.build_query.return_value = parse_select(
+            "SELECT 'Campaign' as campaign, 'id1' as id, 'google' as source, "
+            "100 as impressions, 10 as clicks, 50.0 as cost, 5 as reported_conversion, "
+            "25.0 as reported_conversion_value, 'Campaign' as match_key"
+        )
+
+        with (
+            patch.object(
+                MarketingAnalyticsAggregatedQueryRunner,
+                "_get_marketing_source_adapters",
+                return_value=[mock_adapter],
+            ),
+            patch.object(Database, "create_for", wraps=Database.create_for) as create_for_spy,
+        ):
+            runner.calculate_with_compare()
+
+        assert create_for_spy.call_count == 1, (
+            f"both periods must share one HogQL database (the previous runner has no user); "
+            f"Database.create_for ran {create_for_spy.call_count} times"
+        )

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_analytics_aggregated_query_runner.py
@@ -81,10 +81,6 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
         assert pretty_print_in_tests(hogql, self.team.pk) == self.snapshot
 
     def test_compare_shares_database_across_periods(self):
-        # The previous-period runner has no user; if it builds its own HogQL database it resolves
-        # warehouse tables without the user's access, the marketing source adapters come back empty,
-        # and every previous value silently falls back to 0. Sharing the current period's database
-        # (built with the user) fixes that — observable as Database.create_for running once, not twice.
         query = MarketingAnalyticsAggregatedQuery(
             dateRange=self.default_date_range,
             compareFilter=CompareFilter(compare=True),
@@ -117,9 +113,8 @@ class TestMarketingAnalyticsAggregatedQueryRunner(ClickhouseTestMixin, BaseTest)
         )
 
     def test_compare_previous_period_not_zeroed_under_user_scoped_adapters(self):
-        # Reproduces the symptom: warehouse adapters resolve only for a user-scoped runner (warehouse
-        # RBAC). A user-less previous runner gets no adapters -> empty cost fallback -> previous = 0.
-        # Passing the user to the previous runner fixes it.
+        # Adapters resolve only for a user-scoped runner (warehouse RBAC); a user-less previous runner
+        # gets none, falls back to the empty cost source, and zeroes the previous period.
         query = MarketingAnalyticsAggregatedQuery(
             dateRange=self.default_date_range,
             compareFilter=CompareFilter(compare=True),


### PR DESCRIPTION
## Problem

In the marketing-analytics summary cards (aggregated totals), comparing with the previous period shows every previous-period value as empty / "–" — cost, clicks, impressions, conversions, all of them. The per-campaign table compare works; only the aggregated cards show the symptom.

Root cause: the three marketing compare runners build a fresh runner for the previous period **without a user**. `self.user` feeds two things — the HogQL database (`Database.create_for`) and the conversion-goal property RBAC (`ConversionGoalProcessor(..., user=self.user)`). A user-less previous runner therefore:
1. resolves warehouse tables without the user's access, so `_get_marketing_source_adapters` returns no adapters, the cost union collapses to the empty placeholder (`SELECT ... WHERE 1=0`), and every previous metric falls back to `0`;
2. runs the conversion goals' property RBAC user-less.

The aggregated runner is the one that shows the visible bug because — unlike the table and non-integrated runners — it also didn't share the current request's prebuilt database, so even the database came out user-less. The table runners masked (1) by sharing the database, but all three still ran (2) user-less.

(Initially misdiagnosed as a `LEFT JOIN ... ON 1` issue — see the closed #66591. That join works in ClickHouse; the previous values were already `0` before the join.)

## Changes

- Pass `user=self.user` to the previous-period runner in all three compare runners (aggregated, table, non-integrated) — the root-cause fix for both the warehouse access and the property RBAC.
- Keep sharing the prebuilt `_shared_hogql_database` so the compare still pays `Database.create_for` once, not twice (the aggregated runner now shares it too).

## How did you test this code?

I'm an agent (Claude Code). Automated tests via `hogli test`:
- `test_compare_previous_period_not_zeroed_under_user_scoped_adapters`: simulates warehouse RBAC (adapters resolve only for a user-scoped runner), runs the aggregated compare, and asserts the previous-period Cost is populated. It **reproduces the symptom on master** (`assert 0.0 == 50.0` — previous falls back to the empty cost source) and **passes with this change**.
- `test_compare_shares_database_across_periods`: asserts `Database.create_for` runs once across both periods (guards the shared database).
- Existing aggregated- and table-runner suites still pass.

The empty-previous regression and this root cause were confirmed against production: the previous-period subquery's cost source was the empty `WHERE 1=0` placeholder while the current period read the warehouse sources normally.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @jabahamondes. Skills invoked: `/writing-tests`.

Reproduced the full query against prod, extracted and ran the previous-period subquery in isolation (it returned 0), and traced the empty cost source to a user-less previous runner. The reviewer's prompt ("share the db, or pass the user?") is what surfaced that passing the user is the real root cause — `self.user` also drives the conversion-goal property RBAC, which sharing the database alone leaves user-less; hence the fix passes the user across all three runners. Replaces the closed #66591.
