### PR TITLE
feat(data-warehouse): implement assemblyai import source

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/SOURCES.md
@@ -56,6 +56,7 @@ the row lists both.
 | appsflyer               | HTTP (CSV reports)          | requests                                                        | ✅                          |
 | asana                   | HTTP                        | requests                                                        | ✅                          |
 | ashby                   | HTTP                        | requests                                                        | ✅                          |
+| assemblyai              | HTTP                        | requests                                                        | ✅                          |
 | attentive               | HTTP (webhook-first)        | requests (webhook management)                                   | ✅                          |
 | attio                   | HTTP                        | requests + `rest_source.RESTClient`                             | ✅                          |
 | aviationstack           | HTTP                        | requests                                                        | ✅                          |
@@ -318,7 +319,6 @@ doesn't conflict with concurrent PRs.
 - apple_search_ads
 - appstack
 - apptivo
-- assemblyai
 - auth0
 - awin
 - aws_cloudtrail

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
@@ -1,7 +1,7 @@
 import dataclasses
 from collections.abc import Iterator
 from typing import Any
-from urllib.parse import urlencode, urljoin
+from urllib.parse import urlencode, urljoin, urlsplit
 
 import requests
 from structlog.types import FilteringBoundLogger
@@ -48,11 +48,18 @@ def _get_headers(api_key: str) -> dict[str, str]:
     }
 
 
-def _absolute_url(base_url: str, url: str) -> str:
-    """page_details URLs may come back absolute or as a relative path; normalize to absolute."""
-    if url.startswith("http://") or url.startswith("https://"):
-        return url
-    return urljoin(base_url, url)
+def _pinned_url(base_url: str, url: str) -> str:
+    """Resolve a page_details URL (absolute or relative) and pin it to the selected base host.
+
+    next_url comes from the API response body (and is persisted in resume state), so a tampered
+    response must not be able to redirect the credential-bearing request to another host. Anything
+    that resolves off the selected base origin is rejected.
+    """
+    resolved = url if url.startswith(("http://", "https://")) else urljoin(base_url, url)
+    base, target = urlsplit(base_url), urlsplit(resolved)
+    if (target.scheme, target.netloc) != (base.scheme, base.netloc):
+        raise ValueError(f"AssemblyAI pagination URL {resolved!r} is not on the selected host {base_url!r}")
+    return resolved
 
 
 @retry(
@@ -115,7 +122,8 @@ def get_rows(
 
     resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
     if resume is not None and resume.next_url:
-        url = resume.next_url
+        # Persisted state is still untrusted input — pin it to the selected host before fetching.
+        url = _pinned_url(base_url, resume.next_url)
         logger.debug(f"AssemblyAI: resuming from URL: {url}")
     else:
         url = f"{base_url}{config.path}?{urlencode({'limit': PAGE_SIZE})}"
@@ -140,7 +148,7 @@ def get_rows(
 
         # Save AFTER yielding the page so a crash re-yields the just-finished page rather than
         # skipping it — merge dedupes on the primary key. Resume picks up at the next page.
-        url = _absolute_url(base_url, next_url)
+        url = _pinned_url(base_url, next_url)
         resumable_source_manager.save_state(AssemblyAIResumeConfig(next_url=url))
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/assemblyai.py
@@ -1,0 +1,174 @@
+import dataclasses
+from collections.abc import Iterator
+from typing import Any
+from urllib.parse import urlencode, urljoin
+
+import requests
+from structlog.types import FilteringBoundLogger
+from tenacity import retry, retry_if_exception_type, stop_after_attempt, wait_exponential_jitter
+
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceResponse
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import ASSEMBLYAI_ENDPOINTS
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.http import make_tracked_session
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+
+# AssemblyAI offers a US base URL and an EU data-residency variant. The Authorization header is the
+# raw API key (no "Bearer" prefix).
+BASE_URLS: dict[str, str] = {
+    "us": "https://api.assemblyai.com",
+    "eu": "https://api.eu.assemblyai.com",
+}
+DEFAULT_REGION = "us"
+
+# List endpoint max page size is 200.
+PAGE_SIZE = 200
+
+REQUEST_TIMEOUT_SECONDS = 60
+
+
+class AssemblyAIRetryableError(Exception):
+    pass
+
+
+@dataclasses.dataclass
+class AssemblyAIResumeConfig:
+    # Absolute URL of the next list page to fetch (from page_details.next_url). Following it walks
+    # newest-to-oldest through the transcript list via the API's before_id cursor.
+    next_url: str | None = None
+
+
+def base_url_for_region(region: str | None) -> str:
+    return BASE_URLS.get((region or DEFAULT_REGION).lower(), BASE_URLS[DEFAULT_REGION])
+
+
+def _get_headers(api_key: str) -> dict[str, str]:
+    return {
+        "Authorization": api_key,
+        "Accept": "application/json",
+    }
+
+
+def _absolute_url(base_url: str, url: str) -> str:
+    """page_details URLs may come back absolute or as a relative path; normalize to absolute."""
+    if url.startswith("http://") or url.startswith("https://"):
+        return url
+    return urljoin(base_url, url)
+
+
+@retry(
+    retry=retry_if_exception_type(
+        (AssemblyAIRetryableError, requests.ReadTimeout, requests.ConnectionError),
+    ),
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    reraise=True,
+)
+def _fetch(session: requests.Session, url: str, headers: dict[str, str], logger: FilteringBoundLogger) -> dict:
+    response = session.get(url, headers=headers, timeout=REQUEST_TIMEOUT_SECONDS)
+
+    if response.status_code == 429 or response.status_code >= 500:
+        raise AssemblyAIRetryableError(f"AssemblyAI API error (retryable): status={response.status_code}, url={url}")
+
+    if not response.ok:
+        logger.error(f"AssemblyAI API error: status={response.status_code}, body={response.text}, url={url}")
+        response.raise_for_status()
+
+    return response.json()
+
+
+def validate_credentials(api_key: str, region: str | None) -> bool:
+    # Cheapest probe that exercises the token: list a single transcript.
+    base_url = base_url_for_region(region)
+    url = f"{base_url}/v2/transcript?{urlencode({'limit': 1})}"
+    try:
+        response = make_tracked_session().get(url, headers=_get_headers(api_key), timeout=10)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _hydrate_transcript(
+    session: requests.Session,
+    base_url: str,
+    transcript_id: str,
+    headers: dict[str, str],
+    logger: FilteringBoundLogger,
+) -> dict[str, Any]:
+    """Fetch the full transcript object for a single id."""
+    url = f"{base_url}/v2/transcript/{transcript_id}"
+    return _fetch(session, url, headers, logger)
+
+
+def get_rows(
+    api_key: str,
+    region: str | None,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[AssemblyAIResumeConfig],
+) -> Iterator[list[dict[str, Any]]]:
+    config = ASSEMBLYAI_ENDPOINTS[endpoint]
+    base_url = base_url_for_region(region)
+    headers = _get_headers(api_key)
+    # One session reused across every list page and hydration request so urllib3 keeps the
+    # connection alive instead of re-handshaking per request.
+    session = make_tracked_session()
+
+    resume = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
+    if resume is not None and resume.next_url:
+        url = resume.next_url
+        logger.debug(f"AssemblyAI: resuming from URL: {url}")
+    else:
+        url = f"{base_url}{config.path}?{urlencode({'limit': PAGE_SIZE})}"
+
+    while True:
+        data = _fetch(session, url, headers, logger)
+
+        items = data.get(endpoint, [])
+        if not items:
+            break
+
+        if config.hydrate:
+            rows = [_hydrate_transcript(session, base_url, item["id"], headers, logger) for item in items]
+        else:
+            rows = items
+
+        yield rows
+
+        next_url = data.get("page_details", {}).get("next_url")
+        if not next_url:
+            break
+
+        # Save AFTER yielding the page so a crash re-yields the just-finished page rather than
+        # skipping it — merge dedupes on the primary key. Resume picks up at the next page.
+        url = _absolute_url(base_url, next_url)
+        resumable_source_manager.save_state(AssemblyAIResumeConfig(next_url=url))
+
+
+def assemblyai_source(
+    api_key: str,
+    region: str | None,
+    endpoint: str,
+    logger: FilteringBoundLogger,
+    resumable_source_manager: ResumableSourceManager[AssemblyAIResumeConfig],
+) -> SourceResponse:
+    endpoint_config = ASSEMBLYAI_ENDPOINTS[endpoint]
+
+    return SourceResponse(
+        name=endpoint,
+        items=lambda: get_rows(
+            api_key=api_key,
+            region=region,
+            endpoint=endpoint,
+            logger=logger,
+            resumable_source_manager=resumable_source_manager,
+        ),
+        primary_keys=endpoint_config.primary_keys,
+        partition_count=1,
+        partition_size=1,
+        partition_mode="datetime" if endpoint_config.partition_key else None,
+        partition_format="week" if endpoint_config.partition_key else None,
+        partition_keys=[endpoint_config.partition_key] if endpoint_config.partition_key else None,
+        # The list endpoint returns transcripts newest-first and exposes no ascending sort, so rows
+        # arrive in descending creation order. Full refresh only, so this never drives a watermark.
+        sort_mode="desc",
+    )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/canonical_descriptions.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/canonical_descriptions.py
@@ -1,0 +1,41 @@
+"""Canonical, documentation-sourced descriptions for AssemblyAI endpoints and columns.
+
+Sourced from the official AssemblyAI API reference (https://www.assemblyai.com/docs/api-reference/transcripts/get).
+Keyed by the endpoint names in `settings.py` `ASSEMBLYAI_ENDPOINTS`, which match the
+`ExternalDataSchema.name` of a synced AssemblyAI table. Columns absent here fall back to LLM enrichment.
+"""
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
+
+CANONICAL_DESCRIPTIONS: CanonicalDescriptions = {
+    "transcripts": {
+        "description": "A speech-to-text transcript produced by AssemblyAI, including the recognized text and any requested audio-intelligence results (summary, sentiment, entities, chapters, and more).",
+        "docs_url": "https://www.assemblyai.com/docs/api-reference/transcripts/get",
+        "columns": {
+            "id": "Unique identifier for the transcript.",
+            "status": "Processing status of the transcript: queued, processing, completed, or error.",
+            "audio_url": "URL of the media file that was transcribed.",
+            "text": "The full transcribed text of the audio.",
+            "language_code": "The language of the audio (e.g. en_us), detected or specified at submission.",
+            "language_detection": "Whether automatic language detection was enabled.",
+            "confidence": "Overall confidence score of the transcription, between 0 and 1.",
+            "audio_duration": "Duration of the source audio in seconds.",
+            "words": "Per-word results with text, start/end timestamps, confidence, and speaker label.",
+            "utterances": "Speaker-segmented utterances when speaker diarization is enabled.",
+            "summary": "Generated summary of the audio when summarization is enabled.",
+            "summary_type": "The formatting model used for the summary (e.g. bullets, paragraph).",
+            "summary_model": "The summarization model used to produce the summary.",
+            "sentiment_analysis_results": "Sentiment (positive/neutral/negative) per segment when sentiment analysis is enabled.",
+            "entities": "Detected named entities (people, organizations, locations, etc.) when entity detection is enabled.",
+            "chapters": "Auto-generated chapters with headlines and summaries when auto chapters is enabled.",
+            "iab_categories_result": "IAB topic categories detected in the audio when topic detection is enabled.",
+            "content_safety_labels": "Content moderation labels detected in the audio when content safety is enabled.",
+            "auto_highlights_result": "Key phrases and their occurrences when auto highlights is enabled.",
+            "speaker_labels": "Whether speaker diarization was enabled for this transcript.",
+            "webhook_url": "The URL AssemblyAI called on completion of this transcript, if a webhook was configured.",
+            "error": "Error message when status is error.",
+        },
+    },
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/settings.py
@@ -1,0 +1,53 @@
+from dataclasses import dataclass, field
+from typing import Optional
+
+from products.warehouse_sources.backend.types import IncrementalField, IncrementalFieldType
+
+
+@dataclass
+class AssemblyAIEndpointConfig:
+    name: str
+    # List endpoint path (relative to the regional base URL).
+    path: str
+    # Field used to partition the warehouse table. Must be a stable creation timestamp,
+    # never an updated_at-style field that rewrites partitions on every sync.
+    partition_key: Optional[str] = None
+    # Each list row is hydrated via GET {path}/{id} to fetch the full object (the list
+    # endpoint only returns a summary). False would yield the list summary as-is.
+    hydrate: bool = True
+    primary_keys: list[str] = field(default_factory=lambda: ["id"])
+    incremental_fields: list[IncrementalField] = field(default_factory=list)
+    should_sync_default: bool = True
+
+
+# AssemblyAI's only listable resource is Transcripts. The list endpoint (GET /v2/transcript)
+# returns lightweight summaries (id/status/audio_url/created/completed); the full transcript —
+# text, words, utterances, summary, sentiment, etc. — requires a per-id GET /v2/transcript/{id},
+# so we hydrate each row.
+#
+# Full refresh only: the list endpoint exposes no server-side `created >= X` timestamp filter
+# (only an exact `created_on=YYYY-MM-DD` day filter and non-monotonic UUID `after_id`/`before_id`
+# cursors), so there is no watermark we can map a `db_incremental_field_last_value` onto. The API
+# also only retains transcripts for the last 90 days. `created` is exposed as an incremental field
+# option for the UI, but the schema advertises full refresh (see source.get_schemas).
+ASSEMBLYAI_ENDPOINTS: dict[str, AssemblyAIEndpointConfig] = {
+    "transcripts": AssemblyAIEndpointConfig(
+        name="transcripts",
+        path="/v2/transcript",
+        partition_key="created",
+        incremental_fields=[
+            {
+                "label": "created",
+                "type": IncrementalFieldType.DateTime,
+                "field": "created",
+                "field_type": IncrementalFieldType.DateTime,
+            },
+        ],
+    ),
+}
+
+ENDPOINTS = tuple(ASSEMBLYAI_ENDPOINTS.keys())
+
+INCREMENTAL_FIELDS: dict[str, list[IncrementalField]] = {
+    name: config.incremental_fields for name, config in ASSEMBLYAI_ENDPOINTS.items()
+}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
@@ -16,6 +16,7 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
     SourceResponse,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
+    BASE_URLS,
     AssemblyAIResumeConfig,
     assemblyai_source,
     validate_credentials as validate_assemblyai_credentials,
@@ -43,6 +44,12 @@ class AssemblyAISource(ResumableSource[AssemblyAISourceConfig, AssemblyAIResumeC
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.ASSEMBLYAI
+
+    @property
+    def connection_host_fields(self) -> list[str]:
+        # `region` picks the host the stored API key is sent to. Retargeting it must re-require the
+        # secret so a preserved key can't be aimed at a different regional endpoint without re-entry.
+        return ["region"]
 
     @property
     def get_source_config(self) -> SourceConfig:
@@ -94,10 +101,9 @@ class AssemblyAISource(ResumableSource[AssemblyAISourceConfig, AssemblyAIResumeC
     def get_non_retryable_errors(self) -> dict[str, str | None]:
         # AssemblyAI returns 401 for a missing/invalid token. There's no scope/permission model, so a
         # 401 is always a credential problem retrying can't fix. Match the stable status text + host.
-        return {
-            "401 Client Error: Unauthorized for url: https://api.assemblyai.com": "Your AssemblyAI API key is invalid or has been revoked. Create a new key in the AssemblyAI dashboard, then reconnect.",
-            "401 Client Error: Unauthorized for url: https://api.eu.assemblyai.com": "Your AssemblyAI API key is invalid or has been revoked. Create a new key in the AssemblyAI dashboard, then reconnect.",
-        }
+        # Derive from BASE_URLS so a newly added region stays covered without updating two places.
+        user_message = "Your AssemblyAI API key is invalid or has been revoked. Create a new key in the AssemblyAI dashboard, then reconnect."
+        return {f"401 Client Error: Unauthorized for url: {url}": user_message for url in BASE_URLS.values()}
 
     def get_schemas(
         self,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/source.py
@@ -1,19 +1,45 @@
-from typing import cast
+from typing import Optional, cast
 
 from posthog.schema import (
     DataWarehouseSourceCategory,
     ExternalDataSourceType as SchemaExternalDataSourceType,
+    ReleaseStatus,
     SourceConfig,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldSelectConfig,
+    SourceFieldSelectConfigOption,
 )
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, SimpleSource
+from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
+    SourceInputs,
+    SourceResponse,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
+    AssemblyAIResumeConfig,
+    assemblyai_source,
+    validate_credentials as validate_assemblyai_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import (
+    ASSEMBLYAI_ENDPOINTS,
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.base import FieldType, ResumableSource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.canonical_descriptions import (
+    CanonicalDescriptions,
+)
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AssemblyAISourceConfig
 from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 
 @SourceRegistry.register
-class AssemblyAISource(SimpleSource[AssemblyAISourceConfig]):
+class AssemblyAISource(ResumableSource[AssemblyAISourceConfig, AssemblyAIResumeConfig]):
+    lists_tables_without_credentials = True  # static endpoint catalog — safe for public docs
+
     @property
     def source_type(self) -> ExternalDataSourceType:
         return ExternalDataSourceType.ASSEMBLYAI
@@ -24,7 +50,102 @@ class AssemblyAISource(SimpleSource[AssemblyAISourceConfig]):
             name=SchemaExternalDataSourceType.ASSEMBLY_AI,
             category=DataWarehouseSourceCategory.ENGINEERING___MONITORING,
             label="AssemblyAI",
-            iconPath="/static/services/assemblyai.png",
-            fields=cast(list[FieldType], []),
+            releaseStatus=ReleaseStatus.ALPHA,
             unreleasedSource=True,
+            caption=(
+                "Enter your AssemblyAI API key to sync your speech-to-text transcripts into the PostHog "
+                "Data warehouse. Find your key in the [AssemblyAI dashboard](https://www.assemblyai.com/app/api-keys).\n\n"
+                "Only transcripts created in the **last 90 days** are retained by AssemblyAI and available to sync."
+            ),
+            iconPath="/static/services/assemblyai.png",
+            docsUrl="https://posthog.com/docs/cdp/sources/assemblyai",
+            fields=cast(
+                list[FieldType],
+                [
+                    SourceFieldInputConfig(
+                        name="api_key",
+                        label="API key",
+                        type=SourceFieldInputConfigType.PASSWORD,
+                        required=True,
+                        placeholder="",
+                        secret=True,
+                    ),
+                    SourceFieldSelectConfig(
+                        name="region",
+                        label="Region",
+                        required=True,
+                        defaultValue="us",
+                        options=[
+                            SourceFieldSelectConfigOption(label="US (api.assemblyai.com)", value="us"),
+                            SourceFieldSelectConfigOption(label="EU (api.eu.assemblyai.com)", value="eu"),
+                        ],
+                    ),
+                ],
+            ),
+        )
+
+    def get_canonical_descriptions(self) -> CanonicalDescriptions:
+        from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.canonical_descriptions import (
+            CANONICAL_DESCRIPTIONS,
+        )
+
+        return CANONICAL_DESCRIPTIONS
+
+    def get_non_retryable_errors(self) -> dict[str, str | None]:
+        # AssemblyAI returns 401 for a missing/invalid token. There's no scope/permission model, so a
+        # 401 is always a credential problem retrying can't fix. Match the stable status text + host.
+        return {
+            "401 Client Error: Unauthorized for url: https://api.assemblyai.com": "Your AssemblyAI API key is invalid or has been revoked. Create a new key in the AssemblyAI dashboard, then reconnect.",
+            "401 Client Error: Unauthorized for url: https://api.eu.assemblyai.com": "Your AssemblyAI API key is invalid or has been revoked. Create a new key in the AssemblyAI dashboard, then reconnect.",
+        }
+
+    def get_schemas(
+        self,
+        config: AssemblyAISourceConfig,
+        team_id: int,
+        with_counts: bool = False,
+        names: list[str] | None = None,
+        force_refresh: bool = False,
+    ) -> list[SourceSchema]:
+        def _build_schema(endpoint: str) -> SourceSchema:
+            return SourceSchema(
+                name=endpoint,
+                # No server-side `created >= X` filter exists, so an "incremental" sync would still
+                # walk the whole list every run — ship full refresh only. See settings.py.
+                supports_incremental=False,
+                supports_append=False,
+                incremental_fields=INCREMENTAL_FIELDS.get(endpoint, []),
+                should_sync_default=ASSEMBLYAI_ENDPOINTS[endpoint].should_sync_default,
+                description="Lists transcripts and hydrates each with its full text, words, and audio-intelligence results. AssemblyAI retains only the last 90 days. Full refresh only.",
+            )
+
+        schemas = [_build_schema(endpoint) for endpoint in ENDPOINTS]
+        if names is not None:
+            names_set = set(names)
+            schemas = [s for s in schemas if s.name in names_set]
+        return schemas
+
+    def validate_credentials(
+        self, config: AssemblyAISourceConfig, team_id: int, schema_name: Optional[str] = None
+    ) -> tuple[bool, str | None]:
+        if validate_assemblyai_credentials(config.api_key, config.region):
+            return True, None
+
+        return False, "Invalid AssemblyAI API key"
+
+    def get_resumable_source_manager(self, inputs: SourceInputs) -> ResumableSourceManager[AssemblyAIResumeConfig]:
+        return ResumableSourceManager[AssemblyAIResumeConfig](inputs, AssemblyAIResumeConfig)
+
+    def source_for_pipeline(
+        self,
+        config: AssemblyAISourceConfig,
+        resumable_source_manager: ResumableSourceManager[AssemblyAIResumeConfig],
+        inputs: SourceInputs,
+    ) -> SourceResponse:
+        return assemblyai_source(
+            api_key=config.api_key,
+            region=config.region,
+            endpoint=inputs.schema_name,
+            logger=inputs.logger,
+            resumable_source_manager=resumable_source_manager,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
@@ -5,7 +5,7 @@ from unittest import mock
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
     AssemblyAIResumeConfig,
-    _absolute_url,
+    _pinned_url,
     assemblyai_source,
     base_url_for_region,
     get_rows,
@@ -59,7 +59,7 @@ class TestBaseUrlForRegion:
         assert base_url_for_region(region) == expected
 
 
-class TestAbsoluteUrl:
+class TestPinnedUrl:
     @pytest.mark.parametrize(
         "url, expected",
         [
@@ -70,8 +70,21 @@ class TestAbsoluteUrl:
             ("/v2/transcript?before_id=abc", "https://api.assemblyai.com/v2/transcript?before_id=abc"),
         ],
     )
-    def test_absolute_url(self, url: str, expected: str) -> None:
-        assert _absolute_url("https://api.assemblyai.com", url) == expected
+    def test_pinned_url_keeps_same_host(self, url: str, expected: str) -> None:
+        assert _pinned_url("https://api.assemblyai.com", url) == expected
+
+    @pytest.mark.parametrize(
+        "url",
+        [
+            # A tampered next_url must not redirect the credential-bearing request off the base host.
+            "https://evil.example.com/v2/transcript",
+            "http://api.assemblyai.com/v2/transcript",  # scheme downgrade
+            "https://api.eu.assemblyai.com/v2/transcript",  # different region host
+        ],
+    )
+    def test_pinned_url_rejects_other_hosts(self, url: str) -> None:
+        with pytest.raises(ValueError):
+            _pinned_url("https://api.assemblyai.com", url)
 
 
 class TestValidateCredentials:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai.py
@@ -1,0 +1,191 @@
+from typing import Any
+
+import pytest
+from unittest import mock
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
+    AssemblyAIResumeConfig,
+    _absolute_url,
+    assemblyai_source,
+    base_url_for_region,
+    get_rows,
+    validate_credentials,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import ENDPOINTS
+
+US_LIST_URL = "https://api.assemblyai.com/v2/transcript?limit=200"
+
+
+def _make_manager(resume_state: AssemblyAIResumeConfig | None = None) -> mock.MagicMock:
+    manager = mock.MagicMock()
+    manager.can_resume.return_value = resume_state is not None
+    manager.load_state.return_value = resume_state
+    return manager
+
+
+def _resp(json_body: Any, status: int = 200) -> mock.MagicMock:
+    resp = mock.MagicMock()
+    resp.json.return_value = json_body
+    resp.status_code = status
+    resp.ok = status < 400
+    return resp
+
+
+def _list_page(items: list[dict[str, Any]], next_url: str | None) -> dict[str, Any]:
+    return {"transcripts": items, "page_details": {"next_url": next_url}}
+
+
+def _url_router(responses: dict[str, dict[str, Any]]) -> Any:
+    """Return a session.get side_effect that maps each requested URL to a mocked response."""
+
+    def fake_get(url: str, headers: Any = None, timeout: Any = None) -> mock.MagicMock:
+        return _resp(responses[url])
+
+    return fake_get
+
+
+class TestBaseUrlForRegion:
+    @pytest.mark.parametrize(
+        "region, expected",
+        [
+            ("us", "https://api.assemblyai.com"),
+            ("eu", "https://api.eu.assemblyai.com"),
+            ("EU", "https://api.eu.assemblyai.com"),
+            (None, "https://api.assemblyai.com"),
+            ("unknown", "https://api.assemblyai.com"),
+        ],
+    )
+    def test_base_url_for_region(self, region: str | None, expected: str) -> None:
+        assert base_url_for_region(region) == expected
+
+
+class TestAbsoluteUrl:
+    @pytest.mark.parametrize(
+        "url, expected",
+        [
+            (
+                "https://api.assemblyai.com/v2/transcript?before_id=abc",
+                "https://api.assemblyai.com/v2/transcript?before_id=abc",
+            ),
+            ("/v2/transcript?before_id=abc", "https://api.assemblyai.com/v2/transcript?before_id=abc"),
+        ],
+    )
+    def test_absolute_url(self, url: str, expected: str) -> None:
+        assert _absolute_url("https://api.assemblyai.com", url) == expected
+
+
+class TestValidateCredentials:
+    @pytest.mark.parametrize("status_code, expected", [(200, True), (401, False), (403, False), (500, False)])
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_status_mapping(self, mock_session: mock.MagicMock, status_code: int, expected: bool) -> None:
+        mock_session.return_value.get.return_value = _resp({}, status=status_code)
+        assert validate_credentials("key", "us") is expected
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_swallows_exceptions(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.side_effect = Exception("boom")
+        assert validate_credentials("key", "us") is False
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_eu_region_probes_eu_host(self, mock_session: mock.MagicMock) -> None:
+        mock_session.return_value.get.return_value = _resp({}, status=200)
+        validate_credentials("key", "eu")
+        called_url = mock_session.return_value.get.call_args.args[0]
+        assert called_url.startswith("https://api.eu.assemblyai.com/v2/transcript")
+
+
+class TestGetRows:
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_lists_then_hydrates_each_transcript(self, mock_session: mock.MagicMock) -> None:
+        next_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=t2"
+        responses = {
+            US_LIST_URL: _list_page([{"id": "t1"}, {"id": "t2"}], next_url),
+            "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello", "status": "completed"},
+            "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world", "status": "completed"},
+            next_url: _list_page([{"id": "t3"}], None),
+            "https://api.assemblyai.com/v2/transcript/t3": {"id": "t3", "text": "again", "status": "completed"},
+        }
+        mock_session.return_value.get.side_effect = _url_router(responses)
+
+        manager = _make_manager()
+        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+
+        rows = [row for batch in batches for row in batch]
+        # Rows are the hydrated full objects, not the list summaries.
+        assert [r["id"] for r in rows] == ["t1", "t2", "t3"]
+        assert all("text" in r for r in rows)
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_saves_state_after_each_page_only_when_more_remain(self, mock_session: mock.MagicMock) -> None:
+        next_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=t1"
+        responses = {
+            US_LIST_URL: _list_page([{"id": "t1"}], next_url),
+            "https://api.assemblyai.com/v2/transcript/t1": {"id": "t1", "text": "hello"},
+            next_url: _list_page([{"id": "t2"}], None),
+            "https://api.assemblyai.com/v2/transcript/t2": {"id": "t2", "text": "world"},
+        }
+        mock_session.return_value.get.side_effect = _url_router(responses)
+
+        manager = _make_manager()
+        list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+
+        # Only the first page has a next_url, so state is saved exactly once, pointing at page two.
+        manager.save_state.assert_called_once()
+        assert manager.save_state.call_args.args[0].next_url == next_url
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_resumes_from_saved_state(self, mock_session: mock.MagicMock) -> None:
+        resume_url = "https://api.assemblyai.com/v2/transcript?limit=200&before_id=resume"
+        responses = {
+            resume_url: _list_page([{"id": "r1"}], None),
+            "https://api.assemblyai.com/v2/transcript/r1": {"id": "r1", "text": "resumed"},
+        }
+        mock_session.return_value.get.side_effect = _url_router(responses)
+
+        manager = _make_manager(AssemblyAIResumeConfig(next_url=resume_url))
+        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+
+        rows = [row for batch in batches for row in batch]
+        assert [r["id"] for r in rows] == ["r1"]
+        # The initial list URL must never be requested when resuming.
+        requested = [call.args[0] for call in mock_session.return_value.get.call_args_list]
+        assert US_LIST_URL not in requested
+
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai.make_tracked_session"
+    )
+    def test_empty_list_yields_nothing(self, mock_session: mock.MagicMock) -> None:
+        responses = {US_LIST_URL: _list_page([], None)}
+        mock_session.return_value.get.side_effect = _url_router(responses)
+
+        manager = _make_manager()
+        batches = list(get_rows("key", "us", "transcripts", mock.MagicMock(), manager))
+
+        assert batches == []
+        manager.save_state.assert_not_called()
+
+
+class TestAssemblyAISource:
+    def test_endpoints_inventory(self) -> None:
+        assert ENDPOINTS == ("transcripts",)
+
+    def test_source_response_shape(self) -> None:
+        response = assemblyai_source("key", "us", "transcripts", mock.MagicMock(), _make_manager())
+        assert response.name == "transcripts"
+        assert response.primary_keys == ["id"]
+        assert response.partition_mode == "datetime"
+        assert response.partition_keys == ["created"]
+        # The list endpoint returns newest-first and exposes no ascending sort.
+        assert response.sort_mode == "desc"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
@@ -31,6 +31,10 @@ class TestAssemblyAISource:
     def test_source_type(self):
         assert self.source.source_type == ExternalDataSourceType.ASSEMBLYAI
 
+    def test_connection_host_fields_includes_region(self):
+        # `region` selects the host the stored API key is sent to, so editing it must re-require the secret.
+        assert self.source.connection_host_fields == ["region"]
+
     def test_get_source_config(self):
         config = self.source.get_source_config
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/assemblyai/tests/test_assemblyai_source.py
@@ -1,0 +1,147 @@
+import pytest
+from unittest import mock
+
+from posthog.schema import (
+    DataWarehouseSourceCategory,
+    ReleaseStatus,
+    SourceFieldInputConfig,
+    SourceFieldInputConfigType,
+    SourceFieldSelectConfig,
+)
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.assemblyai import (
+    AssemblyAIResumeConfig,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.settings import (
+    ENDPOINTS,
+    INCREMENTAL_FIELDS,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.source import AssemblyAISource
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import AssemblyAISourceConfig
+from products.warehouse_sources.backend.types import ExternalDataSourceType
+
+
+class TestAssemblyAISource:
+    def setup_method(self):
+        self.source = AssemblyAISource()
+        self.team_id = 123
+        self.config = AssemblyAISourceConfig(api_key="key", region="us")
+
+    def test_source_type(self):
+        assert self.source.source_type == ExternalDataSourceType.ASSEMBLYAI
+
+    def test_get_source_config(self):
+        config = self.source.get_source_config
+
+        assert config.name.value == "AssemblyAI"
+        assert config.label == "AssemblyAI"
+        assert config.category == DataWarehouseSourceCategory.ENGINEERING___MONITORING
+        assert config.releaseStatus == ReleaseStatus.ALPHA
+        assert config.unreleasedSource is True
+        assert config.iconPath == "/static/services/assemblyai.png"
+        assert config.docsUrl == "https://posthog.com/docs/cdp/sources/assemblyai"
+
+    def test_source_config_fields(self):
+        config = self.source.get_source_config
+        assert [f.name for f in config.fields] == ["api_key", "region"]
+
+        api_key = next(f for f in config.fields if isinstance(f, SourceFieldInputConfig) and f.name == "api_key")
+        assert api_key.type == SourceFieldInputConfigType.PASSWORD
+        assert api_key.secret is True
+        assert api_key.required is True
+
+        region = next(f for f in config.fields if isinstance(f, SourceFieldSelectConfig) and f.name == "region")
+        assert {opt.value for opt in region.options} == {"us", "eu"}
+        assert region.defaultValue == "us"
+
+    def test_lists_tables_without_credentials(self):
+        # get_schemas iterates a static endpoint catalog with no I/O, so the public docs catalog renders.
+        assert self.source.lists_tables_without_credentials is True
+        documented = self.source.get_documented_tables()
+        assert [t["name"] for t in documented] == ["transcripts"]
+        assert documented[0]["sync_methods"] == ["Full refresh"]
+
+    def test_get_schemas_is_full_refresh_only(self):
+        schemas = {s.name: s for s in self.source.get_schemas(self.config, self.team_id)}
+
+        assert set(schemas) == set(ENDPOINTS)
+        transcripts = schemas["transcripts"]
+        # AssemblyAI exposes no server-side `created >= X` filter, so we never advertise incremental.
+        assert transcripts.supports_incremental is False
+        assert transcripts.supports_append is False
+        assert transcripts.incremental_fields == INCREMENTAL_FIELDS["transcripts"]
+
+    def test_get_schemas_filtered_by_names(self):
+        assert [s.name for s in self.source.get_schemas(self.config, self.team_id, names=["transcripts"])] == [
+            "transcripts"
+        ]
+        assert self.source.get_schemas(self.config, self.team_id, names=["nope"]) == []
+
+    @pytest.mark.parametrize(
+        "observed_error",
+        [
+            "401 Client Error: Unauthorized for url: https://api.assemblyai.com/v2/transcript?limit=200",
+            "401 Client Error: Unauthorized for url: https://api.eu.assemblyai.com/v2/transcript/abc",
+        ],
+    )
+    def test_non_retryable_errors_match_auth_failures(self, observed_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert any(key in observed_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "other_error",
+        [
+            "500 Server Error: Internal Server Error for url: https://api.assemblyai.com/v2/transcript",
+            "429 Client Error: Too Many Requests for url: https://api.assemblyai.com/v2/transcript",
+            "401 Client Error: Unauthorized for url: https://api.stripe.com/v1/customers",
+        ],
+    )
+    def test_non_retryable_errors_does_not_match_transient_or_unrelated(self, other_error):
+        non_retryable_errors = self.source.get_non_retryable_errors()
+        assert not any(key in other_error for key in non_retryable_errors)
+
+    @pytest.mark.parametrize(
+        "mock_return, expected_valid, expected_message",
+        [
+            (True, True, None),
+            (False, False, "Invalid AssemblyAI API key"),
+        ],
+    )
+    @mock.patch(
+        "products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.source.validate_assemblyai_credentials"
+    )
+    def test_validate_credentials(self, mock_validate, mock_return, expected_valid, expected_message):
+        mock_validate.return_value = mock_return
+
+        is_valid, error_message = self.source.validate_credentials(self.config, self.team_id)
+
+        assert is_valid is expected_valid
+        assert error_message == expected_message
+        mock_validate.assert_called_once_with(self.config.api_key, self.config.region)
+
+    def test_get_resumable_source_manager_binds_resume_config(self):
+        manager = self.source.get_resumable_source_manager(mock.MagicMock())
+
+        assert isinstance(manager, ResumableSourceManager)
+        assert manager._data_class is AssemblyAIResumeConfig
+
+    @mock.patch("products.warehouse_sources.backend.temporal.data_imports.sources.assemblyai.source.assemblyai_source")
+    def test_source_for_pipeline_plumbs_arguments(self, mock_assemblyai_source):
+        inputs = mock.MagicMock()
+        inputs.schema_name = "transcripts"
+        manager = mock.MagicMock()
+
+        self.source.source_for_pipeline(self.config, manager, inputs)
+
+        mock_assemblyai_source.assert_called_once()
+        kwargs = mock_assemblyai_source.call_args.kwargs
+        assert kwargs["api_key"] == "key"
+        assert kwargs["region"] == "us"
+        assert kwargs["endpoint"] == "transcripts"
+        assert kwargs["resumable_source_manager"] is manager
+
+    def test_canonical_descriptions_keyed_by_endpoint(self):
+        descriptions = self.source.get_canonical_descriptions()
+        assert set(descriptions).issubset(set(ENDPOINTS))
+        assert "transcripts" in descriptions

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/generated_configs.py
@@ -330,7 +330,8 @@ class AshbySourceConfig(config.Config):
 
 @config.config
 class AssemblyAISourceConfig(config.Config):
-    pass
+    api_key: str
+    region: Literal["us", "eu"] = config.value(default="us")
 
 
 @config.config


### PR DESCRIPTION
## Problem

PostHog supports importing data from many SaaS APIs into the data warehouse, but [AssemblyAI](https://www.assemblyai.com) (speech-to-text / audio-intelligence) was only a scaffolded stub. Teams using AssemblyAI for transcription couldn't pull their transcripts into PostHog to join against product and event data.

## Changes

Implements the `assemblyai` source end-to-end following the `implementing-warehouse-sources` skill's architecture contract (`source.py` / `settings.py` / `assemblyai.py` split).

- **Resource:** the Transcripts resource — the only listable AssemblyAI resource. Each sync lists transcripts via `GET /v2/transcript` (cursor pagination through `page_details.next_url`) and hydrates each row via `GET /v2/transcript/{id}`, since the list endpoint returns only a summary while the full text, words, utterances, and audio-intelligence results live on the per-id object.
- **Full refresh only.** The list endpoint exposes no server-side `created >= X` timestamp filter — only an exact `created_on=YYYY-MM-DD` day filter and non-monotonic UUID `after_id`/`before_id` cursors — so there's no watermark to map an incremental cursor onto. AssemblyAI also retains only the **last 90 days** of transcripts. `created` is exposed as a partition key (stable creation timestamp), and the schema advertises full refresh.
- **Resumable.** `ResumableSource` resumes list pagination after heartbeat timeouts; state (the next page URL) is saved *after* each page is yielded, so a crash re-yields the just-finished page rather than skipping it — merge dedupes on the `id` primary key.
- **Regions.** US (`api.assemblyai.com`) and EU (`api.eu.assemblyai.com`) data-residency hosts via a region select field. The `Authorization` header carries the raw API key (no `Bearer` prefix).
- **Tracked transport.** All outbound HTTP goes through `make_tracked_session()`; `tenacity` retries 429/5xx/transient errors. `get_non_retryable_errors()` fails fast on 401 (no scope/permission model exists, so a 401 is always a credential problem).
- Canonical column descriptions from the official API docs; `lists_tables_without_credentials = True` so the public docs catalog renders.
- Ships behind `unreleasedSource=True` with `releaseStatus=alpha`. Uses the AssemblyAI logo PNG already present in `frontend/public/services/`. Moved `assemblyai` from Scaffolded to Implemented in `SOURCES.md`.

## How did you test this code?

I'm an agent. I ran these automated tests (35 passing in the source's two test modules, plus the cross-source suites):

- `tests/test_assemblyai.py` — transport: region→base-URL mapping, absolute/relative next-URL normalization, credential status mapping (incl. EU host probe), list→hydrate flow, save-state-per-page semantics, resume-from-saved-state, and empty-list termination.
- `tests/test_assemblyai_source.py` — source class: config fields/labels, full-refresh schema, non-retryable error matching (and that transient/unrelated errors stay retryable), credential plumbing, resumable-manager binding, `source_for_pipeline` argument plumbing, and the documented-tables catalog.
- `tests/test_source_categories.py` and `common/test/test_source_config_generator.py` pass with the new source registered.

`ruff check` and `ruff format` are clean on the changed files. I regenerated `generated_configs.py` via the config generator (then re-applied repo formatting so the diff is just the AssemblyAI block).

I could **not** curl-verify the live pagination/filter behavior — it requires a valid API key I don't have. The unauthenticated API confirms the base URL, auth header shape, and 401 error body; the pagination/sort/filter logic follows the current public API docs, and the conservative full-refresh choice means no incremental watermark depends on unverified ordering. Noted in a code comment in `settings.py`.

## Docs update

The user-facing doc belongs in the **posthog.com** repo (`contents/docs/cdp/sources/assemblyai.md`), which isn't checked out here, so I couldn't add it or run `audit_source_docs`. `docsUrl` is set to `https://posthog.com/docs/cdp/sources/assemblyai` to match. The doc content (canonical template, shared snippets, `<SourceParameters />` + `<SourceTables />`, alpha callout) still needs to land in posthog.com as a follow-up.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Built with Claude Code. Skills invoked: `/implementing-warehouse-sources` (followed its end-to-end workflow and architecture contract) and `/documenting-warehouse-sources` (for the doc shape).

Key decisions:
- **Full refresh, not incremental** — chose this deliberately per the skill's rule that `supports_incremental` requires a genuine server-side timestamp filter. AssemblyAI's `after_id`/`before_id` are UUID cursors (non-monotonic) and `created_on` is an exact-day filter, neither of which maps to the pipeline's timestamp watermark.
- **Hydrate each transcript** — the list endpoint only returns id/status/audio_url/created/completed, so the full object (text, words, audio-intelligence) requires a per-id GET. Yields one `list[dict]` per page; the pipeline batches.
- **ResumableSource over SimpleSource** — list pagination via `next_url` is a deterministic resume point.
- Used the existing committed AssemblyAI logo PNG rather than fetching a new SVG via Logo.dev (no API key needed, valid logo already present).

Agent-authored — requires human review.
