### PR TITLE
feat(integrations): allow members to create batch-export integrations

### DIFF
--- a/posthog/api/integration.py
+++ b/posthog/api/integration.py
@@ -802,6 +802,19 @@ class GitHubOAuthAuthorizeResponseSerializer(serializers.Serializer):
     oauth_url = serializers.CharField(help_text="GitHub User OAuth URL the client should redirect to.")
 
 
+# Integration kinds that back batch export destinations. Creating these is allowed at project
+# member level (matching batch-export creation) rather than admin — their credentials live in
+# sensitive_config, which is never serialized back, so there is no info-disclosure risk.
+BATCH_EXPORT_INTEGRATION_KINDS = {
+    Integration.IntegrationKind.DATABRICKS,
+    Integration.IntegrationKind.GOOGLE_CLOUD_SERVICE_ACCOUNT,
+    Integration.IntegrationKind.AZURE_BLOB,
+    Integration.IntegrationKind.POSTGRESQL,
+    Integration.IntegrationKind.AWS_S3,
+    Integration.IntegrationKind.S3_COMPATIBLE,
+}
+
+
 @extend_schema(extensions={"x-product": "integrations"})
 class IntegrationViewSet(
     TeamAndOrgViewSetMixin,
@@ -858,6 +871,15 @@ class IntegrationViewSet(
             ]
         # Any project member may ask an admin to connect an integration — connecting still requires admin.
         if self.action == "request_access":
+            return [
+                IsAuthenticated(),
+                APIScopePermission(),
+                AccessControlPermission(),
+                TeamMemberAccessPermission(),
+            ]
+        # Batch-export-destination integrations are creatable at member level (matching batch-export
+        # creation).
+        if self.action == "create" and self.request.data.get("kind") in BATCH_EXPORT_INTEGRATION_KINDS:
             return [
                 IsAuthenticated(),
                 APIScopePermission(),

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -812,7 +812,7 @@ class TestBatchExportIntegrationMemberAccess:
             content_type="application/json",
         )
 
-        assert response.status_code != status.HTTP_403_FORBIDDEN, response.json()
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.json()
 
     @pytest.mark.parametrize("kind", ["slack", "email", "twilio"])
     def test_member_cannot_create_non_batch_export_kinds(self, kind, client: HttpClient):

--- a/posthog/api/test/test_integration.py
+++ b/posthog/api/test/test_integration.py
@@ -787,6 +787,54 @@ class TestS3CompatibleIntegration:
         assert response.json()["detail"] == expected_error_message
 
 
+class TestBatchExportIntegrationMemberAccess:
+    @pytest.fixture(autouse=True)
+    def setup_integration(self, db):
+        self.organization = Organization.objects.create(name="Test Org")
+        self.team = Team.objects.create(organization=self.organization, name="Test Team")
+        self.member = User.objects.create_and_join(
+            self.organization, "member@posthog.com", "test", level=OrganizationMembership.Level.MEMBER
+        )
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["databricks", "google-cloud-service-account", "azure-blob", "postgresql", "aws-s3", "s3-compatible"],
+    )
+    def test_member_is_permitted_to_create_batch_export_kinds(self, kind, client: HttpClient):
+        # The permission check runs before serializer validation, so an incomplete body resolves to a
+        # 400 (permitted, but invalid) rather than a 403 (forbidden). This isolates the permission grant
+        # from each kind's external credential validation.
+        client.force_login(self.member)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {"kind": kind, "config": {}},
+            content_type="application/json",
+        )
+
+        assert response.status_code != status.HTTP_403_FORBIDDEN, response.json()
+
+    @pytest.mark.parametrize("kind", ["slack", "email", "twilio"])
+    def test_member_cannot_create_non_batch_export_kinds(self, kind, client: HttpClient):
+        client.force_login(self.member)
+
+        response = client.post(
+            f"/api/environments/{self.team.pk}/integrations",
+            {"kind": kind, "config": {}},
+            content_type="application/json",
+        )
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+    def test_member_cannot_destroy_batch_export_integration(self, client: HttpClient):
+        integration = Integration.objects.create(team=self.team, kind="databricks", config={}, sensitive_config={})
+        client.force_login(self.member)
+
+        response = client.delete(f"/api/environments/{self.team.pk}/integrations/{integration.id}")
+
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
 class TestIntegrationAPIKeyAccess:
     @pytest.fixture(autouse=True)
     def setup_integration(self, db):


### PR DESCRIPTION
## Problem

Creating any integration requires project **admin** (`TeamMemberStrictManagementPermission` on `IntegrationViewSet`, added in #48925 to enforce access control on integration settings).

That regressed batch exports. Previously a project **member** with batch-export access could create a batch export with inline destination credentials. Several destinations — Databricks, BigQuery, Azure Blob, Postgres — now store their credentials in a separate `Integration` object instead of inline, and creating that object requires admin. So a member who can create a batch export can no longer supply its destination credentials.

## Changes

Relax integration **creation** to project member level for the kinds that back batch export destinations (`databricks`, `google-cloud-service-account`, `azure-blob`, `postgresql`, `aws-s3`, `s3-compatible`). All other kinds, and all `update`/`destroy`, stay admin-only.

- New `BATCH_EXPORT_INTEGRATION_KINDS` set + a `create`-action branch in `IntegrationViewSet.dangerously_get_permissions()` that returns a member-level stack (drops `TeamMemberStrictManagementPermission`) for those kinds. Any other/missing kind falls through to the default strict-admin requirement (fail-closed).
- Backend-only. The batch-export integration creation UI (`IntegrationChoice` → setup modals) already has no admin gate, so members can reach it as soon as the backend permits. No serializer/response changes, so generated types are unaffected.

Why it's safe: these kinds' secrets land in `Integration.sensitive_config`, which is **not** a serializer field and is never returned — a member can supply a secret but can never read one back. The field-level `field_access_control(..., "project", "admin")` wrappers only apply on update, not create, so they don't block (and still protect) the relaxed path.

Scope decisions: relaxation is membership-level only (session/UI flow). A personal API key still needs the `integration:write` scope — we did not relax scopes to accept `batch_export:write`.

## How did you test this code?

I'm an agent (PostHog Code); I have not tested manually. Automated tests only:

- Added `TestBatchExportIntegrationMemberAccess` to `posthog/api/test/test_integration.py`, covering three regressions no existing test caught: (1) a member is permitted to create each of the six batch-export kinds — guards against a kind being dropped from the set or the branch breaking; (2) a member is still 403 on non-batch-export kinds (`slack`/`email`/`twilio`) — guards against over-broad relaxation; (3) a member is still 403 on `destroy` of a batch-export kind — confirms only `create` was relaxed.
- Ran the new suite (10 cases) and the existing per-kind create suites (`TestDatabricksIntegration`, `TestAwsS3Integration`, `TestS3CompatibleIntegration` — 20 cases). All pass.

Not run: manual UI verification, and any end-to-end check of a member connecting a destination from the batch export form.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude). Skills invoked while producing this PR: `/improving-drf-endpoints` (DRF viewset change — confirmed no serializer/type-pipeline impact) and `/writing-tests` (gated the test additions to the three regressions above).

Key decisions:
- Branch on `request.data["kind"]` inside the existing `dangerously_get_permissions()` hook rather than adding a new permission class — reuses the established per-action override pattern (`refresh_github_repos`, `request_access`) and keeps the change to one method. Fail-closed: unknown/missing kind defaults back to admin.
- Membership-only relaxation, not scope relaxation — keeps `integration:write` required for API keys, narrowing the surface to the UI flow that actually regressed.
- Included `aws-s3` / `s3-compatible` for symmetry even though S3 batch exports still collect credentials inline today (no integration object created from that form yet) — harmless and future-proofs the S3 destinations.
- Tested the permission boundary via "incomplete body → not 403" rather than mocking each kind's external credential validation: the permission check runs before serializer validation, so this isolates the grant cleanly across all six kinds.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*