### PR TITLE
fix(conversations): remove per-ticket rollout flag from AI coordinator

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -419,7 +419,6 @@ export const FEATURE_FLAGS = {
     PRODUCT_AUTONOMY: 'product-autonomy', // owner: #team-self-driving
     PRODUCT_BUSINESS_KNOWLEDGE: 'product-business-knowledge', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_AI_SUGGESTION: 'product-support-ai-suggestion', // owner: @veryayskiy #team-conversations
-    PRODUCT_SUPPORT_AI_SUGGESTION_ROLLOUT: 'product-support-ai-suggestion-rollout', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_CREATE_TICKET: 'product-support-create-ticket', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_GITHUB_CHANNEL: 'product-support-github-channel', // owner: @veryayskiy #team-conversations
     PRODUCT_SUPPORT_SIDE_PANEL: 'product-support-side-panel', // owner: @veryayskiy #team-conversations

--- a/products/conversations/backend/temporal/coordinator.py
+++ b/products/conversations/backend/temporal/coordinator.py
@@ -47,7 +47,6 @@ MAX_TICKETS_PER_TEAM_PER_RUN = 10
 MAX_TICKETS_PER_RUN = 50
 
 MASTER_FLAG = "product-support-ai-suggestion"
-ROLLOUT_FLAG = "product-support-ai-suggestion-rollout"
 
 # Minimum number of READY BK sources required before the coordinator will draft replies.
 # Set to 0 locally to skip the BK readiness check entirely.
@@ -82,15 +81,6 @@ def _is_master_flag_enabled(team_id: int) -> bool:
         posthoganalytics.feature_enabled(
             MASTER_FLAG,
             str(team_id),
-        )
-    )
-
-
-def _is_rollout_enabled(ticket_id: str) -> bool:
-    return bool(
-        posthoganalytics.feature_enabled(
-            ROLLOUT_FLAG,
-            ticket_id,
         )
     )
 
@@ -159,10 +149,9 @@ def _collect_eligible(lookback_minutes: int = TICKET_LOOKBACK_MINUTES) -> list[E
             if prev is None or comment_created_at > prev:
                 latest_customer_msg[item_id] = comment_created_at
 
-    # Rollout is sampled last (after the cheap gates, dedupe, and settle window) so we don't burn
-    # the bucket on tickets that were never going to run this tick. Per-team and global caps bound
-    # how many child workflows a single tick can fan out so externally-created ticket volume can't
-    # directly translate into unbounded LLM work; overflow rolls to the next tick (still in lookback).
+    # Per-team and global caps bound how many child workflows a single tick can fan out so
+    # externally-created ticket volume can't directly translate into unbounded LLM work; overflow
+    # rolls to the next tick (still in lookback).
     settle_cutoff = now - timedelta(minutes=TICKET_SETTLE_MINUTES)
     eligible: list[EligibleTicket] = []
     per_team_counts: dict[int, int] = {}
@@ -178,8 +167,6 @@ def _collect_eligible(lookback_minutes: int = TICKET_LOOKBACK_MINUTES) -> list[E
         if last_activity > settle_cutoff:
             continue
         if per_team_counts.get(team_id, 0) >= MAX_TICKETS_PER_TEAM_PER_RUN:
-            continue
-        if not _is_rollout_enabled(ticket_id_str):
             continue
         per_team_counts[team_id] = per_team_counts.get(team_id, 0) + 1
         eligible.append(EligibleTicket(team_id=team_id, ticket_id=ticket_id_str))

--- a/products/conversations/backend/temporal/tests/test_coordinator.py
+++ b/products/conversations/backend/temporal/tests/test_coordinator.py
@@ -73,14 +73,12 @@ class TestCollectEligible:
             ("no_ready_sources", {"has_ready_sources": False}),
             ("has_ai_note", {"has_ai_note": True}),
             ("has_team_reply", {"has_team_reply": True}),
-            ("rollout_off", {"rollout": False}),
             ("channel_not_allowed", {"ai_resolution_channels": ["email"], "channel_source": "widget"}),
         ]
     )
     # Force the BK-readiness gate on (production default MIN_READY_BK_SOURCES=0 skips it) so the
     # no_ready_sources case actually exercises the check. A literal patch value injects no arg.
     @patch(f"{COORD_MODULE}.MIN_READY_BK_SOURCES", 1)
-    @patch(f"{COORD_MODULE}._is_rollout_enabled")
     @patch(f"{COORD_MODULE}.has_ready_sources")
     @patch(f"{COORD_MODULE}.Comment")
     @patch(f"{COORD_MODULE}.Ticket")
@@ -93,7 +91,6 @@ class TestCollectEligible:
         mock_ticket_model,
         mock_comment_model,
         mock_has_ready,
-        mock_rollout,
     ):
         master_flag = overrides.get("master_flag", True)
         ai_suggestions_enabled = overrides.get("ai_suggestions_enabled", True)
@@ -101,7 +98,6 @@ class TestCollectEligible:
         has_ready = overrides.get("has_ready_sources", True)
         has_ai = overrides.get("has_ai_note", False)
         has_team_reply = overrides.get("has_team_reply", False)
-        rollout = overrides.get("rollout", True)
 
         ticket, ticket_id, team = _make_ticket(
             ai_suggestions_enabled=ai_suggestions_enabled,
@@ -124,12 +120,9 @@ class TestCollectEligible:
             rows.append((ticket_id, "support", now))
         mock_comment_model.objects.filter.return_value.values_list.return_value = rows
 
-        mock_rollout.return_value = rollout
-
         result = _collect_eligible()
         assert result == []
 
-    @patch(f"{COORD_MODULE}._is_rollout_enabled", return_value=True)
     @patch(f"{COORD_MODULE}.has_ready_sources", return_value=True)
     @patch(f"{COORD_MODULE}.Comment")
     @patch(f"{COORD_MODULE}.Ticket")
@@ -140,7 +133,6 @@ class TestCollectEligible:
         mock_ticket_model,
         mock_comment_model,
         mock_has_ready,
-        mock_rollout,
     ):
         ticket, ticket_id, team = _make_ticket()
         mock_ticket_model.objects.filter.return_value.select_related.return_value = [ticket]
@@ -159,7 +151,6 @@ class TestCollectEligible:
             ("null_allows_all", None, "slack"),
         ]
     )
-    @patch(f"{COORD_MODULE}._is_rollout_enabled", return_value=True)
     @patch(f"{COORD_MODULE}.has_ready_sources", return_value=True)
     @patch(f"{COORD_MODULE}.Comment")
     @patch(f"{COORD_MODULE}.Ticket")
@@ -173,7 +164,6 @@ class TestCollectEligible:
         mock_ticket_model,
         mock_comment_model,
         mock_has_ready,
-        mock_rollout,
     ):
         ticket, ticket_id, team = _make_ticket(
             channel_source=channel_source,
@@ -185,7 +175,6 @@ class TestCollectEligible:
         result = _collect_eligible()
         assert len(result) == 1
 
-    @patch(f"{COORD_MODULE}._is_rollout_enabled", return_value=True)
     @patch(f"{COORD_MODULE}.has_ready_sources", return_value=True)
     @patch(f"{COORD_MODULE}.Comment")
     @patch(f"{COORD_MODULE}.Ticket")
@@ -196,7 +185,6 @@ class TestCollectEligible:
         mock_ticket_model,
         mock_comment_model,
         mock_has_ready,
-        mock_rollout,
     ):
         ticket, ticket_id, team = _make_ticket()
         mock_ticket_model.objects.filter.return_value.select_related.return_value = [ticket]
@@ -216,7 +204,6 @@ class TestCollectEligible:
             ("old_customer_followup_settled", 30, 30, True),
         ]
     )
-    @patch(f"{COORD_MODULE}._is_rollout_enabled", return_value=True)
     @patch(f"{COORD_MODULE}.has_ready_sources", return_value=True)
     @patch(f"{COORD_MODULE}.Comment")
     @patch(f"{COORD_MODULE}.Ticket")
@@ -231,7 +218,6 @@ class TestCollectEligible:
         mock_ticket_model,
         mock_comment_model,
         mock_has_ready,
-        mock_rollout,
     ):
         # Guards the debounce: a ticket whose customer just sent a message (or was just created)
         # must not be drafted until they've gone quiet for TICKET_SETTLE_MINUTES, so follow-up
@@ -260,7 +246,6 @@ class TestCollectEligibleScanWindow:
         ]
     )
     @pytest.mark.django_db
-    @patch(f"{COORD_MODULE}._is_rollout_enabled", return_value=True)
     @patch(f"{COORD_MODULE}._is_master_flag_enabled", return_value=True)
     def test_scan_keys_on_last_message_not_created_at(
         self,
@@ -268,7 +253,6 @@ class TestCollectEligibleScanWindow:
         last_msg_min_ago,
         expected_collected,
         mock_master_flag,
-        mock_rollout,
     ):
         # Models imported lazily: this module defines a @workflow.defn stub, so Temporal's sandbox
         # re-imports the whole file during validation and top-level Django ORM imports break it.


### PR DESCRIPTION
## Problem
The support AI coordinator gated tickets through two feature flags: `product-support-ai-suggestion` (team-level) and `product-support-ai-suggestion-rollout` (per-ticket).
Team-level gating via the master flag is sufficient for controlled rollout.

## Changes
- Remove `_is_rollout_enabled`, `ROLLOUT_FLAG`, and the per-ticket check from the coordinator eligibility scan
- Drop `PRODUCT_SUPPORT_AI_SUGGESTION_ROLLOUT` from frontend constants
- Update coordinator tests to match
Rollout percentage can live on `product-support-ai-suggestion` itself if needed later (team-level distinct_id).
