### PR TITLE
fix(persons): allow personal API key access to batch endpoints

### DIFF
--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1577,8 +1577,9 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                     for person in persons:
                         person._distinct_ids = ids
 
+        serializer_context = {**self.get_serializer_context(), "get_team": lambda: self.team}
         results: dict[str, Any] = {
-            distinct_id: MinimalPersonSerializer(person, context={"get_team": lambda: self.team}).data
+            distinct_id: MinimalPersonSerializer(person, context=serializer_context).data
             for distinct_id, person in persons_by_distinct_id.items()
         }
         return response.Response({"results": results})
@@ -1602,9 +1603,10 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         with personhog_caller_tag("persons/batch-by-uuids"):
             persons = get_persons_by_uuids(self.team_id, uuids, distinct_id_limit=10)
 
+        serializer_context = {**self.get_serializer_context(), "get_team": lambda: self.team}
         results: dict[str, Any] = {}
         for person in persons:
-            results[str(person.uuid)] = MinimalPersonSerializer(person, context={"get_team": lambda: self.team}).data
+            results[str(person.uuid)] = MinimalPersonSerializer(person, context=serializer_context).data
 
         return response.Response({"results": results})
 

--- a/posthog/api/person.py
+++ b/posthog/api/person.py
@@ -1546,7 +1546,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
 
         return response.Response(status=202)
 
-    @action(methods=["POST"], detail=False, url_path="batch_by_distinct_ids")
+    @action(methods=["POST"], detail=False, url_path="batch_by_distinct_ids", required_scopes=["person:read"])
     def batch_by_distinct_ids(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         distinct_ids = request.data.get("distinct_ids", [])
 
@@ -1583,7 +1583,7 @@ class PersonViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         }
         return response.Response({"results": results})
 
-    @action(methods=["POST"], detail=False, url_path="batch_by_uuids")
+    @action(methods=["POST"], detail=False, url_path="batch_by_uuids", required_scopes=["person:read"])
     def batch_by_uuids(self, request: request.Request, *args: Any, **kwargs: Any) -> response.Response:
         uuids = request.data.get("uuids", [])
 

--- a/posthog/api/test/test_person.py
+++ b/posthog/api/test/test_person.py
@@ -25,6 +25,7 @@ from rest_framework import status
 
 import posthog.models.person.deletion
 from posthog.clickhouse.client import sync_execute
+from posthog.constants import AvailableFeature
 from posthog.models import Organization, Person, PropertyDefinition, Team
 from posthog.models.async_deletion import AsyncDeletion, DeletionType
 from posthog.models.person.missing_person import uuidFromDistinctId
@@ -39,6 +40,8 @@ from posthog.models.person.util import (
 from posthog.personhog_client.fake_client import fake_personhog_client
 from posthog.test.persons import add_distinct_id, create_person, delete_person
 
+from products.access_control.backend.models.property_access_control import PropertyAccessControl
+from products.access_control.backend.property_access_control import PropertyAccessLevel
 from products.cohorts.backend.models.cohort import Cohort
 
 
@@ -2093,3 +2096,51 @@ class TestPersonFromClickhouse(TestPerson):
 
         response_include_total = self.client.get("/api/person/?limit=10&include_total").json()
         self.assertEqual(response_include_total["count"], 19)  #  With `include_total`, the total count is returned too
+
+
+class TestPersonBatchRestrictedProperties(ClickhouseTestMixin, APIBaseTest):
+    # Regression: batch_by_distinct_ids / batch_by_uuids built MinimalPersonSerializer with a bare
+    # {"get_team": ...} context, skipping get_serializer_context() — so restricted_person_properties
+    # was never injected and field-level access control was bypassed. The single-person GET path
+    # strips restricted properties; the batch paths must too.
+    def setUp(self) -> None:
+        super().setUp()
+        self.organization.available_product_features = [
+            {"name": AvailableFeature.PROPERTY_ACCESS_CONTROL, "key": AvailableFeature.PROPERTY_ACCESS_CONTROL}
+        ]
+        self.organization.save()
+        restricted = PropertyDefinition.objects.create(
+            team=self.team, name="ssn", property_type="String", type=PropertyDefinition.Type.PERSON
+        )
+        # A default rule (no member/role) restricts the property for the default test user, a plain MEMBER.
+        PropertyAccessControl.objects.create(
+            team=self.team, property_definition=restricted, access_level=PropertyAccessLevel.NONE.value
+        )
+
+    @parameterized.expand(["batch_by_distinct_ids", "batch_by_uuids"])
+    def test_batch_endpoint_strips_restricted_person_properties(self, action: str) -> None:
+        person = _create_person(
+            team=self.team,
+            distinct_ids=["restricted_user"],
+            properties={"email": "visible@example.com", "ssn": "123-45-6789"},
+            immediate=True,
+        )
+        flush_persons_and_events()
+
+        if action == "batch_by_distinct_ids":
+            body: dict[str, list[str]] = {"distinct_ids": ["restricted_user"]}
+            result_key = "restricted_user"
+        else:
+            body = {"uuids": [str(person.uuid)]}
+            result_key = str(person.uuid)
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/persons/{action}/",
+            body,
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        properties = response.json()["results"][result_key]["properties"]
+        self.assertEqual(properties.get("email"), "visible@example.com")
+        self.assertNotIn("ssn", properties)

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -787,7 +787,7 @@ class TestPersonalAPIKeysWithPersonScope(PersonalAPIKeysBaseTest):
     def test_allows_batch_endpoint_with_person_read_scope(self, action):
         self.key.scopes = ["person:read"]
         self.key.save()
-        body = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
+        body: dict[str, list[str]] = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
         response = self.client.post(
             f"/api/projects/{self.team.id}/persons/{action}/",
             body,
@@ -801,7 +801,7 @@ class TestPersonalAPIKeysWithPersonScope(PersonalAPIKeysBaseTest):
     def test_denies_batch_endpoint_without_person_scope(self, action):
         self.key.scopes = ["feature_flag:read"]
         self.key.save()
-        body = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
+        body: dict[str, list[str]] = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
         response = self.client.post(
             f"/api/projects/{self.team.id}/persons/{action}/",
             body,

--- a/posthog/api/test/test_personal_api_keys.py
+++ b/posthog/api/test/test_personal_api_keys.py
@@ -777,6 +777,41 @@ class TestPersonalAPIKeysWithCommentScope(PersonalAPIKeysBaseTest):
         assert response.json()["detail"] == "API key missing required scope 'comment:read'"
 
 
+class TestPersonalAPIKeysWithPersonScope(PersonalAPIKeysBaseTest):
+    # Regression: batch_by_distinct_ids and batch_by_uuids shipped without
+    # `required_scopes`, so APIScopePermission rejected every personal API key —
+    # even one scoped `*` — with "This action does not support personal API key
+    # access". Both are reads, so they must accept `person:read`.
+
+    @parameterized.expand(["batch_by_distinct_ids", "batch_by_uuids"])
+    def test_allows_batch_endpoint_with_person_read_scope(self, action):
+        self.key.scopes = ["person:read"]
+        self.key.save()
+        body = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/persons/{action}/",
+            body,
+            format="json",
+            headers={"authorization": f"Bearer {self.value}"},
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert response.json() == {"results": {}}
+
+    @parameterized.expand(["batch_by_distinct_ids", "batch_by_uuids"])
+    def test_denies_batch_endpoint_without_person_scope(self, action):
+        self.key.scopes = ["feature_flag:read"]
+        self.key.save()
+        body = {"distinct_ids": []} if action == "batch_by_distinct_ids" else {"uuids": []}
+        response = self.client.post(
+            f"/api/projects/{self.team.id}/persons/{action}/",
+            body,
+            format="json",
+            headers={"authorization": f"Bearer {self.value}"},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+        assert response.json()["detail"] == "API key missing required scope 'person:read'"
+
+
 class TestPersonalAPIKeysWithApprovalsScope(PersonalAPIKeysBaseTest):
     def setUp(self):
         super().setUp()


### PR DESCRIPTION
## Problem

The persons batch-lookup endpoints — `POST /api/projects/:id/persons/batch_by_distinct_ids/` and `.../batch_by_uuids/` — reject every personal API key with `403 "This action does not support personal API key access"`, even keys granted full (`*`) access. The API reference lists these as personal-API-key endpoints, so callers integrating against them are blocked with no key configuration that works.

They function from inside the app only because session auth bypasses scope checks, which is why the gap went unnoticed since the endpoints were added in #47058.

## Changes

Two related changes, both scoped to the `batch_by_distinct_ids` and `batch_by_uuids` actions.

**1. Declare `required_scopes=["person:read"]` — unblocks personal API keys.**

Both actions were declared without `required_scopes`. With no explicit scope and an action name that isn't in the default read/write lists, `APIScopePermission._get_required_scopes` returns `None`, and `has_permission` treats that as "not reachable by token auth" — a branch that short-circuits *before* the `*` wildcard grant, so no key could pass, not even one scoped `*`. Both endpoints are read-only (they return `MinimalPersonSerializer` output, no mutations), so `person:read` is the correct scope. This matches how the codebase already classifies `batch_by_distinct_ids` as a read-only POST in the read-only-impersonation allowlist (`posthog/middleware.py`). Session auth is unchanged.

**2. Route the serializer through `get_serializer_context()` — applies field-level property access control.**

Both actions built `MinimalPersonSerializer` with a bare `{"get_team": ...}` context instead of going through `get_serializer_context()`. That method injects `restricted_person_properties` — the set of person properties hidden from the requesting user by `PropertyAccessControl` rules, which `PersonSerializer.to_representation` strips before returning. Because the batch actions bypassed it, they did not apply this filtering to their output, unlike the single-person `GET` path. Both actions now build the serializer with `{**self.get_serializer_context(), "get_team": ...}`, so restrictions are computed for the requesting principal (for a personal API key, the key's owner) and applied consistently with the rest of the persons API.

## How did you test this code?

I'm an agent. I did not run the suite manually — the sandbox has no Django/ClickHouse environment. I ran `ruff check` / `ruff format` (clean) and added automated tests for CI to execute.

**Scope gating** — `TestPersonalAPIKeysWithPersonScope` in `test_personal_api_keys.py`, parameterized over both endpoints:

- a `person:read` key reaches the endpoint (`200`, `{"results": {}}`) — catches the regression where the scope is dropped again and personal-API-key access silently breaks
- an unrelated-scope key is rejected with `API key missing required scope 'person:read'` — confirms the scope is actually enforced, not just absent

Requests use empty bodies, so they exercise only the permission layer and need no persons data.

**Property access control** — `TestPersonBatchRestrictedProperties` in `test_person.py`, parameterized over both endpoints: with `PROPERTY_ACCESS_CONTROL` enabled and a person property marked restricted, a batch lookup returns the unrestricted property but omits the restricted one. Guards change #2 against a silent revert to a bare serializer context.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The API reference auto-generates the `Required API key scopes` line from `required_scopes` (`posthog/api/documentation.py`), so the published docs for these endpoints will now correctly show `person:read` — no manual docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by Christiaan Hendriksen, who traced a `403` from a user report down to the missing scope declaration and asked for the fix. Authored with Claude Code (PostHog Code).

Skills invoked: `/improving-drf-endpoints` and `/writing-tests` (read from the repo and applied).

Decisions:

- Scoped to the two batch actions. Left `posthog/middleware.py` untouched: `batch_by_uuids` is missing from the read-only-impersonation allowlist that already lists `batch_by_distinct_ids`, but that's a separate subsystem with no demonstrated need — flagging it as a possible follow-up rather than bundling it.
- Brought field-level property access control to the batch endpoints (change #2): they previously skipped `get_serializer_context()`, so the restricted-property filtering applied by the single-person `GET` path was not applied to their output. Routed both through it for consistency.
- Verified the change doesn't churn generated artifacts: the batch operations aren't in the generated frontend clients (they lack `@extend_schema`), the global OAuth scope list is unchanged (`person:read` already exists), and `products/persons/mcp/tools.yaml` is hand-authored source.
- Considered adding `@extend_schema` + typed response serializers to these actions (flagged by `/improving-drf-endpoints`) but left it out to keep the fix tight — reasonable follow-up.

---

*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
