### PR TITLE
chore(surveys): add debugging-surveys agent skill

### DIFF
--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: debugging-surveys
+description: >-
+  Debug, support, and build PostHog Surveys across the backend and all five SDKs
+  (web/posthog-js, iOS, Android, Flutter, React Native). Use whenever a Surveys
+  support ticket is pasted ("survey not showing", "fewer responses than expected",
+  "responses disappeared", "survey shows on wrong platform"), when diagnosing why a
+  survey does or doesn't display, or when doing survey feature work that must ship
+  across SDKs. Covers the eligibility pipeline, cross-SDK feature parity, the known-cause
+  catalog, read-only diagnostic queries, staff access, and the customer-reply style guide.
+---
+
+# Debugging surveys
+
+PostHog Surveys is a no-code in-app form builder. A customer creates a survey in the
+PostHog UI; it must then be evaluated and rendered by whichever SDK their app runs.
+**Most "survey not showing" tickets are eligibility problems, not rendering bugs** — the
+SDK correctly decided the user is not eligible, and the job is to find _which_ gate
+failed and _why_.
+
+## Repos
+
+GitHub is the source of truth for where the code lives. When you need to read or change
+SDK source, resolve a local checkout via the registry described in
+[references/local-repos.md](references/local-repos.md) (or `scripts/repos.py`) so a clone
+is found once and reused — don't re-clone every session.
+
+| Concern              | Repo                                                                        | Where to look                                                            |
+| -------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| Product UI + backend | this monorepo (PostHog/posthog)                                             | UI: `frontend/src/scenes/surveys/`, backend: `products/surveys/backend/` |
+| Web SDK              | [PostHog/posthog-js](https://github.com/PostHog/posthog-js)                 | `packages/browser/`                                                      |
+| React Native SDK     | [PostHog/posthog-js](https://github.com/PostHog/posthog-js) (same monorepo) | `packages/react-native/`                                                 |
+| iOS SDK              | [PostHog/posthog-ios](https://github.com/PostHog/posthog-ios)               | survey rendering + eligibility                                           |
+| Android SDK          | [PostHog/posthog-android](https://github.com/PostHog/posthog-android)       | eligibility (delegate-based UI)                                          |
+| Flutter SDK          | [PostHog/posthog-flutter](https://github.com/PostHog/posthog-flutter)       | Dart rendering; native iOS/Android handles eligibility                   |
+| Public docs          | [PostHog/posthog.com](https://github.com/PostHog/posthog.com)               | `contents/docs/surveys/`                                                 |
+
+Always check the local checkout is present and on a sane branch before quoting code; line
+numbers drift, so grep for the symbol rather than trusting a remembered line number.
+
+## Cross-SDK feature parity (check this FIRST)
+
+A large class of tickets is "customer expects a feature their platform doesn't support."
+Confirm the survey's `lib` / the customer's platform before anything else, then consult
+this table. Verified against the SDK source — re-verify if it's been months, the gaps
+get filled over time.
+
+| Feature                         | Web (posthog-js)                | iOS                                       | Android                            | Flutter                            | React Native                            |
+| ------------------------------- | ------------------------------- | ----------------------------------------- | ---------------------------------- | ---------------------------------- | --------------------------------------- |
+| Rendering                       | DOM + shadow root               | Native SwiftUI (`SurveysWindow`)          | **No built-in UI** — delegate only | Dart widgets (`SurveyBottomSheet`) | RN components (`SurveyModal`)           |
+| Event-based triggers            | yes (since 1.137.0, 2024-06-05) | yes                                       | yes                                | yes (native side)                  | yes                                     |
+| URL / screen targeting          | yes                             | decoded but **NOT evaluated** (`// TODO`) | decoded but **NOT evaluated**      | **NOT evaluated** (native gap)     | **explicitly excluded** in filter       |
+| Feature-flag / cohort targeting | yes                             | yes                                       | yes                                | yes (native side)                  | yes                                     |
+| `seenSurveyWaitPeriodInDays`    | yes                             | yes                                       | yes                                | yes (native side)                  | stored but **comparison commented out** |
+| `surveyPopupDelaySeconds`       | yes                             | **not implemented**                       | **not implemented**                | **not implemented**                | **not implemented** (TODO)              |
+
+Consequences worth memorizing:
+
+- **`surveyPopupDelaySeconds` is web-only.** If a mobile ticket blames the delay, it's a red herring.
+- **URL targeting is effectively web-only.** Mobile SDKs decode the field but never enforce it; React Native filters those surveys out entirely. A mobile survey with a URL condition behaves as "no URL condition" (mobile/flutter) or "never shows" (RN).
+- **Android ships no survey UI.** The app (or the Flutter plugin) must provide a `PostHogSurveysDelegate`. "Survey never renders on Android" is often a missing delegate, not a PostHog bug.
+- **Flutter is hybrid:** triggering/eligibility runs in the native iOS/Android layer; rendering is Dart (`SurveyService.showSurvey` → `showModalBottomSheet`). It does _not_ "just call native" for UI. So a Flutter rendering bug lives in Dart; a Flutter eligibility bug lives in native.
+- **React Native wait period is silently disabled** (the check is commented out). Don't blame the wait period on RN.
+
+For a deeper version-by-version capability audit, see the `survey-sdk-audit` skill if available.
+
+## How a survey actually gets shown (the web eligibility pipeline)
+
+The web SDK is the most complex and the most common in tickets. Mental model from
+`packages/browser/src/extensions/surveys.tsx` (`checkSurveyEligibility`) — checks run in
+order, first failure wins:
+
+1. `isSurveyRunning` — has `start_date`, no `end_date`.
+2. survey `type` is in-app (Popover / Widget / API).
+3. `linked_flag_key` enabled (if set).
+4. `targeting_flag_key` enabled (if set) — customer-defined property targeting.
+5. `_internalFlagCheckSatisfied` — the auto-generated internal targeting flag.
+6. `hasWaitPeriodPassed` — `seenSurveyWaitPeriodInDays` vs `localStorage.lastSeenSurveyDate`.
+7. `getSurveySeen` — per-survey seen flag.
+
+Then in `getActiveMatchingSurveys`: URL/device/selector match, event/action trigger fired, and flag re-check.
+
+Two non-obvious facts that drive real tickets:
+
+- **The server returns ALL non-archived surveys** (`SurveyViewSet`, `products/surveys/backend/api/survey.py`). It does **not** pre-filter by the internal targeting flag. All eligibility is client-side. So you cannot conclude "the backend excluded them" — the SDK did.
+- **The wait period has TWO independent implementations.** `canActivateRepeatedly` (true when `schedule: 'always'`) short-circuits `_internalFlagCheckSatisfied` (step 5) — so `always` bypasses the internal flag, including its `$last_seen_survey_date` rule. But `hasWaitPeriodPassed` (step 6) reads `localStorage.lastSeenSurveyDate` directly and is **NOT** bypassed by `canActivateRepeatedly`. So a `schedule: 'always'` survey with `seenSurveyWaitPeriodInDays: 30` still enforces the 30-day wait via the localStorage path. `lastSeenSurveyDate` is updated whenever _any_ survey is shown, regardless of completion.
+
+## Debugging workflow
+
+1. **Parse the ticket.** Extract: org/project ID, instance (US vs EU — URLs differ), survey ID(s), the `lib` (platform), the symptom in precise terms, and what the customer already tried. If the ticket is aged or has prior support replies, the config may have been edited mid-thread — treat earlier claims as stale and re-pull current state.
+
+2. **Disambiguate "none" vs "fewer."** Customers say "no responses" when they mean "fewer." Pull the `survey shown` vs `survey sent` counts before/after the suspected change (see [references/diagnostic-queries.md](references/diagnostic-queries.md)). If the _response rate_ (sent/shown) is stable, the problem is upstream eligibility (fewer people shown), not rendering or submission. This single check redirects most investigations correctly.
+
+3. **Platform parity check.** Confirm the `lib` and consult the parity table. Eliminate features the platform doesn't support before investigating them.
+
+4. **Pull the survey definition.** `GET /api/projects/<id>/surveys/<sid>/`. Inspect `conditions` (events, url, seenSurveyWaitPeriodInDays), `appearance.surveyPopupDelaySeconds`, `schedule`, `linked_flag`, `targeting_flag`, `internal_targeting_flag.filters`, `responses_limit`, `iteration_*`.
+
+5. **Pull the targeting-flag activity log** for any "stopped showing" ticket. Cohort swaps and rollout changes are invisible in the current config but show up here: `GET /api/projects/<id>/activity_log/?scope=FeatureFlag&item_id=<flag_id>&limit=20`. Also `?scope=Survey&item_id=<sid>` to see whether the survey itself was edited.
+
+6. **Confirm with events.** Use `$feature_flag_called` to see what the gating flag actually returned for affected users, and whether `$groups` is set (see group-aggregation cause below). Use `survey shown` to see real reach vs the stats UI.
+
+7. **Diagnose against the known-cause catalog**, confirm with one targeted query, then write the reply.
+
+## Known-cause catalog
+
+Ordered roughly by how often they're the answer.
+
+### "Survey shows to fewer users than expected"
+
+- **`surveyPopupDelaySeconds` + URL re-check (web only).** After the event fires and eligibility passes, the SDK waits N seconds, then re-checks `doesSurveyUrlMatch` against the _current_ URL before rendering (`handlePopoverSurvey`). If the user navigated during the delay, the survey is silently dropped — no `survey shown`. Common on navigation-heavy apps with a non-trivial delay. Fix: lower the delay to 0–2s.
+- **`seenSurveyWaitPeriodInDays` + the customer's other surveys.** Any survey shown to a user updates `lastSeenSurveyDate`; this survey is then blocked for the wait window. Completion status is irrelevant. Verify by checking whether the _unshown_ cohort saw another survey recently — and confirm against a control group (do the _shown_ users differ?). Fix: lower the wait period, or pause competing surveys.
+- **Cohort composition changed.** If the survey targets a cohort and someone edited the source dynamic cohort (e.g. added a behavioral filter), every static snapshot taken afterward inherits the narrower definition. Reach drops without any survey-side change. Find it in the flag activity log (cohort swap) and confirm cohort sizes via `static_cohort_people`.
+
+### "Event-based survey never fires"
+
+- **Timing race at session start.** Event captured before `/api/surveys` returns and the capture hook registers. Signature: event fires very early in session. Unavoidable client-side; mitigate by triggering on a slightly later event.
+- **Group-aggregated `linked_flag` with no group context.** If `linked_flag` (or targeting flag) has `aggregation_group_type_index` set, it evaluates against a _group_, not the person. Without `posthog.group(<index>, <key>)` set before the event fires, the flag returns **false** and the survey never shows. Signature: `$feature_flag_called` returns `false` with empty `$groups`, and the `$feature/<key>` property is missing from the trigger events. Fix: set group context in the SDK, or switch the survey to a person-level flag.
+- **Customer wired the survey to the wrong flag.** They create a flag with email/property targeting but the survey's `linked_flag`/`targeting_flag` points at a _different_ flag. Always confirm the actual `linked_flag.key` / `targeting_flag.key` from the API — don't trust the customer's description.
+- **Behavioral cohort in a realtime flag.** A cohort with `performed_event`/behavioral filters can't be evaluated in realtime flag bytecode (`"Unsupported behavioral filter for realtime bytecode"`, `posthog/api/cohort.py`). The cohort shows a `bytecode_error`. Surveys/flags can't use it directly — the customer must make a _static_ copy of the cohort and target that.
+
+### "Responses show as zero in the UI but raw events exist"
+
+- **Max AI corrupted the survey definition.** Max's `edit_survey` tool (`products/surveys/backend/max_tools.py`) has two failure modes: (a) on reorder/edit it rebuilds each question from `QUESTION_TYPE_MAP` (`nps`→scale 10, `csat`→scale 5, etc.), so picking the wrong semantic type silently changes a question's scale; (b) the `id` field expects 1-indexed labels (`"1"`,`"2"`) — passing a real UUID falls through and a _fresh_ UUID is generated, so responses keyed by `$survey_response_<old_uuid>` no longer join to the question. Raw events are intact; only the definition is wrong. Fix: PATCH the `questions` array back to the original UUIDs (recoverable from the response events) and restore the question type. Tell the customer to edit question _text_ via the UI, and avoid asking Max to reorder questions on a survey with historical responses until the tool guards UUIDs.
+
+### "Cohort count shows 0 but the cohort is populated"
+
+- Cosmetic UI bug, does **not** affect targeting. Confirm the real count via `static_cohort_people`. NOTE: this is _not_ a simple one-line bug — the normal `insert_cohort_from_query` path does recompute count via `count_cohort_members`; the `count=0` display only appears on certain failure paths. Do not promise a quick fix without reproducing the specific path.
+
+### General caution
+
+- **Aged tickets are dirty.** Config may have been edited by the customer or a prior agent during troubleshooting. Pull activity logs; frame secondary findings as "while you're in there, double-check X" rather than "we found X is broken."
+- **The stats UI can undercount vs raw `survey shown` events.** If the numbers don't reconcile, trust the raw events and flag the discrepancy as a separate follow-up.
+
+## Diagnostic queries
+
+Read-only HogQL templates for the disambiguators and confirmations above live in
+[references/diagnostic-queries.md](references/diagnostic-queries.md). Run them via the
+PostHog MCP `execute-sql` against the customer's project.
+
+## Access for debugging
+
+Prefer **read-only** paths in this order:
+
+1. **PostHog MCP tools** (`survey`, `feature-flag`, `cohorts`, `execute-sql`, `activity-log`, `persons`) against the customer's project. This is read-only by default and the safest way to inspect config and run queries — no impersonation, no write risk. Use this first.
+2. **Survey/flag API endpoints** read via the browser while impersonating (staff). Good for the full JSON the MCP may not surface verbatim (e.g. raw `internal_targeting_flag.filters`).
+3. **Django admin** only when 1 and 2 can't answer it. It's powerful and write-capable, so treat it as read-only by discipline: look, don't change. Never edit a customer's survey/flag/cohort from admin without explicit customer consent.
+
+When you need a value the MCP can't infer (project ID, instance, which survey), ask the
+operator to paste the survey API JSON — it skips several round-trips.
+
+## Writing the customer reply
+
+Voice derived from the PostHog handbook support values (reassuringly human, humble, ship
+fixes, clear with no jargon). Rules:
+
+- **Lead with the cause, then the fix.** One line on what's happening, then what to do.
+- **Bold the issue and bold each action.** Make the problem and the next step scannable.
+- **Use the labels the customer sees in the UI,** never internal field names. Grep `frontend/src/scenes/surveys/` for the real string. E.g. `surveyPopupDelaySeconds` → "Delay survey popup by at least N seconds once the display conditions are met"; the wait period is "Survey wait period" / "Don't show this survey if another one was shown to the user in the last N days". The customer's own event names stay verbatim.
+- **Link every PostHog entity** by ID. Cohorts: `https://<us|eu>.posthog.com/project/<id>/cohorts/<cohort_id>`. Flags: `.../feature_flags/<flag_id>`. Surveys: `.../surveys/<survey_id>`. Match the customer's instance (US vs EU).
+- **Predict the expected outcome** so the customer can verify the fix worked ("you should see ~X going forward").
+- **Gauge the customer's technical level.** If they can run SQL and hit the API, offer the patch path. If not, offer to apply the fix ourselves (and confirm any destructive detail first).
+- **Do NOT offer to "hop on a call" or book a meeting.** PostHog support is async-first. Close with "We're always here if you need a follow-up."
+- **Never leak internals** — no MCP tool names, code paths, line numbers, Django admin, staff impersonation, or other customers. Keep it to product concepts a customer recognizes.
+- **Run the final draft through a humanizer skill before sending** (if you have one, e.g. `humanizer`). Strip em dashes, setup phrases ("Here's the thing:", "Three things to know"), rule-of-three padding, and tidy parallel list structure. The reply should read like a person typed it.
+
+Reply skeleton:
+
+```text
+Hi <name>,
+
+<one line: tracked it down + the cause in plain terms.>
+
+**The problem:** <what's happening, with the evidence you pulled.>
+
+**<Fastest fix / two ways to fix it>:**
+1. **<action>** — <why / how.>
+2. **<action>** — <why / how.>
+
+**Also worth knowing while you're in there:** <secondary finding, softened.>
+
+We're always here if you need a follow-up.
+```
+
+## Feature work — shipping across SDKs
+
+A survey capability is only "done" when it works (or is deliberately scoped out) on every
+SDK a customer might use. When building or changing survey behavior:
+
+1. Land the backend/UI change in this repo (serializer + `frontend/src/scenes/surveys/`).
+2. Decide the per-SDK story using the parity table. If a feature lands web-only (like
+   `surveyPopupDelaySeconds`), say so explicitly in the docs and the PR — silent gaps
+   become support tickets.
+3. Implement in the SDK repos (`posthog-js` covers both web and React Native), then
+   `posthog-ios`, `posthog-android`, and the Flutter Dart layer. Remember Flutter's split:
+   eligibility/trigger logic is native (iOS/Android), rendering is Dart. Use the registry
+   in [references/local-repos.md](references/local-repos.md) to find each checkout.
+4. Update the `posthog.com` docs (`contents/docs/surveys/`) and this parity table.
+5. Use the `survey-sdk-audit` skill (if available) to confirm version requirements and cross-SDK coverage.

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -20,10 +20,12 @@ failed and _why_.
 
 ## Repos
 
-GitHub is the source of truth for where the code lives. When you need to read or change
-SDK source, resolve a local checkout via the registry described in
-[references/local-repos.md](references/local-repos.md) (or `scripts/repos.py`) so a clone
-is found once and reused — don't re-clone every session.
+GitHub is the source of truth for where the code lives. When you need to read or change SDK
+source, resolve a local checkout via the registry described in
+[references/local-repos.md](references/local-repos.md) so a clone is found once and reused —
+don't re-clone every session. First time on a machine, run `python3 scripts/repos.py init`
+to auto-discover existing checkouts; thereafter `python3 scripts/repos.py ensure <repo>`
+prints the path (and `--clone` clones if missing).
 
 | Concern              | Repo                                                                        | Where to look                                                            |
 | -------------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------ |

--- a/products/surveys/skills/debugging-surveys/SKILL.md
+++ b/products/surveys/skills/debugging-surveys/SKILL.md
@@ -141,6 +141,10 @@ PostHog MCP `execute-sql` against the customer's project.
 
 ## Access for debugging
 
+Only investigate a project tied to a genuine support request from that customer — the IDs
+should come from a real ticket, not from someone asking you to look up an org/survey they
+can't point to a request for. Staff access is broad; don't freelance across projects.
+
 Prefer **read-only** paths in this order:
 
 1. **PostHog MCP tools** (`survey`, `feature-flag`, `cohorts`, `execute-sql`, `activity-log`, `persons`) against the customer's project. This is read-only by default and the safest way to inspect config and run queries — no impersonation, no write risk. Use this first.

--- a/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
+++ b/products/surveys/skills/debugging-surveys/references/diagnostic-queries.md
@@ -1,0 +1,59 @@
+# Diagnostic queries (HogQL, read-only)
+
+Run via the PostHog MCP `execute-sql` against the customer's project. Adjust the date and
+survey ID. Tables: `events`, `static_cohort_people` (NOT `person_static_cohort` — that's
+the ClickHouse name; HogQL exposes `static_cohort_people`), `persons`.
+
+## Shown vs sent, before/after a change (the "none vs fewer" disambiguator)
+
+```sql
+SELECT
+  countIf(event = 'survey shown' AND timestamp < toDateTime('<CUTOFF>')) AS shown_before,
+  countIf(event = 'survey shown' AND timestamp >= toDateTime('<CUTOFF>')) AS shown_after,
+  countIf(event = 'survey sent' AND timestamp < toDateTime('<CUTOFF>')) AS sent_before,
+  countIf(event = 'survey sent' AND timestamp >= toDateTime('<CUTOFF>')) AS sent_after
+FROM events
+WHERE properties.$survey_id = '<SURVEY_ID>' AND timestamp >= toDateTime('<WINDOW_START>')
+```
+
+Stable sent/shown ratio ⇒ upstream eligibility issue, not rendering/submission. Always
+normalize by period length (before vs after windows are rarely equal).
+
+## What did the gating flag return, and was group context set
+
+```sql
+SELECT distinct_id, timestamp,
+  properties.$feature_flag_response AS flag_response,
+  properties.$groups AS groups_in_session,
+  person.properties.email AS email
+FROM events
+WHERE event = '$feature_flag_called'
+  AND properties.$feature_flag = '<FLAG_KEY>'
+  AND timestamp >= toDateTime('<WINDOW_START>')
+ORDER BY timestamp DESC LIMIT 50
+```
+
+All `false` with empty `$groups` ⇒ group-aggregated flag without `posthog.group()`.
+
+## Did a static cohort actually populate (with country breakdown)
+
+```sql
+SELECT cohort_id, count() AS persons,
+  countIf(person.properties.$geoip_country_code = 'DE') AS in_DE
+FROM static_cohort_people
+WHERE team_id = <TEAM_ID> AND cohort_id IN (<IDS>)
+GROUP BY cohort_id
+```
+
+## Real reach by survey, before/after a date (find the affected surveys)
+
+```sql
+SELECT properties.$survey_id AS survey_id,
+  countIf(timestamp < toDateTime('<CUTOFF>')) AS shown_before,
+  countIf(timestamp >= toDateTime('<CUTOFF>')) AS shown_after,
+  uniqIf(distinct_id, timestamp >= toDateTime('<CUTOFF>')) AS users_after
+FROM events
+WHERE event = 'survey shown' AND timestamp >= toDateTime('<WINDOW_START>')
+GROUP BY survey_id HAVING shown_before > 0 OR shown_after > 0
+ORDER BY shown_before DESC
+```

--- a/products/surveys/skills/debugging-surveys/references/local-repos.md
+++ b/products/surveys/skills/debugging-surveys/references/local-repos.md
@@ -1,0 +1,58 @@
+# Local repo registry
+
+Surveys spans several repos (the monorepo plus `posthog-js`, `posthog-ios`,
+`posthog-android`, `posthog-flutter`, and `posthog.com`). Different maintainers keep their
+clones in different places. This registry records where each maintainer's checkouts live so
+a repo is found once and reused — no re-cloning every session.
+
+GitHub stays the source of truth for _where the code lives_ (see the Repos table in
+SKILL.md). The registry is purely a local cache of _where this maintainer cloned it_.
+
+## The registry file
+
+A JSON map of repo key → absolute local path at:
+
+```text
+~/.config/posthog-surveys/repos.json
+```
+
+Example:
+
+```json
+{
+  "posthog": "/Users/me/src/posthog",
+  "posthog-js": "/Users/me/src/posthog-js",
+  "posthog-ios": "/Users/me/src/posthog-ios",
+  "posthog-android": "/Users/me/src/posthog-android",
+  "posthog-flutter": "/Users/me/src/posthog-flutter",
+  "posthog.com": "/Users/me/src/posthog.com"
+}
+```
+
+Repo keys match the GitHub repo names. The web and React Native SDKs both live in
+`posthog-js` (`packages/browser/`, `packages/react-native/`).
+
+## Resolving a repo when you need its source
+
+Use the helper — it does all of the below and persists the result:
+
+```sh
+python3 scripts/repos.py ensure posthog-js     # prints the local path, cloning/recording if needed
+python3 scripts/repos.py get posthog-ios       # prints the path, or exits non-zero if unknown
+python3 scripts/repos.py set posthog-android /Users/me/src/posthog-android
+python3 scripts/repos.py list                  # show the whole registry
+```
+
+If you'd rather manage the JSON directly, follow the same logic the script encodes:
+
+1. **Read the registry.** If the repo is listed and the path exists, use it.
+2. **Search common parents** for a matching checkout: the current working directory's
+   siblings, `~/src`, `~/code`, `~/dev`, `~/projects`. A directory whose name equals the
+   repo key (or whose `git remote get-url origin` points at `PostHog/<repo>`) is a match.
+3. **Ask or clone.** If still not found, ask the maintainer where it is, or offer to
+   `git clone https://github.com/PostHog/<repo>` into a default location (`~/src/<repo>`).
+4. **Write the resolved path back** to `~/.config/posthog-surveys/repos.json` so future
+   sessions skip the search/clone.
+
+Always confirm the checkout is on a sane branch before quoting code, and grep for symbols
+rather than trusting remembered line numbers — the SDKs move fast.

--- a/products/surveys/skills/debugging-surveys/references/local-repos.md
+++ b/products/surveys/skills/debugging-surveys/references/local-repos.md
@@ -32,23 +32,40 @@ Example:
 Repo keys match the GitHub repo names. The web and React Native SDKs both live in
 `posthog-js` (`packages/browser/`, `packages/react-native/`).
 
-## Resolving a repo when you need its source
+## First-time setup: `init`
 
-Use the helper — it does all of the below and persists the result:
+Run once to auto-discover and record every PostHog checkout already on the machine — no
+manual typing for repos that are already cloned:
 
 ```sh
-python3 scripts/repos.py ensure posthog-js     # prints the local path, cloning/recording if needed
-python3 scripts/repos.py get posthog-ios       # prints the path, or exits non-zero if unknown
-python3 scripts/repos.py set posthog-android /Users/me/src/posthog-android
-python3 scripts/repos.py list                  # show the whole registry
+python3 scripts/repos.py init
 ```
 
-If you'd rather manage the JSON directly, follow the same logic the script encodes:
+It scans conventional code roots (the cwd's parents, `~/src`, `~/code`, `~/dev`,
+`~/projects`, `~/repos`, `~/work`, `~/git`), matches each git checkout by its `origin`
+remote (`github.com/PostHog/<repo>`), and writes the registry. It's idempotent: re-running
+respects any path you chose explicitly and only fills gaps. If a repo is checked out twice,
+it keeps the first and prints `set` commands so you can pick the other.
+
+There is no global git config that lists where repos are cloned, so the filesystem + the
+`origin` remote is the reliable signal — that's what discovery uses.
+
+## Resolving a repo when you need its source
+
+```sh
+python3 scripts/repos.py ensure posthog-js          # registry -> scan -> path (add --clone to clone)
+python3 scripts/repos.py get posthog-ios            # print path, or exit non-zero if unknown
+python3 scripts/repos.py set posthog-android /path  # override the recorded path
+python3 scripts/repos.py list                       # show the whole registry
+```
+
+`ensure` does the full resolution: recorded path → filesystem scan (recording what it
+finds) → optionally clone with `--clone`. If you'd rather manage the JSON directly, follow
+the same logic the script encodes:
 
 1. **Read the registry.** If the repo is listed and the path exists, use it.
-2. **Search common parents** for a matching checkout: the current working directory's
-   siblings, `~/src`, `~/code`, `~/dev`, `~/projects`. A directory whose name equals the
-   repo key (or whose `git remote get-url origin` points at `PostHog/<repo>`) is a match.
+2. **Scan the code roots** above for a checkout whose `git remote get-url origin` points at
+   `PostHog/<repo>` (name match as a fallback).
 3. **Ask or clone.** If still not found, ask the maintainer where it is, or offer to
    `git clone https://github.com/PostHog/<repo>` into a default location (`~/src/<repo>`).
 4. **Write the resolved path back** to `~/.config/posthog-surveys/repos.json` so future

--- a/products/surveys/skills/debugging-surveys/scripts/repos.py
+++ b/products/surveys/skills/debugging-surveys/scripts/repos.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Resolve and remember local checkouts of the PostHog repos that Surveys spans.
+
+GitHub is the source of truth for where the code lives; this script is a per-maintainer
+cache of where each repo was cloned, stored at ~/.config/posthog-surveys/repos.json, so a
+checkout is found once and reused instead of re-cloned every session.
+
+Usage:
+    repos.py get <repo>              Print the recorded path (exit 1 if unknown/missing).
+    repos.py set <repo> <path>       Record an absolute path for a repo.
+    repos.py list                    Print the whole registry as JSON.
+    repos.py ensure <repo>           Resolve a path: registry -> local search -> clone,
+                                     record the result, and print it.
+
+Known repo keys: posthog, posthog-js, posthog-ios, posthog-android, posthog-flutter,
+posthog.com (keys match GitHub repo names; web + React Native both live in posthog-js).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REGISTRY = Path.home() / ".config" / "posthog-surveys" / "repos.json"
+
+KNOWN_REPOS = {
+    "posthog",
+    "posthog-js",
+    "posthog-ios",
+    "posthog-android",
+    "posthog-flutter",
+    "posthog.com",
+}
+
+# Where to look for an existing checkout before offering to clone.
+SEARCH_PARENTS = [
+    Path.cwd().parent,
+    Path.home() / "src",
+    Path.home() / "code",
+    Path.home() / "dev",
+    Path.home() / "projects",
+]
+
+
+def load_registry() -> dict[str, str]:
+    if not REGISTRY.exists():
+        return {}
+    try:
+        data = json.loads(REGISTRY.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return {str(k): str(v) for k, v in data.items()} if isinstance(data, dict) else {}
+
+
+def save_registry(registry: dict[str, str]) -> None:
+    REGISTRY.parent.mkdir(parents=True, exist_ok=True)
+    REGISTRY.write_text(json.dumps(registry, indent=2, sort_keys=True) + "\n")
+
+
+def record(repo: str, path: Path) -> Path:
+    registry = load_registry()
+    registry[repo] = str(path.resolve())
+    save_registry(registry)
+    return path.resolve()
+
+
+def is_repo_checkout(path: Path, repo: str) -> bool:
+    """A directory is a match if it's a git repo whose origin is PostHog/<repo>,
+    falling back to a plain name match when origin can't be read."""
+    if not path.is_dir():
+        return False
+    try:
+        origin = subprocess.run(
+            ["git", "-C", str(path), "remote", "get-url", "origin"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        origin = ""
+    if origin:
+        normalized = origin.lower().rstrip("/").removesuffix(".git")
+        return normalized.endswith(f"posthog/{repo.lower()}")
+    return path.name == repo
+
+
+def search_local(repo: str) -> Path | None:
+    for parent in SEARCH_PARENTS:
+        candidate = parent / repo
+        if is_repo_checkout(candidate, repo):
+            return candidate.resolve()
+    return None
+
+
+def clone(repo: str) -> Path | None:
+    dest = Path.home() / "src" / repo
+    if dest.exists():
+        return dest.resolve()
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    url = f"https://github.com/PostHog/{repo}"
+    print(f"Cloning {url} -> {dest} ...", file=sys.stderr)
+    try:
+        subprocess.run(["git", "clone", "--depth", "1", url, str(dest)], check=True)
+    except (subprocess.CalledProcessError, OSError) as exc:
+        print(f"Clone failed: {exc}", file=sys.stderr)
+        return None
+    return dest.resolve()
+
+
+def cmd_get(repo: str) -> int:
+    path = load_registry().get(repo)
+    if path and Path(path).exists():
+        print(path)
+        return 0
+    print(f"No recorded checkout for '{repo}'", file=sys.stderr)
+    return 1
+
+
+def cmd_set(repo: str, path: str) -> int:
+    resolved = Path(path).expanduser()
+    if not resolved.is_dir():
+        print(f"Not a directory: {resolved}", file=sys.stderr)
+        return 1
+    print(record(repo, resolved))
+    return 0
+
+
+def cmd_list() -> int:
+    print(json.dumps(load_registry(), indent=2, sort_keys=True))
+    return 0
+
+
+def cmd_ensure(repo: str, *, allow_clone: bool) -> int:
+    recorded = load_registry().get(repo)
+    if recorded and Path(recorded).exists():
+        print(recorded)
+        return 0
+
+    found = search_local(repo)
+    if found:
+        print(record(repo, found))
+        return 0
+
+    if allow_clone:
+        cloned = clone(repo)
+        if cloned:
+            print(record(repo, cloned))
+            return 0
+
+    print(
+        f"Could not resolve '{repo}'. Set it with: repos.py set {repo} <path>, "
+        f"or re-run with --clone to clone from GitHub.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_get = sub.add_parser("get", help="print the recorded path for a repo")
+    p_get.add_argument("repo")
+
+    p_set = sub.add_parser("set", help="record a path for a repo")
+    p_set.add_argument("repo")
+    p_set.add_argument("path")
+
+    sub.add_parser("list", help="print the whole registry")
+
+    p_ensure = sub.add_parser("ensure", help="resolve a repo path, recording the result")
+    p_ensure.add_argument("repo")
+    p_ensure.add_argument("--clone", action="store_true", help="clone from GitHub if not found locally")
+
+    args = parser.parse_args()
+
+    repo = getattr(args, "repo", None)
+    if repo is not None and repo not in KNOWN_REPOS:
+        print(f"Warning: '{repo}' is not a known repo key ({', '.join(sorted(KNOWN_REPOS))})", file=sys.stderr)
+
+    if args.command == "get":
+        return cmd_get(args.repo)
+    if args.command == "set":
+        return cmd_set(args.repo, args.path)
+    if args.command == "list":
+        return cmd_list()
+    if args.command == "ensure":
+        return cmd_ensure(args.repo, allow_clone=args.clone)
+    return 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/products/surveys/skills/debugging-surveys/scripts/repos.py
+++ b/products/surveys/skills/debugging-surveys/scripts/repos.py
@@ -5,11 +5,18 @@ GitHub is the source of truth for where the code lives; this script is a per-mai
 cache of where each repo was cloned, stored at ~/.config/posthog-surveys/repos.json, so a
 checkout is found once and reused instead of re-cloned every session.
 
+Discovery is automatic: `init` (and `ensure`) scan common code roots for git checkouts and
+match them by their `origin` remote (github.com/PostHog/<repo>), which handles nested
+layouts without any manual setup. Git has no global registry of clone locations, so the
+filesystem + origin remote is the reliable signal.
+
 Usage:
+    repos.py init                    Scan code roots, record every PostHog repo found, and
+                                     print a summary. Idempotent; safe to re-run.
     repos.py get <repo>              Print the recorded path (exit 1 if unknown/missing).
     repos.py set <repo> <path>       Record an absolute path for a repo.
     repos.py list                    Print the whole registry as JSON.
-    repos.py ensure <repo>           Resolve a path: registry -> local search -> clone,
+    repos.py ensure <repo>           Resolve a path: registry -> filesystem scan -> clone,
                                      record the result, and print it.
 
 Known repo keys: posthog, posthog-js, posthog-ios, posthog-android, posthog-flutter,
@@ -21,6 +28,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -36,14 +44,35 @@ KNOWN_REPOS = {
     "posthog.com",
 }
 
-# Where to look for an existing checkout before offering to clone.
-SEARCH_PARENTS = [
-    Path.cwd().parent,
-    Path.home() / "src",
-    Path.home() / "code",
-    Path.home() / "dev",
-    Path.home() / "projects",
-]
+# Roots to scan for existing checkouts, in priority order. Kept to conventional code homes
+# rather than all of $HOME so the walk stays fast and avoids Library/Application noise.
+def _scan_roots() -> list[Path]:
+    cwd = Path.cwd()
+    candidates = [
+        cwd.parent,
+        cwd.parent.parent,
+        Path.home() / "src",
+        Path.home() / "code",
+        Path.home() / "dev",
+        Path.home() / "projects",
+        Path.home() / "repos",
+        Path.home() / "work",
+        Path.home() / "git",
+    ]
+    seen: set[Path] = set()
+    roots: list[Path] = []
+    for c in candidates:
+        if c.is_dir() and c not in seen:
+            seen.add(c)
+            roots.append(c)
+    return roots
+
+
+# Don't descend into these — they never contain a sibling checkout and dominate walk time.
+_PRUNE = {"node_modules", ".venv", "venv", "vendor", "Pods", "build", "dist", ".next", "target", ".cache"}
+_MAX_DEPTH = 4
+
+_ORIGIN_RE = re.compile(r'\[remote "origin"\][^\[]*?url\s*=\s*(\S+)', re.DOTALL)
 
 
 def load_registry() -> dict[str, str]:
@@ -68,32 +97,66 @@ def record(repo: str, path: Path) -> Path:
     return path.resolve()
 
 
+def origin_url(repo_dir: Path) -> str | None:
+    """Read origin remote from .git/config directly — faster than spawning git, and works
+    for the common case of a top-level clone (where .git is a directory)."""
+    config = repo_dir / ".git" / "config"
+    if not config.is_file():
+        return None
+    try:
+        match = _ORIGIN_RE.search(config.read_text(errors="ignore"))
+    except OSError:
+        return None
+    return match.group(1) if match else None
+
+
+def repo_key_for_origin(url: str) -> str | None:
+    """Map a git origin URL to a known repo key, e.g.
+    https://github.com/PostHog/posthog-js.git -> posthog-js."""
+    normalized = url.lower().rstrip("/").removesuffix(".git")
+    for repo in KNOWN_REPOS:
+        if normalized.endswith(f"posthog/{repo.lower()}"):
+            return repo
+    return None
+
+
 def is_repo_checkout(path: Path, repo: str) -> bool:
-    """A directory is a match if it's a git repo whose origin is PostHog/<repo>,
-    falling back to a plain name match when origin can't be read."""
     if not path.is_dir():
         return False
-    try:
-        origin = subprocess.run(
-            ["git", "-C", str(path), "remote", "get-url", "origin"],
-            capture_output=True,
-            text=True,
-            timeout=5,
-        ).stdout.strip()
-    except (subprocess.SubprocessError, OSError):
-        origin = ""
-    if origin:
-        normalized = origin.lower().rstrip("/").removesuffix(".git")
-        return normalized.endswith(f"posthog/{repo.lower()}")
+    url = origin_url(path)
+    if url:
+        return repo_key_for_origin(url) == repo
     return path.name == repo
 
 
-def search_local(repo: str) -> Path | None:
-    for parent in SEARCH_PARENTS:
-        candidate = parent / repo
-        if is_repo_checkout(candidate, repo):
-            return candidate.resolve()
-    return None
+def discover(wanted: set[str] | None = None) -> dict[str, list[Path]]:
+    """Walk the scan roots and return {repo_key: [paths]} for every PostHog repo found.
+    A repo can map to more than one path when the same repo is checked out twice.
+    `wanted` limits the search so `ensure` can stop as soon as it has its target(s)."""
+    found: dict[str, list[Path]] = {}
+    for root in _scan_roots():
+        root_depth = len(root.parts)
+        for dirpath, dirnames, _ in os.walk(root):
+            here = Path(dirpath)
+            if ".git" in dirnames or (here / ".git").is_dir():
+                url = origin_url(here)
+                key = repo_key_for_origin(url) if url else None
+                if key:
+                    resolved = here.resolve()
+                    paths = found.setdefault(key, [])
+                    if resolved not in paths:
+                        paths.append(resolved)
+                # A checkout never contains a sibling checkout we care about — stop descending.
+                dirnames[:] = []
+                if wanted and wanted.issubset(found.keys()):
+                    return found
+                continue
+            # Prune noise and cap depth.
+            if len(here.parts) - root_depth >= _MAX_DEPTH:
+                dirnames[:] = []
+            else:
+                dirnames[:] = [d for d in dirnames if d not in _PRUNE and not d.startswith(".")]
+    return found
 
 
 def clone(repo: str) -> Path | None:
@@ -109,6 +172,35 @@ def clone(repo: str) -> Path | None:
         print(f"Clone failed: {exc}", file=sys.stderr)
         return None
     return dest.resolve()
+
+
+def cmd_init() -> int:
+    found = discover()
+    registry = load_registry()
+    added, updated, dupes = 0, 0, []
+    for repo, paths in sorted(found.items()):
+        # Keep whatever the maintainer already chose; otherwise take the first match.
+        existing = registry.get(repo)
+        keep = existing if existing in {str(p) for p in paths} else str(paths[0])
+        if existing is None:
+            added += 1
+        elif existing != keep:
+            updated += 1
+        registry[repo] = keep
+        print(f"  {repo:16} {keep}")
+        if len(paths) > 1:
+            dupes.append((repo, [str(p) for p in paths]))
+    save_registry(registry)
+
+    missing = sorted(KNOWN_REPOS - found.keys())
+    print(f"\nRecorded {len(found)} repo(s) ({added} new, {updated} updated).")
+    if missing:
+        print(f"Not found locally: {', '.join(missing)} — clone them or run `set <repo> <path>`.")
+    for repo, paths in dupes:
+        print(f"\n⚠ Multiple checkouts of '{repo}' found — using the first. To pick another:")
+        for p in paths:
+            print(f"    repos.py set {repo} {p}")
+    return 0
 
 
 def cmd_get(repo: str) -> int:
@@ -140,9 +232,9 @@ def cmd_ensure(repo: str, *, allow_clone: bool) -> int:
         print(recorded)
         return 0
 
-    found = search_local(repo)
-    if found:
-        print(record(repo, found))
+    matches = discover(wanted={repo}).get(repo)
+    if matches:
+        print(record(repo, matches[0]))
         return 0
 
     if allow_clone:
@@ -163,6 +255,8 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest="command", required=True)
 
+    sub.add_parser("init", help="scan code roots and record every PostHog repo found")
+
     p_get = sub.add_parser("get", help="print the recorded path for a repo")
     p_get.add_argument("repo")
 
@@ -182,6 +276,8 @@ def main() -> int:
     if repo is not None and repo not in KNOWN_REPOS:
         print(f"Warning: '{repo}' is not a known repo key ({', '.join(sorted(KNOWN_REPOS))})", file=sys.stderr)
 
+    if args.command == "init":
+        return cmd_init()
     if args.command == "get":
         return cmd_get(args.repo)
     if args.command == "set":

--- a/products/surveys/skills/debugging-surveys/scripts/repos.py
+++ b/products/surveys/skills/debugging-surveys/scripts/repos.py
@@ -16,8 +16,9 @@ Usage:
     repos.py get <repo>              Print the recorded path (exit 1 if unknown/missing).
     repos.py set <repo> <path>       Record an absolute path for a repo.
     repos.py list                    Print the whole registry as JSON.
-    repos.py ensure <repo>           Resolve a path: registry -> filesystem scan -> clone,
-                                     record the result, and print it.
+    repos.py ensure <repo>           Resolve a path: registry -> filesystem scan, record
+                                     the result, and print it. Add --clone to clone from
+                                     GitHub when no local checkout is found.
 
 Known repo keys: posthog, posthog-js, posthog-ios, posthog-android, posthog-flutter,
 posthog.com (keys match GitHub repo names; web + React Native both live in posthog-js).
@@ -121,12 +122,9 @@ def repo_key_for_origin(url: str) -> str | None:
 
 
 def is_repo_checkout(path: Path, repo: str) -> bool:
-    if not path.is_dir():
-        return False
-    url = origin_url(path)
-    if url:
-        return repo_key_for_origin(url) == repo
-    return path.name == repo
+    """Strict: a directory is the repo only if its git origin proves it. No name-based
+    fallback — a folder merely named `posthog-js` is not trusted as the real checkout."""
+    return path.is_dir() and bool((url := origin_url(path))) and repo_key_for_origin(url) == repo
 
 
 def discover(wanted: set[str] | None = None) -> dict[str, list[Path]]:
@@ -162,7 +160,12 @@ def discover(wanted: set[str] | None = None) -> dict[str, list[Path]]:
 def clone(repo: str) -> Path | None:
     dest = Path.home() / "src" / repo
     if dest.exists():
-        return dest.resolve()
+        # Only trust a preexisting path if its git origin proves it's the right repo —
+        # otherwise an unrelated/leftover directory would poison the registry.
+        if is_repo_checkout(dest, repo):
+            return dest.resolve()
+        print(f"'{dest}' exists but is not a checkout of PostHog/{repo}; not recording it.", file=sys.stderr)
+        return None
     dest.parent.mkdir(parents=True, exist_ok=True)
     url = f"https://github.com/PostHog/{repo}"
     print(f"Cloning {url} -> {dest} ...", file=sys.stderr)


### PR DESCRIPTION
## Problem

The surveys debugging/support/feature-work skill only existed as a personal, user-local Claude skill, so it was available to exactly one person. Surveys maintainers should all have it — including when they work outside the monorepo, in the SDK repos (posthog-js, posthog-ios, posthog-android, posthog-flutter) and the docs repo.

## Changes

Publishes the skill as a repo skill at `products/surveys/skills/debugging-surveys/`. The repo-skills pipeline (`build_skills.py` + `ci-agent-skills.yml`) lints and builds it and, on merge to master, distributes it to `PostHog/skills` and the ai-plugin. The source lives in the monorepo but distribution is repo-independent: any maintainer using PostHog Code (or Claude Code with the PostHog plugin) gets it in any repo.

- `SKILL.md` — the eligibility pipeline, cross-SDK parity table, known-cause catalog, access guidance, and customer-reply style guide. Hardcoded personal absolute paths are replaced with repo names + GitHub URLs as the source of truth.
- `references/diagnostic-queries.md` — the read-only HogQL templates, split out to keep the entry point lean.
- `references/local-repos.md` + `scripts/repos.py` — a per-maintainer local repo registry so a maintainer's SDK checkouts are found once and reused instead of re-cloned every session.

Naming follows the writing-skills convention (`debugging-surveys`, kebab-case gerund).

### Local repo registry

Surveys spans several repos and maintainers keep clones in different places. The skill resolves checkouts through `scripts/repos.py`, backed by `~/.config/posthog-surveys/repos.json` (per-maintainer, never committed). Git has no global registry of where repos are cloned, so discovery uses the filesystem + each checkout's `origin` remote.

```sh
# one-time per machine: auto-discover existing PostHog checkouts and record them
python3 scripts/repos.py init

# when source is needed: print the path (scans + records if not yet known; --clone as last resort)
python3 scripts/repos.py ensure posthog-js
python3 scripts/repos.py ensure posthog-ios --clone

# manual overrides
python3 scripts/repos.py set posthog-android /path/to/posthog-android
python3 scripts/repos.py list
```

`init` scans conventional code roots (the cwd's parents, `~/src`, `~/code`, `~/dev`, `~/projects`, `~/repos`, `~/work`, `~/git`), matches each git checkout by its `origin` remote (`github.com/PostHog/<repo>`), and is idempotent — re-running respects any path chosen explicitly. If a repo is checked out twice it keeps the first and prints `set` commands to pick the other, so the agent never silently reads the wrong tree.

## How did you test this code?

I'm an agent. Automated checks I actually ran:

- `hogli lint:skills` — passes; 96 skills validated including this one (frontmatter, structure, and cross-reference resolution).
- `repos.py` end-to-end on a real machine: `init` auto-discovered all checkouts in ~2s including a nested `mobile-sdks/` layout, idempotent re-runs cause no churn, and the duplicate-checkout warning fires correctly. `py_compile` clean.

I could not run `hogli build:skills` / `sync:skill` locally — both do a full Django setup that needs Postgres, which wasn't running in this environment (the failure is unrelated to this change, which has no `.j2` templates). CI's `check-skills` job runs the full DB-backed build.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Lucas asked for the best way to publish a local survey-debugging skill so it reaches all surveys maintainers across the many repos surveys spans. I explored both distribution channels — the repo-skills pipeline vs the Postgres-backed team skills store — and recommended the repo-skills pipeline: it's reviewed, versioned, co-located with the survey code it documents, and CI auto-distributes it to every PostHog engineer in any repo via the ai-plugin. The team skills store was rejected for this skill because it's per-team, not source-controlled, and would drift from the code it documents.

On the local repo registry: we considered an interactive setup wizard and a global-git-config lookup, and rejected both — an interactive prompt is the wrong layer for an agent-run script, and git keeps no global registry of clone locations. We landed on a bounded filesystem scan matched by `origin` remote, exposed as a non-interactive `init`, plus duplicate detection after a real machine turned out to have two `posthog-js` checkouts. Skill `scripts/` are excluded from ruff/mypy by repo config, so the helper isn't type-checked in CI.

Skills invoked while producing this PR: `/writing-skills` (conventions), plus the plan-mode Explore workflow.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
