### PR TITLE
fix(auth): remove em-dash usage in auth pages and templates

### DIFF
--- a/frontend/src/lib/oauth/oauthClient.ts
+++ b/frontend/src/lib/oauth/oauthClient.ts
@@ -154,7 +154,7 @@ export async function buildAuthorizeUrl(pending: PendingAuth): Promise<string> {
 /** Exchange the authorization code for tokens and persist the session. */
 export async function exchangeCodeForToken(pending: PendingAuth, code: string, state: string): Promise<OAuthSession> {
     if (pending.state !== state) {
-        throw new Error('OAuth state mismatch — please start the login again.')
+        throw new Error('OAuth state mismatch. Please start the login again.')
     }
     // Trailing slash is required: CORS_URLS_REGEX only grants CORS headers to `/oauth/token/`.
     const response = await fetch(`${pending.backendHost}/oauth/token/`, {

--- a/frontend/src/lib/oauth/oauthLogic.ts
+++ b/frontend/src/lib/oauth/oauthLogic.ts
@@ -65,7 +65,7 @@ export const oauthLogic = kea<oauthLogicType>([
         handleCallback: async ({ code, state }) => {
             const { pendingAuth } = values
             if (!pendingAuth) {
-                actions.setLoginError('No pending OAuth flow found — please start the login again.')
+                actions.setLoginError('No pending OAuth flow found. Please start the login again.')
                 return
             }
             try {
@@ -95,7 +95,7 @@ export const oauthLogic = kea<oauthLogicType>([
             if (searchParams.code) {
                 actions.handleCallback(searchParams.code, searchParams.state)
             } else if (!searchParams.error) {
-                actions.setLoginError('No authorization code received — please start the login again.')
+                actions.setLoginError('No authorization code received. Please start the login again.')
             }
         },
     })),

--- a/frontend/src/scenes/authentication/cli/CLIAuthorize.tsx
+++ b/frontend/src/scenes/authentication/cli/CLIAuthorize.tsx
@@ -127,7 +127,7 @@ export function CLIAuthorize(): JSX.Element {
                             />
                         </div>
                         <p className="text-muted text-sm mb-2">
-                            Permissions granted to the CLI. Pick a preset or fine-tune individual scopes — only grant
+                            Permissions granted to the CLI. Pick a preset or fine-tune individual scopes. Only grant
                             what you need.
                         </p>
 

--- a/frontend/src/scenes/authentication/shared/OtherRegionHint.tsx
+++ b/frontend/src/scenes/authentication/shared/OtherRegionHint.tsx
@@ -33,7 +33,7 @@ export function OtherRegionHint(): JSX.Element | null {
 
     return (
         <LemonBanner type="info">
-            Already have a PostHog Cloud account? It may live in our {otherRegion} region — you're currently on{' '}
+            Already have a PostHog Cloud account? It may live in our {otherRegion} region. You're currently on{' '}
             {preflight.region}.{' '}
             <Link
                 to={otherRegionLoginUrl(preflight.region, location.search)}

--- a/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
+++ b/frontend/src/scenes/authentication/signup/variants/paper-desk/PaperDeskSignup.tsx
@@ -154,7 +154,7 @@ function PendingInvitePanel(): JSX.Element {
             {pendingInviteResent ? (
                 <div className="flex gap-2 items-start py-2.5 px-3 text-sm text-primary text-left bg-success-highlight border border-success rounded">
                     <span className="font-bold text-success">✓</span>
-                    <span>Sent. Look for an email from {org} — the link inside takes you straight in.</span>
+                    <span>Sent. Look for an email from {org}. The link inside takes you straight in.</span>
                 </div>
             ) : (
                 <div className="flex flex-col gap-2.5">

--- a/frontend/src/scenes/authentication/verify-email/variants/paper-desk/PaperDeskVerifyEmail.tsx
+++ b/frontend/src/scenes/authentication/verify-email/variants/paper-desk/PaperDeskVerifyEmail.tsx
@@ -225,7 +225,7 @@ function VerifyEmail(): JSX.Element {
                         Check your inbox
                     </h1>
                     <p className="PaperDesk__sub mt-2 mb-4 text-sm text-secondary text-center text-pretty">
-                        We sent you a verification link. Click the link inside and you're in — it's valid for 24 hours.
+                        We sent you a verification link. Click the link inside and you're in. It's valid for 24 hours.
                     </p>
                     <NotSeeingIt />
                 </div>

--- a/frontend/src/toolbar/bar/AuthConfirmModal.tsx
+++ b/frontend/src/toolbar/bar/AuthConfirmModal.tsx
@@ -139,7 +139,7 @@ export function AuthConfirmModal({ visible, onClose }: AuthConfirmModalProps): J
                 <p className="flex items-center gap-1">
                     <IconWarning className="text-warning shrink-0" />
                     <span>
-                        Only continue if you recognize this domain as your PostHog instance — signing in elsewhere could
+                        Only continue if you recognize this domain as your PostHog instance. Signing in elsewhere could
                         expose your account.
                     </span>
                 </p>

--- a/posthog/templates/auth_md.md
+++ b/posthog/templates/auth_md.md
@@ -25,13 +25,13 @@ The user-claimed device flow (`service_auth`, `anonymous`) is not supported yet.
 
 ## Scopes
 
-{% for scope, description in scopes %}- `{{ scope }}` — {{ description }}
+{% for scope, description in scopes %}- `{{ scope }}`: {{ description }}
 {% endfor %}
 
 ## Changing scopes
 
 Access tokens carry the scope set granted when they were issued.
-Scopes do not change on refresh — refreshing a token returns the same or narrower scopes, never more.
+Scopes do not change on refresh. Refreshing a token returns the same or narrower scopes, never more.
 
 If your app needs additional scopes, for example a newly required scope, or a request that returns `403` because the token is missing a required scope, start a new authorization at `{{ base_url }}/oauth/authorize/`.
 The user re-consents and the new token carries the updated scopes.

--- a/posthog/templates/email/2fa_backup_code_used.html
+++ b/posthog/templates/email/2fa_backup_code_used.html
@@ -4,6 +4,6 @@
 
 <p>Someone used a backup code to bypass two-factor authentication and access {{ user_email }}.</p>
 
-<p>Hopefully, that was you—if so, there's no need for alarm. If it wasn't you then you should let us know urgently, as someone may have accessed your account without your permission. And that would be bad. </p>
+<p>Hopefully, that was you. If so, there's no need for alarm. If it wasn't you then you should let us know urgently, as someone may have accessed your account without your permission. And that would be bad. </p>
 
 {% endblock %}

--- a/posthog/templates/email/delegation_invite.html
+++ b/posthog/templates/email/delegation_invite.html
@@ -6,7 +6,7 @@
 <p class="text-center">
     <strong>{{ inviter_first_name }}</strong> ({{ inviter_email }}) started setting up PostHog for
     <strong>{{ org_name }}</strong> and would like you to finish the setup. Accept the invitation below to get
-    started — you'll be taken through the full setup flow.
+    started. You'll be taken through the full setup flow.
 </p>
 <p class="text-center">
     PostHog is an all-in-one platform for product analytics, session replays, feature flags, experiments, surveys,


### PR DESCRIPTION
## Problem

Em-dashes (—) were used as sentence connectors across auth pages, email templates, and OAuth copy. This style is inconsistent with the rest of the product UI and can feel typographically heavy in short, functional copy like login flows.

Closes #GROW-48

## Changes

Replaced all sentence-connector em-dashes with periods (splitting into two sentences) in:

- `OtherRegionHint.tsx` — region hint banner
- `PaperDeskSignup.tsx` — invite resent confirmation
- `PaperDeskVerifyEmail.tsx` — verification link sent message
- `CLIAuthorize.tsx` — scope selection description
- `AuthConfirmModal.tsx` — toolbar auth warning
- `oauthLogic.ts` — OAuth error messages (×2)
- `oauthClient.ts` — OAuth state mismatch error
- `templates/email/2fa_backup_code_used.html` — 2FA backup code email
- `templates/email/delegation_invite.html` — delegation invite email
- `templates/auth_md.md` — OAuth scope documentation template (×2; one separator changed to `:`)

The standalone em-dash in `LoginSessions.tsx` (used as a table cell placeholder, not a sentence connector) was intentionally left unchanged.

## How did you test this code?

Agent-authored. Changes are purely copy/text — no logic, no types, no component structure changed. No automated tests cover this copy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by PostHog Code (Claude Sonnet 4.6). The user asked to implement GROW-48, which removes em-dash usage from auth-related pages and templates.

Skills invoked: none (pure copy change).

The agent searched all auth-related frontend files and Django templates for em-dash characters (U+2014) and HTML entities, then replaced each sentence-connector usage with a period split. The one standalone em-dash used as a table-cell placeholder (`LoginSessions.tsx`) was left alone as it serves a different typographic role.