### PR TITLE
feat(tasks): overlap repo clone with agent-server boot

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -4,6 +4,7 @@ SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
 STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
+OVERLAP_CLONE_BOOT_FEATURE_FLAG = "tasks-overlap-clone-boot"
 
 ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]
 CodexPermissionMode = Literal["auto", "read-only", "full-access"]

--- a/products/tasks/backend/logic/services/docker_sandbox.py
+++ b/products/tasks/backend/logic/services/docker_sandbox.py
@@ -721,6 +721,7 @@ class DockerSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        repo_ready_file: str | None = None,
     ) -> str:
         # The host proxy URL (e.g. localhost:8003) is unreachable from inside the container;
         # rewrite it the same way POSTHOG_API_URL is for Docker sandboxes.
@@ -739,6 +740,7 @@ class DockerSandbox(SandboxBase):
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
+        repo_ready_flag = f" --repoReadyFile {shlex.quote(repo_ready_file)}" if repo_ready_file else ""
         # Scope BASH_ENV to the agent-server process (not the container env) so only the
         # agent's per-command tool shells re-source the refreshed token. Backend maintenance
         # execs (clone/checkout/token injection) must not source it — the script could be
@@ -748,7 +750,7 @@ class DockerSandbox(SandboxBase):
             f"env {unset_flags}BASH_ENV={shlex.quote(BASH_ENV_SCRIPT)} "
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}{repo_ready_flag}"
         )
 
         # agentsh injects HTTP_PROXY pointing at a per-session egress proxy port; undici
@@ -798,6 +800,8 @@ class DockerSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        repo_ready_file: str | None = None,
+        wait_for_health: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -845,9 +849,20 @@ class DockerSandbox(SandboxBase):
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            repo_ready_file=repo_ready_file,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
+
+        if not wait_for_health:
+            result = self.execute(command, timeout_seconds=30)
+            if result.exit_code != 0:
+                raise SandboxExecutionError(
+                    "Agent-server process failed to launch",
+                    {"sandbox_id": self.id, "stderr": result.stderr, "exit_code": str(result.exit_code)},
+                    cause=RuntimeError(result.stderr or "launch command returned non-zero exit"),
+                )
+            return
 
         if self._launch_and_check(command):
             logger.info(f"Agent-server started on port {self._host_port}")
@@ -879,6 +894,7 @@ class DockerSandbox(SandboxBase):
                 allowed_domains=allowed_domains,
                 event_ingest_token=event_ingest_token,
                 event_ingest_url=event_ingest_url,
+                repo_ready_file=repo_ready_file,
             )
             if self._launch_and_check(command):
                 logger.info(f"Agent-server started on port {self._host_port} (without --baseBranch)")
@@ -892,6 +908,21 @@ class DockerSandbox(SandboxBase):
             {"sandbox_id": self.id, "log": log_result.stdout},
             cause=RuntimeError("Health check failed after retries"),
         )
+
+    def wait_for_agent_server_ready(self, allowed_domains: list[str] | None = None) -> None:
+        if self._wait_for_health_check(max_attempts=240):
+            logger.info(f"Agent-server ready on port {self._host_port}")
+            return
+        log_result = self.execute("cat /tmp/agent-server.log 2>/dev/null || echo 'No log file'", timeout_seconds=5)
+        logger.warning(f"Agent-server health check failed for sandbox {self.id}. Log output:\n{log_result.stdout}")
+        raise SandboxExecutionError(
+            "Agent-server failed to start",
+            {"sandbox_id": self.id, "log": log_result.stdout},
+            cause=RuntimeError("Health check failed after retries"),
+        )
+
+    def mark_repo_ready(self, repo_ready_file: str) -> None:
+        self.execute(f"touch {shlex.quote(repo_ready_file)}", timeout_seconds=10)
 
     def _setup_agentsh(self, workspace_path: str, allowed_domains: list[str] | None = None) -> None:
         if allowed_domains is not None:

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -693,6 +693,7 @@ class ModalSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        repo_ready_file: str | None = None,
     ) -> str:
         env_prefix = build_agent_runtime_env_prefix(
             interaction_origin=interaction_origin,
@@ -707,6 +708,7 @@ class ModalSandbox(SandboxBase):
         repo_flag = f" --repositoryPath {shlex.quote(repo_path)}" if repo_path else ""
         branch_flag = f" --baseBranch {shlex.quote(branch)}" if branch else ""
         domains_flag = f" --allowedDomains {shlex.quote(','.join(allowed_domains))}" if allowed_domains else ""
+        repo_ready_flag = f" --repoReadyFile {shlex.quote(repo_ready_file)}" if repo_ready_file else ""
         # Scope BASH_ENV to the agent-server process (not the container env) so only the
         # agent's per-command tool shells re-source the refreshed token. Backend maintenance
         # execs (clone/checkout/token injection) must not source it — the script could be
@@ -716,7 +718,7 @@ class ModalSandbox(SandboxBase):
             f"env {unset_flags}BASH_ENV={shlex.quote(BASH_ENV_SCRIPT)} "
             f"{env_prefix}./node_modules/.bin/agent-server --port {AGENT_SERVER_PORT}{repo_flag} "
             f"--taskId {shlex.quote(task_id)} --runId {shlex.quote(run_id)} --mode {shlex.quote(mode)}"
-            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}"
+            f"{create_pr_flag}{branch_flag}{mcp_servers_arg}{domains_flag}{repo_ready_flag}"
         )
 
         inner = f"cd /scripts && {server_cmd} > /tmp/agent-server.log 2>&1"
@@ -800,6 +802,8 @@ class ModalSandbox(SandboxBase):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        repo_ready_file: str | None = None,
+        wait_for_health: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -846,10 +850,24 @@ class ModalSandbox(SandboxBase):
             allowed_domains=allowed_domains,
             event_ingest_token=event_ingest_token,
             event_ingest_url=event_ingest_url,
+            repo_ready_file=repo_ready_file,
         )
 
         logger.info(f"Starting agent-server in sandbox {self.id} for {repository or 'no-repo'}")
-        if not self._launch_and_check(command):
+        launch_result = self.execute(command, timeout_seconds=30)
+        if launch_result.exit_code != 0:
+            logger.warning(f"Agent-server process failed to launch in sandbox {self.id}: {launch_result.stderr}")
+            raise SandboxExecutionError(
+                "Agent-server process failed to launch",
+                {"sandbox_id": self.id, "stderr": launch_result.stderr, "exit_code": str(launch_result.exit_code)},
+                cause=RuntimeError(launch_result.stderr or "launch command returned non-zero exit"),
+            )
+
+        if wait_for_health:
+            self.wait_for_agent_server_ready(allowed_domains)
+
+    def wait_for_agent_server_ready(self, allowed_domains: list[str] | None = None) -> None:
+        if not self._wait_for_health_check():
             diagnostics = self._diagnose_startup_failure(allowed_domains)
             raise SandboxExecutionError(
                 "Agent-server failed to start",
@@ -857,7 +875,8 @@ class ModalSandbox(SandboxBase):
                 cause=RuntimeError(diagnostics.get("failure_reason", "Health check failed after retries")),
             )
 
-        logger.info(f"Agent-server started in sandbox {self.id}")
+    def mark_repo_ready(self, repo_ready_file: str) -> None:
+        self.execute(f"touch {shlex.quote(repo_ready_file)}", timeout_seconds=10)
 
     def _setup_agentsh(self, workspace_path: str, allowed_domains: list[str] | None = None) -> None:
         if allowed_domains is not None:

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -867,13 +867,15 @@ class ModalSandbox(SandboxBase):
             self.wait_for_agent_server_ready(allowed_domains)
 
     def wait_for_agent_server_ready(self, allowed_domains: list[str] | None = None) -> None:
-        if not self._wait_for_health_check():
-            diagnostics = self._diagnose_startup_failure(allowed_domains)
-            raise SandboxExecutionError(
-                "Agent-server failed to start",
-                {"sandbox_id": self.id, **diagnostics},
-                cause=RuntimeError(diagnostics.get("failure_reason", "Health check failed after retries")),
-            )
+        if self._wait_for_health_check():
+            logger.info(f"Agent-server ready in sandbox {self.id}")
+            return
+        diagnostics = self._diagnose_startup_failure(allowed_domains)
+        raise SandboxExecutionError(
+            "Agent-server failed to start",
+            {"sandbox_id": self.id, **diagnostics},
+            cause=RuntimeError(diagnostics.get("failure_reason", "Health check failed after retries")),
+        )
 
     def mark_repo_ready(self, repo_ready_file: str) -> None:
         self.execute(f"touch {shlex.quote(repo_ready_file)}", timeout_seconds=10)

--- a/products/tasks/backend/logic/services/modal_sandbox.py
+++ b/products/tasks/backend/logic/services/modal_sandbox.py
@@ -731,13 +731,6 @@ class ModalSandbox(SandboxBase):
         else:
             return f"cd /scripts && env -0 > {ENV_FILE} && nohup {server_cmd} > /tmp/agent-server.log 2>&1 &"
 
-    def _launch_and_check(self, command: str) -> bool:
-        result = self.execute(command, timeout_seconds=30)
-        if result.exit_code != 0:
-            logger.warning(f"Agent-server process failed to launch in sandbox {self.id}: {result.stderr}")
-            return False
-        return self._wait_for_health_check()
-
     def _diagnose_startup_failure(self, allowed_domains: list[str] | None) -> dict[str, str]:
         diagnostics: dict[str, str] = {}
         try:
@@ -858,7 +851,7 @@ class ModalSandbox(SandboxBase):
         if launch_result.exit_code != 0:
             logger.warning(f"Agent-server process failed to launch in sandbox {self.id}: {launch_result.stderr}")
             raise SandboxExecutionError(
-                "Agent-server process failed to launch",
+                "Agent-server failed to start",
                 {"sandbox_id": self.id, "stderr": launch_result.stderr, "exit_code": str(launch_result.exit_code)},
                 cause=RuntimeError(launch_result.stderr or "launch command returned non-zero exit"),
             )

--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -111,6 +111,8 @@ class SandboxConfig(BaseModel):
 
 WORKING_DIR = "/tmp/workspace"
 
+REPO_READY_FILE = f"{WORKING_DIR}/.repo-ready"
+
 PUBLIC_SANDBOX_REPOS: frozenset[str] = frozenset({"posthog/hedgebox", "posthog/.github"})
 """Repos the sandbox is allowed to clone unauthenticated, even when the team has no GitHub integration"""
 # TODO: Remove `posthog/.github` when we switch repo discovery to repo-less agent (now it works as a lightweight dummy)
@@ -258,6 +260,8 @@ class SandboxBase(ABC):
         allowed_domains: list[str] | None = None,
         event_ingest_token: str | None = None,
         event_ingest_url: str | None = None,
+        repo_ready_file: str | None = None,
+        wait_for_health: bool = True,
     ) -> None:
         """Start the agent-server HTTP server in the sandbox.
 
@@ -265,6 +269,12 @@ class SandboxBase(ABC):
         before calling this method.
         """
         ...
+
+    @abstractmethod
+    def wait_for_agent_server_ready(self, allowed_domains: list[str] | None = None) -> None: ...
+
+    @abstractmethod
+    def mark_repo_ready(self, repo_ready_file: str) -> None: ...
 
     @abstractmethod
     def create_snapshot(self) -> str: ...

--- a/products/tasks/backend/temporal/__init__.py
+++ b/products/tasks/backend/temporal/__init__.py
@@ -15,6 +15,7 @@ from .create_snapshot.activities import (
 )
 from .create_snapshot.workflow import CreateSnapshotForRepositoryWorkflow
 from .process_task.activities import (
+    await_agent_server_ready,
     checkout_branch_in_sandbox,
     cleanup_sandbox,
     clone_repository_in_sandbox,
@@ -26,6 +27,8 @@ from .process_task.activities import (
     get_sandbox_for_repository,
     get_task_processing_context,
     inject_fresh_tokens_on_resume,
+    launch_agent_server,
+    mark_repo_ready,
     post_slack_update,
     prepare_sandbox_for_repository,
     read_sandbox_logs,
@@ -65,6 +68,9 @@ ACTIVITIES = [
     create_resume_snapshot,
     send_followup_to_sandbox,
     start_agent_server,
+    launch_agent_server,
+    await_agent_server_ready,
+    mark_repo_ready,
     read_sandbox_logs,
     cleanup_sandbox,
     emit_progress_activity,

--- a/products/tasks/backend/temporal/process_task/activities/__init__.py
+++ b/products/tasks/backend/temporal/process_task/activities/__init__.py
@@ -32,7 +32,15 @@ from .refresh_sandbox_credentials import (
 )
 from .relay_sandbox_events import RelaySandboxEventsInput, relay_sandbox_events
 from .send_followup_to_sandbox import SendFollowupToSandboxInput, send_followup_to_sandbox
-from .start_agent_server import StartAgentServerInput, StartAgentServerOutput, start_agent_server
+from .start_agent_server import (
+    MarkRepoReadyInput,
+    StartAgentServerInput,
+    StartAgentServerOutput,
+    await_agent_server_ready,
+    launch_agent_server,
+    mark_repo_ready,
+    start_agent_server,
+)
 from .track_workflow_event import TrackWorkflowEventInput, track_workflow_event
 from .update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 
@@ -56,6 +64,7 @@ __all__ = [
     "ReadSandboxLogsInput",
     "RefreshSandboxCredentialsInput",
     "RefreshSandboxCredentialsOutput",
+    "MarkRepoReadyInput",
     "StartAgentServerInput",
     "StartAgentServerOutput",
     "TaskProcessingContext",
@@ -79,6 +88,9 @@ __all__ = [
     "read_sandbox_logs",
     "refresh_sandbox_credentials",
     "start_agent_server",
+    "launch_agent_server",
+    "await_agent_server_ready",
+    "mark_repo_ready",
     "track_workflow_event",
     "update_task_run_status",
     "clone_repository_in_sandbox",

--- a/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_sandbox_for_repository.py
@@ -94,6 +94,7 @@ class GetSandboxForRepositoryOutput:
     connect_token: str | None
     used_snapshot: bool
     should_create_snapshot: bool
+    agent_server_launched: bool = False
 
 
 @activity.defn

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -14,6 +14,7 @@ from posthog.temporal.common.utils import asyncify, close_db_connections
 from products.tasks.backend.constants import (
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
+    OVERLAP_CLONE_BOOT_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
 )
 from products.tasks.backend.exceptions import TaskInvalidStateError, TaskRunNotReadyError
@@ -76,6 +77,7 @@ class TaskProcessingContext:
     # Burstable by default; the per-run state can opt out to pin a fixed-size box
     # (request == limit). Captured at workflow start so it's stable across activity retries.
     burstable_sandbox_resources_enabled: bool = True
+    overlap_clone_boot_enabled: bool = False
 
     @property
     def mode(self) -> str:
@@ -329,6 +331,45 @@ def _is_burstable_sandbox_resources_enabled(
     return True
 
 
+def _is_overlap_clone_boot_enabled(
+    *,
+    distinct_id: str,
+    organization_id: str,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    state_override = (state or {}).get("overlap_clone_boot_enabled")
+    if isinstance(state_override, bool):
+        log_with_activity_context(
+            "overlap_clone_boot_state_override",
+            run_id=run_id,
+            overlap_clone_boot_enabled=state_override,
+        )
+        return state_override
+
+    try:
+        enabled = bool(
+            posthoganalytics.feature_enabled(
+                OVERLAP_CLONE_BOOT_FEATURE_FLAG,
+                distinct_id=distinct_id,
+                groups={"organization": organization_id},
+                group_properties={"organization": {"id": organization_id}},
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
+        )
+    except Exception as e:
+        log_with_activity_context("overlap_clone_boot_flag_check_failed", run_id=run_id, error=str(e))
+        return False
+
+    log_with_activity_context(
+        "overlap_clone_boot_flag_checked",
+        run_id=run_id,
+        overlap_clone_boot_enabled=enabled,
+    )
+    return enabled
+
+
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -503,6 +544,17 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"burstable_sandbox_resources_enabled: {burstable_sandbox_resources_enabled} for this task run",
     )
+    overlap_clone_boot_enabled = _is_overlap_clone_boot_enabled(
+        distinct_id=distinct_id,
+        organization_id=organization_id,
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"overlap_clone_boot_enabled: {overlap_clone_boot_enabled} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -535,4 +587,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
         burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
+        overlap_clone_boot_enabled=overlap_clone_boot_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
+++ b/products/tasks/backend/temporal/process_task/activities/start_agent_server.py
@@ -15,12 +15,13 @@ from posthog.temporal.oauth import PosthogMcpScopes
 from products.tasks.backend.exceptions import OAuthTokenError, SandboxExecutionError
 from products.tasks.backend.logic.services.agentsh import ENV_FILE, ENV_WRAPPER_SCRIPT, build_exec_prefix
 from products.tasks.backend.logic.services.connection_token import create_sandbox_event_ingest_token
-from products.tasks.backend.logic.services.sandbox import Sandbox, SandboxBase
+from products.tasks.backend.logic.services.sandbox import REPO_READY_FILE, Sandbox, SandboxBase
 from products.tasks.backend.models import Task, TaskRun
 from products.tasks.backend.temporal.metrics import record_agent_server_boot_ms
 from products.tasks.backend.temporal.oauth import create_oauth_access_token
 from products.tasks.backend.temporal.observability import emit_agent_log, log_activity_execution
 from products.tasks.backend.temporal.process_task.utils import (
+    McpServerConfig,
     format_allowed_domains_for_log,
     get_sandbox_ph_mcp_configs,
     get_user_mcp_server_configs,
@@ -139,12 +140,191 @@ class StartAgentServerInput:
     sandbox_url: str
     sandbox_connect_token: str | None = None
     posthog_mcp_scopes: PosthogMcpScopes = "read_only"
+    defer_for_clone: bool = False
+
+
+@dataclass
+class MarkRepoReadyInput:
+    sandbox_id: str
+    run_id: str
 
 
 @dataclass
 class StartAgentServerOutput:
     sandbox_url: str
     connect_token: str | None = None
+
+
+@dataclass
+class _LaunchParams:
+    mcp_configs: list[McpServerConfig]
+    agentsh_domains: list[str] | None
+    protected_base_branch: str | None
+    event_ingest_token: str | None
+    event_ingest_url: str | None
+
+
+def _agentsh_domains_for(ctx: TaskProcessingContext) -> list[str] | None:
+    # Modal enforces egress at the edge (gVisor only), so agentsh is skipped only when it does.
+    return None if (ctx.use_modal_network_allowlist and not ctx.use_modal_vm_sandbox) else ctx.allowed_domains
+
+
+def _prepare_launch(ctx: TaskProcessingContext, scopes: PosthogMcpScopes) -> _LaunchParams:
+    try:
+        task = Task.objects.select_related("created_by").get(id=ctx.task_id)
+        access_token = create_oauth_access_token(task, scopes=scopes)
+    except OAuthTokenError:
+        raise
+    except Exception as e:
+        raise OAuthTokenError(
+            f"Failed to create OAuth access token for MCP auth in task {ctx.task_id}",
+            {"task_id": ctx.task_id, "error": str(e)},
+            cause=e,
+        )
+
+    event_stream_ingest_enabled = ctx.sandbox_event_ingest_enabled
+    event_ingest_token: str | None = None
+    # When the agent-proxy is configured, route the sandbox ingest POST to it instead of the
+    # Django ASGI short-circuit. Only meaningful once sequenced ingest is enabled. Unset means
+    # the agent falls back to POSTHOG_API_URL (Django).
+    event_ingest_url: str | None = settings.TASKS_AGENT_PROXY_INGEST_URL if event_stream_ingest_enabled else None
+    if event_stream_ingest_enabled:
+        try:
+            task_run = TaskRun.objects.get(id=ctx.run_id, task_id=ctx.task_id, team_id=ctx.team_id)
+            event_ingest_token = create_sandbox_event_ingest_token(task_run)
+        except Exception as e:
+            raise SandboxExecutionError(
+                "Failed to create sandbox event ingest token",
+                {"task_id": ctx.task_id, "run_id": ctx.run_id, "error": str(e)},
+                cause=e,
+            )
+
+    mcp_configs = get_sandbox_ph_mcp_configs(
+        token=access_token,
+        project_id=ctx.team_id,
+        scopes=scopes,
+        interaction_origin=ctx.interaction_origin,
+        task_id=str(ctx.task_id),
+    )
+    if task.created_by_id:
+        user_mcp_configs = get_user_mcp_server_configs(
+            token=access_token,
+            team_id=ctx.team_id,
+            user_id=task.created_by_id,
+            interaction_origin=ctx.interaction_origin,
+        )
+        if user_mcp_configs:
+            mcp_configs = mcp_configs + user_mcp_configs
+
+    if mcp_configs:
+        emit_agent_log(
+            ctx.run_id,
+            "debug",
+            f"Resolved {len(mcp_configs)} MCP config(s) for agent server: {', '.join(config.name for config in mcp_configs)}",
+        )
+    else:
+        emit_agent_log(
+            ctx.run_id,
+            "warn",
+            "No MCP configs were resolved for this run. PostHog MCP tools will be unavailable in the agent session.",
+        )
+
+    agentsh_domains = _agentsh_domains_for(ctx)
+    if ctx.use_modal_network_allowlist and not ctx.use_modal_vm_sandbox and ctx.allowed_domains is not None:
+        environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
+        emit_agent_log(
+            ctx.run_id,
+            "debug",
+            f"Enforcing network allowlist for '{environment_name}' via Modal (agentsh disabled)",
+        )
+    elif agentsh_domains is not None:
+        environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
+        emit_agent_log(
+            ctx.run_id,
+            "debug",
+            f"Applying agentsh network policy for '{environment_name}' with allowlist: {format_allowed_domains_for_log(agentsh_domains)}",
+        )
+    elif ctx.sandbox_environment_id:
+        environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id
+        emit_agent_log(
+            ctx.run_id,
+            "debug",
+            f"Sandbox environment '{environment_name}' grants full network access; starting without agentsh restrictions",
+        )
+
+    protected_base_branch = _resolve_protected_base_branch(ctx)
+
+    return _LaunchParams(
+        mcp_configs=mcp_configs,
+        agentsh_domains=agentsh_domains,
+        protected_base_branch=protected_base_branch,
+        event_ingest_token=event_ingest_token,
+        event_ingest_url=event_ingest_url,
+    )
+
+
+def _invoke_start_agent_server(
+    sandbox: SandboxBase,
+    ctx: TaskProcessingContext,
+    params: _LaunchParams,
+    *,
+    repo_ready_file: str | None,
+    wait_for_health: bool,
+) -> None:
+    try:
+        sandbox.start_agent_server(
+            repository=ctx.repository,
+            task_id=ctx.task_id,
+            run_id=ctx.run_id,
+            mode=ctx.mode,
+            create_pr=ctx.create_pr,
+            interaction_origin=ctx.interaction_origin,
+            branch=params.protected_base_branch,
+            runtime_adapter=ctx.runtime_adapter,
+            provider=ctx.provider,
+            model=ctx.model,
+            reasoning_effort=ctx.reasoning_effort,
+            mcp_configs=params.mcp_configs or None,
+            allowed_domains=params.agentsh_domains,
+            event_ingest_token=params.event_ingest_token,
+            event_ingest_url=params.event_ingest_url,
+            repo_ready_file=repo_ready_file,
+            wait_for_health=wait_for_health,
+        )
+
+        # Mark startup-time token issuance so follow-ups within the next
+        # 30m window skip the redundant refresh.
+        if params.mcp_configs:
+            mark_mcp_token_issued(ctx.run_id)
+
+        if params.agentsh_domains is not None:
+            _emit_agentsh_log_tail(ctx, sandbox)
+    except Exception as e:
+        if params.agentsh_domains is not None:
+            _emit_agentsh_log_tail(ctx, sandbox)
+        _emit_agent_server_log_tail(ctx, sandbox)
+        raise SandboxExecutionError(
+            "Failed to start agent server in sandbox",
+            {
+                "task_id": ctx.task_id,
+                "sandbox_id": sandbox.id,
+                "repository": ctx.repository,
+                "error": str(e),
+            },
+            cause=e,
+        )
+
+
+def _emit_post_ready_diagnostics(
+    ctx: TaskProcessingContext, sandbox: SandboxBase, agentsh_domains: list[str] | None
+) -> None:
+    if agentsh_domains is not None:
+        emit_agent_log(ctx.run_id, "debug", "agentsh policy initialized successfully")
+        _emit_agentsh_log_tail(ctx, sandbox)
+    _emit_agent_server_log_tail(ctx, sandbox)
+    # Connectivity diagnostics — run inside the agentsh exec context when
+    # domains are restricted so we can verify the env wrapper + DNS proxy work.
+    _run_connectivity_diagnostics(ctx, sandbox)
 
 
 @activity.defn
@@ -162,162 +342,82 @@ def start_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
         sandbox_id=input.sandbox_id,
         **ctx.to_log_context(),
     ):
-        sandbox_url = input.sandbox_url
-        connect_token = input.sandbox_connect_token
-
         emit_agent_log(ctx.run_id, "debug", "Starting agent server")
 
         sandbox = Sandbox.get_by_id(input.sandbox_id)
+        params = _prepare_launch(ctx, input.posthog_mcp_scopes)
 
-        scopes: PosthogMcpScopes = input.posthog_mcp_scopes
+        _invoke_start_agent_server(sandbox, ctx, params, repo_ready_file=None, wait_for_health=True)
+        _emit_post_ready_diagnostics(ctx, sandbox, params.agentsh_domains)
 
-        try:
-            task = Task.objects.select_related("created_by").get(id=ctx.task_id)
-            access_token = create_oauth_access_token(task, scopes=scopes)
-        except OAuthTokenError:
-            raise
-        except Exception as e:
-            raise OAuthTokenError(
-                f"Failed to create OAuth access token for MCP auth in task {ctx.task_id}",
-                {"task_id": ctx.task_id, "error": str(e)},
-                cause=e,
-            )
-
-        event_stream_ingest_enabled = ctx.sandbox_event_ingest_enabled
-        event_ingest_token: str | None = None
-        # When the agent-proxy is configured, route the sandbox ingest POST to it instead of the
-        # Django ASGI short-circuit. Only meaningful once sequenced ingest is enabled. Unset means
-        # the agent falls back to POSTHOG_API_URL (Django).
-        event_ingest_url: str | None = settings.TASKS_AGENT_PROXY_INGEST_URL if event_stream_ingest_enabled else None
-        if event_stream_ingest_enabled:
-            try:
-                task_run = TaskRun.objects.get(id=ctx.run_id, task_id=ctx.task_id, team_id=ctx.team_id)
-                event_ingest_token = create_sandbox_event_ingest_token(task_run)
-            except Exception as e:
-                raise SandboxExecutionError(
-                    "Failed to create sandbox event ingest token",
-                    {"task_id": ctx.task_id, "run_id": ctx.run_id, "error": str(e)},
-                    cause=e,
-                )
-
-        mcp_configs = get_sandbox_ph_mcp_configs(
-            token=access_token,
-            project_id=ctx.team_id,
-            scopes=scopes,
-            interaction_origin=ctx.interaction_origin,
-            task_id=str(ctx.task_id),
-        )
-        if task.created_by_id:
-            user_mcp_configs = get_user_mcp_server_configs(
-                token=access_token,
-                team_id=ctx.team_id,
-                user_id=task.created_by_id,
-                interaction_origin=ctx.interaction_origin,
-            )
-            if user_mcp_configs:
-                mcp_configs = mcp_configs + user_mcp_configs
-
-        if mcp_configs:
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Resolved {len(mcp_configs)} MCP config(s) for agent server: {', '.join(config.name for config in mcp_configs)}",
-            )
-        else:
-            emit_agent_log(
-                ctx.run_id,
-                "warn",
-                "No MCP configs were resolved for this run. PostHog MCP tools will be unavailable in the agent session.",
-            )
-
-        # Modal enforces egress at the edge (gVisor only), so agentsh is skipped only when it does.
-        agentsh_domains = (
-            None if (ctx.use_modal_network_allowlist and not ctx.use_modal_vm_sandbox) else ctx.allowed_domains
-        )
-
-        if ctx.use_modal_network_allowlist and not ctx.use_modal_vm_sandbox and ctx.allowed_domains is not None:
-            environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Enforcing network allowlist for '{environment_name}' via Modal (agentsh disabled)",
-            )
-        elif agentsh_domains is not None:
-            environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id or "selected environment"
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Applying agentsh network policy for '{environment_name}' with allowlist: {format_allowed_domains_for_log(agentsh_domains)}",
-            )
-        elif ctx.sandbox_environment_id:
-            environment_name = ctx.sandbox_environment_name or ctx.sandbox_environment_id
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Sandbox environment '{environment_name}' grants full network access; starting without agentsh restrictions",
-            )
-
-        protected_base_branch = _resolve_protected_base_branch(ctx)
-
-        try:
-            sandbox.start_agent_server(
-                repository=ctx.repository,
-                task_id=ctx.task_id,
-                run_id=ctx.run_id,
-                mode=ctx.mode,
-                create_pr=ctx.create_pr,
-                interaction_origin=ctx.interaction_origin,
-                branch=protected_base_branch,
-                runtime_adapter=ctx.runtime_adapter,
-                provider=ctx.provider,
-                model=ctx.model,
-                reasoning_effort=ctx.reasoning_effort,
-                mcp_configs=mcp_configs or None,
-                allowed_domains=agentsh_domains,
-                event_ingest_token=event_ingest_token,
-                event_ingest_url=event_ingest_url,
-            )
-
-            # Mark startup-time token issuance so follow-ups within the next
-            # 30m window skip the redundant refresh.
-            if mcp_configs:
-                mark_mcp_token_issued(ctx.run_id)
-
-            # emit agentsh logs
-            if agentsh_domains is not None:
-                _emit_agentsh_log_tail(ctx, sandbox)
-        except Exception as e:
-            if agentsh_domains is not None:
-                _emit_agentsh_log_tail(ctx, sandbox)
-            _emit_agent_server_log_tail(ctx, sandbox)
-            raise SandboxExecutionError(
-                "Failed to start agent server in sandbox",
-                {
-                    "task_id": ctx.task_id,
-                    "sandbox_id": input.sandbox_id,
-                    "repository": ctx.repository,
-                    "error": str(e),
-                },
-                cause=e,
-            )
-
-        if agentsh_domains is not None:
-            emit_agent_log(ctx.run_id, "debug", "agentsh policy initialized successfully")
-            _emit_agentsh_log_tail(ctx, sandbox)
-        _emit_agent_server_log_tail(ctx, sandbox)
-
-        # Connectivity diagnostics — run inside the agentsh exec context when
-        # domains are restricted so we can verify the env wrapper + DNS proxy work.
-        _run_connectivity_diagnostics(ctx, sandbox)
+        emit_agent_log(ctx.run_id, "debug", f"Agent server started at {input.sandbox_url}")
+        activity.logger.info(f"Agent server started at {input.sandbox_url} for task {ctx.task_id}")
 
         boot_ms = sandbox.read_agent_server_boot_ms()
         if boot_ms is not None:
             record_agent_server_boot_ms(boot_ms)
 
-        emit_agent_log(ctx.run_id, "debug", f"Agent server started at {sandbox_url}")
-        activity.logger.info(f"Agent server started at {sandbox_url} for task {ctx.task_id}")
+        return StartAgentServerOutput(sandbox_url=input.sandbox_url, connect_token=input.sandbox_connect_token)
 
-        return StartAgentServerOutput(
-            sandbox_url=sandbox_url,
-            connect_token=connect_token,
-        )
+
+@activity.defn
+@asyncify
+def launch_agent_server(input: StartAgentServerInput) -> StartAgentServerOutput:
+    ctx = input.context
+
+    with log_activity_execution(
+        "launch_agent_server",
+        sandbox_id=input.sandbox_id,
+        **ctx.to_log_context(),
+    ):
+        emit_agent_log(ctx.run_id, "debug", "Launching agent server (deferred readiness)")
+
+        sandbox = Sandbox.get_by_id(input.sandbox_id)
+        params = _prepare_launch(ctx, input.posthog_mcp_scopes)
+
+        repo_ready_file = REPO_READY_FILE if input.defer_for_clone else None
+        _invoke_start_agent_server(sandbox, ctx, params, repo_ready_file=repo_ready_file, wait_for_health=False)
+
+        activity.logger.info(f"Agent server process launched for task {ctx.task_id}")
+        return StartAgentServerOutput(sandbox_url=input.sandbox_url, connect_token=input.sandbox_connect_token)
+
+
+@activity.defn
+@asyncify
+def mark_repo_ready(input: MarkRepoReadyInput) -> None:
+    sandbox = Sandbox.get_by_id(input.sandbox_id)
+    sandbox.mark_repo_ready(REPO_READY_FILE)
+    emit_agent_log(input.run_id, "debug", "Repo ready; released agent-server session barrier")
+
+
+@activity.defn
+@asyncify
+def await_agent_server_ready(input: StartAgentServerInput) -> StartAgentServerOutput:
+    ctx = input.context
+
+    with log_activity_execution(
+        "await_agent_server_ready",
+        sandbox_id=input.sandbox_id,
+        **ctx.to_log_context(),
+    ):
+        sandbox = Sandbox.get_by_id(input.sandbox_id)
+        agentsh_domains = _agentsh_domains_for(ctx)
+
+        try:
+            sandbox.wait_for_agent_server_ready(agentsh_domains)
+        except Exception:
+            if agentsh_domains is not None:
+                _emit_agentsh_log_tail(ctx, sandbox)
+            _emit_agent_server_log_tail(ctx, sandbox)
+            raise
+
+        _emit_post_ready_diagnostics(ctx, sandbox, agentsh_domains)
+
+        emit_agent_log(ctx.run_id, "debug", f"Agent server ready at {input.sandbox_url}")
+        activity.logger.info(f"Agent server ready at {input.sandbox_url} for task {ctx.task_id}")
+
+        boot_ms = sandbox.read_agent_server_boot_ms()
+        if boot_ms is not None:
+            record_agent_server_boot_ms(boot_ms)
+
+        return StartAgentServerOutput(sandbox_url=input.sandbox_url, connect_token=input.sandbox_connect_token)

--- a/products/tasks/backend/temporal/process_task/workflow.py
+++ b/products/tasks/backend/temporal/process_task/workflow.py
@@ -46,7 +46,15 @@ from .activities.provision_sandbox import (
 from .activities.read_sandbox_logs import ReadSandboxLogsInput, read_sandbox_logs
 from .activities.relay_sandbox_events import RelaySandboxEventsInput, relay_sandbox_events
 from .activities.send_followup_to_sandbox import SendFollowupToSandboxInput, send_followup_to_sandbox
-from .activities.start_agent_server import StartAgentServerInput, StartAgentServerOutput, start_agent_server
+from .activities.start_agent_server import (
+    MarkRepoReadyInput,
+    StartAgentServerInput,
+    StartAgentServerOutput,
+    await_agent_server_ready,
+    launch_agent_server,
+    mark_repo_ready,
+    start_agent_server,
+)
 from .activities.track_workflow_event import TrackWorkflowEventInput, track_workflow_event
 from .activities.update_task_run_status import UpdateTaskRunStatusInput, update_task_run_status
 from .credential_refresh import SANDBOX_GONE_ERROR_MESSAGE, CredentialRefreshExitReason, run_credential_refresh_loop
@@ -422,8 +430,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
                 await self._post_slack_update()
 
             # Start agent-server for direct connection from PostHog Code
-            await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
-            agent_server_output = await self._start_agent_server(sandbox_output)
+            if sandbox_output.agent_server_launched:
+                agent_server_output = await self._await_agent_server_ready(sandbox_output)
+            else:
+                await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
+                agent_server_output = await self._start_agent_server(sandbox_output)
             await self._emit_progress("agent", "completed", "Started agent", "setup")
 
             await self._track_workflow_event(
@@ -698,6 +709,11 @@ class ProcessTaskWorkflow(PostHogWorkflow):
         will_clone = bool(prepared.repository and not prepared.used_snapshot and has_clone_credentials)
         will_checkout = bool(prepared.repository and prepared.branch and has_clone_credentials)
 
+        overlap = bool(self.context.overlap_clone_boot_enabled and will_clone)
+        if overlap:
+            await self._emit_progress("agent", "in_progress", "Starting agent", "setup")
+            await self._launch_agent_server(created, defer_for_clone=True)
+
         if will_clone:
             await self._emit_progress("clone", "in_progress", "Cloning repository", "setup")
             await workflow.execute_activity(
@@ -736,12 +752,16 @@ class ProcessTaskWorkflow(PostHogWorkflow):
             )
             await self._emit_progress("checkout", "completed", branch_label_done, "setup")
 
+        if overlap:
+            await self._mark_repo_ready(created.sandbox_id)
+
         return GetSandboxForRepositoryOutput(
             sandbox_id=created.sandbox_id,
             sandbox_url=created.sandbox_url,
             connect_token=created.connect_token,
             used_snapshot=prepared.used_snapshot,
             should_create_snapshot=prepared.should_create_snapshot,
+            agent_server_launched=overlap,
         )
 
     async def _cleanup_sandbox(self, sandbox_id: str) -> None:
@@ -774,6 +794,45 @@ class ProcessTaskWorkflow(PostHogWorkflow):
     async def _start_agent_server(self, sandbox_output: GetSandboxForRepositoryOutput) -> StartAgentServerOutput:
         return await workflow.execute_activity(
             start_agent_server,
+            StartAgentServerInput(
+                context=self.context,
+                sandbox_id=sandbox_output.sandbox_id,
+                sandbox_url=sandbox_output.sandbox_url,
+                sandbox_connect_token=sandbox_output.connect_token,
+                posthog_mcp_scopes=self._posthog_mcp_scopes,
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+    async def _launch_agent_server(
+        self, created: GetSandboxForRepositoryOutput, *, defer_for_clone: bool
+    ) -> StartAgentServerOutput:
+        return await workflow.execute_activity(
+            launch_agent_server,
+            StartAgentServerInput(
+                context=self.context,
+                sandbox_id=created.sandbox_id,
+                sandbox_url=created.sandbox_url,
+                sandbox_connect_token=created.connect_token,
+                posthog_mcp_scopes=self._posthog_mcp_scopes,
+                defer_for_clone=defer_for_clone,
+            ),
+            start_to_close_timeout=timedelta(minutes=5),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+    async def _mark_repo_ready(self, sandbox_id: str) -> None:
+        await workflow.execute_activity(
+            mark_repo_ready,
+            MarkRepoReadyInput(sandbox_id=sandbox_id, run_id=self.context.run_id),
+            start_to_close_timeout=timedelta(seconds=30),
+            retry_policy=RetryPolicy(maximum_attempts=3),
+        )
+
+    async def _await_agent_server_ready(self, sandbox_output: GetSandboxForRepositoryOutput) -> StartAgentServerOutput:
+        return await workflow.execute_activity(
+            await_agent_server_ready,
             StartAgentServerInput(
                 context=self.context,
                 sandbox_id=sandbox_output.sandbox_id,


### PR DESCRIPTION
## Problem

Cloud task runs boot the agent-server only after the repo finishes cloning into the sandbox, so clone time and boot time stack up before the agent can take its first turn. Clone is the larger, more variable cost; boot is mostly fixed subprocess + session init. Running them back-to-back wastes the boot window

## Changes

Behind the `tasks-overlap-clone-boot` [flag](https://us.posthog.com/project/2/feature_flags/735968), the `get_sandbox_for_repository` step now:

1. launches the agent-server as soon as the sandbox exists (`launch_agent_server` with `defer_for_clone=True`
2. clones / checks out the repo concurrently
3. drops a `.repo-ready` sentinel (`mark_repo_ready`) once the working tree is in place sp we are ready

The workflow then runs `await_agent_server_ready` instead of `start_agent_server` when the box was launched early, flag resolution is captured once at workflow start so a mid-run flip can't reshape a live box

