### PR TITLE
feat(replay): a/b test defaulting recordings sort to relevance

### DIFF
--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -439,6 +439,7 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_COLLAPSE_INSPECTOR_ITEMS: 'replay-collapse-inspector-items', // owner: @fasyy612 #team-replay
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
+    REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT: 'replay-playlist-relevance-sort-experiment', // owner: #team-replay multivariate=control,test — test arm defaults the recordings list sort to relevance
     REPLAY_PLAYLIST_SURFACING_SCORE: 'replay-playlist-surfacing-score', // owner: #team-replay
     REPLAY_TRIGGERS_V2: 'replay-triggers-v2', // owner: #team-replay
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -439,7 +439,7 @@ export const FEATURE_FLAGS = {
     REMOTE_CONFIG: 'remote-config', // owner: #team-platform-features
     REPLAY_COLLAPSE_INSPECTOR_ITEMS: 'replay-collapse-inspector-items', // owner: @fasyy612 #team-replay
     REPLAY_FILTERS_REDESIGN: 'replay-filters-redesign', // owner: @ksvat #team-replay
-    REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT: 'replay-playlist-relevance-sort-experiment', // owner: #team-replay multivariate=control,test — test arm defaults the recordings list sort to relevance
+    REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT: 'replay-playlist-relevance-sort-experiment', // owner: @arnohillen #team-replay multivariate=control,test
     REPLAY_PLAYLIST_SURFACING_SCORE: 'replay-playlist-surfacing-score', // owner: #team-replay
     REPLAY_TRIGGERS_V2: 'replay-triggers-v2', // owner: #team-replay
     REPLAY_UI_REDESIGN_2026: 'replay-ui-redesign-2026', // owner: #team-replay, New UI layout for replay

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.test.ts
@@ -1,0 +1,67 @@
+import { RecordingUniversalFilters } from '~/types'
+
+import { getSortChangedEvent } from './SessionRecordingsPlaylistSettings'
+
+type Sort = Parameters<typeof getSortChangedEvent>[1]
+
+const filters = (order?: string, order_direction?: 'ASC' | 'DESC'): RecordingUniversalFilters =>
+    ({ order, order_direction }) as RecordingUniversalFilters
+
+describe('getSortChangedEvent', () => {
+    it('returns null when the sort is unchanged so no-op clicks are not logged', () => {
+        expect(
+            getSortChangedEvent(filters('start_time', 'DESC'), { order: 'start_time', order_direction: 'DESC' })
+        ).toBeNull()
+    })
+
+    const cases: [string, RecordingUniversalFilters, Sort, Record<string, string>][] = [
+        [
+            'the order changes',
+            filters('start_time', 'DESC'),
+            { order: 'activity_score', order_direction: 'DESC' },
+            {
+                sort_key: 'activity_score',
+                sort_direction: 'DESC',
+                previous_sort_key: 'start_time',
+                previous_sort_direction: 'DESC',
+            },
+        ],
+        [
+            'only the direction changes',
+            filters('start_time', 'DESC'),
+            { order: 'start_time', order_direction: 'ASC' },
+            {
+                sort_key: 'start_time',
+                sort_direction: 'ASC',
+                previous_sort_key: 'start_time',
+                previous_sort_direction: 'DESC',
+            },
+        ],
+        [
+            'a user switches away from relevance',
+            filters('surfacing_score', 'DESC'),
+            { order: 'start_time', order_direction: 'DESC' },
+            {
+                sort_key: 'start_time',
+                sort_direction: 'DESC',
+                previous_sort_key: 'surfacing_score',
+                previous_sort_direction: 'DESC',
+            },
+        ],
+        [
+            'filters carry no explicit sort yet',
+            filters(undefined, undefined),
+            { order: 'surfacing_score', order_direction: 'DESC' },
+            {
+                sort_key: 'surfacing_score',
+                sort_direction: 'DESC',
+                previous_sort_key: 'start_time',
+                previous_sort_direction: 'DESC',
+            },
+        ],
+    ]
+
+    it.each(cases)('captures previous and new sort when %s', (_name, currentFilters, sort, expected) => {
+        expect(getSortChangedEvent(currentFilters, sort)).toEqual(expected)
+    })
+})

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -1,5 +1,6 @@
 import { useActions, useValues } from 'kea'
 import { router } from 'kea-router'
+import posthog from 'posthog-js'
 
 import { IconChevronRight, IconEllipsis, IconEye, IconPlus, IconSort, IconTrash } from '@posthog/icons'
 import { LemonBadge, LemonButton, LemonCheckbox, LemonInput, LemonModal, Spinner } from '@posthog/lemon-ui'
@@ -60,18 +61,35 @@ function SortedBy({
     disabledReason?: string
 }): JSX.Element {
     const surfacingScoreEnabled = useFeatureFlag('REPLAY_PLAYLIST_SURFACING_SCORE')
+    const inRelevanceSortExperiment = useFeatureFlag('REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT', 'test')
+    const showRelevanceSort = surfacingScoreEnabled || inRelevanceSortExperiment
+
+    // Capture every sort change so the relevance-sort experiment can measure how many users switch away from relevance
+    const changeSort = (
+        order: NonNullable<RecordingUniversalFilters['order']>,
+        order_direction: 'ASC' | 'DESC'
+    ): void => {
+        posthog.capture('session recording list sort changed', {
+            sort_key: order,
+            sort_direction: order_direction,
+            previous_sort_key: filters.order ?? 'start_time',
+            previous_sort_direction: filters.order_direction ?? 'DESC',
+        })
+        setFilters({ order, order_direction })
+    }
+
     return (
         <SettingsMenu
             highlightWhenActive={false}
             disabledReason={disabledReason}
             items={[
-                ...(surfacingScoreEnabled
+                ...(showRelevanceSort
                     ? [
                           {
                               label: SortingKeyToLabel['surfacing_score'],
                               tooltip:
                                   'Ranks recordings by a relevance score so the sessions most likely to be worth watching appear first.',
-                              onClick: () => setFilters({ order: 'surfacing_score', order_direction: 'DESC' }),
+                              onClick: () => changeSort('surfacing_score', 'DESC'),
                               active: filters.order === 'surfacing_score',
                           },
                       ]
@@ -81,25 +99,25 @@ function SortedBy({
                     items: [
                         {
                             label: 'Latest',
-                            onClick: () => setFilters({ order: 'start_time', order_direction: 'DESC' }),
+                            onClick: () => changeSort('start_time', 'DESC'),
                             active:
                                 !filters.order || (filters.order === 'start_time' && filters.order_direction !== 'ASC'),
                         },
                         {
                             label: 'Oldest',
-                            onClick: () => setFilters({ order: 'start_time', order_direction: 'ASC' }),
+                            onClick: () => changeSort('start_time', 'ASC'),
                             active: filters.order === 'start_time' && filters.order_direction === 'ASC',
                         },
                     ],
                 },
                 {
                     label: SortingKeyToLabel['activity_score'],
-                    onClick: () => setFilters({ order: 'activity_score', order_direction: 'DESC' }),
+                    onClick: () => changeSort('activity_score', 'DESC'),
                     active: filters.order === 'activity_score',
                 },
                 {
                     label: SortingKeyToLabel['console_error_count'],
-                    onClick: () => setFilters({ order: 'console_error_count', order_direction: 'DESC' }),
+                    onClick: () => changeSort('console_error_count', 'DESC'),
                     active: filters.order === 'console_error_count',
                 },
                 {
@@ -107,17 +125,17 @@ function SortedBy({
                     items: [
                         {
                             label: SortingKeyToLabel['duration'],
-                            onClick: () => setFilters({ order: 'duration', order_direction: 'DESC' }),
+                            onClick: () => changeSort('duration', 'DESC'),
                             active: filters.order === 'duration',
                         },
                         {
                             label: SortingKeyToLabel['active_seconds'],
-                            onClick: () => setFilters({ order: 'active_seconds', order_direction: 'DESC' }),
+                            onClick: () => changeSort('active_seconds', 'DESC'),
                             active: filters.order === 'active_seconds',
                         },
                         {
                             label: SortingKeyToLabel['inactive_seconds'],
-                            onClick: () => setFilters({ order: 'inactive_seconds', order_direction: 'DESC' }),
+                            onClick: () => changeSort('inactive_seconds', 'DESC'),
                             active: filters.order === 'inactive_seconds',
                         },
                     ],
@@ -127,24 +145,24 @@ function SortedBy({
                     items: [
                         {
                             label: SortingKeyToLabel['click_count'],
-                            onClick: () => setFilters({ order: 'click_count', order_direction: 'DESC' }),
+                            onClick: () => changeSort('click_count', 'DESC'),
                             active: filters.order === 'click_count',
                         },
                         {
                             label: SortingKeyToLabel['keypress_count'],
-                            onClick: () => setFilters({ order: 'keypress_count', order_direction: 'DESC' }),
+                            onClick: () => changeSort('keypress_count', 'DESC'),
                             active: filters.order === 'keypress_count',
                         },
                         {
                             label: SortingKeyToLabel['mouse_activity_count'],
-                            onClick: () => setFilters({ order: 'mouse_activity_count', order_direction: 'DESC' }),
+                            onClick: () => changeSort('mouse_activity_count', 'DESC'),
                             active: filters.order === 'mouse_activity_count',
                         },
                     ],
                 },
                 {
                     label: 'Expiration',
-                    onClick: () => setFilters({ order: 'recording_ttl', order_direction: 'ASC' }),
+                    onClick: () => changeSort('recording_ttl', 'ASC'),
                     active: filters.order === 'recording_ttl',
                 },
             ]}

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -64,17 +64,19 @@ function SortedBy({
     const inRelevanceSortExperiment = useFeatureFlag('REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT', 'test')
     const showRelevanceSort = surfacingScoreEnabled || inRelevanceSortExperiment
 
-    // Capture every sort change so the relevance-sort experiment can measure how many users switch away from relevance
+    // Track sort changes for the relevance-sort experiment
     const changeSort = (
         order: NonNullable<RecordingUniversalFilters['order']>,
         order_direction: 'ASC' | 'DESC'
     ): void => {
-        posthog.capture('session recording list sort changed', {
-            sort_key: order,
-            sort_direction: order_direction,
-            previous_sort_key: filters.order ?? 'start_time',
-            previous_sort_direction: filters.order_direction ?? 'DESC',
-        })
+        if (order !== filters.order || order_direction !== filters.order_direction) {
+            posthog.capture('session recording list sort changed', {
+                sort_key: order,
+                sort_direction: order_direction,
+                previous_sort_key: filters.order ?? 'start_time',
+                previous_sort_direction: filters.order_direction ?? 'DESC',
+            })
+        }
         setFilters({ order, order_direction })
     }
 

--- a/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
+++ b/frontend/src/scenes/session-recordings/playlist/SessionRecordingsPlaylistSettings.tsx
@@ -51,6 +51,24 @@ function getLabel(filters: RecordingUniversalFilters): string {
     return SortingKeyToLabel[order_field as keyof typeof SortingKeyToLabel]
 }
 
+type RecordingSort = { order: NonNullable<RecordingUniversalFilters['order']>; order_direction: 'ASC' | 'DESC' }
+
+/** The analytics payload for a sort change, or null when the sort is unchanged so we don't log no-op switches. */
+export function getSortChangedEvent(
+    filters: RecordingUniversalFilters,
+    sort: RecordingSort
+): Record<string, string> | null {
+    if (sort.order === filters.order && sort.order_direction === filters.order_direction) {
+        return null
+    }
+    return {
+        sort_key: sort.order,
+        sort_direction: sort.order_direction,
+        previous_sort_key: filters.order ?? 'start_time',
+        previous_sort_direction: filters.order_direction ?? 'DESC',
+    }
+}
+
 function SortedBy({
     filters,
     setFilters,
@@ -65,19 +83,12 @@ function SortedBy({
     const showRelevanceSort = surfacingScoreEnabled || inRelevanceSortExperiment
 
     // Track sort changes for the relevance-sort experiment
-    const changeSort = (
-        order: NonNullable<RecordingUniversalFilters['order']>,
-        order_direction: 'ASC' | 'DESC'
-    ): void => {
-        if (order !== filters.order || order_direction !== filters.order_direction) {
-            posthog.capture('session recording list sort changed', {
-                sort_key: order,
-                sort_direction: order_direction,
-                previous_sort_key: filters.order ?? 'start_time',
-                previous_sort_direction: filters.order_direction ?? 'DESC',
-            })
+    const changeSort = (sort: RecordingSort): void => {
+        const sortChangedEvent = getSortChangedEvent(filters, sort)
+        if (sortChangedEvent) {
+            posthog.capture('session recording list sort changed', sortChangedEvent)
         }
-        setFilters({ order, order_direction })
+        setFilters(sort)
     }
 
     return (
@@ -91,7 +102,7 @@ function SortedBy({
                               label: SortingKeyToLabel['surfacing_score'],
                               tooltip:
                                   'Ranks recordings by a relevance score so the sessions most likely to be worth watching appear first.',
-                              onClick: () => changeSort('surfacing_score', 'DESC'),
+                              onClick: () => changeSort({ order: 'surfacing_score', order_direction: 'DESC' }),
                               active: filters.order === 'surfacing_score',
                           },
                       ]
@@ -101,25 +112,25 @@ function SortedBy({
                     items: [
                         {
                             label: 'Latest',
-                            onClick: () => changeSort('start_time', 'DESC'),
+                            onClick: () => changeSort({ order: 'start_time', order_direction: 'DESC' }),
                             active:
                                 !filters.order || (filters.order === 'start_time' && filters.order_direction !== 'ASC'),
                         },
                         {
                             label: 'Oldest',
-                            onClick: () => changeSort('start_time', 'ASC'),
+                            onClick: () => changeSort({ order: 'start_time', order_direction: 'ASC' }),
                             active: filters.order === 'start_time' && filters.order_direction === 'ASC',
                         },
                     ],
                 },
                 {
                     label: SortingKeyToLabel['activity_score'],
-                    onClick: () => changeSort('activity_score', 'DESC'),
+                    onClick: () => changeSort({ order: 'activity_score', order_direction: 'DESC' }),
                     active: filters.order === 'activity_score',
                 },
                 {
                     label: SortingKeyToLabel['console_error_count'],
-                    onClick: () => changeSort('console_error_count', 'DESC'),
+                    onClick: () => changeSort({ order: 'console_error_count', order_direction: 'DESC' }),
                     active: filters.order === 'console_error_count',
                 },
                 {
@@ -127,17 +138,17 @@ function SortedBy({
                     items: [
                         {
                             label: SortingKeyToLabel['duration'],
-                            onClick: () => changeSort('duration', 'DESC'),
+                            onClick: () => changeSort({ order: 'duration', order_direction: 'DESC' }),
                             active: filters.order === 'duration',
                         },
                         {
                             label: SortingKeyToLabel['active_seconds'],
-                            onClick: () => changeSort('active_seconds', 'DESC'),
+                            onClick: () => changeSort({ order: 'active_seconds', order_direction: 'DESC' }),
                             active: filters.order === 'active_seconds',
                         },
                         {
                             label: SortingKeyToLabel['inactive_seconds'],
-                            onClick: () => changeSort('inactive_seconds', 'DESC'),
+                            onClick: () => changeSort({ order: 'inactive_seconds', order_direction: 'DESC' }),
                             active: filters.order === 'inactive_seconds',
                         },
                     ],
@@ -147,24 +158,24 @@ function SortedBy({
                     items: [
                         {
                             label: SortingKeyToLabel['click_count'],
-                            onClick: () => changeSort('click_count', 'DESC'),
+                            onClick: () => changeSort({ order: 'click_count', order_direction: 'DESC' }),
                             active: filters.order === 'click_count',
                         },
                         {
                             label: SortingKeyToLabel['keypress_count'],
-                            onClick: () => changeSort('keypress_count', 'DESC'),
+                            onClick: () => changeSort({ order: 'keypress_count', order_direction: 'DESC' }),
                             active: filters.order === 'keypress_count',
                         },
                         {
                             label: SortingKeyToLabel['mouse_activity_count'],
-                            onClick: () => changeSort('mouse_activity_count', 'DESC'),
+                            onClick: () => changeSort({ order: 'mouse_activity_count', order_direction: 'DESC' }),
                             active: filters.order === 'mouse_activity_count',
                         },
                     ],
                 },
                 {
                     label: 'Expiration',
-                    onClick: () => changeSort('recording_ttl', 'ASC'),
+                    onClick: () => changeSort({ order: 'recording_ttl', order_direction: 'ASC' }),
                     active: filters.order === 'recording_ttl',
                 },
             ]}

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1305,24 +1305,28 @@ describe('sessionRecordingsPlaylistLogic', () => {
             jest.spyOn(posthog, 'getFeatureFlag').mockImplementation((key) => flags[key as string] as any)
         }
 
-        it('defaults the sort order to relevance for the test arm', () => {
-            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' })
-            expect(getDefaultFilters().order).toBe('surfacing_score')
-        })
+        const cases: [string, Record<string, string | boolean>, string][] = [
+            [
+                'test arm defaults to relevance',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' },
+                'surfacing_score',
+            ],
+            [
+                'control arm keeps recency',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'control' },
+                DEFAULT_RECORDING_FILTERS_ORDER_BY,
+            ],
+            ['not enrolled keeps recency', {}, DEFAULT_RECORDING_FILTERS_ORDER_BY],
+            [
+                'surfacing-score rollout flag forces relevance',
+                { [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true },
+                'surfacing_score',
+            ],
+        ]
 
-        it('keeps the recency sort order for the control arm', () => {
-            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'control' })
-            expect(getDefaultFilters().order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
-        })
-
-        it('keeps the recency sort order when not enrolled in the experiment', () => {
-            mockFlags({})
-            expect(getDefaultFilters().order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
-        })
-
-        it('still defaults to relevance when the surfacing-score rollout flag is enabled', () => {
-            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true })
-            expect(getDefaultFilters().order).toBe('surfacing_score')
+        it.each(cases)('%s', (_name, flags, expectedOrder) => {
+            mockFlags(flags)
+            expect(getDefaultFilters().order).toBe(expectedOrder)
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.test.ts
@@ -1,7 +1,9 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
+import posthog from 'posthog-js'
 
 import api from 'lib/api'
+import { FEATURE_FLAGS } from 'lib/constants'
 import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 
 import { useMocks } from '~/mocks/jest'
@@ -20,6 +22,7 @@ import { sessionRecordingDataCoordinatorLogic } from '../player/sessionRecording
 import { playlistFiltersLogic } from './playlistFiltersLogic'
 import {
     DEFAULT_RECORDING_FILTERS,
+    DEFAULT_RECORDING_FILTERS_ORDER_BY,
     convertLegacyFiltersToUniversalFilters,
     convertUniversalFiltersToRecordingsQuery,
     getDefaultFilters,
@@ -1290,6 +1293,36 @@ describe('sessionRecordingsPlaylistLogic', () => {
             const result = getDefaultFilters(undefined, pinnedFilters)
             const firstGroup = result.filter_group.values[0] as any
             expect(firstGroup.values).toContainEqual(pinnedFilters.values[0])
+        })
+    })
+
+    describe('relevance sort experiment', () => {
+        afterEach(() => {
+            jest.restoreAllMocks()
+        })
+
+        const mockFlags = (flags: Record<string, string | boolean>): void => {
+            jest.spyOn(posthog, 'getFeatureFlag').mockImplementation((key) => flags[key as string] as any)
+        }
+
+        it('defaults the sort order to relevance for the test arm', () => {
+            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'test' })
+            expect(getDefaultFilters().order).toBe('surfacing_score')
+        })
+
+        it('keeps the recency sort order for the control arm', () => {
+            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT]: 'control' })
+            expect(getDefaultFilters().order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
+        })
+
+        it('keeps the recency sort order when not enrolled in the experiment', () => {
+            mockFlags({})
+            expect(getDefaultFilters().order).toBe(DEFAULT_RECORDING_FILTERS_ORDER_BY)
+        })
+
+        it('still defaults to relevance when the surfacing-score rollout flag is enabled', () => {
+            mockFlags({ [FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE]: true })
+            expect(getDefaultFilters().order).toBe('surfacing_score')
         })
     })
 

--- a/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
+++ b/frontend/src/scenes/session-recordings/playlist/sessionRecordingsPlaylistLogic.ts
@@ -177,10 +177,12 @@ export const getDefaultFilters = (
         ...DEFAULT_RECORDING_FILTERS,
         filter_test_accounts: filterTestAccounts,
         date_from: personUUID ? '-30d' : '-3d',
-        // When the surfacing score flag is on, default to sorting by relevance
-        order: posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE)
-            ? 'surfacing_score'
-            : DEFAULT_RECORDING_FILTERS.order,
+        // Default to sorting by relevance for the surfacing-score rollout or the relevance-sort experiment's test arm
+        order:
+            posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_SURFACING_SCORE) ||
+            posthog.getFeatureFlag(FEATURE_FLAGS.REPLAY_PLAYLIST_RELEVANCE_SORT_EXPERIMENT) === 'test'
+                ? 'surfacing_score'
+                : DEFAULT_RECORDING_FILTERS.order,
     }
     if (pinnedFilters) {
         defaults.filter_group = mergePinnedFilters(defaults.filter_group, pinnedFilters)

--- a/posthog/session_recordings/test/test_gate_surfacing_score_order.py
+++ b/posthog/session_recordings/test/test_gate_surfacing_score_order.py
@@ -34,17 +34,28 @@ class TestGateSurfacingScoreOrder(TestCase):
             assert query.order == expected
             feature_enabled.assert_not_called()
 
-    def test_surfacing_score_kept_when_flag_enabled(self):
-        with mock.patch("posthog.session_recordings.utils.posthoganalytics.feature_enabled", return_value=True):
+    @parameterized.expand(
+        [
+            ("surfacing_flag_enabled", True, None, RecordingOrder.SURFACING_SCORE),
+            ("experiment_test_arm", False, "test", RecordingOrder.SURFACING_SCORE),
+            ("experiment_control_arm", False, "control", RecordingOrder.START_TIME),
+            ("neither_enabled", False, None, RecordingOrder.START_TIME),
+        ]
+    )
+    def test_surfacing_score_kept_only_for_rollout_or_experiment_test_arm(
+        self, _name, surfacing_enabled, experiment_variant, expected
+    ):
+        with (
+            mock.patch(
+                "posthog.session_recordings.utils.posthoganalytics.feature_enabled", return_value=surfacing_enabled
+            ),
+            mock.patch(
+                "posthog.session_recordings.utils.posthoganalytics.get_feature_flag", return_value=experiment_variant
+            ),
+        ):
             query = _query(RecordingOrder.SURFACING_SCORE)
             gate_surfacing_score_order(query, _user())
-            assert query.order == RecordingOrder.SURFACING_SCORE
-
-    def test_surfacing_score_falls_back_when_flag_disabled(self):
-        with mock.patch("posthog.session_recordings.utils.posthoganalytics.feature_enabled", return_value=False):
-            query = _query(RecordingOrder.SURFACING_SCORE)
-            gate_surfacing_score_order(query, _user())
-            assert query.order == RecordingOrder.START_TIME
+            assert query.order == expected
 
     def test_surfacing_score_falls_back_without_a_user(self):
         with mock.patch("posthog.session_recordings.utils.posthoganalytics.feature_enabled") as feature_enabled:

--- a/posthog/session_recordings/utils.py
+++ b/posthog/session_recordings/utils.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     from posthog.models import User
 
 SURFACING_SCORE_ORDER_FLAG = "replay-playlist-surfacing-score"
+RELEVANCE_SORT_EXPERIMENT_FLAG = "replay-playlist-relevance-sort-experiment"
 
 
 def recordings_query_has_event_filters(query: RecordingsQuery) -> bool:
@@ -26,19 +27,37 @@ def recordings_query_has_event_filters(query: RecordingsQuery) -> bool:
 def gate_surfacing_score_order(query: RecordingsQuery, user: "User | None") -> None:
     """`surfacing_score` ordering is gated behind a feature flag. It's exposed to clients via the
     generated RecordingOrder enum (both the REST list endpoint and the MCP query), so the gate has to
-    be enforced server-side, not just in the UI. When the flag is off — or there's no user to evaluate
-    it against — fall back to the default ordering rather than erroring on an otherwise valid request."""
+    be enforced server-side, not just in the UI. When neither the surfacing-score rollout nor the
+    relevance-sort experiment's test arm is enabled (or there's no user to evaluate against), fall back
+    to the default ordering rather than erroring on an otherwise valid request."""
     if query.order != RecordingOrder.SURFACING_SCORE:
         return
 
-    enabled = user is not None and posthoganalytics.feature_enabled(
-        SURFACING_SCORE_ORDER_FLAG,
-        str(user.distinct_id),
-        person_properties={"email": user.email},
-        send_feature_flag_events=False,
-    )
-    if not enabled:
+    if user is None or not _can_order_by_surfacing_score(user):
         query.order = RecordingOrder.START_TIME
+
+
+def _can_order_by_surfacing_score(user: "User") -> bool:
+    distinct_id = str(user.distinct_id)
+    person_properties = {"email": user.email}
+    if posthoganalytics.feature_enabled(
+        SURFACING_SCORE_ORDER_FLAG,
+        distinct_id,
+        person_properties=person_properties,
+        send_feature_flag_events=False,
+    ):
+        return True
+    # The relevance-sort experiment's test arm needs the same ordering capability, otherwise the server
+    # resets its default sort back to recency and the experiment measures nothing.
+    return (
+        posthoganalytics.get_feature_flag(
+            RELEVANCE_SORT_EXPERIMENT_FLAG,
+            distinct_id,
+            person_properties=person_properties,
+            send_feature_flag_events=False,
+        )
+        == "test"
+    )
 
 
 def clean_prompt_whitespace(prompt: str) -> str:


### PR DESCRIPTION
## Problem

The session recordings list always sorts by recency. We already compute a relevance score (`surfacing_score`) for recordings, and we want to know whether defaulting the list to relevance actually helps people find useful sessions, or whether they just switch straight back to recency. That is an A/B question, not a guess.

## Changes

Runs a PostHog experiment on the recordings list sort, backed by a new multivariate flag `replay-playlist-relevance-sort-experiment` (`control` / `test`).

**Frontend**

- Test arm defaults the list to relevance (`surfacing_score`) and shows the "Relevance" sort option. Control arm is unchanged (recency default).
- Every real sort change fires a `session recording list sort changed` event with the previous and new sort, so the experiment can measure how many test-arm users switch back to recency. Re-selecting the already-active sort fires nothing.

**Backend**

- `surfacing_score` ordering is gated server-side (it is exposed in the public `RecordingOrder` enum, so the UI alone is not enough). The gate now grants it for the surfacing-score rollout **or** the experiment's test arm. Without this, a test-arm user's `surfacing_score` query was silently reset to recency, so the test arm behaved identically to control and the experiment would have measured nothing.

The existing `replay-playlist-surfacing-score` rollout keeps working exactly as before, so this is backwards compatible. The experiment object (50/50 split, exposure, and goal metric) is created in the PostHog app pointing at the new flag and the `session recording list sort changed` event.

## How did you test this code?

I'm an agent (Claude Code), so automated tests only. No manual UI clicking.

- Backend: parameterized `test_gate_surfacing_score_order.py` over rollout-on, experiment test arm, experiment control arm, and neither (7 pass). Catches the server failing to grant, or wrongly granting, relevance sorting per arm.
- Frontend: parameterized `getDefaultFilters` tests per variant, plus a `getSortChangedEvent` test for the no-op-event guard and the event payload (72 pass). Catches the default sort flipping wrongly and no-op sort events polluting the metric.

Full frontend matrix and backend suites are green on CI.

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8), directed by @arnohillen. The ask: run a relevance-vs-recency sort experiment on the recordings list for 50% of users, and track how many switch back to recency.

Notable decisions:

- Chose session recordings as the surface because it already has a relevance score (`surfacing_score`), so no new ranking algorithm was needed.
- Modeled it as a multivariate experiment flag (matching existing `multivariate=control,test` flags) rather than a boolean toggle, leaving the existing surfacing-score rollout untouched.
- Found and fixed a server-side gap: the `surfacing_score` order gate only honored the rollout flag, so it would have silently downgraded the experiment's test arm to recency. The gate now honors the test arm too, using `get_feature_flag(...) == "test"` so the control arm is not also granted access.

No repo skills were strictly required (no migrations, serializer, or endpoint-schema changes).
