### PR TITLE
fix(notebooks): restore width toggle in menu bar

### DIFF
--- a/frontend/src/scenes/notebooks/NotebookSceneMenuBar.tsx
+++ b/frontend/src/scenes/notebooks/NotebookSceneMenuBar.tsx
@@ -116,25 +116,23 @@ function NotebookSceneMenuBarInner({ shortId }: { shortId: string }): JSX.Elemen
                 </SceneMenuBarCheckboxItem>
             </SceneMenuBarMenu>
             <SceneMenuBarMenu label="View" dataAttr={`${RESOURCE_TYPE}-menubar-view`}>
-                {/* Table of contents and width toggle only apply to rich (non-markdown) notebooks. */}
+                {/* Table of contents only applies to rich (non-markdown) notebooks. */}
                 {!isMarkdownNotebook && (
-                    <>
-                        <SceneMenuBarCheckboxItem
-                            checked={showTableOfContents}
-                            onCheckedChange={(checked) => setShowTableOfContents(checked)}
-                            data-attr={`${RESOURCE_TYPE}-menubar-toc`}
-                        >
-                            Table of contents
-                        </SceneMenuBarCheckboxItem>
-                        <SceneMenuBarCheckboxItem
-                            checked={isExpanded}
-                            onCheckedChange={(checked) => setIsExpanded(checked)}
-                            data-attr={`${RESOURCE_TYPE}-menubar-fill-width`}
-                        >
-                            Fill content width
-                        </SceneMenuBarCheckboxItem>
-                    </>
+                    <SceneMenuBarCheckboxItem
+                        checked={showTableOfContents}
+                        onCheckedChange={(checked) => setShowTableOfContents(checked)}
+                        data-attr={`${RESOURCE_TYPE}-menubar-toc`}
+                    >
+                        Table of contents
+                    </SceneMenuBarCheckboxItem>
                 )}
+                <SceneMenuBarCheckboxItem
+                    checked={isExpanded}
+                    onCheckedChange={(checked) => setIsExpanded(checked)}
+                    data-attr={`${RESOURCE_TYPE}-menubar-fill-width`}
+                >
+                    Fill content width
+                </SceneMenuBarCheckboxItem>
                 {showKernelToggle && (
                     <SceneMenuBarCheckboxItem
                         checked={showKernelInfo}
@@ -144,8 +142,7 @@ function NotebookSceneMenuBarInner({ shortId }: { shortId: string }): JSX.Elemen
                         Kernel info
                     </SceneMenuBarCheckboxItem>
                 )}
-                {/* Only divide when a display toggle actually rendered above. */}
-                {(!isMarkdownNotebook || showKernelToggle) && <SceneMenuBarSeparator />}
+                <SceneMenuBarSeparator />
                 <SceneMenuBarItem
                     opensFloatingUi
                     onClick={() => selectNotebook(shortId)}


### PR DESCRIPTION
## Problem

Markdown notebooks can use the width mode styling, but when the Scene menu bar is enabled the View menu hid the `Fill content width` control behind the rich-notebook-only gate. Users in the OS-like menu header mode could no longer toggle wide mode from the notebook header controls.

## Changes

<img width="747" height="765" alt="2026-06-29 12 18 38" src="https://github.com/user-attachments/assets/fa564200-6b98-4d03-bb3e-f2a97a054268" />

Expose `View > Fill content width` for all notebook types in the notebook Scene menu bar.

Keep `View > Table of contents` limited to rich notebooks, where that control applies.

## How did you test this code?

- `git diff --check`
- `pnpm --filter=@posthog/frontend typescript:check` fails on existing current-master generated/kea type errors outside this change, including inbox, data retention, and tracing logic type files.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this restores an existing notebook view control in the new menu header.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex made the one-file frontend change in the local checkout, invoked `/scene-menu-bar` for menu placement conventions, and used the GitHub publish workflow to branch, commit, push, and create this draft PR.

The implementation keeps the table of contents item scoped to rich notebooks, but moves the width toggle out of that gate because markdown notebook CSS still responds to `Notebook--expanded`.