### PR TITLE
fix(postgres): keep oversized numeric values as text instead of crashing sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -433,13 +433,17 @@ def test_table_from_py_list_decimal_exceeding_max_scale_is_rounded():
     assert table.column("column").to_pylist() == [decimal.Decimal("1." + "1" * 32), None]
 
 
-def test_table_from_py_list_decimal_too_large_for_decimal256_raises():
-    # A value whose integer part can't fit decimal256(76, 32) even after rounding to the max
-    # scale is genuinely unrepresentable, so the hard ValueError must still surface.
-    value = decimal.Decimal("9" * 45 + "." + "1" * 40)
+def test_table_from_py_list_decimal_too_large_for_decimal256_falls_back_to_string():
+    # An unconstrained Postgres `numeric` can hold a value with more significant digits than
+    # decimal256 can represent (76), so it's unrepresentable as any Delta-compatible decimal.
+    # Keep it as text rather than crashing the whole sync (mirrors the huge-int fallback above).
+    # A None is mixed in to exercise the null passthrough.
+    value = decimal.Decimal("9" * 100)
 
-    with pytest.raises(ValueError, match="Cannot build decimal array from values"):
-        table_from_py_list([{"column": value}])
+    table = table_from_py_list([{"column": value}, {"column": None}])
+
+    assert table.schema.field("column").type == pa.string()
+    assert table.column("column").to_pylist() == [str(value), None]
 
 
 def test_table_from_py_list_normal_int_column_stays_int64():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -916,11 +916,19 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
                         if py_type is decimal.Decimal
                         else [_convert_to_decimal_or_none(x) for x in all_values]
                     )
-                    number_arr = _decimal_array_from_values(decimal_values)
-                    new_field_type = number_arr.type
-
-                    py_type = decimal.Decimal
-                    unique_types_in_column = {decimal.Decimal}
+                    try:
+                        number_arr = _decimal_array_from_values(decimal_values)
+                        new_field_type = number_arr.type
+                        py_type = decimal.Decimal
+                        unique_types_in_column = {decimal.Decimal}
+                    except ValueError:
+                        # Too large for even decimal256 (e.g. an unconstrained Postgres `numeric`
+                        # with more significant digits than 76) — keep it as text rather than
+                        # crash the sync (mirrors the huge-int fallback below).
+                        number_arr = pa.array([None if v is None else str(v) for v in decimal_values], type=pa.string())
+                        new_field_type = number_arr.type
+                        py_type = str
+                        unique_types_in_column = {str}
                 else:
                     raise
 


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import was crashing in the batch processor with an unhandled `ArrowInvalid`:

> Decimal type with precision 247 does not fit into precision inferred from first array element: 38

Reported by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f0eb2-e4e3-70f2-8a4c-a28986c82b75)) — 21 occurrences across 21 affected syncs.

The root cause: an unconstrained Postgres `numeric` column held a value with **more significant digits than `decimal256` can represent (76)**. Such a value is genuinely valid source data — a `numeric` with no precision/scale can hold thousands of digits — but it can't be expressed as any Delta-compatible decimal.

The exception chain confirms the source path: `get_rows` (postgres) → `table_from_iterator` → `_process_batch` → `_decimal_array_from_values`, which raises `ValueError("Cannot build decimal array from values")` and fails the entire table sync.

## Changes

`_process_batch`'s decimal-precision fallback now degrades an unrepresentable decimal column to **text** instead of crashing. This mirrors the int-overflow path immediately below it, which already does exactly this ("keep it as text rather than crash the sync") when a Python int is too large for even `decimal256`. The two sibling paths were asymmetric; this aligns them.

Keeping the value as a string preserves full fidelity (no truncation or silent data loss) while letting the rest of the table import succeed.

This is a fix in the shared `pipeline/utils.py` helper rather than the Postgres source module, because that's where the crash and the analogous int-overflow fallback live — any source feeding a too-large decimal hits the same code. Postgres is just where it surfaced (unconstrained `numeric`).

## How did you test this code?

I'm an agent. I ran the automated tests below; I did not perform manual testing.

- Updated the existing `test_..._decimal_too_large_for_decimal256_raises` test (which codified the crash) to `..._falls_back_to_string`, asserting the column is now kept as text. **Regression caught:** an oversized unconstrained-`numeric` value crashing the whole sync instead of degrading to a string column — no existing test covered the decimal path's graceful fallback (only the int path did).
- Verified the test fails on the pre-fix code with the exact reported `ValueError: Cannot build decimal array from values`, and passes with the fix.
- Ran the full `test_pipeline_utils.py` suite (79 passed), plus `ruff check` / `ruff format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to pull the full stack trace and confirm the failure originated in the Postgres source's read path. Read the implementation to find that the decimal fallback in `_process_batch` raises while its int-overflow sibling degrades to string for the identical "too large for decimal256" condition — chose to align them rather than add a Postgres-specific guard, since the defect is in the shared helper. Scoped strictly to this error; no retry-policy or unrelated changes.