### PR TITLE
fix(caching): warm insight cache as creator

### DIFF
--- a/posthog/caching/insight_cache.py
+++ b/posthog/caching/insight_cache.py
@@ -84,6 +84,7 @@ def update_cache(caching_state_id: UUID):
                 cast(dict[str, Any], insight.query),
                 dashboard_filters_json=dashboard.filters if dashboard is not None else None,
                 execution_mode=ExecutionMode.CALCULATE_BLOCKING_ALWAYS,
+                user=insight.created_by,
                 analytics_props={"source": EventSource.CACHE_WARMING},
             )
             # TRICKY: `result` is null, because `process_query` already set the cache. `cache_type` also irrelevant

--- a/posthog/caching/warming.py
+++ b/posthog/caching/warming.py
@@ -243,6 +243,7 @@ def warm_insight_cache_task(insight_id: int, dashboard_id: Optional[int]):
                 # - if insight + dashboard combinations have the same cache key, we prevent needless recalculations
                 limit_context=LimitContext.QUERY_ASYNC,
                 execution_mode=ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                user=insight.created_by,
                 insight_id=insight_id,
                 dashboard_id=dashboard_id,
                 analytics_props={"source": EventSource.CACHE_WARMING},


### PR DESCRIPTION
## Problem

Follow-up to: https://github.com/PostHog/posthog/pull/61686

Cache warming runs saved insight queries without a user. With warehouse access control enabled, that can fail for warehouse-backed insights because userless HogQL contexts filter out access-scoped warehouse resources.

Ideally, cache warming would compute the full-access team cache partition. But simply passing `bypass_warehouse_access_control=True` is not enough: if the query references warehouse sources, `get_cache_payload()` can still add `restricted_resources=["warehouse_table", "warehouse_view"]` because the cache fingerprint is computed from a userless context. That means execution and cache fingerprinting can disagree.

This PR takes the smaller fix for now: run cache warming as the insight creator.

## Changes

- Pass `insight.created_by` into both insight cache warming paths.
- This keeps cache warming on the normal user-scoped HogQL access-control path

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

Considered a fuller fix where cache warming computes with explicit full warehouse access. That needs the cache fingerprint to understand the same access mode as execution; otherwise `bypass_warehouse_access_control=True` can still produce a userless restricted cache key.

For this PR, we chose the simpler creator-principal fix. The creator can edit/share the insight, so using them as the warming principal is a reasonable approximation of insight ownership. If the creator later loses warehouse access, cache warming may no longer compute the full-access cache entry, but that is preferable to adding a broad bypass without fixing cache fingerprinting at the same time.

This is also aligned with subscriptions/alerts. Those background jobs use the saved insight creator as the effective principal when rendering or evaluating an insight, rather than bypassing access control as an unrestricted internal actor. 