### PR TITLE
fix(google_ads): retry quota RESOURCE_EXHAUSTED with in-process backoff

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -553,9 +553,12 @@ def _is_transient_grpc_error(exc: BaseException) -> bool:
     if isinstance(candidate, google_api_exceptions.ResourceExhausted):
         return _RECEIVE_LIMIT_EXHAUSTED_SIGNATURE not in str(candidate)
     code = getattr(candidate, "code", None)
-    if not (callable(code) and code() in _TRANSIENT_GRPC_STATUS_CODES):
+    if not callable(code):
         return False
-    if code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
+    status = code()
+    if status not in _TRANSIENT_GRPC_STATUS_CODES:
+        return False
+    if status == grpc.StatusCode.RESOURCE_EXHAUSTED:
         return _RECEIVE_LIMIT_EXHAUSTED_SIGNATURE not in str(candidate)
     return True
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -515,32 +515,49 @@ def google_ads_source(
     )
 
 
-# Google flags both ``UNAVAILABLE`` (e.g. its frontend returning ``502:Bad Gateway`` — the request
-# never reached a healthy backend) and ``INTERNAL`` ("Internal error encountered." from the
-# backend) as transient, retry-with-backoff statuses: a fresh attempt after a short backoff usually
+# Google flags ``UNAVAILABLE`` (e.g. its frontend returning ``502:Bad Gateway`` — the request never
+# reached a healthy backend), ``INTERNAL`` ("Internal error encountered." from the backend), and
+# ``RESOURCE_EXHAUSTED`` ("Resource has been exhausted (e.g. check quota)." — a quota/rate-limit
+# rejection) as transient, retry-with-backoff statuses: a fresh attempt after a short backoff usually
 # succeeds. Riding the blip out in-process keeps the whole import activity from failing — which
 # would otherwise re-fetch schemas, rebuild the gRPC client, and restart pagination from the last
 # checkpoint — and avoids the captured error-tracking noise.
 _MAX_TRANSIENT_SEARCH_ATTEMPTS = 4
 
-_TRANSIENT_GRPC_STATUS_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.INTERNAL})
+_TRANSIENT_GRPC_STATUS_CODES = frozenset(
+    {grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.INTERNAL, grpc.StatusCode.RESOURCE_EXHAUSTED}
+)
+
+# A client-side "Received message larger than max" abort also carries ``RESOURCE_EXHAUSTED`` (see the
+# receive-limit note at the top of this module), but it is deterministic — a retry re-requests the
+# same oversized page and fails identically — so it is excluded from the transient set. Raising the
+# receive limit, not retrying, is what addresses it.
+_RECEIVE_LIMIT_EXHAUSTED_SIGNATURE = "Received message larger than max"
 
 
 def _is_transient_grpc_error(exc: BaseException) -> bool:
     """Return True for a transient gRPC failure Google's guidance says to retry.
 
     The gapic transport usually surfaces these as ``google.api_core.exceptions.ServiceUnavailable``
-    / ``InternalServerError``, but the raw ``grpc`` ``_InactiveRpcError`` (whose ``code()`` returns
-    the ``StatusCode``) can also propagate. The Google Ads SDK additionally re-wraps the transport
-    error in a ``GoogleAdsException`` when it can pull an ads ``failure`` from the trailing metadata
-    (e.g. a backend ``DEADLINE_EXCEEDED`` returned alongside the status); the gRPC status then lives
-    on the wrapped ``error``, so we unwrap and inspect it too.
+    / ``InternalServerError`` / ``ResourceExhausted``, but the raw ``grpc`` ``_InactiveRpcError``
+    (whose ``code()`` returns the ``StatusCode``) can also propagate. The Google Ads SDK additionally
+    re-wraps the transport error in a ``GoogleAdsException`` when it can pull an ads ``failure`` from
+    the trailing metadata (e.g. a backend ``DEADLINE_EXCEEDED`` returned alongside the status); the
+    gRPC status then lives on the wrapped ``error``, so we unwrap and inspect it too.
     """
     if isinstance(exc, google_api_exceptions.ServiceUnavailable | google_api_exceptions.InternalServerError):
         return True
     candidate: typing.Any = exc.error if isinstance(exc, GoogleAdsException) else exc
+    # ``ResourceExhausted`` exposes ``code`` as an HTTP int, not a callable ``StatusCode``, so the
+    # gapic-wrapped form is matched by type rather than via the ``code()`` check below.
+    if isinstance(candidate, google_api_exceptions.ResourceExhausted):
+        return _RECEIVE_LIMIT_EXHAUSTED_SIGNATURE not in str(candidate)
     code = getattr(candidate, "code", None)
-    return callable(code) and code() in _TRANSIENT_GRPC_STATUS_CODES
+    if not (callable(code) and code() in _TRANSIENT_GRPC_STATUS_CODES):
+        return False
+    if code() == grpc.StatusCode.RESOURCE_EXHAUSTED:
+        return _RECEIVE_LIMIT_EXHAUSTED_SIGNATURE not in str(candidate)
+    return True
 
 
 def _search_with_transient_retry(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -594,15 +594,23 @@ class TestTransientClientInitErrorDetection:
 class _StatusCodeRpcError(grpc.RpcError):
     """A raw gRPC error whose ``code()`` reports a given ``StatusCode`` (``_InactiveRpcError`` shape)."""
 
-    def __init__(self, status_code: grpc.StatusCode):
+    def __init__(self, status_code: grpc.StatusCode, message: str = ""):
         self._status_code = status_code
+        self._message = message
 
     def code(self) -> grpc.StatusCode:
         return self._status_code
 
+    def __str__(self) -> str:
+        return self._message
+
 
 def _grpc_unavailable_error() -> grpc.RpcError:
     return _StatusCodeRpcError(grpc.StatusCode.UNAVAILABLE)
+
+
+def _grpc_resource_exhausted_error(message: str = "") -> grpc.RpcError:
+    return _StatusCodeRpcError(grpc.StatusCode.RESOURCE_EXHAUSTED, message)
 
 
 def _google_ads_exception_wrapping(grpc_error: grpc.RpcError) -> GoogleAdsException:
@@ -629,6 +637,18 @@ class TestTransientGrpcErrorDetection:
             # gapic wrapper and the raw _InactiveRpcError must both be ridden out in-process.
             (google_api_exceptions.InternalServerError("500 Internal error encountered."), True),
             (_grpc_internal_error(), True),
+            # A quota/rate-limit RESOURCE_EXHAUSTED ("Resource has been exhausted (e.g. check
+            # quota).") is Google-flagged retryable — both the gapic wrapper (whose ``code`` is an
+            # HTTP int, not a callable ``StatusCode``) and the raw _InactiveRpcError must be ridden out.
+            (google_api_exceptions.ResourceExhausted("Resource has been exhausted (e.g. check quota)."), True),
+            (_grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota)."), True),
+            # A client-side "Received message larger than max" abort is RESOURCE_EXHAUSTED too, but is
+            # deterministic — it must not be retried in-process regardless of which shape it arrives as.
+            (
+                google_api_exceptions.ResourceExhausted("Received message larger than max (90000000 vs. 67108864)"),
+                False,
+            ),
+            (_grpc_resource_exhausted_error("Received message larger than max (90000000 vs. 67108864)"), False),
             # A different gapic error must not be treated as transient.
             (google_api_exceptions.PermissionDenied("PERMISSION_DENIED"), False),
             # Google Ads API errors carry no transient gRPC status — they route through the existing
@@ -666,6 +686,8 @@ class TestSearchTransientRetry:
             _google_ads_exception_wrapping(_grpc_unavailable_error()),
             google_api_exceptions.InternalServerError("500 Internal error encountered."),
             _grpc_internal_error(),
+            google_api_exceptions.ResourceExhausted("Resource has been exhausted (e.g. check quota)."),
+            _grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota)."),
         ],
     )
     def test_rides_out_transient_error(self, error):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -642,6 +642,14 @@ class TestTransientGrpcErrorDetection:
             # HTTP int, not a callable ``StatusCode``) and the raw _InactiveRpcError must be ridden out.
             (google_api_exceptions.ResourceExhausted("Resource has been exhausted (e.g. check quota)."), True),
             (_grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota)."), True),
+            # The SDK can also wrap a RESOURCE_EXHAUSTED transport status in a GoogleAdsException — the
+            # unwrapped raw _InactiveRpcError then takes the ``code()`` path with the signature guard.
+            (
+                _google_ads_exception_wrapping(
+                    _grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota).")
+                ),
+                True,
+            ),
             # A client-side "Received message larger than max" abort is RESOURCE_EXHAUSTED too, but is
             # deterministic — it must not be retried in-process regardless of which shape it arrives as.
             (
@@ -649,6 +657,12 @@ class TestTransientGrpcErrorDetection:
                 False,
             ),
             (_grpc_resource_exhausted_error("Received message larger than max (90000000 vs. 67108864)"), False),
+            (
+                _google_ads_exception_wrapping(
+                    _grpc_resource_exhausted_error("Received message larger than max (90000000 vs. 67108864)")
+                ),
+                False,
+            ),
             # A different gapic error must not be treated as transient.
             (google_api_exceptions.PermissionDenied("PERMISSION_DENIED"), False),
             # Google Ads API errors carry no transient gRPC status — they route through the existing
@@ -688,6 +702,9 @@ class TestSearchTransientRetry:
             _grpc_internal_error(),
             google_api_exceptions.ResourceExhausted("Resource has been exhausted (e.g. check quota)."),
             _grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota)."),
+            _google_ads_exception_wrapping(
+                _grpc_resource_exhausted_error("Resource has been exhausted (e.g. check quota).")
+            ),
         ],
     )
     def test_rides_out_transient_error(self, error):


### PR DESCRIPTION
## Problem

The `google_ads` data-warehouse import source surfaced a live error in error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f13e9-aa81-7a20-a5ba-07518f9167d1)):

```
_InactiveRpcError ... status = StatusCode.RESOURCE_EXHAUSTED
details = "Resource has been exhausted (e.g. check quota)."
```

This is a gRPC `RESOURCE_EXHAUSTED` (status 8) returned by Google's Ads API endpoint — a quota/rate-limit rejection. It fired as a short burst across several syncs at once. The stack originates in our code at `_search_with_transient_retry` → `_search_as_arrow_tables` → `get_rows` in `google_ads.py`.

Google flags `RESOURCE_EXHAUSTED` as a retry-with-backoff status, but our in-process transient-retry set only covered `UNAVAILABLE` and `INTERNAL`. So a recoverable rate-limit blip was re-raised immediately and showed up as avoidable error-tracking noise, instead of being ridden out in-process like the other retryable statuses.

## Changes

- Add `grpc.StatusCode.RESOURCE_EXHAUSTED` to the in-process transient-retry set so a quota/rate-limit rejection is retried with the existing short backoff before falling through to Temporal's retry policy.
- Match both shapes the status arrives in: the gapic `ResourceExhausted` wrapper (whose `code` is an HTTP int, not a callable `StatusCode`, so it needs a type check) and the raw `_InactiveRpcError`.
- Explicitly **exclude** the client-side "Received message larger than max" abort, which also carries `RESOURCE_EXHAUSTED` but is deterministic — retrying it would re-request the same oversized page and mask a real limit. Raising the receive limit (already in place) is what addresses that case.

This stays scoped to this one status in this source — no change to global retry policy or `NonRetryableErrors`.

## How did you test this code?

I'm an agent. I ran the source's existing test suite plus the new cases (all green):

- `TestTransientGrpcErrorDetection` — added parametrized cases asserting both the gapic and raw shapes of a quota `RESOURCE_EXHAUSTED` are transient, and that the "Received message larger than max" variant of each shape is **not**.
- `TestSearchTransientRetry::test_rides_out_transient_error` — added quota `RESOURCE_EXHAUSTED` cases proving the search loop retries and then serves the page with no data lost.
- Full file: `100 passed`.

These catch a regression no existing test covered: a quota rate-limit being treated as fatal, and the inverse risk of the deterministic message-size abort being retried/masked.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used the PostHog error-tracking MCP tools to confirm the issue (full stack trace, exception types, frequency) and verify the failure originates in `google_ads.py` rather than only appearing in serialized context.

Decision: treated this as a fixable fragility, not a `NonRetryableErrors` case. `RESOURCE_EXHAUSTED` is a recoverable rate-limit that Google says to retry with backoff, so adding it to `NonRetryableErrors` would wrongly stop retrying a transient condition. The main subtlety was that the same status code is also produced by a deterministic client-side message-size abort — handled by excluding that signature so we don't mask a genuine limit. Checked open PRs (including the maintainer's) for an existing fix; none addresses this.