### PR TITLE
fix(insights): reset stuck Query error boundary on filter/tab change

### DIFF
--- a/frontend/src/queries/Query/Query.tsx
+++ b/frontend/src/queries/Query/Query.tsx
@@ -305,8 +305,15 @@ export function Query<Q extends Node>(props: QueryProps<Q>): JSX.Element | null 
         component = <DataNode attachTo={props.attachTo} query={query} cachedResults={props.cachedResults} />
     }
 
+    // Let the ErrorBoundary recover on a data refresh. PostHogErrorBoundary has no reset path, so once
+    // it catches (e.g. the `removeChild` NotFoundError that browser extensions trigger during
+    // reconciliation) the fallback stays mounted until the boundary is unmounted. Resetting on the
+    // query / filter overrides means a filter or tab change clears the error and lets the tile recover
+    // instead of staying stuck on the pink error box.
+    const errorBoundaryResetKey = JSON.stringify([query, filtersOverride ?? null, variablesOverride ?? null])
+
     return (
-        <ErrorBoundary>
+        <ErrorBoundary resetKeys={[errorBoundaryResetKey]}>
             <>
                 {queryContext.showQueryEditor ? (
                     <>


### PR DESCRIPTION
## Problem

Each query tile renders through `Query.tsx`'s `<ErrorBoundary>`, which had no reset path — so once a tile caught (e.g. the `removeChild` `NotFoundError` browser extensions trigger during reconciliation), the pink fallback stayed mounted obstructing the dashboard until the user navigated away.

This is the consumer half of the error-boundary fix split out of #66590. It depends on #66643 (`feat(error-boundary): add resetKeys for recoverable boundaries`), which introduces the `resetKeys` prop this PR passes.

> **Stacked PR.** Base is `posthog-code/error-boundary-reset-keys` (#66643), not `master`. Review/merge that first; this should auto-retarget to `master` once it lands. The diff to review here is just `Query.tsx`.

## Changes

`Query` opts into `ErrorBoundary`'s `resetKeys`, keyed on the query plus filter/variable overrides. A filter or tab change now clears a stuck tile and lets it recover, instead of leaving it on the error box until navigation. Healthy tiles are never remounted (the boundary only resets while it's actually showing the fallback).

## How did you test this code?

I'm an agent and did not run the suite in this environment (no local JS toolchain), so CI runs the tests on this PR. No new test is added here — the recovery semantics are covered by `ErrorBoundary.test.tsx` in the base PR, and `Query`'s existing tests guard against consumer regressions. A dedicated test would only re-assert the boundary behavior already proven in #66643.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Split out of #66590 at the human's direction. Kept separate from the `ErrorBoundary` primitive (#66643) so the reusable capability and the app-wide consumer wiring are assessed independently — this PR is where `Query` tile behavior actually changes. Code is lifted verbatim from the original commit with no modification.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
