### PR TITLE
fix(experiments): source feature flag config in parameters from the flag

### DIFF
--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -271,6 +271,8 @@ class ExperimentBaseSerializer(UserAccessControlSerializerMixin, serializers.Mod
         groups = filters.get("groups") or []
         if groups and groups[0].get("rollout_percentage") is not None:
             parameters["rollout_percentage"] = groups[0]["rollout_percentage"]
+        else:
+            parameters.pop("rollout_percentage", None)
 
         data["parameters"] = parameters
 

--- a/products/experiments/backend/presentation/serializers.py
+++ b/products/experiments/backend/presentation/serializers.py
@@ -6,6 +6,7 @@ All serializer classes and custom field classes live here.
 ViewSet remains in experiments.py.
 """
 
+from copy import deepcopy
 from typing import Any
 
 from drf_spectacular.utils import extend_schema_field
@@ -233,6 +234,45 @@ class ExperimentBaseSerializer(UserAccessControlSerializerMixin, serializers.Mod
         if annotated is not None:
             return annotated
         return experiment_has_legacy_metrics(obj)
+
+    def to_representation(self, instance: Experiment) -> dict[str, Any]:
+        data = super().to_representation(instance)
+        self._project_feature_flag_config(data, instance.feature_flag)
+        return data
+
+    @staticmethod
+    def _project_feature_flag_config(data: dict[str, Any], flag: FeatureFlag | None) -> None:
+        """Source feature-flag config in the deprecated `parameters` projection from the linked flag.
+
+        The flag is the source of truth for variants/rollout/aggregation group type — `parameters`
+        is a deprecated compatibility surface (see the experiment model's `parameters` comment).
+        Reading these keys from the flag instead of the stored column lets us stop persisting the
+        `parameters` mirror without changing the API response. The linked flag is already serialized
+        into `data["feature_flag"]`, so this adds no queries.
+        """
+        if flag is None:
+            return
+        parameters = dict(data.get("parameters") or {})
+
+        variants = deepcopy(flag.variants)
+        for variant in variants:
+            # Mirror ExperimentParametersField.to_representation: the UI edits splits via split_percent.
+            if isinstance(variant, dict) and "rollout_percentage" in variant:
+                variant["split_percent"] = variant["rollout_percentage"]
+        parameters["feature_flag_variants"] = variants
+
+        filters = flag.get_filters()
+        aggregation_group_type_index = filters.get("aggregation_group_type_index")
+        if aggregation_group_type_index is not None:
+            parameters["aggregation_group_type_index"] = aggregation_group_type_index
+        else:
+            parameters.pop("aggregation_group_type_index", None)
+
+        groups = filters.get("groups") or []
+        if groups and groups[0].get("rollout_percentage") is not None:
+            parameters["rollout_percentage"] = groups[0]["rollout_percentage"]
+
+        data["parameters"] = parameters
 
 
 class ExperimentSerializer(ExperimentBaseSerializer):

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -2191,6 +2191,74 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["parameters"]["recommended_sample_size"], 1500)
 
+    def test_parameters_feature_flag_config_is_sourced_from_the_flag(self):
+        """The `parameters` projection sources feature-flag config (variants, rollout percentage,
+        aggregation group type) from the linked flag, not the stored `parameters` column. This is
+        what lets us stop persisting the mirror — a stale column must never surface in the response.
+        """
+        ff_key = "ff-config-from-flag"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "Source of truth",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "name": "Control Group", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test Variant", "rollout_percentage": 50},
+                    ],
+                    "rollout_percentage": 100,
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        # Make the flag (the source of truth) diverge from the stored mirror: new rollouts,
+        # an aggregation group type, and a 20% overall rollout.
+        flag = FeatureFlag.objects.get(key=ff_key, team_id=self.team.id)
+        flag.filters = {
+            "groups": [{"properties": [], "rollout_percentage": 20}],
+            "multivariate": {
+                "variants": [
+                    {"key": "control", "name": "Control Group", "rollout_percentage": 60},
+                    {"key": "test", "name": "Test Variant", "rollout_percentage": 40},
+                ]
+            },
+            "aggregation_group_type_index": 1,
+        }
+        flag.save()
+
+        # Leave a deliberately stale mirror in the column — what the reverse-sync used to keep
+        # fresh. The projection must ignore it entirely and read from the flag.
+        experiment = Experiment.objects.get(id=experiment_id)
+        experiment.parameters = {
+            **(experiment.parameters or {}),
+            "feature_flag_variants": [{"key": "stale", "rollout_percentage": 99}],
+            "rollout_percentage": 100,
+            "aggregation_group_type_index": None,
+        }
+        experiment.save()
+
+        expected_variants = [
+            {"key": "control", "name": "Control Group", "rollout_percentage": 60, "split_percent": 60},
+            {"key": "test", "name": "Test Variant", "rollout_percentage": 40, "split_percent": 40},
+        ]
+
+        # Detail endpoint (ExperimentSerializer)
+        detail_parameters = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment_id}").json()[
+            "parameters"
+        ]
+        self.assertEqual(detail_parameters["feature_flag_variants"], expected_variants)
+        self.assertEqual(detail_parameters["rollout_percentage"], 20)
+        self.assertEqual(detail_parameters["aggregation_group_type_index"], 1)
+
+        # List endpoint (ExperimentBasicSerializer shares the same projection)
+        results = self.client.get(f"/api/projects/{self.team.id}/experiments/").json()["results"]
+        list_parameters = next(e["parameters"] for e in results if e["id"] == experiment_id)
+        self.assertEqual(list_parameters["feature_flag_variants"], expected_variants)
+        self.assertEqual(list_parameters["aggregation_group_type_index"], 1)
+
     def test_experiment_response_includes_feature_flag(self):
         """Test that experiment responses include the feature_flag field correctly serialized."""
         response = self.client.post(


### PR DESCRIPTION
## Problem

`Experiment.parameters` is a deprecated catch-all blob we are splitting into dedicated homes. Feature flag config (`feature_flag_variants`, `rollout_percentage`, `aggregation_group_type_index`) belongs on the linked `FeatureFlag`, which is already the source of truth at runtime.

Today the `parameters` column still holds a copy of that config. It is kept fresh by a reverse sync in `FeatureFlagSerializer.update`, and the API still returns it under `parameters` for clients (frontend fallback, MCP, external API) that read `parameters.feature_flag_variants`.

Before we can stop writing that copy, the API has to stop reading it. This PR does the read switch. It is the first step toward removing `feature_flag_variants` from `parameters` entirely.

## Changes

The `parameters` projection in the experiment API now derives `feature_flag_variants` (with `split_percent`), `rollout_percentage`, and `aggregation_group_type_index` from the linked feature flag instead of the stored `parameters` column.

- Added `to_representation` and `_project_feature_flag_config` to `ExperimentBaseSerializer`, so both the detail serializer (`ExperimentSerializer`) and the list serializer (`ExperimentBasicSerializer`) share one projection.
- No extra queries. The linked flag is already serialized into the `feature_flag` field on both endpoints.
- This is behavior preserving. The reverse sync keeps the column equal to the flag today, so the response values do not change. The only difference is where they come from.

This unblocks a follow-up PR that deletes the reverse sync and stops persisting the mirror, without breaking clients that still read `parameters.feature_flag_variants`. That follow-up must deploy after this one is live, so there is never a window where the column is stale and the API still reads it.

No `hogli build:openapi` run was needed. No fields were added or removed, so `parameters` still renders under the existing `ExperimentParameters` schema.

## How did you test this code?

I am an agent. I ran these automated tests locally, all green:

- `products/experiments/backend/test/test_presentation_api.py` (213 passed)
- `products/experiments/backend/test/test_facade.py`, `test_contracts.py`
- `posthog/api/test/test_web_experiment.py` (15 passed)

New test: `test_parameters_feature_flag_config_is_sourced_from_the_flag`. It creates an experiment, then makes the flag diverge from the stored column and leaves a deliberately stale mirror in `parameters`. It asserts the detail and list responses both reflect the flag, not the stale column. No existing test covered this because the reverse sync kept the two equal, so nothing pinned the read source.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @andehen. Invoked the `/improving-drf-endpoints` skill since this touches a serializer. The skill confirmed no `help_text` or schema annotation changes were needed because this is a read-side `to_representation` change with no new fields.

Approach: traced every reader and writer of `parameters.feature_flag_variants` first. Every runtime reader that matters (frontend `getExperimentVariants`, `get_analytics_metadata`, query runners) already reads the flag. The serializer projection was the last reader of the stored column for API clients, so switching it is the safe first slice. Kept the change behavior preserving and deferred deleting the reverse sync and the stored copy to a follow-up, to respect deploy ordering on this public repo.

One thing for the follow-up: `ee/hogai/context/experiment/context.py` reads `experiment.parameters["feature_flag_variants"]` off the model instance. It must move to `experiment.feature_flag.variants` before the mirror is dropped. The serializer projection only covers API readers.
