### PR TITLE
fix(batch-import): drop duplicate event uuids before sending to capture

### DIFF
--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -100,11 +100,15 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         let mut duplicates: u64 = 0;
         for captured in data {
             // Drop repeat UUIDs so a source-level duplicate can't make capture reject the batch.
-            if !seen.insert(captured.inner.uuid) {
+            if seen.contains(&captured.inner.uuid) {
                 duplicates += 1;
                 continue;
             }
-            events.push(convert_event(captured)?);
+            // Record the UUID only after a successful conversion, so a convert error never
+            // leaves a UUID marked seen with no corresponding event.
+            let event = convert_event(captured)?;
+            seen.insert(captured.inner.uuid);
+            events.push(event);
         }
         drop(events);
         drop(seen);

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -1,4 +1,5 @@
 use std::{
+    collections::HashSet,
     io::{self, Write},
     sync::Mutex,
     time::{Duration, Instant},
@@ -10,6 +11,7 @@ use common_types::{InternallyCapturedEvent, RawEvent};
 use metrics::counter;
 use posthog_rs::{Client, Event};
 use tracing::{info, warn};
+use uuid::Uuid;
 
 use super::{Emitter, Transaction};
 
@@ -23,6 +25,10 @@ pub struct CaptureTransaction<'a> {
     send_rate: u64,
     start: Instant,
     events: Mutex<Vec<Event>>,
+    // Capture's V1 endpoint rejects a whole batch if two events in one request share a UUID,
+    // and a source export can contain duplicate event UUIDs. Track UUIDs across the whole
+    // transaction so duplicates are dropped before they reach (and poison) a capture request.
+    seen_uuids: Mutex<HashSet<Uuid>>,
 }
 
 impl CaptureEmitter {
@@ -39,6 +45,7 @@ impl Emitter for CaptureEmitter {
             send_rate: self.send_rate,
             start: Instant::now(),
             events: Mutex::new(Vec::new()),
+            seen_uuids: Mutex::new(HashSet::new()),
         }))
     }
 }
@@ -81,12 +88,34 @@ fn convert_event(ice: &InternallyCapturedEvent) -> Result<Event, Error> {
 #[async_trait]
 impl<'a> Transaction<'a> for CaptureTransaction<'a> {
     async fn emit(&self, data: &[InternallyCapturedEvent]) -> Result<(), Error> {
-        let converted: Vec<Event> = data.iter().map(convert_event).collect::<Result<_, _>>()?;
-
-        self.events
+        let mut seen = self
+            .seen_uuids
             .lock()
-            .map_err(|e| Error::msg(format!("events lock poisoned: {e}")))?
-            .extend(converted);
+            .map_err(|e| Error::msg(format!("seen_uuids lock poisoned: {e}")))?;
+        let mut events = self
+            .events
+            .lock()
+            .map_err(|e| Error::msg(format!("events lock poisoned: {e}")))?;
+
+        let mut duplicates: u64 = 0;
+        for captured in data {
+            // Drop repeat UUIDs so a source-level duplicate can't make capture reject the batch.
+            if !seen.insert(captured.inner.uuid) {
+                duplicates += 1;
+                continue;
+            }
+            events.push(convert_event(captured)?);
+        }
+        drop(events);
+        drop(seen);
+
+        if duplicates > 0 {
+            warn!(
+                duplicates,
+                "dropped events with duplicate uuids before sending to capture"
+            );
+            counter!("capture_batch_duplicate_uuids_total").increment(duplicates);
+        }
 
         Ok(())
     }
@@ -363,6 +392,7 @@ mod tests {
             send_rate: 10_000,
             start: Instant::now(),
             events: Mutex::new(vec![event]),
+            seen_uuids: Mutex::new(HashSet::new()),
         })
     }
 
@@ -426,6 +456,7 @@ mod tests {
             send_rate: 10_000,
             start: Instant::now(),
             events: Mutex::new(vec![]),
+            seen_uuids: Mutex::new(HashSet::new()),
         });
 
         let result = txn.commit_write().await;
@@ -627,10 +658,39 @@ mod tests {
             send_rate: 10_000,
             start: Instant::now(),
             events: Mutex::new(events),
+            seen_uuids: Mutex::new(HashSet::new()),
         });
 
         let result = txn.commit_write().await;
         assert!(result.is_ok(), "got {result:?}");
         mock.assert();
+    }
+
+    #[tokio::test]
+    async fn test_emit_drops_duplicate_uuids_within_and_across_batches() {
+        let dup = Uuid::now_v7();
+        let unique = Uuid::now_v7();
+        let mut a = make_internally_captured_event("e", "u", serde_json::json!({}), None, None);
+        let mut b = make_internally_captured_event("e", "u", serde_json::json!({}), None, None);
+        let mut c = make_internally_captured_event("e", "u", serde_json::json!({}), None, None);
+        let mut d = make_internally_captured_event("e", "u", serde_json::json!({}), None, None);
+        a.inner.uuid = dup;
+        b.inner.uuid = dup; // duplicate within the first emit
+        c.inner.uuid = unique;
+        d.inner.uuid = dup; // duplicate across emit calls
+
+        let client = make_client("http://localhost:1").await;
+        let txn = CaptureTransaction {
+            client: &client,
+            send_rate: 10_000,
+            start: Instant::now(),
+            events: Mutex::new(Vec::new()),
+            seen_uuids: Mutex::new(HashSet::new()),
+        };
+        txn.emit(&[a, b]).await.unwrap();
+        txn.emit(&[c, d]).await.unwrap();
+
+        let events = txn.events.lock().unwrap();
+        assert_eq!(events.len(), 2, "only the first event per uuid is kept");
     }
 }


### PR DESCRIPTION
## Problem

Capture's V1 endpoint rejects an entire batch if two events in the same request share a UUID — `validate_events` builds a fresh seen-set per request and returns `duplicate_event_uuid` on the first collision. A source export can legitimately contain duplicate event UUIDs (deterministic, content-derived IDs), which then poisons the whole chunk. Combined with the offset rollback from #66676, the worker retries the same chunk forever and the import wedges.

This was observed in production after #66676 shipped: a chunk failed with `duplicate_event_uuid` and rolled back, with no way to make progress.

## Changes

Track seen event UUIDs across the capture transaction and drop repeats before they reach a capture request, so a source-level duplicate can't reject the batch.

Emit a `warn` log and a `capture_batch_duplicate_uuids_total` counter when duplicates are dropped, for visibility.

Dropping is correct: capture treats same-UUID events as the same event and cannot store both, so the duplicate was never ingestable. Deduping across the whole transaction also avoids the splitter sending the same UUID in two separate sub-requests.

## How did you test this code?

I'm an agent; automated tests only, all passing locally (`cargo test -p batch-import-worker`, `cargo fmt`, `cargo clippy --all-targets --all-features -D warnings` clean):

- `test_emit_drops_duplicate_uuids_within_and_across_batches` — proves repeat UUIDs are dropped both within a single `emit` call and across multiple `emit` calls on the same transaction, keeping only the first occurrence.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, follow-up to #66676. Root-caused the production `duplicate_event_uuid` failure by reading capture's `validate_events` (the error is strictly an in-request duplicate check, not cross-request memory), so the fix is to dedupe in the worker rather than change capture. Chose transaction-level dedup over per-sub-batch to also prevent the splitter from delivering the same UUID twice.
