### PR TITLE
chore(experiments): stop persisting feature flag config in parameters

### DIFF
--- a/ee/hogai/context/experiment/context.py
+++ b/ee/hogai/context/experiment/context.py
@@ -97,16 +97,14 @@ class ExperimentContext:
             variants_section = EXPERIMENT_VARIANTS_TEMPLATE.format(variants_list=variants_list)
 
         feature_flag_variants_section = ""
-        if experiment.parameters:
-            params = experiment.parameters
-            if params.get("feature_flag_variants"):
-                variants_list = "\n".join(
-                    f"- {v.get('key', 'unknown')}: {v.get('rollout_percentage', 0)}%"
-                    for v in params["feature_flag_variants"]
-                )
-                feature_flag_variants_section = EXPERIMENT_FEATURE_FLAG_VARIANTS_TEMPLATE.format(
-                    variants_list=variants_list
-                )
+        flag_variants = experiment.feature_flag.variants if experiment.feature_flag else []
+        if flag_variants:
+            variants_list = "\n".join(
+                f"- {v.get('key', 'unknown')}: {v.get('rollout_percentage', 0)}%" for v in flag_variants
+            )
+            feature_flag_variants_section = EXPERIMENT_FEATURE_FLAG_VARIANTS_TEMPLATE.format(
+                variants_list=variants_list
+            )
 
         return EXPERIMENT_CONTEXT_TEMPLATE.format(
             experiment_name=experiment.name,

--- a/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
+++ b/posthog/tasks/test/__snapshots__/test_process_scheduled_changes.ambr
@@ -311,45 +311,6 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.20
   '''
-  SELECT "posthog_experiment"."id",
-         "posthog_experiment"."name",
-         "posthog_experiment"."description",
-         "posthog_experiment"."team_id",
-         "posthog_experiment"."filters",
-         "posthog_experiment"."parameters",
-         "posthog_experiment"."secondary_metrics",
-         "posthog_experiment"."created_by_id",
-         "posthog_experiment"."feature_flag_id",
-         "posthog_experiment"."exposure_cohort_id",
-         "posthog_experiment"."holdout_id",
-         "posthog_experiment"."start_date",
-         "posthog_experiment"."end_date",
-         "posthog_experiment"."created_at",
-         "posthog_experiment"."updated_at",
-         "posthog_experiment"."archived",
-         "posthog_experiment"."feature_flag_auto_archived",
-         "posthog_experiment"."deleted",
-         "posthog_experiment"."type",
-         "posthog_experiment"."variants",
-         "posthog_experiment"."exposure_criteria",
-         "posthog_experiment"."metrics",
-         "posthog_experiment"."metrics_secondary",
-         "posthog_experiment"."primary_metrics_ordered_uuids",
-         "posthog_experiment"."secondary_metrics_ordered_uuids",
-         "posthog_experiment"."stats_config",
-         "posthog_experiment"."scheduling_config",
-         "posthog_experiment"."running_time_calculation",
-         "posthog_experiment"."excluded_variants",
-         "posthog_experiment"."only_count_matured_users",
-         "posthog_experiment"."status",
-         "posthog_experiment"."conclusion",
-         "posthog_experiment"."conclusion_comment"
-  FROM "posthog_experiment"
-  WHERE "posthog_experiment"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.21
-  '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
          "posthog_organization"."slug",
@@ -390,7 +351,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.22
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.21
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -492,7 +453,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.22
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -531,7 +492,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.24
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.23
   '''
   SELECT "posthog_user"."id",
          "posthog_user"."password",
@@ -577,7 +538,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.25
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.24
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -679,7 +640,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.26
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.25
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -711,7 +672,7 @@
   UPDATE
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.27
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.26
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",
@@ -743,7 +704,7 @@
   LIMIT 1
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.28
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.27
   '''
   SELECT "posthog_filesystem"."team_id",
          "posthog_filesystem"."id",
@@ -768,7 +729,7 @@
                   AND "posthog_filesystem"."shortcut" IS NOT NULL))
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.28
   '''
   SELECT "posthog_filesystemshortcut"."id",
          "posthog_filesystemshortcut"."team_id",
@@ -789,6 +750,25 @@
          AND NOT ("posthog_filesystemshortcut"."path" = 'flag-1'
                   AND "posthog_filesystemshortcut"."href" = '__skipped__'
                   AND "posthog_filesystemshortcut"."href" IS NOT NULL))
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.29
+  '''
+  SELECT "posthog_integration"."id",
+         "posthog_integration"."team_id",
+         "posthog_integration"."kind",
+         "posthog_integration"."integration_id",
+         "posthog_integration"."config",
+         "posthog_integration"."sensitive_config",
+         "posthog_integration"."repository_cache",
+         "posthog_integration"."repository_cache_updated_at",
+         "posthog_integration"."errors",
+         "posthog_integration"."created_at",
+         "posthog_integration"."created_by_id"
+  FROM "posthog_integration"
+  WHERE ("posthog_integration"."kind" = 'vercel'
+         AND "posthog_integration"."team_id" = 99999)
+  LIMIT 21
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.3
@@ -821,25 +801,6 @@
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.30
-  '''
-  SELECT "posthog_integration"."id",
-         "posthog_integration"."team_id",
-         "posthog_integration"."kind",
-         "posthog_integration"."integration_id",
-         "posthog_integration"."config",
-         "posthog_integration"."sensitive_config",
-         "posthog_integration"."repository_cache",
-         "posthog_integration"."repository_cache_updated_at",
-         "posthog_integration"."errors",
-         "posthog_integration"."created_at",
-         "posthog_integration"."created_by_id"
-  FROM "posthog_integration"
-  WHERE ("posthog_integration"."kind" = 'vercel'
-         AND "posthog_integration"."team_id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -881,7 +842,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.31
   '''
   SELECT "posthog_organizationintegration"."id",
          "posthog_organizationintegration"."organization_id",
@@ -896,6 +857,24 @@
   WHERE ("posthog_organizationintegration"."kind" = 'vercel'
          AND "posthog_organizationintegration"."organization_id" = '00000000-0000-0000-0000-000000000000'::uuid)
   LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.32
+  '''
+  SELECT "posthog_taggeditem"."id",
+         "posthog_taggeditem"."tag_id",
+         "posthog_taggeditem"."dashboard_id",
+         "posthog_taggeditem"."insight_id",
+         "posthog_taggeditem"."event_definition_id",
+         "posthog_taggeditem"."property_definition_id",
+         "posthog_taggeditem"."action_id",
+         "posthog_taggeditem"."feature_flag_id",
+         "posthog_taggeditem"."experiment_saved_metric_id",
+         "posthog_taggeditem"."ticket_id",
+         "posthog_taggeditem"."account_id",
+         "posthog_taggeditem"."endpoint_id"
+  FROM "posthog_taggeditem"
+  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.33
@@ -918,20 +897,47 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.34
   '''
-  SELECT "posthog_taggeditem"."id",
-         "posthog_taggeditem"."tag_id",
-         "posthog_taggeditem"."dashboard_id",
-         "posthog_taggeditem"."insight_id",
-         "posthog_taggeditem"."event_definition_id",
-         "posthog_taggeditem"."property_definition_id",
-         "posthog_taggeditem"."action_id",
-         "posthog_taggeditem"."feature_flag_id",
-         "posthog_taggeditem"."experiment_saved_metric_id",
-         "posthog_taggeditem"."ticket_id",
-         "posthog_taggeditem"."account_id",
-         "posthog_taggeditem"."endpoint_id"
-  FROM "posthog_taggeditem"
-  WHERE "posthog_taggeditem"."feature_flag_id" = 99999
+  SELECT "posthog_survey"."id",
+         "posthog_survey"."team_id",
+         "posthog_survey"."name",
+         "posthog_survey"."description",
+         "posthog_survey"."linked_flag_id",
+         "posthog_survey"."targeting_flag_id",
+         "posthog_survey"."linked_insight_id",
+         "posthog_survey"."internal_targeting_flag_id",
+         "posthog_survey"."internal_response_sampling_flag_id",
+         "posthog_survey"."type",
+         "posthog_survey"."conditions",
+         "posthog_survey"."questions",
+         "posthog_survey"."appearance",
+         "posthog_survey"."created_at",
+         "posthog_survey"."created_by_id",
+         "posthog_survey"."start_date",
+         "posthog_survey"."end_date",
+         "posthog_survey"."updated_at",
+         "posthog_survey"."archived",
+         "posthog_survey"."responses_limit",
+         "posthog_survey"."response_sampling_start_date",
+         "posthog_survey"."response_sampling_interval_type",
+         "posthog_survey"."response_sampling_interval",
+         "posthog_survey"."response_sampling_limit",
+         "posthog_survey"."response_sampling_daily_limits",
+         "posthog_survey"."iteration_count",
+         "posthog_survey"."iteration_frequency_days",
+         "posthog_survey"."iteration_start_dates",
+         "posthog_survey"."current_iteration",
+         "posthog_survey"."current_iteration_start_date",
+         "posthog_survey"."schedule",
+         "posthog_survey"."enable_partial_responses",
+         "posthog_survey"."enable_iframe_embedding",
+         "posthog_survey"."headline_summary",
+         "posthog_survey"."headline_response_count",
+         "posthog_survey"."question_summaries",
+         "posthog_survey"."form_content",
+         "posthog_survey"."base_language",
+         "posthog_survey"."translations"
+  FROM "posthog_survey"
+  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.35
@@ -981,47 +987,13 @@
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.36
   '''
-  SELECT "posthog_survey"."id",
-         "posthog_survey"."team_id",
-         "posthog_survey"."name",
-         "posthog_survey"."description",
-         "posthog_survey"."linked_flag_id",
-         "posthog_survey"."targeting_flag_id",
-         "posthog_survey"."linked_insight_id",
-         "posthog_survey"."internal_targeting_flag_id",
-         "posthog_survey"."internal_response_sampling_flag_id",
-         "posthog_survey"."type",
-         "posthog_survey"."conditions",
-         "posthog_survey"."questions",
-         "posthog_survey"."appearance",
-         "posthog_survey"."created_at",
-         "posthog_survey"."created_by_id",
-         "posthog_survey"."start_date",
-         "posthog_survey"."end_date",
-         "posthog_survey"."updated_at",
-         "posthog_survey"."archived",
-         "posthog_survey"."responses_limit",
-         "posthog_survey"."response_sampling_start_date",
-         "posthog_survey"."response_sampling_interval_type",
-         "posthog_survey"."response_sampling_interval",
-         "posthog_survey"."response_sampling_limit",
-         "posthog_survey"."response_sampling_daily_limits",
-         "posthog_survey"."iteration_count",
-         "posthog_survey"."iteration_frequency_days",
-         "posthog_survey"."iteration_start_dates",
-         "posthog_survey"."current_iteration",
-         "posthog_survey"."current_iteration_start_date",
-         "posthog_survey"."schedule",
-         "posthog_survey"."enable_partial_responses",
-         "posthog_survey"."enable_iframe_embedding",
-         "posthog_survey"."headline_summary",
-         "posthog_survey"."headline_response_count",
-         "posthog_survey"."question_summaries",
-         "posthog_survey"."form_content",
-         "posthog_survey"."base_language",
-         "posthog_survey"."translations"
-  FROM "posthog_survey"
-  WHERE "posthog_survey"."internal_response_sampling_flag_id" = 99999
+  SELECT "ee_featureflagroleaccess"."id",
+         "ee_featureflagroleaccess"."feature_flag_id",
+         "ee_featureflagroleaccess"."role_id",
+         "ee_featureflagroleaccess"."added_at",
+         "ee_featureflagroleaccess"."updated_at"
+  FROM "ee_featureflagroleaccess"
+  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.37
@@ -1036,95 +1008,6 @@
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.38
-  '''
-  SELECT "ee_featureflagroleaccess"."id",
-         "ee_featureflagroleaccess"."feature_flag_id",
-         "ee_featureflagroleaccess"."role_id",
-         "ee_featureflagroleaccess"."added_at",
-         "ee_featureflagroleaccess"."updated_at"
-  FROM "ee_featureflagroleaccess"
-  WHERE "ee_featureflagroleaccess"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.39
-  '''
-  SELECT "posthog_experiment"."id",
-         "posthog_experiment"."name",
-         "posthog_experiment"."description",
-         "posthog_experiment"."team_id",
-         "posthog_experiment"."filters",
-         "posthog_experiment"."parameters",
-         "posthog_experiment"."secondary_metrics",
-         "posthog_experiment"."created_by_id",
-         "posthog_experiment"."feature_flag_id",
-         "posthog_experiment"."exposure_cohort_id",
-         "posthog_experiment"."holdout_id",
-         "posthog_experiment"."start_date",
-         "posthog_experiment"."end_date",
-         "posthog_experiment"."created_at",
-         "posthog_experiment"."updated_at",
-         "posthog_experiment"."archived",
-         "posthog_experiment"."feature_flag_auto_archived",
-         "posthog_experiment"."deleted",
-         "posthog_experiment"."type",
-         "posthog_experiment"."variants",
-         "posthog_experiment"."exposure_criteria",
-         "posthog_experiment"."metrics",
-         "posthog_experiment"."metrics_secondary",
-         "posthog_experiment"."primary_metrics_ordered_uuids",
-         "posthog_experiment"."secondary_metrics_ordered_uuids",
-         "posthog_experiment"."stats_config",
-         "posthog_experiment"."scheduling_config",
-         "posthog_experiment"."running_time_calculation",
-         "posthog_experiment"."excluded_variants",
-         "posthog_experiment"."only_count_matured_users",
-         "posthog_experiment"."status",
-         "posthog_experiment"."conclusion",
-         "posthog_experiment"."conclusion_comment"
-  FROM "posthog_experiment"
-  WHERE "posthog_experiment"."feature_flag_id" = 99999
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.4
-  '''
-  SELECT "posthog_featureflag"."id",
-         "posthog_featureflag"."key",
-         "posthog_featureflag"."name",
-         "posthog_featureflag"."filters",
-         "posthog_featureflag"."team_id",
-         "posthog_featureflag"."created_by_id",
-         "posthog_featureflag"."created_at",
-         "posthog_featureflag"."updated_at",
-         "posthog_featureflag"."deleted",
-         "posthog_featureflag"."active",
-         "posthog_featureflag"."archived",
-         "posthog_featureflag"."version",
-         "posthog_featureflag"."last_modified_by_id",
-         "posthog_featureflag"."rollback_conditions",
-         "posthog_featureflag"."performed_rollback",
-         "posthog_featureflag"."ensure_experience_continuity",
-         "posthog_featureflag"."usage_dashboard_id",
-         "posthog_featureflag"."has_enriched_analytics",
-         "posthog_featureflag"."is_remote_configuration",
-         "posthog_featureflag"."has_encrypted_payloads",
-         "posthog_featureflag"."evaluation_runtime",
-         "posthog_featureflag"."bucketing_identifier",
-         "posthog_featureflag"."last_called_at"
-  FROM "posthog_featureflag"
-  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
-  WHERE (NOT ("posthog_featureflag"."deleted")
-         AND ("posthog_featureflag"."team_id" =
-                (SELECT U0."parent_team_id" AS "parent_team_id"
-                 FROM "posthog_team" U0
-                 WHERE U0."id" = 99999
-                 LIMIT 1)
-              OR ("posthog_team"."parent_team_id" IS NULL
-                  AND "posthog_featureflag"."team_id" = 99999))
-         AND "posthog_featureflag"."id" = 99999)
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.40
   '''
   SELECT "posthog_organization"."id",
          "posthog_organization"."name",
@@ -1166,7 +1049,7 @@
   LIMIT 21
   '''
 # ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.41
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.39
   '''
   SELECT "posthog_team"."id",
          "posthog_team"."uuid",
@@ -1265,6 +1148,95 @@
          "posthog_team"."business_model"
   FROM "posthog_team"
   WHERE "posthog_team"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.4
+  '''
+  SELECT "posthog_featureflag"."id",
+         "posthog_featureflag"."key",
+         "posthog_featureflag"."name",
+         "posthog_featureflag"."filters",
+         "posthog_featureflag"."team_id",
+         "posthog_featureflag"."created_by_id",
+         "posthog_featureflag"."created_at",
+         "posthog_featureflag"."updated_at",
+         "posthog_featureflag"."deleted",
+         "posthog_featureflag"."active",
+         "posthog_featureflag"."archived",
+         "posthog_featureflag"."version",
+         "posthog_featureflag"."last_modified_by_id",
+         "posthog_featureflag"."rollback_conditions",
+         "posthog_featureflag"."performed_rollback",
+         "posthog_featureflag"."ensure_experience_continuity",
+         "posthog_featureflag"."usage_dashboard_id",
+         "posthog_featureflag"."has_enriched_analytics",
+         "posthog_featureflag"."is_remote_configuration",
+         "posthog_featureflag"."has_encrypted_payloads",
+         "posthog_featureflag"."evaluation_runtime",
+         "posthog_featureflag"."bucketing_identifier",
+         "posthog_featureflag"."last_called_at"
+  FROM "posthog_featureflag"
+  INNER JOIN "posthog_team" ON ("posthog_featureflag"."team_id" = "posthog_team"."id")
+  WHERE (NOT ("posthog_featureflag"."deleted")
+         AND ("posthog_featureflag"."team_id" =
+                (SELECT U0."parent_team_id" AS "parent_team_id"
+                 FROM "posthog_team" U0
+                 WHERE U0."id" = 99999
+                 LIMIT 1)
+              OR ("posthog_team"."parent_team_id" IS NULL
+                  AND "posthog_featureflag"."team_id" = 99999))
+         AND "posthog_featureflag"."id" = 99999)
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.40
+  '''
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."timezone",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE "posthog_scheduledchange"."id" = 99999
+  LIMIT 21
+  '''
+# ---
+# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.41
+  '''
+  SELECT "posthog_scheduledchange"."id",
+         "posthog_scheduledchange"."record_id",
+         "posthog_scheduledchange"."model_name",
+         "posthog_scheduledchange"."payload",
+         "posthog_scheduledchange"."scheduled_at",
+         "posthog_scheduledchange"."executed_at",
+         "posthog_scheduledchange"."failure_reason",
+         "posthog_scheduledchange"."failure_count",
+         "posthog_scheduledchange"."is_recurring",
+         "posthog_scheduledchange"."recurrence_interval",
+         "posthog_scheduledchange"."last_executed_at",
+         "posthog_scheduledchange"."cron_expression",
+         "posthog_scheduledchange"."end_date",
+         "posthog_scheduledchange"."timezone",
+         "posthog_scheduledchange"."team_id",
+         "posthog_scheduledchange"."created_at",
+         "posthog_scheduledchange"."created_by_id",
+         "posthog_scheduledchange"."updated_at"
+  FROM "posthog_scheduledchange"
+  WHERE "posthog_scheduledchange"."id" = 99999
   LIMIT 21
   '''
 # ---
@@ -1319,56 +1291,6 @@
   '''
 # ---
 # name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.44
-  '''
-  SELECT "posthog_scheduledchange"."id",
-         "posthog_scheduledchange"."record_id",
-         "posthog_scheduledchange"."model_name",
-         "posthog_scheduledchange"."payload",
-         "posthog_scheduledchange"."scheduled_at",
-         "posthog_scheduledchange"."executed_at",
-         "posthog_scheduledchange"."failure_reason",
-         "posthog_scheduledchange"."failure_count",
-         "posthog_scheduledchange"."is_recurring",
-         "posthog_scheduledchange"."recurrence_interval",
-         "posthog_scheduledchange"."last_executed_at",
-         "posthog_scheduledchange"."cron_expression",
-         "posthog_scheduledchange"."end_date",
-         "posthog_scheduledchange"."timezone",
-         "posthog_scheduledchange"."team_id",
-         "posthog_scheduledchange"."created_at",
-         "posthog_scheduledchange"."created_by_id",
-         "posthog_scheduledchange"."updated_at"
-  FROM "posthog_scheduledchange"
-  WHERE "posthog_scheduledchange"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.45
-  '''
-  SELECT "posthog_scheduledchange"."id",
-         "posthog_scheduledchange"."record_id",
-         "posthog_scheduledchange"."model_name",
-         "posthog_scheduledchange"."payload",
-         "posthog_scheduledchange"."scheduled_at",
-         "posthog_scheduledchange"."executed_at",
-         "posthog_scheduledchange"."failure_reason",
-         "posthog_scheduledchange"."failure_count",
-         "posthog_scheduledchange"."is_recurring",
-         "posthog_scheduledchange"."recurrence_interval",
-         "posthog_scheduledchange"."last_executed_at",
-         "posthog_scheduledchange"."cron_expression",
-         "posthog_scheduledchange"."end_date",
-         "posthog_scheduledchange"."timezone",
-         "posthog_scheduledchange"."team_id",
-         "posthog_scheduledchange"."created_at",
-         "posthog_scheduledchange"."created_by_id",
-         "posthog_scheduledchange"."updated_at"
-  FROM "posthog_scheduledchange"
-  WHERE "posthog_scheduledchange"."id" = 99999
-  LIMIT 21
-  '''
-# ---
-# name: TestProcessScheduledChanges.test_schedule_feature_flag_multiple_changes.46
   '''
   SELECT "posthog_featureflag"."id",
          "posthog_featureflag"."key",

--- a/products/experiments/backend/experiment_service.py
+++ b/products/experiments/backend/experiment_service.py
@@ -515,6 +515,21 @@ class ExperimentService:
                 f"Must be one of: {', '.join(sorted(variant_keys))}"
             )
 
+    # Feature-flag config keys that belong on the linked FeatureFlag (the source of truth). They are
+    # accepted as create/update input to build/sync the flag, projected back into the deprecated
+    # `parameters` API field at read time (see ExperimentBaseSerializer), but never persisted into
+    # the `parameters` column.
+    FEATURE_FLAG_CONFIG_KEYS = ("feature_flag_variants", "rollout_percentage", "aggregation_group_type_index")
+
+    @classmethod
+    def _strip_feature_flag_config(cls, parameters: dict | None) -> dict | None:
+        """Return ``parameters`` without the feature-flag config keys, so they are not stored in the
+        deprecated column. Callers consume those keys earlier to build/sync the flag; reads
+        re-derive them from it. Returns a new dict, leaving the caller's input untouched."""
+        if not parameters:
+            return parameters
+        return {k: v for k, v in parameters.items() if k not in cls.FEATURE_FLAG_CONFIG_KEYS}
+
     @staticmethod
     def _variant_keys(variants: list | None) -> list[str]:
         """Extract variant keys from a feature_flag_variants list, skipping malformed entries."""
@@ -855,7 +870,9 @@ class ExperimentService:
             "name": name,
             "description": description,
             "type": type,
-            "parameters": parameters,
+            # Feature-flag config was already consumed by _ensure_feature_flag above; strip it so it
+            # lives only on the flag, not mirrored into the deprecated `parameters` column.
+            "parameters": self._strip_feature_flag_config(parameters),
             "running_time_calculation": running_time_calculation,
             "excluded_variants": excluded_variants,
             "metrics": metrics if metrics is not None else [],
@@ -2249,6 +2266,10 @@ class ExperimentService:
             feature_flag.save()
 
         # --- apply changes and save ----------------------------------------
+        # Feature-flag config was already synced to the flag above; strip it so it is not mirrored
+        # into the deprecated `parameters` column. Reads re-derive it from the flag.
+        if update_data.get("parameters") is not None:
+            update_data["parameters"] = self._strip_feature_flag_config(update_data["parameters"])
         for attr, value in update_data.items():
             setattr(experiment, attr, value)
         experiment.save()

--- a/products/experiments/backend/test/test_create_from_prompt.py
+++ b/products/experiments/backend/test/test_create_from_prompt.py
@@ -103,8 +103,10 @@ class TestExperimentsCreateFromPrompt(APILicensedTest):
         self.assertEqual(prompt_metadata["templates"], [template_name])
         self.assertEqual(prompt_metadata["versions"], versions)
 
-        # Variant split distribution sums to 100 with the right shape
-        variants = experiment.parameters["feature_flag_variants"]
+        # Variant split distribution sums to 100 with the right shape. The flag is the source of
+        # truth for variants (parameters no longer mirrors them).
+        feature_flag = FeatureFlag.objects.get(key=experiment.feature_flag.key, team_id=self.team.id)
+        variants = feature_flag.filters["multivariate"]["variants"]
         self.assertEqual(len(variants), n)
         self.assertEqual(sum(_split_distribution(variants)), 100)
         self.assertEqual(_split_distribution(variants), _expected_splits(n))
@@ -116,11 +118,6 @@ class TestExperimentsCreateFromPrompt(APILicensedTest):
             expected_key = "test" if n == 2 else f"test-{i}"
             self.assertEqual(variant["key"], expected_key)
             self.assertEqual(variant["name"], f"v{versions[i]}")
-
-        # Feature flag was created with the variants
-        feature_flag = FeatureFlag.objects.get(key=experiment.feature_flag.key, team_id=self.team.id)
-        flag_variants = feature_flag.filters["multivariate"]["variants"]
-        self.assertEqual([v["key"] for v in flag_variants], [v["key"] for v in variants])
 
         # Each variant carries a JSON payload with {prompt_name, prompt_version} so the SDK can
         # read it via flags.get_flag_payload(...) without consulting any other state.

--- a/products/experiments/backend/test/test_max_tools.py
+++ b/products/experiments/backend/test/test_max_tools.py
@@ -208,12 +208,13 @@ class TestCreateExperimentTool(APIBaseTest):
         assert "Successfully created" in result
 
         experiment = await Experiment.objects.aget(name="Parameter Test", team=self.team)
-        assert experiment.parameters is not None
-        assert experiment.parameters["feature_flag_variants"] == [
+        # Variants live on the flag (the source of truth), not mirrored into `parameters`.
+        flag = await FeatureFlag.objects.aget(key="param-test", team=self.team)
+        assert flag.variants == [
             {"key": "control", "name": "Control", "rollout_percentage": 50},
             {"key": "test", "name": "Test", "rollout_percentage": 50},
         ]
-        assert "minimum_detectable_effect" not in experiment.parameters
+        assert "minimum_detectable_effect" not in (experiment.parameters or {})
         assert experiment.running_time_calculation == {"minimum_detectable_effect": 30}
         assert experiment.metrics == []
         assert experiment.metrics_secondary == []
@@ -292,13 +293,16 @@ class TestCreateExperimentTool(APIBaseTest):
         assert "Successfully created" in result
 
         experiment = await Experiment.objects.aget(name="Custom Variants Test", team=self.team)
-        assert experiment.parameters is not None
-        assert len(experiment.parameters["feature_flag_variants"]) == 3
-        assert experiment.parameters["feature_flag_variants"][0]["key"] == "control"
-        assert experiment.parameters["feature_flag_variants"][0]["name"] == "Control"
-        assert experiment.parameters["feature_flag_variants"][0]["rollout_percentage"] == 33
-        assert experiment.parameters["feature_flag_variants"][1]["key"] == "variant_b"
-        assert experiment.parameters["feature_flag_variants"][2]["key"] == "variant_c"
+        # Variants live on the flag (the source of truth), not mirrored into `parameters`.
+        flag = await FeatureFlag.objects.aget(key="custom-variants-flag", team=self.team)
+        assert experiment.feature_flag_id == flag.id
+        variants = flag.variants
+        assert len(variants) == 3
+        assert variants[0]["key"] == "control"
+        assert variants[0]["name"] == "Control"
+        assert variants[0]["rollout_percentage"] == 33
+        assert variants[1]["key"] == "variant_b"
+        assert variants[2]["key"] == "variant_c"
 
     async def test_create_experiment_flag_without_control_variant(self):
         await self._create_multivariate_flag(

--- a/products/experiments/backend/test/test_presentation_api.py
+++ b/products/experiments/backend/test/test_presentation_api.py
@@ -2259,6 +2259,56 @@ class TestExperimentCRUD(APILicensedTest):
         self.assertEqual(list_parameters["feature_flag_variants"], expected_variants)
         self.assertEqual(list_parameters["aggregation_group_type_index"], 1)
 
+    def test_feature_flag_config_is_not_persisted_into_parameters(self):
+        """Create and update consume feature-flag config to build/sync the flag, but never store it
+        in the deprecated `parameters` column. Non-flag keys (e.g. variant_notes) are preserved.
+        """
+        ff_key = "ff-config-not-stored"
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/experiments/",
+            {
+                "name": "No mirror",
+                "feature_flag_key": ff_key,
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ],
+                    "rollout_percentage": 100,
+                    "variant_notes": {"control": "baseline"},
+                },
+            },
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        experiment_id = response.json()["id"]
+
+        experiment = Experiment.objects.get(id=experiment_id)
+        assert experiment.parameters is not None
+        self.assertNotIn("feature_flag_variants", experiment.parameters)
+        self.assertNotIn("rollout_percentage", experiment.parameters)
+        self.assertEqual(experiment.parameters["variant_notes"], {"control": "baseline"})
+        flag = FeatureFlag.objects.get(key=ff_key, team_id=self.team.id)
+        self.assertEqual([v["key"] for v in flag.variants], ["control", "test"])
+
+        # A draft update that re-sends the full parameters blob also strips the flag config and
+        # keeps the non-flag keys.
+        self.client.patch(
+            f"/api/projects/{self.team.id}/experiments/{experiment_id}",
+            {
+                "parameters": {
+                    "feature_flag_variants": [
+                        {"key": "control", "name": "Control", "rollout_percentage": 50},
+                        {"key": "test", "name": "Test", "rollout_percentage": 50},
+                    ],
+                    "variant_notes": {"control": "still baseline"},
+                },
+            },
+        )
+        experiment.refresh_from_db()
+        assert experiment.parameters is not None
+        self.assertNotIn("feature_flag_variants", experiment.parameters)
+        self.assertEqual(experiment.parameters["variant_notes"], {"control": "still baseline"})
+
     def test_experiment_response_includes_feature_flag(self):
         """Test that experiment responses include the feature_flag field correctly serialized."""
         response = self.client.post(
@@ -3197,13 +3247,15 @@ class TestExperimentCRUD(APILicensedTest):
             },
         )
 
-        # Verify that Experiment.parameters.feature_flag_variants reflects the updated FeatureFlag.filters.multivariate.variants
-        experiment = Experiment.objects.get(id=experiment_id)
-        assert experiment.parameters is not None
-        parameters = cast(dict[str, Any], experiment.parameters)
+        # The flag is the source of truth; the experiment API projects variants and aggregation
+        # group type from it (no `parameters` mirror is persisted).
+        parameters = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment_id}").json()["parameters"]
         self.assertEqual(
             parameters["feature_flag_variants"],
-            [{"key": "control", "rollout_percentage": 10}, {"key": "test", "rollout_percentage": 90}],
+            [
+                {"key": "control", "rollout_percentage": 10, "split_percent": 10},
+                {"key": "test", "rollout_percentage": 90, "split_percent": 90},
+            ],
         )
         self.assertEqual(parameters["aggregation_group_type_index"], 1)
 
@@ -3247,10 +3299,9 @@ class TestExperimentCRUD(APILicensedTest):
             },
         )
 
-        # Verify that aggregation_group_type_index is removed from experiment parameters
-        experiment = Experiment.objects.get(id=experiment_id)
-        assert experiment.parameters is not None
-        self.assertNotIn("aggregation_group_type_index", cast(dict[str, Any], experiment.parameters))
+        # With no aggregation_group_type_index on the flag, it is absent from the projection too.
+        parameters = self.client.get(f"/api/projects/{self.team.id}/experiments/{experiment_id}").json()["parameters"]
+        self.assertNotIn("aggregation_group_type_index", parameters)
 
     def test_update_experiment_exposure_config_valid(self):
         feature_flag = FeatureFlag.objects.create(
@@ -7239,11 +7290,11 @@ class TestExperimentRunningTimeCalculation(APILicensedTest):
             experiment.running_time_calculation,
             {"minimum_detectable_effect": 10, "recommended_running_time": 7},
         )
-        # `parameters` is untouched: variants survive and no calculator keys leak in.
-        assert experiment.parameters is not None
-        self.assertEqual(len(experiment.parameters["feature_flag_variants"]), 2)
-        self.assertNotIn("minimum_detectable_effect", experiment.parameters)
-        self.assertNotIn("recommended_running_time", experiment.parameters)
+        # Calculator keys never leak into `parameters`, and the variants on the flag are untouched.
+        self.assertNotIn("minimum_detectable_effect", experiment.parameters or {})
+        self.assertNotIn("recommended_running_time", experiment.parameters or {})
+        flag = FeatureFlag.objects.get(key="running-time-flag")
+        self.assertEqual(len(flag.filters["multivariate"]["variants"]), 2)
 
     def test_update_running_time_calculation_does_not_touch_feature_flag(self):
         variants = [
@@ -7363,9 +7414,9 @@ class TestExperimentExcludedVariants(APILicensedTest):
         experiment = Experiment.objects.get(pk=created["id"])
         self.assertEqual(experiment.excluded_variants, ["test-2"])
         # Only the column is written; the deprecated parameters blob is untouched
-        assert experiment.parameters is not None
-        self.assertNotIn("excluded_variants", experiment.parameters)
-        self.assertEqual(len(experiment.parameters["feature_flag_variants"]), 3)
+        self.assertNotIn("excluded_variants", experiment.parameters or {})
+        flag = FeatureFlag.objects.get(key="excluded-variants-flag")
+        self.assertEqual(len(flag.filters["multivariate"]["variants"]), 3)
 
     def test_update_excluded_variants_does_not_touch_feature_flag(self):
         created = self._create_experiment(parameters={"feature_flag_variants": self.THREE_VARIANTS})

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -1953,22 +1953,9 @@ class FeatureFlagSerializer(
                 # nosemgrep: idor-lookup-without-team -- dashboard objects validated via get_fields() queryset restriction
                 FeatureFlagDashboards.objects.get_or_create(dashboard=dashboard, feature_flag=instance)
 
-        # Propagate the new variants and aggregation group type index to the linked experiments
-        if "filters" in validated_data:
-            filters = validated_data["filters"] or {}
-            multivariate = filters.get("multivariate") or {}
-            variants = multivariate.get("variants", [])
-            aggregation_group_type_index = filters.get("aggregation_group_type_index")
-
-            for experiment in instance.experiment_set.all():
-                if experiment.parameters is None:
-                    experiment.parameters = {}
-                experiment.parameters["feature_flag_variants"] = variants
-                if aggregation_group_type_index is not None:
-                    experiment.parameters["aggregation_group_type_index"] = aggregation_group_type_index
-                else:
-                    experiment.parameters.pop("aggregation_group_type_index", None)
-                experiment.save()
+        # The linked feature flag is the source of truth for variants and aggregation group type.
+        # Experiment reads derive these from the flag (see ExperimentBaseSerializer), so there is no
+        # longer a `parameters` mirror to keep in sync here.
 
         if old_key != instance.key:
             _update_feature_flag_dashboard(instance, old_key)


### PR DESCRIPTION
> Stacked on #66632, which is now merged — this PR is rebased onto master and the diff is only the second step.

## Problem

`Experiment.parameters` is a deprecated catch-all blob. Feature flag config (`feature_flag_variants`, `rollout_percentage`, `aggregation_group_type_index`) belongs on the linked `FeatureFlag`, which is already the source of truth at runtime.

The stacked PR underneath (#66632) made the `parameters` API field project those keys from the flag. With reads no longer depending on the stored column, the mirror is dead weight. This PR stops writing it.

## Changes

- Removed the reverse sync in `FeatureFlagSerializer.update` that copied flag variants and aggregation group type back into every linked experiment's `parameters`.
- `ExperimentService` now strips the three feature flag config keys from `parameters` on create and update. They are still accepted as input and used to build or sync the flag, they just never get stored in the column. Non flag keys like `variant_notes` and `prompt_metadata` are preserved.
- Pointed the last backend reader of the stored mirror, the Max AI experiment context (`ee/hogai/context/experiment/context.py`), at `experiment.feature_flag.variants`. The serializer projection already covers API readers.
- **No data migration in this PR — deliberately deferred.** Existing rows keep their stored flag config keys for now, so a revert of this PR (or a deeper revert past #66632) still has the mirror data to fall back on for untouched rows. Reads ignore the stored keys after #66632, so they are dead weight, not a correctness problem. A follow-up migration (#67766, `0026`; the `0025` slot was taken by #66597) will strip them once this has baked in production. The keys are fully re-derivable from the linked flag at any time, so the eventual cleanup is not destructive.

After this, `feature_flag_variants` is no longer written to `parameters` — new and updated experiments never store it, and flag edits no longer sync it back. Existing untouched rows keep their stored copy (which will go stale as flags are edited) until the follow-up migration removes it. The key survives as a read time projection and as create input, both of which are handled in later PRs.

## How did you test this code?

I am an agent. I ran these automated tests locally, all green:

- `products/experiments/backend/test/test_presentation_api.py`, `test_experiment_service.py`, `test_facade.py`, `test_contracts.py`, `test_max_tools.py`, `test_create_from_prompt.py`
- `products/feature_flags/backend/api/test/test_feature_flag.py` (experiment-related subset)
- `ee/hogai/context/experiment/test/test_format.py`
- `makemigrations --dry-run` reports no model state drift (this PR ships no migration).

Tests I updated: the ones that asserted variants on the stored `experiment.parameters` now read them from the flag, since that is the source of truth. The reverse sync test (`test_feature_flag_and_experiment_sync`) now asserts the experiment API response reflects flag edits, instead of asserting the stored mirror. New test `test_feature_flag_config_is_not_persisted_into_parameters` pins that create and update keep flag config out of the column while preserving non flag keys. No existing test covered that, because the old code deliberately stored the mirror.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @andehen. Invoked `/improving-drf-endpoints` (serializer surface).

Decisions: stripped only the three keys that #66632 made flag-sourced, leaving `feature_flag_payloads` and `ensure_experience_continuity` for separate follow-up so this PR stays scoped. The data migration that strips existing rows was written but intentionally pulled out of this PR to keep the revert path simple; it follows separately after a bake period. Verified the Max AI context was the last backend reader of the stored mirror (repo-wide sweep across Python, TypeScript, and Rust); remaining readers all consume the API projection from #66632. The create input contract (`parameters.feature_flag_variants`) is intentionally unchanged here, so external and MCP clients keep working until a later deprecation window.
