### PR TITLE
feat(signals): frame report scouts' report: key as an inbox pointer

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -246,9 +246,9 @@ main failure mode here, so the discipline is **search, then decide**:
 
 - **Search first, every time.** Before authoring anything, call
   `inbox-reports-list` (filter/search by the entity, error, or topic you're about
-  to report on) and read the closest matches with `inbox-reports-retrieve`. Keep a
-  `report:<domain>:<entity>` scratchpad entry per report you author so future runs
-  find it even when the inbox phrasing has drifted.
+  to report on) and read the closest matches with `inbox-reports-retrieve` — plus
+  your `report:<domain>:<entity>` scratchpad pointer from a prior run (see *The
+  `report:` scratchpad entry is a pointer*).
 - **Edit when it already exists.** If a report covers the issue, prefer
   `signals-scout-edit-report`: `append_note` to add your fresh evidence (additive,
   audit-friendly, and works on any report — even one you didn't author), or
@@ -268,9 +268,9 @@ main failure mode here, so the discipline is **search, then decide**:
 
 - **Search first, every time.** Before authoring anything, call
   `inbox-reports-list` (filter/search by the entity, error, or topic you're about
-  to report on) and read the closest matches with `inbox-reports-retrieve`. Keep a
-  `report:<domain>:<entity>` scratchpad entry per report you author so future runs
-  find it even when the inbox phrasing has drifted.
+  to report on) and read the closest matches with `inbox-reports-retrieve` — plus
+  your `report:<domain>:<entity>` scratchpad pointer from a prior run (see *The
+  `report:` scratchpad entry is a pointer*).
 - **Don't duplicate an existing report.** This run can't edit reports, so if one
   already covers the issue, leave it alone — record a `remember(...)` note and
   skip rather than authoring a near-duplicate.
@@ -295,6 +295,28 @@ report your evidence bears on, then keep it current:
 - **Don't retry blindly.** `edit_report` is NOT idempotent — a retried
   `append_note` appends a second note. If unsure whether an edit landed, re-read
   the report rather than re-sending."""
+
+_REPORT_SCRATCHPAD_POINTER = """# The `report:` scratchpad entry is a pointer, not a copy
+
+After you author or edit a report, stash its `report_id` under a stable
+`report:<domain>:<entity>` scratchpad key — in the same namespace as your other
+scratchpad keys, so your step-1 `scratchpad-search` surfaces it. It is the cheap way
+to re-find *your* report next run, keyed on the entity rather than on inbox phrasing.
+
+Treat it as an **index into the inbox, never a copy of the report**:
+
+- **The inbox is the source of truth.** The entry holds an id, not the report's
+  state. Always `inbox-reports-retrieve` the live report before you edit it — its
+  `title`, `summary`, and `status` may have moved since you wrote the pointer.
+- **The pipeline can overwrite what you authored.** When later signals consolidate on
+  the same topic, the pipeline may re-research your report and rewrite its `title` /
+  `summary`. That's expected — your durable record of "I filed this" is the `report_id`
+  in the pointer, so re-find by the pointer (or by entity via `inbox-reports-list`),
+  not by remembering the exact title.
+- **Don't copy report content into the pointer.** Keep it to the `report_id` plus the
+  minimum to recognize the entity. Title, body, and status live in the inbox — read
+  them there, fresh, rather than trusting a stale snapshot."""
+
 
 _SUGGESTED_REVIEWERS_REPORT = """# Suggested reviewers route the report
 
@@ -443,13 +465,23 @@ def _report_tail_sections(*, can_emit: bool, can_edit: bool) -> list[str]:
     author-time sections (suggested reviewers, writing a report) only when the scout can author."""
     if can_emit and can_edit:
         how_a_run_works = f"{_HOW_A_RUN_WORKS_HEAD}\n{_REPORT_STEPS_BOTH}\n{_REPORT_CLOSE_OUT_STEP}"
-        channel_sections = [_AUTHORING_VS_EDITING_REPORT_BOTH, _SUGGESTED_REVIEWERS_REPORT, _WRITING_REPORT]
+        channel_sections = [
+            _AUTHORING_VS_EDITING_REPORT_BOTH,
+            _REPORT_SCRATCHPAD_POINTER,
+            _SUGGESTED_REVIEWERS_REPORT,
+            _WRITING_REPORT,
+        ]
     elif can_emit:
         how_a_run_works = f"{_HOW_A_RUN_WORKS_HEAD}\n{_REPORT_STEPS_EMIT_ONLY}\n{_REPORT_CLOSE_OUT_STEP}"
-        channel_sections = [_AUTHORING_REPORT_EMIT_ONLY, _SUGGESTED_REVIEWERS_REPORT, _WRITING_REPORT]
+        channel_sections = [
+            _AUTHORING_REPORT_EMIT_ONLY,
+            _REPORT_SCRATCHPAD_POINTER,
+            _SUGGESTED_REVIEWERS_REPORT,
+            _WRITING_REPORT,
+        ]
     else:  # edit-only — no authoring, so no suggested-reviewers / writing-a-report sections
         how_a_run_works = f"{_HOW_A_RUN_WORKS_HEAD}\n{_REPORT_STEPS_EDIT_ONLY}\n{_REPORT_CLOSE_OUT_STEP}"
-        channel_sections = [_EDITING_REPORT_EDIT_ONLY]
+        channel_sections = [_EDITING_REPORT_EDIT_ONLY, _REPORT_SCRATCHPAD_POINTER]
     return [
         how_a_run_works,
         _SCRATCHPAD_KEYS,

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -189,6 +189,7 @@ class TestPromptBuilder(BaseTest):
         # signals, it does not author reports.
         assert "signals-scout-emit-report" not in prompt
         assert "Suggested reviewers route the report" not in prompt
+        assert "scratchpad entry is a pointer" not in prompt
 
     def test_report_channel_renders_report_persona_and_guidance(self) -> None:
         LLMSkill.objects.create(
@@ -216,6 +217,12 @@ class TestPromptBuilder(BaseTest):
         assert "inbox-reports-list" in prompt
         assert "Suggested reviewers route the report" in prompt
         assert "suggested_reviewers" in prompt
+        # The report channel teaches that the `report:` scratchpad entry is a pointer
+        # into the inbox, not a copy of the report — the inbox stays the source of
+        # truth, so the scout retrieves the live report before editing. Dropping this
+        # discipline re-opens the duplicate / stale-edit failure mode.
+        assert "scratchpad entry is a pointer" in prompt
+        assert "source of truth" in prompt
         # Signal-only sections (weak-finding schema, tagging taxonomy) are dropped
         # for a report scout — it doesn't fire `emit_signal`.
         assert "signals-scout-emit-signal" not in prompt


### PR DESCRIPTION
## Problem

Every Signals scout that opts into the report channel gets the same report-persona prompt (the fork added in #66596). It already teaches search-first, non-idempotency, and the `report:<domain>:<entity>` scratchpad key — but it never says what that scratchpad entry *is*. A scout can reasonably read it as a cache of the report's content/state, which opens two failure modes:

- it edits off a **stale snapshot** instead of the live report;
- because the pipeline can re-research and **overwrite** an authored report's `title`/`summary` (accepted behavior), a scout that re-finds its report by remembered title misses it and **files a duplicate** — the exact thing the non-idempotent channel is most fragile to.

The discipline that prevents this was being restated, unevenly, in individual scout skill bodies rather than stated once in the shared prompt.

## Changes

Adds one report-persona section — **"The `report:` scratchpad entry is a pointer, not a copy"** — to `build_run_prompt`, rendered for all three report variants (emit+edit, emit-only, edit-only) and never for signal scouts. It frames the entry as an index into the inbox, not a copy of the report:

- the **inbox is the source of truth** — `inbox-reports-retrieve` the live report before editing;
- the **pipeline may overwrite** the authored title/summary, so re-find by the pointer (or by entity via `inbox-reports-list`), not by a remembered title;
- **don't copy report content** into the entry — keep it to the `report_id` plus the minimum to recognize the entity.

The now-redundant "keep a `report:` entry" clause in the author/search sections is trimmed to a cross-reference, so the discipline lives in exactly one place. Centralizing it in the harness prompt means new report scouts inherit it without each skill body restating it — and sets up a clean one-place migration if report dedup ever moves server-side (a `dedup_key` on the report row would make these scratchpad pointers optional).

## How did you test this code?

I'm an agent. I could not run the DB-backed `TestPromptBuilder` suite locally — this environment has no running Postgres and the suite's `BaseTest` needs the dev stack — so those assertions run in CI.

What I did run:
- `ruff check` and `ruff format --check` on both files — clean.
- Static verification of the wiring: the new section constant is defined once, referenced in all three report `channel_sections`, absent from the signal tail list, and both files parse.

Test changes (extend existing tests, no new functions):
- `test_report_channel_renders_report_persona_and_guidance` gains two assertions (the section header + "source of truth"). Catches the section being dropped or unwired from the report persona — the regression that re-opens the duplicate / stale-edit failure mode. No existing test exercised it.
- the signal-persona test gains one negative assertion that the section never leaks into a signal scout's prompt.

## Docs update

None needed — the harness `CLAUDE.md` already documents the prompt fork at a level this refines.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Andy directed this; it came out of a discussion about whether the scout's `report:` scratchpad key just duplicates the report/inbox DB table. Conclusion: it's a **semantic index** (`subject → report_id`) the inbox can't natively answer — worth keeping as a pointer, but it should be framed as an index, not a copy. So the fix is to say that once, centrally, in the harness prompt rather than restating it in each scout body.

Skill invoked: `/writing-tests` (the gate for the test additions — confirmed the change extends existing tests rather than adding redundant ones).

Follow-on noted in discussion, not in this PR: a first-class `dedup_key` on the authored report would let `inbox-reports-list` answer the dedup question server-side and make these scratchpad pointers optional — the principled end state this prompt change is compatible with.
