### PR TITLE
fix(redshift): treat non-SSL server connection as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/source.py
@@ -40,6 +40,7 @@ RedshiftErrors = {
     'database "': "Database does not exist",
     "timeout expired": "Connection timed out. Does your database have our IP addresses allowed?",
     "SSL connection has been closed unexpectedly": "SSL connection error. Please check your SSL settings.",
+    "server does not support SSL": "The server does not support SSL, which we require for Redshift. Please check the host and port point to your Redshift cluster.",
     "Connection refused": "Connection refused. Please check the host and port.",
 }
 
@@ -143,6 +144,7 @@ class RedshiftSource(SQLSource[RedshiftSourceConfig], SSHTunnelMixin, ValidateDa
             "No primary key defined for table": None,
             "failed: timeout expired": None,
             "SSL connection has been closed unexpectedly": None,
+            "server does not support SSL": None,
             "does not exist": None,
             "QueryTimeoutException": None,
             "TemporaryFileSizeExceedsLimitException": None,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -820,12 +820,40 @@ class TestRedshiftSourceNonRetryableErrors:
         [
             "Source column type changed",
             "SchemaColumnTypeChangedException: Source column type changed: 'id' has values that no longer fit",
+            'connection failed: connection to server at "10.0.0.1", port 5439 failed: server does not support SSL, but SSL was required',
         ],
     )
     def test_widened_integer_column_errors_are_non_retryable(self, error_msg):
         non_retryable = RedshiftSource().get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable
+
+
+class TestRedshiftValidateCredentials:
+    def test_server_without_ssl_returns_friendly_error_without_capturing(self, mocker):
+        # We always connect with sslmode=require, so a server that doesn't support SSL is a
+        # host/port misconfiguration on the customer's side — surface guidance, don't report it.
+        config = _make_config()
+        source = RedshiftSource()
+        mocker.patch.object(source, "ssh_tunnel_is_valid", return_value=(True, None))
+        mocker.patch.object(source, "is_database_host_valid", return_value=(True, None))
+        mocker.patch.object(
+            source,
+            "get_schemas",
+            side_effect=psycopg.OperationalError(
+                'connection failed: connection to server at "10.0.0.1", port 5439 failed: '
+                "server does not support SSL, but SSL was required"
+            ),
+        )
+        capture = mocker.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.redshift.source.capture_exception"
+        )
+
+        ok, error = source.validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert error is not None and "does not support SSL" in error
+        capture.assert_not_called()
 
 
 class TestRedshiftSourceForPipeline:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py
@@ -820,10 +820,18 @@ class TestRedshiftSourceNonRetryableErrors:
         [
             "Source column type changed",
             "SchemaColumnTypeChangedException: Source column type changed: 'id' has values that no longer fit",
-            'connection failed: connection to server at "10.0.0.1", port 5439 failed: server does not support SSL, but SSL was required',
         ],
     )
     def test_widened_integer_column_errors_are_non_retryable(self, error_msg):
+        non_retryable = RedshiftSource().get_non_retryable_errors()
+        is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
+        assert is_non_retryable
+
+    def test_ssl_server_error_is_non_retryable(self):
+        error_msg = (
+            'connection failed: connection to server at "10.0.0.1", port 5439 failed: '
+            "server does not support SSL, but SSL was required"
+        )
         non_retryable = RedshiftSource().get_non_retryable_errors()
         is_non_retryable = any(pattern in error_msg for pattern in non_retryable.keys())
         assert is_non_retryable


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `psycopg.OperationalError` from the Redshift import source during credential validation / schema discovery:

> connection failed: connection to server at "&lt;redacted&gt;", port &lt;redacted&gt; failed: server does not support SSL, but SSL was required

Issue: https://us.posthog.com/project/2/error_tracking/019f0ad2-c68d-7d61-8853-ff7203d06c14

The stack originates in this source's own code — `redshift/source.py::validate_credentials` → `common/sql/base.py::get_schemas` → `redshift/redshift.py::connect`, where `psycopg.connect(...)` is called.

Our Redshift driver always connects with `sslmode=require` (correct — Redshift supports SSL and we shouldn't silently downgrade). When the configured host/port points at a server that doesn't speak SSL, libpq raises this `OperationalError`. It can never succeed on retry, so it's a customer-side connection misconfiguration (wrong host/port, or a target that isn't an SSL-capable Redshift cluster).

This message wasn't recognised by the source, so two things went wrong:
- During credential validation the loop fell through to `capture_exception`, generating error-tracking noise plus a generic "could not connect" toast.
- A mid-sync connect failure with the same cause would be retried pointlessly.

## Changes

Recognise the stable libpq substring `server does not support SSL` in both places that already handle the existing `SSL connection has been closed unexpectedly` case:

- `RedshiftErrors` — credential validation now returns actionable guidance ("check the host and port point to your Redshift cluster") instead of capturing the exception.
- `get_non_retryable_errors` — a connect failure with this cause stops retrying mid-sync.

The match is on the fixed libpq phrase only; the variable host/port in the message are not part of the substring.

## How did you test this code?

I'm an agent. I added/extended automated tests and ran them — no manual testing:

- Extended `TestRedshiftSourceNonRetryableErrors` with a representative full message to assert the SSL phrase is classified non-retryable (regression: a non-SSL-capable target retried forever).
- Added `TestRedshiftValidateCredentials::test_server_without_ssl_returns_friendly_error_without_capturing` asserting validation returns a friendly error and does **not** call `capture_exception` (regression: this exact error spamming error tracking with a generic toast).

`pytest products/warehouse_sources/backend/temporal/data_imports/sources/redshift/tests/test_redshift.py` — 94 passed. `ruff check` / `ruff format --check` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to confirm the issue (frequency, affected team, full stack trace) and that the failure genuinely originates in the Redshift source code rather than only appearing in serialized log context.

Decision: user/upstream config error → non-retryable. Considered whether to relax `sslmode`, but rejected it — silently disabling SSL is a security downgrade and Redshift supports SSL, so a non-SSL target indicates a wrong host/port. Scoped strictly to this error string; mirrors the existing `SSL connection has been closed unexpectedly` handling that already appears in both dicts. Checked open PRs (including the maintainer's) for an existing fix — none addresses this.