### PR TITLE
fix(workflows): always fetch fresh app metrics instead of cached

### DIFF
--- a/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
+++ b/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
@@ -96,8 +96,6 @@ export const loadAppMetricsTotals = async (
     const response = await api.queryHogQL(
         query,
         { scene: 'HogFunction', productKey: 'pipeline_destinations' },
-        // Don't serve cached totals — metrics like "email sent" must reflect the
-        // latest counts, not a result that can be up to several hours stale.
         { refresh: 'force_blocking' }
     )
 
@@ -212,7 +210,6 @@ const loadAppMetricsTimeSeries = async (
     const response = await api.queryHogQL(
         query,
         { scene: 'HogFunction', productKey: 'pipeline_destinations' },
-        // Don't serve cached time series — metrics must reflect the latest counts.
         { refresh: 'force_blocking' }
     )
 

--- a/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
+++ b/frontend/src/lib/components/AppMetrics/appMetricsLogic.ts
@@ -96,7 +96,9 @@ export const loadAppMetricsTotals = async (
     const response = await api.queryHogQL(
         query,
         { scene: 'HogFunction', productKey: 'pipeline_destinations' },
-        { refresh: 'async_except_on_cache_miss' }
+        // Don't serve cached totals — metrics like "email sent" must reflect the
+        // latest counts, not a result that can be up to several hours stale.
+        { refresh: 'force_blocking' }
     )
 
     const res: AppMetricsTotalsResponse = {}
@@ -210,7 +212,8 @@ const loadAppMetricsTimeSeries = async (
     const response = await api.queryHogQL(
         query,
         { scene: 'HogFunction', productKey: 'pipeline_destinations' },
-        { refresh: 'async_except_on_cache_miss' }
+        // Don't serve cached time series — metrics must reflect the latest counts.
+        { refresh: 'force_blocking' }
     )
 
     const labels = response.results?.[0]?.[0].map((label: string) => {


### PR DESCRIPTION
## Problem

Workflow metrics such as "email sent" counts showed stale numbers. The values only updated after re-selecting the time range (e.g. "today"), because the underlying app-metrics queries were served from a cached HogQL result that could be several hours old.

## Changes

The shared `appMetricsLogic` fetched both totals and time series with `refresh: 'async_except_on_cache_miss'`, which immediately returns a cached query result (and only recalculates in the background). Switched both to `refresh: 'force_blocking'` so the metrics are recalculated on every load and always reflect the latest counts.

This covers all workflow metric surfaces (email-sent/conversion/in-progress totals, the trend charts, and per-step node counts), since they all route through these two functions.

## How did you test this code?

I'm an agent (PostHog Slack app). No automated tests were added — this is a one-line change to the query refresh mode. Reviewers should sanity-check that the metrics views remain responsive now that queries are synchronous.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: the workflow "email sent" metric was showing a cached count and required re-selecting the time range to refresh. Traced the staleness to the `async_except_on_cache_miss` refresh mode in `frontend/src/lib/components/AppMetrics/appMetricsLogic.ts` (default HogQL cache TTL is ~6h for a `day` interval), and changed it to `force_blocking` for both the totals and time-series loaders. Considered `blocking`, but that still serves very-fresh cache entries, which doesn't fully satisfy the "not cached" requirement.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1782741276628989?thread_ts=1782741276.628989&cid=C06GG249PR6)*
