### PR TITLE
feat(replay): rename recordings "Relevant" sort to "Relevance"

### DIFF
--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -38,7 +38,7 @@ const SortingKeyToLabel = {
     keypress_count: 'Keystrokes',
     mouse_activity_count: 'Mouse activity',
     recording_ttl: 'Expiration',
-    surfacing_score: 'Relevant',
+    surfacing_score: 'Relevance',
 }
 
 function getLabel(filters: RecordingUniversalFilters): string {
@@ -69,6 +69,8 @@ function SortedBy({
                     ? [
                           {
                               label: SortingKeyToLabel['surfacing_score'],
+                              tooltip:
+                                  'Ranks recordings by a relevance score so the sessions most likely to be worth watching appear first.',
                               onClick: () => setFilters({ order: 'surfacing_score', order_direction: 'DESC' }),
                               active: filters.order === 'surfacing_score',
                           },


### PR DESCRIPTION
## Problem

The session recordings sort menu offers a relevance-based option (the flag-gated `surfacing_score` order, shown under `REPLAY_PLAYLIST_SURFACING_SCORE`). It was labeled **"Relevant"**, which reads awkwardly as a sort option and gave users no hint about what the ranking does.

## Changes

- Rename the `surfacing_score` sort option from **Relevant** to **Relevance**. This updates both the menu item and the sort trigger button text when that order is selected.
- Add a tooltip on the option explaining the ranking: "Ranks recordings by a relevance score so the sessions most likely to be worth watching appear first."

No behavior change to the sort itself, only the label and an added explanation. The option remains gated behind `REPLAY_PLAYLIST_SURFACING_SCORE`.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I ran locally:

- `pnpm --filter=@posthog/frontend typescript:check` — no errors introduced by this change (`tooltip` is a valid `LemonMenuItem` prop). Remaining failures are pre-existing stale kea typegen artifacts in unrelated products.
- Confirmed `SortingKeyToLabel` is referenced only in this file and that no tests, stories, or snapshots assert the old "Relevant" sort label.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of @arnohillen. Initial drafting briefly targeted the wrong sort key (`activity_score`, labeled "Activity") because the local checkout was well behind master; corrected after confirming against the live UI that the relevant option is the flag-gated `surfacing_score` labeled "Relevant". The branch was rebuilt on current master so the diff is a single isolated change. Popover copy was kept deliberately high-level rather than describing the scoring internals.