### PR TITLE
feat(replay-vision): cut signal false positives (bar, masking, fps)

### DIFF
--- a/products/replay_vision/backend/temporal/scanners/base.py
+++ b/products/replay_vision/backend/temporal/scanners/base.py
@@ -1,12 +1,17 @@
 """Base class for all Replay Vision scanner types."""
 
+import re
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Annotated, Any, ClassVar, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from products.replay_vision.backend.temporal.scanners.prompt_env import render_prompt
+
+# `(t 123)` / `(t 123, t 456)` citation markers the model leaks into the plain-text signal description despite the
+# prompt forbidding them. Matched leniently (whitespace, comma-joined times) so the strip catches every variant.
+_SIGNAL_TIMESTAMP_MARKER_RE = re.compile(r"\s*\(\s*t\s*\d+(?:\s*,\s*t?\s*\d+)*\s*\)")
 
 
 # Sited here rather than `temporal/types.py`: `types.py` imports from this module, so siting Segment in types.py would close the cycle.
@@ -56,8 +61,9 @@ class SignalFinding(BaseModel, frozen=True):
             "Actionable prose a reader with no session context can act on. Lead with what you saw on screen that "
             "reveals the issue — the visual detail the events don't capture (e.g. a spinner overlapping a button, an "
             "error toast that flashed off-screen, a layout shift, visible hesitation). Then say what happened, where "
-            "in the product, and the user impact. Quote exact on-screen labels and button text when visible. Use "
-            "plain prose. Do not use `(t …)` citation markers — this is a signal field, not a cited summary."
+            "in the product, and the user impact. Quote exact on-screen labels and button text when visible. Plain "
+            "prose with no timestamp references — no `(t …)` markers, no `REC_T`, no 'at N seconds', no event IDs; "
+            "the timing lives in `start_time`/`end_time`."
         )
     )
     confidence: float = Field(
@@ -65,6 +71,14 @@ class SignalFinding(BaseModel, frozen=True):
         le=1,
         description="Calibrated confidence that this is a real, actionable issue. Apply the calibration rules.",
     )
+
+    @field_validator("description", mode="after")
+    @classmethod
+    def _strip_timestamp_markers(cls, value: str) -> str:
+        # The model leaks `(t 123)` markers into this embedded, free-text-searchable field despite the prompt — strip
+        # them so the timing stays only in start_time/end_time and the prose reads cleanly. Collapse any double space
+        # the removal (or the model) leaves so the prose stays clean.
+        return re.sub(r"\s{2,}", " ", _SIGNAL_TIMESTAMP_MARKER_RE.sub("", value)).strip()
 
 
 class SignalsResponse(BaseModel, frozen=True):

--- a/products/replay_vision/backend/temporal/scanners/prompts/preamble.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/preamble.jinja
@@ -1,8 +1,12 @@
 You're analyzing a recorded user session from {{ team_name }}. Ground every claim in direct evidence — a specific moment in the video, or an analytics event; when evidence is ambiguous or absent, lower `confidence` and say so. Prefer admitting uncertainty over fabricating detail.
 
 <video>
-The video plays at 8× speed with inactive periods cut — time jumps in the video correspond to those cuts. A footer at the bottom of every frame shows the current page `URL:` and `REC_T:` — the whole number of seconds since the recording started.
+The video plays at normal speed but at a low frame rate (about 3 frames per second), so motion looks choppy and brief states can flash by or be skipped between frames — don't mistake low-framerate choppiness (a cursor jumping, a tooltip appearing in different spots, a half-drawn frame) for a rendering glitch. Inactive periods are cut, so time can jump forward. A footer at the bottom of every frame shows the current page `URL:` and `REC_T:` — the whole number of seconds since the recording started; judge how long something lasted from `REC_T`, not from how fast it looks on screen.
 </video>
+
+<masking>
+Session Replay hides privacy-sensitive content before it is recorded. Masked elements render as solid or diagonally-striped black/grey boxes; masked input text is replaced with asterisks (`*`) or similar filler characters. This is deliberate privacy masking configured by the customer — it is NOT a bug, missing content, a rendering glitch, a broken layout, or a failure to load. Never flag masked content as an issue, and never read meaning into the masked characters: the real value was visible to the user; you are only seeing the masked stand-in.
+</masking>
 
 <events_tool>
 You have a tool, `get_events_around`: pass a footer `REC_T` and it returns the events within a few seconds of that moment, each tagged with its own `rec_t`. Fields include `event`, `$current_url`, `$event_type`, `elements_chain_*` (what was interacted with), and `$exception_types`/`$exception_values`.

--- a/products/replay_vision/backend/temporal/scanners/prompts/signals_step.jinja
+++ b/products/replay_vision/backend/temporal/scanners/prompts/signals_step.jinja
@@ -1,7 +1,12 @@
-One more pass — a different job from the work above. Watch for product issues that hurt the user — a bug, a crash, or a design flaw that clearly blocked or slowed them — and put each in the `signals` list.
+One more pass — a different job from the work above. You're looking for a genuine product defect this recording caught: a bug, a crash, or a design flaw that clearly broke or blocked the user. Put each in the `signals` list. The default is an empty list, and for most recordings that is the correct answer.
 
-What makes a finding belong here is that you *saw* it: the visual observation drives it — a spinner overlapping the button, a broken layout, an error toast that flashed, a visible hesitation before a click. The `description` must lead with that on-screen detail. If you can't point to something you saw, don't list it.
+The bar is deliberately high. Report a finding only when ALL of these hold:
+- **You can point to the exact thing on screen that reveals it** — a real error state, a crash, a broken or overlapping layout, a control that visibly does nothing when used. If you are inferring it, guessing, or it could be normal behavior, leave it out.
+- **It materially hurt the user** — it blocked, broke, or derailed what they were doing. Ordinary slowness, a brief spinner, a loading state that resolves, an empty-state that fills a moment later, or anything you would merely design better are NOT findings.
+- **An engineer opening this recording at that `REC_T` would unambiguously agree it is a defect.** If there is any real chance you are wrong, do not report it — a missed issue is far better than an invented one.
 
-Corroboration from the event log *raises* your confidence — call `get_events_around` at the moment of a finding to look for an `$exception`, a failed request, or a `$rageclick`/`$dead_click` at that `REC_T` that backs up what you saw. But the finding has to stand on the visual: never report an issue you only know about from the events, with nothing on screen to show for it.
+What makes a finding belong here is that you *saw* it: the `description` must lead with the on-screen detail. Corroboration from the event log *raises* your confidence — call `get_events_around` at the finding's `REC_T` to confirm an `$exception`, a failed request, or a `$rageclick`/`$dead_click` backs up what you saw — but never report an issue you only know about from the events.
 
-One recording can surface several distinct issues; list each separately. The bar is high — most sessions have nothing worth flagging, so `signals` is usually empty. Don't repeat the earlier turns' conclusions. Skip anything below {{ min_signal_confidence }} confidence.
+Write the `description` as plain prose with no timestamp references — no `(t …)` markers, no `REC_T`, no "at N seconds", no event IDs. The timing belongs in `start_time` and `end_time`, not the text.
+
+One recording can surface more than one distinct defect; list each separately. Don't repeat the earlier turns' conclusions. Skip anything below {{ min_signal_confidence }} confidence.

--- a/products/replay_vision/backend/tests/test_scanners.py
+++ b/products/replay_vision/backend/tests/test_scanners.py
@@ -78,6 +78,13 @@ class TestPreamble:
         assert "session from Acme" in rendered
         assert "REC_T" in rendered
 
+    def test_preamble_explains_privacy_masking(self) -> None:
+        # The model must not flag masked content (striped boxes / asterisks) as a bug or missing content.
+        rendered = scanner_from_db(_build_replay_scanner()).preamble(team_name="Acme")
+        assert "<masking>" in rendered
+        assert "asterisks" in rendered
+        assert "not a bug" in rendered.lower()
+
     def test_preamble_exposes_events_via_tool_not_inline(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner())
         rendered = scanner.preamble(team_name="Acme")
@@ -716,17 +723,40 @@ class TestSignalSideMission:
         scanner = scanner_from_db(_build_replay_scanner(emits_signals=emits_signals))
         assert (_signals_step(scanner) is not None) == expected
 
-    def test_signals_step_is_visual_driven_with_event_corroboration(self) -> None:
+    def test_signals_step_sets_a_high_visual_evidence_bar(self) -> None:
         scanner = scanner_from_db(_build_replay_scanner(emits_signals=True))
         step = _signals_step(scanner)
         assert step is not None
         instruction = step.instruction
-        # The visual observation drives the finding; a finding with no on-screen basis is excluded.
-        assert "the visual observation drives it" in instruction
-        assert "If you can't point to something you saw, don't list it." in instruction
-        # Event corroboration RAISES confidence — it is not a basis for exclusion.
+        # Default-empty + a deliberately high bar with three gates: exact on-screen proof, material harm, certainty.
+        assert "The default is an empty list" in instruction
+        assert "The bar is deliberately high" in instruction
+        assert "materially hurt the user" in instruction
+        assert "unambiguously agree it is a defect" in instruction
+        # Low-severity noise is explicitly excluded.
+        assert "Ordinary slowness" in instruction
+        # The finding must stand on the visual; corroboration RAISES confidence but pure event-restatement is excluded.
         assert "Corroboration from the event log *raises* your confidence" in instruction
-        # Only pure event-restatement (no visual) is excluded.
         assert "an issue you only know about from the events" in instruction
+        # No timestamp references in the description text.
+        assert "no timestamp references" in instruction
         # Old event-steering must stay gone.
         assert "name the specific events and their sequence" not in instruction
+
+    @pytest.mark.parametrize(
+        "raw, clean",
+        [
+            ("The error toast fired (t 844) and blocked checkout", "The error toast fired and blocked checkout"),
+            ("Clicked ten times (t 39, t 57) before it responded", "Clicked ten times before it responded"),
+            (
+                "Comma-joined without the second t (t 39, 57) still strips",
+                "Comma-joined without the second t still strips",
+            ),
+            ("Failed twice (t 844) then again (t 862) on /cart", "Failed twice then again on /cart"),
+            ("No markers here at all", "No markers here at all"),
+        ],
+    )
+    def test_signal_description_strips_leaked_timestamp_markers(self, raw: str, clean: str) -> None:
+        # The description is embedded for free-text search, so leaked `(t …)` markers must never reach it.
+        signal = SignalFinding.model_validate({**self._VALID_SIGNAL, "description": raw})
+        assert signal.description == clean


### PR DESCRIPTION
## Problem

The signal side-mission emitted too many low-quality findings — trivial friction and confident non-issues, including privacy-masked content (striped boxes / asterisks) read as bugs and low-framerate choppiness read as rendering failures. The preamble also mislabeled the video as 8× speed when it plays at normal speed at ~3 fps.

## Changes

- Raise the side-mission bar: on-screen proof + material harm + certainty; default empty list.
- `<masking>` preamble block: masked content is intentional, not a defect.
- Correct the playback description to normal speed ~3 fps; judge duration from the footer `REC_T`.
- Strip leaked `(t …)` markers from the embedded signal description.

No schema or migration changes; persisted output shape unchanged.

## How did you test this code?

Agent-authored. 80 automated tests, plus an offline A/B on recent production observations (~−50% signal volume; masked-content and low-framerate false-positive classes eliminated). Not yet validated on live signal quality.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Built with Claude Code.