### PR TITLE
test: move DRF validation matrices to no-DB SimpleTestCases with wiring guards

### DIFF
--- a/posthog/api/test/test_event_filter_config.py
+++ b/posthog/api/test/test_event_filter_config.py
@@ -1,9 +1,12 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.event_filter_config import EventFilterConfigSerializer, EventFilterConfigViewSet
 from posthog.models.event_filter_config import EventFilterConfig, EventFilterMode
 from posthog.models.organization import Organization
 from posthog.models.team.team import Team
@@ -183,55 +186,6 @@ class TestEventFilterConfigAPI(APIBaseTest):
 
     # -- Validation --
 
-    def test_rejects_invalid_filter_tree(self):
-        response = self.client.post(
-            self._url(),
-            data={"filter_tree": {"type": "condition", "field": "bad_field", "operator": "exact", "value": "x"}},
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        data = response.json()
-        self.assertEqual(data["type"], "validation_error")
-        self.assertEqual(data["attr"], "filter_tree__filter_tree")
-        self.assertIn("field must be one of", data["detail"])
-
-    def test_rejects_invalid_test_cases(self):
-        response = self.client.post(
-            self._url(),
-            data={"test_cases": [{"expected_result": "maybe"}]},
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        data = response.json()
-        self.assertEqual(data["type"], "validation_error")
-        self.assertEqual(data["attr"], "test_cases__test_cases")
-        self.assertIn("must be 'drop' or 'ingest'", data["detail"])
-
-    def test_rejects_invalid_mode(self):
-        response = self.client.post(self._url(), data={"mode": "turbo"}, format="json")
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        data = response.json()
-        self.assertEqual(data["type"], "validation_error")
-        self.assertEqual(data["attr"], "mode")
-
-    def test_rejects_failing_test_cases(self):
-        response = self.client.post(
-            self._url(),
-            data={
-                "filter_tree": _cond("event_name", "exact", "$pageview"),
-                "test_cases": [{"event_name": "$pageview", "expected_result": "ingest"}],
-            },
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        data = response.json()
-        self.assertEqual(data["type"], "validation_error")
-        self.assertIn("expected 'ingest' but got 'drop'", data["detail"])
-
     def test_rejected_request_does_not_persist(self):
         seed = self._seed_config()
 
@@ -398,3 +352,42 @@ class TestEventFilterConfigAPI(APIBaseTest):
         response = self.client.get(self._url())
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+
+class TestEventFilterConfigValidationNoDB(SimpleTestCase):
+    # validate_filter_tree / validate_test_cases / validate (run_test_cases) are pure
+    # (no context, no DB), so the matrix runs without a database. The endpoint wiring is
+    # guarded by the meta test below and by test_rejected_request_does_not_persist.
+    def test_rejects_invalid_filter_tree(self) -> None:
+        serializer = EventFilterConfigSerializer(
+            data={"filter_tree": {"type": "condition", "field": "bad_field", "operator": "exact", "value": "x"}}
+        )
+        assert not serializer.is_valid()
+        assert "field must be one of" in str(serializer.errors["filter_tree"])
+
+    def test_rejects_invalid_test_cases(self) -> None:
+        serializer = EventFilterConfigSerializer(data={"test_cases": [{"expected_result": "maybe"}]})
+        assert not serializer.is_valid()
+        assert "must be 'drop' or 'ingest'" in str(serializer.errors["test_cases"])
+
+    def test_rejects_invalid_mode(self) -> None:
+        serializer = EventFilterConfigSerializer(data={"mode": "turbo"})
+        assert not serializer.is_valid()
+        assert "mode" in serializer.errors
+
+    def test_rejects_failing_test_cases(self) -> None:
+        serializer = EventFilterConfigSerializer(
+            data={
+                "filter_tree": _cond("event_name", "exact", "$pageview"),
+                "test_cases": [{"event_name": "$pageview", "expected_result": "ingest"}],
+            }
+        )
+        assert not serializer.is_valid()
+        assert "expected 'ingest' but got 'drop'" in str(serializer.errors["test_cases"])
+
+    def test_validation_serializer_is_wired_to_viewset(self) -> None:
+        # Wiring guard (no DB): the create/update actions validate through this serializer
+        # (self.get_serializer(...).is_valid(raise_exception=True)). If serializer_class is
+        # swapped or dropped, the no-DB matrix above would still pass but the endpoint would
+        # stop validating.
+        assert EventFilterConfigViewSet.serializer_class is EventFilterConfigSerializer

--- a/posthog/api/test/test_llm_prompt.py
+++ b/posthog/api/test/test_llm_prompt.py
@@ -3,14 +3,14 @@ from typing import Any
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
 
 from posthog.api.llm_prompt import LLMPromptViewSet
-from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES
+from posthog.api.llm_prompt_serializers import MAX_PROMPT_PAYLOAD_BYTES, LLMPromptDuplicateSerializer
 from posthog.api.services.llm_prompt import MAX_PROMPT_VERSION
 from posthog.rate_limit import BurstRateThrottle, LLMPromptPublishBurstRateThrottle, SustainedRateThrottle
 
@@ -881,21 +881,14 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.status_code == status.HTTP_400_BAD_REQUEST
         assert "already exists" in response.json()["detail"]
 
-    @parameterized.expand(
-        [
-            ("spaces", "invalid name with spaces"),
-            ("slash", "has/slash"),
-            ("dot", "has.dot"),
-            ("reserved_new", "new"),
-            ("reserved_new_upper", "NEW"),
-        ]
-    )
-    def test_duplicate_prompt_rejects_invalid_new_name(self, _label, bad_name):
+    def test_duplicate_prompt_rejects_invalid_new_name(self):
+        # Wiring guard: the duplicate action validates new_name through LLMPromptDuplicateSerializer.
+        # The full invalid-name matrix runs without a DB in TestLLMPromptDuplicateSerializerValidationNoDB.
         self.create_prompt_version(name="original", version=1, is_latest=True, prompt="content")
 
         response = self.client.post(
             f"/api/environments/{self.team.id}/llm_prompts/name/original/duplicate/",
-            data={"new_name": bad_name},
+            data={"new_name": "invalid name with spaces"},
             format="json",
         )
 
@@ -928,3 +921,25 @@ class TestLLMPromptAPI(APIBaseTest):
         assert response.status_code == status.HTTP_201_CREATED
         assert response.json()["name"] == "archived-name"
         assert response.json()["version"] == 1
+
+
+class TestLLMPromptDuplicateSerializerValidationNoDB(SimpleTestCase):
+    # validate_new_name is a pure regex + reserved-name check (no context, no DB). The duplicate
+    # endpoint's use of this serializer is guarded by test_duplicate_prompt_rejects_invalid_new_name.
+    @parameterized.expand(
+        [
+            ("spaces", "invalid name with spaces"),
+            ("slash", "has/slash"),
+            ("dot", "has.dot"),
+            ("reserved_new", "new"),
+            ("reserved_new_upper", "NEW"),
+        ]
+    )
+    def test_rejects_invalid_new_name(self, _label: str, bad_name: str) -> None:
+        serializer = LLMPromptDuplicateSerializer(data={"new_name": bad_name})
+        assert not serializer.is_valid()
+        assert "new_name" in serializer.errors
+
+    def test_accepts_valid_new_name(self) -> None:
+        serializer = LLMPromptDuplicateSerializer(data={"new_name": "a-valid_name1"})
+        assert serializer.is_valid(), serializer.errors

--- a/posthog/api/test/test_organization_domain.py
+++ b/posthog/api/test/test_organization_domain.py
@@ -6,12 +6,15 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest, BaseTest
 from unittest.mock import ANY, patch
 
+from django.test import SimpleTestCase
 from django.utils import timezone
 
 import dns.rrset
 import dns.resolver
-from rest_framework import status
+from parameterized import parameterized
+from rest_framework import serializers, status
 
+from posthog.api.organization_domain import OrganizationDomainSerializer, OrganizationDomainViewset
 from posthog.constants import AvailableFeature
 from posthog.models import Organization, OrganizationDomain, OrganizationMembership, Team
 
@@ -172,29 +175,23 @@ class TestOrganizationDomainsAPI(APIBaseTest):
         self.assertEqual(OrganizationDomain.objects.count(), count)
 
     def test_cannot_create_invalid_domain(self):
+        # Wiring guard + no-persist check: the endpoint rejects an invalid domain and writes nothing.
+        # The full invalid/valid matrix is exercised without a DB in TestOrganizationDomainValidationNoDB.
         count = OrganizationDomain.objects.count()
         self.organization_membership.level = OrganizationMembership.Level.ADMIN
         self.organization_membership.save()
-        invalid_domains = [
-            "test@posthog.com",
-            "🦔🦔🦔.com",
-            "one.two.c",
-            "--alpha.com",
-            "javascript: alert(1)",
-        ]
 
-        for _domain in invalid_domains:
-            response = self.client.post("/api/organizations/@current/domains/", {"domain": _domain})
-            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-            self.assertEqual(
-                response.json(),
-                {
-                    "type": "validation_error",
-                    "code": "invalid_input",
-                    "detail": "Please enter a valid domain or subdomain name.",
-                    "attr": "domain",
-                },
-            )
+        response = self.client.post("/api/organizations/@current/domains/", {"domain": "test@posthog.com"})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.json(),
+            {
+                "type": "validation_error",
+                "code": "invalid_input",
+                "detail": "Please enter a valid domain or subdomain name.",
+                "attr": "domain",
+            },
+        )
 
         self.assertEqual(OrganizationDomain.objects.count(), count)
 
@@ -897,3 +894,34 @@ class TestSCIMRequestLogsAPI(APILicensedTest):
         assert "identity_provider" in result
         assert "duration_ms" in result
         assert "created_at" in result
+
+
+class TestOrganizationDomainValidationNoDB(SimpleTestCase):
+    # OrganizationDomainSerializer.is_valid() hits the DB (the `domain` field carries a
+    # UniqueValidator), but validate_domain is a pure regex check — call it directly, no DB.
+    # The endpoint path is guarded by test_cannot_create_invalid_domain and the meta test below.
+    @parameterized.expand(
+        [
+            ["email address", "test@posthog.com"],
+            ["emoji", "🦔🦔🦔.com"],
+            ["tld too short", "one.two.c"],
+            ["leading dashes", "--alpha.com"],
+            ["javascript scheme", "javascript: alert(1)"],
+        ]
+    )
+    def test_validate_domain_rejects_invalid(self, _name: str, domain: str) -> None:
+        with self.assertRaises(serializers.ValidationError):
+            OrganizationDomainSerializer().validate_domain(domain)
+
+    @parameterized.expand(
+        [
+            ["bare domain", "posthog.com"],
+            ["subdomain", "eu.posthog.com"],
+        ]
+    )
+    def test_validate_domain_accepts_valid(self, _name: str, domain: str) -> None:
+        assert OrganizationDomainSerializer().validate_domain(domain) == domain
+
+    def test_validation_serializer_is_wired_to_viewset(self) -> None:
+        # Wiring guard (no DB): the ModelViewSet validates input through this serializer.
+        assert OrganizationDomainViewset.serializer_class is OrganizationDomainSerializer

--- a/posthog/api/test/test_web_experiment.py
+++ b/posthog/api/test/test_web_experiment.py
@@ -3,8 +3,12 @@ from datetime import UTC, datetime, timedelta
 from posthog.test.base import APIBaseTest
 from unittest.mock import ANY, patch
 
+from django.test import SimpleTestCase
+
+from parameterized import parameterized
 from rest_framework import status
 
+from posthog.api.web_experiment import WebExperimentsAPISerializer, WebExperimentViewSet
 from posthog.models.activity_logging.activity_log import ActivityLog
 
 from products.experiments.backend.models.web_experiment import WebExperiment
@@ -319,122 +323,6 @@ class TestWebExperiment(APIBaseTest):
         # New variant should not have transforms (not in original experiment)
         assert "transforms" not in variants["new_variant"]
 
-    def test_rejects_xss_in_text_field(self):
-        """Test that XSS attacks in text field are rejected"""
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/web_experiments/",
-            data={
-                "name": "XSS Text Test",
-                "variants": {
-                    "control": {
-                        "transforms": [{"html": "", "text": "Safe text", "selector": "#test"}],
-                        "rollout_percentage": 50,
-                    },
-                    "test": {
-                        "transforms": [
-                            {
-                                "html": "",
-                                "text": '<script>alert("XSS")</script>Hello',
-                                "selector": "#test",
-                            }
-                        ],
-                        "rollout_percentage": 50,
-                    },
-                },
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response_data = response.json()
-        assert "script" in str(response_data).lower()
-
-    def test_rejects_xss_event_handlers_in_html(self):
-        """Test that event handlers in html field are rejected"""
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/web_experiments/",
-            data={
-                "name": "XSS Event Handler Test",
-                "variants": {
-                    "control": {
-                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
-                        "rollout_percentage": 50,
-                    },
-                    "test": {
-                        "transforms": [
-                            {
-                                "html": "<img src=x onerror=\"alert('XSS')\">",
-                                "text": "Test",
-                                "selector": "#test",
-                            }
-                        ],
-                        "rollout_percentage": 50,
-                    },
-                },
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response_data = response.json()
-        assert "event handler" in str(response_data).lower()
-
-    def test_rejects_javascript_protocol(self):
-        """Test that javascript: protocol is rejected"""
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/web_experiments/",
-            data={
-                "name": "XSS JavaScript Protocol Test",
-                "variants": {
-                    "control": {
-                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
-                        "rollout_percentage": 50,
-                    },
-                    "test": {
-                        "transforms": [
-                            {
-                                "html": '<a href="javascript:alert(1)">Click</a>',
-                                "text": "Test",
-                                "selector": "#test",
-                            }
-                        ],
-                        "rollout_percentage": 50,
-                    },
-                },
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response_data = response.json()
-        assert "javascript:" in str(response_data).lower()
-
-    def test_rejects_iframe_tags(self):
-        """Test that iframe tags are rejected"""
-        response = self.client.post(
-            f"/api/projects/{self.team.id}/web_experiments/",
-            data={
-                "name": "XSS Iframe Test",
-                "variants": {
-                    "control": {
-                        "transforms": [{"html": "", "text": "Safe", "selector": "#test"}],
-                        "rollout_percentage": 50,
-                    },
-                    "test": {
-                        "transforms": [
-                            {
-                                "html": '<iframe src="https://evil.com"></iframe>',
-                                "text": "Test",
-                                "selector": "#test",
-                            }
-                        ],
-                        "rollout_percentage": 50,
-                    },
-                },
-            },
-            format="json",
-        )
-        assert response.status_code == status.HTTP_400_BAD_REQUEST
-        response_data = response.json()
-        assert "iframe" in str(response_data).lower()
-
     def test_web_experiment_activity_log_on_create_and_update(self):
         response = self._create_web_experiment()
         response_data = response.json()
@@ -537,3 +425,56 @@ class TestWebExperiment(APIBaseTest):
         # HTML should be preserved with original formatting
         assert transforms["html"] == complex_html
         assert transforms["text"] == "Safe <b>formatted</b> text"
+
+
+def _variants_with_test_transform(transform: dict) -> dict:
+    return {
+        "control": {"rollout_percentage": 50},
+        "test": {"rollout_percentage": 50, "transforms": [transform]},
+    }
+
+
+class TestWebExperimentValidationNoDB(SimpleTestCase):
+    # validate() / validate_no_xss are pure (no context, no DB), so the matrix runs without
+    # a database. test_validation_serializer_is_wired_to_viewset guards that the endpoint
+    # actually validates through this serializer.
+    def _assert_invalid(self, variants: dict, expected_substring: str) -> None:
+        serializer = WebExperimentsAPISerializer(data={"name": "x", "variants": variants})
+        assert not serializer.is_valid()
+        assert expected_substring in str(serializer.errors).lower()
+
+    @parameterized.expand(
+        [
+            ["script tag in text", {"selector": "#t", "text": '<script>alert("x")</script>'}, "script"],
+            ["event handler in html", {"selector": "#t", "html": '<img src=x onerror="alert(1)">'}, "event handler"],
+            [
+                "javascript protocol in html",
+                {"selector": "#t", "html": '<a href="javascript:alert(1)">x</a>'},
+                "javascript:",
+            ],
+            ["iframe in html", {"selector": "#t", "html": '<iframe src="https://evil.com"></iframe>'}, "iframe"],
+            ["object tag in html", {"selector": "#t", "html": "<object data=x></object>"}, "object"],
+            ["data:text/html in html", {"selector": "#t", "html": "data:text/html,<b>x</b>"}, "data:text/html"],
+        ]
+    )
+    def test_rejects_xss_in_transform(self, _name: str, transform: dict, expected_substring: str) -> None:
+        self._assert_invalid(_variants_with_test_transform(transform), expected_substring)
+
+    def test_rejects_missing_control_variant(self) -> None:
+        self._assert_invalid({"test": {"rollout_percentage": 50}}, "control variant")
+
+    def test_rejects_variant_without_rollout_percentage(self) -> None:
+        self._assert_invalid({"control": {}}, "rollout percentage")
+
+    def test_rejects_non_control_transform_without_selector(self) -> None:
+        variants = {
+            "control": {"rollout_percentage": 50},
+            "test": {"rollout_percentage": 50, "transforms": [{"text": "hi"}]},
+        }
+        self._assert_invalid(variants, "selector")
+
+    def test_validation_serializer_is_wired_to_viewset(self) -> None:
+        # Wiring guard (no DB): the ModelViewSet validates input through this serializer on
+        # create/update, so the no-DB matrix above covers the real endpoint validation path.
+        # If serializer_class is swapped or dropped, validation silently stops running.
+        assert WebExperimentViewSet.serializer_class is WebExperimentsAPISerializer

--- a/products/ai_observability/backend/api/test/test_models.py
+++ b/products/ai_observability/backend/api/test/test_models.py
@@ -1,12 +1,14 @@
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.test import SimpleTestCase
+
 from rest_framework import status
 
 from products.ai_observability.backend.api.models import LLMModelInfoSerializer, LLMModelsListResponseSerializer
 
 
-class TestLLMModelInfoSerializer(APIBaseTest):
+class TestLLMModelInfoSerializer(SimpleTestCase):
     def test_serializes_expected_shape(self):
         serializer = LLMModelInfoSerializer(data={"id": "gpt-4o-mini", "posthog_available": True})
         self.assertTrue(serializer.is_valid(), serializer.errors)
@@ -18,7 +20,7 @@ class TestLLMModelInfoSerializer(APIBaseTest):
         self.assertIn("posthog_available", serializer.errors)
 
 
-class TestLLMModelsListResponseSerializer(APIBaseTest):
+class TestLLMModelsListResponseSerializer(SimpleTestCase):
     def test_serializes_nested_models(self):
         serializer = LLMModelsListResponseSerializer(
             data={

--- a/products/experiments/backend/test/test_metrics_recalculation_serializer.py
+++ b/products/experiments/backend/test/test_metrics_recalculation_serializer.py
@@ -1,5 +1,7 @@
 from posthog.test.base import BaseTest
 
+from django.test import SimpleTestCase
+
 from parameterized import parameterized
 
 from posthog.models.scoping import team_scope
@@ -94,7 +96,7 @@ class TestExperimentMetricsRecalculationSerializer(BaseTest):
         assert data["result_source"] == "timeseries_fallback"
 
 
-class TestRecalculateMetricsRequestSerializer(BaseTest):
+class TestRecalculateMetricsRequestSerializer(SimpleTestCase):
     def test_defaults_trigger_to_manual_when_omitted(self):
         s = RecalculateMetricsRequestSerializer(data={})
         assert s.is_valid(), s.errors
@@ -123,7 +125,7 @@ class TestRecalculateMetricsRequestSerializer(BaseTest):
         assert "trigger" in s.errors
 
 
-class TestMetricRecalculationResultSerializer(BaseTest):
+class TestMetricRecalculationResultSerializer(SimpleTestCase):
     @parameterized.expand(
         [
             (


### PR DESCRIPTION
## Problem

Six serializers' input-validation tests ran through `APIBaseTest`/`BaseTest`, paying for Postgres setup (and a per-test transaction) to exercise validation that executes entirely in memory. This is the batch follow-up to the earlier one-off conversions (#66707, #66708, #66712), bundling the clean candidates into one PR.

## Changes

Each serializer's validation matrix moves to a `SimpleTestCase` (no DB), and each keeps a guard proving the viewset still validates through the serializer.

| Serializer | Matrix → no-DB | Wiring guard |
|---|---|---|
| `WebExperimentsAPISerializer` (XSS / variant shape) | ✅ | meta: `WebExperimentViewSet.serializer_class` |
| `EventFilterConfigSerializer` (filter-tree / test-cases / mode / failing case) | ✅ | meta + kept no-persist endpoint test |
| `OrganizationDomainSerializer.validate_domain` | ✅ (calls the validator method directly) | meta + reduced endpoint no-persist test |
| `LLMPromptDuplicateSerializer.validate_new_name` | ✅ | kept one duplicate-endpoint test (inline serializer) |
| `LLMModelInfo` / `LLMModelsListResponse` | ✅ reparent | existing `TestLLMModelsViewSet` |
| experiments `RecalculateMetricsRequest` / `MetricRecalculationResult` | ✅ reparent | n/a (shape serializers) |

**Wiring guards.** Per the `writing-tests` skill, the no-DB serializer test proves the validation logic but not that the viewset invokes the serializer. Where a viewset wires via `serializer_class`, a **no-DB meta test** asserts that wiring (`assert ViewSet.serializer_class is TheSerializer`) — it catches a refactor that swaps or drops the serializer and silently stops validating. Where the serializer is instantiated inline in an action (LLMPrompt duplicate), a meta test can't see it, so one endpoint test stays as the guard.

**One thing worth a look during review:** `OrganizationDomainSerializer.is_valid()` actually hits the DB — the `domain` field carries a `UniqueValidator`, which queries during field validation regardless of whether the value is even a valid domain. So the no-DB matrix calls the pure `validate_domain` method directly rather than going through `is_valid()`. (Good reminder that "it's just validation" isn't automatically no-DB on a `ModelSerializer`.)

**Deliberately excluded:**
- `LLMPromptPublishSerializer` — `base_version` and nested `edits.old/new` are required, so field errors fire before the mutual-exclusion `validate()`; constructing valid scaffolding to isolate each case is fiddly enough that it's a better separate change.
- `cdp` / cohort / integration serializers — their `validate()` needs the DB or request context (documented in the earlier rounds).

No validation logic or endpoint behavior changed.

## How did you test this code?

I'm an agent, and Postgres isn't available in my sandbox, so I ran every **converted no-DB class** with no database: **45 passed**. All six touched files still collect (**203 tests**), and `ruff check`/`ruff format` are clean. The kept endpoint guards (and the meta tests, which import settings but touch no rows) are exercised by CI.

Regressions caught: each no-DB matrix fails if its validator regresses (XSS bypass, bad filter-tree accepted, invalid domain/prompt-name accepted, etc.); each wiring guard fails if the viewset stops validating through the serializer.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul asked for one combined PR across the candidate backlog, with strong "serializer is wired to the validator" tests — explicitly fine with a meta test that the validator is wired in. Invoked `/writing-tests`. Used no-DB meta wiring tests for `serializer_class`-wired viewsets and kept endpoint guards where serializers are instantiated inline. Verified each candidate's purity before converting (the `OrganizationDomain` `UniqueValidator` DB hit and the `LLMPromptPublish` required-field entanglement were both caught by probing before committing). Companion: #66704 codifies the wiring-guard requirement in the skill.
