### PR TITLE
fix(data-warehouse): prevent partition information loss when schema mismatch error raises

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/delta_table_helper.py
@@ -423,7 +423,7 @@ class DeltaTableHelper:
                     _write_deltalake,
                     delta_table,
                     data,
-                    partition_by=None,
+                    partition_by=PARTITION_KEY if use_partitioning else None,
                     mode=mode,
                     schema_mode="overwrite",
                     commit_properties=commit_properties,

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_delta_table_helper.py
@@ -437,6 +437,47 @@ class TestIncrementalBatchDeduplication:
         assert final.column("name").to_pylist() == ["second_copy"]
 
 
+class TestSchemaMismatchFallbackPreservesPartitioning:
+    """The SchemaMismatchError fallback must preserve the table's partitioning layout.
+
+    Previously the fallback retried with partition_by=None, leaving the partition key as
+    a plain data column while partition_columns=[] in metadata. Subsequent writes that
+    derived partitioning from column presence then failed with:
+        "Specified table partitioning does not match table partitioning"
+    """
+
+    @pytest.mark.asyncio
+    async def test_schema_mismatch_fallback_keeps_partitioning(self, tmp_path: Path) -> None:
+        delta_path = str(tmp_path / "table")
+
+        deltalake.write_deltalake(
+            delta_path,
+            pa.table({"id": pa.array([1]), PARTITION_KEY: pa.array(["p0"])}),
+            partition_by=PARTITION_KEY,
+        )
+        dt = deltalake.DeltaTable(delta_path)
+        assert dt.metadata().partition_columns == [PARTITION_KEY]
+
+        helper = _make_local_helper(delta_path)
+
+        batch = pa.table(
+            {
+                "id": pa.array([2]),
+                "new_col": pa.array(["x"]),
+                PARTITION_KEY: pa.array(["p0"]),
+            }
+        )
+
+        result = await helper.write_to_deltalake(
+            data=batch,
+            write_type="full_refresh",
+            should_overwrite_table=True,
+            primary_keys=None,
+        )
+
+        assert result.metadata().partition_columns == [PARTITION_KEY]
+
+
 class TestRealignDecimalBuffers:
     """delta-rs aborts the worker on 8-byte-aligned Decimal128 buffers; we realign them
     to pyarrow's 64-byte allocator before any Delta write. See delta-io/delta-rs#3884."""


### PR DESCRIPTION
## Problem

The `SchemaMismatchError` fallback in `write_to_deltalake` retried writes with `partition_by=None`, even when the table was partitioned. This left `_ph_partition_key` as a plain data column while the table's `partition_columns` metadata became `[]`. Subsequent writes that derived partitioning from column presence then passed `partition_by=_ph_partition_key` against a table delta-rs considered unpartitioned, raising:

```
Specified table partitioning does not match table partitioning: expected: [], got: ["_ph_partition_key"]
```

This is the root cause behind the inconsistent state that [#65992](https://github.com/PostHog/posthog/pull/65992) works around. That PR guards against the symptom (reading the table's actual partition metadata before writing), while this PR prevents the inconsistency from being created in the first place.

## Changes

The `SchemaMismatchError` fallback now preserves the original `partition_by` value instead of dropping it to `None`. `SchemaMismatchError` is about column types/names, not partitioning layout, so there's no reason to change the partitioning decision when retrying with `schema_mode="overwrite"`.

## How did you test this code?

Agent-authored. Ran the full `test_delta_table_helper.py` suite (35 tests pass).

New test `TestSchemaMismatchFallbackPreservesPartitioning` seeds a partitioned table, writes a batch through the full_refresh path, and asserts the table stays partitioned after the write. This catches the regression where the fallback silently dropped partitioning.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Fixing the root cause of PR #65992