### PR TITLE
fix(postgres): keep transient SSL connection drops retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -172,6 +172,12 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # no-SSL-support source fails with a different message ("server does not support SSL") and, on
     # require_ssl sources, is converted to SSLRequiredError before reaching this check.
     "ssl connection has been closed unexpectedly",
+    # The lower-level form of the same TLS drop: a socket-level failure during the SSL handshake or
+    # read (EOF, connection reset) surfaces as "... SSL SYSCALL error: EOF detected" (and similar).
+    # Same transient class as the bare SSL drop above — a pooler/firewall idle cull, failover, or
+    # network blip mid-handshake — and recovers on reconnect. Never the unsupported-SSL signal,
+    # which is the distinct "server does not support SSL" message.
+    "ssl syscall error",
     "no connection to the server",
     "terminating connection due to",
     # psycopg's own message when libpq finds the socket already gone (PGconn.socket
@@ -540,7 +546,12 @@ def _connect_to_postgres(
             **kwargs,
         )
     except psycopg.OperationalError as e:
-        if require_ssl and "SSL" in str(e) and not _is_invalid_ssl_negotiation_response(e):
+        if (
+            require_ssl
+            and "SSL" in str(e)
+            and not _is_invalid_ssl_negotiation_response(e)
+            and not _is_connection_dropped_error(e)
+        ):
             raise SSLRequiredError(
                 "SSL/TLS connection is required but your database does not support it. "
                 "Please enable SSL/TLS on your PostgreSQL server or contact your database administrator."
@@ -2539,7 +2550,12 @@ def postgres_source(
                     options=FORCE_UTF8_CLIENT_ENCODING,
                 )
             except psycopg.OperationalError as e:
-                if require_ssl and "SSL" in str(e) and not _is_invalid_ssl_negotiation_response(e):
+                if (
+                    require_ssl
+                    and "SSL" in str(e)
+                    and not _is_invalid_ssl_negotiation_response(e)
+                    and not _is_connection_dropped_error(e)
+                ):
                     raise SSLRequiredError(
                         "SSL/TLS connection is required but your database does not support it. "
                         "Please enable SSL/TLS on your PostgreSQL server or contact your database administrator."
@@ -2858,7 +2874,12 @@ def postgres_source(
                         options=FORCE_UTF8_CLIENT_ENCODING,
                     )
                 except psycopg.OperationalError as e:
-                    if require_ssl and "SSL" in str(e) and not _is_invalid_ssl_negotiation_response(e):
+                    if (
+                        require_ssl
+                        and "SSL" in str(e)
+                        and not _is_invalid_ssl_negotiation_response(e)
+                        and not _is_connection_dropped_error(e)
+                    ):
                         raise SSLRequiredError(
                             "SSL/TLS connection is required but your database does not support it. "
                             "Please enable SSL/TLS on your PostgreSQL server or contact your database administrator."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -990,6 +990,13 @@ class TestIsConnectionDroppedError:
                 'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
                 "SSL connection has been closed unexpectedly"
             ),
+            # libpq's lower-level form of the same TLS drop — a socket-level EOF/reset during the
+            # SSL handshake or read. Transient (pooler/firewall idle cull, failover, network blip),
+            # not the permanent no-SSL-support case, so the in-process reconnect must catch it.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "SSL SYSCALL error: EOF detected"
+            ),
             psycopg.OperationalError("terminating connection due to administrator command"),
             # psycopg's message when libpq finds the socket already gone (raised from
             # PGconn.socket inside the commit at the end of get_connection). A transient
@@ -1448,6 +1455,33 @@ class TestInvalidSSLNegotiationResponse:
                 _connect_to_postgres(
                     host="db", port=5432, database="db", user="postgres", password="x", require_ssl=True
                 )
+
+    @pytest.mark.parametrize(
+        "message",
+        [
+            "SSL connection has been closed unexpectedly",
+            "SSL SYSCALL error: EOF detected",
+        ],
+    )
+    def test_transient_ssl_drop_is_not_wrapped_as_ssl_required(self, message):
+        # require_ssl=True, but the message is a transient TLS drop (pooler/firewall idle cull,
+        # failover, network blip) — it must surface raw so the connect-retry / Temporal can treat
+        # it as retryable, not as the non-retryable SSLRequiredError, which would permanently stop
+        # the sync with a misleading "enable SSL on your server" message.
+        connect_mock = mock.MagicMock(
+            side_effect=psycopg.OperationalError(
+                f'connection failed: connection to server at "10.0.0.1", port 5432 failed: {message}'
+            )
+        )
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.psycopg.connect",
+            connect_mock,
+        ):
+            with pytest.raises(psycopg.OperationalError) as exc_info:
+                _connect_to_postgres(
+                    host="db", port=5432, database="db", user="postgres", password="x", require_ssl=True
+                )
+        assert not isinstance(exc_info.value, SSLRequiredError)
 
 
 class TestStatementTimeoutAsNonRetryable:


### PR DESCRIPTION
## Problem

The Postgres data-warehouse import source was surfacing a recurring `OperationalError` in error tracking: a TLS connection dropping on connect — `SSL connection has been closed unexpectedly` and `SSL SYSCALL error: EOF detected`.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f09c5-5460-7171-acf5-265837239ea1

The stack shows the failure originates in this source's connect path (`get_connection` → `_connect_with_options_fallback` in `postgres.py`), wrapped through `_retry_on_connection_dropped`.

These messages are **transient** drops — a connection pooler/firewall idle cull, a failover, or a network blip mid-handshake — and the code already documents them as such (they're a sibling of the libpq drops in `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`, and `source.py` explicitly keeps `SSL connection has been closed unexpectedly` out of `get_non_retryable_errors`).

The bug: the connect-time SSL guard matched **any** message containing `"SSL"` and converted it to `SSLRequiredError`, which *is* non-retryable. So a transient blip was turned into a permanent failure, and the user saw a misleading "enable SSL on your PostgreSQL server" message even though their database supports SSL fine. The genuine unsupported-SSL case has a distinct message (`server does not support SSL, but SSL was required`).

## Changes

- Narrow the three identical SSL-required wrap sites so a connection-dropped error is excluded from the `SSLRequiredError` conversion, mirroring the existing `_is_invalid_ssl_negotiation_response` carve-out. Transient SSL drops now fall through to the existing reconnect/retry machinery; genuine "server does not support SSL" still wraps as before.
- Add `ssl syscall error` to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` so the lower-level socket-level form of the same TLS drop is recognised and recovered in-process during schema discovery and sync setup.

## How did you test this code?

I'm an agent. I ran the existing unit tests plus the new ones — no manual testing.

- Extended `TestIsConnectionDroppedError` to assert the `SSL SYSCALL error: EOF detected` connect message is detected as a transient drop (guards the in-process reconnect path).
- Added `test_transient_ssl_drop_is_not_wrapped_as_ssl_required` (parametrized over both transient SSL messages) asserting `_connect_to_postgres(require_ssl=True)` surfaces the raw `OperationalError` rather than the non-retryable `SSLRequiredError`. The existing `test_genuine_unsupported_ssl_still_raises_ssl_required` continues to pass, confirming the genuine unsupported-SSL case is unaffected.
- Ran the SSL/connection-dropped/non-retryable test classes: 197 passed. (One unrelated test that requires a live Postgres DB errored in setup due to no DB in the sandbox.)

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the Postgres source. Confirmed the issue in error tracking (3 occurrences across 3 sources, stack rooted in `postgres.py`'s connect path), then read the source to find the root cause.

Decision: this is a fixable bug, not a NonRetryableErrors case. The error is transient infrastructure noise that should stay retryable — the code's own comments already say so — but an over-broad `"SSL" in str(e)` check was intercepting it before the retry logic and mislabeling it as the permanent `SSLRequiredError`. Kept the fix scoped to the connect-time SSL guard and the dropped-error signature list; no retry-policy or global changes.

No skills were applicable to this change.