### PR TITLE
fix(data-warehouse): make sql editor error scrollable on small heights

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -1021,19 +1021,21 @@ const ErrorState = ({ responseError, sourceQuery, queryCancelled, response }: an
 
     return (
         <div className={clsx('flex-1 absolute top-0 left-0 right-0 bottom-0 overflow-auto')}>
-            <InsightErrorState
-                query={sourceQuery}
-                excludeDetail
-                title={
-                    <pre className="text-xs bg-danger-highlight p-2 rounded overflow-auto max-h-40 max-w-[80%] mx-auto text-left whitespace-pre-wrap break-words">
-                        {error}
-                    </pre>
-                }
-                excludeActions={queryCancelled} // Don't display fix/debugger buttons if the query was cancelled
-                fixWithAIComponent={
-                    <FixErrorButton contentOverride="Fix error with AI" type="primary" source="query-error" />
-                }
-            />
+            <div className="flex min-h-full flex-col justify-center">
+                <InsightErrorState
+                    query={sourceQuery}
+                    excludeDetail
+                    title={
+                        <pre className="text-xs bg-danger-highlight p-2 rounded overflow-auto max-h-40 max-w-[80%] mx-auto text-left whitespace-pre-wrap break-words">
+                            {error}
+                        </pre>
+                    }
+                    excludeActions={queryCancelled} // Don't display fix/debugger buttons if the query was cancelled
+                    fixWithAIComponent={
+                        <FixErrorButton contentOverride="Fix error with AI" type="primary" source="query-error" />
+                    }
+                />
+            </div>
         </div>
     )
 }


### PR DESCRIPTION
## Problem

In the SQL query editor's **Results** tab, when a query errors and the results pane is short, the error message and the warning icon get clipped at the top with no way to scroll up to them. You can't read the error or reach the icon depending on the pane height.

## Changes

The error state rendered the shared `InsightErrorState` (whose root is `h-full` + `justify-center`) directly inside an `overflow-auto` container. Because the inner content was always exactly the container's height, it never overflowed — so `overflow-auto` never produced a scrollbar, and `justify-center` pushed the icon and top of the message out of view on a short pane.

Wrapped the error state in an intermediate `min-h-full` centering div. It stays centered when there's room but grows past the viewport when the pane is short, letting the parent's `overflow-auto` scroll to the icon and the full message. No behavior change on tall panes.

Single file touched: `frontend/src/scenes/data-warehouse/editor/OutputPane.tsx` (the `ErrorState` component).

## How did you test this code?

I'm an agent — I did not run the app manually. This is a CSS-only layout change (one wrapper div with Tailwind classes); the edited file was formatted via the repo's pre-commit pipeline. No automated tests were added — the change is visual-only with no testable logic.

Suggested manual check for the reviewer: open the SQL editor, run a query that errors (e.g. `SELECT * FROM nonexistent_table`), shrink the results pane, and confirm you can scroll up to the icon and full error; verify a tall pane still centers the error.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). The agent explored the editor's output-pane components to locate the error rendering path, identified the `h-full` + `justify-center` inside `overflow-auto` interaction as the root cause, and applied a `min-h-full` wrapper as the minimal local fix (chosen over editing the widely-shared `InsightErrorState`, which would have risked regressions on insight pages). No skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
