### PR TITLE
fix(deps): pin @posthog/icons via pnpm catalog to dedupe products

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -70,7 +70,7 @@
         "@posthog/hedgehog-mode": "^0.0.52",
         "@posthog/hogql-parser": "1.3.75",
         "@posthog/hogvm": "workspace:*",
-        "@posthog/icons": "^0.37.2",
+        "@posthog/icons": "catalog:",
         "@posthog/products-access-control": "workspace:*",
         "@posthog/products-actions": "workspace:*",
         "@posthog/products-ai-gateway": "workspace:*",

--- a/frontend/src/lib/lemon-ui/icons/categories.ts
+++ b/frontend/src/lib/lemon-ui/icons/categories.ts
@@ -222,6 +222,8 @@ export const ELEMENTS = {
         'IconUnlock',
         'IconPrivacy',
         'IconShield',
+        'IconShieldEmpty',
+        'IconShieldExclamation',
         'IconShieldLock',
         'IconWarning',
         'IconQuestion',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,6 +18,9 @@ catalogs:
     '@playwright/test':
       specifier: 1.60.0
       version: 1.60.0
+    '@posthog/icons':
+      specifier: ^0.37.4
+      version: 0.37.4
     '@posthog/react':
       specifier: ^1.9.0
       version: 1.9.0
@@ -598,8 +601,8 @@ importers:
         specifier: workspace:*
         version: link:../common/hogvm/typescript
       '@posthog/icons':
-        specifier: ^0.37.2
-        version: 0.37.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/products-access-control':
         specifier: workspace:*
         version: link:../products/access_control
@@ -2166,8 +2169,8 @@ importers:
   products/actions:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -2533,8 +2536,8 @@ importers:
   products/ai_gateway:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.37.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -2570,8 +2573,8 @@ importers:
   products/ai_observability:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -2649,8 +2652,8 @@ importers:
   products/alerts:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2688,8 +2691,8 @@ importers:
   products/business_knowledge:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2720,8 +2723,8 @@ importers:
   products/cohorts:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -2751,8 +2754,8 @@ importers:
   products/conversations:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2853,8 +2856,8 @@ importers:
         specifier: '*'
         version: 3.2.1(react@18.3.1)
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@9.3.4)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -2901,8 +2904,8 @@ importers:
   products/dashboards:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -2956,8 +2959,8 @@ importers:
   products/data_modeling:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -2985,8 +2988,8 @@ importers:
   products/data_warehouse:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3021,8 +3024,8 @@ importers:
   products/early_access_features:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -3054,8 +3057,8 @@ importers:
   products/endpoints:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3121,8 +3124,8 @@ importers:
         specifier: '*'
         version: 3.2.1(react@18.3.1)
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -3202,8 +3205,8 @@ importers:
   products/experiments:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3235,8 +3238,8 @@ importers:
   products/feature_flags:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3274,8 +3277,8 @@ importers:
   products/games:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3301,8 +3304,8 @@ importers:
   products/groups:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3328,8 +3331,8 @@ importers:
   products/growth:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -3358,8 +3361,8 @@ importers:
   products/legal_documents:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3397,8 +3400,8 @@ importers:
   products/links:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -3430,8 +3433,8 @@ importers:
   products/live_debugger:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3481,8 +3484,8 @@ importers:
         specifier: '*'
         version: 3.2.1(react@18.3.1)
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/products-error-tracking':
         specifier: workspace:*
         version: link:../error_tracking
@@ -3569,8 +3572,8 @@ importers:
   products/managed_migrations:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3632,8 +3635,8 @@ importers:
   products/mcp_store:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3658,8 +3661,8 @@ importers:
   products/metrics:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/products-error-tracking':
         specifier: workspace:*
         version: link:../error_tracking
@@ -3694,8 +3697,8 @@ importers:
   products/notebooks:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3723,8 +3726,8 @@ importers:
   products/persons:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3752,8 +3755,8 @@ importers:
   products/posthog_ai:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.37.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -3822,8 +3825,8 @@ importers:
   products/product_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-charts':
         specifier: workspace:*
         version: link:../../packages/quill/packages/charts
@@ -3866,8 +3869,8 @@ importers:
   products/replay:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -3893,8 +3896,8 @@ importers:
   products/replay_vision:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/lemon-ui':
         specifier: '*'
         version: 0.0.0(antd@5.26.0(date-fns@4.1.0)(luxon@3.7.2)(moment@2.29.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(kea-router@3.4.1(kea@4.0.0-pre.5(react@18.3.1)))(kea@4.0.0-pre.5(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3939,8 +3942,8 @@ importers:
   products/revenue_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/quill-charts':
         specifier: workspace:*
         version: link:../../packages/quill/packages/charts
@@ -3984,8 +3987,8 @@ importers:
   products/session_summaries:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -4007,8 +4010,8 @@ importers:
   products/skills:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -4050,8 +4053,8 @@ importers:
   products/surveys:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -4081,8 +4084,8 @@ importers:
   products/tasks:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -4120,8 +4123,8 @@ importers:
   products/tracing:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/react':
         specifier: '*'
         version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -4160,8 +4163,8 @@ importers:
   products/user_interviews:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@storybook/react':
         specifier: 'catalog:'
         version: 10.4.6(@types/react-dom@18.3.7(@types/react@18.3.27))(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@6.0.3)
@@ -4196,8 +4199,8 @@ importers:
   products/visual_review:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@posthog/react':
         specifier: '*'
         version: 1.9.0(@types/react@18.3.27)(posthog-js@1.396.1)(react@18.3.1)
@@ -4234,8 +4237,8 @@ importers:
   products/web_analytics:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -4273,8 +4276,8 @@ importers:
   products/workflows:
     dependencies:
       '@posthog/icons':
-        specifier: '*'
-        version: 0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        specifier: 'catalog:'
+        version: 0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/react':
         specifier: 18.3.27
         version: 18.3.27
@@ -9905,20 +9908,8 @@ packages:
   '@posthog/hogql-parser@1.3.75':
     resolution: {integrity: sha512-r282QitLBwxaT5YHGi6iAq1lCE5SMkg0Oq/qzvqNio4jh/P4lK70UpyTRMDZ6VFbqJWDg8Ly7T6TBUHxhmmiVg==}
 
-  '@posthog/icons@0.36.4':
-    resolution: {integrity: sha512-xnusbGNz/5vSMUWdEViWuai7D/gxiMZSDDnP6s/acndMqzN+W4asPUgUNnTUps7OyAS1IKaO9zxhdikFrtooJA==}
-    peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
-
-  '@posthog/icons@0.36.6':
-    resolution: {integrity: sha512-L/UJyGN99dSoGIbKwEN2W1a3CmCkPzLmBFfgVTRPOLNIs8ZYUYK0+tfpf4w1JNmH232ZQkJGqcQ1NFmQszwcnQ==}
-    peerDependencies:
-      react: 18.3.1
-      react-dom: 18.3.1
-
-  '@posthog/icons@0.37.3':
-    resolution: {integrity: sha512-nVgnFtpctBpMa3quVfHE7XJXVrH4D8wkwwdUM9KdgQa8VX9k+pjXbfu0nvTFFNrqQDlbFjXpr21EYMYOLzCYhw==}
+  '@posthog/icons@0.37.4':
+    resolution: {integrity: sha512-Xl3jtjTG4dacTgKqLmKbryzjQw6JBLoFKozNusHfNKNMjFdZl1yUBXr/uO057dJgWvdPugAdnHwPJDdBgHToGw==}
     peerDependencies:
       react: 18.3.1
       react-dom: 18.3.1
@@ -30366,17 +30357,7 @@ snapshots:
 
   '@posthog/hogql-parser@1.3.75': {}
 
-  '@posthog/icons@0.36.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@posthog/icons@0.36.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
-    dependencies:
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-
-  '@posthog/icons@0.37.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+  '@posthog/icons@0.37.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -38,6 +38,7 @@ catalog:
     kea-waitfor: ^0.2.1
     kea-window-values: ^3.0.1
     # PostHog packages
+    '@posthog/icons': ^0.37.4
     '@posthog/react': ^1.9.0
     posthog-js: ^1.396.1
     # Build tools

--- a/products/actions/package.json
+++ b/products/actions/package.json
@@ -14,7 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/ai_gateway/package.json
+++ b/products/ai_gateway/package.json
@@ -14,7 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/ai_observability/package.json
+++ b/products/ai_observability/package.json
@@ -18,7 +18,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@testing-library/jest-dom": "*",
         "@testing-library/react": "*",

--- a/products/alerts/package.json
+++ b/products/alerts/package.json
@@ -11,7 +11,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@types/react": "*",
         "kea-forms": "*",

--- a/products/business_knowledge/package.json
+++ b/products/business_knowledge/package.json
@@ -11,7 +11,7 @@
         "posthog-js": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@types/react": "*",
         "react": "*"

--- a/products/cohorts/package.json
+++ b/products/cohorts/package.json
@@ -12,7 +12,7 @@
         "@storybook/react": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/conversations/package.json
+++ b/products/conversations/package.json
@@ -19,7 +19,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@testing-library/jest-dom": "*",
         "@testing-library/react": "*",

--- a/products/customer_analytics/package.json
+++ b/products/customer_analytics/package.json
@@ -17,7 +17,7 @@
         "@dnd-kit/modifiers": "*",
         "@dnd-kit/sortable": "*",
         "@dnd-kit/utilities": "*",
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@testing-library/dom": "*",
         "@testing-library/react": "*",

--- a/products/dashboards/package.json
+++ b/products/dashboards/package.json
@@ -18,7 +18,7 @@
         "jest": "^29.7.0"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "*",
         "@testing-library/jest-dom": "*",
         "@testing-library/react": "*",

--- a/products/data_modeling/package.json
+++ b/products/data_modeling/package.json
@@ -10,7 +10,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "react": "*",
         "react-dom": "*"

--- a/products/data_warehouse/package.json
+++ b/products/data_warehouse/package.json
@@ -13,7 +13,7 @@
         "posthog-js": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@storybook/react": "catalog:",
         "@types/react": "*",

--- a/products/early_access_features/package.json
+++ b/products/early_access_features/package.json
@@ -11,7 +11,7 @@
         "kea-subscriptions": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/endpoints/package.json
+++ b/products/endpoints/package.json
@@ -10,7 +10,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fast-deep-equal": "*",

--- a/products/error_tracking/package.json
+++ b/products/error_tracking/package.json
@@ -19,7 +19,7 @@
         "@dnd-kit/modifiers": "*",
         "@dnd-kit/sortable": "*",
         "@dnd-kit/utilities": "*",
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@testing-library/jest-dom": "*",
         "@testing-library/react": "*",

--- a/products/experiments/package.json
+++ b/products/experiments/package.json
@@ -12,7 +12,7 @@
         "@storybook/react": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/feature_flags/package.json
+++ b/products/feature_flags/package.json
@@ -14,7 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/games/package.json
+++ b/products/games/package.json
@@ -6,7 +6,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/groups/package.json
+++ b/products/groups/package.json
@@ -6,7 +6,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/growth/package.json
+++ b/products/growth/package.json
@@ -8,7 +8,7 @@
         "kea-loaders": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/legal_documents/package.json
+++ b/products/legal_documents/package.json
@@ -11,7 +11,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@storybook/react": "catalog:",
         "@testing-library/dom": "*",

--- a/products/links/package.json
+++ b/products/links/package.json
@@ -11,7 +11,7 @@
         "qrcode.react": "^4.2.0"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/live_debugger/package.json
+++ b/products/live_debugger/package.json
@@ -10,7 +10,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@types/react": "*",
         "@types/react-dom": "*",

--- a/products/logs/package.json
+++ b/products/logs/package.json
@@ -19,7 +19,7 @@
         "@dnd-kit/modifiers": "*",
         "@dnd-kit/sortable": "*",
         "@dnd-kit/utilities": "*",
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/products-error-tracking": "workspace:*",
         "@storybook/react": "catalog:",
         "@testing-library/jest-dom": "*",

--- a/products/managed_migrations/package.json
+++ b/products/managed_migrations/package.json
@@ -10,7 +10,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@types/react": "*",
         "react": "*"

--- a/products/mcp_store/package.json
+++ b/products/mcp_store/package.json
@@ -10,7 +10,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "react": "*"
     }

--- a/products/metrics/package.json
+++ b/products/metrics/package.json
@@ -12,7 +12,7 @@
         "posthog-js": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/products-error-tracking": "workspace:*",
         "@types/react": "*",
         "clsx": "*",

--- a/products/notebooks/package.json
+++ b/products/notebooks/package.json
@@ -9,7 +9,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/persons/package.json
+++ b/products/persons/package.json
@@ -6,7 +6,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/posthog_ai/package.json
+++ b/products/posthog_ai/package.json
@@ -19,7 +19,7 @@
         "msw": "*"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "@types/react-dom": "*",

--- a/products/product_analytics/package.json
+++ b/products/product_analytics/package.json
@@ -15,7 +15,7 @@
         "@testing-library/react": "*"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/replay/package.json
+++ b/products/replay/package.json
@@ -9,7 +9,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/replay_vision/package.json
+++ b/products/replay_vision/package.json
@@ -14,7 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/lemon-ui": "*",
         "@storybook/react": "catalog:",
         "@types/react": "*",

--- a/products/revenue_analytics/package.json
+++ b/products/revenue_analytics/package.json
@@ -11,7 +11,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/session_summaries/package.json
+++ b/products/session_summaries/package.json
@@ -6,7 +6,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "react": "*"
     }

--- a/products/skills/package.json
+++ b/products/skills/package.json
@@ -14,7 +14,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "react": "*",

--- a/products/surveys/package.json
+++ b/products/surveys/package.json
@@ -12,7 +12,7 @@
         "@storybook/react": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/tasks/package.json
+++ b/products/tasks/package.json
@@ -9,7 +9,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "@types/react-dom": "*",

--- a/products/tracing/package.json
+++ b/products/tracing/package.json
@@ -13,7 +13,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@testing-library/react": "*",
         "@types/react": "*",
         "clsx": "*",

--- a/products/user_interviews/package.json
+++ b/products/user_interviews/package.json
@@ -10,7 +10,7 @@
         "posthog-js": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@storybook/react": "catalog:",
         "@types/react": "*",
         "clsx": "*",

--- a/products/visual_review/package.json
+++ b/products/visual_review/package.json
@@ -17,7 +17,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@posthog/react": "*",
         "@storybook/react": "catalog:",
         "@types/react": "*",

--- a/products/web_analytics/package.json
+++ b/products/web_analytics/package.json
@@ -9,7 +9,7 @@
         "kea-router": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "clsx": "*",
         "fuse.js": "*",

--- a/products/workflows/package.json
+++ b/products/workflows/package.json
@@ -19,7 +19,7 @@
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {
-        "@posthog/icons": "*",
+        "@posthog/icons": "catalog:",
         "@types/react": "*",
         "@xyflow/react": "*",
         "clsx": "*",


### PR DESCRIPTION
## Problem

Every product package declared `@posthog/icons` as a `"*"` peer dependency. `"*"` gives pnpm no constraint, so it satisfied each product with whatever copy was already in the store rather than the version the app actually builds with. The committed lockfile resolved:

| icons version | importers |
|---|---|
| 0.36.4 | 28 |
| 0.36.6 | 12 |
| 0.37.3 (what the app shipped) | 3 |

So the **majority of products resolved an icons API two minors behind `frontend`**. When product code is resolved from its own directory — jest tests, and the production bundle (vite dedupes `@base-ui/react` but not `@posthog/icons`) — it sees the stale copy. Any product that uses a newly-added icon silently breaks: the named export is `undefined`. This surfaced when a recently-added icon was used in a product component and its jest test failed because the product dir resolved an old icons copy.

## Changes

- Add `@posthog/icons: ^0.37.4` to the pnpm catalog in `pnpm-workspace.yaml`.
- Point all 43 workspace manifests (42 products + `frontend`) at `"catalog:"` so the entire workspace resolves a single icons version.
- Regenerate `pnpm-lock.yaml`: all 43 importers now resolve `0.37.4`, and the stale `0.36.4` / `0.36.6` copies are removed from the lockfile entirely.

This bumps the app's own icons from `^0.37.2` to `^0.37.4` as a side effect of making `frontend` reference the catalog too — needed so the catalog is the single source of truth rather than `frontend` being a lone pin that can drift again.

Net effect: tests, dev, and production builds all resolve the same icons version, retiring a whole class of "product resolves a stale shared UI lib" bugs instead of patching it per-product.

## How did you test this code?

I'm an agent (agent-assisted, human-directed). Automated checks I actually ran locally:

- Regenerated the lockfile with `pnpm install --lockfile-only` and verified all 43 workspace importers resolve `0.37.4` and zero `0.36.x` references remain.
- Confirmed product `node_modules/@posthog/icons` symlinks (conversations, product_analytics, error_tracking) now point at `0.37.4`.
- Ran an existing product jest suite that transitively imports icons — `products/conversations/frontend/scenes/tickets/SupportTicketsScene.test.tsx` — green (2/2).

CI runs the full type-check and test suites.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Came out of reviewing a [separate PR](https://github.com/PostHog/posthog/pull/54628/changes) where a conversations jest test failed because the product directory pulled an older `@posthog/icons` than the app. Rather than alias icons in `jest.config.ts` per-product, this fixes the root cause for the whole workspace by cataloging the dependency — matching the existing pnpm-catalog convention already used for kea, base-ui, etc.

Considered but not done here: adding `@posthog/icons` to vite/esbuild `dedupe` as belt-and-suspenders. With the catalog forcing one resolved version that's no longer necessary, but it could be added later if a transitive dep ever reintroduces a second copy.

Tools: Claude Code (Opus 4.8). No repo skills were required for this change.
