### PR TITLE
fix(postgres): retry recovery conflicts that surface as QueryCanceled during setup

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2552,11 +2552,11 @@ def postgres_source(
             conn.autocommit = True
             return conn
 
-        # A hot-standby recovery conflict ("terminating connection due to conflict with recovery")
-        # terminates the whole connection mid-probe, so autocommit alone can't isolate it — every
-        # subsequent probe on the dead connection fails too. Reconnect and retry the metadata
-        # probes a bounded number of times with backoff, mirroring how the read loop recovers from
-        # the same conflict. Only once the conflicts are sustained do we raise the non-retryable
+        # A hot-standby recovery conflict ("conflict with recovery") cancels or terminates the probe
+        # mid-flight, so autocommit alone can't isolate it — the connection is left unusable and
+        # every subsequent probe on it fails too. Reconnect and retry the metadata probes a bounded
+        # number of times with backoff, mirroring how the read loop recovers from the same conflict.
+        # Only once the conflicts are sustained do we raise the non-retryable
         # "successive SerializationFailure errors" abort the read path already uses, rather than
         # letting Temporal re-run setup straight back into the same wall.
         setup_recovery_conflicts = 0
@@ -2794,7 +2794,14 @@ def postgres_source(
                     # retryable dropped-connection error instead.
                     _raise_if_setup_connection_broken(connection)
                 break
-            except psycopg.errors.SerializationFailure as e:
+            except (psycopg.errors.SerializationFailure, psycopg.errors.QueryCanceled) as e:
+                # A hot-standby recovery conflict surfaces as either SerializationFailure (the
+                # transaction was aborted — "terminating connection due to conflict with recovery")
+                # or QueryCanceled (the statement was canceled — "canceling statement due to conflict
+                # with recovery", e.g. a replica reconnect) depending on the conflict and the server.
+                # Both are the same transient condition and recover on reconnect. Any other
+                # QueryCanceled here is a statement_timeout and must re-raise. QueryCanceled subclasses
+                # OperationalError, so this clause must precede the connection-dropped handler below.
                 if "conflict with recovery" not in "".join(e.args):
                     raise
                 # Connection is dead; close defensively before reconnecting.
@@ -2803,7 +2810,7 @@ def postgres_source(
                 if setup_recovery_conflicts >= _MAX_SETUP_RECOVERY_CONFLICT_RETRIES:
                     raise _recovery_conflict_abort_error(setup_recovery_conflicts) from e
                 logger.debug(
-                    f"SerializationFailure during table setup ({e}). Reconnecting and retrying "
+                    f"Recovery conflict during table setup ({e}). Reconnecting and retrying "
                     f"(attempt {setup_recovery_conflicts}/{_MAX_SETUP_RECOVERY_CONFLICT_RETRIES})"
                 )
                 time.sleep(min(2 * setup_recovery_conflicts, 30))

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -866,8 +866,22 @@ class TestPostgresSourceSetupRecoveryConflictRetry:
             db_incremental_field_last_value=None,
         )
 
-    def test_sustained_recovery_conflict_during_setup_aborts_non_retryably(self):
-        err = psycopg.errors.SerializationFailure("terminating connection due to conflict with recovery")
+    @pytest.mark.parametrize(
+        "err",
+        [
+            # A hot-standby recovery conflict surfaces as either SerializationFailure (the
+            # transaction was aborted) or QueryCanceled (the statement was canceled, e.g. a replica
+            # reconnect) — the same transient condition. Both must be retried in-process during setup
+            # and end in the non-retryable abort once sustained; before the QueryCanceled fix that
+            # flavor escaped on the first probe and failed the whole activity.
+            psycopg.errors.SerializationFailure("terminating connection due to conflict with recovery"),
+            psycopg.errors.QueryCanceled(
+                "canceling statement due to conflict with recovery\n"
+                "DETAIL:  User query might have conflicted with replica reconnect."
+            ),
+        ],
+    )
+    def test_sustained_recovery_conflict_during_setup_aborts_non_retryably(self, err):
         connection = self._make_failing_connection(err)
 
         with patch(
@@ -885,60 +899,25 @@ class TestPostgresSourceSetupRecoveryConflictRetry:
         # Each retry reconnects, so connect is called once per attempt.
         assert connect_mock.call_count == _MAX_SETUP_RECOVERY_CONFLICT_RETRIES
 
-    def test_non_recovery_serialization_failure_during_setup_is_not_retried(self):
-        # A serialization failure unrelated to standby recovery must propagate immediately —
-        # the retry is scoped strictly to "conflict with recovery".
-        err = psycopg.errors.SerializationFailure("could not serialize access due to concurrent update")
+    @pytest.mark.parametrize(
+        "err",
+        [
+            # The in-process retry is scoped strictly to "conflict with recovery": a serialization
+            # failure from a concurrent update, and a QueryCanceled from a statement_timeout, are
+            # both unrelated to standby recovery and must propagate on the first probe.
+            psycopg.errors.SerializationFailure("could not serialize access due to concurrent update"),
+            psycopg.errors.QueryCanceled("canceling statement due to statement timeout"),
+        ],
+    )
+    def test_non_recovery_conflict_during_setup_is_not_retried(self, err):
         connection = self._make_failing_connection(err)
 
         with patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
             return_value=connection,
         ) as connect_mock:
-            with pytest.raises(psycopg.errors.SerializationFailure):
+            with pytest.raises(type(err)):
                 self._call_postgres_source()
-
-        assert connect_mock.call_count == 1
-
-    def test_recovery_conflict_as_query_canceled_during_setup_is_retried(self):
-        # A hot-standby recovery conflict can surface as QueryCanceled ("canceling statement due to
-        # conflict with recovery") rather than SerializationFailure — the same transient condition.
-        # The setup loop must retry it in-process exactly like the SerializationFailure flavor;
-        # before the fix it escaped on the first probe and failed the whole activity.
-        err = psycopg.errors.QueryCanceled(
-            "canceling statement due to conflict with recovery\n"
-            "DETAIL:  User query might have conflicted with replica reconnect."
-        )
-        connection = self._make_failing_connection(err)
-
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
-            return_value=connection,
-        ) as connect_mock:
-            with patch("products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"):
-                with pytest.raises(Exception) as exc_info:
-                    self._call_postgres_source()
-
-        message = str(exc_info.value)
-        assert "conflict with recovery" in message and "max_standby_streaming_delay" in message
-        non_retryable = PostgresSource().get_non_retryable_errors()
-        assert any(pattern in message for pattern in non_retryable.keys())
-        # Each retry reconnects, so connect is called once per attempt.
-        assert connect_mock.call_count == _MAX_SETUP_RECOVERY_CONFLICT_RETRIES
-
-    def test_statement_timeout_query_canceled_during_setup_is_not_retried(self):
-        # A QueryCanceled that isn't a recovery conflict (a statement_timeout) must propagate
-        # immediately — the in-process retry is scoped strictly to "conflict with recovery".
-        err = psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
-        connection = self._make_failing_connection(err)
-
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
-            return_value=connection,
-        ) as connect_mock:
-            with patch("products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"):
-                with pytest.raises(psycopg.errors.QueryCanceled):
-                    self._call_postgres_source()
 
         assert connect_mock.call_count == 1
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -900,6 +900,48 @@ class TestPostgresSourceSetupRecoveryConflictRetry:
 
         assert connect_mock.call_count == 1
 
+    def test_recovery_conflict_as_query_canceled_during_setup_is_retried(self):
+        # A hot-standby recovery conflict can surface as QueryCanceled ("canceling statement due to
+        # conflict with recovery") rather than SerializationFailure — the same transient condition.
+        # The setup loop must retry it in-process exactly like the SerializationFailure flavor;
+        # before the fix it escaped on the first probe and failed the whole activity.
+        err = psycopg.errors.QueryCanceled(
+            "canceling statement due to conflict with recovery\n"
+            "DETAIL:  User query might have conflicted with replica reconnect."
+        )
+        connection = self._make_failing_connection(err)
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            return_value=connection,
+        ) as connect_mock:
+            with patch("products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+                with pytest.raises(Exception) as exc_info:
+                    self._call_postgres_source()
+
+        message = str(exc_info.value)
+        assert "conflict with recovery" in message and "max_standby_streaming_delay" in message
+        non_retryable = PostgresSource().get_non_retryable_errors()
+        assert any(pattern in message for pattern in non_retryable.keys())
+        # Each retry reconnects, so connect is called once per attempt.
+        assert connect_mock.call_count == _MAX_SETUP_RECOVERY_CONFLICT_RETRIES
+
+    def test_statement_timeout_query_canceled_during_setup_is_not_retried(self):
+        # A QueryCanceled that isn't a recovery conflict (a statement_timeout) must propagate
+        # immediately — the in-process retry is scoped strictly to "conflict with recovery".
+        err = psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+        connection = self._make_failing_connection(err)
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            return_value=connection,
+        ) as connect_mock:
+            with patch("products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.time.sleep"):
+                with pytest.raises(psycopg.errors.QueryCanceled):
+                    self._call_postgres_source()
+
+        assert connect_mock.call_count == 1
+
     def test_connection_dropped_while_opening_setup_connection_is_retried(self):
         # A transient drop while opening the setup connection ("server closed the connection
         # unexpectedly") is the same class of error the read path already recovers from. The setup


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `QueryCanceled` ("Canceling statement due to conflict with recovery. User query might have conflicted with replica reconnect.") raised inside the Postgres import source during schema discovery — [error tracking issue](https://us.posthog.com/project/2/error_tracking/019f0ac5-96ee-7a12-98f1-a467ba11dad0). The stack originates in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py` (`_get_table` → `postgres_source`).

This is a hot-standby **recovery conflict**: a customer is syncing from a read replica, and the replica canceled an in-flight metadata query while applying changes from the primary (here, around a replica reconnect). It's transient — reconnecting and retrying recovers.

The setup/discovery path already has deliberate in-process recovery for exactly this condition (`setup_recovery_conflicts`: reconnect with bounded backoff, then a non-retryable abort once sustained). But it only matched the `SerializationFailure` flavor of the conflict (`"terminating connection due to conflict with recovery"`). When the same conflict arrives as `QueryCanceled` (`"canceling statement due to conflict with recovery"` — the statement is canceled rather than the connection terminated), it slipped past the handler and failed the whole activity. `QueryCanceled` subclasses `OperationalError`, so it fell through to the connection-dropped handler, didn't match, and re-raised.

## Changes

- The setup-phase recovery-conflict clause in `postgres_source` now catches both `SerializationFailure` and `QueryCanceled`. Both are gated on the same `"conflict with recovery"` substring, so any other `QueryCanceled` (a `statement_timeout`) still re-raises unchanged — the in-process retry stays scoped strictly to recovery conflicts.
- This is **not** a `NonRetryableErrors` change: a single recovery conflict is transient and stays retryable in-process; only the existing sustained-conflict abort remains non-retryable.

## How did you test this code?

I'm an agent (Claude Code). I added two regression tests next to the existing setup-recovery tests and ran them with the rest of the file:

- `test_recovery_conflict_as_query_canceled_during_setup_is_retried` — a `QueryCanceled` recovery conflict during setup is now retried in-process (one reconnect per attempt) and ends in the non-retryable abort once sustained. Before the fix it escaped on the first probe.
- `test_statement_timeout_query_canceled_during_setup_is_not_retried` — a non-recovery `QueryCanceled` (statement timeout) still propagates on the first attempt, locking in the scoping.

`TestPostgresSourceSetupRecoveryConflictRetry` passes (8/8). The wider file passes too, except for pre-existing tests that require a live Postgres connection (they error at `psycopg.connect` in this sandbox) and are unrelated to this change. `ruff check` and `ruff format --check` are clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook. Pulled the issue and a representative stack trace via the PostHog MCP error-tracking tools, traced the call path into `_get_table`/`postgres_source`, and confirmed the failing path against the existing recovery-conflict handling.

Decision: this is a fixable fragility bug, not a `NonRetryableErrors` addition. The code already intends to absorb recovery conflicts in-process during discovery; it just keyed off one psycopg exception class when the same condition can arrive as a sibling class. Kept the change to a single `except` clause plus a comment, mirroring the existing read-path handling. Verified no open PR (including the maintainer's own) already covers this.
