### PR TITLE
feat(data-warehouse): promote convex source to GA

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
@@ -3,6 +3,7 @@ from typing import Optional, cast
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
     SourceFieldInputConfig,
     SourceFieldInputConfigType,
@@ -39,7 +40,7 @@ class ConvexSource(ResumableSource[ConvexSourceConfig, ConvexResumeConfig]):
             name=SchemaExternalDataSourceType.CONVEX,
             category=DataWarehouseSourceCategory.DATABASES,
             label="Convex",
-            releaseStatus="beta",
+            releaseStatus=ReleaseStatus.GA,
             caption="""Enter your Convex deployment URL and deploy key to sync your Convex tables into PostHog.
 
 You can find your deployment URL and deploy key in your [Convex Dashboard](https://dashboard.convex.dev/) under **Settings** > **URL & Deploy Key**.


### PR DESCRIPTION
## Problem

The Convex data-warehouse source has been shipping as Beta. It now clears our GA bar, so users should see it labelled as generally available.

## Changes

Bump the `Convex` source's `releaseStatus` from `beta` to `ga` in its `get_source_config`. This is the value surfaced by `/api/public_source_configs/`. Also switched the bare `"beta"` string literal to the `ReleaseStatus.GA` enum, matching the convention other sources follow.

This is a status promotion only — no connector behavior, schema, or sync-logic changes. Convex has no `featureFlag` or `unreleasedSource` gating, so there was nothing else to remove.

### Why it qualifies (7-day window)

| Criterion | Threshold | Current |
| --- | --- | --- |
| Adoption | 100+ teams **or** live 3+ months | 44 teams · live 3.2 months ✅ (via tenure) |
| Import error rate (7d) | < 2.5% | 0.3% ✅ |

## How did you test this code?

I'm an agent. I ran `ruff check` on the modified file (passes). No test asserts the Convex release status, so none needed updating. No manual testing performed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Single-line status flip in `products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py`. Invoked the `/implementing-warehouse-sources` skill for repo conventions — it calls for using the `ReleaseStatus` enum rather than a string literal, hence the small import addition alongside the value change. Checked open PRs (including the maintainer's own) for an existing Convex promotion before opening this; none found.
