### PR TITLE
perf(hogvm): cache compiled regexes and trim per-rule context cost

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -4460,6 +4460,8 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "chrono-tz",
+ "once_cell",
+ "quick_cache",
  "rand 0.8.5",
  "regex",
  "serde",

--- a/rust/common/hogvm/Cargo.toml
+++ b/rust/common/hogvm/Cargo.toml
@@ -14,3 +14,5 @@ regex.workspace = true
 rand.workspace = true
 chrono.workspace = true
 chrono-tz.workspace = true
+once_cell.workspace = true
+quick_cache.workspace = true

--- a/rust/common/hogvm/src/stl.rs
+++ b/rust/common/hogvm/src/stl.rs
@@ -1,7 +1,9 @@
 use core::str;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use chrono::{DateTime, Datelike, LocalResult, NaiveDate, NaiveDateTime, TimeZone};
+use once_cell::sync::Lazy;
 use rand::Rng;
 use serde_json::{json, Value as JsonValue};
 
@@ -20,16 +22,23 @@ pub const TO_STRING_RECURSION_LIMIT: usize = 32;
 
 // A "native function" is a function that can be called from within the VM. It takes a list
 // of arguments, and returns either a value, or null. It's pure (cannot modify the VM state).
-pub type NativeFunction = Box<dyn Fn(&HogVM, Vec<HogValue>) -> Result<HogValue, VmError>>;
+// `Arc` (not `Box`) so the static registry below can be cloned cheaply per execution context.
+pub type NativeFunction =
+    Arc<dyn Fn(&HogVM, Vec<HogValue>) -> Result<HogValue, VmError> + Send + Sync>;
+
+// The native and hog STL registries are process-constant: build them once and hand out cheap clones
+// instead of reconstructing (and, for the hog STL, re-parsing its bytecode) on every context.
+static STL_NATIVE_FNS: Lazy<HashMap<String, NativeFunction>> =
+    Lazy::new(|| stl().into_iter().collect());
+static HOG_STL_MODULES: Lazy<HashMap<String, Module>> =
+    Lazy::new(|| HashMap::from([("stl".to_string(), hog_stl())]));
 
 pub fn stl_map() -> HashMap<String, NativeFunction> {
-    stl().into_iter().collect()
+    STL_NATIVE_FNS.clone()
 }
 
 pub fn hog_stl_map() -> HashMap<String, Module> {
-    let mut res = HashMap::new();
-    res.insert("stl".to_string(), hog_stl());
-    res
+    HOG_STL_MODULES.clone()
 }
 
 // NOTE - if you make changes to this, be sure to re-run `bin/dump_hogvmrs_stl`
@@ -617,7 +626,7 @@ fn err_to_null(
 /// Helper to construct a HogVM native function from a closure.
 pub fn native_func<F>(func: F) -> NativeFunction
 where
-    F: Fn(&HogVM, Vec<HogValue>) -> Result<HogValue, VmError> + 'static,
+    F: Fn(&HogVM, Vec<HogValue>) -> Result<HogValue, VmError> + Send + Sync + 'static,
 {
-    Box::new(func)
+    Arc::new(func)
 }

--- a/rust/common/hogvm/src/util.rs
+++ b/rust/common/hogvm/src/util.rs
@@ -17,19 +17,28 @@ use crate::{
 // (rather than per-VM) so a pattern is compiled at most once fleet-wide instead of once per worker.
 static REGEX_CACHE: Lazy<Cache<(String, bool), Arc<Regex>>> = Lazy::new(|| Cache::new(8192));
 
+// Patterns longer than this are compiled fresh on every call instead of being cached. A Hog program
+// can build a regex from event properties, so without this an attacker could ingest many unique
+// large patterns and retain them all in the process-wide cache (bounded by entry count, not bytes).
+// Real rule patterns are far shorter than this.
+const MAX_CACHEABLE_PATTERN_LEN: usize = 1024;
+
 fn compiled_regex(pattern: &str, case_insensitive: bool) -> Result<Arc<Regex>, VmError> {
-    let key = (pattern.to_owned(), case_insensitive);
-    if let Some(regex) = REGEX_CACHE.get(&key) {
-        return Ok(regex);
-    }
-    let regex = Arc::new(
+    let compile = || {
         RegexBuilder::new(pattern)
             .case_insensitive(case_insensitive)
             .build()
-            .map_err(|e| VmError::InvalidRegex(pattern.to_string(), e.to_string()))?,
-    );
-    REGEX_CACHE.insert(key, regex.clone());
-    Ok(regex)
+            .map(Arc::new)
+            .map_err(|e| VmError::InvalidRegex(pattern.to_string(), e.to_string()))
+    };
+
+    if pattern.len() > MAX_CACHEABLE_PATTERN_LEN {
+        return compile();
+    }
+
+    // `get_or_insert_with` computes at most once per key even under concurrent first access, so two
+    // threads racing the same cold pattern don't both compile, and a failed compile isn't cached.
+    REGEX_CACHE.get_or_insert_with(&(pattern.to_owned(), case_insensitive), compile)
 }
 
 pub fn like(
@@ -230,6 +239,17 @@ mod tests {
         // Case variants are distinct cache entries, not aliases.
         let insensitive = compiled_regex("foo.*bar", true).unwrap();
         assert!(!Arc::ptr_eq(&a, &insensitive));
+    }
+
+    #[test]
+    fn test_oversized_patterns_are_not_cached() {
+        // Patterns past the length cap still compile and match correctly, but are recompiled each
+        // call rather than retained — so large attacker-controlled patterns can't accumulate.
+        let big = "x".repeat(MAX_CACHEABLE_PATTERN_LEN + 1);
+        let a = compiled_regex(&big, false).unwrap();
+        let b = compiled_regex(&big, false).unwrap();
+        assert!(!Arc::ptr_eq(&a, &b), "oversized pattern must not be cached");
+        assert!(regex_match(&big, &big, true).unwrap()); // the literal still matches itself
     }
 
     #[test]

--- a/rust/common/hogvm/src/util.rs
+++ b/rust/common/hogvm/src/util.rs
@@ -1,4 +1,8 @@
-use regex::RegexBuilder;
+use std::sync::Arc;
+
+use once_cell::sync::Lazy;
+use quick_cache::sync::Cache;
+use regex::{Regex, RegexBuilder};
 use serde_json::Value;
 
 use crate::{
@@ -6,6 +10,27 @@ use crate::{
     values::{HogValue, Num},
     vm::HogVM,
 };
+
+// Compiling a regex is orders of magnitude more expensive than matching against an already-compiled
+// one, and rule patterns are constant across the events they run on — so compile once and reuse.
+// The cache is bounded so dynamically constructed patterns can't grow it without limit, and global
+// (rather than per-VM) so a pattern is compiled at most once fleet-wide instead of once per worker.
+static REGEX_CACHE: Lazy<Cache<(String, bool), Arc<Regex>>> = Lazy::new(|| Cache::new(8192));
+
+fn compiled_regex(pattern: &str, case_insensitive: bool) -> Result<Arc<Regex>, VmError> {
+    let key = (pattern.to_owned(), case_insensitive);
+    if let Some(regex) = REGEX_CACHE.get(&key) {
+        return Ok(regex);
+    }
+    let regex = Arc::new(
+        RegexBuilder::new(pattern)
+            .case_insensitive(case_insensitive)
+            .build()
+            .map_err(|e| VmError::InvalidRegex(pattern.to_string(), e.to_string()))?,
+    );
+    REGEX_CACHE.insert(key, regex.clone());
+    Ok(regex)
+}
 
 pub fn like(
     val: impl AsRef<str>,
@@ -21,12 +46,7 @@ pub fn regex_match(
     pattern: impl AsRef<str>,
     case_sensitive: bool,
 ) -> Result<bool, VmError> {
-    let mut builder = RegexBuilder::new(pattern.as_ref());
-    // TODO - this is expensive, but I'm not keen on optimizing it right now
-    let regex = builder
-        .case_insensitive(!case_sensitive)
-        .build()
-        .map_err(|e| VmError::InvalidRegex(pattern.as_ref().to_string(), e.to_string()))?;
+    let regex = compiled_regex(pattern.as_ref(), !case_sensitive)?;
     Ok(regex.is_match(val.as_ref()))
 }
 
@@ -34,9 +54,7 @@ pub fn regex_extract(
     haystack: impl AsRef<str>,
     pattern: impl AsRef<str>,
 ) -> Result<String, VmError> {
-    let regex = RegexBuilder::new(pattern.as_ref())
-        .build()
-        .map_err(|e| VmError::InvalidRegex(pattern.as_ref().to_string(), e.to_string()))?;
+    let regex = compiled_regex(pattern.as_ref(), false)?;
     let Some(captures) = regex.captures(haystack.as_ref()) else {
         return Ok(String::new());
     };
@@ -200,5 +218,38 @@ mod tests {
         // Backslash loses special meaning if not escaping a metacharacter
         assert!(like("hello\\there", "hello\\there", true).unwrap());
         assert!(like("hello\\x", "hello\\x", true).unwrap());
+    }
+
+    #[test]
+    fn test_compiled_regex_is_cached() {
+        // Same (pattern, case) must hand back the same compiled regex instead of recompiling.
+        let a = compiled_regex("foo.*bar", false).unwrap();
+        let b = compiled_regex("foo.*bar", false).unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+
+        // Case variants are distinct cache entries, not aliases.
+        let insensitive = compiled_regex("foo.*bar", true).unwrap();
+        assert!(!Arc::ptr_eq(&a, &insensitive));
+    }
+
+    #[test]
+    fn test_regex_match_case_sensitivity() {
+        assert!(regex_match("Hello", "hello", false).unwrap()); // case-insensitive matches
+        assert!(!regex_match("Hello", "hello", true).unwrap()); // case-sensitive does not
+    }
+
+    #[test]
+    fn test_invalid_regex_errors() {
+        assert!(matches!(
+            regex_match("anything", "(unclosed", true),
+            Err(VmError::InvalidRegex(..))
+        ));
+    }
+
+    #[test]
+    fn test_regex_extract_uses_cache() {
+        assert_eq!(regex_extract("id=42;", r"id=(\d+)").unwrap(), "42");
+        // Second call exercises the cached compilation path and stays correct.
+        assert_eq!(regex_extract("id=7;", r"id=(\d+)").unwrap(), "7");
     }
 }

--- a/rust/cymbal/src/modes/processing/rules/assignment.rs
+++ b/rust/cymbal/src/modes/processing/rules/assignment.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use common_types::TeamId;
 use hogvm::{ExecutionContext, Program, StepOutcome, VmError};
@@ -179,11 +177,10 @@ impl AssignmentRule {
             }
         };
 
-        let mut globals = HashMap::new();
-        globals.insert("issue".to_string(), issue.clone());
-        globals.insert("properties".to_string(), props.clone());
-        let globals: Value = serde_json::to_value(globals)
-            .expect("Can construct a json object from a hashmap of String:JsonValue");
+        let globals = Value::Object(serde_json::Map::from_iter([
+            ("issue".to_string(), issue.clone()),
+            ("properties".to_string(), props.clone()),
+        ]));
         let program = Program::new(rule_bytecode.clone())?;
         let context = ExecutionContext::with_defaults(program).with_globals(globals);
         let mut vm = context.to_vm()?;

--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use common_types::TeamId;
 use hogvm::{ExecutionContext, Program, StepOutcome, VmError};
@@ -95,10 +93,10 @@ impl GroupingRule {
             }
         };
 
-        let mut globals = HashMap::new();
-        globals.insert("properties".to_string(), props.clone());
-        let globals: Value = serde_json::to_value(globals)
-            .expect("Can construct a json object from a hashmap of String:JsonValue");
+        let globals = Value::Object(serde_json::Map::from_iter([(
+            "properties".to_string(),
+            props.clone(),
+        )]));
         let program = Program::new(rule_bytecode.clone())?;
         let context = ExecutionContext::with_defaults(program).with_globals(globals);
         let mut vm = context.to_vm()?;

--- a/rust/cymbal/src/modes/processing/rules/suppression.rs
+++ b/rust/cymbal/src/modes/processing/rules/suppression.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use chrono::{DateTime, Utc};
 use common_types::TeamId;
 use hogvm::{ExecutionContext, Program, StepOutcome, VmError};
@@ -103,10 +101,10 @@ impl SuppressionRule {
             }
         };
 
-        let mut globals = HashMap::new();
-        globals.insert("properties".to_string(), props.clone());
-        let globals: Value = serde_json::to_value(globals)
-            .expect("Can construct a json object from a hashmap of String:JsonValue");
+        let globals = Value::Object(serde_json::Map::from_iter([(
+            "properties".to_string(),
+            props.clone(),
+        )]));
         let program = Program::new(rule_bytecode.clone())?;
         let context = ExecutionContext::with_defaults(program).with_globals(globals);
         let mut vm = context.to_vm()?;


### PR DESCRIPTION
## Problem

Error-tracking ingestion (`cymbal`) evaluates grouping, suppression, and assignment rules by running Hog bytecode in the Rust HogVM on every event. Production profiling (prod-US, 1h CPU profile via Pyroscope) showed two avoidable costs dominating the rule path:

- **Regex compilation at ~4% of total fleet CPU.** `hogvm::util::regex_match` recompiled the regex from scratch on every call (`RegexBuilder::build`), even though rule patterns are constant across the events they run on. Compilation was ~87% of the regex operator's cost; matching was the cheap remainder.
- **Redundant per-rule work.** Each rule rebuilt the entire VM context from scratch — re-serializing the event properties through `serde_json::to_value`, and reconstructing the STL registry (including re-parsing the hog STL bytecode) — for every rule, on every event.

## Changes

- Cache compiled regexes behind a bounded, process-global LRU keyed by `(pattern, case_insensitive)`, so `regex_match` / `regex_extract` / `like` compile each pattern at most once instead of per call. Compilation is race-safe (`get_or_insert_with`, so concurrent cold-compiles don't duplicate), and patterns over 1 KiB are compiled fresh rather than cached so large attacker-controlled patterns can't accumulate.
- Memoize the native and hog STL registries as process-constant statics so `ExecutionContext::with_defaults` stops rebuilding them on every evaluation; `NativeFunction` moves from `Box` to `Arc` so the registry clones cheaply.
- Build rule globals directly as a JSON object instead of round-tripping a `HashMap` through `serde_json::to_value`, dropping a full properties re-walk per rule (in grouping, suppression, and assignment).

Estimated impact from the prod profile: roughly 7–8% of the error-tracking ingestion fleet's CPU, the bulk of it from the regex cache and the dropped re-serialization. The STL memoization is small on current prod traffic but removes a per-rule JSON parse and benefits other VM consumers.

## How did you test this code?

I'm an agent (Claude Code), so this is automated-test-only — no manual product testing.

- `cargo test -p hogvm` — full suite passes, including new `util` tests: cache identity (`Arc::ptr_eq` across calls), case-sensitive vs case-insensitive entries not colliding, invalid regex still returns `VmError::InvalidRegex`, `regex_extract` correctness across cached calls, and oversized patterns compiling/matching correctly without being cached.
- `cargo test -p cymbal --lib suppression` — 8 tests pass, exercising the new globals construction in `try_match`.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, and `cargo shear` clean on both crates.
- A temporary microbench (removed before commit) measured ~650x faster per-match on a rule-shaped pattern with the cache (compile-once vs compile-per-call).
- The grouping/assignment `#[sqlx::test]` cases need a Postgres test DB and were not run locally; they share the `try_match` path the suppression unit tests cover, and CI runs them.

The new tests catch regressions an existing test would not: results going wrong after introducing the cache, case-folding entries aliasing each other, invalid patterns silently succeeding, and the oversized-pattern cache bypass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of @jose-sequeira. The work started from a production CPU profile of `cymbal` pulled via the Grafana Pyroscope MCP (prod-US and a dev canary), which surfaced regex compilation and per-rule context reconstruction as the top avoidable costs in the HogVM rule path.

Decisions along the way:
- Chose a bounded global `quick_cache` for the regex cache over a thread-local or per-VM cache, so a pattern compiles at most once fleet-wide rather than once per worker.
- After review, made the cache race-safe (`get_or_insert_with`, so two threads racing the same cold pattern don't both compile) and made it skip caching patterns over 1 KiB, so large patterns a Hog program derives from event properties can't accumulate in the process-wide cache.
- Changed `NativeFunction` from `Box<dyn Fn>` to `Arc<dyn Fn + Send + Sync>` specifically to allow the STL registry to live in a `static` and be cloned cheaply. The only external constructor (`hogvm/tests/vm.rs`) uses non-capturing closures and compiles unchanged.
- Left the single `props.clone()` per rule in place — eliminating it requires making `ExecutionContext` borrow its globals (a larger VM-lifetime refactor), deferred to a follow-up.

No repo skills were invoked. This touches the shared `hogvm` crate, so it warrants normal review.
