### PR TITLE
fix(tasks): return 404 for malformed task UUID in run views

### DIFF
--- a/products/tasks/backend/presentation/views/api.py
+++ b/products/tasks/backend/presentation/views/api.py
@@ -7,6 +7,7 @@ from collections.abc import AsyncGenerator
 from datetime import datetime
 from typing import Any
 from urllib.parse import parse_qs, urlparse
+from uuid import UUID
 
 from django.conf import settings
 from django.http import HttpResponse, JsonResponse
@@ -742,6 +743,10 @@ class TaskRunViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
         task_id = self.kwargs.get("parent_lookup_task_id")
         if not task_id:
             raise NotFound("Task ID is required")
+        try:
+            UUID(task_id)
+        except (ValueError, TypeError):
+            raise NotFound("Task not found")
         return task_id
 
     def _user_id(self) -> int | None:

--- a/products/tasks/backend/tests/test_api.py
+++ b/products/tasks/backend/tests/test_api.py
@@ -3287,6 +3287,11 @@ class TestTaskAutomationAPI(BaseTaskAPITest):
 
 
 class TestTaskRunAPI(BaseTaskAPITest):
+    def test_list_runs_with_malformed_task_id_returns_404(self):
+        # A non-UUID task id in the URL must 404, not 500 through the UUIDField filter.
+        response = self.client.get("/api/projects/@current/tasks/not-a-uuid/runs/")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     @patch("products.tasks.backend.models.TaskRun.publish_stream_state_event")
     @patch("products.tasks.backend.facade.api.signal_workflow_completion")
     def test_update_run_status_publishes_stream_state_event(self, mock_signal, mock_publish_stream_state_event):


### PR DESCRIPTION
## Problem

Hitting a task-run endpoint with a non-UUID task id in the URL (e.g. `/api/projects/@current/tasks/not-a-uuid/runs/`) returned a 500 instead of a 404. The raw URL segment flowed straight into `Task.objects.filter(id=task_id, ...)`, and since `Task.id` is a `UUIDField`, Django raised `ValueError`/`ValidationError` during query prep, surfacing as an unhandled server error.

## Changes

Validate the task id as a UUID at the single boundary where it enters the run views — `TaskRunViewSet._task_id()` — and raise `NotFound("Task not found")` for malformed values. This is the one chokepoint feeding every run-view action (`list`, `retrieve`, `logs`, `resume_in_cloud`, etc.), so all of them now return a clean 404. The facade is untouched, and the semantics match what already happens for non-existent or invisible tasks.

## How did you test this code?

I'm an agent. I added a regression test (`TestTaskRunAPI::test_list_runs_with_malformed_task_id_returns_404`) asserting a non-UUID task id returns 404 — this catches the exact 500-vs-404 regression and no existing test covered it. Ran it locally against the dev Postgres; it passes. Ruff check + format are clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code from a PostHog error-tracking issue (malformed-UUID 500 in the tasks run views). Traced the stack trace from `task_accessible_for_run_view` back to `_task_id()`, found that the URL-derived task id reaches a `UUIDField` filter unvalidated, and fixed it at that boundary rather than wrapping the ORM call — keeps the fix in one place and reuses the existing `NotFound` semantics. The run `pk` path has the same shape but wasn't in the reported error, so it's left out to keep the change focused.
