### PR TITLE
feat(notebooks): add editable titles to markdown notebook blocks

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -1141,17 +1141,17 @@ snapshots:
     components-markdown-editor-rich--with-markdown--light:
         hash: v1.k794b7964.a73d574094e4664a4cfe8a28bbb74d6bf7d6b7cbe0b5f05aeb3a11fc42a8109e.fHAFZolNByYE1LYlKSbW0YVDUxDdmt31lCq06SkXjYA
     components-markdown-notebook--component-catalog--dark:
-        hash: v1.k794b7964.832623613193ab99ac0a00d1f5f9732a909b02fc1d5f7290a64d81c7dc542de1.ltfo8mYb_a2fR_rLRuRZVUUmFQUMOLKHWTS5gQrFvjc
+        hash: v1.k794b7964.49eb53d700b45319492eedb3aae6f483682f330c1563d8e1750843271c53dbb9.jnzJ4XMAFpsbqd9mg8UGUFQazGFpZ1B2Lfs6Nl8MxE4
     components-markdown-notebook--component-catalog--light:
-        hash: v1.k794b7964.9faa165798f401938528a87fa41329e296e7749bf61466a69f2f88217c245162.BfGpBpjn7m9iwrfUp46t1fX8sQj9umkC6sZqdg9H1UQ
+        hash: v1.k794b7964.69bf9f899998887b1921f38c0984e110f96446d66f1b6b051346c5f8831a0dd4.d0rO5SEFqWRGO2DGaKqceQgZEYxP5KpSwIuwIlBGlck
     components-markdown-notebook--edit-mode--dark:
-        hash: v1.k794b7964.832623613193ab99ac0a00d1f5f9732a909b02fc1d5f7290a64d81c7dc542de1.tA4sUWXQenbduv8UE9dQR8x46YOH3B3BL00BMEdRDgg
+        hash: v1.k794b7964.49eb53d700b45319492eedb3aae6f483682f330c1563d8e1750843271c53dbb9.YXR3bagXp4Xd-XaAgIoTaSSscPrwl4bEmJOEJXVjkPM
     components-markdown-notebook--edit-mode--light:
-        hash: v1.k794b7964.9faa165798f401938528a87fa41329e296e7749bf61466a69f2f88217c245162.KvrayoAf7Cz3RSCTeUitF9-oXasCeVFoIbtI1bhp3FE
+        hash: v1.k794b7964.69bf9f899998887b1921f38c0984e110f96446d66f1b6b051346c5f8831a0dd4.lBePGyN0pgumeBpAv8_KugjJTZ8XMjxw-J4BLpCvs3U
     components-markdown-notebook--embeds--dark:
-        hash: v1.k794b7964.3b4dda5b0cada27729c4427c43be60d1e815d6fd3c84e68268b255a4e7e23f60.uYNIFJbaL5VM89vLWY2HCk7eWOL8XcWqjbcqtQYIGRM
+        hash: v1.k794b7964.7274d5446c7b03e6d8ad6060710dd8c3b7a2bfa7c2cc5506162eed77063113e0.v9rJ2BY1b5OGyyNNojvbiUEX-dSUKmkHHsF5BObf6TE
     components-markdown-notebook--embeds--light:
-        hash: v1.k794b7964.8f761414a13f2167d2f47f3f46d9965544868c3e1275df33140dc0cb2b0df56b.0P1nX_WazbEKZi7C0488MUrX3lN2Ibza-rZUoIqvo7I
+        hash: v1.k794b7964.f50b8d7168c122c8fda4b3446b96063fc5b1c2fa096dc2851b309a119ba4bd1d.8WbN6sQFio9jC9k7qophCbK8fOQ7Nl_KkFh2KIkQjO0
     components-markdown-notebook--empty-notebook--dark:
         hash: v1.k794b7964.0eb2fee680711682f4b6159df1983f335ac8b78f350f711beb9a79ab0c85b854.zyKS2sjcaaVAdDHG3mh_mUx8PEF-AI9BrFxbm9SHHbw
     components-markdown-notebook--empty-notebook--light:
@@ -1161,9 +1161,9 @@ snapshots:
     components-markdown-notebook--headings-and-inline-formatting--light:
         hash: v1.k794b7964.e185d2dec172262bd04b43b4c4eee924b51e9d28fbc2a1c986b1b96d9e747b9f.Ru7nLBBYPZrv9erZAFkefVrYLrBKshvAIQxbIIBYaPc
     components-markdown-notebook--invalid-component-props--dark:
-        hash: v1.k794b7964.da2891dfa2439fbc75953cb1c044e8029c9b049adf52096b749c6f7a41f0da17.OMhOLoQGYXjPVt7vvR7hF0W6_c6loi2IGFH0_mo821M
+        hash: v1.k794b7964.87a3c4445a0f7c947f1612396cdbcd687587a0a8aa4ef14cffe364f20013faa7.R0dD6hMZhIU5d4Mp7dGB1DUWnkkSmtWzZajuOAIFz9M
     components-markdown-notebook--invalid-component-props--light:
-        hash: v1.k794b7964.168fe9b7645f8dd36de47221cf4e2bf7533e6d27d05ccf23ad061d30b14f77b8.2hbmM5btMB8k2TFBPRJ-lLea8IXpmz2CKhObMqWzB0g
+        hash: v1.k794b7964.16d5ec636e10d582c8ff13d366523dd0331eaba7efd7ad97ca02621fad906d1f.VjCFqCR51H0ChYuoLngmACc8Er2ER1wS7JcnPlTKlyw
     components-markdown-notebook--lists-and-links--dark:
         hash: v1.k794b7964.8c3d28d551fd8e41e22529339f20bd371eff00fb197c8016908b4f4a263e7673.XACptJGA3d0BrSsLmv663ks2jcoFalHke7Vb6pga3FY
     components-markdown-notebook--lists-and-links--light:

--- a/frontend/src/lib/components/MarkdownNotebook/COMPONENTS.md
+++ b/frontend/src/lib/components/MarkdownNotebook/COMPONENTS.md
@@ -72,9 +72,13 @@ If it is omitted, the component can still render from markdown but does not appe
 `validateProps` returns user-facing validation errors.
 The notebook shell renders those above the component.
 
-`getTitle(node)` returns the toolbar title shown when the component filters panel is hidden.
-Use it for the compact summary a reader needs while filters are collapsed, such as a URL, insight name, code title, or cached AI answer summary.
+`getTitle(node)` returns a computed contextual title — a compact summary such as a URL, insight name, code title, or cached AI answer summary.
 If omitted, the shell falls back to string props such as `title`, `name`, `url`, `href`, `src`, or `id`.
+
+Every component also has a generic, user-editable title backed by the `title` prop.
+In edit mode the shell renders an editable title field in the toolbar, watermarked with the `getTitle` value (or "Add a title").
+In view mode the shell shows the user's title if set, otherwise the `getTitle` value.
+A `title` equal to the component's own label (e.g. code blocks default `title` to "Python") is treated as no user title, so the field reads as empty by default.
 
 `ViewComponent` renders the read panel.
 `EditComponent` is optional; if omitted, the component only has a view panel.
@@ -194,7 +198,7 @@ Add or update tests for:
 
 - parsing and serializing the tag
 - rendering the view component
-- toolbar title behavior when filters are hidden
+- editable toolbar title (edit-mode field, view-mode display, `getTitle` watermark)
 - editing props through `updateProps`
 - slash-menu insertion when `insertCommand` is present
 - validation errors when `validateProps` rejects invalid props

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.scss
@@ -1651,6 +1651,30 @@ h3.MarkdownNotebook__text-block--heading {
     white-space: nowrap;
 }
 
+.MarkdownNotebook__component-toolbar-title--input {
+    padding: 0.125rem 0.375rem;
+    color: var(--color-text-primary);
+    appearance: none;
+    background: transparent;
+    border: 1px solid transparent;
+    border-radius: 0.25rem;
+
+    &::placeholder {
+        color: var(--color-text-tertiary);
+        opacity: 1;
+    }
+
+    &:hover {
+        border-color: var(--color-border-primary);
+    }
+
+    &:focus,
+    &:focus-visible {
+        border-color: var(--color-accent);
+        outline: none;
+    }
+}
+
 .MarkdownNotebook__component-actions {
     flex: 0 0 auto;
 }

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -8569,6 +8569,26 @@ After component`,
         expect(onChange.mock.calls.at(-1)?.[0]).toContain('title="Weekly signups"')
     })
 
+    it('discards the title edit on Escape without persisting', () => {
+        const onChange = jest.fn()
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                value: '<Query query={{"kind":"DataTableNode","source":{"kind":"EventsQuery"}}} />',
+                onChange,
+            })
+        )
+        const titleInput = container.querySelector(
+            'input.MarkdownNotebook__component-toolbar-title--input'
+        ) as HTMLInputElement
+
+        titleInput.focus()
+        fireEvent.change(titleInput, { target: { value: 'Scratch title' } })
+        fireEvent.keyDown(titleInput, { key: 'Escape' })
+
+        expect(onChange).not.toHaveBeenCalled()
+        expect(titleInput.value).toEqual('')
+    })
+
     it('shows the saved component title read-only in view mode', () => {
         const { container } = render(
             createElement(MarkdownNotebook, {

--- a/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
+++ b/frontend/src/lib/components/MarkdownNotebook/MarkdownNotebook.test.ts
@@ -8548,31 +8548,42 @@ After component`,
         expect(container.querySelector('.MarkdownNotebook__component-preview')).toBeNull()
     })
 
-    it('shows component toolbar titles when filters are hidden', () => {
-        const { container, rerender } = render(
+    it('persists an edited component title to markdown', () => {
+        const onChange = jest.fn()
+        const { container } = render(
             createElement(MarkdownNotebook, {
-                value: '<Embed hideFilters title="PostHog docs" src="https://posthog.com/docs" />',
+                value: '<Query query={{"kind":"DataTableNode","source":{"kind":"EventsQuery"}}} />',
+                onChange,
             })
         )
-        const toolbarChildren = Array.from(
-            container.querySelector('.MarkdownNotebook__component-toolbar')?.children ?? []
-        )
+        const titleInput = container.querySelector(
+            'input.MarkdownNotebook__component-toolbar-title--input'
+        ) as HTMLInputElement
 
-        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')?.textContent).toEqual(
-            'PostHog docs'
-        )
-        expect(toolbarChildren[1].classList.contains('MarkdownNotebook__component-toolbar-title')).toBe(true)
+        expect(titleInput).toBeInstanceOf(HTMLInputElement)
+        expect(titleInput.value).toEqual('')
 
-        rerender(
-            createElement(MarkdownNotebook, {
-                value: '<Embed title="PostHog docs" src="https://posthog.com/docs" />',
-            })
-        )
+        fireEvent.change(titleInput, { target: { value: 'Weekly signups' } })
+        fireEvent.blur(titleInput)
 
-        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')).toBeNull()
+        expect(onChange.mock.calls.at(-1)?.[0]).toContain('title="Weekly signups"')
     })
 
-    it('shows component toolbar titles for single-mode components', () => {
+    it('shows the saved component title read-only in view mode', () => {
+        const { container } = render(
+            createElement(MarkdownNotebook, {
+                mode: 'view',
+                value: '<Query title="Weekly signups" query={{"kind":"DataTableNode","source":{"kind":"EventsQuery"}}} />',
+            })
+        )
+
+        expect(container.querySelector('input.MarkdownNotebook__component-toolbar-title--input')).toBeNull()
+        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')?.textContent).toEqual(
+            'Weekly signups'
+        )
+    })
+
+    it('shows the computed title as the editable title placeholder', () => {
         const registry = createMarkdownNotebookRegistry([
             {
                 tagName: 'SummaryCard',
@@ -8586,12 +8597,38 @@ After component`,
         const { container } = render(
             createElement(MarkdownNotebook, { value: '<SummaryCard id="summary-id" />', registry })
         )
+        const titleInput = container.querySelector(
+            'input.MarkdownNotebook__component-toolbar-title--input'
+        ) as HTMLInputElement
 
         expect(container.querySelector('[data-testid="summary-output"]')).toBeInstanceOf(HTMLElement)
         expect(container.querySelector('.MarkdownNotebook__component-mode-actions')).toBeNull()
-        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')?.textContent).toEqual(
-            'Cached answer summary'
+        expect(titleInput.value).toEqual('')
+        expect(titleInput.placeholder).toEqual('Cached answer summary')
+    })
+
+    it('does not suggest the query body or schema kinds as the title placeholder', () => {
+        const getPlaceholder = (): string =>
+            (container.querySelector('input.MarkdownNotebook__component-toolbar-title--input') as HTMLInputElement)
+                .placeholder
+        const { container, rerender } = render(
+            createElement(MarkdownNotebook, {
+                value: '<DuckSQL code="select * from events" returnVariable="duck_df" />',
+            })
         )
+
+        expect(getPlaceholder()).toEqual('Add a title')
+
+        rerender(
+            createElement(MarkdownNotebook, {
+                value: '<Query query={{"kind":"DataTableNode","source":{"kind":"HogQLQuery","query":"select event from events"}}} />',
+            })
+        )
+
+        const placeholder = getPlaceholder()
+        expect(placeholder).not.toContain('select')
+        expect(placeholder).not.toContain('DataTableNode')
+        expect(placeholder).toEqual('Add a title')
     })
 
     it('collapses single-mode component tags locally from the title button', () => {
@@ -8655,7 +8692,7 @@ After component`,
         expect(onChange).toHaveBeenLastCalledWith('# Intro\n\nOutro')
     })
 
-    it('does not show empty single-mode component toolbar titles', () => {
+    it('reflects the user title in the editable title field, empty by default', () => {
         const registry = createMarkdownNotebookRegistry([
             {
                 tagName: 'SummaryCard',
@@ -8666,12 +8703,15 @@ After component`,
                 ViewComponent: () => createElement('div', { 'data-testid': 'summary-output' }, 'Loading'),
             },
         ])
+        const getTitleInput = (): HTMLInputElement =>
+            container.querySelector('input.MarkdownNotebook__component-toolbar-title--input') as HTMLInputElement
         const { container, rerender } = render(
             createElement(MarkdownNotebook, { value: '<SummaryCard id="summary-id" />', registry })
         )
 
         expect(container.querySelector('[data-testid="summary-output"]')).toBeInstanceOf(HTMLElement)
-        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')).toBeNull()
+        expect(getTitleInput().value).toEqual('')
+        expect(getTitleInput().placeholder).toEqual('Add a title')
 
         rerender(
             createElement(MarkdownNotebook, {
@@ -8680,9 +8720,7 @@ After component`,
             })
         )
 
-        expect(container.querySelector('.MarkdownNotebook__component-toolbar-title')?.textContent).toEqual(
-            'Conversation title'
-        )
+        expect(getTitleInput().value).toEqual('Conversation title')
     })
 
     it('does not remount a stable component when its summary changes', () => {

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -6,6 +6,7 @@ import {
     ReactNode,
     memo,
     useMemo,
+    useRef,
     useState,
 } from 'react'
 
@@ -112,6 +113,9 @@ export function NotebookComponentShell({
         [componentPanels, showEditPanel, showViewPanel]
     )
     const [titleDraft, setTitleDraft] = useState<string | null>(null)
+    // Escape blurs the input, which fires commitTitle synchronously before the titleDraft
+    // state update lands — this ref lets commitTitle see the cancel intent in that same tick
+    const cancellingTitleRef = useRef(false)
     const titleInputValue = titleDraft ?? userTitle
     const titleContent = (
         <>
@@ -185,6 +189,10 @@ export function NotebookComponentShell({
         })
     }
     const commitTitle = (): void => {
+        if (cancellingTitleRef.current) {
+            cancellingTitleRef.current = false
+            return
+        }
         if (titleDraft === null) {
             return
         }
@@ -200,6 +208,7 @@ export function NotebookComponentShell({
             event.currentTarget.blur()
         } else if (event.key === 'Escape') {
             event.preventDefault()
+            cancellingTitleRef.current = true
             setTitleDraft(null)
             event.currentTarget.blur()
         }

--- a/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/NotebookComponentShell.tsx
@@ -90,7 +90,13 @@ export function NotebookComponentShell({
     const hasOpenComponentPanel = componentPanels.filters || componentPanels.results
     const titleDisplay = getComponentTitleDisplay(node, definition)
     const toolbarTitle = getComponentToolbarTitle(node, definition, titleDisplay.label)
-    const showToolbarTitle = !!toolbarTitle && (mode === 'view' || !componentPanels.filters || !showModeActions)
+    // The user-set title (props.title) wins; the computed contextual title is the watermark/fallback.
+    // A title equal to the component's own label (e.g. code blocks default to "Python") is treated
+    // as "no user title" so the field reads as empty by default.
+    const rawTitle = (getNotebookStringProp(node.props.title) ?? '').trim()
+    const userTitle = rawTitle && rawTitle !== titleDisplay.label ? rawTitle : ''
+    const titlePlaceholder = toolbarTitle ?? 'Add a title'
+    const resolvedTitle = userTitle || toolbarTitle || null
     const filtersLabel = componentPanels.filters ? 'Hide filters' : 'Show filters'
     const resultsLabel = componentPanels.results ? 'Hide results' : 'Show results'
     const titleClassName = clsx(
@@ -105,6 +111,8 @@ export function NotebookComponentShell({
         }),
         [componentPanels, showEditPanel, showViewPanel]
     )
+    const [titleDraft, setTitleDraft] = useState<string | null>(null)
+    const titleInputValue = titleDraft ?? userTitle
     const titleContent = (
         <>
             {titleDisplay.icon ? (
@@ -176,6 +184,26 @@ export function NotebookComponentShell({
             }
         })
     }
+    const commitTitle = (): void => {
+        if (titleDraft === null) {
+            return
+        }
+        const nextTitle = titleDraft.trim()
+        setTitleDraft(null)
+        if (nextTitle !== userTitle) {
+            updateProps({ title: nextTitle || undefined })
+        }
+    }
+    const handleTitleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+        if (event.key === 'Enter') {
+            event.preventDefault()
+            event.currentTarget.blur()
+        } else if (event.key === 'Escape') {
+            event.preventDefault()
+            setTitleDraft(null)
+            event.currentTarget.blur()
+        }
+    }
     const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
         if (mode !== 'edit' || event.target !== event.currentTarget) {
             return
@@ -206,14 +234,14 @@ export function NotebookComponentShell({
         }
     }
     const handleToolbarPointerDownCapture = (event: ReactPointerEvent<HTMLDivElement>): void => {
-        if (event.button !== 0) {
+        if (event.button !== 0 || isTitleInputTarget(event.target)) {
             return
         }
 
         event.stopPropagation()
     }
     const handleToolbarMouseDownCapture = (event: ReactMouseEvent<HTMLDivElement>): void => {
-        if (event.button !== 0) {
+        if (event.button !== 0 || isTitleInputTarget(event.target)) {
             return
         }
 
@@ -272,9 +300,20 @@ export function NotebookComponentShell({
                         </div>
                     ) : null}
                 </div>
-                {showToolbarTitle ? (
-                    <div className="MarkdownNotebook__component-toolbar-title" title={toolbarTitle}>
-                        {toolbarTitle}
+                {mode === 'edit' ? (
+                    <input
+                        className="MarkdownNotebook__component-toolbar-title MarkdownNotebook__component-toolbar-title--input"
+                        value={titleInputValue}
+                        placeholder={titlePlaceholder}
+                        aria-label="Component title"
+                        spellCheck={false}
+                        onChange={(event) => setTitleDraft(event.target.value)}
+                        onBlur={commitTitle}
+                        onKeyDown={handleTitleKeyDown}
+                    />
+                ) : resolvedTitle ? (
+                    <div className="MarkdownNotebook__component-toolbar-title" title={resolvedTitle}>
+                        {resolvedTitle}
                     </div>
                 ) : null}
                 {mode === 'edit' ? (
@@ -331,6 +370,10 @@ export function NotebookComponentShell({
             </ComponentPanelContext.Provider>
         </div>
     )
+}
+
+function isTitleInputTarget(target: EventTarget | null): boolean {
+    return target instanceof HTMLElement && !!target.closest('.MarkdownNotebook__component-toolbar-title--input')
 }
 
 export function NotebookComponentPanelErrorBoundary({

--- a/frontend/src/lib/components/MarkdownNotebook/registry.tsx
+++ b/frontend/src/lib/components/MarkdownNotebook/registry.tsx
@@ -435,7 +435,8 @@ function getEmbedComponentTitle(node: NotebookComponentBlockNode): string | null
 }
 
 function getCodeComponentTitle(node: NotebookComponentBlockNode, fallback: string): string | null {
-    return getStringProp(node.props.title) ?? summarizeText(getStringProp(node.props.code)) ?? fallback
+    // Never suggest the code/SQL body itself as a title — fall back to the language label
+    return getStringProp(node.props.title) ?? fallback
 }
 
 function getQueryComponentTitle(node: NotebookComponentBlockNode): string | null {
@@ -453,7 +454,8 @@ function getQueryComponentTitle(node: NotebookComponentBlockNode): string | null
         return getStringProp(query?.name) ?? getStringProp(query?.shortId) ?? 'Saved insight'
     }
     if (sourceKind === 'HogQLQuery') {
-        return summarizeText(getStringProp(source?.query)) ?? 'SQL query'
+        // Leave SQL queries untitled initially — never suggest the SQL body or a generic label
+        return null
     }
     if (sourceKind === 'TrendsQuery') {
         return source ? (getSeriesSummary(source) ?? 'Trend') : 'Trend'
@@ -464,8 +466,12 @@ function getQueryComponentTitle(node: NotebookComponentBlockNode): string | null
     if (sourceKind === 'EventsQuery') {
         return 'Events'
     }
+    if (sourceKind === 'ActorsQuery') {
+        return 'People'
+    }
 
-    return queryKind ?? sourceKind ?? getDefaultComponentTitle(node)
+    // Don't suggest raw schema kinds (e.g. "DataTableNode") as a title
+    return getDefaultComponentTitle(node)
 }
 
 function getSeriesSummary(query: Record<string, NotebookPropValue>): string | null {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.test.tsx
@@ -7,6 +7,7 @@ import {
     RealNotebookNodeEdit,
     getEditableNodeAttributeKeys,
     getMarkdownNodeAttributeLabel,
+    getQueryTitle,
     getSerializableAttributeInputValue,
     getSerializableProps,
 } from './markdownNotebookRegistry'
@@ -74,6 +75,25 @@ describe('markdownNotebookRegistry', () => {
         expect(getSerializableAttributeInputValue(NotebookNodeType.Group, 'groupTypeIndex', ' not-a-number ')).toEqual(
             'not-a-number'
         )
+    })
+
+    describe('getQueryTitle', () => {
+        it.each([
+            [
+                'ActorsQuery resolves to People, not the schema kind',
+                { kind: 'DataTableNode', source: { kind: 'ActorsQuery' } },
+                'People',
+            ],
+            ['EventsQuery resolves to Events', { kind: 'DataTableNode', source: { kind: 'EventsQuery' } }, 'Events'],
+            [
+                'HogQLQuery stays untitled — no SQL body, no generic label',
+                { kind: 'DataTableNode', source: { kind: 'HogQLQuery', query: 'select event from events' } },
+                null,
+            ],
+            ['an unrecognized query suggests no title rather than the raw kind', { kind: 'DataTableNode' }, null],
+        ])('%s', (_label, query, expected) => {
+            expect(getQueryTitle(query)).toEqual(expected)
+        })
     })
 
     describe('getSerializableProps', () => {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookRegistry.tsx
@@ -236,7 +236,8 @@ export function getMarkdownNotebookNodeTitle(
     }
 
     if (nodeType === NotebookNodeType.Query) {
-        return getQueryTitle(attributes.query) ?? fallback
+        // No fallback label: an unnamed/SQL query stays empty so the title field reads as "Add a title"
+        return getQueryTitle(attributes.query)
     }
     if (nodeType === NotebookNodeType.Embed) {
         return getUnknownStringProp(attributes.src) ?? fallback
@@ -254,7 +255,8 @@ export function getMarkdownNotebookNodeTitle(
         nodeType === NotebookNodeType.DuckSQL ||
         nodeType === NotebookNodeType.HogQLSQL
     ) {
-        return summarizeTitle(getUnknownStringProp(attributes.code)) ?? fallback
+        // Never suggest the code/SQL body itself as a title — fall back to the language label
+        return fallback
     }
 
     return (
@@ -291,7 +293,8 @@ export function getQueryTitle(queryValue: unknown): string | null {
         return getNotebookStringProp(query.name) ?? getNotebookStringProp(query.shortId) ?? 'Saved insight'
     }
     if (sourceKind === 'HogQLQuery') {
-        return summarizeTitle(getNotebookStringProp(source?.query)) ?? 'SQL query'
+        // Leave SQL queries untitled initially — never suggest the SQL body or a generic label
+        return null
     }
     if (sourceKind === 'TrendsQuery') {
         return source ? (getSeriesTitle(source) ?? 'Trend') : 'Trend'
@@ -302,8 +305,12 @@ export function getQueryTitle(queryValue: unknown): string | null {
     if (sourceKind === 'EventsQuery') {
         return 'Events'
     }
+    if (sourceKind === 'ActorsQuery') {
+        return 'People'
+    }
 
-    return queryKind ?? sourceKind
+    // Don't suggest raw schema kinds (e.g. "DataTableNode") as a title
+    return null
 }
 
 export function getSeriesTitle(query: Record<string, NotebookPropValue>): string | null {


### PR DESCRIPTION
## Problem

Markdown notebook component blocks (queries, SQL, code, etc.) had no way for a user to give a block a title. The toolbar only showed a computed, read-only label — and that label often surfaced unhelpful values: the raw SQL/code body, or schema internals like `DataTableNode` for a People node.

## Changes

Every markdown notebook block now has a generic, user-editable title backed by the `title` prop:

- **Edit mode** renders an inline title field in the block toolbar, watermarked with the computed contextual title (or "Add a title"). Committed on blur / Enter, Escape cancels.
- **View mode** shows the saved title read-only when set.
- A `title` equal to the block's own label (code blocks default to e.g. "Python") is treated as empty, so the field reads as empty by default.

<img width="2274" height="1558" alt="2026-06-29 11 20 36" src="https://github.com/user-attachments/assets/8c2a9a4d-df9e-4cbd-840e-6a7816be7fee" />




Title suggestions are cleaned up so we never auto-fill something unhelpful:

| Block | Before | After |
| --- | --- | --- |
| SQL query (HogQL) | the SQL body / "SQL query" | empty ("Add a title") |
| SQL / code block | the code body | empty |
| People node (ActorsQuery) | `DataTableNode` | "People" |
| Unrecognized query | raw schema kind | empty |

Recognized non-SQL queries keep their friendly labels (Events, Trend, Funnel, saved-insight name). The fix lives in both the live `markdownNotebookRegistry` path and the base `registry`, kept in sync.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). I did not manually click through the UI. Automated coverage I actually ran (all green):

- `MarkdownNotebook.test.ts` (336 tests) — updated the three tests that asserted the old read-only title, plus new tests for: editing persists to markdown, view-mode read-only display, the computed title as placeholder, empty-by-default, and that the placeholder never echoes the SQL body or `DataTableNode`.
- `markdownNotebookRegistry.test.tsx` — added a parameterized `getQueryTitle` test locking in ActorsQuery→"People", Events→"Events", HogQL→untitled, unknown→untitled.

These catch the regression that motivated the PR: title suggestions leaking SQL bodies or schema kinds, which no existing test covered.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). No repo-provided skills were needed for this change — it's a self-contained frontend feature.

Key decisions:
- **Reused the existing `title` prop** rather than inventing a new one. Every component's `getTitle` already does `props.title ?? <computed>`, so `title` was already the canonical user-title slot — it just lacked editing UI. This kept the change small and avoided a serialization/prop collision.
- **Two registries.** The product uses `markdownNotebookRegistry` (`getQueryTitle`/`getMarkdownNotebookNodeTitle`), not the base `registry`. An early fix only touched the base one and didn't take effect; both are now updated and kept consistent.
- **"Empty initially" for SQL** was implemented by returning `null` from the title computation and dropping the `?? fallback` in the Query branch, so an unnamed/SQL query stays blank instead of showing a generic label.
- Verified no insertion path writes the SQL into `props.title` (`buildNodeQueryContent` builds `{ query }` only; the classic node sets `titlePlaceholder`, never a persisted title) — the value was purely the computed suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
