### PR TITLE
fix(google_sheets): treat deleted-spreadsheet 404 as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/google_sheets.py
@@ -67,6 +67,17 @@ _RETRYABLE_API_ERROR_CODES = {429, 500, 502, 503, 504}
 # stable, descriptive message so downstream matching can identify it.
 _PERMISSION_DENIED_MESSAGE = "Spreadsheet access denied. Please share the spreadsheet with the PostHog service account."
 
+# gspread converts the Sheets API 404 into `SpreadsheetNotFound` — see gspread/client.py
+# `open_by_key`: `raise SpreadsheetNotFound(ex.response) from ex`. Its `str()` is just the bare
+# response repr (`<Response [404]>`); the "Requested entity was not found" text lives only on the
+# chained APIError cause. The non-retryable matcher does a substring match over `str(e)`, so it has
+# nothing to match on and a deleted/moved/unshared sheet gets retried indefinitely. Re-raise with a
+# stable, descriptive message (mirroring `_PERMISSION_DENIED_MESSAGE` above) so it stops retrying.
+_SPREADSHEET_NOT_FOUND_MESSAGE = (
+    "Spreadsheet not found. The Google Sheet could not be found — it may have been deleted or "
+    "moved, or is no longer shared with the PostHog service account."
+)
+
 T = TypeVar("T")
 
 
@@ -127,6 +138,8 @@ def _get_worksheet(spreadsheet_url: str, worksheet_id: int) -> gspread.Worksheet
             spreadsheet = client.open_by_url(spreadsheet_url)
         except PermissionError as e:
             raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        except gspread.exceptions.SpreadsheetNotFound as e:
+            raise gspread.exceptions.SpreadsheetNotFound(_SPREADSHEET_NOT_FOUND_MESSAGE) from e
         return spreadsheet.get_worksheet_by_id(worksheet_id)
 
     return _retry_on_transient_api_error(execute)
@@ -144,6 +157,8 @@ def get_schemas(config: GoogleSheetsSourceConfig) -> list[tuple[str, int]]:
             spreadsheet = client.open_by_url(config.spreadsheet_url)
         except PermissionError as e:
             raise PermissionError(_PERMISSION_DENIED_MESSAGE) from e
+        except gspread.exceptions.SpreadsheetNotFound as e:
+            raise gspread.exceptions.SpreadsheetNotFound(_SPREADSHEET_NOT_FOUND_MESSAGE) from e
         return spreadsheet.worksheets()
 
     worksheets = _retry_on_transient_api_error(execute)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/source.py
@@ -40,12 +40,13 @@ class GoogleSheetsSource(SimpleSource[GoogleSheetsSourceConfig]):
         return {
             "the header row in the worksheet contains duplicates": "Import failed: There exists duplicate column headers. Please make sure all column headers have values and aren't duplicated.",
             "can't be found": None,
-            "SpreadsheetNotFound": None,
             "must be real number, not str": "Import failed: a numeric column contains a non-numeric value. Ensure every cell in numeric columns is stored as a plain number.",
             "Spreadsheet access denied": "Import failed: PostHog does not have access to this spreadsheet. Please share it with our service account as described at https://posthog.com/docs/cdp/sources/google-sheets",
-            # gspread raises APIError "[404]: Requested entity was not found." when the
-            # spreadsheet has been deleted or is otherwise unreachable. Retrying cannot recover.
-            "Requested entity was not found": "Import failed: the Google Sheet could not be found. It may have been deleted or moved. Please check the spreadsheet URL and that it is shared with our service account.",
+            # gspread surfaces the Sheets API 404 (deleted/moved sheet, or access removed) as a
+            # `SpreadsheetNotFound`, which `google_sheets.py` re-raises with this stable message —
+            # `str(SpreadsheetNotFound)` is otherwise just `<Response [404]>`, with nothing to match.
+            # Retrying cannot recover.
+            "Spreadsheet not found": "Import failed: the Google Sheet could not be found. It may have been deleted or moved. Please check the spreadsheet URL and that it is shared with our service account.",
         }
 
     def get_schemas(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_sheets/tests/test_google_sheets.py
@@ -390,18 +390,37 @@ def test_permission_error_is_non_retryable():
     assert any(key in error_msg for key in non_retryable_errors)
 
 
-def test_not_found_api_error_is_non_retryable():
-    """gspread raises a 404 APIError when the spreadsheet has been deleted/moved — it
-    must match a non-retryable pattern so we stop retrying a permanent failure."""
-    mock_response = mock.MagicMock()
-    mock_response.json.return_value = {
-        "error": {"code": 404, "message": "Requested entity was not found.", "status": "NOT_FOUND"}
-    }
-    error_msg = str(gspread.exceptions.APIError(mock_response))
+@pytest.mark.parametrize(
+    "call_site",
+    [
+        pytest.param(
+            lambda: get_schemas(
+                GoogleSheetsSourceConfig(spreadsheet_url="https://docs.google.com/spreadsheets/d/fake")
+            ),
+            id="get_schemas",
+        ),
+        # Use a unique url/id to avoid the module-level TTLCache returning a prior result
+        pytest.param(lambda: _get_worksheet("not-found-url", 998), id="_get_worksheet"),
+    ],
+)
+def test_reraises_spreadsheet_not_found_with_non_retryable_message(call_site):
+    """gspread converts the Sheets API 404 (deleted/moved/unshared sheet) into
+    `SpreadsheetNotFound`, whose `str()` is only `<Response [404]>` — so the non-retryable matcher
+    (substring over `str(e)`) never fires and a permanent failure is retried forever. We must
+    re-raise it with a stable message that matches one of the source's non-retryable keys."""
+    with mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.google_sheets.google_sheets.google_sheets_client"
+    ) as mock_google_sheets_client:
+        instance = mock_google_sheets_client.return_value
+        instance.open_by_url.side_effect = gspread.exceptions.SpreadsheetNotFound(mock.MagicMock())
 
+        with pytest.raises(gspread.exceptions.SpreadsheetNotFound) as exc_info:
+            call_site()
+
+    error_msg = str(exc_info.value)
     non_retryable_errors = GoogleSheetsSource().get_non_retryable_errors()
     assert any(key in error_msg for key in non_retryable_errors), (
-        f"Google Sheets 404 error {error_msg!r} did not match any non-retryable pattern"
+        f"Re-raised SpreadsheetNotFound {error_msg!r} did not match any non-retryable pattern"
     )
 
 


### PR DESCRIPTION
## Problem

The Google Sheets import source surfaces a recurring error in error tracking:

> `APIError: [404]: Requested entity was not found.`

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1027-7d3b-7600-b729-db983e689bbb

The failure originates in `google_sheets/google_sheets.py` when `client.open_by_url(...)` is called during schema discovery and worksheet acquisition. A 404 here means the spreadsheet was deleted, moved, or is no longer shared with our service account — a permanent, user/upstream condition that retrying cannot recover.

The source already *intended* to treat this as non-retryable (`get_non_retryable_errors` had `"Requested entity was not found"` and `"SpreadsheetNotFound"` keys), but those keys never matched the real exception, so the 404 was classified as retryable, captured to error tracking via `logger.aexception` on every attempt, and retried on every scheduled sync.

## Root cause

gspread's `open_by_key` converts the Sheets API 404 into `SpreadsheetNotFound` (`raise SpreadsheetNotFound(ex.response) from ex`). `SpreadsheetNotFound` is **not** a subclass of `APIError`, and its `str()` is just the bare response repr — `<Response [404]>`. The `"Requested entity was not found"` text lives only on the chained `__cause__` (the `APIError`).

The non-retryable matcher (`_handle_import_error`, and the finalize path in `external_data_job.py`) does a substring match over `str(error)` / `str(e.cause)`, which is `<Response [404]>` — so neither dead key ever matched. The non-retryable path uses debug logging and stops after a few attempts; the retryable path is what captures to error tracking, so the misclassification is exactly what produced this issue.

## Changes

- Catch `gspread.exceptions.SpreadsheetNotFound` at both `open_by_url` call sites in `google_sheets.py` and re-raise it with a stable, descriptive message, mirroring the existing `PermissionError` re-raise pattern in the same file (which exists for the same reason — gspread's raw exception has nothing matchable).
- Point the `get_non_retryable_errors` entry at that stable message (`"Spreadsheet not found"`) and drop the two dead keys.

Scoped strictly to this source — no change to global retry policy or the shared matcher. The message is a fixed string with no customer data (no URL, spreadsheet id, or account info).

## How did you test this code?

I'm an agent. I ran the source's unit test suite (`test_google_sheets.py`, 39 tests) — all pass.

The existing `test_not_found_api_error_is_non_retryable` asserted on a bare `APIError` that never reaches our matcher in production, so it passed while production failed. It's replaced with `test_reraises_spreadsheet_not_found_with_non_retryable_message`, which exercises the real propagated `SpreadsheetNotFound` through both `get_schemas` and `_get_worksheet` and asserts the re-raised message matches a non-retryable key. I verified this new test **fails** without the fix (raw `SpreadsheetNotFound` stringifies to the response repr, matching nothing) and passes with it — the regression the old test missed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Triaged from the error tracking issue above. Pulled the full stack trace via the PostHog error-tracking MCP tools, confirmed the failing frame is in this source (`google_sheets.py` → gspread `open_by_url`/`open_by_key`), and traced how the propagated `SpreadsheetNotFound` flows into the non-retryable matcher. Verified against the installed gspread 6.2.1 source that the exception is not an `APIError` subclass and stringifies to `<Response [404]>`, which is why the existing non-retryable keys were dead.

Decision: user/upstream error (deleted/inaccessible sheet) → make the existing non-retryable intent actually fire, rather than touching the shared matcher (which would change retry behavior for every source). Chose to mirror the in-file `PermissionError` re-raise pattern over walking the `__cause__` chain in the shared helper.
