### PR TITLE
fix(aiobs): bugs around skills

### DIFF
--- a/products/ai_observability/skills/README.md
+++ b/products/ai_observability/skills/README.md
@@ -24,7 +24,7 @@ the standalone Skills product — see `products/skills/skills/`.
 ## Adding a new skill
 
 ```bash
-hogli init:skill -- --product llm_analytics --name my-new-skill
+hogli init:skill -- --product ai_observability --name my-new-skill
 ```
 
 See `products/posthog_ai/scripts/build_skills.py` for the build pipeline

--- a/products/ai_observability/skills/feature-usage-feed/SKILL.md
+++ b/products/ai_observability/skills/feature-usage-feed/SKILL.md
@@ -215,16 +215,20 @@ posthog:llma-evaluation-create
     "model": "<model>"
   },
   "enabled": false,
-  "conditions": {
-    "filters": [
-      // Pattern A — feature-native trace_id prefix:
-      { "key": "$ai_trace_id", "operator": "icontains", "value": "<your-prefix>" }
+  "conditions": [
+    {
+      "id": "default",
+      "rollout_percentage": 100,
+      "properties": [
+        // Pattern A — feature-native trace_id prefix:
+        { "key": "$ai_trace_id", "type": "event", "operator": "icontains", "value": "<your-prefix>" }
 
-      // Pattern B — PostHog AI agent mode (use these INSTEAD of the trace_id filter):
-      // { "key": "ai_product", "operator": "exact", "value": "posthog_ai" },
-      // { "key": "agent_mode", "operator": "exact", "value": "<mode>" }
-    ]
-  }
+        // Pattern B — PostHog AI agent mode (use these INSTEAD of the trace_id filter):
+        // { "key": "ai_product", "type": "event", "operator": "exact", "value": "posthog_ai" },
+        // { "key": "agent_mode", "type": "event", "operator": "exact", "value": "<mode>" }
+      ]
+    }
+  ]
 }
 ```
 
@@ -435,7 +439,7 @@ LIMIT 25
 
 - The reasoning field IS the Slack message — design the prompt for that, not for "chain of thought before classification." Models can produce structured Slack-ready text in one pass.
 - LLM judges are non-deterministic across reruns. Expect 1-5% noise even with a fixed prompt and model. If you need reproducibility, pin a deterministic provider/seed in `model_configuration`.
-- Keep the eval scoped tightly via `conditions.filters` on `$ai_trace_id` prefix. Otherwise it fans out to every `$ai_generation` event in the project and burns LLM cost.
+- Keep the eval scoped tightly via the `conditions` property filters on `$ai_trace_id` prefix. Otherwise it fans out to every `$ai_generation` event in the project and burns LLM cost.
 - For high-volume features (>10k traces/week), consider sampling — set the eval to run on a percentage of matching events rather than all of them. Slack flooding is a real failure mode.
 - The "View Trigger Session" button is the highest-value link in the alert. Without it, the feed is just text — you can't watch what the user was actually doing. Verify it works in step 7 before considering the feed shipped.
 - Once the feed is live, periodically re-run the eval summary tool with `filter: "pass"` to surface the dominant use case clusters. That's how you turn the feed into actual product insights instead of just a notification stream.


### PR DESCRIPTION
## Problem

Still using the old names in some docs + using the wrong shape for eval conditions in skill docs.

## Changes

Fix both.

## How did you test this code?

I'm an agent (PostHog Code). I did not do manual testing. Ran `hogli lint:skills` — 97 skills pass. The corrected `conditions` shape was verified against `EvaluationConditionSerializer` in the backend.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — these are agent-skill source fixes.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Carlos. Found while authoring a new skill (`creating-online-evaluations`) that needed the correct eval `conditions` shape — checking the serializer surfaced that `feature-usage-feed` had the wrong shape and that the skills README pointed `init:skill` at the wrong product folder. Split out as a standalone fix so the new skill can assume these are already correct. Skills invoked: `/writing-skills`, `/user-skills:pr-link`.
