### PR TITLE
feat(mcp): add amp-mcp-client and Poke to CLI mode clients

### DIFF
--- a/services/mcp/src/lib/client-detection.ts
+++ b/services/mcp/src/lib/client-detection.ts
@@ -82,6 +82,12 @@ export const CODING_AGENT_CLIENT_NAME_FRAGMENTS = [
     // `clientInfo.name` as `opencode`. It renders text, not MCP Apps UI, so it
     // wants single-exec mode like the other coding agents.
     'opencode',
+    // Amp is Sourcegraph's coding agent; its MCP client self-reports
+    // `clientInfo.name` as `amp-mcp-client` and benefits from single-exec mode.
+    'amp-mcp-client',
+    // Poke is an LLM-driven assistant that renders text, not MCP Apps UI, so it
+    // wants the same single-exec mode as the coding agents.
+    'poke',
 ] as const
 
 // Known `x-anthropic-client` (`vendorClient`) header values. Anthropic pools

--- a/services/mcp/tests/unit/client-detection.test.ts
+++ b/services/mcp/tests/unit/client-detection.test.ts
@@ -34,6 +34,8 @@ describe('isCliModeEnabledClient', () => {
             ['librechat'],
             ['notion'],
             ['opencode'],
+            ['amp-mcp-client'],
+            ['poke'],
         ])('returns true for %s', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })
@@ -59,6 +61,8 @@ describe('isCliModeEnabledClient', () => {
             ['Devin'],
             ['OpenCode'],
             ['opencode/1.2.3'],
+            ['Amp MCP Client'],
+            ['Poke'],
         ])('returns true for variant %s (case-insensitive substring match)', (clientName) => {
             expect(isCliModeEnabledClient(clientName)).toBe(true)
         })


### PR DESCRIPTION
## Problem

Amp (Sourcegraph's coding agent) and Poke are LLM-driven MCP clients that render formatted text rather than MCP Apps UI. They should run in the same single-exec CLI mode as the other coding agents, but weren't being detected as such.

## Changes

Added `amp-mcp-client` and `poke` to `CODING_AGENT_CLIENT_NAME_FRAGMENTS` in `services/mcp/src/lib/client-detection.ts`, so both clients resolve to CLI (single-exec) mode. Extended the parameterized detection tests to cover the exact fragments and realistic case-insensitive variants.

## How did you test this code?

I'm an agent. I added cases to the existing `client-detection` unit tests and ran them: `npx vitest run tests/unit/client-detection.test.ts` → 183 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested by Georgiy Tarasov via Slack: add `amp-mcp-client` and `Poke` to the MCP CLI-mode client list. Both were appended to the existing coding-agent fragment list (matched as normalized, case-insensitive substrings), alongside short rationale comments matching the surrounding entries. `Poke` was lowercased to `poke` to match the list's convention since matching is case-insensitive. No skills were applicable.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1782726113545029)*
