### PR TITLE
fix(mongodb): stop reporting unescaped-credential errors to error tracking

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/source.py
@@ -229,13 +229,14 @@ class MongoDBSource(SimpleSource[MongoDBSourceConfig], ValidateDatabaseHostMixin
                 return False, _MONGO_HOST_UNRESOLVED_MESSAGE
             return False, _MONGO_UNREACHABLE_MESSAGE
         except Exception as e:
-            capture_exception(e)
             # pymongo raises InvalidURI with the RFC-3986 hint before any network call when the
-            # credentials contain unescaped reserved characters; surface the actionable message
-            # rather than the raw driver string. Any other exception falls back to a generic message
-            # so internal exception text never reaches the user.
+            # credentials contain unescaped reserved characters. This is a malformed connection
+            # string the user must fix — already surfaced with an actionable message — so don't
+            # report it to error tracking as a bug. Any other exception is unexpected: capture it
+            # and fall back to a generic message so internal exception text never reaches the user.
             if "must be escaped according to RFC 3986" in str(e):
                 return False, _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
+            capture_exception(e)
             return False, _MONGO_CONNECT_FAILED_MESSAGE
 
         return True, None

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_database_name.py
@@ -147,3 +147,33 @@ class TestMongoValidateCredentialsOperationFailure:
         assert err == expected_message
         for leaked in forbidden:
             assert leaked not in (err or "")
+
+
+class TestMongoValidateCredentialsErrorTrackingNoise:
+    # Unescaped credentials are a user mistake we already surface an actionable message for, so
+    # they must not be reported to error tracking; genuinely unexpected errors still must be.
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_unescaped_credentials_not_reported(self, mock_get_collections, mock_capture):
+        mock_get_collections.side_effect = InvalidURI(
+            "Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus"
+        )
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_UNESCAPED_CREDENTIALS_MESSAGE
+        mock_capture.assert_not_called()
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.capture_exception")
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.source.get_collection_names")
+    def test_unexpected_error_is_reported(self, mock_get_collections, mock_capture):
+        mock_get_collections.side_effect = Exception("some-internal-driver-detail")
+        config = MongoDBSourceConfig.from_dict({"connection_string": _SRV_WITH_DB})
+
+        ok, err = MongoDBSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert err == _MONGO_CONNECT_FAILED_MESSAGE
+        mock_capture.assert_called_once()


### PR DESCRIPTION
## Problem

The MongoDB data-warehouse source surfaces a recurring `InvalidURI` error in error tracking:

> Username and password must be escaped according to RFC 3986, use urllib.parse.quote_plus

The exception originates in our own code — pymongo's `MongoClient(...)` raises it synchronously inside `mongo_client` (`mongodb/mongo.py`), and it propagates up `get_collection_names` → `validate_credentials` (`mongodb/source.py`) on the credential-validation endpoint.

This is a **user/config mistake**: the connection-string credentials contain unescaped reserved characters (`: / ? # [ ] @ %`). We already classify it as non-retryable and already return an actionable message telling the user to percent-encode their credentials. The only remaining problem is that `validate_credentials` reports it to error tracking as if it were a bug, producing non-actionable noise.

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f116f-5cf6-7570-9932-c901c0702aa9

## Changes

The generic `except Exception` handler in `validate_credentials` called `capture_exception(e)` unconditionally, before the known-error check. Reordered so the known unescaped-credentials case returns its actionable message **without** capturing, and only genuinely unexpected exceptions are captured and mapped to the generic fallback.

This mirrors the existing philosophy in `_get_rows_to_sync`, which deliberately avoids flooding error tracking with expected operational errors and only captures the unexpected ones.

Scope is deliberately narrow — no change to retry policy, and the `OperationFailure` / `ServerSelectionTimeoutError` branches are untouched.

## How did you test this code?

I'm an agent. I added and ran automated tests — no manual testing.

Added `TestMongoValidateCredentialsErrorTrackingNoise` in `test_database_name.py` (mirrors the capture-assertion pattern already used by `TestGetRowsToSync`):

- `test_unescaped_credentials_not_reported` — the RFC-3986 `InvalidURI` returns the actionable message and `capture_exception` is **not** called. This is the regression that no existing test caught: prior tests asserted the returned message but not the absence of error-tracking capture.
- `test_unexpected_error_is_reported` — an unexpected exception still maps to the generic message and **is** captured once, guarding against over-suppression.

Ran the full `mongodb/` test directory: 77 passed. `ruff check` and `ruff format --check` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged a live error-tracking issue for the MongoDB source via the PostHog MCP error-tracking tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`). The captured stack (`mechanism.handled = true`) confirmed the failure originates in the source's `mongo_client` and is captured by `validate_credentials`.
- Decision: not a retry-policy change — the error is already non-retryable and already surfaced with a clean message. The actionable fix is to stop emitting it to error tracking, since it's a config mistake the user must fix.
- Checked open PRs for duplicates. #66548 touches the same function but for a different root cause (`InvalidName` from a forbidden database-name character) and a different branch; it's complementary, not overlapping. No other PR addresses this.
- No skills were required for this change.