### PR TITLE
fix(postgres): retry session-mode pooler saturation in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -208,16 +208,21 @@ _POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited",)
 # connection limit, not because anything is misconfigured. PostgreSQL raises "sorry, too many
 # clients already" once max_connections is reached, "remaining connection slots are reserved for
 # roles with the SUPERUSER attribute" once only the superuser_reserved_connections slots remain,
-# and "too many connections for role" once a role's own CONNECTION LIMIT is hit. All three are
-# transient capacity conditions on the customer's database — a slot frees the moment another
-# connection closes — so a fresh connect after a short backoff usually succeeds. Retried in-process
-# on the read/sync connect path (see `_is_dropped_or_connect_timeout` / `_connect_with_dropped_retry`);
-# kept retryable and intentionally NOT added to `get_non_retryable_errors` for the same reason as
-# pooler saturation (see source.py).
+# and "too many connections for role" once a role's own CONNECTION LIMIT is hit. Supabase's
+# Supavisor session-mode pooler reports its own client-slot exhaustion as "(EMAXCONNSESSION) max
+# clients reached in session mode" (and the older "MaxClientsInSessionMode: max clients reached") —
+# every client slot the pooler exposes is in use, so it refuses the new connection until one frees.
+# All are transient capacity conditions on the customer's database/pooler — a slot frees the moment
+# another connection closes — so a fresh connect after a short backoff usually succeeds. Retried
+# in-process on the read/sync connect path (see `_is_dropped_or_connect_timeout` /
+# `_connect_with_dropped_retry`); kept retryable and intentionally NOT added to
+# `get_non_retryable_errors` for the same reason (see source.py). The volatile pool_size number and
+# the "(EMAXCONNSESSION)" code prefix are excluded — match the stable "max clients reached" phrase.
 _CONNECTION_LIMIT_ERROR_SUBSTRINGS = (
     "sorry, too many clients already",
     "remaining connection slots are reserved",
     "too many connections for role",
+    "max clients reached",
 )
 
 # Exception types that can carry a connection-dropped error. ProtocolViolation is

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1114,6 +1114,18 @@ class TestIsConnectionLimitError:
                 'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
                 'FATAL:  too many connections for role "reader"'
             ),
+            # Supabase/Supavisor session-mode pooler saturation — the pooler is momentarily out of
+            # client slots and recovers as connections free up, so the in-process reconnect must
+            # retry it rather than escape and fail the whole sync. Both observed wordings share the
+            # stable "max clients reached" phrase; the pool_size/code prefix is volatile.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15"
+            ),
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL: MaxClientsInSessionMode: max clients reached"
+            ),
         ],
     )
     def test_connection_limit_errors_are_detected(self, error):


### PR DESCRIPTION
## Problem

Postgres imports against a Supabase/Supavisor **session-mode** connection pooler intermittently fail the whole sync when the pooler is momentarily out of client slots. The pooler refuses the new connection with:

```
OperationalError: connection failed: ... FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: <n>
```

This is a transient capacity condition — every client slot the pooler exposes is in use, and a slot frees the moment another session returns its connection. We already treat the equivalent PostgreSQL refusals (`sorry, too many clients already`, etc.) as transient and retry them in-process on the connect path via `_connect_with_dropped_retry`. But the Supavisor session-mode wording wasn't in `_CONNECTION_LIMIT_ERROR_SUBSTRINGS`, so `_is_connection_limit_error` returned `False`, the refusal escaped the in-process retry loop, got captured as error-tracking noise, and forced a whole-activity Temporal retry instead of a cheap backoff-and-reconnect.

Observed via PostHog error tracking — the failure originates in this source's connect path:

```
get_rows → iterate_date_windows → connect_for_partition_iteration
  → _connect_with_dropped_retry → _retry_on_connection_dropped
  → get_connection → _connect_with_options_fallback  (raises)
```

[Error tracking issue](https://us.posthog.com/project/2/error_tracking/019f0c07-14c7-77d1-b385-82071f3b939d)

## Changes

Add the stable `"max clients reached"` substring to `_CONNECTION_LIMIT_ERROR_SUBSTRINGS`. This covers both observed Supavisor session-mode wordings (`(EMAXCONNSESSION) max clients reached in session mode` and the older `MaxClientsInSessionMode: max clients reached`) while excluding the volatile `pool_size` number and the `(EMAXCONNSESSION)` code prefix.

Effect: the existing in-process connect-retry now backs off and reconnects on session-mode pooler saturation, the same as it does for the native PostgreSQL capacity refusals. It deliberately stays **retryable** — this is **not** added to `get_non_retryable_errors`, because pooler saturation clears on its own. `source.py` already maps the same condition to an actionable message on the credential-validation path and documents that it must remain retryable.

This is complementary to (not a duplicate of) #66510, which handles a different Supavisor failure — the `(ECHECKOUTRETRIES)` `InternalError_` (XX000) pool-checkout retry exhaustion — via the separate `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS` tuple.

## How did you test this code?

I'm an agent. I added the two Supavisor session-mode wordings to `TestIsConnectionLimitError::test_connection_limit_errors_are_detected`, which asserts `_is_connection_limit_error(...) is True` — this fails without the fix and passes with it, directly covering the gap. The existing `TestConnectWithDroppedRetry::test_retries_connection_limit_error_then_succeeds` already exercises the in-process retry mechanism these strings feed into, and `TestPostgresSourceNonRetryableErrors::test_transient_connection_errors_are_retryable` already pins that this wording stays out of `get_non_retryable_errors`.

Ran locally (102 passed):

```
pytest products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py::TestIsConnectionLimitError \
       ::TestConnectWithDroppedRetry ::TestPostgresSourceNonRetryableErrors
```

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from a PostHog error-tracking webhook using the PostHog MCP error-tracking tools to pull the full stack trace, frequency, and a representative event.
- Decision: **fixable bug**, not a user/upstream error. The condition is transient capacity on the customer's pooler that the in-process connect-retry is already designed to absorb — it just didn't recognise the Supavisor session-mode wording. Kept it retryable rather than adding it to `NonRetryableErrors`.
- Considered matching the narrower `max clients reached in session mode` (as `source.py` does for validation messaging), but chose the broader stable `max clients reached` so the older `MaxClientsInSessionMode` wording is caught by the same in-process retry too.
- Checked open PRs (including the maintainer's) for overlap; #66510 touches a different code/tuple and is complementary.
