### PR TITLE
fix(posthogai): handle non-object access in get_nested_value

### DIFF
--- a/common/hogvm/python/test/test_execute.py
+++ b/common/hogvm/python/test/test_execute.py
@@ -121,6 +121,14 @@ class TestBytecodeExecute:
         chain = ["properties", "tuple", 3]
         assert get_nested_value(my_dict, chain) == "item3"
 
+    def test_nested_value_into_non_object_is_nullish(self):
+        # Descending into a non-object must not raise AttributeError. Regression:
+        # an unresolved `{variables.foo}` placeholder evaluates the chain
+        # ["variables", "foo"] against a scalar/None and used to crash here.
+        assert get_nested_value({"variables": 1}, ["variables", "foo"], nullish=True) is None
+        assert get_nested_value("scalar", ["foo"], nullish=True) is None
+        assert get_nested_value(None, ["foo", "bar"], nullish=True) is None
+
     def test_errors(self):
         try:
             execute_bytecode([_H, VERSION, op.TRUE, op.CALL_GLOBAL, "notAFunction", 1], {})

--- a/common/hogvm/python/utils.py
+++ b/common/hogvm/python/utils.py
@@ -70,6 +70,14 @@ def get_nested_value(obj, chain, nullish=False) -> Any:
                     return None
                 obj = obj[key]
         else:
+            if not isinstance(obj, dict):
+                # Descending into a non-object — e.g. an unresolved
+                # `{variables.foo}` placeholder that evaluated to a scalar or
+                # None — must not raise a raw AttributeError. Nullish access
+                # yields null; strict access raises a catchable HogVM error.
+                if nullish:
+                    return None
+                raise HogVMException(f"Can not get key {key} of a non-object value")
             obj = obj.get(key, None)
     return obj
 


### PR DESCRIPTION
## Problem

PostHog AI errors out with an internal error whenever it validates or runs a HogQL query that contains a dotted SQL-variable placeholder such as `{variables.foo}`. This is what users hit when they ask the assistant to edit or run an insight whose query uses SQL variables.

Root cause is in the shared HogVM primitive `get_nested_value`. A dotted placeholder is evaluated by compiling its field chain (`["variables", "foo"]`) to HogVM bytecode and walking it. PostHog AI's SQL tooling substitutes a dummy value for the placeholder keyed on the first chain segment only (`{"variables": <scalar>}`), so the walk descends into a non-object value. The code then called `.get()` on that scalar and raised a raw `AttributeError` (`'…' object has no attribute 'get'`), which is not in the SQL validator's catch list, so it escaped as an unhandled error. A bare single-segment placeholder (`{foo}`) never hits this, which is why only dotted `variables.*` references broke.

The defect is in the shared primitive, so it bites every caller of that path: PostHog AI's SQL validation tool and the MCP `execute-sql` tool.

## Changes

`get_nested_value` now checks the cursor is a dict before descending into it:

- Nullish access (the placeholder and `?.` paths, which already pass `nullish=True`) yields `null` instead of throwing.
- Strict access into a non-object raises a catchable `HogVMException` instead of a raw `AttributeError`.
- Normal dict/list access is unchanged.

This converts the unhandled crash into graceful handling for all callers: the raw `AttributeError` becomes a `QueryError` that the SQL validator catches and reports cleanly. Fully resolving a query's variables to real values still happens via `replace_variables` as before; this change only governs what happens when the chain can't be descended.

## How did you test this code?

I'm an agent (PostHog Code), working with @christiaan-ph.

- Ran the HogVM Python suite `common/hogvm/python/test/test_execute.py` (45 passed), including a new regression test `test_nested_value_into_non_object_is_nullish` asserting that descending into a scalar or `None` under nullish access returns `None` rather than raising.
- Exercised the real path (parse to HogVM bytecode to `get_nested_value`) on a running local backend, via `replace_placeholders` and via PostHog AI's exact SQL-validation dummy block:
  - On master, validating `SELECT {variables.foo}` raises `AttributeError: 'Constant' object has no attribute 'get'`, which escapes the validator.
  - On this branch, the same input returns a catchable `QueryError` ("Placeholder returned an unexpected type") that the validator handles. Normal dict and list access are unchanged.
- Verified in the local PostHog AI UI that the assistant now returns a graceful validation message instead of an internal error when asked to run a query containing `{variables.*}`.
- Confirmed against a production `$exception` that the captured error is exactly `AttributeError: 'Constant' object has no attribute 'get'`, raised through PostHog AI's SQL execution tool when a query contains a dotted `{variables.*}` placeholder, matching the fixed path.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by @christiaan-ph while investigating a report that PostHog AI could not edit or run insights containing SQL variables.

- Tool: PostHog Code (Claude).
- Root-caused from a production `$exception` whose stack terminated in `get_nested_value`, then reproduced the same crash through PostHog AI's SQL validation tool and the MCP `execute-sql` tool: a bare `{foo}` errors cleanly, a dotted `{variables.foo}` raised the unhandled `AttributeError`.
- Decision: fix the shared HogVM primitive so the crash becomes graceful for every caller of that path, rather than patching one agent-specific code path.
- Added a minimal regression unit test.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
