### PR TITLE
fix(logs): force optimized property groups for attribute filters

### DIFF
--- a/posthog/hogql/printer/utils.py
+++ b/posthog/hogql/printer/utils.py
@@ -194,11 +194,14 @@ def prepare_ast_for_printing(
         collector.visit(node)
         context.workload = collector.get_workload()
 
-    # LOGS-cluster tables (logs, spans, metrics) store attributes in `*_map_str/_float` Map columns, not JSON blobs.
-    # Property reads only resolve to those Map columns under OPTIMIZED; otherwise they fall back to JSONExtract, which
-    # errors on a Map. Force OPTIMIZED here — after workload detection, before property resolution reads the modifier —
-    # so every caller (SQL panel, alerts, runners) is correct without each having to set it.
-    if context.workload == Workload.LOGS and context.modifiers.propertyGroupsMode is None:
+    # LOGS-cluster tables (logs, spans, metrics) split attributes across typed `*_map_str/_float/_datetime` Map columns.
+    # A type-suffixed attribute key (e.g. `host__str`) only resolves to its physical column via property groups, which
+    # are active under OPTIMIZED. Without OPTIMIZED the read falls back to a subscript on the un-suffixed `attributes`
+    # alias, where the suffixed key never matches — so `is not` filters match every row and `equals` filters match none
+    # (silently wrong, not an error). OPTIMIZED is therefore required for correctness here, not merely a perf mode, so
+    # force it for every logs query regardless of any non-OPTIMIZED value a caller may have set — after workload
+    # detection, before property resolution reads the modifier.
+    if context.workload == Workload.LOGS and context.modifiers.propertyGroupsMode != PropertyGroupsMode.OPTIMIZED:
         context.modifiers.propertyGroupsMode = PropertyGroupsMode.OPTIMIZED
 
     if context.modifiers.optimizeProjections:

--- a/products/logs/backend/test/test_logs_query_runner.py
+++ b/products/logs/backend/test/test_logs_query_runner.py
@@ -16,6 +16,7 @@ from posthog.schema import (
     LogsQuery,
     PropertyGroupFilter,
     PropertyGroupFilterValue,
+    PropertyGroupsMode,
     PropertyOperator,
 )
 
@@ -595,6 +596,55 @@ class TestLogsQueryRunner(ClickhouseTestMixin, APIBaseTest):
             }
         )
         self.assertLess(len(results), len(unfiltered["results"]))
+
+    def _run_log_attribute_filter(self, operator: PropertyOperator, mode: PropertyGroupsMode) -> list[dict]:
+        query = LogsQuery(
+            dateRange=DateRange(date_from="2025-12-14T00:00:00Z", date_to="2025-12-18T03:00:00Z"),
+            limit=2000,
+            serviceNames=[],
+            severityLevels=[],
+            filterGroup=PropertyGroupFilter(
+                type=FilterLogicalOperator.AND_,
+                values=[
+                    PropertyGroupFilterValue(
+                        type=FilterLogicalOperator.AND_,
+                        values=[
+                            LogPropertyFilter(
+                                key="logtag",
+                                operator=operator,
+                                type=LogPropertyFilterType.LOG_ATTRIBUTE,
+                                value=["F"],
+                            ),
+                        ],
+                    )
+                ],
+            ),
+            kind="LogsQuery",
+        )
+        runner = LogsQueryRunner(query=query, team=self.team)
+        # Simulate a logs query path that reaches the printer with a non-OPTIMIZED mode (the logs-cluster
+        # path this regression covers). The printer must still force OPTIMIZED so the filter resolves the
+        # type-suffixed key against the typed `attributes_map_str` column instead of the un-suffixed alias.
+        runner.modifiers.propertyGroupsMode = mode
+        return runner.calculate().results
+
+    @parameterized.expand([(PropertyGroupsMode.OPTIMIZED,), (PropertyGroupsMode.DISABLED,)])
+    @freeze_time("2025-12-18T03:00:00Z")
+    def test_log_attribute_filter_resolves_regardless_of_property_groups_mode(self, mode: PropertyGroupsMode):
+        # The seed data has 1000 logs with logtag="F" and 11 without. A log-attribute filter must resolve the
+        # type-suffixed key (logtag__str) to its physical Map column for every property-groups mode — otherwise an
+        # `is not` filter matches every row (does nothing) and an `exact` filter matches none, which is the silent
+        # mis-filtering this regression guards against. DISABLED is the mode that fails without the printer's forced
+        # OPTIMIZED; OPTIMIZED is the control.
+        is_not_results = self._run_log_attribute_filter(PropertyOperator.IS_NOT, mode)
+        # The "is not F" filter must actually exclude the 1000 logtag="F" rows — not pass them through.
+        self.assertTrue(all(r["attributes"].get("logtag") != "F" for r in is_not_results))
+        self.assertEqual(len(is_not_results), 11)
+
+        exact_results = self._run_log_attribute_filter(PropertyOperator.EXACT, mode)
+        # The "= F" filter must match the 1000 logtag="F" rows — not return nothing.
+        self.assertTrue(all(r["attributes"].get("logtag") == "F" for r in exact_results))
+        self.assertEqual(len(exact_results), 1000)
 
     @freeze_time("2025-12-16T10:33:00Z")
     def test_resource_negative_attribute_filters(self):


### PR DESCRIPTION
## Problem

A logs attribute filter was reported as no longer filtering: applying `host ≠ <value>` (an "is not" filter) still returned rows where `host` equaled that value. It isn't specific to `host` — it affects every log-attribute filter, in both directions: `is not` matches every row (does nothing), while `equals`/`contains` match none.

Root cause: log-attribute filters build a type-suffixed key (e.g. `host__str`) that only resolves to the physical `attributes_map_str` Map column through property groups, which are active under `OPTIMIZED` property-groups mode. When a logs query reaches property resolution in any non-`OPTIMIZED` mode, the read falls back to a subscript on the un-suffixed `attributes` alias (`mapApply((k, v) -> (left(k, -5), v), attributes_map_str)`), where the suffixed key never matches → `NULL` → `ifNull(notEquals(NULL, …), 1) = 1`, so the `is not` predicate is vacuously true for every row.

This turned silent on 2026-06-23 (#65450): the non-optimized path previously printed `JSONExtract` on a Map column, which errored loudly; afterwards it reads a Map subscript and returns wrong results instead. #65383 mitigated it by forcing `OPTIMIZED` for logs queries, but only when the mode was unset (`None`) — a query arriving with an explicit non-`OPTIMIZED` mode still slipped through.

## Changes

Force `OPTIMIZED` for every logs/observability query at the printer chokepoint, for any non-`OPTIMIZED` mode value — not just when the mode is unset. `OPTIMIZED` is required for correctness on the `logs`/`spans`/`metrics` tables (their attributes live in typed `*_map_str/_float/_datetime` Map columns reachable only via property groups), so this is a correctness guarantee, not a perf tweak. The guard is `workload == Workload.LOGS`, so events/persons queries are unaffected.

## How did you test this code?

I'm an agent (PostHog Code); I did not manually exercise the UI. Automated tests only:

- Added a parameterized regression test in `test_logs_query_runner.py` that runs a log-attribute filter end-to-end against ClickHouse with the property-groups mode forced. With the seed data (1000 `logtag=F` rows, 11 without): `is not "F"` must return the 11, `= "F"` must return the 1000. I verified it **fails without this fix** (the `disabled` case returns all 1011 / 0 respectively) and **passes with it** — so it catches the regression rather than just documenting current behavior.
- Ran the surrounding suites green: `test_logs_query_runner.py`, `test_logs_sql_panel.py`, `test_alert_check_query.py` (155 passed) plus the full HogQL printer suite (721 passed, 186 snapshots) to confirm the shared printer change leaves non-logs queries untouched.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and implemented with PostHog Code (Claude Opus). Most of the effort was diagnosis: I printed the actual generated ClickHouse SQL for `is not` / `equals` / `not contains` log-attribute filters in both `OPTIMIZED` and `DISABLED` modes, seeded rows, and ran the queries end-to-end to confirm the exact mis-filtering and isolate it to the property-groups mode — the generated SQL differs only in whether it reads `attributes_map_str['host__str']` (correct) or `attributes['host__str']` against the un-suffixed alias (never matches).

Weighed three fixes: (1) make the non-optimized fallback strip/route the type suffix — rejected, because float/datetime attributes aren't present in the un-suffixed `attributes` alias at all, so correct resolution is impossible without property groups; (2) make the fallback fail loudly — rejected as it becomes unreachable dead code once `OPTIMIZED` is forced; (3) force `OPTIMIZED` for all logs queries — chosen, the minimal change that matches the existing intent of #65383 and guarantees correctness. No repo skills shaped the change itself.

Reviewer caveat: the guard is `workload == Workload.LOGS`. If workload detection ever fails to tag a logs query, the fix won't trigger — pre-existing and unlikely (the tables declare `workload = Workload.LOGS`), but worth knowing.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
