### PR TITLE
fix(postgres): retry session-mode pooler saturation in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -208,16 +208,21 @@ _POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS = ("edbhandlerexited",)
 # connection limit, not because anything is misconfigured. PostgreSQL raises "sorry, too many
 # clients already" once max_connections is reached, "remaining connection slots are reserved for
 # roles with the SUPERUSER attribute" once only the superuser_reserved_connections slots remain,
-# and "too many connections for role" once a role's own CONNECTION LIMIT is hit. All three are
-# transient capacity conditions on the customer's database — a slot frees the moment another
-# connection closes — so a fresh connect after a short backoff usually succeeds. Retried in-process
-# on the read/sync connect path (see `_is_dropped_or_connect_timeout` / `_connect_with_dropped_retry`);
-# kept retryable and intentionally NOT added to `get_non_retryable_errors` for the same reason as
-# pooler saturation (see source.py).
+# and "too many connections for role" once a role's own CONNECTION LIMIT is hit. Supabase's
+# Supavisor session-mode pooler reports its own variant when every client slot it exposes is in use
+# ("(EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size:
+# <n>"). All of these are transient capacity conditions on the customer's database or pooler — a
+# slot frees the moment another connection closes (or a session ends) — so a fresh connect after a
+# short backoff usually succeeds. Retried in-process on the read/sync connect path (see
+# `_is_dropped_or_connect_timeout` / `_connect_with_dropped_retry`); kept retryable and intentionally
+# NOT added to `get_non_retryable_errors` (see source.py). The Supavisor match is on the stable
+# "max clients reached in session mode" phrase, excluding the volatile pool_size and the
+# "(EMAXCONNSESSION)" code (mirrors the `PostgresErrors` validation mapping in source.py).
 _CONNECTION_LIMIT_ERROR_SUBSTRINGS = (
     "sorry, too many clients already",
     "remaining connection slots are reserved",
     "too many connections for role",
+    "max clients reached in session mode",
 )
 
 # Exception types that can carry a connection-dropped error. ProtocolViolation is

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1114,6 +1114,13 @@ class TestIsConnectionLimitError:
                 'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
                 'FATAL:  too many connections for role "reader"'
             ),
+            # Supabase's Supavisor session-mode pooler refuses a new connection once every client
+            # slot is in use. A plain OperationalError (not the XX000 pooler-drop class), so it must
+            # be recognised here for the in-process connect retry to recover from it.
+            psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5432 failed: '
+                "FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: 15"
+            ),
         ],
     )
     def test_connection_limit_errors_are_detected(self, error):


### PR DESCRIPTION
## Problem

Postgres data-warehouse syncs through Supabase's Supavisor pooler in **session mode** intermittently fail with:

```
OperationalError: connection failed: connection to server at "<redacted>", port 5432 failed: FATAL:  (EMAXCONNSESSION) max clients reached in session mode - max clients are limited to pool_size: <n>
```

This is a transient capacity condition — every client slot the pooler exposes is momentarily in use, and a slot frees the moment another session returns its connection to the pool. The codebase already treats it as transient: it's mapped to an actionable message for credential validation (`PostgresErrors`) and deliberately kept out of `get_non_retryable_errors`.

The gap: the in-process connect retry (`_connect_with_dropped_retry`, which backs off and reconnects) only recovers errors that `_is_connection_limit_error` recognises, and that predicate's substring list (`_CONNECTION_LIMIT_ERROR_SUBSTRINGS`) covered the three PostgreSQL-native limit refusals but **not** the Supavisor session-mode wording. So during a sync the error escaped `get_connection`, failed the activity, and was captured as error-tracking noise — even though the very next attempt would usually succeed.

Surfaced by error tracking: https://us.posthog.com/project/2/error_tracking/019f0c06-f3af-75b2-8be8-7379f4db8690 (raised in `get_connection` → `_connect_with_dropped_retry` during an active import).

## Changes

Add the stable `max clients reached in session mode` phrase to `_CONNECTION_LIMIT_ERROR_SUBSTRINGS`. The match excludes the volatile `pool_size` number and the `(EMAXCONNSESSION)` code, mirroring the vetted `PostgresErrors` key in `source.py`. This is a plain `OperationalError`, so it flows through `_is_connection_limit_error` → `_is_dropped_or_connect_timeout` and is now retried in-process with bounded backoff — the same treatment the PostgreSQL-native limit refusals already get. It stays out of `get_non_retryable_errors` (still retryable at the Temporal layer too).

This is distinct from #66510, which handles a different Supavisor condition (`ECHECKOUTRETRIES`, surfaced as an XX000 `InternalError_`) via `_POOLER_CONNECTION_DROPPED_ERROR_SUBSTRINGS`.

## How did you test this code?

I'm an agent. I added a regression case to `TestIsConnectionLimitError.test_connection_limit_errors_are_detected` asserting the session-mode saturation `OperationalError` is recognised as a connection-limit error — without the fix, `_is_connection_limit_error` returns `False` for this message and the in-process retry never engages. Ran the affected test classes (`TestIsConnectionLimitError`, `TestPostgresSourceNonRetryableErrors`, `TestConnectWithDroppedRetry`) — 101 passed — plus `ruff check`/`format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a postgres import-source error from PostHog error tracking. Confirmed the failure originates in the source's own code path (`get_connection` → `_connect_with_dropped_retry`), classified it as a fixable retry-coverage bug rather than a non-retryable user/upstream error (the code already documents it as transient and keeps it retryable), and verified no open PR addressed this specific code/message (the closest, #66510, targets a different pooler error class). Scoped the change to the single substring list plus a same-layer regression test.