### PR TITLE
chore(tasks): remove burstable sandbox resources flag

### DIFF
--- a/products/tasks/backend/constants.py
+++ b/products/tasks/backend/constants.py
@@ -3,7 +3,6 @@ from typing import Literal, get_args
 SANDBOX_EVENT_INGEST_FEATURE_FLAG = "tasks-cloud-runs-sandbox-event-ingest"
 MODAL_VM_SANDBOX_FEATURE_FLAG = "tasks-modal-vm-sandbox"
 MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG = "tasks-modal-network-allowlist"
-BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG = "tasks-burstable-sandbox-resources"
 STREAM_VIA_PROXY_FEATURE_FLAG = "tasks-stream-via-proxy"
 
 ClaudePermissionMode = Literal["default", "acceptEdits", "plan", "bypassPermissions", "auto"]

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -12,7 +12,6 @@ from posthog.models import Team
 from posthog.temporal.common.utils import asyncify, close_db_connections
 
 from products.tasks.backend.constants import (
-    BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG,
     MODAL_NETWORK_ALLOWLIST_FEATURE_FLAG,
     MODAL_VM_SANDBOX_FEATURE_FLAG,
     SANDBOX_EVENT_INGEST_FEATURE_FLAG,
@@ -74,9 +73,6 @@ class TaskProcessingContext:
     sandbox_event_ingest_enabled: bool = False
     use_modal_vm_sandbox: bool = False
     use_modal_network_allowlist: bool = False
-    # Captured at workflow start so the provisioned box's resource request is stable across
-    # activity retries (a mid-run flag flip can't change a live sandbox's resources anyway).
-    burstable_sandbox_resources_enabled: bool = False
 
     @property
     def mode(self) -> str:
@@ -313,45 +309,6 @@ def _is_modal_vm_sandbox_enabled(
     return result
 
 
-def _is_burstable_sandbox_resources_enabled(
-    *,
-    distinct_id: str,
-    organization_id: str,
-    run_id: str,
-    state: dict | None = None,
-) -> bool:
-    state_override = (state or {}).get("burstable_sandbox_resources_enabled")
-    if isinstance(state_override, bool):
-        log_with_activity_context(
-            "burstable_sandbox_resources_state_override",
-            run_id=run_id,
-            burstable_sandbox_resources_enabled=state_override,
-        )
-        return state_override
-
-    try:
-        enabled = bool(
-            posthoganalytics.feature_enabled(
-                BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG,
-                distinct_id=distinct_id,
-                groups={"organization": organization_id},
-                group_properties={"organization": {"id": organization_id}},
-                only_evaluate_locally=False,
-                send_feature_flag_events=False,
-            )
-        )
-    except Exception as e:
-        log_with_activity_context("burstable_sandbox_resources_flag_check_failed", run_id=run_id, error=str(e))
-        return False
-
-    log_with_activity_context(
-        "burstable_sandbox_resources_flag_checked",
-        run_id=run_id,
-        burstable_sandbox_resources_enabled=enabled,
-    )
-    return enabled
-
-
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -517,17 +474,6 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"use_modal_network_allowlist: {use_modal_network_allowlist} for this task run",
     )
-    burstable_sandbox_resources_enabled = _is_burstable_sandbox_resources_enabled(
-        distinct_id=distinct_id,
-        organization_id=organization_id,
-        run_id=run_id,
-        state=state,
-    )
-    emit_agent_log(
-        run_id,
-        "debug",
-        f"burstable_sandbox_resources_enabled: {burstable_sandbox_resources_enabled} for this task run",
-    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -559,5 +505,4 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
-        burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/get_task_processing_context.py
@@ -73,6 +73,9 @@ class TaskProcessingContext:
     sandbox_event_ingest_enabled: bool = False
     use_modal_vm_sandbox: bool = False
     use_modal_network_allowlist: bool = False
+    # Burstable by default; the per-run state can opt out to pin a fixed-size box
+    # (request == limit). Captured at workflow start so it's stable across activity retries.
+    burstable_sandbox_resources_enabled: bool = True
 
     @property
     def mode(self) -> str:
@@ -309,6 +312,23 @@ def _is_modal_vm_sandbox_enabled(
     return result
 
 
+def _is_burstable_sandbox_resources_enabled(
+    *,
+    run_id: str,
+    state: dict | None = None,
+) -> bool:
+    # Burstable by default; the per-run state can pin a fixed-size box (request == limit).
+    state_override = (state or {}).get("burstable_sandbox_resources_enabled")
+    if isinstance(state_override, bool):
+        log_with_activity_context(
+            "burstable_sandbox_resources_state_override",
+            run_id=run_id,
+            burstable_sandbox_resources_enabled=state_override,
+        )
+        return state_override
+    return True
+
+
 def _is_modal_network_allowlist_enabled(
     *,
     distinct_id: str,
@@ -474,6 +494,15 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         "debug",
         f"use_modal_network_allowlist: {use_modal_network_allowlist} for this task run",
     )
+    burstable_sandbox_resources_enabled = _is_burstable_sandbox_resources_enabled(
+        run_id=run_id,
+        state=state,
+    )
+    emit_agent_log(
+        run_id,
+        "debug",
+        f"burstable_sandbox_resources_enabled: {burstable_sandbox_resources_enabled} for this task run",
+    )
     user_github_integration_id = str(task.github_user_integration_id) if task.github_user_integration_id else None
     if user_github_integration_id is None and get_pr_authorship_mode(task, state).value == "user":
         user_github_integration = resolve_user_github_integration_for_task(task, allow_refresh=False)
@@ -505,4 +534,5 @@ def get_task_processing_context(input: GetTaskProcessingContextInput) -> TaskPro
         sandbox_event_ingest_enabled=sandbox_event_ingest_enabled,
         use_modal_vm_sandbox=use_modal_vm_sandbox,
         use_modal_network_allowlist=use_modal_network_allowlist,
+        burstable_sandbox_resources_enabled=burstable_sandbox_resources_enabled,
     )

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -416,15 +416,19 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             **ctx.sandbox_resource_overrides(),
         )
 
-        # Request a small slice and let the box burst up to the configured size.
-        config.burstable_resources = True
-        emit_agent_log(
-            ctx.run_id,
-            "debug",
-            f"Burstable resources: requesting {config.cpu_request_cores} CPU / "
-            f"{config.memory_request_mb} MiB, bursting up to {config.cpu_cores} CPU / "
-            f"{int(config.memory_gb * 1024)} MiB",
-        )
+        # Request a small slice and let the box burst up to the configured size. Burstable by
+        # default, but the per-run state can opt out to pin a fixed-size box (request == limit).
+        # The decision is captured once in the context at workflow start, so it's stable across
+        # activity retries.
+        if ctx.burstable_sandbox_resources_enabled:
+            config.burstable_resources = True
+            emit_agent_log(
+                ctx.run_id,
+                "debug",
+                f"Burstable resources enabled: requesting {config.cpu_request_cores} CPU / "
+                f"{config.memory_request_mb} MiB, bursting up to {config.cpu_cores} CPU / "
+                f"{int(config.memory_gb * 1024)} MiB",
+            )
 
         # gVisor only — Modal's domain allowlist breaks vm_runtime.
         if ctx.use_modal_network_allowlist and not use_vm_sandbox and ctx.allowed_domains is not None:

--- a/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
+++ b/products/tasks/backend/temporal/process_task/activities/provision_sandbox.py
@@ -416,17 +416,15 @@ def create_sandbox_for_repository(input: CreateSandboxForRepositoryInput) -> Cre
             **ctx.sandbox_resource_overrides(),
         )
 
-        # Request a small slice and let the box burst up to the configured size. The decision is
-        # captured once in the context at workflow start, so it's stable across activity retries.
-        if ctx.burstable_sandbox_resources_enabled:
-            config.burstable_resources = True
-            emit_agent_log(
-                ctx.run_id,
-                "debug",
-                f"Burstable resources enabled: requesting {config.cpu_request_cores} CPU / "
-                f"{config.memory_request_mb} MiB, bursting up to {config.cpu_cores} CPU / "
-                f"{int(config.memory_gb * 1024)} MiB",
-            )
+        # Request a small slice and let the box burst up to the configured size.
+        config.burstable_resources = True
+        emit_agent_log(
+            ctx.run_id,
+            "debug",
+            f"Burstable resources: requesting {config.cpu_request_cores} CPU / "
+            f"{config.memory_request_mb} MiB, bursting up to {config.cpu_cores} CPU / "
+            f"{int(config.memory_gb * 1024)} MiB",
+        )
 
         # gVisor only — Modal's domain allowlist breaks vm_runtime.
         if ctx.use_modal_network_allowlist and not use_vm_sandbox and ctx.allowed_domains is not None:

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -8,17 +8,12 @@ from asgiref.sync import async_to_sync
 from posthog.models import OrganizationMembership, User
 from posthog.models.user_integration import UserIntegration
 
-from products.tasks.backend.constants import (
-    BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG,
-    MODAL_VM_SANDBOX_FEATURE_FLAG,
-    SANDBOX_EVENT_INGEST_FEATURE_FLAG,
-)
+from products.tasks.backend.constants import MODAL_VM_SANDBOX_FEATURE_FLAG, SANDBOX_EVENT_INGEST_FEATURE_FLAG
 from products.tasks.backend.exceptions import TaskInvalidStateError, TaskRunNotReadyError
 from products.tasks.backend.models import SandboxEnvironment, Task
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
-    _is_burstable_sandbox_resources_enabled,
     _is_modal_vm_sandbox_enabled,
     _is_sandbox_event_ingest_enabled,
     _vm_sandbox_allowed_origin_products,
@@ -493,68 +488,6 @@ class TestGetTaskProcessingContextActivity:
     )
     def test_vm_sandbox_allowed_origin_products_parsing(self, payload, expected):
         assert _vm_sandbox_allowed_origin_products(payload) == expected
-
-    @pytest.mark.parametrize(
-        "flag_value,expected",
-        [
-            (True, True),
-            (False, False),
-            (None, False),
-        ],
-    )
-    def test_burstable_sandbox_resources_flag_uses_organization_rollout(self, flag_value, expected):
-        with patch(
-            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-            return_value=flag_value,
-        ) as feature_enabled_mock:
-            assert (
-                _is_burstable_sandbox_resources_enabled(
-                    distinct_id="distinct-id",
-                    organization_id="organization-id",
-                    run_id="run-id",
-                )
-                is expected
-            )
-
-        feature_enabled_mock.assert_called_once_with(
-            BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG,
-            distinct_id="distinct-id",
-            groups={"organization": "organization-id"},
-            group_properties={"organization": {"id": "organization-id"}},
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
-        )
-
-    def test_burstable_sandbox_resources_flag_fails_closed(self):
-        with patch(
-            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-            side_effect=RuntimeError("flag service failed"),
-        ):
-            assert (
-                _is_burstable_sandbox_resources_enabled(
-                    distinct_id="distinct-id",
-                    organization_id="organization-id",
-                    run_id="run-id",
-                )
-                is False
-            )
-
-    def test_burstable_sandbox_resources_state_override_skips_flag_check(self):
-        with patch(
-            "products.tasks.backend.temporal.process_task.activities.get_task_processing_context.posthoganalytics.feature_enabled",
-            return_value=True,
-        ) as feature_enabled_mock:
-            assert (
-                _is_burstable_sandbox_resources_enabled(
-                    distinct_id="distinct-id",
-                    organization_id="organization-id",
-                    run_id="run-id",
-                    state={"burstable_sandbox_resources_enabled": False},
-                )
-                is False
-            )
-
-        feature_enabled_mock.assert_not_called()
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_uses_sandbox_event_ingest_state_override(

--- a/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
+++ b/products/tasks/backend/temporal/process_task/activities/tests/test_get_task_processing_context.py
@@ -14,6 +14,7 @@ from products.tasks.backend.models import SandboxEnvironment, Task
 from products.tasks.backend.temporal.process_task.activities.get_task_processing_context import (
     GetTaskProcessingContextInput,
     TaskProcessingContext,
+    _is_burstable_sandbox_resources_enabled,
     _is_modal_vm_sandbox_enabled,
     _is_sandbox_event_ingest_enabled,
     _vm_sandbox_allowed_origin_products,
@@ -488,6 +489,18 @@ class TestGetTaskProcessingContextActivity:
     )
     def test_vm_sandbox_allowed_origin_products_parsing(self, payload, expected):
         assert _vm_sandbox_allowed_origin_products(payload) == expected
+
+    @pytest.mark.parametrize(
+        "state,expected",
+        [
+            (None, True),
+            ({}, True),
+            ({"burstable_sandbox_resources_enabled": True}, True),
+            ({"burstable_sandbox_resources_enabled": False}, False),
+        ],
+    )
+    def test_burstable_sandbox_resources_defaults_true_and_respects_state(self, state, expected):
+        assert _is_burstable_sandbox_resources_enabled(run_id="run-id", state=state) is expected
 
     @pytest.mark.django_db(transaction=True)
     def test_get_task_processing_context_uses_sandbox_event_ingest_state_override(


### PR DESCRIPTION
## Problem

The `tasks-burstable-sandbox-resources` flag is fully rolled out to everyone, so the flag gate around burstable sandbox resources is now dead weight. Make burstable the default and remove the flag plumbing — while keeping a per-run escape hatch so a run can still be pinned to a fixed-size box.

## Changes

- Removed `BURSTABLE_SANDBOX_RESOURCES_FEATURE_FLAG` and the `posthoganalytics.feature_enabled` check.
- Burstable sandbox resources are now the **default**. The per-run `state` can still opt out (`burstable_sandbox_resources_enabled: false`) to pin a fixed-size box where request == limit; when unset, it defaults to `true`.
- `TaskProcessingContext.burstable_sandbox_resources_enabled` now defaults to `True`, resolved purely from run state.
- Swapped the flag-rollout tests for tests covering the default and the state opt-out. The `SandboxConfig` burstable *mechanism* tests in `test_modal_sandbox.py` are untouched.

The flag itself is left live in PostHog for now — once this merges it no longer controls anything, so it's safe to delete there afterward.

## How did you test this code?

I'm an agent. I ran `ruff check` / `ruff format` on the touched files (clean). I did **not** run the Python test suite — the toolchain wasn't available in my environment. No manual testing performed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: clean up the rolled-out burstable-resources flag and make the behavior default. A follow-up clarified that the per-run state override must be respected (request and burst should sometimes match), defaulting to `true` when unset — so the feature-flag check was removed but the state-driven opt-out was kept. Authored by the PostHog Slack app.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09SK2PAGKF/p1782725669360049?thread_ts=1782725669.360049&cid=C09SK2PAGKF)*
