### PR TITLE
feat(replay-vision): improve scanner prompt with PostHog AI

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3951,6 +3951,12 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: '*'
+        version: 5.17.0
+      '@testing-library/react':
+        specifier: '*'
+        version: 14.3.1(@types/react@18.3.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       kea-test-utils:
         specifier: 'catalog:'
         version: 0.2.4(kea@4.0.0-pre.5(react@18.3.1))
@@ -32709,10 +32715,10 @@ snapshots:
 
   '@testing-library/jest-dom@5.17.0':
     dependencies:
-      '@adobe/css-tools': 4.0.1
+      '@adobe/css-tools': 4.5.0
       '@babel/runtime': 7.29.2
       '@types/testing-library__jest-dom': 5.14.5
-      aria-query: 5.1.3
+      aria-query: 5.3.0
       chalk: 3.0.0
       css.escape: 1.5.1
       dom-accessibility-api: 0.5.14

--- a/products/replay_vision/frontend/observations/ImproveScannerPromptButton.test.tsx
+++ b/products/replay_vision/frontend/observations/ImproveScannerPromptButton.test.tsx
@@ -1,0 +1,105 @@
+import '@testing-library/jest-dom'
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { Provider } from 'kea'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { initKeaTests } from '~/test/init'
+import { SidePanelTab } from '~/types'
+
+import type { ReplayObservationApi } from '../generated/api.schemas'
+import {
+    ImproveScannerPromptButton,
+    buildImproveScannerPromptMessage,
+    describeObservationOutcome,
+} from './ImproveScannerPromptButton'
+
+const observationWithOutput = (modelOutput: Record<string, unknown>): ReplayObservationApi =>
+    ({ scanner_result: { model_output: modelOutput, signals_count: 0 } }) as unknown as ReplayObservationApi
+
+describe('ImproveScannerPromptButton', () => {
+    describe('describeObservationOutcome', () => {
+        it('prefers a monitor verdict', () => {
+            expect(describeObservationOutcome(observationWithOutput({ verdict: 'no' }))).toBe('Verdict: no')
+        })
+
+        it('falls back to a scorer score', () => {
+            expect(describeObservationOutcome(observationWithOutput({ score: 3 }))).toBe('Score: 3')
+        })
+
+        it('falls back to classifier tags', () => {
+            expect(describeObservationOutcome(observationWithOutput({ tags: ['billing', 'churn'] }))).toBe(
+                'Tags: billing, churn'
+            )
+        })
+
+        it('returns null when there is no verdict, score or tags', () => {
+            expect(describeObservationOutcome(observationWithOutput({ summary: 'a summary' }))).toBeNull()
+        })
+    })
+
+    describe('buildImproveScannerPromptMessage', () => {
+        it('includes the prompt, outcome, reasoning and a rewrite instruction', () => {
+            const message = buildImproveScannerPromptMessage({
+                scannerName: 'Checkout drop-off',
+                scannerType: 'monitor',
+                prompt: 'Did the user abandon checkout?',
+                outcome: 'Verdict: no',
+                reasoning: 'The user closed the tab on the payment step.',
+            })
+
+            expect(message).toContain('Checkout drop-off')
+            expect(message).toContain('Scanner type: monitor')
+            expect(message).toContain('Did the user abandon checkout?')
+            expect(message).toContain('Result on this session: Verdict: no')
+            expect(message).toContain("Model's reasoning: The user closed the tab on the payment step.")
+            expect(message).toContain('rewrite the scanner prompt')
+        })
+
+        it('omits the outcome and reasoning lines when absent', () => {
+            const message = buildImproveScannerPromptMessage({
+                scannerName: 'Session summary',
+                scannerType: 'summarizer',
+                prompt: 'Summarize the user goal.',
+            })
+
+            expect(message).not.toContain('Result on this session:')
+            expect(message).not.toContain("Model's reasoning:")
+        })
+    })
+
+    describe('component', () => {
+        beforeEach(() => {
+            initKeaTests()
+            sidePanelStateLogic.mount()
+        })
+
+        afterEach(() => {
+            cleanup()
+        })
+
+        it('opens PostHog AI with the prompt, outcome and reasoning, and auto-runs it', () => {
+            render(
+                <Provider>
+                    <ImproveScannerPromptButton
+                        scannerName="Checkout drop-off"
+                        scannerType="monitor"
+                        prompt="Did the user abandon checkout?"
+                        outcome="Verdict: no"
+                        reasoning="The user closed the tab on the payment step."
+                    />
+                </Provider>
+            )
+
+            fireEvent.click(screen.getByText('Ask PostHog AI to improve this prompt'))
+
+            expect(sidePanelStateLogic.values.selectedTab).toBe(SidePanelTab.Max)
+            const options = sidePanelStateLogic.values.selectedTabOptions ?? ''
+            // Leading "!" tells PostHog AI to auto-run the message.
+            expect(options.startsWith('!')).toBe(true)
+            expect(options).toContain('Did the user abandon checkout?')
+            expect(options).toContain('Result on this session: Verdict: no')
+            expect(options).toContain('The user closed the tab on the payment step.')
+        })
+    })
+})

--- a/products/replay_vision/frontend/observations/ImproveScannerPromptButton.tsx
+++ b/products/replay_vision/frontend/observations/ImproveScannerPromptButton.tsx
@@ -1,0 +1,106 @@
+import { useActions } from 'kea'
+
+import { IconAI } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { sidePanelStateLogic } from '~/layout/navigation-3000/sidepanel/sidePanelStateLogic'
+import { SidePanelTab } from '~/types'
+
+import type { ReplayObservationApi } from '../generated/api.schemas'
+import { readScore, readTags, readVerdict } from '../utils/observation'
+
+/** One-line summary of what the scanner concluded on this session, or null if there's nothing to report. */
+export function describeObservationOutcome(observation: ReplayObservationApi): string | null {
+    const verdict = readVerdict(observation)
+    if (verdict) {
+        return `Verdict: ${verdict}`
+    }
+    const score = readScore(observation)
+    if (score !== null) {
+        return `Score: ${score}`
+    }
+    const tags = readTags(observation)
+    if (tags.length) {
+        return `Tags: ${tags.join(', ')}`
+    }
+    return null
+}
+
+/**
+ * Builds the message handed to PostHog AI when the user asks it to improve a scanner prompt.
+ * Everything the assistant needs is inlined: the current prompt, the outcome, and the reasoning.
+ */
+export function buildImproveScannerPromptMessage({
+    scannerName,
+    scannerType,
+    prompt,
+    outcome,
+    reasoning,
+}: {
+    scannerName: string
+    scannerType: string
+    prompt: string
+    outcome?: string | null
+    reasoning?: string | null
+}): string {
+    const lines = [
+        `The "${scannerName}" replay scanner returned a result that looks wrong, and I want to improve its prompt so it does not happen again.`,
+        '',
+        `Scanner type: ${scannerType}`,
+        '',
+        'Current prompt:',
+        '"""',
+        prompt,
+        '"""',
+    ]
+    if (outcome) {
+        lines.push('', `Result on this session: ${outcome}`)
+    }
+    if (reasoning) {
+        lines.push(`Model's reasoning: ${reasoning}`)
+    }
+    lines.push(
+        '',
+        'Please rewrite the scanner prompt so it correctly handles cases like this one. Explain what you changed and why, then give me the full updated prompt I can paste into the scanner.'
+    )
+    return lines.join('\n')
+}
+
+/**
+ * One-click "Ask PostHog AI to improve this prompt" button shown on a scanner observation result.
+ * Opens PostHog AI in the side panel pre-loaded with the prompt, the outcome, and the reasoning.
+ */
+export function ImproveScannerPromptButton({
+    scannerName,
+    scannerType,
+    prompt,
+    outcome,
+    reasoning,
+}: {
+    scannerName: string
+    scannerType: string
+    prompt: string
+    outcome?: string | null
+    reasoning?: string | null
+}): JSX.Element {
+    const { openSidePanel } = useActions(sidePanelStateLogic)
+
+    return (
+        <LemonButton
+            size="xsmall"
+            type="secondary"
+            icon={<IconAI />}
+            // `!` prefix auto-runs the message in PostHog AI. The side panel carries it via kea state
+            // (not the URL), so a long scanner prompt is delivered intact.
+            onClick={() =>
+                openSidePanel(
+                    SidePanelTab.Max,
+                    `!${buildImproveScannerPromptMessage({ scannerName, scannerType, prompt, outcome, reasoning })}`
+                )
+            }
+            data-attr="replay-vision-improve-prompt-with-ai"
+        >
+            Ask PostHog AI to improve this prompt
+        </LemonButton>
+    )
+}

--- a/products/replay_vision/frontend/observations/ReplayObservation.tsx
+++ b/products/replay_vision/frontend/observations/ReplayObservation.tsx
@@ -52,6 +52,7 @@ import {
     parseIneligibleReason,
     type ScannerType,
 } from '../replay_scanners/types'
+import { ImproveScannerPromptButton, describeObservationOutcome } from './ImproveScannerPromptButton'
 import { replayObservationLogic } from './replayObservationLogic'
 import { replayObservationSceneLogic } from './replayObservationSceneLogic'
 
@@ -460,6 +461,17 @@ export function ReplayObservationSceneComponent(): JSX.Element {
                                         $recording_observed
                                     </Link>
                                 </LabeledRow>
+                            )}
+                            {prompt && scannerType && (
+                                <div className="flex justify-end pt-1">
+                                    <ImproveScannerPromptButton
+                                        scannerName={scannerName}
+                                        scannerType={scannerType}
+                                        prompt={prompt}
+                                        outcome={describeObservationOutcome(observation)}
+                                        reasoning={reasoning}
+                                    />
+                                </div>
                             )}
                         </div>
                     )}

--- a/products/replay_vision/package.json
+++ b/products/replay_vision/package.json
@@ -12,6 +12,8 @@
         "lodash.uniqby": "^4.7.0"
     },
     "devDependencies": {
+        "@testing-library/jest-dom": "*",
+        "@testing-library/react": "*",
         "kea-test-utils": "catalog:"
     },
     "peerDependencies": {


### PR DESCRIPTION
> Stacked on #66775 (classifier-suggest-tags) — this PR's base is that branch, so it reuses the scanner Max tooling and the diff shows only the changes below. Rebase/retarget to master once #66775 merges.

## Problem

When a replay scanner returns a verdict that looks wrong, the fix is almost always a prompt tweak. Today that means copying the scanner's prompt, the verdict, and the model's reasoning off the observation page and pasting them into PostHog AI by hand to get an improved prompt. It works, but it's fiddly and easy to skip.

## Changes

Adds a one-click **"Ask PostHog AI to improve this prompt"** button on a scanner observation result (the "Result" section of `ReplayObservation`, alongside the verdict and reasoning).

Clicking it opens PostHog AI **in the side panel** (in-page) pre-loaded with everything needed to fix the prompt, and auto-runs it:

- the scanner's current prompt (from the observation's `scanner_snapshot`),
- the outcome on this session (monitor verdict / scorer score / classifier tags),
- the model's reasoning,
- and an instruction to rewrite the prompt to catch cases like this one and return the full updated prompt.

Notes:

- Renders only when the observation succeeded and the scanner has a prompt.
- The message rides in kea side-panel state (`selectedTabOptions`), not the URL, so a long scanner prompt is delivered intact. The leading `!` auto-runs it, matching the existing in-app "ask PostHog AI" buttons.
- Reuses `sidePanelStateLogic`; no backend or schema changes. Fully additive.
- Adds `@testing-library/jest-dom` + `@testing-library/react` to `products/replay_vision/package.json` (dev only) so the product can have a component test — it previously had only logic tests.

## How did you test this code?

I'm an agent (Claude Code). Automated tests only:

New `ImproveScannerPromptButton.test.tsx` (7 cases):

- `describeObservationOutcome` derives the right one-line outcome for monitor (verdict), scorer (score), classifier (tags), and returns null when there's none.
- `buildImproveScannerPromptMessage` includes the prompt, outcome, reasoning, and rewrite instruction, and omits the outcome/reasoning lines when absent.
- Component: clicking opens the Max side panel (`selectedTab === Max`) with options that start with `!` (auto-run) and contain the current prompt + outcome + reasoning.

Regression these catch that existing tests don't: the message handed to PostHog AI actually carries the scanner prompt/outcome/reasoning and is auto-run, and the outcome line reflects the scanner type.

Also ran: oxlint on changed files (clean) and the frontend TypeScript check (changed files clean).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). No repo skills were required (frontend-only, no DRF / migration / generated-API surface touched).

Key decisions:

- Placed the button on the observation result (`ReplayObservation`), the surface that already shows the verdict and reasoning the user wants to act on.
- Delivery via the side panel (`openSidePanel(SidePanelTab.Max, '!…')`) rather than a new tab. The message travels in memory, so a near-limit prompt can't overflow the request URL, and the user stays on the result page.
- Inlined the prompt/outcome/reasoning into the message rather than wiring a new Max tool. The existing `draft_replay_vision_scanner_prompt` tool fills a prompt into the scanner editor form, which isn't open on the result page; inlining keeps this frontend-only and matches what users do by hand today. Auto-filling the scanner prompt straight from a result page (a silent mutation) was considered and rejected — the user should review the rewrite first.
- This was first built on the LLM-evaluations product by mistake; relocated here per request. The branch was repointed onto classifier-suggest-tags so it can build on the scanner Max tooling.
