### PR TITLE
refactor(bigquery-batch-export): Move to async write client

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -21,7 +21,6 @@ import google.auth.exceptions
 import google.auth.transport.requests
 import google.auth.impersonated_credentials
 from google.api_core.exceptions import (
-    Aborted,
     BadRequest,
     Forbidden,
     GatewayTimeout,
@@ -32,11 +31,10 @@ from google.api_core.exceptions import (
     ServiceUnavailable,
     TooManyRequests,
 )
-from google.cloud import bigquery, bigquery_storage_v1, iam_admin_v1
+from google.cloud import bigquery, iam_admin_v1
 from google.cloud.bigquery.table import RowIterator, _EmptyRowIterator
-from google.cloud.bigquery_storage_v1 import types
-from google.cloud.bigquery_storage_v1.services.big_query_write.transports import BigQueryWriteGrpcTransport
-from google.cloud.bigquery_storage_v1.writer import AppendRowsStream
+from google.cloud.bigquery_storage import BigQueryWriteAsyncClient, types
+from google.cloud.bigquery_storage_v1.services.big_query_write.transports import BigQueryWriteGrpcAsyncIOTransport
 from google.oauth2 import service_account
 from structlog.contextvars import bind_contextvars
 from temporalio import activity, workflow
@@ -1158,27 +1156,45 @@ class BigQueryConsumer(Consumer):
         self.current_buffer = io.BytesIO()
 
 
+_RETRYABLE_STATUS = {
+    grpc.StatusCode.UNAVAILABLE,
+    grpc.StatusCode.ABORTED,
+    grpc.StatusCode.INTERNAL,
+    grpc.StatusCode.DEADLINE_EXCEEDED,
+    grpc.StatusCode.RESOURCE_EXHAUSTED,
+    grpc.StatusCode.CANCELLED,
+}
+_RETRYABLE_CODES = {s.value[0] for s in _RETRYABLE_STATUS}
+
+
+def get_bigquery_write_async_client(credentials) -> BigQueryWriteAsyncClient:
+    """Create a new BigQuery storage write async client."""
+    channel = BigQueryWriteGrpcAsyncIOTransport.create_channel(
+        credentials=credentials,
+        compression=grpc.Compression.Gzip,
+    )
+    transport = BigQueryWriteGrpcAsyncIOTransport(channel=channel)
+    client = BigQueryWriteAsyncClient(
+        transport=transport,
+    )
+    return client
+
+
 class BigQueryStorageConsumer(Consumer):
     """Consume serialized record batch bytes to a BigQuery storage stream."""
 
     def __init__(
         self,
-        client: BigQueryClient,
+        client: BigQueryWriteAsyncClient,
         table: BigQueryTable,
         transformer: SerializedStreamTransformer,
         model: str = "events",
     ):
         super().__init__(model=model)
-        channel = BigQueryWriteGrpcTransport.create_channel(
-            credentials=client.sync_client._credentials,
-            compression=grpc.Compression.Gzip,
-        )
-        transport = BigQueryWriteGrpcTransport(channel=channel)
-        self.write_client = bigquery_storage_v1.BigQueryWriteClient(
-            transport=transport,
-        )
-        self.stream: AppendRowsStream | None = None
+        self._stub = client.transport.append_rows
+        self._first = True
 
+        self.stream = None
         self.transformer = transformer
         self.table = table
         self.logger = self.logger.bind(table=self.table)
@@ -1191,8 +1207,9 @@ class BigQueryStorageConsumer(Consumer):
         self.logger.debug(
             "Send to stream starting",
         )
+
         try:
-            await asyncio.to_thread(self.send_data, data)
+            await self.send(data)
         except Exception:
             self.logger.exception("Send to stream failed")
             await self.close_stream()
@@ -1202,72 +1219,96 @@ class BigQueryStorageConsumer(Consumer):
             "Send to stream finished",
         )
 
-    def send_data(self, data: bytes, max_attempts: int = 5) -> None:
-        """Actually send the data, this is blocking."""
-        req = types.AppendRowsRequest()
-        req.arrow_rows.rows.serialized_record_batch = data
+    async def send(self, data: bytes, max_attempts: int = 5):
+        """Send a request on a gRPC stream.
 
-        # NOTE: This retry loop can generate duplicates. The default stream is
-        # at-least-once, which means the chunk could have been ingested before
-        # the connection is dropped. We can't tell whether that was the case
-        # from here and must retry the chunk. The solution would be to switch
-        #  to a PENDING stream with offsets, so that we can incrementally
-        # commit. But that is more complicated, as it requires keeping track of
-        # said offset, so we accept the duplicates for now.
-        # TODO: Evaluate switching over and do it.
+        The request will be retried up to max_attempts. This retry loop can
+        generate duplicates when using the default stream as it only offers
+        at-least-once semantics. In other words, the chunk could have been
+        ingested completely before an error is delivered to us, which means
+        retrying the same request would lead to a duplicate.
+
+        TODO: Consider switching over to a non-default stream which requires
+        offset tracking.
+        """
+
         attempt = 0
+
         while True:
+            request = self.prepare_request(data)
+
             try:
-                stream = self.stream or self.start_stream()
-                send = stream.send(req)
-                return send.result()
-            except (ServiceUnavailable, Aborted, InternalServerError):
-                attempt += 1
-                if attempt >= max_attempts:
-                    raise
+                stream = self.stream or self.open_stream()
+                await stream.write(request)
+                resp = await stream.read()
 
-                backoff = min(2**attempt, 32)
-                self.logger.warning(
-                    "Storage stream transient error encountered",
-                    attempt=attempt,
-                    backoff=backoff,
-                    exc_info=True,
+                if resp.error.code:
+                    if resp.error.code in _RETRYABLE_CODES and attempt < max_attempts:
+                        backoff = min(2**attempt, 32)
+                        self.logger.warning(
+                            "Storage stream transient error encountered", attempt=attempt, backoff=backoff
+                        )
+
+                        await self.close_stream()
+                        await asyncio.sleep(backoff)
+                        attempt += 1
+                        continue
+
+                    raise RuntimeError(f"{resp.error.code}: {resp.error.message}")
+
+                return resp
+
+            except grpc.aio.AioRpcError as exc:
+                if exc.code() in _RETRYABLE_STATUS and attempt < max_attempts:
+                    backoff = min(2**attempt, 32)
+                    self.logger.warning("Storage stream transient error encountered", attempt=attempt, backoff=backoff)
+
+                    await self.close_stream()
+                    await asyncio.sleep(backoff)
+                    attempt += 1
+                    continue
+
+                raise
+
+    def prepare_request(self, data: bytes):
+        req = types.AppendRowsRequest(  # type: ignore
+            arrow_rows=types.AppendRowsRequest.ArrowData(  # type: ignore
+                rows=types.ArrowRecordBatch(  # type: ignore
+                    serialized_record_batch=data,
                 )
-                try:
-                    # Reset the stream for the next attempt
-                    stream.close()
-                except Exception:
-                    pass
-                finally:
-                    self.stream = None
-
-                time.sleep(backoff)
-
-    def start_stream(self) -> AppendRowsStream:
-        """Start an append rows stream."""
-        stream_name = (
-            f"projects/{self.table.project_id}/datasets/{self.table.dataset_id}/tables/{self.table.name}/_default"
+            )
         )
-        template = types.AppendRowsRequest()
-        template.write_stream = stream_name
-        template.arrow_rows.writer_schema.serialized_schema = self.transformer.schema.serialize().to_pybytes()
-        self.stream = AppendRowsStream(self.write_client, template)
-        return self.stream
+
+        if self._first:
+            stream_name = (
+                f"projects/{self.table.project_id}/datasets/{self.table.dataset_id}/tables/{self.table.name}/_default"
+            )
+            req.write_stream = stream_name
+            schema = self.transformer.schema.serialize().to_pybytes()
+            req.arrow_rows.writer_schema = types.ArrowSchema(serialized_schema=schema)  # type: ignore
+            self._first = False
+
+        return req
+
+    def open_stream(self):
+        """Open a new stream."""
+        stream = self._stub()  # type: ignore
+        self.stream = stream  # type: ignore
+        return stream
 
     async def close_stream(self) -> None:
-        """Close open stream, if any."""
-        if not self.stream:
-            return
+        """Attempt to close current stream."""
+        stream = self.stream
 
-        try:
-            await asyncio.to_thread(self.stream.close)
-            self.stream = None
-        except bigquery_storage_v1.exceptions.StreamClosedError:
-            # Stream was already closed, so nothing to do here.
-            self.stream = None
-        except Exception:
-            self.logger.exception("Stream close failed")
-            raise
+        if stream is not None:
+            try:  # type: ignore
+                await stream.done_writing()
+            except Exception:
+                # Stream is already dead, move on
+                self.logger.warning("Stream close failed", exc_info=True)
+
+        self.stream = None
+        self._first = True
 
     async def finalize_file(self) -> None:
         """No files here, just serialized bytes."""
@@ -1275,9 +1316,8 @@ class BigQueryStorageConsumer(Consumer):
         pass
 
     async def finalize(self) -> None:
-        """Finalize by closing the stream and underlying client."""
+        """Finalize by closing the stream."""
         await self.close_stream()
-        await asyncio.to_thread(self.write_client.transport.close)
 
 
 async def run_consumers(
@@ -1289,73 +1329,98 @@ async def run_consumers(
     can_perform_merge: bool,
     max_consumers: int,
     model: str = "events",
-    use_storage_stream: bool = False,
 ) -> BatchExportResult:
     tasks = []
     max_file_size_bytes_per_consumer = settings.BATCH_EXPORT_BIGQUERY_UPLOAD_CHUNK_SIZE_BYTES // max_consumers
 
     async with asyncio.TaskGroup() as tg:
         for _ in range(max_consumers):
-            if use_storage_stream:
-                serialized = SerializedStreamTransformer()
-                transformer: ChunkTransformerProtocol = PipelineTransformer(
+            consumer = BigQueryConsumer(
+                client=client,
+                table=table,
+                file_format=file_format,
+                model=model,
+            )
+            if can_perform_merge:
+                transformer = PipelineTransformer(
                     transformers=(
                         SchemaTransformer(
                             table=table,
-                            extra_compatible_types={
-                                # BigQuery Storage requires INTEGER columns be signed
-                                # Cast is safe and will throw on overflow.
-                                (pa.uint64(), pa.int64()): functools.partial(_cast_as_type, type=pa.int64()),
-                                (pa.uint8(), pa.int64()): functools.partial(_cast_as_type, type=pa.int64()),
-                                # BigQuery Storage requires that TIMESTAMP columns be 'us'
-                                (pa.timestamp("ms", tz="UTC"), pa.timestamp("us", tz="UTC")): functools.partial(
-                                    _cast_to_lossless_timestamp, unit="us"
-                                ),
-                                (pa.timestamp("ms", tz="Etc/UTC"), pa.timestamp("us", tz="UTC")): functools.partial(
-                                    _cast_to_lossless_timestamp, unit="us"
-                                ),
-                            },
                         ),
-                        serialized,
+                        ParquetStreamTransformer(
+                            compression="zstd",
+                            max_file_size_bytes=max_file_size_bytes_per_consumer,
+                        ),
                     )
-                )
-                consumer: Consumer = BigQueryStorageConsumer(
-                    client=client,
-                    table=table,
-                    transformer=serialized,
-                    model=model,
                 )
             else:
-                consumer = BigQueryConsumer(
-                    client=client,
-                    table=table,
-                    file_format=file_format,
-                    model=model,
+                transformer = PipelineTransformer(
+                    transformers=(
+                        SchemaTransformer(
+                            table=table,
+                        ),
+                        JSONLStreamTransformer(
+                            max_file_size_bytes=max_file_size_bytes_per_consumer,
+                        ),
+                    )
                 )
-                if can_perform_merge:
-                    transformer = PipelineTransformer(
-                        transformers=(
-                            SchemaTransformer(
-                                table=table,
-                            ),
-                            ParquetStreamTransformer(
-                                compression="zstd",
-                                max_file_size_bytes=max_file_size_bytes_per_consumer,
-                            ),
-                        )
-                    )
-                else:
-                    transformer = PipelineTransformer(
-                        transformers=(
-                            SchemaTransformer(
-                                table=table,
-                            ),
-                            JSONLStreamTransformer(
-                                max_file_size_bytes=max_file_size_bytes_per_consumer,
-                            ),
-                        )
-                    )
 
+            tasks.append(
+                tg.create_task(
+                    consumer.start(
+                        queue=queue,
+                        producer_task=producer_task,
+                        transformer=transformer,
+                        json_columns=(),
+                    )
+                )
+            )
+
+    await raise_on_task_failure(producer_task)
+
+    return reduce_batch_export_results(task.result() for task in tasks)
+
+
+async def run_storage_stream_consumers(
+    client: BigQueryWriteAsyncClient,
+    table: BigQueryTable,
+    producer_task: asyncio.Task[None],
+    queue: RecordBatchQueue,
+    max_consumers: int,
+    model: str = "events",
+) -> BatchExportResult:
+    tasks = []
+    serialized = SerializedStreamTransformer()
+    transformer: ChunkTransformerProtocol = PipelineTransformer(
+        transformers=(
+            SchemaTransformer(
+                table=table,
+                extra_compatible_types={
+                    # BigQuery Storage requires INTEGER columns be signed
+                    # Cast is safe and will throw on overflow.
+                    (pa.uint64(), pa.int64()): functools.partial(_cast_as_type, type=pa.int64()),
+                    (pa.uint8(), pa.int64()): functools.partial(_cast_as_type, type=pa.int64()),
+                    # BigQuery Storage requires that TIMESTAMP columns be 'us'
+                    (pa.timestamp("ms", tz="UTC"), pa.timestamp("us", tz="UTC")): functools.partial(
+                        _cast_to_lossless_timestamp, unit="us"
+                    ),
+                    (pa.timestamp("ms", tz="Etc/UTC"), pa.timestamp("us", tz="UTC")): functools.partial(
+                        _cast_to_lossless_timestamp, unit="us"
+                    ),
+                },
+            ),
+            serialized,
+        )
+    )
+
+    async with asyncio.TaskGroup() as tg:
+        for _ in range(max_consumers):
+            consumer: Consumer = BigQueryStorageConsumer(
+                client=client,
+                table=table,
+                transformer=serialized,
+                model=model,
+            )
             tasks.append(
                 tg.create_task(
                     consumer.start(
@@ -1648,8 +1713,9 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                             )
                         )
 
+                        write_client = get_bigquery_write_async_client(bq_client.sync_client._credentials)
                         consumer = BigQueryStorageConsumer(
-                            client=bq_client,
+                            client=write_client,
                             table=bigquery_consumer_table,
                             transformer=serialized,
                             model=model.name if isinstance(model, BatchExportModel) else "events",
@@ -1689,17 +1755,27 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                     )
 
                 else:
-                    result = await run_consumers(
-                        client=bq_client,
-                        table=bigquery_consumer_table,
-                        file_format=file_format,
-                        producer_task=producer_task,
-                        queue=queue,
-                        can_perform_merge=can_perform_merge,
-                        max_consumers=settings.BATCH_EXPORT_BIGQUERY_MAX_CONSUMERS,
-                        model=model.name if isinstance(model, BatchExportModel) else "events",
-                        use_storage_stream=use_storage_stream,
-                    )
+                    if use_storage_stream:
+                        write_client = get_bigquery_write_async_client(bq_client.sync_client._credentials)
+                        result = await run_storage_stream_consumers(
+                            client=write_client,
+                            table=bigquery_consumer_table,
+                            producer_task=producer_task,
+                            queue=queue,
+                            max_consumers=settings.BATCH_EXPORT_BIGQUERY_MAX_CONSUMERS,
+                            model=model.name if isinstance(model, BatchExportModel) else "events",
+                        )
+                    else:
+                        result = await run_consumers(
+                            client=bq_client,
+                            table=bigquery_consumer_table,
+                            file_format=file_format,
+                            producer_task=producer_task,
+                            queue=queue,
+                            can_perform_merge=can_perform_merge,
+                            max_consumers=settings.BATCH_EXPORT_BIGQUERY_MAX_CONSUMERS,
+                            model=model.name if isinstance(model, BatchExportModel) else "events",
+                        )
 
                 if can_perform_merge:
                     _ = await bq_client.merge_tables(


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

The current implementation of the storage write consumer uses a sync client. This requires multiple threads being opened, which is costly. The BigQuery library has an async client, so we should use it.

It is a bit awkward to use the client, as the async client expects an iterator of requests, whereas our consumers process individual chunks. Moreover, a lot of type hints are not applicable or incorrect, so we have to ignore types a lot more than I would wish. Still, this passes all tests, without threading overhead, and should scale better by adding more consumers as consumers are not starting a bunch of threads.

Another optimization is that we do not need one transformer per consumer, but rather all consumers can share the transformer, as there is no state to track (besides the schema, which is only tracked once).

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

See above.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran all tests with a hardcoded `use_storage_stream = True` and `max_consumers = 10`.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

Had some back and forth with claude to figure out the internals of the bigquery client.

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
