### PR TITLE
fix(web-analytics): unblock authorized URL edits on restricted projects

### DIFF
--- a/posthog/api/project.py
+++ b/posthog/api/project.py
@@ -26,6 +26,7 @@ from posthog.api.shared import ProjectBackwardCompatBasicSerializer
 # project.py must NOT depend on team.py at that point. The parity *logic* (config writes, retention check,
 # and the team-config actions) is defined locally below rather than imported, so it survives that removal.
 from posthog.api.team import (
+    TEAM_CONFIG_FIELD_ACCESS_CONTROLLED_FIELDS,
     TEAM_CONFIG_FIELDS,
     TEAM_CONFIG_MEMBER_FIELDS_SET,
     EvaluationContextSuggestionRequestSerializer,
@@ -1354,14 +1355,15 @@ class ProjectViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets
         if mixin_result is not None:
             return mixin_result
 
-        # See TeamViewSet.dangerously_get_required_scopes for the rationale. Only downgrade
-        # to project:read when every field is a member-safe team config field; anything else
-        # falls through to project:write so admin-only settings require admin object access.
+        # See TeamViewSet.dangerously_get_required_scopes for the rationale. Only downgrade to
+        # project:read when every field is member-safe or carries its own field-level access control;
+        # anything else falls through to project:write so admin-only settings require admin object access.
         if self.action == "partial_update":
             is_session_auth = isinstance(request.successful_authenticator, SessionAuthentication)
             if is_session_auth:
                 request_fields = set(request.data.keys())
-                if request_fields and request_fields.issubset(TEAM_CONFIG_MEMBER_FIELDS_SET):
+                downgradable_fields = TEAM_CONFIG_MEMBER_FIELDS_SET | TEAM_CONFIG_FIELD_ACCESS_CONTROLLED_FIELDS
+                if request_fields and request_fields.issubset(downgradable_fields):
                     return ["project:read"]
 
         # Team-level config actions that any member should be able to edit via the UI.

--- a/posthog/api/team.py
+++ b/posthog/api/team.py
@@ -428,6 +428,11 @@ TEAM_CONFIG_ADMIN_FIELDS_SET: set[str] = (TEAM_CONFIG_FIELDS_SET - TEAM_CONFIG_M
     "access_control",
 }
 
+# Fields that are not member-safe but carry their own `field_access_control` (enforced in
+# UserAccessControlSerializerMixin.validate). The request-level scope can be downgraded for these so
+# the field-level check is the real authority — e.g. `app_urls` is governed by web_analytics:editor.
+TEAM_CONFIG_FIELD_ACCESS_CONTROLLED_FIELDS: set[str] = {"app_urls"}
+
 
 class TeamRevenueAnalyticsConfigSerializer(serializers.ModelSerializer, UserAccessControlSerializerMixin):
     events = serializers.JSONField(required=False)
@@ -1843,7 +1848,12 @@ class TeamViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.Mo
             is_session_auth = isinstance(request.successful_authenticator, SessionAuthentication)
             if is_session_auth:
                 request_fields = set(request.data.keys())
-                if request_fields and request_fields.issubset(TEAM_CONFIG_MEMBER_FIELDS_SET):
+                # Member-safe fields, plus fields whose write is governed by their own field-level
+                # access control — keep the request gate from demanding project:write (admin) for the
+                # latter, otherwise e.g. a web analytics editor on a restricted project is blocked
+                # before UserAccessControlSerializerMixin.validate can authorize the field.
+                downgradable_fields = TEAM_CONFIG_MEMBER_FIELDS_SET | TEAM_CONFIG_FIELD_ACCESS_CONTROLLED_FIELDS
+                if request_fields and request_fields.issubset(downgradable_fields):
                     return ["project:read"]
 
         # Team-level config actions that any member should be able to edit via the UI.

--- a/posthog/api/test/test_team.py
+++ b/posthog/api/test/test_team.py
@@ -3178,10 +3178,18 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
         self.assertEqual(self.team.timezone, "UTC")
         self.assertEqual(self.team.session_recording_opt_in, False)
 
-    def test_web_analytics_editor_can_write_app_urls_with_access_control(self):
-        # A web analytics editor (org member, no project-admin) must be able to manage the toolbar /
+    @parameterized.expand(
+        [
+            ("default_admin_access", False),
+            ("restricted_project_member_access", True),
+        ]
+    )
+    def test_web_analytics_editor_can_write_app_urls_with_access_control(self, _name, restrict_project_to_member):
+        # A web analytics editor (org member, not project admin) must be able to manage the toolbar /
         # web analytics authorized URLs. `app_urls` carries a web-analytics-editor field access control,
-        # and web analytics defaults to editor, so a plain member passes without any explicit grant.
+        # and web analytics defaults to editor, so an editor passes the field-level check. This must hold
+        # even on a restricted project where the editor's effective project access is only `member` — the
+        # request gate must not demand project admin for `app_urls`, or the field-level check never runs.
         self.organization_membership.level = OrganizationMembership.Level.MEMBER
         self.organization_membership.save()
 
@@ -3192,6 +3200,16 @@ class TestTeamAPI(team_api_test_factory()):  # type: ignore
             },
         ]
         self.organization.save()
+
+        if restrict_project_to_member:
+            # Lower the project's baseline from the implicit admin default to member, so the acting
+            # user is a project member but not an admin.
+            AccessControl.objects.create(
+                team=self.team,
+                resource="project",
+                resource_id=self.team.id,
+                access_level="member",
+            )
 
         response = self.client.patch(
             "/api/environments/@current/",


### PR DESCRIPTION
## Problem

A user with **web analytics: Editor** access got `Update current team failed: You do not have admin access to this resource.` when adding an authorized URL on the toolbar page — but only on a **restricted project** (where their effective project access is `member`, not the default `admin`). #66026 moved `app_urls` to a `web_analytics:editor` field-level access control, but the request-level `AccessControlPermission` gate still demanded project `admin` for `app_urls` (it wasn't in the scope-downgrade set), so the request was rejected before the field-level check could authorize it. The existing tests left project access at the default `admin`, so they passed and the gap went unnoticed.

## Changes

Add `app_urls` to the session-auth scope downgrade in `dangerously_get_required_scopes` for both `TeamViewSet` and `ProjectViewSet`, via a new named const `TEAM_CONFIG_FIELD_ACCESS_CONTROLLED_FIELDS`. The request gate now requires only project `member`; the existing `UserAccessControlSerializerMixin.validate` is the real authority and enforces `web_analytics:editor`. Safe: it fails closed (any payload touching a real admin field still requires admin), non-RBAC orgs stay project-admin-gated via `validate_team_attrs`, and `recording_domains` stays admin-only.

## How did you test this code?

I'm an agent. Backend tests only (no manual UI testing). Parameterized the existing editor test to add a `restricted_project_member_access` case — verified it fails with the exact `403 "You do not have admin access to this resource."` when the fix is stashed, and passes with it. Existing editor/viewer + `TestTeamAdminFieldAuthorization` + member-write suites stay green (54 passed); `test_field_access_control.py` (5 passed). Lint clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code. Skills invoked: `/improving-drf-endpoints` (confirmed permission/scope logic only, no serializer or schema changes, so no OpenAPI/type regen) and `/writing-tests` (gated the new case into a parameterized variant rather than a near-duplicate test). Root-caused via the three-layer enforcement chain (request gate, `validate_team_attrs`, field-level mixin) and confirmed #66026 only fixed the latter two. Chose a named const over inlining `{"app_urls"}` or adding it to `TEAM_CONFIG_MEMBER_FIELDS_SET` (the latter would conflate "member-writable" with "needs web_analytics:editor" and leave `app_urls` in both the member and admin sets).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
