### PR TITLE
fix(postgres): correct misleading timeout message for fallback primary-key probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2796,10 +2796,10 @@ def postgres_source(
                                     has_duplicate_primary_keys = _has_duplicate_primary_keys(
                                         cursor, schema, table_name, primary_keys, logger
                                     )
-                                except psycopg.errors.QueryCanceled:
+                                except psycopg.errors.QueryCanceled as e:
                                     # Surface a message about the assumed `id` primary key rather than
                                     # falling through to the generic incremental-field timeout below.
-                                    raise _pk_uniqueness_probe_timeout_error()
+                                    raise _pk_uniqueness_probe_timeout_error() from e
                         except psycopg.errors.QueryCanceled:
                             if should_use_incremental_field:
                                 raise QueryTimeoutException(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -421,6 +421,24 @@ def _statement_timeout_as_non_retryable(
     )
 
 
+def _pk_uniqueness_probe_timeout_error() -> QueryTimeoutException:
+    """Build the timeout error for the fallback `id` primary-key uniqueness probe.
+
+    When a table has no declared primary key we fall back to assuming `id` is unique and verify
+    it with a full-table `GROUP BY id HAVING COUNT(*) > 1`, which can exhaust the statement_timeout
+    on large tables. The generic table-setup timeout message points at the incremental field, but
+    indexing that field doesn't help this probe — the fix is a primary key / index on `id`. Keeps
+    the "has an appropriate index" fragment so it stays non-retryable at the activity layer too
+    (see source.py).
+    """
+    return QueryTimeoutException(
+        'Timed out verifying that the "id" column is unique. This table has no primary key, so '
+        'PostHog assumed "id" was unique to sync incrementally but could not confirm it within the '
+        'timeout. Add a primary key, or ensure the "id" column has an appropriate index created, so '
+        "PostHog can sync this table incrementally."
+    )
+
+
 @dataclasses.dataclass(frozen=True)
 class PostgresDiscoveredSchema:
     source_catalog: str | None
@@ -2774,9 +2792,14 @@ def postgres_source(
                             has_duplicate_primary_keys = False
                             if used_id_pk_fallback:
                                 logger.debug("Checking duplicate primary keys...")
-                                has_duplicate_primary_keys = _has_duplicate_primary_keys(
-                                    cursor, schema, table_name, primary_keys, logger
-                                )
+                                try:
+                                    has_duplicate_primary_keys = _has_duplicate_primary_keys(
+                                        cursor, schema, table_name, primary_keys, logger
+                                    )
+                                except psycopg.errors.QueryCanceled:
+                                    # Surface a message about the assumed `id` primary key rather than
+                                    # falling through to the generic incremental-field timeout below.
+                                    raise _pk_uniqueness_probe_timeout_error()
                         except psycopg.errors.QueryCanceled:
                             if should_use_incremental_field:
                                 raise QueryTimeoutException(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -95,6 +95,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.p
     _is_unsupported_function_error,
     _next_recovery_conflict_chunk_size,
     _normalize_function_names,
+    _pk_uniqueness_probe_timeout_error,
     _raise_if_setup_connection_broken,
     _recovery_conflict_abort_error,
     _rls_active_from_conn,
@@ -787,6 +788,18 @@ class TestPostgresSourceNonRetryableErrors:
         # The class-name key can't catch the raw message (str(e) carries no class name); the
         # dedicated message fragment is what recognises it at the activity layer.
         assert "QueryTimeoutException" not in matching_keys
+        assert "has an appropriate index" in matching_keys
+
+    def test_pk_uniqueness_probe_timeout_is_non_retryable_and_points_at_primary_key(self, source):
+        # A statement_timeout in the fallback `id` uniqueness probe used to surface the generic
+        # "index your incremental field" message, which won't fix this full-table GROUP BY. The
+        # message must point at the assumed primary key while staying non-retryable at the raw
+        # activity-level layer (where str(e) carries no class name).
+        error_msg = str(_pk_uniqueness_probe_timeout_error())
+        assert "primary key" in error_msg
+        assert "incremental field" not in error_msg
+        non_retryable = source.get_non_retryable_errors()
+        matching_keys = [pattern for pattern in non_retryable if pattern in error_msg]
         assert "has an appropriate index" in matching_keys
 
     def test_ssh_handshake_eof_is_non_retryable(self, source):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring `QueryCanceled` ("canceling statement due to statement timeout") from the Postgres import source.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f0ac6-5f8a-7350-b3aa-a74e3d7f4942

The stack confirms the failure originates in this source's code. When a table has **no declared primary key** but does have an `id` column, the import falls back to assuming `id` is the primary key and verifies it is actually unique with a full-table `SELECT id ... GROUP BY id HAVING COUNT(*) > 1` probe (`_has_duplicate_primary_keys`). On a large table that aggregation can exhaust the 10-minute `statement_timeout` and raise `QueryCanceled`.

The probe re-raises the timeout into the table-setup handler, which converts *any* setup-phase timeout into a `QueryTimeoutException` whose message tells the user to *"ensure your incremental field (…) has an appropriate index created"*. That remediation is wrong here: the timeout is the `id`-uniqueness `GROUP BY`, not the incremental read, so indexing the incremental field won't fix it.

## Decision: fixable bug (misleading message), not a retry-policy change

The statement timeout is a user/upstream condition (large table, missing index), and it is **already** classified non-retryable via the existing `QueryTimeoutException` / `"has an appropriate index"` keys — so the retry behavior is correct and was left untouched. The bug is purely the misdirecting error message that the user acts on.

## Changes

- Intercept the `QueryCanceled` raised by the fallback `id`-uniqueness probe at its call site and raise a `QueryTimeoutException` whose message points at the **assumed primary key** — add a primary key, or index the `id` column — instead of falling through to the generic incremental-field message.
- The new message keeps the `"has an appropriate index"` fragment, so it stays non-retryable at both the activity layer (which matches on `str(e)` with no class name) and the workflow layer.
- Extracted the message into a small `_pk_uniqueness_probe_timeout_error()` helper, mirroring the existing `_statement_timeout_as_non_retryable` / `_recovery_conflict_abort_error` helpers.

Scoped to this one probe — no retry-policy, pipeline, or `NonRetryableErrors` changes.

## How did you test this code?

I'm an agent. I added a regression test (`test_pk_uniqueness_probe_timeout_is_non_retryable_and_points_at_primary_key`) asserting the new message references the primary key, does **not** mention the incremental field, and is still matched as non-retryable by the source's `get_non_retryable_errors()`. This catches a regression no existing test did: re-wording the message in a way that drops the non-retryable fragment (which would make the activity layer retry the timeout forever) or that re-introduces the incremental-field misdirection.

Ran the affected suites with the repo venv pytest:
- `TestPostgresSourceNonRetryableErrors` — 88 passed
- `TestStatementTimeoutAsNonRetryable` and the mock-based `TestHasDuplicatePrimaryKeys` cases — passed (3 `TestHasDuplicatePrimaryKeys` cases need a live Postgres and errored on connection in the sandbox; unrelated to this change)

`ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Tools: PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`) to confirm the issue, frequency, and exception chain (`QueryCanceled` → `QueryTimeoutException`, top frame `postgres.py:2782`), then code reading to trace the call path through `_has_duplicate_primary_keys`. No repo skills were required for this change.

Considered and rejected: (1) extending `NonRetryableErrors` — the error is already non-retryable, so that would be a no-op; (2) making the probe degrade gracefully to "no duplicates" on timeout — unsafe, a false negative would let a non-unique `id` corrupt an incremental sync. Chose to keep the safety semantics and only fix the misdirecting message. Checked open PRs (including the maintainer's) for duplicates; none address this.