### PR TITLE
fix(data-management): clamp coverage trends window to event lifetime

### DIFF
--- a/frontend/src/scenes/data-management/events/EventDefinitionSchema.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionSchema.tsx
@@ -42,17 +42,19 @@ function PropertyRow({ property }: { property: SchemaPropertyGroupProperty }): J
 function PropertyGroupCard({
     schema,
     eventName,
+    eventFirstSeen,
     onEdit,
     onRemove,
 }: {
     schema: EventSchema
     eventName: string
+    eventFirstSeen?: string | null
     onEdit: () => void
     onRemove: () => void
 }): JSX.Element {
     const queryResult = useMemo(
-        () => buildPropertyGroupTrendsQuery(eventName, schema.property_group.properties),
-        [eventName, schema.property_group.properties]
+        () => buildPropertyGroupTrendsQuery(eventName, schema.property_group.properties, eventFirstSeen),
+        [eventName, eventFirstSeen, schema.property_group.properties]
     )
 
     const linkQuery = useMemo(
@@ -108,7 +110,7 @@ function PropertyGroupCard({
                     <div className="p-4 bg-bg-light">
                         <h4 className="font-semibold mb-2 text-sm flex items-center gap-1">
                             <Link to={insightUrl} className="text-default hover:text-link">
-                                Property Coverage Trends (90 days)
+                                Property Coverage Trends ({queryResult.dateRangeLabel})
                             </Link>
                             <Tooltip title="% of events containing this property">
                                 <IconInfo className="text-xl text-secondary shrink-0" />
@@ -211,6 +213,7 @@ export function EventDefinitionSchema({ definition }: { definition: EventDefinit
                                 key={schema.id}
                                 schema={schema}
                                 eventName={definition.name}
+                                eventFirstSeen={definition.created_at}
                                 onEdit={() => {
                                     setEditingPropertyGroup(schema.property_group)
                                     setPropertyGroupModalOpen(true)

--- a/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.test.ts
+++ b/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.test.ts
@@ -1,0 +1,78 @@
+import { dayjs } from 'lib/dayjs'
+
+import { TrendsQuery } from '~/queries/schema/schema-general'
+
+import { SchemaPropertyGroupProperty } from '../schema/schemaManagementLogic'
+import { buildPropertyGroupTrendsQuery } from './propertyGroupTrendsQuery'
+
+describe('buildPropertyGroupTrendsQuery', () => {
+    const properties = [
+        {
+            id: '1',
+            name: 'plan',
+            property_type: 'String',
+            is_required: true,
+            is_optional_in_types: false,
+            description: '',
+        },
+        {
+            id: '2',
+            name: 'price',
+            property_type: 'Numeric',
+            is_required: false,
+            is_optional_in_types: false,
+            description: '',
+        },
+    ] as SchemaPropertyGroupProperty[]
+
+    const sourceOf = (...args: Parameters<typeof buildPropertyGroupTrendsQuery>): TrendsQuery =>
+        buildPropertyGroupTrendsQuery(...args).query.source as TrendsQuery
+
+    it('builds one coverage formula (propertyCount / eventCount) per property', () => {
+        const source = sourceOf('download-game', properties)
+
+        // Base count series A, then one is_set series per property (B, C, …).
+        expect(source.series).toHaveLength(3)
+        expect(source.series[0]).toMatchObject({ event: 'download-game', math: 'total' })
+        expect(source.series[1]).toMatchObject({
+            event: 'download-game',
+            properties: [{ key: 'plan', operator: 'is_set' }],
+        })
+        expect(source.trendsFilter?.formulaNodes).toEqual([
+            { formula: 'B/A * 100', custom_name: 'plan' },
+            { formula: 'C/A * 100', custom_name: 'price' },
+        ])
+        expect(source.trendsFilter?.aggregationAxisFormat).toBe('percentage')
+    })
+
+    it('truncates to 25 properties so series labels stay within B–Z', () => {
+        const many = Array.from({ length: 30 }, (_, i) => ({ ...properties[0], id: String(i), name: `p${i}` }))
+        const result = buildPropertyGroupTrendsQuery('e', many)
+
+        expect(result.isTruncated).toBe(true)
+        expect(result.totalProperties).toBe(30)
+        expect(result.displayedProperties).toBe(25)
+        expect((result.query.source as TrendsQuery).series).toHaveLength(26) // base + 25
+    })
+
+    // The bug this guards: weeks before the event existed evaluate coverage as 0/0 → 0%, painting a
+    // flat 0% line across the whole window. Clamping the start to the event's first-seen removes them.
+    it('clamps the window to first-seen for an event younger than 90 days', () => {
+        const firstSeen = dayjs().subtract(10, 'day').toISOString()
+        const result = buildPropertyGroupTrendsQuery('e', properties, firstSeen)
+
+        expect((result.query.source as TrendsQuery).dateRange?.date_from).toBe(dayjs(firstSeen).format('YYYY-MM-DD'))
+        expect(result.dateRangeLabel).toBe(`since ${dayjs(firstSeen).format('MMM D, YYYY')}`)
+    })
+
+    it.each([
+        ['first-seen is older than the window', dayjs().subtract(200, 'day').toISOString()],
+        ['first-seen is unknown', undefined],
+        ['first-seen is unparseable', 'not-a-date'],
+    ])('keeps the default 90-day window when %s', (_label, firstSeen) => {
+        const result = buildPropertyGroupTrendsQuery('e', properties, firstSeen)
+
+        expect((result.query.source as TrendsQuery).dateRange?.date_from).toBe('-90d')
+        expect(result.dateRangeLabel).toBe('last 90 days')
+    })
+})

--- a/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.test.ts
+++ b/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.test.ts
@@ -1,16 +1,17 @@
 import { dayjs } from 'lib/dayjs'
 
 import { TrendsQuery } from '~/queries/schema/schema-general'
+import { PropertyType } from '~/types'
 
 import { SchemaPropertyGroupProperty } from '../schema/schemaManagementLogic'
 import { buildPropertyGroupTrendsQuery } from './propertyGroupTrendsQuery'
 
 describe('buildPropertyGroupTrendsQuery', () => {
-    const properties = [
+    const properties: SchemaPropertyGroupProperty[] = [
         {
             id: '1',
             name: 'plan',
-            property_type: 'String',
+            property_type: PropertyType.String,
             is_required: true,
             is_optional_in_types: false,
             description: '',
@@ -18,24 +19,24 @@ describe('buildPropertyGroupTrendsQuery', () => {
         {
             id: '2',
             name: 'price',
-            property_type: 'Numeric',
+            property_type: PropertyType.Numeric,
             is_required: false,
             is_optional_in_types: false,
             description: '',
         },
-    ] as SchemaPropertyGroupProperty[]
+    ]
 
     const sourceOf = (...args: Parameters<typeof buildPropertyGroupTrendsQuery>): TrendsQuery =>
         buildPropertyGroupTrendsQuery(...args).query.source as TrendsQuery
 
     it('builds one coverage formula (propertyCount / eventCount) per property', () => {
-        const source = sourceOf('download-game', properties)
+        const source = sourceOf('purchase', properties)
 
         // Base count series A, then one is_set series per property (B, C, …).
         expect(source.series).toHaveLength(3)
-        expect(source.series[0]).toMatchObject({ event: 'download-game', math: 'total' })
+        expect(source.series[0]).toMatchObject({ event: 'purchase', math: 'total' })
         expect(source.series[1]).toMatchObject({
-            event: 'download-game',
+            event: 'purchase',
             properties: [{ key: 'plan', operator: 'is_set' }],
         })
         expect(source.trendsFilter?.formulaNodes).toEqual([

--- a/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.ts
+++ b/frontend/src/scenes/data-management/events/propertyGroupTrendsQuery.ts
@@ -1,20 +1,26 @@
+import { dayjs } from 'lib/dayjs'
+
 import { EventsNode, InsightVizNode, NodeKind, TrendsQuery } from '~/queries/schema/schema-general'
 import { BaseMathType, PropertyFilterType, PropertyOperator } from '~/types'
 
 import { SchemaPropertyGroupProperty } from '../schema/schemaManagementLogic'
 
 const MAX_PROPERTIES = 25
+const LOOKBACK_DAYS = 90
 
 export interface PropertyGroupTrendsQueryResult {
     query: InsightVizNode
     isTruncated: boolean
     totalProperties: number
     displayedProperties: number
+    /** Human-readable description of the charted window, e.g. "last 90 days" or "since Jun 15, 2026". */
+    dateRangeLabel: string
 }
 
 export function buildPropertyGroupTrendsQuery(
     eventName: string,
-    properties: SchemaPropertyGroupProperty[]
+    properties: SchemaPropertyGroupProperty[],
+    eventFirstSeen?: string | null
 ): PropertyGroupTrendsQueryResult {
     // Limit to 25 properties since we use letters B-Z for series labels (A is reserved for the base series)
     const isTruncated = properties.length > MAX_PROPERTIES
@@ -56,6 +62,16 @@ export function buildPropertyGroupTrendsQuery(
         }
     })
 
+    // Coverage is `propertyCount / eventCount`, so weeks where the event never fired evaluate to 0/0,
+    // which the formula engine renders as 0% rather than a gap. For an event younger than the lookback
+    // window that paints a misleading flat 0% line across every week before the event existed, hiding
+    // the real coverage in the final buckets. Never start the window before the event first appeared.
+    const defaultFrom = dayjs().subtract(LOOKBACK_DAYS, 'day')
+    const firstSeen = eventFirstSeen ? dayjs(eventFirstSeen) : null
+    const clampedFrom = firstSeen && firstSeen.isValid() && firstSeen.isAfter(defaultFrom) ? firstSeen : null
+    const dateFrom = clampedFrom ? clampedFrom.format('YYYY-MM-DD') : `-${LOOKBACK_DAYS}d`
+    const dateRangeLabel = clampedFrom ? `since ${clampedFrom.format('MMM D, YYYY')}` : `last ${LOOKBACK_DAYS} days`
+
     const trendsQuery: TrendsQuery = {
         kind: NodeKind.TrendsQuery,
         series,
@@ -63,7 +79,7 @@ export function buildPropertyGroupTrendsQuery(
         interval: 'week',
         dateRange: {
             date_to: null,
-            date_from: '-90d',
+            date_from: dateFrom,
             explicitDate: false,
         },
         trendsFilter: {
@@ -85,5 +101,6 @@ export function buildPropertyGroupTrendsQuery(
         isTruncated,
         totalProperties: properties.length,
         displayedProperties: limitedProperties.length,
+        dateRangeLabel,
     }
 }


### PR DESCRIPTION
## Problem

The property coverage trends chart on an event's Schema section (Data management → Event definitions → the event → Schema) plots per-property coverage as `propertyCount / eventCount * 100`, weekly, over a fixed 90-day window.

For any week in that window where the event had **zero** occurrences, the per-week formula evaluates `0 / 0`. Empty buckets are filled with `0` before the formula runs (the trends `FormulaAST` can't handle nulls), so those weeks render as **0% coverage** rather than "no data". For an event younger than 90 days (or one that only recently started firing), that paints a flat 0% line across every week before the event existed and squeezes the real coverage into the last buckets at the right edge. It reads as "0% coverage" when coverage is actually ~100%, and the one informative point is a pixel wide and hard to hover.

The coverage series for a recently-started event comes back as:

```
[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 100, 100, 100]
 └──────── weeks before the event existed = "0%" ───────┘  └ real ┘
```

## Changes

Clamp the chart's window start to the event's first-seen date (`EventDefinition.created_at`) so it never extends before the event could have produced data:

- Established events (first seen more than 90 days ago) keep the full 90-day window, unchanged.
- Younger events start at first-seen, which drops the phantom 0% weeks entirely (the series above becomes `[100, 100, 100]`).

The card heading now reflects the real window: `Property Coverage Trends (last 90 days)` or `Property Coverage Trends (since Jun 15, 2026)`.

Properties instrumented after the event started still show their real 0% → 100% ramp, because the denominator (event count) is non-zero in those weeks. The clamp only removes weeks where the event itself never fired.

## How did you test this code?

Automated checks (run by PostHog Code):

- New Jest unit test `propertyGroupTrendsQuery.test.ts` (**6/6 pass**). Covers the coverage-formula shape, the 25-property truncation, and the new clamp (younger-than-90d sets the window start to first-seen; older, missing, or unparseable first-seen falls back to the 90d default). The clamp cases guard the exact regression fixed here; no existing test exercised this pure function.
- `oxlint --fix` + `oxfmt` on the changed files: clean, 0 warnings/errors.
- `tsgo --noEmit` (full frontend typecheck): no new errors in the changed files.
- Validated the query shape via the trends query API: clamping `date_from` to first-seen returns clean ~100% values with no leading zeros.

Manual UI testing (local stack, via Data management > Event definitions > the event > Schema section):

- Seeded a young event (first seen 21 days ago) with a property group of three properties at different coverage levels (~100% / ~75% / ~45%) and three weeks of events, reproducing the clamp scenario.
- Confirmed the card heading reads `Property Coverage Trends (since Jun 9, 2026)` (clamped to the event's first-seen date) instead of the old `(90 days)`.
- Confirmed the chart starts at the first-seen week with no leading flat-0% weeks, and the three property lines render at their expected coverage levels.

> 📸 **Screenshot:** _paste the Property Coverage Trends card from the event's Schema section here_

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). DRI: @christiaan-ph

Investigated from a report that this chart showed a flat 0% line. Root cause is `FormulaAST` coercing `0/0` to `0` for empty weeks, a behavior shared by every formula insight, so deliberately not changed globally. Considered three fixes: (a) change the global formula engine, (b) null-fill empty buckets in the trends runner, (c) clamp the window to the event lifetime. Chose (c) as the lowest-risk, feature-local change; (a) and (b) have a much broader blast radius.

Skills invoked: `/writing-tests` (repo skill, used to gate and shape the unit test). Tooling: PostHog Code agent with the PostHog MCP (trends/SQL queries for reproduction).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
