### PR TITLE
fix(billing): bypass warehouse access control for internal dags

### DIFF
--- a/ee/billing/dags/customer_archetype.py
+++ b/ee/billing/dags/customer_archetype.py
@@ -447,6 +447,8 @@ def archetype_account_data(
             team=team,
             query_type="archetype_account_data",
             limit_context=LimitContext.SAVED_QUERY,
+            # Internal billing DAG runs without a user; bypass warehouse ACL for this trusted ETL read.
+            bypass_warehouse_access_control=True,
         )
 
         if not response.results:

--- a/ee/billing/dags/job_switchers.py
+++ b/ee/billing/dags/job_switchers.py
@@ -147,6 +147,8 @@ def job_switchers_to_clay(
         team=team,
         query_type="job_switchers_query",
         limit_context=LimitContext.SAVED_QUERY,
+        # Internal billing DAG runs without a user; bypass warehouse ACL for this trusted ETL read.
+        bypass_warehouse_access_control=True,
     )
     results = response.results
 

--- a/ee/billing/dags/productled_outbound_targets.py
+++ b/ee/billing/dags/productled_outbound_targets.py
@@ -346,6 +346,8 @@ def plo_base_targets(
         team=team,
         query_type="plo_base_targets",
         limit_context=LimitContext.SAVED_QUERY,
+        # Internal billing DAG runs without a user; bypass warehouse ACL for this trusted ETL read.
+        bypass_warehouse_access_control=True,
     )
 
     if not response.results:


### PR DESCRIPTION
## Problem
Internal billing DAGs query saved warehouse views without a request user. When warehouse access control is enabled, those userless HogQL queries can fail (no access to all warehouse tables and views). 

## Changes
- Pass `bypass_warehouse_access_control=True` for the three internal billing saved-query reads:
  - `ee/billing/dags/customer_archetype.py`
  - `ee/billing/dags/productled_outbound_targets.py`
  - `ee/billing/dags/job_switchers.py`
- Added short inline comments explaining the bypass at each call site.

## How did you test this code?
No tests for this small change.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update
No