### PR TITLE
fix(marketing-analytics): read cost precompute per source instead of all-or-nothing

### DIFF
--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -194,7 +194,9 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             return level
         return MarketingAnalyticsDrillDownLevel.CAMPAIGN
 
-    def _build_costs_from_precompute(self, date_range: QueryDateRange) -> Optional[ast.SelectQuery]:
+    def _build_costs_from_precompute(
+        self, date_range: QueryDateRange
+    ) -> Optional[ast.SelectQuery | ast.SelectSetQuery]:
         """Native-table cost source: ensure each source's cost rows are materialized at the grain
         matching the current drill-down (one lazy job per source), then read them with the SAME column
         contract `build_union_query_ast` produces — so `_build_campaign_cost_select` is unchanged.
@@ -237,6 +239,13 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
         for adapter in mat_adapters:
             insert_query = adapter.build_materialization_query(adapter.get_source_id())
             if insert_query is None:
+                logger.info(
+                    "marketing_costs_precompute",
+                    outcome="source_fallback_unmaterializable",
+                    team_id=self.team.pk,
+                    grain=grain_value,
+                    source_id=adapter.get_source_id(),
+                )
                 s3_fallback_adapters.append(adapter)
                 continue
             result = ensure_precomputed(
@@ -248,6 +257,13 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
                 table=LazyComputationTable.MARKETING_COSTS_PREAGGREGATED,
             )
             if not result.ready:
+                logger.info(
+                    "marketing_costs_precompute",
+                    outcome="source_fallback_jobs_not_ready",
+                    team_id=self.team.pk,
+                    grain=grain_value,
+                    source_id=adapter.get_source_id(),
+                )
                 s3_fallback_adapters.append(adapter)
                 continue
             job_ids.extend(result.job_ids)

--- a/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
+++ b/products/marketing_analytics/backend/hogql_queries/marketing_analytics_base_query_runner.py
@@ -230,18 +230,15 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             return None
 
         ttl_seconds = {"0d": 6 * 60 * 60, "1d": 24 * 60 * 60, "default": 7 * 24 * 60 * 60}
+        # Per source: read the native table when it materializes, otherwise keep that one source on the
+        # live S3 union. A single unmaterializable/syncing source must not force every source back to S3.
         job_ids: list = []
+        s3_fallback_adapters: list[MarketingSourceAdapter] = []
         for adapter in mat_adapters:
             insert_query = adapter.build_materialization_query(adapter.get_source_id())
             if insert_query is None:
-                logger.info(
-                    "marketing_costs_precompute",
-                    outcome="fallback_unmaterializable_source",
-                    team_id=self.team.pk,
-                    grain=grain_value,
-                    source_id=adapter.get_source_id(),
-                )
-                return None
+                s3_fallback_adapters.append(adapter)
+                continue
             result = ensure_precomputed(
                 team=self.team,
                 insert_query=insert_query,
@@ -251,16 +248,12 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
                 table=LazyComputationTable.MARKETING_COSTS_PREAGGREGATED,
             )
             if not result.ready:
-                logger.info(
-                    "marketing_costs_precompute",
-                    outcome="fallback_jobs_not_ready",
-                    team_id=self.team.pk,
-                    grain=grain_value,
-                    source_id=adapter.get_source_id(),
-                )
-                return None
+                s3_fallback_adapters.append(adapter)
+                continue
             job_ids.extend(result.job_ids)
+
         if not job_ids:
+            # Nothing materialized — let the caller read every source live, as before.
             logger.info(
                 "marketing_costs_precompute",
                 outcome="fallback_no_jobs",
@@ -270,8 +263,15 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             )
             return None
 
+        cost_sources: list[ast.SelectQuery | ast.SelectSetQuery] = [
+            self._costs_native_read_query(job_ids, grain, date_range)
+        ]
+        # Sources that couldn't materialize stay on the live S3 union so the dashboard stays complete.
+        if s3_fallback_adapters:
+            cost_sources.append(mat_factory.build_union_query_ast(s3_fallback_adapters))
+
         self._costs_precompute_used = True
-        self._costs_sources_materialized = len(mat_adapters)
+        self._costs_sources_materialized = len(mat_adapters) - len(s3_fallback_adapters)
         self._costs_grain = grain_value
         logger.info(
             "marketing_costs_precompute",
@@ -279,9 +279,13 @@ class MarketingAnalyticsBaseQueryRunner(AnalyticsQueryRunner[ResponseType], ABC,
             team_id=self.team.pk,
             grain=grain_value,
             source_count=len(mat_adapters),
+            precompute_sources=len(mat_adapters) - len(s3_fallback_adapters),
+            s3_fallback_sources=len(s3_fallback_adapters),
             job_count=len(job_ids),
         )
-        return self._costs_native_read_query(job_ids, grain, date_range)
+        if len(cost_sources) == 1:
+            return cost_sources[0]
+        return ast.SelectSetQuery.create_from_queries(cost_sources, set_operator="UNION ALL")
 
     def _costs_native_read_query(
         self, job_ids: list, grain: MarketingAnalyticsDrillDownLevel, date_range: QueryDateRange

--- a/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
+++ b/products/marketing_analytics/backend/hogql_queries/test_marketing_costs_precompute.py
@@ -3,12 +3,14 @@ from datetime import date, datetime
 from pathlib import Path
 
 from posthog.test.base import BaseTest, ClickhouseTestMixin
+from unittest.mock import Mock, patch
 
 from django.test import override_settings
 
 from posthog.schema import DateRange, MarketingAnalyticsDrillDownLevel, MarketingAnalyticsTableQuery
 
 from posthog.hogql import ast
+from posthog.hogql.parser import parse_select
 from posthog.hogql.placeholders import replace_placeholders
 from posthog.hogql.query import execute_hogql_query
 
@@ -22,6 +24,7 @@ from products.marketing_analytics.backend.hogql_queries.adapters.base import (
     MarketingSourceAdapter,
     QueryContext,
 )
+from products.marketing_analytics.backend.hogql_queries.adapters.factory import MarketingSourceFactory
 from products.marketing_analytics.backend.hogql_queries.adapters.google_ads import GoogleAdsAdapter
 from products.marketing_analytics.backend.hogql_queries.marketing_analytics_table_query_runner import (
     MarketingAnalyticsTableQueryRunner,
@@ -208,3 +211,49 @@ class TestMarketingCostsPrecompute(ClickhouseTestMixin, BaseTest):
         result_rows, result_cols = self._execute(read)
         total_cost = sum(float(r[self._col(result_cols, MarketingSourceAdapter.cost_field)]) for r in result_rows)
         assert total_cost == 150.0, f"expected latest job cost 150 (argMax), got {total_cost} (sum would be 250)"
+
+    def test_one_unmaterializable_source_does_not_force_all_to_s3(self):
+        # One source materializes, one can't. The result must read the native table for the materialized
+        # source and keep only the other on the live S3 union — not fall back to S3 for everything.
+        runner = MarketingAnalyticsTableQueryRunner(
+            query=MarketingAnalyticsTableQuery(
+                dateRange=DateRange(date_from="2023-01-01", date_to="2023-01-31"), limit=100, offset=0, properties=[]
+            ),
+            team=self.team,
+        )
+        runner.config.costs_precomputation_enabled = True
+
+        good = Mock()
+        good.get_source_id.return_value = "good"
+        good.supports_level.return_value = True
+        good.config.source_id = "good"
+        good.build_materialization_query.return_value = parse_select("SELECT 1")
+
+        bad = Mock()
+        bad.get_source_id.return_value = "bad"
+        bad.supports_level.return_value = True
+        bad.config.source_id = "bad"
+        bad.build_materialization_query.return_value = None  # cannot materialize -> stays on S3
+        bad.build_query.return_value = parse_select("SELECT 'live_s3_marker' AS source")
+
+        date_range = QueryDateRange(
+            date_range=DateRange(date_from="2023-01-01", date_to="2023-01-31"),
+            team=self.team,
+            interval=None,
+            now=datetime(2023, 2, 1),
+        )
+        ready = Mock(ready=True, job_ids=["00000000-0000-0000-0000-000000000001"])
+        with (
+            patch.object(MarketingSourceFactory, "create_adapters", lambda self: [good, bad]),
+            patch.object(MarketingSourceFactory, "get_valid_adapters", lambda self, adapters: adapters),
+            patch(
+                "products.marketing_analytics.backend.hogql_queries.marketing_analytics_base_query_runner.ensure_precomputed",
+                return_value=ready,
+            ),
+        ):
+            result = runner._build_costs_from_precompute(date_range)
+
+        assert result is not None, "one unmaterializable source must not force every source back to S3"
+        hogql = result.to_hogql()
+        assert "marketing_costs_preaggregated" in hogql, "materialized source should read the native table"
+        assert "live_s3_marker" in hogql, "unmaterializable source should stay on the live S3 union"


### PR DESCRIPTION
## Problem

`_build_costs_from_precompute` is all-or-nothing: it loops the materializable sources and, on the **first** source whose rows can't be materialized (a source missing required tables, still syncing, or whose job isn't ready yet), it `return None` — which sends the caller to the live S3 adapter union for **every** source.

So a single broken/syncing source disables the native cost read for all of them. In practice the precompute table is still written for the healthy sources (the materialization runs before the bail), so the dashboard pays to materialize them *and* then reads everything live from S3 anyway — the worst of both. The aggregated cards and the table read live S3 cost on every load even though most sources are materialized.

## Changes

Make the cost read per source: materialize each source independently, read the native `marketing_costs_preaggregated` table for the ones that succeed, and keep only the sources that can't materialize on the live S3 union. The two are combined with `UNION ALL` (both already emit the same cost column contract, so the downstream `campaign_costs` CTE is unchanged).

- All sources materialize → native read only (unchanged from before).
- No source materializes → `return None`, full live S3 fallback (unchanged).
- Some materialize → native read for those + live S3 union for the rest. This is the new path.

Result: healthy sources get the fast native read, broken/syncing sources stay correct via S3, and the dashboard is both faster and complete.

## How did you test this code?

I'm an agent (Claude Code). Automated test via `hogli test`:
- New case `test_one_unmaterializable_source_does_not_force_all_to_s3`: one source materializes, one returns no materialization query. Asserts the result reads the native table for the materialized source **and** keeps the other on the live S3 union. It **fails on master** (`_build_costs_from_precompute` returns `None`, forcing all to S3) and **passes with this change**.
- Existing cost-precompute and table-runner suites still pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @jabahamondes while profiling the marketing dashboard. The trend tile (which reads the native table directly) loads in ~60ms while the aggregated cards read live S3 (~seconds); tracing that gap surfaced the all-or-nothing fallback as the reason the materialized data goes unused. Skills invoked: `/writing-tests`.

Note: this addresses the cost-read side. The dominant dashboard cost is the read-time conversion attribution, tracked separately.
