### PR TITLE
fix(batch-import): disable S3 response checksum validation for ranged GETs

### DIFF
--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -379,6 +379,11 @@ impl S3SourceConfig {
             .region(Region::new(self.region.clone()))
             .credentials_provider(aws_credentials)
             .behavior_version(BehaviorVersion::latest())
+            // S3-compatible stores (GCS) return whole-object checksums on ranged GETs, which the
+            // SDK then validates against the partial body and fails. Only validate when requested.
+            .response_checksum_validation(
+                aws_sdk_s3::config::ResponseChecksumValidation::WhenRequired,
+            )
             .timeout_config(
                 TimeoutConfig::builder()
                     .operation_timeout(Duration::from_secs(30))


### PR DESCRIPTION
## Problem

Batch imports from S3-compatible object stores (GCS in particular) fail with errors like:

```
Failed to read body data from S3 object …: streaming error: body checksum mismatch.
expected body checksum to be 70ed034c but it was 7af0004a
```

The batch-import worker reads objects in chunks via ranged GETs (`bytes=offset-end`). Since aws-sdk-s3 v1.69.0, response checksum validation defaults to `WhenSupported`, so the SDK validates any checksum header on the response against the body it received. Real S3 omits that header on `206 Partial Content`, but GCS returns the checksum of the **whole object** even on a ranged response. The SDK then compares a whole-object checksum against the partial range body and fails every chunk.

AWS treats `WhenSupported` as the intended default for first-party services and directs S3-compatible users to opt out — it is not reverted in newer SDK versions, so this is config, not a version bump.

## Changes

Set `response_checksum_validation` to `WhenRequired` on the S3 client config in the batch-import worker, so the SDK only validates response checksums when the request explicitly opts in (ranged GETs do not). This is applied in `build_s3_config`, so both the plain and gzip S3 sources are covered.

In-transit integrity is still guaranteed by TLS, and any genuinely corrupt chunk would fail downstream JSONL parsing rather than be imported silently. Request-side (upload) checksums are unaffected.

## How did you test this code?

I'm an agent (Claude Code, agent-assisted). I did not run a live import against GCS. Automated checks run locally in the worktree:

- `cargo clippy -p batch-import-worker --all-targets` — clean (no new warnings)
- `cargo fmt -p batch-import-worker`

No tests added: the change configures SDK transport behavior that isn't observable through a unit test without a live S3-compatible endpoint, and there's no existing harness that exercises real ranged GETs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a reported `body checksum mismatch` from a GCS-backed batch import. Traced it to the ranged-GET path in `rust/batch-import-worker/src/source/s3.rs` and the SDK's post-v1.69.0 default checksum validation. Confirmed against the upstream announcement (awslabs/aws-sdk-rust #1240) that AWS keeps `WhenSupported` as the default and steers compatible-store users to `WhenRequired`, so the fix is a config flag rather than a dependency upgrade. Chose the in-code option (over the `AWS_RESPONSE_CHECKSUM_VALIDATION` env var or shared config) so it's explicit and scoped to this client, and applied it unconditionally in the shared `build_s3_config` so plain and gzip sources stay consistent.

Tool: Claude Code. No repo skills were invoked.
