### PR TITLE
fix(bigquery): retry transient job-internal-error in primary-key probe

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -28,7 +28,7 @@ from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery.job import QueryJobConfig
-from google.cloud.bigquery.retry import DEFAULT_JOB_RETRY
+from google.cloud.bigquery.retry import DEFAULT_JOB_RETRY, _job_should_retry
 from google.cloud.bigquery_storage_v1.services.big_query_read.transports.grpc import BigQueryReadGrpcTransport
 from google.oauth2 import service_account
 from structlog.types import FilteringBoundLogger
@@ -117,7 +117,10 @@ _BIGQUERY_JOB_RETRY_RECOMMENDED = "Retrying the job may solve the problem"
 
 
 def _query_job_should_retry(exc: Exception) -> bool:
-    return _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or DEFAULT_JOB_RETRY._predicate(exc)
+    # Defer to the library's own default predicate for the reasons it already covers; importing it
+    # directly (rather than reading the private `Retry._predicate`) means a library rename fails
+    # loudly at import instead of silently dropping that default coverage.
+    return _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or _job_should_retry(exc)
 
 
 BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_retry)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -28,6 +28,7 @@ from google.auth.exceptions import RefreshError
 from google.auth.transport.requests import AuthorizedSession
 from google.cloud import bigquery, bigquery_storage
 from google.cloud.bigquery.job import QueryJobConfig
+from google.cloud.bigquery.retry import DEFAULT_JOB_RETRY
 from google.cloud.bigquery_storage_v1.services.big_query_read.transports.grpc import BigQueryReadGrpcTransport
 from google.oauth2 import service_account
 from structlog.types import FilteringBoundLogger
@@ -105,6 +106,21 @@ BIGQUERY_DATASET_NOT_FOUND_ERROR = (
     "it may live in a different region — verify your dataset and table names, and set the dataset "
     "region in your source configuration if it isn't in the US."
 )
+
+# BigQuery occasionally fails a query job with a transient `jobInternalError`, surfaced from the
+# `jobs.getQueryResults` REST call as a 400 BadRequest whose message ends "The job encountered an
+# error during execution. Retrying the job may solve the problem.". The client's default job-retry
+# predicate retries backendError / internalError / rateLimitExceeded but not this reason, so it
+# escapes `QueryJob.result()` and crashes the import. BigQuery itself recommends retrying, so re-run
+# the job in place — matched on its stable retry-recommendation wording, not the volatile job id/URL.
+_BIGQUERY_JOB_RETRY_RECOMMENDED = "Retrying the job may solve the problem"
+
+
+def _query_job_should_retry(exc: Exception) -> bool:
+    return _BIGQUERY_JOB_RETRY_RECOMMENDED in str(exc) or DEFAULT_JOB_RETRY._predicate(exc)
+
+
+BIGQUERY_QUERY_JOB_RETRY = DEFAULT_JOB_RETRY.with_predicate(_query_job_should_retry)
 
 
 class BigQueryDatasetNotFoundError(Exception):
@@ -469,7 +485,7 @@ def _get_primary_keys_for_table(table: bigquery.Table, client: bigquery.Client) 
     job = client.query(query, job_config=job_config, project=table.project)
 
     primary_keys = []
-    for row in job.result():
+    for row in job.result(job_retry=BIGQUERY_QUERY_JOB_RETRY):
         field_name = row["column_name"].removeprefix(f"{table.table_id}.")
 
         if field_name not in existing_fields:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -12,12 +12,14 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery import bigquery as bq_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
+    BIGQUERY_QUERY_JOB_RETRY,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryCredentialsRejectedError,
     BigQueryDatasetNotFoundError,
     BigQueryImplementation,
     BigQueryTokenRefreshError,
     _bq_select_clause,
+    _get_primary_keys_for_table,
     _get_query,
     _get_rows_to_sync,
     _has_duplicate_primary_keys,
@@ -937,6 +939,53 @@ def test_has_duplicate_primary_keys_captures_unexpected_errors():
 
     assert result is False
     mock_capture.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # The transient `jobInternalError` from `jobs.getQueryResults` (volatile project/job id redacted).
+        BadRequest(
+            "GET https://bigquery.googleapis.com/bigquery/v2/projects/<redacted>/queries/<redacted>"
+            "?maxResults=0&location=US&prettyPrint=false: The job encountered an error during execution. "
+            "Retrying the job may solve the problem."
+        ),
+        # The library default's own retryable reasons must still be honoured.
+        BadRequest("query failed", errors=[{"reason": "backendError", "message": "internal error"}]),
+        BadRequest("query failed", errors=[{"reason": "rateLimitExceeded", "message": "slow down"}]),
+    ],
+)
+def test_bigquery_query_job_retry_retries_transient_job_errors(exc):
+    assert BIGQUERY_QUERY_JOB_RETRY._predicate(exc) is True
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        # A genuinely malformed query is deterministic — retrying never helps, so it must surface.
+        BadRequest("Syntax error: Unexpected keyword SELECT"),
+        BadRequest("query failed", errors=[{"reason": "invalidQuery", "message": "bad SQL"}]),
+    ],
+)
+def test_bigquery_query_job_retry_does_not_retry_deterministic_errors(exc):
+    assert BIGQUERY_QUERY_JOB_RETRY._predicate(exc) is False
+
+
+def test_bigquery_get_primary_keys_for_table_passes_job_retry():
+    """The primary-key probe must run under the extended job retry so a transient BigQuery job
+    error is re-tried in place instead of crashing the import."""
+    table = mock.MagicMock()
+    table.schema = []
+    table.dataset_id = "dataset"
+    table.table_id = "table"
+    table.project = "project"
+
+    client = mock.MagicMock()
+    client.query.return_value.result.return_value = []
+
+    _get_primary_keys_for_table(table, client)
+
+    assert client.query.return_value.result.call_args.kwargs["job_retry"] is BIGQUERY_QUERY_JOB_RETRY
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

A customer's BigQuery import crashed with a transient `BadRequest` raised from the primary-key discovery query in `_get_primary_keys_for_table`:

> The job encountered an error during execution. Retrying the job may solve the problem.

This is BigQuery's transient `jobInternalError`, surfaced from the `jobs.getQueryResults` REST call as a 400. BigQuery itself recommends retrying. The google-cloud-bigquery client's default job-retry predicate (`DEFAULT_JOB_RETRY`) retries `backendError` / `internalError` / `rateLimitExceeded` but **not** this reason, so the error escaped `QueryJob.result()`, bubbled up through `_build_source_response` → `build_pipeline`, and failed the whole `import_data_activity_sync`.

Error-tracking issue: [019f12d2-8430-7c52-a4b7-ae746f0312d7](https://us.posthog.com/project/2/error_tracking/019f12d2-8430-7c52-a4b7-ae746f0312d7) (single occurrence — Temporal retried the whole activity and recovered, but the crash is avoidable and the noise is non-actionable).

## Decision

This is a **transient** server-side error, not a user/config problem, so it must stay retryable — adding it to `NonRetryableErrors` would be wrong, and silently skipping primary-key discovery would risk syncing a table without its keys. The right fix is to let the BigQuery client re-run the job in place, which is exactly what its native `job_retry` mechanism is for. The default predicate simply has a gap for the `jobInternalError` reason.

## Changes

- Extend the query job-retry predicate (`BIGQUERY_QUERY_JOB_RETRY`) so it also retries when BigQuery returns its stable retry-recommendation wording, while delegating to the library default for everything else (so `backendError` / `rateLimitExceeded` etc. keep retrying and deterministic errors keep surfacing).
- Pass that retry to the `result()` call in `_get_primary_keys_for_table`.
- Match on the stable phrase `"Retrying the job may solve the problem"` — no job id, URL, or location, so no customer data and no volatile parts.

Scoped strictly to the reported error path. This is distinct from #66534, which retries a *different* failure (a `NotFound` "Job ... not found" metadata race) via its own `NotFound`-only predicate — that helper does not catch this `BadRequest`.

## How did you test this code?

I'm an agent. I ran the BigQuery source test suite locally with pytest:

- `test_source.py` — full file, **97 passed**.
- New regression tests:
  - `test_bigquery_query_job_retry_retries_transient_job_errors` — the predicate recognises the observed transient message (and still honours the library's `backendError` / `rateLimitExceeded` reasons).
  - `test_bigquery_query_job_retry_does_not_retry_deterministic_errors` — a syntax error / `invalidQuery` is not retried.
  - `test_bigquery_get_primary_keys_for_table_passes_job_retry` — the probe wires the extended retry into `result()`, so a future refactor that drops it is caught.

`ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by an agent (PostHog Code) triaging a live error-tracking issue for the BigQuery warehouse source. Considered three options: (1) add to `NonRetryableErrors` — rejected, the error is transient and recoverable; (2) gracefully skip primary-key discovery like `_has_duplicate_primary_keys` does — rejected, returning no keys on a transient blip risks dropping a table's primary keys and changing dedup behaviour; (3) close the gap in the client's `job_retry` predicate so the job is retried in place — chosen, as it keeps the error retryable, avoids a heavyweight full-activity restart, and removes the non-actionable error-tracking noise. No skills were applicable.