### PR TITLE
fix(mcp-analytics): dash the in-progress day on the activity chart

### DIFF
--- a/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
+++ b/products/mcp_analytics/frontend/MCPAnalyticsDashboardOverview.tsx
@@ -30,6 +30,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
         harnessRows,
         harnessRowsLoading,
         dailyActivity,
+        activityIncompleteTail,
         activityRowsLoading,
         toolDailySeries,
         toolDailyRowsLoading,
@@ -93,6 +94,7 @@ export function MCPAnalyticsDashboardOverview(): JSX.Element {
                                 theme={theme}
                                 timezone={timezone}
                                 interval={interval}
+                                incompleteTail={activityIncompleteTail}
                             />
                         </div>
                         <HarnessDonut rows={harnessRows} loading={harnessRowsLoading} theme={theme} />

--- a/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
@@ -18,20 +18,26 @@ export function ActivityChart({
     theme,
     timezone,
     interval,
+    incompleteTail,
 }: {
     daily: DailyActivity
     loading: boolean
     theme: ChartTheme
     timezone: string
     interval: TimeInterval
+    // When true, the final bucket is the current in-progress interval — dash that segment so the
+    // partial period reads as "not finished yet" rather than a drop in tool calls.
+    incompleteTail?: boolean
 }): JSX.Element {
     const series = useMemo<Series[]>(() => {
         const totals = daily.successes.map((s, i) => s + (daily.errors[i] ?? 0))
+        const dashedFromIndex = incompleteTail && totals.length >= 2 ? totals.length - 1 : undefined
+        const partialStroke = dashedFromIndex !== undefined ? { partial: { fromIndex: dashedFromIndex } } : undefined
         return [
-            { key: 'calls', label: 'Tool calls', color: theme.colors[0], data: totals },
-            { key: 'errors', label: 'Errors', color: theme.colors[4], data: daily.errors },
+            { key: 'calls', label: 'Tool calls', color: theme.colors[0], data: totals, stroke: partialStroke },
+            { key: 'errors', label: 'Errors', color: theme.colors[4], data: daily.errors, stroke: partialStroke },
         ]
-    }, [daily, theme])
+    }, [daily, theme, incompleteTail])
     // quill's built-in date tick formatter only kicks in when both interval and timezone are set.
     const config = useMemo<TimeSeriesLineChartConfig>(
         () => ({

--- a/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
+++ b/products/mcp_analytics/frontend/dashboard/ActivityChart.tsx
@@ -31,8 +31,10 @@ export function ActivityChart({
 }): JSX.Element {
     const series = useMemo<Series[]>(() => {
         const totals = daily.successes.map((s, i) => s + (daily.errors[i] ?? 0))
-        const dashedFromIndex = incompleteTail && totals.length >= 2 ? totals.length - 1 : undefined
-        const partialStroke = dashedFromIndex !== undefined ? { partial: { fromIndex: dashedFromIndex } } : undefined
+        // `incompleteTail` is only true when the window has ≥2 buckets (lastBucketIsInProgress owns
+        // that rule), and `daily` is zero-filled to the bucket count — so the final segment exists.
+        // The renderer also clamps fromIndex, so a stray single-point series can't go out of range.
+        const partialStroke = incompleteTail ? { partial: { fromIndex: totals.length - 1 } } : undefined
         return [
             { key: 'calls', label: 'Tool calls', color: theme.colors[0], data: totals, stroke: partialStroke },
             { key: 'errors', label: 'Errors', color: theme.colors[4], data: daily.errors, stroke: partialStroke },

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -20,6 +20,7 @@ import {
     buildKpiWindow,
     buildToolDailySeries,
     deltaPct,
+    lastBucketIsInProgress,
     mcpDashboardOverviewLogic,
     normalizeBucket,
     pickNotableSessions,
@@ -226,6 +227,27 @@ describe('mcpDashboardOverviewLogic', () => {
                 successes: [0, 0, 0],
                 errors: [0, 0, 0],
             })
+        })
+    })
+
+    describe('lastBucketIsInProgress', () => {
+        const tz = 'UTC'
+        const keys = ['2026-06-27 00:00:00', '2026-06-28 00:00:00', '2026-06-29 00:00:00']
+
+        it('flags the tail when the last bucket is the interval containing now', () => {
+            const now = dayjs.tz('2026-06-29 09:15:00', tz)
+            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(true)
+        })
+
+        it('leaves the tail solid when the window ends in the past', () => {
+            const now = dayjs.tz('2026-07-05 09:15:00', tz)
+            expect(lastBucketIsInProgress(keys, tz, 'day', now)).toBe(false)
+        })
+
+        it('does not dash when there is no segment to dash', () => {
+            const now = dayjs.tz('2026-06-29 09:15:00', tz)
+            expect(lastBucketIsInProgress(['2026-06-29 00:00:00'], tz, 'day', now)).toBe(false)
+            expect(lastBucketIsInProgress([], tz, 'day', now)).toBe(false)
         })
     })
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.test.ts
@@ -228,6 +228,22 @@ describe('mcpDashboardOverviewLogic', () => {
                 errors: [0, 0, 0],
             })
         })
+
+        // The in-progress-tail dash applies `fromIndex = successes.length - 1` to line up with the
+        // last bucket key, so the series must stay exactly bucketKeys-length — including when rows
+        // fall outside the window. If this drifts, the dashed segment lands on the wrong point.
+        it('keeps series length equal to bucketKeys, ignoring rows outside the window', () => {
+            const bucketKeys = ['2024-01-01 00:00:00', '2024-01-02 00:00:00', '2024-01-03 00:00:00']
+            const rows: ActivityRow[] = [
+                { day: '2024-01-02 00:00:00', successes: 5, errors: 1 },
+                { day: '2023-12-31 00:00:00', successes: 9, errors: 9 }, // outside bucketKeys — must be dropped
+            ]
+            const result = buildDailyActivity(rows, bucketKeys)
+            expect(result.labels).toHaveLength(bucketKeys.length)
+            expect(result.successes).toHaveLength(bucketKeys.length)
+            expect(result.errors).toHaveLength(bucketKeys.length)
+            expect(result.successes).toEqual([0, 5, 0])
+        })
     })
 
     describe('lastBucketIsInProgress', () => {

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -281,6 +281,10 @@ function startOfBucket(d: dayjs.Dayjs, interval: IntervalType): dayjs.Dayjs {
     return d.startOf(interval)
 }
 
+// The one format for bucket keys — must match ClickHouse dateTrunc's DateTime output so the
+// zero-fill join and the in-progress-tail comparison line up. Change it here, nowhere else.
+const BUCKET_FORMAT = 'YYYY-MM-DD HH:mm:ss'
+
 // Every bucket key across the resolved window [start, end] at the active interval, formatted to
 // match dateTrunc's DateTime output ('YYYY-MM-DD HH:mm:ss'). The activity and tool-usage series are
 // zero-filled against these so the x-axis spans the whole selected range instead of clipping to the
@@ -292,7 +296,7 @@ export function buildBucketKeys(dateFilter: DateFilter, timezone: string, interv
     let cursor = startOfBucket(start, interval)
     // Bounded dashboard windows keep this small; the cap is just a guard against a pathological range.
     for (let i = 0; cursor.valueOf() <= last && i < 100000; i++) {
-        keys.push(cursor.format('YYYY-MM-DD HH:mm:ss'))
+        keys.push(cursor.format(BUCKET_FORMAT))
         cursor = cursor.add(1, interval)
     }
     return keys
@@ -310,13 +314,13 @@ export function lastBucketIsInProgress(
     if (bucketKeys.length < 2) {
         return false
     }
-    const currentBucket = startOfBucket(now.tz(timezone), interval).format('YYYY-MM-DD HH:mm:ss')
+    const currentBucket = startOfBucket(now.tz(timezone), interval).format(BUCKET_FORMAT)
     return bucketKeys[bucketKeys.length - 1] === currentBucket
 }
 
 export function normalizeBucket(raw: unknown, timezone: string): string {
     const s = String(raw ?? '')
-    return s ? dayjs(s).tz(timezone).format('YYYY-MM-DD HH:mm:ss') : ''
+    return s ? dayjs(s).tz(timezone).format(BUCKET_FORMAT) : ''
 }
 
 // Project the daily success/error rows onto the full set of buckets, defaulting empty buckets to 0.
@@ -349,7 +353,7 @@ export function buildKpiWindow(dateFilter: DateFilter, timezone: string, interva
     return {
         dateFrom: priorStart.toISOString(),
         dateTo: end.toISOString(),
-        currentStartBucket: start.startOf(interval).format('YYYY-MM-DD HH:mm:ss'),
+        currentStartBucket: start.startOf(interval).format(BUCKET_FORMAT),
     }
 }
 

--- a/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
+++ b/products/mcp_analytics/frontend/mcpDashboardOverviewLogic.ts
@@ -298,6 +298,22 @@ export function buildBucketKeys(dateFilter: DateFilter, timezone: string, interv
     return keys
 }
 
+// True when the final bucket is the current, still-running interval (open-ended window), so the
+// chart can dash that segment as "in progress" rather than letting the partial period read as data
+// loss. Needs ≥2 buckets to have a segment to dash; `now` is injectable so the logic stays testable.
+export function lastBucketIsInProgress(
+    bucketKeys: string[],
+    timezone: string,
+    interval: IntervalType,
+    now: dayjs.Dayjs = dayjs()
+): boolean {
+    if (bucketKeys.length < 2) {
+        return false
+    }
+    const currentBucket = startOfBucket(now.tz(timezone), interval).format('YYYY-MM-DD HH:mm:ss')
+    return bucketKeys[bucketKeys.length - 1] === currentBucket
+}
+
 export function normalizeBucket(raw: unknown, timezone: string): string {
     const s = String(raw ?? '')
     return s ? dayjs(s).tz(timezone).format('YYYY-MM-DD HH:mm:ss') : ''
@@ -585,6 +601,13 @@ export const mcpDashboardOverviewLogic = kea<mcpDashboardOverviewLogicType>([
             (s) => [s.dateFilter, s.timezone, s.interval],
             (dateFilter: DateFilter, timezone: string, interval: IntervalType): string[] =>
                 buildBucketKeys(dateFilter, timezone, interval),
+        ],
+        // Whether the activity chart's final bucket is the current, still-running interval — the
+        // chart dashes that segment so a partial period doesn't read as a drop in tool calls.
+        activityIncompleteTail: [
+            (s) => [s.bucketKeys, s.timezone, s.interval],
+            (bucketKeys: string[], timezone: string, interval: IntervalType): boolean =>
+                lastBucketIsInProgress(bucketKeys, timezone, interval),
         ],
         dailyActivity: [
             (s) => [s.activityRows, s.bucketKeys],


### PR DESCRIPTION
## Problem

The MCP analytics dashboard's "Tool calls and errors" time-series appeared to "show very few tool calls" — the latest point cratered toward zero. Investigation against live data ruled out the suspected cause (a recent move of dashboard tiles onto backend query runners): that chart was never migrated and still runs its inline HogQL, and the canonical `$mcp_tool_call` event is healthy (tracks the legacy `mcp_tool_call` alias ~1:1 right up to now).

The real cause is benign: the window's `end` is `now` in the project timezone, and the bucket keys always include the bucket containing `now`. So the final point is the **current, in-progress day** — at ~01:00 Pacific it holds ~1h of data and nose-dives at the right edge. It reads as data loss when it's just a partial period.

## Changes

Render the final segment of the activity chart **dashed** when the last bucket is the current in-progress interval, so a partial period reads as "not finished yet" instead of a drop. Windows that end in the past stay fully solid.

This reuses the existing quill-charts `stroke.partial.fromIndex` mechanism — the same convention PostHog's trends charts use to signal incomplete periods (`incompletenessOffsetFromEnd`). No query, event, or data changes.

- `mcpDashboardOverviewLogic.ts` — pure helper `lastBucketIsInProgress(...)` (reuses existing `startOfBucket`) + an `activityIncompleteTail` selector.
- `ActivityChart.tsx` — optional `incompleteTail` prop; dashes the last segment of both the calls and errors lines when set.
- `MCPAnalyticsDashboardOverview.tsx` — wires the selector to the prop.

The pre-June-15 empty left edge (canonical `$mcp_tool_call` didn't exist before then) is a separate transitional artifact and is intentionally left alone — it self-heals as the window rolls forward.

## How did you test this code?

I'm an agent. I added unit tests for the new helper (`lastBucketIsInProgress`) covering: tail at the current interval → dashed; window ending in the past → solid; fewer than two buckets → no dash. I could not run jest or the typecheck locally (the JS toolchain isn't installed in this worktree) — CI will run both, including the kea typegen that regenerates the gitignored logic type for the new selector.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). Paul directed the work, initially suspecting the frontend→backend query-runner migration had broken the graph.

The bulk of the effort was diagnosis: I confirmed against live project data that (1) the chart was never moved to a runner, (2) canonical vs legacy event volumes match ~1:1 in the recent window, and (3) the apparent undercount is the current incomplete day in the project's Pacific timezone. We considered and rejected a couple of directions Paul weighed in on — reading the legacy event or coalescing legacy+canonical to fill history, and leaving the left-edge gap as-is — landing on a purely presentational dashed-tail fix scoped to the in-progress bucket.

No repo skills were strictly required (no migrations, DRF, or API-type changes); the frontend conventions and kea/quill-charts patterns guided the implementation.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
