### PR TITLE
fix(postgres): keep oversized numeric columns as text instead of crashing sync

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/test/test_pipeline_utils.py
@@ -433,13 +433,17 @@ def test_table_from_py_list_decimal_exceeding_max_scale_is_rounded():
     assert table.column("column").to_pylist() == [decimal.Decimal("1." + "1" * 32), None]
 
 
-def test_table_from_py_list_decimal_too_large_for_decimal256_raises():
-    # A value whose integer part can't fit decimal256(76, 32) even after rounding to the max
-    # scale is genuinely unrepresentable, so the hard ValueError must still surface.
-    value = decimal.Decimal("9" * 45 + "." + "1" * 40)
+def test_table_from_py_list_decimal_too_large_for_decimal256_falls_back_to_string():
+    # A value whose integer part can't fit decimal256(76, 32) even after rounding to the max scale
+    # is genuinely unrepresentable as a decimal. It must fall back to text rather than crash the
+    # sync, mirroring the huge-int fallback. A normal value is mixed in to confirm the whole column
+    # stringifies consistently.
+    huge = decimal.Decimal("9" * 247)
 
-    with pytest.raises(ValueError, match="Cannot build decimal array from values"):
-        table_from_py_list([{"column": value}])
+    table = table_from_py_list([{"column": huge}, {"column": decimal.Decimal("1.5")}, {"column": None}])
+
+    assert table.schema.field("column").type == pa.string()
+    assert table.column("column").to_pylist() == [str(huge), "1.5", None]
 
 
 def test_table_from_py_list_normal_int_column_stays_int64():

--- a/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/pipelines/pipeline/utils.py
@@ -916,11 +916,19 @@ def _process_batch(table_data: list[dict], schema: Optional[pa.Schema] = None) -
                         if py_type is decimal.Decimal
                         else [_convert_to_decimal_or_none(x) for x in all_values]
                     )
-                    number_arr = _decimal_array_from_values(decimal_values)
-                    new_field_type = number_arr.type
-
-                    py_type = decimal.Decimal
-                    unique_types_in_column = {decimal.Decimal}
+                    try:
+                        number_arr = _decimal_array_from_values(decimal_values)
+                        new_field_type = number_arr.type
+                        py_type = decimal.Decimal
+                        unique_types_in_column = {decimal.Decimal}
+                    except ValueError:
+                        # A value is too large even for decimal256 (e.g. an unconstrained Postgres
+                        # `numeric` with more than 76 significant digits) — keep the column as text
+                        # rather than crash the sync, mirroring the huge-int fallback below.
+                        number_arr = pa.array([None if v is None else str(v) for v in decimal_values], type=pa.string())
+                        new_field_type = pa.string()
+                        py_type = str
+                        unique_types_in_column = {str}
                 else:
                     raise
 


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import was permanently failing with `ArrowInvalid: Decimal type with precision 247 does not fit into precision inferred from first array element: 38`, surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f0eb5-87f5-7023-a667-c65a9feeed83)).

Postgres `numeric` allows values with far more significant digits than Arrow can store — Arrow's widest decimal type (`decimal256`) caps at 76 total digits. When a column carries a value with more than 76 significant digits (the reported case had ~247), the value is genuinely unrepresentable as any Arrow/Delta decimal.

The decimal column path in `_process_batch` (shared `pipeline/utils.py`) called `_decimal_array_from_values` without catching its `ValueError`. So an oversized value propagated out of the Postgres source's `get_rows`, was wrapped as a `NonRetryableException`, and **permanently failed the entire table sync** — one extreme value killed the whole import.

## Changes

The huge-**int** column path already handles this gracefully: when a value is too large even for `decimal256`, it falls back to a **text** column rather than crashing. The huge-**decimal** path was missing the same catch.

This change mirrors the existing int fallback in the decimal path: when `_decimal_array_from_values` raises `ValueError`, the column is stored as text (preserving the values via their string form) instead of failing the sync. `_decimal_array_from_values`'s contract is unchanged — it still raises, and both call sites now handle it consistently.

This is a fixable bug, not a user/upstream error: the upstream data is valid Postgres `numeric`, and our pipeline was the thing falling over. So it does **not** belong in `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I added/updated automated tests only — no manual testing.

- Reproduced the exact downstream failure chain (`Rescaling Decimal256 value would cause data loss` → `decimal.InvalidOperation` → `ValueError`) with pyarrow 18.1.0 to confirm the root cause.
- Updated `test_table_from_py_list_decimal_too_large_for_decimal256_*` to assert the new text fallback (it previously asserted the crash), using a value with ~247 significant digits mixed with a normal value and a null to confirm the whole column stringifies consistently.
- Ran the full `test_pipeline_utils.py` suite: 79 passed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged an error-tracking issue for the Postgres warehouse source. Confirmed via the PostHog error-tracking MCP tools that the failure originates in `get_rows` (postgres source) → shared `pipeline/utils.py` helper, not just in serialized log context. Verified no existing open PR addresses this (checked the maintainer's open PRs and searched by exception type, message, and module path).

Decision: fixable bug rather than a non-retryable user error — the data is valid upstream, and the codebase already had a graceful text fallback for the analogous huge-int case, so the fix brings the decimal path in line with it.

Tools used: PostHog MCP error-tracking tools, local pytest/ruff. No repo skills were applicable to this change.