### PR TITLE
fix(notebooks): pass user to notebook HogQL execution

### DIFF
--- a/products/notebooks/backend/kernel_runtime.py
+++ b/products/notebooks/backend/kernel_runtime.py
@@ -552,7 +552,9 @@ class KernelRuntimeService:
         else:
             try:
                 placeholders = self._parse_hogql_placeholders_payload(placeholders_payload)
-                response = execute_hogql_query(query=query, team=team, placeholders=placeholders)
+                response = execute_hogql_query(
+                    query=query, team=team, placeholders=placeholders, user=handle.runtime.user
+                )
                 if hasattr(response, "model_dump"):
                     response_payload = response.model_dump(exclude_none=True)
                 else:

--- a/products/notebooks/backend/presentation/views/notebook.py
+++ b/products/notebooks/backend/presentation/views/notebook.py
@@ -781,7 +781,9 @@ class NotebookViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, ForbidD
         notebook = self._get_notebook_for_kernel()
 
         try:
-            response = execute_hogql_query(query=serializer.validated_data["query"], team=self.team)
+            response = execute_hogql_query(
+                query=serializer.validated_data["query"], team=self.team, user=self._current_user()
+            )
         except Exception as err:
             logger.exception("notebook_hogql_execute_failed", notebook_short_id=notebook.short_id)
             return Response({"error": str(err)}, status=400)

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -1,7 +1,7 @@
 import json
 import time
-from typing import Any
 
+import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -11,25 +11,20 @@ import fakeredis
 from rest_framework import status
 
 from posthog import redis as redis_module
+from posthog.constants import AvailableFeature
 from posthog.models import Team
 from posthog.models.activity_logging.activity_log import ActivityLog
+from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.notebooks.backend import presence
 from products.notebooks.backend.collab import SubmitResult, submit_steps
 from products.notebooks.backend.models import Notebook
+from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
 
 SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
 UPDATED_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Updated"}]}]}
-
-
-class _FakeHogQLResponse:
-    def __init__(self, payload: dict[str, Any]) -> None:
-        self.payload = payload
-
-    def dict(self, exclude_none: bool = False) -> dict[str, Any]:
-        return self.payload
 
 
 class TestNotebookCollabSaveAPI(APIBaseTest):
@@ -771,18 +766,79 @@ class TestNotebookMarkdownSaveAPI(APIBaseTest):
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
 
 
+@pytest.mark.ee
 class TestNotebookHogQLExecuteAPI(APIBaseTest):
-    def test_hogql_execute_passes_request_user(self) -> None:
-        notebook = Notebook.objects.create(team=self.team, created_by=self.user, last_modified_by=self.user)
+    def setUp(self) -> None:
+        super().setUp()
 
-        with patch("products.notebooks.backend.presentation.views.notebook.execute_hogql_query") as mock_execute:
-            mock_execute.return_value = _FakeHogQLResponse({"results": [[1]], "columns": ["count"]})
-            response = self.client.post(
-                f"/api/projects/{self.team.id}/notebooks/{notebook.short_id}/hogql/execute/",
-                data={"query": "select * from warehouse_table"},
-                format="json",
-            )
+        from ee.models.rbac.access_control import AccessControl
 
-        assert response.status_code == status.HTTP_200_OK
-        mock_execute.assert_called_once()
-        assert mock_execute.call_args.kwargs["user"] == self.user
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
+            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
+        ]
+        self.organization.save()
+
+        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
+        self.membership.level = OrganizationMembership.Level.MEMBER
+        self.membership.save()
+
+        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
+        self.allowed_table = DataWarehouseTable.objects.create(
+            name="notebook_allowed_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/notebook/allowed/*",
+            columns={"id": "String"},
+        )
+        self.denied_table = DataWarehouseTable.objects.create(
+            name="notebook_denied_table",
+            format=DataWarehouseTable.TableFormat.Parquet,
+            team=self.team,
+            credential=credential,
+            url_pattern="s3://bucket/notebook/denied/*",
+            columns={"id": "String"},
+        )
+        AccessControl.objects.create(team=self.team, resource="warehouse_objects", access_level="none")
+        AccessControl.objects.create(
+            team=self.team,
+            resource="warehouse_table",
+            resource_id=str(self.allowed_table.id),
+            access_level="viewer",
+            organization_member=self.membership,
+        )
+
+        self.notebook = Notebook.objects.create(team=self.team, created_by=self.user, last_modified_by=self.user)
+
+    @staticmethod
+    def _feature_enabled(feature_key: str, *args, **kwargs) -> bool:
+        return feature_key == "hogql-warehouse-access-control"
+
+    @patch("posthog.hogql.query.sync_execute")
+    @patch("posthog.hogql.database.database.feature_enabled_or_false")
+    def test_hogql_execute_uses_request_user_warehouse_permissions(
+        self, mock_feature_enabled_or_false, mock_sync_execute
+    ) -> None:
+        mock_feature_enabled_or_false.side_effect = self._feature_enabled
+        mock_sync_execute.return_value = ([("value",)], [("id", "String")])
+
+        allowed_response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks/{self.notebook.short_id}/hogql/execute/",
+            data={"query": f"select id from {self.allowed_table.name}"},
+            format="json",
+        )
+
+        assert allowed_response.status_code == status.HTTP_200_OK, allowed_response.json()
+        mock_sync_execute.assert_called_once()
+
+        mock_sync_execute.reset_mock()
+        denied_response = self.client.post(
+            f"/api/projects/{self.team.id}/notebooks/{self.notebook.short_id}/hogql/execute/",
+            data={"query": f"select id from {self.denied_table.name}"},
+            format="json",
+        )
+
+        assert denied_response.status_code == status.HTTP_400_BAD_REQUEST
+        assert "don't have access" in denied_response.json()["error"]
+        mock_sync_execute.assert_not_called()

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -1,7 +1,6 @@
 import json
 import time
 
-import pytest
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
@@ -11,17 +10,14 @@ import fakeredis
 from rest_framework import status
 
 from posthog import redis as redis_module
-from posthog.constants import AvailableFeature
 from posthog.models import Team
 from posthog.models.activity_logging.activity_log import ActivityLog
-from posthog.models.organization import OrganizationMembership
 from posthog.models.personal_api_key import PersonalAPIKey
 from posthog.models.utils import generate_random_token_personal, hash_key_value
 
 from products.notebooks.backend import presence
 from products.notebooks.backend.collab import SubmitResult, submit_steps
 from products.notebooks.backend.models import Notebook
-from products.warehouse_sources.backend.facade.models import DataWarehouseCredential, DataWarehouseTable
 
 SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
 UPDATED_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Updated"}]}]}
@@ -764,81 +760,3 @@ class TestNotebookMarkdownSaveAPI(APIBaseTest):
 
         response = self._markdown_save(notebook, version=notebook["version"], markdown="anything")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
-
-
-@pytest.mark.ee
-class TestNotebookHogQLExecuteAPI(APIBaseTest):
-    def setUp(self) -> None:
-        super().setUp()
-
-        from ee.models.rbac.access_control import AccessControl
-
-        self.organization.available_product_features = [
-            {"key": AvailableFeature.ACCESS_CONTROL, "name": AvailableFeature.ACCESS_CONTROL},
-            {"key": AvailableFeature.ROLE_BASED_ACCESS, "name": AvailableFeature.ROLE_BASED_ACCESS},
-        ]
-        self.organization.save()
-
-        self.membership = OrganizationMembership.objects.get(user=self.user, organization=self.organization)
-        self.membership.level = OrganizationMembership.Level.MEMBER
-        self.membership.save()
-
-        credential = DataWarehouseCredential.objects.create(team=self.team, access_key="key", access_secret="secret")
-        self.allowed_table = DataWarehouseTable.objects.create(
-            name="notebook_allowed_table",
-            format=DataWarehouseTable.TableFormat.Parquet,
-            team=self.team,
-            credential=credential,
-            url_pattern="s3://bucket/notebook/allowed/*",
-            columns={"id": "String"},
-        )
-        self.denied_table = DataWarehouseTable.objects.create(
-            name="notebook_denied_table",
-            format=DataWarehouseTable.TableFormat.Parquet,
-            team=self.team,
-            credential=credential,
-            url_pattern="s3://bucket/notebook/denied/*",
-            columns={"id": "String"},
-        )
-        AccessControl.objects.create(team=self.team, resource="warehouse_objects", access_level="none")
-        AccessControl.objects.create(
-            team=self.team,
-            resource="warehouse_table",
-            resource_id=str(self.allowed_table.id),
-            access_level="viewer",
-            organization_member=self.membership,
-        )
-
-        self.notebook = Notebook.objects.create(team=self.team, created_by=self.user, last_modified_by=self.user)
-
-    @staticmethod
-    def _feature_enabled(feature_key: str, *args, **kwargs) -> bool:
-        return feature_key == "hogql-warehouse-access-control"
-
-    @patch("posthog.hogql.query.sync_execute")
-    @patch("posthog.hogql.database.database.feature_enabled_or_false")
-    def test_hogql_execute_uses_request_user_warehouse_permissions(
-        self, mock_feature_enabled_or_false, mock_sync_execute
-    ) -> None:
-        mock_feature_enabled_or_false.side_effect = self._feature_enabled
-        mock_sync_execute.return_value = ([("value",)], [("id", "String")])
-
-        allowed_response = self.client.post(
-            f"/api/projects/{self.team.id}/notebooks/{self.notebook.short_id}/hogql/execute/",
-            data={"query": f"select id from {self.allowed_table.name}"},
-            format="json",
-        )
-
-        assert allowed_response.status_code == status.HTTP_200_OK, allowed_response.json()
-        mock_sync_execute.assert_called_once()
-
-        mock_sync_execute.reset_mock()
-        denied_response = self.client.post(
-            f"/api/projects/{self.team.id}/notebooks/{self.notebook.short_id}/hogql/execute/",
-            data={"query": f"select id from {self.denied_table.name}"},
-            format="json",
-        )
-
-        assert denied_response.status_code == status.HTTP_400_BAD_REQUEST
-        assert "don't have access" in denied_response.json()["error"]
-        mock_sync_execute.assert_not_called()

--- a/products/notebooks/backend/test/test_collab_api.py
+++ b/products/notebooks/backend/test/test_collab_api.py
@@ -1,5 +1,6 @@
 import json
 import time
+from typing import Any
 
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
@@ -21,6 +22,14 @@ from products.notebooks.backend.models import Notebook
 
 SAMPLE_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Test"}]}]}
 UPDATED_DOC = {"type": "doc", "content": [{"type": "heading", "content": [{"type": "text", "text": "Updated"}]}]}
+
+
+class _FakeHogQLResponse:
+    def __init__(self, payload: dict[str, Any]) -> None:
+        self.payload = payload
+
+    def dict(self, exclude_none: bool = False) -> dict[str, Any]:
+        return self.payload
 
 
 class TestNotebookCollabSaveAPI(APIBaseTest):
@@ -760,3 +769,20 @@ class TestNotebookMarkdownSaveAPI(APIBaseTest):
 
         response = self._markdown_save(notebook, version=notebook["version"], markdown="anything")
         assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+class TestNotebookHogQLExecuteAPI(APIBaseTest):
+    def test_hogql_execute_passes_request_user(self) -> None:
+        notebook = Notebook.objects.create(team=self.team, created_by=self.user, last_modified_by=self.user)
+
+        with patch("products.notebooks.backend.presentation.views.notebook.execute_hogql_query") as mock_execute:
+            mock_execute.return_value = _FakeHogQLResponse({"results": [[1]], "columns": ["count"]})
+            response = self.client.post(
+                f"/api/projects/{self.team.id}/notebooks/{notebook.short_id}/hogql/execute/",
+                data={"query": "select * from warehouse_table"},
+                format="json",
+            )
+
+        assert response.status_code == status.HTTP_200_OK
+        mock_execute.assert_called_once()
+        assert mock_execute.call_args.kwargs["user"] == self.user

--- a/products/notebooks/backend/test/test_kernel_runtime.py
+++ b/products/notebooks/backend/test/test_kernel_runtime.py
@@ -47,6 +47,7 @@ class _FakeSandbox:
         self.stream = stream
         self.command: str | None = None
         self.timeout_seconds: int | None = None
+        self.written_files: dict[str, bytes] = {}
 
     def execute(self, command: str, timeout_seconds: int | None = None) -> _FakeExecutionResult:
         self.command = command
@@ -59,6 +60,10 @@ class _FakeSandbox:
         if self.stream is None:
             raise RuntimeError("Fake sandbox stream not configured")
         return self.stream
+
+    def write_file(self, path: str, content: bytes) -> _FakeExecutionResult:
+        self.written_files[path] = content
+        return self.result
 
 
 class _FakeSandboxStream:
@@ -341,6 +346,43 @@ class TestKernelRuntimeService(BaseTest):
 
         assert execution_result.stdout == "before\nafter"
         mock_payload.assert_called_once_with(bridge_payload_json, handle)
+
+    def test_notebook_bridge_hogql_executes_as_runtime_user(self) -> None:
+        service = KernelRuntimeService(execution_timeout=5)
+        notebook = Notebook.objects.create(team=self.team)
+        runtime = KernelRuntime.objects.create(
+            team=self.team,
+            notebook=notebook,
+            notebook_short_id=notebook.short_id,
+            user=self.user,
+            status=KernelRuntime.Status.RUNNING,
+            backend=KernelRuntime.Backend.DOCKER,
+            connection_file="/tmp/connection.json",
+            sandbox_id="sandbox-1",
+        )
+        handle = _KernelHandle(
+            runtime=runtime,
+            lock_name="lock",
+            started_at=timezone.now(),
+            last_activity_at=timezone.now(),
+            backend=KernelRuntime.Backend.DOCKER,
+            sandbox_id=runtime.sandbox_id,
+        )
+        sandbox = _FakeSandbox(_FakeExecutionResult(stdout=""))
+        _FakeSandboxClass.sandbox = sandbox
+        payload = {"call": "hogql_execute", "query": "select * from warehouse_table", "response_path": "/tmp/resp.json"}
+
+        with (
+            patch.object(service, "_get_sandbox_class", return_value=_FakeSandboxClass),
+            patch("products.notebooks.backend.kernel_runtime.execute_hogql_query") as mock_execute,
+        ):
+            mock_execute.return_value.model_dump.return_value = {"results": [[1]], "columns": ["count"]}
+            service._handle_notebook_bridge_payload(json.dumps(payload), handle)
+
+        mock_execute.assert_called_once()
+        assert mock_execute.call_args.kwargs["user"] == self.user
+        header, body = sandbox.written_files["/tmp/resp.json"].split(b"\n", 1)
+        assert int(header) == len(body)
 
     def test_execute_in_sandbox_stream_yields_output_and_result(self) -> None:
         service = KernelRuntimeService(execution_timeout=5)


### PR DESCRIPTION
## Problem

Notebook SQL/HogQL execution had two user-triggered paths that ran HogQL without a user: the direct `hogql/execute` endpoint and the Python bridge used by notebook SQL nodes.

With [warehouse access control](https://github.com/PostHog/posthog/pull/61686) enabled, that userless context fails closed and filters out all warehouse tables/views. Users who should be allowed to query a warehouse object from a notebook can hit table resolution failures instead.

## Changes

- Pass the request user into direct notebook HogQL execution.
- Pass the kernel runtime user into notebook bridge HogQL execution.
- Test for the notebook bridge path, where the user is recovered from the persisted kernel runtime rather than the request object.

## How did you test this code?

Tests

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No