### PR TITLE
fix(web): guard Node DOM mutations against browser-extension crashes

### DIFF
--- a/frontend/src/domMutationGuard.test.ts
+++ b/frontend/src/domMutationGuard.test.ts
@@ -1,0 +1,68 @@
+import { patchDomMutationMethodsForExtensions } from './domMutationGuard'
+
+describe('domMutationGuard', () => {
+    beforeAll(() => {
+        patchDomMutationMethodsForExtensions()
+    })
+
+    it('removeChild on a node that is no longer a child returns it instead of throwing', () => {
+        // Simulates a browser extension having relocated the node out of `parent` before React's
+        // commit phase calls removeChild — previously this threw NotFoundError and crashed reconciliation.
+        const parent = document.createElement('div')
+        const orphan = document.createElement('span')
+
+        expect(() => parent.removeChild(orphan)).not.toThrow()
+        expect(parent.removeChild(orphan)).toBe(orphan)
+    })
+
+    it('removeChild still removes a genuine child', () => {
+        const parent = document.createElement('div')
+        const child = document.createElement('span')
+        parent.appendChild(child)
+
+        expect(parent.removeChild(child)).toBe(child)
+        expect(parent.contains(child)).toBe(false)
+    })
+
+    it('insertBefore with a reference node from a different parent returns the new node instead of throwing', () => {
+        const parent = document.createElement('div')
+        const otherParent = document.createElement('div')
+        const reference = document.createElement('span')
+        otherParent.appendChild(reference)
+        const newNode = document.createElement('em')
+
+        expect(() => parent.insertBefore(newNode, reference)).not.toThrow()
+        expect(parent.insertBefore(newNode, reference)).toBe(newNode)
+    })
+
+    it('insertBefore still inserts before a valid reference node', () => {
+        const parent = document.createElement('div')
+        const reference = document.createElement('span')
+        parent.appendChild(reference)
+        const newNode = document.createElement('em')
+
+        parent.insertBefore(newNode, reference)
+        expect(parent.firstChild).toBe(newNode)
+        expect(newNode.nextSibling).toBe(reference)
+    })
+
+    it('insertBefore with a null reference appends, as the spec requires', () => {
+        const parent = document.createElement('div')
+        const existing = document.createElement('span')
+        parent.appendChild(existing)
+        const newNode = document.createElement('em')
+
+        parent.insertBefore(newNode, null)
+        expect(parent.lastChild).toBe(newNode)
+    })
+
+    it('is idempotent — patching twice does not break normal mutation', () => {
+        patchDomMutationMethodsForExtensions()
+        const parent = document.createElement('div')
+        const child = document.createElement('span')
+        parent.appendChild(child)
+
+        expect(parent.removeChild(child)).toBe(child)
+        expect(parent.contains(child)).toBe(false)
+    })
+})

--- a/frontend/src/domMutationGuard.ts
+++ b/frontend/src/domMutationGuard.ts
@@ -1,0 +1,45 @@
+/**
+ * Hardens React reconciliation against browser extensions that mutate the DOM out from under React.
+ *
+ * Extensions such as Google Translate, ad blockers, and "dark mode" injectors relocate or delete
+ * text nodes that React still holds a reference to. During React's commit phase this turns into a
+ * call to `removeChild` / `insertBefore` with a node that is no longer a child of the expected
+ * parent, and the browser throws `NotFoundError: Failed to execute 'removeChild' on 'Node'`
+ * (or the `insertBefore` equivalent). That exception escapes into the reconciler and tears down the
+ * surrounding subtree — on the Web analytics dashboard it leaves the page stuck behind an error box.
+ *
+ * These guards make the two methods a no-op — returning the node, exactly as a successful spec call
+ * would — when the node isn't actually a child of `this`. The extension-induced mismatch then can't
+ * crash the app. This is the well-known Node-prototype workaround for the React + extension
+ * interaction (see facebook/react#11538).
+ */
+
+const PATCH_FLAG = '__phDomMutationGuarded'
+
+export function patchDomMutationMethodsForExtensions(): void {
+    if (typeof Node !== 'function' || !Node.prototype) {
+        return
+    }
+
+    const proto = Node.prototype as Node & Record<string, unknown>
+    if (proto[PATCH_FLAG]) {
+        return
+    }
+    proto[PATCH_FLAG] = true
+
+    const originalRemoveChild = Node.prototype.removeChild
+    Node.prototype.removeChild = function <T extends Node>(this: Node, child: T): T {
+        if (child.parentNode !== this) {
+            return child
+        }
+        return originalRemoveChild.call(this, child) as T
+    }
+
+    const originalInsertBefore = Node.prototype.insertBefore
+    Node.prototype.insertBefore = function <T extends Node>(this: Node, newNode: T, referenceNode: Node | null): T {
+        if (referenceNode && referenceNode.parentNode !== this) {
+            return newNode
+        }
+        return originalInsertBefore.call(this, newNode, referenceNode) as T
+    }
+}

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -12,9 +12,13 @@ import { PostHogProvider } from '@posthog/react'
 
 import { App } from 'scenes/App'
 
+import { patchDomMutationMethodsForExtensions } from './domMutationGuard'
 import { initKea } from './initKea'
 import { ErrorBoundary } from './layout/ErrorBoundary'
 import { loadPostHogJS } from './loadPostHogJS'
+
+// Guard against browser-extension DOM mutations crashing React reconciliation. Must run before render.
+patchDomMutationMethodsForExtensions()
 
 loadPostHogJS()
 initKea()


### PR DESCRIPTION
## Problem

Browser-extension DOM mutations (Google Translate, ad blockers, "dark mode" injectors) relocate or delete text nodes that React still holds a reference to. During React's commit phase this becomes a `removeChild` / `insertBefore` call against a node that is no longer a child of the expected parent, and the browser throws `NotFoundError: Failed to execute 'removeChild' on 'Node'`. That exception escapes into the reconciler and tears down the surrounding subtree.

This is one of three independent fixes split out of #66590 so each can be assessed on its own merits. It is the broadest in blast radius — a global `Node.prototype` patch applied once at app startup — which is exactly why it deserves review in isolation.

## Changes

`patchDomMutationMethodsForExtensions()` (new `domMutationGuard.ts`) patches `Node.prototype.removeChild` and `insertBefore` to no-op — returning the node, exactly as a successful spec call would — when the node isn't actually a child of `this`. It is idempotent (guarded by a prototype flag) and runs once from `index.tsx` before render. This is the well-known facebook/react#11538 workaround for the React + extension interaction.

## How did you test this code?

I'm an agent and did not run the suite in this environment (no local JS toolchain), so CI runs the tests on this PR. New test added:

- `domMutationGuard.test.ts` — guards that `removeChild`/`insertBefore` no longer throw when a node was relocated out from under React, that normal mutation still works (genuine child removal, valid `insertBefore`, `null` reference appends), and that the patch is idempotent. Catches the regression that the crash would re-throw if the guard's parent check were dropped or inverted.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #66590 at the human's direction so the global prototype patch is reviewed on its own rather than bundled with the unrelated URL-cascade and error-boundary fixes (each now its own PR). Code is lifted verbatim from the original commit with no modification.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
