### PR TITLE
chore(experiments): remove dead step_sessions result handling

### DIFF
--- a/products/experiments/backend/hogql_queries/test/test_experiment_utils.py
+++ b/products/experiments/backend/hogql_queries/test/test_experiment_utils.py
@@ -34,7 +34,6 @@ from products.experiments.stats.shared.statistics import ProportionStatistic, Sa
 def _columns_for(
     metric: ExperimentFunnelMetric | ExperimentMeanMetric | ExperimentRatioMetric | ExperimentRetentionMetric,
     *,
-    has_step_sessions: bool = False,
     cuped: bool = False,
 ) -> list[str]:
     """
@@ -57,8 +56,6 @@ def _columns_for(
 
     if isinstance(metric, ExperimentFunnelMetric):
         cols.append("step_counts")
-        if has_step_sessions:
-            cols.append("steps_event_data")
 
     if isinstance(metric, (ExperimentRatioMetric, ExperimentRetentionMetric)):
         cols.extend(["denominator_sum", "denominator_sum_squares", "numerator_denominator_sum_product"])
@@ -192,31 +189,6 @@ class TestGetVariantResult:
         assert stats.sum_squares == 90.0
         assert stats.step_counts == [120, 90]
         assert stats.step_sessions is None
-
-    def test_funnel_metric_with_sessions(self):
-        metric = self.create_funnel_metric()
-        # With step_sessions data
-        sessions_data = [
-            [
-                ("user1", "session1", "uuid1", "2024-01-01T00:00:00Z"),
-                ("user2", "session2", "uuid2", "2024-01-01T00:00:01Z"),
-            ],  # Step 0 sessions
-            [("user1", "session1", "uuid3", "2024-01-01T00:00:02Z")],  # Step 1 sessions
-        ]
-        result = ("control", 100, 80.0, 80.0, [100, 80], sessions_data)
-
-        breakdown_value, stats = get_variant_result(result, _columns_for(metric, has_step_sessions=True))
-
-        assert breakdown_value is None
-        assert stats.key == "control"
-        assert stats.step_counts == [100, 80]
-        assert stats.step_sessions is not None
-        assert len(stats.step_sessions) == 2
-        assert len(stats.step_sessions[0]) == 2  # First step has 2 sessions
-        assert len(stats.step_sessions[1]) == 1  # Second step has 1 session
-        assert stats.step_sessions[0][0].person_id == "user1"
-        assert stats.step_sessions[0][0].session_id == "session1"
-        assert stats.step_sessions[0][0].event_uuid == "uuid1"
 
     # Ratio Metric Tests
     def test_ratio_metric_without_breakdown(self):
@@ -379,68 +351,6 @@ class TestGetVariantResult:
 
         assert breakdown_tuple == ("MacOS", "1920")  # Both as strings
         assert stats.number_of_samples == 100
-
-    def test_funnel_metric_with_breakdown_and_sessions(self):
-        """Test funnel metric with breakdown and sessions combined."""
-        metric = ExperimentFunnelMetric(
-            series=[
-                EventsNode(event="$pageview", name="$pageview"),
-                EventsNode(event="purchase", name="purchase"),
-            ],
-            breakdownFilter=BreakdownFilter(breakdowns=[Breakdown(property="$browser")]),
-        )
-        sessions_data = [
-            [("user1", "session1", "uuid1", "2024-01-01T00:00:00Z")],
-            [("user1", "session1", "uuid2", "2024-01-01T00:00:01Z")],
-        ]
-        # Result: variant, breakdown, samples, sum, sum_squares, step_counts, step_sessions
-        result = ("test", "Chrome", 100, 80.0, 80.0, [100, 80], sessions_data)
-
-        breakdown_tuple, stats = get_variant_result(result, _columns_for(metric, has_step_sessions=True))
-
-        assert breakdown_tuple == ("Chrome",)
-        assert stats.key == "test"
-        assert stats.number_of_samples == 100
-        assert stats.step_counts == [100, 80]
-        assert stats.step_sessions is not None
-        assert len(stats.step_sessions) == 2
-        assert len(stats.step_sessions[0]) == 1
-        assert stats.step_sessions[0][0].person_id == "user1"
-
-    def test_funnel_metric_with_multiple_breakdowns_and_sessions(self):
-        """Test funnel metric with multiple breakdowns and sessions."""
-        metric = ExperimentFunnelMetric(
-            series=[
-                EventsNode(event="$pageview", name="$pageview"),
-                EventsNode(event="purchase", name="purchase"),
-            ],
-            breakdownFilter=BreakdownFilter(
-                breakdowns=[
-                    Breakdown(property="$os"),
-                    Breakdown(property="$browser"),
-                ]
-            ),
-        )
-        sessions_data = [
-            [
-                ("user1", "session1", "uuid1", "2024-01-01T00:00:00Z"),
-                ("user2", "session2", "uuid2", "2024-01-01T00:00:01Z"),
-            ],
-            [("user1", "session1", "uuid3", "2024-01-01T00:00:02Z")],
-        ]
-        # Result: variant, os, browser, samples, sum, sum_squares, step_counts, step_sessions
-        result = ("control", "MacOS", "Chrome", 100, 80.0, 80.0, [100, 80], sessions_data)
-
-        breakdown_tuple, stats = get_variant_result(result, _columns_for(metric, has_step_sessions=True))
-
-        assert breakdown_tuple == ("MacOS", "Chrome")
-        assert stats.key == "control"
-        assert stats.number_of_samples == 100
-        assert stats.step_counts == [100, 80]
-        assert stats.step_sessions is not None
-        assert len(stats.step_sessions) == 2
-        assert len(stats.step_sessions[0]) == 2
-        assert len(stats.step_sessions[1]) == 1
 
     def test_ratio_metric_with_multiple_breakdowns(self):
         """Test ratio metric with multiple breakdowns."""
@@ -712,72 +622,6 @@ class TestAggregateVariantsAcrossBreakdowns:
         assert control.number_of_samples == 180  # 100 + 80
         assert control.sum == 140.0  # 80 + 60
         assert control.step_counts == [180, 155, 140]  # Element-wise sum
-
-    def test_aggregate_funnel_metrics_with_step_sessions(self):
-        """Test that funnel step_sessions are aggregated across breakdowns for actors view."""
-        from posthog.schema import SessionData
-
-        variants = [
-            (
-                ("Chrome",),
-                ExperimentStatsBase(
-                    key="control",
-                    number_of_samples=100,
-                    sum=80.0,
-                    sum_squares=80.0,
-                    step_counts=[100, 80],
-                    step_sessions=[
-                        [
-                            SessionData(
-                                person_id="user1", session_id="s1", event_uuid="e1", timestamp="2024-01-01T00:00:00Z"
-                            )
-                        ],
-                        [
-                            SessionData(
-                                person_id="user1", session_id="s1", event_uuid="e2", timestamp="2024-01-01T00:00:01Z"
-                            )
-                        ],
-                    ],
-                ),
-            ),
-            (
-                ("Safari",),
-                ExperimentStatsBase(
-                    key="control",
-                    number_of_samples=80,
-                    sum=60.0,
-                    sum_squares=60.0,
-                    step_counts=[80, 60],
-                    step_sessions=[
-                        [
-                            SessionData(
-                                person_id="user2", session_id="s2", event_uuid="e3", timestamp="2024-01-01T00:00:02Z"
-                            )
-                        ],
-                        [
-                            SessionData(
-                                person_id="user2", session_id="s2", event_uuid="e4", timestamp="2024-01-01T00:00:03Z"
-                            )
-                        ],
-                    ],
-                ),
-            ),
-        ]
-
-        aggregated = aggregate_variants_across_breakdowns(
-            cast(list[tuple[tuple[str, ...] | None, ExperimentStatsBase]], variants)
-        )
-
-        assert len(aggregated) == 1
-        control = aggregated[0]
-        assert control.key == "control"
-        assert control.step_counts == [180, 140]
-        assert control.step_sessions is not None
-        assert len(control.step_sessions) == 2  # Two steps
-        assert len(control.step_sessions[0]) == 2  # Aggregated from both breakdowns
-        assert len(control.step_sessions[1]) == 2  # Aggregated from both breakdowns
-        assert control.step_sessions[0][0].person_id == "user1"
-        assert control.step_sessions[0][1].person_id == "user2"
 
     def test_aggregate_ratio_metrics_denominator_fields(self):
         """Test that ratio metric denominator fields are aggregated correctly."""

--- a/products/experiments/backend/hogql_queries/utils.py
+++ b/products/experiments/backend/hogql_queries/utils.py
@@ -16,7 +16,6 @@ from posthog.schema import (
     ExperimentVariantResultBayesian,
     ExperimentVariantResultFrequentist,
     ExperimentVariantTrendsBaseStats,
-    SessionData,
 )
 
 from posthog.hogql import ast
@@ -179,17 +178,6 @@ def get_variant_result(
         field: row_dict[alias] for alias, field in _ALIAS_TO_STATS_FIELD.items() if alias in row_dict
     }
 
-    # steps_event_data is the only column needing structural conversion
-    # (raw tuples → SessionData); all other aliases map directly via _ALIAS_TO_STATS_FIELD.
-    if "steps_event_data" in row_dict and row_dict["steps_event_data"] is not None:
-        base_stats["step_sessions"] = [
-            [
-                SessionData(person_id=person_id, session_id=session_id, event_uuid=event_uuid, timestamp=timestamp)
-                for person_id, session_id, event_uuid, timestamp in step_sessions
-            ]
-            for step_sessions in row_dict["steps_event_data"]
-        ]
-
     return breakdown_tuple, ExperimentStatsBase(**base_stats)
 
 
@@ -239,18 +227,6 @@ def aggregate_variants_across_breakdowns(
             aggregated_stats["step_counts"] = [
                 sum(step_values) for step_values in zip(*[v.step_counts for v in variant_list if v.step_counts])
             ]
-
-            # Aggregate step_sessions across breakdowns for actors view
-            if variant_list[0].step_sessions is not None:
-                aggregated_stats["step_sessions"] = [
-                    [
-                        session
-                        for variant in variant_list
-                        if variant.step_sessions
-                        for session in variant.step_sessions[step_idx]
-                    ]
-                    for step_idx in range(len(variant_list[0].step_sessions))
-                ]
 
         if variant_list[0].denominator_sum is not None:
             aggregated_stats.update(
@@ -312,8 +288,6 @@ def validate_variant_result(
     # Include funnel-specific fields if present
     if hasattr(variant_result, "step_counts") and variant_result.step_counts is not None:
         validated_result.step_counts = variant_result.step_counts
-    if hasattr(variant_result, "step_sessions") and variant_result.step_sessions is not None:
-        validated_result.step_sessions = variant_result.step_sessions
 
     # Include ratio-specific fields if present
     if hasattr(variant_result, "denominator_sum") and variant_result.denominator_sum is not None:
@@ -539,7 +513,6 @@ def get_frequentist_experiment_result(
             sum=test_variant_validated.sum,
             sum_squares=test_variant_validated.sum_squares,
             step_counts=test_variant_validated.step_counts,
-            step_sessions=getattr(test_variant_validated, "step_sessions", None),
             validation_failures=test_variant_validated.validation_failures,
         )
 
@@ -643,7 +616,6 @@ def get_bayesian_experiment_result(
             sum=test_variant_validated.sum,
             sum_squares=test_variant_validated.sum_squares,
             step_counts=test_variant_validated.step_counts,
-            step_sessions=getattr(test_variant_validated, "step_sessions", None),
             validation_failures=test_variant_validated.validation_failures,
         )
 


### PR DESCRIPTION
## Problem

`step_sessions` has been unpopulated since the funnel query stopped emitting `steps_event_data` (PR #66377). The code that parsed and aggregated it is now dead.

## Changes

- Remove the dead `step_sessions` parsing, cross-breakdown aggregation, and result-builder plumbing in `utils.py`, plus the tests that exercised it.
- Keep the dormant `step_sessions` schema field and `strip_step_sessions` for now. The result models are `extra=forbid` and stored result rows still carry the key, so removing the field is a separate follow-up once those age out.

This PR is stacked on the actors-query flag removal PR. Review and merge that one first.

## How did you test this code?

I'm an agent. I ran the experiment utils tests and a funnel integration test. All pass. The funnel query SQL is unchanged.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Kept the schema field and strip helper on purpose: the four result models use `extra=forbid` and `ExperimentMetricResult.result` is a plain JSON column whose old rows still contain `step_sessions`. Removing the field now risks breaking deserialization, for near-zero benefit, so it is deferred.
