### PR TITLE
fix(data-warehouse): skip over-long column names in semantic enrichment

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
@@ -344,17 +344,23 @@ def _get_business_context(team: Team) -> str:
 # Never worth enriching: they carry no user-facing meaning and each one would burn an LLM column slot.
 _INTERNAL_COLUMNS = frozenset({"_dlt_id", "_dlt_load_id", "_ph_debug", PARTITION_KEY})
 
+# An annotation is keyed by `column_name`, a varchar(400). A column whose name doesn't fit can't be
+# stored or surfaced, so skip it rather than letting the insert raise (DataError) and crash the whole
+# table's enrichment into a Temporal retry loop.
+_MAX_COLUMN_NAME_LENGTH: int = WarehouseColumnAnnotation._meta.get_field("column_name").max_length or 400
+
 
 def _columns_from_table(table: DataWarehouseTable) -> list[dict[str, Any]]:
     """Source-agnostic `[{name, data_type, is_nullable}]` from `DataWarehouseTable.columns`.
 
     `columns` is populated after every sync for every source type (unlike SQL-only `schema_metadata`),
     keyed by column name with a ClickHouse type. Handles both the dict shape (`{"clickhouse": ...}`)
-    and the legacy plain-string shape. Internal plumbing columns are skipped.
+    and the legacy plain-string shape. Internal plumbing columns, and any whose name exceeds the
+    annotation key length, are skipped.
     """
     result: list[dict[str, Any]] = []
     for name, definition in (table.columns or {}).items():
-        if name in _INTERNAL_COLUMNS:
+        if name in _INTERNAL_COLUMNS or len(name) > _MAX_COLUMN_NAME_LENGTH:
             continue
         if isinstance(definition, dict):
             clickhouse_type = definition.get("clickhouse") or definition.get("hogql") or ""

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/enrich_table_semantics.py
@@ -350,7 +350,7 @@ _INTERNAL_COLUMNS = frozenset({"_dlt_id", "_dlt_load_id", "_ph_debug", PARTITION
 _MAX_COLUMN_NAME_LENGTH: int = WarehouseColumnAnnotation._meta.get_field("column_name").max_length or 400
 
 
-def _columns_from_table(table: DataWarehouseTable) -> list[dict[str, Any]]:
+def _columns_from_table(table: DataWarehouseTable, log: Any = logger) -> list[dict[str, Any]]:
     """Source-agnostic `[{name, data_type, is_nullable}]` from `DataWarehouseTable.columns`.
 
     `columns` is populated after every sync for every source type (unlike SQL-only `schema_metadata`),
@@ -360,7 +360,17 @@ def _columns_from_table(table: DataWarehouseTable) -> list[dict[str, Any]]:
     """
     result: list[dict[str, Any]] = []
     for name, definition in (table.columns or {}).items():
-        if name in _INTERNAL_COLUMNS or len(name) > _MAX_COLUMN_NAME_LENGTH:
+        if name in _INTERNAL_COLUMNS:
+            continue
+        if len(name) > _MAX_COLUMN_NAME_LENGTH:
+            # Surface the drop — otherwise the column silently vanishes from enrichment with no trace,
+            # the same opacity that made the original DataError crash hard to diagnose.
+            log.warning(
+                "warehouse_enrichment.column_name_too_long",
+                column_name_prefix=name[:64],
+                column_name_length=len(name),
+                max_column_name_length=_MAX_COLUMN_NAME_LENGTH,
+            )
             continue
         if isinstance(definition, dict):
             clickhouse_type = definition.get("clickhouse") or definition.get("hogql") or ""
@@ -418,7 +428,7 @@ def enrich_table_semantics_sync(team_id: int, schema_id: uuid.UUID) -> dict[str,
 
     # Columns + types come from `table.columns`, populated for every source type after sync — so this
     # enriches REST sources (Stripe, Hubspot, …) as well as SQL ones. Foreign keys remain SQL-only.
-    columns = [column for column in _columns_from_table(table) if column.get("name")]
+    columns = [column for column in _columns_from_table(table, log) if column.get("name")]
     event_props["columns_total"] = len(columns)
     if not columns:
         emit_completed("skipped", reason="no_columns")

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
@@ -19,6 +19,7 @@ from products.warehouse_sources.backend.temporal.data_imports.workflow_activitie
     enrich_table_semantics as enrich,
 )
 from products.warehouse_sources.backend.temporal.data_imports.workflow_activities.enrich_table_semantics import (
+    _MAX_COLUMN_NAME_LENGTH,
     MAX_BUSINESS_CONTEXT_CHARS,
     MAX_PROMPT_CHARS,
     EnrichTableSemanticsInputs,
@@ -319,9 +320,9 @@ class TestColumnsFromTable:
         assert names == {"id", "amount"}
 
     def test_skips_columns_whose_name_exceeds_annotation_key_length(self):
-        # A column name longer than the annotation's varchar(400) key can't be stored — including it
-        # would crash the whole table's enrichment with a DataError. It must be dropped, not enriched.
-        long_name = "a" * 401
+        # A column name longer than the annotation's varchar key can't be stored — including it would
+        # crash the whole table's enrichment with a DataError. It must be dropped, not enriched.
+        long_name = "a" * (_MAX_COLUMN_NAME_LENGTH + 1)
         table = DataWarehouseTable(columns={"id": {"clickhouse": "String"}, long_name: {"clickhouse": "String"}})
         names = {column["name"] for column in _columns_from_table(table)}
         assert names == {"id"}

--- a/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/workflow_activities/tests/test_enrich_table_semantics.py
@@ -318,6 +318,14 @@ class TestColumnsFromTable:
         names = {column["name"] for column in _columns_from_table(table)}
         assert names == {"id", "amount"}
 
+    def test_skips_columns_whose_name_exceeds_annotation_key_length(self):
+        # A column name longer than the annotation's varchar(400) key can't be stored — including it
+        # would crash the whole table's enrichment with a DataError. It must be dropped, not enriched.
+        long_name = "a" * 401
+        table = DataWarehouseTable(columns={"id": {"clickhouse": "String"}, long_name: {"clickhouse": "String"}})
+        names = {column["name"] for column in _columns_from_table(table)}
+        assert names == {"id"}
+
 
 class TestExtractJsonObject:
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

While investigating a stream of `data warehouse table enrichment error` events, one error class stood out as a genuine code bug crashing a live customer team's enrichment on every sync:

```
value too long for type character varying(400)
```

`WarehouseColumnAnnotation.column_name` is a `varchar(400)`. A synced warehouse column whose **name** exceeds 400 characters makes `_upsert_annotation`'s `get_or_create(..., column_name=name, ...)` raise a `DataError`. That error isn't caught inside `enrich_table_semantics_sync` (only the LLM call is wrapped), so it propagates to the activity wrapper, gets re-raised, and Temporal retries it — which fails again the same way every sync. The error events for the affected team have `stage`/`source`/`schema` all `None`, confirming the exception escapes the inner handler entirely.

## Changes

Skip columns whose name can't fit the annotation key when reading columns from the table (`_columns_from_table`). Such a column can't be stored or surfaced in the catalog anyway, so there's nothing to enrich — and one pathological name shouldn't take down the whole table's enrichment. The length bound is derived from the model field (`column_name` max_length) so it stays in sync if the column ever changes.

This sits alongside the existing internal-plumbing-column skip, and also keeps the over-long name out of the LLM prompt.

## How did you test this code?

I'm an agent (Claude, via Claude Code), working agent-assisted under Tom's direction.

- Added `test_skips_columns_whose_name_exceeds_annotation_key_length` to `TestColumnsFromTable`: a 401-char column name is dropped while a normal one is kept. It reproduces the crash path without the guard.
- Ran `ruff check` / `ruff format` clean.
- The module's tests are `django_db`-marked and need ClickHouse/DB setup that this local checkout can't provide (pre-existing environment limitation), so the suite runs in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tom asked why this activity was emitting a lot of error events. I queried the `data warehouse table enrichment error` events and grouped by message/stage/team. Most of the volume is infra/config rather than code (see below); this PR fixes the one clear, customer-affecting code defect — the `varchar(400)` overflow on `column_name`.

For the record, the larger error buckets that are **not** addressed here because they're environmental, not code:

- `LLM_GATEWAY_URL and LLM_GATEWAY_API_KEY must be configured` — by far the highest volume, but confined to one internal team and steady at ~1.2k/day: the worker path serving that team's enrichment lacks the gateway credentials. A deploy/config fix, not code.
- `litellm.ContextWindowExceededError: prompt is too long` — a single internal team on a single day with a very wide table; the char-based prompt bound (`MAX_PROMPT_CHARS`) is too loose to guarantee a token-count fit. Worth a follow-up to make the bound token-aware or to catch and degrade, but out of scope here.
- `You have reached your specified workspace API limit` — spread across many teams; an LLM-gateway quota/budget cap, transient and idempotent on the next sync.
