### PR TITLE
fix(postgres): disable idle-in-transaction timeout on CDC stream connection

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py
@@ -92,11 +92,15 @@ class PgCDCStreamReader:
                 user=self._params.user,
                 password=self._params.password,
                 require_ssl=self._params.require_ssl,
-                # Server-side ceiling (30m) so a stalled WAL decode can't hang the streaming
-                # connection indefinitely. Bounds a single peek; the caller's soft deadline
-                # bounds the whole run. Dropped if the source sits behind a pooler that rejects
-                # the libpq `options` parameter (CDC sources never do).
-                options="-c statement_timeout=1800000",
+                # statement_timeout (30m) is a server-side ceiling so a stalled WAL decode can't
+                # hang the streaming connection indefinitely; it bounds a single peek, the caller's
+                # soft deadline bounds the whole run. idle_in_transaction_session_timeout=0 stops the
+                # source culling our backend (SQLSTATE 25P03) while the named cursor's transaction
+                # sits idle between yields as the caller flushes to S3 and advances the slot —
+                # statement_timeout doesn't apply there because no statement is running. Both are
+                # dropped if the source sits behind a pooler that rejects the libpq `options`
+                # parameter (CDC sources never do).
+                options="-c statement_timeout=1800000 -c idle_in_transaction_session_timeout=0",
             ),
             logger,
         )

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -109,7 +109,7 @@ class TestPgCDCStreamReaderConnect:
 
 
 class TestPgCDCStreamReaderConnectOptions:
-    def test_connect_sets_statement_timeout(self, params):
+    def test_connect_sets_streaming_timeouts(self, params):
         connect = mock.MagicMock(return_value=mock.MagicMock())
         reader = PgCDCStreamReader(params)
         with patch(
@@ -118,21 +118,12 @@ class TestPgCDCStreamReaderConnectOptions:
         ):
             reader.connect()
 
+        options = connect.call_args.kwargs["options"]
         # A stalled server-side WAL decode can't hang the streaming connection indefinitely.
-        assert "statement_timeout=1800000" in connect.call_args.kwargs["options"]
-
-    def test_connect_disables_idle_in_transaction_timeout(self, params):
-        connect = mock.MagicMock(return_value=mock.MagicMock())
-        reader = PgCDCStreamReader(params)
-        with patch(
-            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
-            connect,
-        ):
-            reader.connect()
-
+        assert "statement_timeout=1800000" in options
         # The named cursor holds a transaction open while the caller flushes between yields, so the
         # source must not cull the backend (SQLSTATE 25P03) for sitting idle in that transaction.
-        assert "idle_in_transaction_session_timeout=0" in connect.call_args.kwargs["options"]
+        assert "idle_in_transaction_session_timeout=0" in options
 
 
 class TestPgCDCStreamReaderReadChanges:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/tests/test_stream_reader.py
@@ -121,6 +121,19 @@ class TestPgCDCStreamReaderConnectOptions:
         # A stalled server-side WAL decode can't hang the streaming connection indefinitely.
         assert "statement_timeout=1800000" in connect.call_args.kwargs["options"]
 
+    def test_connect_disables_idle_in_transaction_timeout(self, params):
+        connect = mock.MagicMock(return_value=mock.MagicMock())
+        reader = PgCDCStreamReader(params)
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.cdc.stream_reader._connect_to_postgres",
+            connect,
+        ):
+            reader.connect()
+
+        # The named cursor holds a transaction open while the caller flushes between yields, so the
+        # source must not cull the backend (SQLSTATE 25P03) for sitting idle in that transaction.
+        assert "idle_in_transaction_session_timeout=0" in connect.call_args.kwargs["options"]
+
 
 class TestPgCDCStreamReaderReadChanges:
     def _reader_serving(self, params, rows):


### PR DESCRIPTION
## Problem

Postgres CDC syncs intermittently fail with `IdleInTransactionSessionTimeout: terminating connection due to idle-in-transaction timeout` (SQLSTATE 25P03), surfaced by error tracking ([issue](https://us.posthog.com/project/2/error_tracking/019f13f3-7255-7522-a893-346dfd731249)). The stack lands in `products/warehouse_sources/backend/temporal/data_imports/sources/postgres/cdc/stream_reader.py` inside `read_changes`, where we iterate the named server-side cursor.

Root cause: the CDC stream reader uses a named server-side cursor (`pg_logical_slot_peek_binary_changes`), which holds a transaction open for the entire read loop. The caller (`_read_wal_loop`) does its real work — flushing micro-batches to S3 and advancing the replication slot — *between* generator yields, while the streaming cursor is suspended. During that window the cursor's transaction is idle, and a source configured with a tight `idle_in_transaction_session_timeout` terminates our backend. The existing `statement_timeout` ceiling doesn't help here because no statement is running during the idle gap.

The rest of the Postgres source already treats this exact condition as a recoverable connection drop (`_is_connection_dropped_error` / `_CONNECTION_DROPPED_ERROR_TYPES` both special-case `IdleInTransactionSessionTimeout`), and the non-CDC read/sync path absorbs it in-process. The CDC streaming-read iteration had no equivalent protection, so the error flapped the schemas to FAILED, emitted failure-visibility, and got captured before Temporal retried the whole activity (re-peeking the backlog from scratch).

## Changes

Disable `idle_in_transaction_session_timeout` for the CDC streaming session by adding `-c idle_in_transaction_session_timeout=0` to the libpq `options` string that already pins `statement_timeout`. This tells the source we intend to hold the cursor's transaction open while we stream, so it stops culling our backend during the idle-between-yields work. `statement_timeout` still bounds active statements, and the caller's soft deadline / Temporal heartbeat still bound the overall run, so we don't trade away the safety net against a genuinely stuck read.

This is scoped to the CDC stream connection only — no change to global retry policy. The option is dropped automatically by the existing `_connect_with_options_fallback` if a source rejects libpq `options` (CDC sources don't sit behind such poolers).

This is a fixable-fragility fix rather than a `NonRetryableErrors` addition: there's a sensible thing for us to do (stop provoking the cull on our own session), and the condition is transient/recoverable, not a permanent user-credential/config failure.

## How did you test this code?

I'm an agent. Automated tests only:

- Extended `TestPgCDCStreamReaderConnectOptions` with `test_connect_disables_idle_in_transaction_timeout`, asserting `connect()` passes `idle_in_transaction_session_timeout=0` in the streaming connection's `options` (mirrors the existing `statement_timeout` assertion).
- Ran the full `test_stream_reader.py` suite: 13 passed.
- `ruff check` and `ruff format --check` clean on both changed files.

This catches the regression of someone dropping the idle-timeout option from the streaming connect — which existing tests, that only assert `statement_timeout`, would not.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook for the Postgres warehouse source. Confirmed the issue via the PostHog error-tracking MCP tools (full stack trace, exception type, representative event) — the failure genuinely originates in the postgres CDC `stream_reader.py`.
- Decision: fixable bug, not a `NonRetryableErrors` entry. `IdleInTransactionSessionTimeout` is already modeled as a recoverable connection drop elsewhere in this source; the streaming read path simply lacked the protection. Disabling the idle timeout on our own session at the connection layer prevents the cull at its root, matching the intent of the existing `statement_timeout` option on the same connect.
- Considered (and rejected) in-process reconnect-and-re-peek for the streaming loop: larger change, and it would re-decode the backlog while the underlying idle-gap cause recurred. Preventing the cull is simpler and addresses the root cause.
- No duplicate found among open PRs (searched the exception type, message phrasing, the module path, and the maintainer's own open PRs).