### PR TITLE
fix(conversations): evaluate support AI flag with team uuid

### DIFF
--- a/products/conversations/backend/temporal/coordinator.py
+++ b/products/conversations/backend/temporal/coordinator.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime, timedelta
+from typing import TYPE_CHECKING
 
 from temporalio import activity, workflow
 from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
+
+if TYPE_CHECKING:
+    from posthog.models import Team
 
 with workflow.unsafe.imports_passed_through():
     from django.db.models import Q
@@ -76,11 +80,18 @@ class CollectEligibleTicketsOutput:
     tickets: list[EligibleTicket]
 
 
-def _is_master_flag_enabled(team_id: int) -> bool:
+def _is_master_flag_enabled(team: Team) -> bool:
     return bool(
         posthoganalytics.feature_enabled(
             MASTER_FLAG,
-            str(team_id),
+            str(team.uuid),
+            groups={"organization": str(team.organization_id), "project": str(team.id)},
+            group_properties={
+                "organization": {"id": str(team.organization_id)},
+                "project": {"id": str(team.id)},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
         )
     )
 
@@ -102,7 +113,7 @@ def _collect_eligible(lookback_minutes: int = TICKET_LOOKBACK_MINUTES) -> list[E
     for ticket in recent_tickets:
         team = ticket.team
 
-        if not _is_master_flag_enabled(team.id):
+        if not _is_master_flag_enabled(team):
             continue
 
         settings_dict = team.conversations_settings or {}

--- a/products/conversations/backend/temporal/tests/test_coordinator.py
+++ b/products/conversations/backend/temporal/tests/test_coordinator.py
@@ -16,8 +16,12 @@ from products.conversations.backend.temporal.coordinator import (
     EligibleTicket,
     SupportReplyCoordinatorWorkflow,
     _collect_eligible,
+    _is_master_flag_enabled,
     support_collect_eligible_tickets_activity,
 )
+
+TEST_TEAM_UUID = uuid.UUID("11111111-1111-4111-8111-111111111111")
+TEST_ORG_UUID = uuid.UUID("22222222-2222-4222-8222-222222222222")
 
 COORD_MODULE = "products.conversations.backend.temporal.coordinator"
 
@@ -50,6 +54,8 @@ def _make_ticket(
     org.is_ai_data_processing_approved = ai_data_processing_approved
     team = MagicMock()
     team.id = team_id
+    team.uuid = TEST_TEAM_UUID
+    team.organization_id = TEST_ORG_UUID
     team.organization = org
     settings: dict = {"ai_suggestions_enabled": ai_suggestions_enabled}
     if ai_resolution_channels is not None:
@@ -62,6 +68,31 @@ def _make_ticket(
     # Default well past the settle window so eligibility tests aren't gated on debounce.
     ticket.created_at = timezone.now() - timedelta(minutes=created_minutes_ago)
     return ticket, ticket_id, team
+
+
+class TestMasterFlagEnabled:
+    @patch(f"{COORD_MODULE}.posthoganalytics.feature_enabled", return_value=True)
+    def test_evaluates_flag_with_team_uuid_and_groups(self, mock_feature_enabled):
+        team = MagicMock()
+        team.id = 2
+        team.uuid = TEST_TEAM_UUID
+        team.organization_id = TEST_ORG_UUID
+
+        assert _is_master_flag_enabled(team) is True
+        mock_feature_enabled.assert_called_once_with(
+            "product-support-ai-suggestion",
+            str(TEST_TEAM_UUID),
+            groups={
+                "organization": str(TEST_ORG_UUID),
+                "project": "2",
+            },
+            group_properties={
+                "organization": {"id": str(TEST_ORG_UUID)},
+                "project": {"id": "2"},
+            },
+            only_evaluate_locally=False,
+            send_feature_flag_events=False,
+        )
 
 
 class TestCollectEligible:


### PR DESCRIPTION
## Problem

The support reply coordinator gates ticket pickup on `product-support-ai-suggestion`, but evaluated it with `str(team.id)` . Internal rollouts target project uuid or org/project groups, so enabled teams were silently skipped even with AI suggestions turned on in settings.

## Changes

- Evaluate the master flag with `str(team.uuid)` instead of numeric team id
- Pass organization and project groups to match backend flag eval elsewhere (warehouse enrichment)
- Disable feature-flag event capture on the coordinator poll path
- Add a unit test locking in the `feature_enabled` call contract

