### PR TITLE
fix(taxonomic-filter): keep popover open when picking a SQL autocomplete value

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -556,9 +556,8 @@ export function TaxonomicFilterMenu({
             if (target.closest?.('[data-quill-portal]')) {
                 return
             }
-            // Monaco suggestion/hover widgets (e.g. from a SQL expression editor) portal to a shared
-            // div at body level, outside our popover. Treat clicks there as inside so picking an
-            // autocomplete value doesn't close the whole filter and discard the in-progress query.
+            // Monaco portals suggestion widgets to a shared body-level div; treat clicks there as
+            // inside so picking a SQL autocomplete value doesn't close the filter.
             if (target.closest?.('[data-attr="monaco-overflow-root"]')) {
                 return
             }

--- a/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/menu/TaxonomicFilterMenu.tsx
@@ -556,6 +556,12 @@ export function TaxonomicFilterMenu({
             if (target.closest?.('[data-quill-portal]')) {
                 return
             }
+            // Monaco suggestion/hover widgets (e.g. from a SQL expression editor) portal to a shared
+            // div at body level, outside our popover. Treat clicks there as inside so picking an
+            // autocomplete value doesn't close the whole filter and discard the in-progress query.
+            if (target.closest?.('[data-attr="monaco-overflow-root"]')) {
+                return
+            }
             if (triggerWrapRef.current?.contains(target)) {
                 return
             }

--- a/frontend/src/lib/monaco/__tests__/sharedMonacoOverflowRoot.test.ts
+++ b/frontend/src/lib/monaco/__tests__/sharedMonacoOverflowRoot.test.ts
@@ -24,8 +24,6 @@ describe('sharedMonacoOverflowRoot', () => {
     })
 
     it('carries the click-outside-block class so suggestion clicks do not dismiss the host popover', () => {
-        // Suggestion/hover widgets portal here at body level; without the block class a click on a
-        // SQL-expression autocomplete would read as an outside click and close the TaxonomicFilter.
         const root = sharedMonacoOverflowRoot()
 
         expect(root?.classList.contains(CLICK_OUTSIDE_BLOCK_CLASS)).toBe(true)

--- a/frontend/src/lib/monaco/__tests__/sharedMonacoOverflowRoot.test.ts
+++ b/frontend/src/lib/monaco/__tests__/sharedMonacoOverflowRoot.test.ts
@@ -1,3 +1,4 @@
+import { CLICK_OUTSIDE_BLOCK_CLASS } from 'lib/hooks/useOutsideClickHandler'
 import { _resetSharedMonacoOverflowRootForTests, sharedMonacoOverflowRoot } from 'lib/monaco/sharedMonacoOverflowRoot'
 
 describe('sharedMonacoOverflowRoot', () => {
@@ -20,6 +21,14 @@ describe('sharedMonacoOverflowRoot', () => {
         expect(first).not.toBeUndefined()
         expect(first).toBe(second)
         expect(first?.parentNode).toBe(document.body)
+    })
+
+    it('carries the click-outside-block class so suggestion clicks do not dismiss the host popover', () => {
+        // Suggestion/hover widgets portal here at body level; without the block class a click on a
+        // SQL-expression autocomplete would read as an outside click and close the TaxonomicFilter.
+        const root = sharedMonacoOverflowRoot()
+
+        expect(root?.classList.contains(CLICK_OUTSIDE_BLOCK_CLASS)).toBe(true)
     })
 
     it('reattaches if the singleton was removed externally and stays unique on body', () => {

--- a/frontend/src/lib/monaco/sharedMonacoOverflowRoot.ts
+++ b/frontend/src/lib/monaco/sharedMonacoOverflowRoot.ts
@@ -1,3 +1,5 @@
+import { CLICK_OUTSIDE_BLOCK_CLASS } from 'lib/hooks/useOutsideClickHandler'
+
 // Shared monaco-editor portal div for popups (tooltips, suggestion list,
 // etc). Monaco's global services (HoverService, ContextView) register
 // DomListeners against whatever node we hand them as overflowWidgetsDomNode
@@ -22,7 +24,11 @@ export function sharedMonacoOverflowRoot(): HTMLDivElement | undefined {
         return sharedMonacoOverflowRootEl
     }
     sharedMonacoOverflowRootEl = document.createElement('div')
-    sharedMonacoOverflowRootEl.classList.add('monaco-editor')
+    // This div lives at body level, outside any popover's DOM subtree, so a click on a
+    // suggestion/hover widget portaled here reads as an "outside click" and dismisses whatever
+    // popover hosts the editor (e.g. a SQL expression inside the TaxonomicFilter). The block class
+    // exempts it from both the floating-ui Popover dismiss path and useOutsideClickHandler.
+    sharedMonacoOverflowRootEl.classList.add('monaco-editor', CLICK_OUTSIDE_BLOCK_CLASS)
     sharedMonacoOverflowRootEl.style.zIndex = 'var(--z-tooltip)'
     sharedMonacoOverflowRootEl.setAttribute('data-attr', 'monaco-overflow-root')
     document.body.appendChild(sharedMonacoOverflowRootEl)

--- a/frontend/src/lib/monaco/sharedMonacoOverflowRoot.ts
+++ b/frontend/src/lib/monaco/sharedMonacoOverflowRoot.ts
@@ -24,10 +24,8 @@ export function sharedMonacoOverflowRoot(): HTMLDivElement | undefined {
         return sharedMonacoOverflowRootEl
     }
     sharedMonacoOverflowRootEl = document.createElement('div')
-    // This div lives at body level, outside any popover's DOM subtree, so a click on a
-    // suggestion/hover widget portaled here reads as an "outside click" and dismisses whatever
-    // popover hosts the editor (e.g. a SQL expression inside the TaxonomicFilter). The block class
-    // exempts it from both the floating-ui Popover dismiss path and useOutsideClickHandler.
+    // Block class: this div is at body level, so clicking a suggestion widget here would otherwise
+    // dismiss the popover hosting the editor (e.g. a SQL expression inside the TaxonomicFilter).
     sharedMonacoOverflowRootEl.classList.add('monaco-editor', CLICK_OUTSIDE_BLOCK_CLASS)
     sharedMonacoOverflowRootEl.style.zIndex = 'var(--z-tooltip)'
     sharedMonacoOverflowRootEl.setAttribute('data-attr', 'monaco-overflow-root')


### PR DESCRIPTION
## Problem

When writing a SQL/HogQL expression in the TaxonomicFilter, clicking a Monaco autocomplete suggestion closed the entire filter popover and discarded the in-progress expression.

Monaco portals its suggestion/hover widgets to a single shared `div` appended to `document.body` (so they can overflow the editor box). That div sits outside the filter popover's DOM subtree, so a click on a suggestion looked like an "outside click" and dismissed the popover.

## Changes

- `sharedMonacoOverflowRoot.ts` — tag the shared overflow root with the existing `click-outside-block` class. Both the floating-ui `Popover` dismiss path and `useOutsideClickHandler` already honor that class, so this fixes the dismissal everywhere a Monaco editor lives inside a popover, not just the taxonomic filter.
- `menu/TaxonomicFilterMenu.tsx` (the rebuild-menu variant) uses its own manual `pointerdown` handler that doesn't check the block class, so it gets an explicit guard for `[data-attr="monaco-overflow-root"]`.

This covers all three TaxonomicFilter surfaces (`legacy-control`, `legacy-pill`, `rebuild-menu`).

## How did you test this code?

Verified this fix works locally.

-----

I'm an agent. I added a unit test in `sharedMonacoOverflowRoot.test.ts` asserting the overflow root carries the `click-outside-block` class (the regression: someone dropping the class would silently reintroduce the dismissal). I ran the automated tests only — no manual browser testing:

- `sharedMonacoOverflowRoot.test.ts` — 4/4 pass
- `Popover.test.tsx` — 2/2 pass

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated and fixed via the PostHog Slack app. Invoked the `/modifying-taxonomic-filter` skill, which flagged that the change had to be mirrored across the legacy and rebuild data layers — the rebuild menu doesn't route through `taxonomicFilterLogic`/`Popover` and has its own outside-click detection, so it needed a separate guard.

Considered fixing only the rebuild menu's `pointerdown` handler, but the legacy `HogQLEditor` path was affected too. Tagging the shared overflow root with `click-outside-block` is the narrower, more general fix (every Monaco-in-popover instance benefits), with the menu guard layered on for the variant that ignores that class.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782737789545569?thread_ts=1782737789.545569&cid=C0ACRAMJUAG)*
