### PR TITLE
fix(subscriptions): don't refire delivery on schedule-only edits

### DIFF
--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -128,13 +128,7 @@ class DashboardExportInsightsField(serializers.Field):
 class SubscriptionSerializer(serializers.ModelSerializer):
     """Standard Subscription serializer."""
 
-    # Scalar fields whose value defines *what* (and where) gets delivered. A change to any of these
-    # warrants an immediate confirmation delivery on update; schedule/meta edits (frequency, interval,
-    # title, summary_*, …) must not re-fire one. `integration_id` is delivery-relevant because Slack
-    # routing depends on the connected workspace, not just `target_value`. The dashboard_export_insights
-    # M2M is also delivery-relevant but is popped from validated_data and compared separately in update()
-    # (it can't live in this scalar set).
-    DELIVERY_RELEVANT_FIELDS: ClassVar[tuple[str, ...]] = (
+    FIELDS_THAT_TRIGGER_REDELIVERY: ClassVar[tuple[str, ...]] = (
         "target_value",
         "target_type",
         "integration_id",
@@ -530,6 +524,29 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             # Telemetry must never poison the validation path.
             pass
 
+    def _capture_update_delivery_decision(
+        self, instance: Subscription, *, delivery_triggered: bool, re_enabled: bool
+    ) -> None:
+        try:
+            posthoganalytics.capture(
+                distinct_id=self._caller_distinct_id(),
+                event="subscription_update_delivery_decision",
+                properties={
+                    "subscription_id": instance.id,
+                    "team_id": instance.team_id,
+                    "resource_type": instance.resource_type,
+                    "target_type": instance.target_type,
+                    "delivery_triggered": delivery_triggered,
+                    "reason": "re_enabled"
+                    if re_enabled
+                    else ("delivery_field_changed" if delivery_triggered else "no_delivery_relevant_change"),
+                },
+                groups=groups(None, instance.team),
+            )
+        except Exception:
+            # Telemetry must never block the update.
+            capture_exception()
+
     def _evaluate_feature_flag(self, flag_key: str) -> bool:
         """Evaluate a feature flag for the caller's organization.
 
@@ -705,7 +722,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         # whether the edit actually changed what gets delivered. Only snapshot the
         # dashboard_export_insights M2M when the payload carries it — that's the only case
         # `.set()` can mutate the relation, so a schedule/meta-only edit pays no M2M query.
-        old_delivery_values = {field: getattr(instance, field) for field in self.DELIVERY_RELEVANT_FIELDS}
+        old_delivery_values = {field: getattr(instance, field) for field in self.FIELDS_THAT_TRIGGER_REDELIVERY}
         old_export_insight_ids = (
             set(instance.dashboard_export_insights.values_list("id", flat=True)) if export_insights_in_payload else None
         )
@@ -763,7 +780,15 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         delivery_target_changed = any(
             getattr(instance, field) != old_value for field, old_value in old_delivery_values.items()
         ) or (old_export_insight_ids is not None and set(dashboard_export_insight_ids) != old_export_insight_ids)
-        if not is_re_enabling and not delivery_target_changed:
+
+        # The "<kind> subscription updated" event fires from the post_save signal before this decision is
+        # made, so it can't tell an edit that fired a confirmation from one that intentionally skipped.
+        # Emit the decision explicitly so a regression that silently suppressed deliveries stays observable.
+        delivery_triggered = is_re_enabling or delivery_target_changed
+        self._capture_update_delivery_decision(
+            instance, delivery_triggered=delivery_triggered, re_enabled=is_re_enabling
+        )
+        if not delivery_triggered:
             return instance
 
         temporal = sync_connect()

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -695,6 +695,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         was_disabled = instance.enabled is False
         is_delete = not instance.deleted and validated_data.get("deleted") is True
         invite_message = validated_data.pop("invite_message", "")
+        # Track payload PRESENCE, not truthiness: an empty list (clearing all exports) is delivery-relevant
+        # too, so `bool(ids)` would miss it. Pop loses presence, so capture it first.
+        export_insights_in_payload = "dashboard_export_insights" in validated_data
         dashboard_export_insight_ids = validated_data.pop("dashboard_export_insights", [])
         analytics_props = get_request_analytics_properties(request)
 
@@ -704,9 +707,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         # `.set()` can mutate the relation, so a schedule/meta-only edit pays no M2M query.
         old_delivery_values = {field: getattr(instance, field) for field in self.DELIVERY_RELEVANT_FIELDS}
         old_export_insight_ids = (
-            set(instance.dashboard_export_insights.values_list("id", flat=True))
-            if dashboard_export_insight_ids
-            else set()
+            set(instance.dashboard_export_insights.values_list("id", flat=True)) if export_insights_in_payload else None
         )
 
         if is_delete:
@@ -734,7 +735,8 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             instance = super().update(instance, validated_data)
         _invalidate_summary_quota_cache(instance.team.organization_id)
 
-        if dashboard_export_insight_ids:
+        # Apply the M2M whenever the field is in the payload — including an empty list, which clears it.
+        if export_insights_in_payload:
             instance.dashboard_export_insights.set(dashboard_export_insight_ids)
 
         is_re_enabling = was_disabled and instance.enabled
@@ -760,7 +762,7 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         # the model's save() but must not push a fresh delivery.
         delivery_target_changed = any(
             getattr(instance, field) != old_value for field, old_value in old_delivery_values.items()
-        ) or (bool(dashboard_export_insight_ids) and set(dashboard_export_insight_ids) != old_export_insight_ids)
+        ) or (old_export_insight_ids is not None and set(dashboard_export_insight_ids) != old_export_insight_ids)
         if not is_re_enabling and not delivery_target_changed:
             return instance
 

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -674,6 +674,17 @@ class SubscriptionSerializer(serializers.ModelSerializer):
 
         return instance
 
+    # Fields whose value defines *what* gets delivered. A change to any of these
+    # warrants an immediate confirmation delivery on update; schedule/meta edits
+    # (frequency, interval, title, summary_*, …) must not re-fire one.
+    DELIVERY_RELEVANT_FIELDS: ClassVar[tuple[str, ...]] = (
+        "target_value",
+        "target_type",
+        "prompt",
+        "insight_id",
+        "dashboard_id",
+    )
+
     def update(self, instance: Subscription, validated_data: dict, *args, **kwargs) -> Subscription:
         request = self.context["request"]
         previous_value = instance.target_value
@@ -682,6 +693,11 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         invite_message = validated_data.pop("invite_message", "")
         dashboard_export_insight_ids = validated_data.pop("dashboard_export_insights", [])
         analytics_props = get_request_analytics_properties(request)
+
+        # Snapshot delivery-relevant values before the write so we can tell, after,
+        # whether the edit actually changed what gets delivered.
+        old_delivery_values = {field: getattr(instance, field) for field in self.DELIVERY_RELEVANT_FIELDS}
+        old_export_insight_ids = set(instance.dashboard_export_insights.values_list("id", flat=True))
 
         if is_delete:
             with slo_operation(
@@ -711,19 +727,32 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         if dashboard_export_insight_ids:
             instance.dashboard_export_insights.set(dashboard_export_insight_ids)
 
+        is_re_enabling = was_disabled and instance.enabled
+
         # Re-enabling clears the stale next_delivery_date that was frozen while
         # disabled. Without this, the scheduler picks the sub up on its next tick
         # (the past date matches `next_delivery_date__lte=now`) and fires a second
         # SCHEDULED delivery right after the immediate TARGET_CHANGE confirmation.
-        if was_disabled and instance.enabled:
+        if is_re_enabling:
             instance.set_next_delivery_date()
             instance.save(update_fields=["next_delivery_date"])
 
         # Skip the workflow trigger when the resulting state is disabled. No delivery
         # should fire for a disabled subscription regardless of whether it was just
-        # disabled or already disabled. Re-enabling (`enabled: false → true`) DOES
-        # trigger the workflow so the user gets immediate confirmation delivery.
+        # disabled or already disabled.
         if not instance.enabled:
+            return instance
+
+        # Only fire the immediate confirmation delivery when the edit changed *what*
+        # gets delivered, or when re-enabling (`enabled: false → true`) — the user
+        # expects a confirmation delivery in both cases. A schedule/meta-only edit
+        # (frequency, interval, title, summary_*, …) re-saves next_delivery_date via
+        # the model's save() but must not push a fresh delivery.
+        delivery_target_changed = (
+            any(getattr(instance, field) != old_value for field, old_value in old_delivery_values.items())
+            or set(instance.dashboard_export_insights.values_list("id", flat=True)) != old_export_insight_ids
+        )
+        if not is_re_enabling and not delivery_target_changed:
             return instance
 
         temporal = sync_connect()

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -674,9 +674,11 @@ class SubscriptionSerializer(serializers.ModelSerializer):
 
         return instance
 
-    # Fields whose value defines *what* gets delivered. A change to any of these
+    # Scalar fields whose value defines *what* gets delivered. A change to any of these
     # warrants an immediate confirmation delivery on update; schedule/meta edits
-    # (frequency, interval, title, summary_*, …) must not re-fire one.
+    # (frequency, interval, title, summary_*, …) must not re-fire one. The
+    # dashboard_export_insights M2M is also delivery-relevant but is popped from
+    # validated_data and compared separately in update() (it can't live in this scalar set).
     DELIVERY_RELEVANT_FIELDS: ClassVar[tuple[str, ...]] = (
         "target_value",
         "target_type",
@@ -694,10 +696,16 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         dashboard_export_insight_ids = validated_data.pop("dashboard_export_insights", [])
         analytics_props = get_request_analytics_properties(request)
 
-        # Snapshot delivery-relevant values before the write so we can tell, after,
-        # whether the edit actually changed what gets delivered.
+        # Snapshot delivery-relevant scalar values before the write so we can tell, after,
+        # whether the edit actually changed what gets delivered. Only snapshot the
+        # dashboard_export_insights M2M when the payload carries it — that's the only case
+        # `.set()` can mutate the relation, so a schedule/meta-only edit pays no M2M query.
         old_delivery_values = {field: getattr(instance, field) for field in self.DELIVERY_RELEVANT_FIELDS}
-        old_export_insight_ids = set(instance.dashboard_export_insights.values_list("id", flat=True))
+        old_export_insight_ids = (
+            set(instance.dashboard_export_insights.values_list("id", flat=True))
+            if dashboard_export_insight_ids
+            else set()
+        )
 
         if is_delete:
             with slo_operation(
@@ -748,10 +756,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
         # expects a confirmation delivery in both cases. A schedule/meta-only edit
         # (frequency, interval, title, summary_*, …) re-saves next_delivery_date via
         # the model's save() but must not push a fresh delivery.
-        delivery_target_changed = (
-            any(getattr(instance, field) != old_value for field, old_value in old_delivery_values.items())
-            or set(instance.dashboard_export_insights.values_list("id", flat=True)) != old_export_insight_ids
-        )
+        delivery_target_changed = any(
+            getattr(instance, field) != old_value for field, old_value in old_delivery_values.items()
+        ) or (bool(dashboard_export_insight_ids) and set(dashboard_export_insight_ids) != old_export_insight_ids)
         if not is_re_enabling and not delivery_target_changed:
             return instance
 

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -128,6 +128,21 @@ class DashboardExportInsightsField(serializers.Field):
 class SubscriptionSerializer(serializers.ModelSerializer):
     """Standard Subscription serializer."""
 
+    # Scalar fields whose value defines *what* (and where) gets delivered. A change to any of these
+    # warrants an immediate confirmation delivery on update; schedule/meta edits (frequency, interval,
+    # title, summary_*, …) must not re-fire one. `integration_id` is delivery-relevant because Slack
+    # routing depends on the connected workspace, not just `target_value`. The dashboard_export_insights
+    # M2M is also delivery-relevant but is popped from validated_data and compared separately in update()
+    # (it can't live in this scalar set).
+    DELIVERY_RELEVANT_FIELDS: ClassVar[tuple[str, ...]] = (
+        "target_value",
+        "target_type",
+        "integration_id",
+        "prompt",
+        "insight_id",
+        "dashboard_id",
+    )
+
     created_by = UserBasicSerializer(read_only=True)
     summary = serializers.CharField(read_only=True, help_text="Human-readable schedule summary, e.g. 'sent daily'.")
     invite_message = serializers.CharField(
@@ -673,19 +688,6 @@ class SubscriptionSerializer(serializers.ModelSerializer):
             )
 
         return instance
-
-    # Scalar fields whose value defines *what* gets delivered. A change to any of these
-    # warrants an immediate confirmation delivery on update; schedule/meta edits
-    # (frequency, interval, title, summary_*, …) must not re-fire one. The
-    # dashboard_export_insights M2M is also delivery-relevant but is popped from
-    # validated_data and compared separately in update() (it can't live in this scalar set).
-    DELIVERY_RELEVANT_FIELDS: ClassVar[tuple[str, ...]] = (
-        "target_value",
-        "target_type",
-        "prompt",
-        "insight_id",
-        "dashboard_id",
-    )
 
     def update(self, instance: Subscription, validated_data: dict, *args, **kwargs) -> Subscription:
         request = self.context["request"]

--- a/ee/api/subscription.py
+++ b/ee/api/subscription.py
@@ -543,9 +543,9 @@ class SubscriptionSerializer(serializers.ModelSerializer):
                 },
                 groups=groups(None, instance.team),
             )
-        except Exception:
+        except Exception as e:
             # Telemetry must never block the update.
-            capture_exception()
+            capture_exception(e)
 
     def _evaluate_feature_flag(self, flag_key: str) -> bool:
         """Evaluate a feature flag for the caller's organization.

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import Optional
 from uuid import uuid4
@@ -206,22 +207,118 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert activity_inputs.previous_value == "test@posthog.com"
         assert activity_inputs.invite_message == "hi new user"
 
+    # Each setup builds a subscription and returns (sub_id, patch_payload) for the parameterized
+    # delivery test below. Cases vary only in fixtures and payload; the fire/no-fire assertion is shared.
+    def _setup_frequency_edit(self) -> tuple[int, dict]:
+        return self._create_subscription(invite_message=None).json()["id"], {"frequency": "daily"}
+
+    def _setup_interval_edit(self) -> tuple[int, dict]:
+        return self._create_subscription(invite_message=None).json()["id"], {"interval": 3}
+
+    def _setup_title_edit(self) -> tuple[int, dict]:
+        return self._create_subscription(invite_message=None).json()["id"], {"title": "Renamed"}
+
+    def _setup_target_value_edit(self) -> tuple[int, dict]:
+        sub_id = self._create_subscription(invite_message=None).json()["id"]
+        return sub_id, {"target_value": "test@posthog.com,extra@posthog.com"}
+
+    def _setup_target_type_change(self) -> tuple[int, dict]:
+        # Switching channel routes delivery elsewhere — needs a Slack integration to land on.
+        integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        sub_id = self._create_subscription(invite_message=None).json()["id"]
+        return sub_id, {"target_type": "slack", "target_value": "#general", "integration_id": integration.id}
+
+    def _setup_re_enable(self) -> tuple[int, dict]:
+        # disabled → enabled: no delivery field changes, but the re-enable carve-out must still fire.
+        subscription = Subscription.objects.create(
+            team=self.team,
+            target_type="email",
+            target_value="vasco@posthog.com",
+            frequency="daily",
+            start_date=timezone.now(),
+            insight=self.insight,
+            title="t",
+            enabled=False,
+        )
+        return subscription.id, {"enabled": True}
+
+    def _setup_integration_swap(self) -> tuple[int, dict]:
+        # Slack routing depends on the connected workspace, not just target_value — swapping the
+        # integration while target_type/target_value stay the same must still fire.
+        old_integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        new_integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        subscription = Subscription.objects.create(
+            team=self.team,
+            target_type="slack",
+            target_value="#general",
+            integration=old_integration,
+            frequency="daily",
+            start_date=timezone.now(),
+            insight=self.insight,
+            title="t",
+        )
+        return subscription.id, {"integration_id": new_integration.id}
+
+    def _setup_dashboard_export_change(self) -> tuple[int, dict]:
+        # Changing which insights a dashboard subscription exports is delivery-relevant (the M2M branch).
+        self.dashboard.tiles.create(insight=self.insight)
+        other_insight = Insight.objects.create(team=self.team, name="other")
+        self.dashboard.tiles.create(insight=other_insight)
+        sub_id = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            {
+                "dashboard": self.dashboard.id,
+                "dashboard_export_insights": [self.insight.id],
+                "target_type": "email",
+                "target_value": "test@posthog.com",
+                "frequency": "weekly",
+                "interval": 1,
+                "start_date": "2022-01-01T00:00:00",
+                "title": "Dash",
+            },
+        ).json()["id"]
+        return sub_id, {"dashboard_export_insights": [self.insight.id, other_insight.id]}
+
+    def _setup_dashboard_export_resubmit_same(self) -> tuple[int, dict]:
+        # Re-submitting the identical export set (alongside a meta edit) is not a change — must short-circuit.
+        self.dashboard.tiles.create(insight=self.insight)
+        sub_id = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            {
+                "dashboard": self.dashboard.id,
+                "dashboard_export_insights": [self.insight.id],
+                "target_type": "email",
+                "target_value": "test@posthog.com",
+                "frequency": "weekly",
+                "interval": 1,
+                "start_date": "2022-01-01T00:00:00",
+                "title": "Dash",
+            },
+        ).json()["id"]
+        return sub_id, {"dashboard_export_insights": [self.insight.id], "title": "Renamed"}
+
     @parameterized.expand(
         [
-            # Schedule/meta-only edits must NOT re-fire a delivery — regression guard for an
-            # enabled subscription emitting a full delivery on every frequency/title tweak.
-            ("frequency", {"frequency": "daily"}, False),
-            ("interval", {"interval": 3}, False),
-            ("title", {"title": "Renamed"}, False),
-            # Delivery-relevant edits MUST fire — recipients changed, so a confirmation is expected.
-            ("target_value", {"target_value": "test@posthog.com,extra@posthog.com"}, True),
+            # Schedule/meta-only edits must NOT re-fire a delivery — guards against an enabled
+            # subscription emitting a full delivery on every frequency/title tweak.
+            ("frequency", _setup_frequency_edit, False),
+            ("interval", _setup_interval_edit, False),
+            ("title", _setup_title_edit, False),
+            # Delivery-relevant edits MUST fire a confirmation — what (or where) gets delivered changed,
+            # or the subscription was re-enabled.
+            ("target_value", _setup_target_value_edit, True),
+            ("target_type", _setup_target_type_change, True),
+            ("re_enable", _setup_re_enable, True),
+            ("integration_swap", _setup_integration_swap, True),
+            ("dashboard_export_change", _setup_dashboard_export_change, True),
+            # ...except re-submitting the identical export set, which changes nothing.
+            ("dashboard_export_resubmit_same", _setup_dashboard_export_resubmit_same, False),
         ]
     )
     def test_update_fires_delivery_only_when_delivery_relevant_field_changes(
-        self, _name: str, patch_payload: dict, should_fire: bool
+        self, _name: str, setup: Callable[["TestSubscriptionTemporal"], tuple[int, dict]], should_fire: bool
     ):
-        sub_id = self._create_subscription(invite_message=None).json()["id"]
-        self.mock_temporal_client.start_workflow.assert_called_once()  # the create itself fired
+        sub_id, patch_payload = setup(self)
         self.mock_temporal_client.start_workflow.reset_mock()
 
         response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
@@ -252,119 +349,36 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert after is not None
         assert after < before
 
-    def test_update_target_type_change_fires_delivery(self):
-        # target_type is delivery-relevant; switching channel must fire a confirmation.
-        integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        sub_id = self._create_subscription(invite_message=None).json()["id"]
-        self.mock_temporal_client.start_workflow.reset_mock()
+    @parameterized.expand(
+        [
+            ("delivery_field_changed", _setup_target_value_edit, True, "delivery_field_changed"),
+            ("meta_only_edit", _setup_frequency_edit, False, "no_delivery_relevant_change"),
+            ("re_enable", _setup_re_enable, True, "re_enabled"),
+        ]
+    )
+    def test_update_emits_delivery_decision_event(
+        self,
+        _name: str,
+        setup: Callable[["TestSubscriptionTemporal"], tuple[int, dict]],
+        expected_triggered: bool,
+        expected_reason: str,
+    ):
+        # The decision must be observable so a regression that silently suppresses deliveries is caught
+        # — the "<kind> subscription updated" event fires pre-decision and can't carry this signal.
+        sub_id, patch_payload = setup(self)
+        with patch("ee.api.subscription.posthoganalytics.capture") as mock_capture:
+            response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
+            assert response.status_code == status.HTTP_200_OK, response.content
 
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
-            {"target_type": "slack", "target_value": "#general", "integration_id": integration.id},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_called_once()
-
-    def test_re_enable_fires_delivery_even_without_delivery_field_change(self):
-        # disabled → enabled must still send the confirmation delivery even though no
-        # delivery-relevant field changed — guards the re-enable carve-out against the
-        # new "only fire on delivery-field change" short-circuit.
-        subscription = Subscription.objects.create(
-            team=self.team,
-            target_type="email",
-            target_value="vasco@posthog.com",
-            frequency="daily",
-            start_date=timezone.now(),
-            insight=self.insight,
-            title="t",
-            enabled=False,
-        )
-        self.mock_temporal_client.start_workflow.reset_mock()
-
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{subscription.id}",
-            {"enabled": True},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_called_once()
-
-    def test_update_integration_swap_fires_delivery(self):
-        # Slack routing depends on the connected workspace, not just target_value — swapping the
-        # integration while keeping target_type/target_value unchanged must still fire a confirmation.
-        old_integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        new_integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        subscription = Subscription.objects.create(
-            team=self.team,
-            target_type="slack",
-            target_value="#general",
-            integration=old_integration,
-            frequency="daily",
-            start_date=timezone.now(),
-            insight=self.insight,
-            title="t",
-        )
-        self.mock_temporal_client.start_workflow.reset_mock()
-
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{subscription.id}",
-            {"integration_id": new_integration.id},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_called_once()
-
-    def test_update_dashboard_export_insights_change_fires_delivery(self):
-        # Changing which insights a dashboard subscription exports is delivery-relevant (the M2M branch
-        # of the change check, not the scalar comparison), so it must fire a confirmation.
-        self.dashboard.tiles.create(insight=self.insight)
-        other_insight = Insight.objects.create(team=self.team, name="other")
-        self.dashboard.tiles.create(insight=other_insight)
-        sub_id = self.client.post(
-            f"/api/projects/{self.team.id}/subscriptions",
-            {
-                "dashboard": self.dashboard.id,
-                "dashboard_export_insights": [self.insight.id],
-                "target_type": "email",
-                "target_value": "test@posthog.com",
-                "frequency": "weekly",
-                "interval": 1,
-                "start_date": "2022-01-01T00:00:00",
-                "title": "Dash",
-            },
-        ).json()["id"]
-        self.mock_temporal_client.start_workflow.reset_mock()
-
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
-            {"dashboard_export_insights": [self.insight.id, other_insight.id]},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_called_once()
-
-    def test_update_resubmitting_same_dashboard_export_insights_does_not_fire(self):
-        # Re-submitting the identical export set is not a delivery-relevant change — the set comparison
-        # must short-circuit so a meta-only edit that echoes the M2M payload doesn't re-fire a delivery.
-        self.dashboard.tiles.create(insight=self.insight)
-        sub_id = self.client.post(
-            f"/api/projects/{self.team.id}/subscriptions",
-            {
-                "dashboard": self.dashboard.id,
-                "dashboard_export_insights": [self.insight.id],
-                "target_type": "email",
-                "target_value": "test@posthog.com",
-                "frequency": "weekly",
-                "interval": 1,
-                "start_date": "2022-01-01T00:00:00",
-                "title": "Dash",
-            },
-        ).json()["id"]
-        self.mock_temporal_client.start_workflow.reset_mock()
-
-        response = self.client.patch(
-            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
-            {"dashboard_export_insights": [self.insight.id], "title": "Renamed"},
-        )
-        assert response.status_code == status.HTTP_200_OK, response.content
-        self.mock_temporal_client.start_workflow.assert_not_called()
+        decision_calls = [
+            call
+            for call in mock_capture.call_args_list
+            if call.kwargs.get("event") == "subscription_update_delivery_decision"
+        ]
+        assert len(decision_calls) == 1
+        properties = decision_calls[0].kwargs["properties"]
+        assert properties["delivery_triggered"] is expected_triggered
+        assert properties["reason"] == expected_reason
 
     def test_can_create_dashboard_subscription_with_dashboard_export_insights(self):
         self.dashboard.tiles.create(insight=self.insight)
@@ -1677,7 +1691,7 @@ class TestSubscriptionTemporal(APILicensedTest):
         [
             # The confirmation-delivery workflow fires only on a re-enable or a delivery-relevant change —
             # not on a meta-only edit (title) or a redundant enable that changes nothing. (This narrows the
-            # previous "every edit to an enabled sub fires" matrix; see DELIVERY_RELEVANT_FIELDS.)
+            # previous "every edit to an enabled sub fires" matrix; see FIELDS_THAT_TRIGGER_REDELIVERY.)
             ("enabled_to_enabled_field_edit", True, {"title": "renamed"}, False),
             ("redundant_enable", True, {"enabled": True}, False),
             ("disable_enabled", True, {"enabled": False}, False),

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -287,6 +287,84 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert response.status_code == status.HTTP_200_OK, response.content
         self.mock_temporal_client.start_workflow.assert_called_once()
 
+    def test_update_integration_swap_fires_delivery(self):
+        # Slack routing depends on the connected workspace, not just target_value — swapping the
+        # integration while keeping target_type/target_value unchanged must still fire a confirmation.
+        old_integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        new_integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        subscription = Subscription.objects.create(
+            team=self.team,
+            target_type="slack",
+            target_value="#general",
+            integration=old_integration,
+            frequency="daily",
+            start_date=timezone.now(),
+            insight=self.insight,
+            title="t",
+        )
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription.id}",
+            {"integration_id": new_integration.id},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_called_once()
+
+    def test_update_dashboard_export_insights_change_fires_delivery(self):
+        # Changing which insights a dashboard subscription exports is delivery-relevant (the M2M branch
+        # of the change check, not the scalar comparison), so it must fire a confirmation.
+        self.dashboard.tiles.create(insight=self.insight)
+        other_insight = Insight.objects.create(team=self.team, name="other")
+        self.dashboard.tiles.create(insight=other_insight)
+        sub_id = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            {
+                "dashboard": self.dashboard.id,
+                "dashboard_export_insights": [self.insight.id],
+                "target_type": "email",
+                "target_value": "test@posthog.com",
+                "frequency": "weekly",
+                "interval": 1,
+                "start_date": "2022-01-01T00:00:00",
+                "title": "Dash",
+            },
+        ).json()["id"]
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+            {"dashboard_export_insights": [self.insight.id, other_insight.id]},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_called_once()
+
+    def test_update_resubmitting_same_dashboard_export_insights_does_not_fire(self):
+        # Re-submitting the identical export set is not a delivery-relevant change — the set comparison
+        # must short-circuit so a meta-only edit that echoes the M2M payload doesn't re-fire a delivery.
+        self.dashboard.tiles.create(insight=self.insight)
+        sub_id = self.client.post(
+            f"/api/projects/{self.team.id}/subscriptions",
+            {
+                "dashboard": self.dashboard.id,
+                "dashboard_export_insights": [self.insight.id],
+                "target_type": "email",
+                "target_value": "test@posthog.com",
+                "frequency": "weekly",
+                "interval": 1,
+                "start_date": "2022-01-01T00:00:00",
+                "title": "Dash",
+            },
+        ).json()["id"]
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+            {"dashboard_export_insights": [self.insight.id], "title": "Renamed"},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_not_called()
+
     def test_can_create_dashboard_subscription_with_dashboard_export_insights(self):
         self.dashboard.tiles.create(insight=self.insight)
         response = self.client.post(

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -206,6 +206,87 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert activity_inputs.previous_value == "test@posthog.com"
         assert activity_inputs.invite_message == "hi new user"
 
+    @parameterized.expand(
+        [
+            # Schedule/meta-only edits must NOT re-fire a delivery — regression guard for an
+            # enabled subscription emitting a full delivery on every frequency/title tweak.
+            ("frequency", {"frequency": "daily"}, False),
+            ("interval", {"interval": 3}, False),
+            ("title", {"title": "Renamed"}, False),
+            # Delivery-relevant edits MUST fire — recipients changed, so a confirmation is expected.
+            ("target_value", {"target_value": "test@posthog.com,extra@posthog.com"}, True),
+        ]
+    )
+    def test_update_fires_delivery_only_when_delivery_relevant_field_changes(
+        self, _name: str, patch_payload: dict, should_fire: bool
+    ):
+        sub_id = self._create_subscription(invite_message=None).json()["id"]
+        self.mock_temporal_client.start_workflow.assert_called_once()  # the create itself fired
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
+        assert response.status_code == status.HTTP_200_OK, response.content
+
+        if should_fire:
+            self.mock_temporal_client.start_workflow.assert_called_once()
+        else:
+            self.mock_temporal_client.start_workflow.assert_not_called()
+
+    def test_schedule_only_update_still_recomputes_next_delivery_date(self):
+        # A schedule edit must not fire a delivery but MUST still reschedule — the model
+        # save() recomputes next_delivery_date; this guards that the no-fire short-circuit
+        # doesn't accidentally skip the reschedule.
+        sub_id = self._create_subscription(invite_message=None, frequency="weekly").json()["id"]
+        before = Subscription.objects.get(id=sub_id).next_delivery_date
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+            {"frequency": "daily"},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_not_called()
+        after = Subscription.objects.get(id=sub_id).next_delivery_date
+        # Daily cadence brings the next delivery strictly earlier than the weekly one.
+        assert after is not None
+        assert after < before
+
+    def test_update_target_type_change_fires_delivery(self):
+        # target_type is delivery-relevant; switching channel must fire a confirmation.
+        integration = Integration.objects.create(team=self.team, kind="slack", config={})
+        sub_id = self._create_subscription(invite_message=None).json()["id"]
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
+            {"target_type": "slack", "target_value": "#general", "integration_id": integration.id},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_called_once()
+
+    def test_re_enable_fires_delivery_even_without_delivery_field_change(self):
+        # disabled → enabled must still send the confirmation delivery even though no
+        # delivery-relevant field changed — guards the re-enable carve-out against the
+        # new "only fire on delivery-field change" short-circuit.
+        subscription = Subscription.objects.create(
+            team=self.team,
+            target_type="email",
+            target_value="vasco@posthog.com",
+            frequency="daily",
+            start_date=timezone.now(),
+            insight=self.insight,
+            title="t",
+            enabled=False,
+        )
+        self.mock_temporal_client.start_workflow.reset_mock()
+
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/subscriptions/{subscription.id}",
+            {"enabled": True},
+        )
+        assert response.status_code == status.HTTP_200_OK, response.content
+        self.mock_temporal_client.start_workflow.assert_called_once()
+
     def test_can_create_dashboard_subscription_with_dashboard_export_insights(self):
         self.dashboard.tiles.create(insight=self.insight)
         response = self.client.post(
@@ -2476,12 +2557,13 @@ class TestAISubscriptionAPI(APILicensedTest):
 
     def test_can_update_ai_subscription_prompt(self, mock_is_cloud, mock_flag, mock_sync):
         self._enable_ai()
-        self._mock_temporal(mock_sync)
+        mock_client = self._mock_temporal(mock_sync)
         create_resp = self.client.post(
             f"/api/projects/{self.team.id}/subscriptions",
             self._make_ai_payload(),
         )
         sub_id = create_resp.json()["id"]
+        mock_client.start_workflow.reset_mock()
 
         update_resp = self.client.patch(
             f"/api/projects/{self.team.id}/subscriptions/{sub_id}",
@@ -2489,6 +2571,9 @@ class TestAISubscriptionAPI(APILicensedTest):
         )
         assert update_resp.status_code == status.HTTP_200_OK, update_resp.json()
         assert update_resp.json()["prompt"] == "Show me new error events"
+        # prompt is delivery-relevant for AI subscriptions; editing it must re-fire the
+        # confirmation delivery so recipients see the updated report.
+        mock_client.start_workflow.assert_called_once()
 
     def test_resource_type_is_derived_and_read_only(self, mock_is_cloud, mock_flag, mock_sync):
         # resource_type is derived from the populated target and read-only — a client can

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -1674,9 +1674,11 @@ class TestSubscriptionTemporal(APILicensedTest):
 
     @parameterized.expand(
         [
-            # Locks the workflow-trigger matrix across all four (initial, final) enabled states.
-            ("enabled_to_enabled_field_edit", True, {"title": "renamed"}, True),
-            ("redundant_enable", True, {"enabled": True}, True),
+            # The confirmation-delivery workflow fires only on a re-enable or a delivery-relevant change —
+            # not on a meta-only edit (title) or a redundant enable that changes nothing. (This narrows the
+            # previous "every edit to an enabled sub fires" matrix; see DELIVERY_RELEVANT_FIELDS.)
+            ("enabled_to_enabled_field_edit", True, {"title": "renamed"}, False),
+            ("redundant_enable", True, {"enabled": True}, False),
             ("disable_enabled", True, {"enabled": False}, False),
             ("redundant_disable", False, {"enabled": False}, False),
             ("enable_disabled", False, {"enabled": True}, True),

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -245,17 +245,22 @@ class TestSubscriptionTemporal(APILicensedTest):
             },
         ).json()["id"]
 
-    # Each case is (name, build, should_fire); build(test) -> (sub_id, patch_payload). The inline factory
-    # keeps each case's setup next to its expected outcome.
+    # Each case is (name, build, should_fire, expected_reason); build(test) -> (sub_id, patch_payload).
+    # The inline factory keeps each case's setup next to its expected outcome.
     @parameterized.expand(
         [
             # Schedule/meta-only edits must NOT re-fire a delivery.
-            ("frequency", lambda t: (t._basic_sub(), {"frequency": "daily"}), False),
-            ("interval", lambda t: (t._basic_sub(), {"interval": 3}), False),
-            ("title", lambda t: (t._basic_sub(), {"title": "Renamed"}), False),
+            ("frequency", lambda t: (t._basic_sub(), {"frequency": "daily"}), False, "no_delivery_relevant_change"),
+            ("interval", lambda t: (t._basic_sub(), {"interval": 3}), False, "no_delivery_relevant_change"),
+            ("title", lambda t: (t._basic_sub(), {"title": "Renamed"}), False, "no_delivery_relevant_change"),
             # Delivery-relevant edits MUST fire a confirmation — what (or where) gets delivered changed,
             # or the subscription was re-enabled.
-            ("target_value", lambda t: (t._basic_sub(), {"target_value": "test@posthog.com,extra@posthog.com"}), True),
+            (
+                "target_value",
+                lambda t: (t._basic_sub(), {"target_value": "test@posthog.com,extra@posthog.com"}),
+                True,
+                "delivery_field_changed",
+            ),
             (
                 "target_type",  # switching channel routes delivery elsewhere — needs a Slack integration
                 lambda t: (
@@ -267,8 +272,9 @@ class TestSubscriptionTemporal(APILicensedTest):
                     },
                 ),
                 True,
+                "delivery_field_changed",
             ),
-            ("re_enable", lambda t: (t._disabled_email_sub(), {"enabled": True}), True),
+            ("re_enable", lambda t: (t._disabled_email_sub(), {"enabled": True}), True, "re_enabled"),
             (
                 "integration_swap",  # Slack routing depends on the workspace, not just target_value
                 lambda t: (
@@ -285,6 +291,7 @@ class TestSubscriptionTemporal(APILicensedTest):
                     {"integration_id": Integration.objects.create(team=t.team, kind="slack", config={}).id},
                 ),
                 True,
+                "delivery_field_changed",
             ),
             (
                 "dashboard_export_change",  # changing the exported insight set hits the M2M branch
@@ -296,6 +303,7 @@ class TestSubscriptionTemporal(APILicensedTest):
                     {"dashboard_export_insights": [t.insight.id, other.id]},
                 ),
                 True,
+                "delivery_field_changed",
             ),
             # ...except re-submitting the identical export set, which changes nothing.
             (
@@ -305,22 +313,41 @@ class TestSubscriptionTemporal(APILicensedTest):
                     {"dashboard_export_insights": [t.insight.id], "title": "Renamed"},
                 ),
                 False,
+                "no_delivery_relevant_change",
             ),
         ]
     )
     def test_update_fires_delivery_only_when_delivery_relevant_field_changes(
-        self, _name: str, build: Callable[["TestSubscriptionTemporal"], tuple[int, dict]], should_fire: bool
+        self,
+        _name: str,
+        build: Callable[["TestSubscriptionTemporal"], tuple[int, dict]],
+        should_fire: bool,
+        expected_reason: str,
     ):
         sub_id, patch_payload = build(self)
         self.mock_temporal_client.start_workflow.reset_mock()
 
-        response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
-        assert response.status_code == status.HTTP_200_OK, response.content
+        with patch("ee.api.subscription.posthoganalytics.capture") as mock_capture:
+            response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
+            assert response.status_code == status.HTTP_200_OK, response.content
 
+        # The workflow fires only when the edit warrants a confirmation delivery...
         if should_fire:
             self.mock_temporal_client.start_workflow.assert_called_once()
         else:
             self.mock_temporal_client.start_workflow.assert_not_called()
+
+        # ...and the decision is always emitted so a silent suppression is observable — the post_save
+        # "<kind> subscription updated" event fires pre-decision and can't carry this signal.
+        decision_calls = [
+            call
+            for call in mock_capture.call_args_list
+            if call.kwargs.get("event") == "subscription_update_delivery_decision"
+        ]
+        assert len(decision_calls) == 1
+        properties = decision_calls[0].kwargs["properties"]
+        assert properties["delivery_triggered"] is should_fire
+        assert properties["reason"] == expected_reason
 
     def test_schedule_only_update_still_recomputes_next_delivery_date(self):
         # A schedule edit must not fire a delivery but MUST still reschedule — the model
@@ -341,47 +368,6 @@ class TestSubscriptionTemporal(APILicensedTest):
         assert before is not None
         assert after is not None
         assert after < before
-
-    @parameterized.expand(
-        [
-            (
-                "delivery_field_changed",
-                lambda t: (t._basic_sub(), {"target_value": "test@posthog.com,extra@posthog.com"}),
-                True,
-                "delivery_field_changed",
-            ),
-            (
-                "meta_only_edit",
-                lambda t: (t._basic_sub(), {"frequency": "daily"}),
-                False,
-                "no_delivery_relevant_change",
-            ),
-            ("re_enable", lambda t: (t._disabled_email_sub(), {"enabled": True}), True, "re_enabled"),
-        ]
-    )
-    def test_update_emits_delivery_decision_event(
-        self,
-        _name: str,
-        build: Callable[["TestSubscriptionTemporal"], tuple[int, dict]],
-        expected_triggered: bool,
-        expected_reason: str,
-    ):
-        # The decision must be observable so a regression that silently suppresses deliveries is caught
-        # — the "<kind> subscription updated" event fires pre-decision and can't carry this signal.
-        sub_id, patch_payload = build(self)
-        with patch("ee.api.subscription.posthoganalytics.capture") as mock_capture:
-            response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
-            assert response.status_code == status.HTTP_200_OK, response.content
-
-        decision_calls = [
-            call
-            for call in mock_capture.call_args_list
-            if call.kwargs.get("event") == "subscription_update_delivery_decision"
-        ]
-        assert len(decision_calls) == 1
-        properties = decision_calls[0].kwargs["properties"]
-        assert properties["delivery_triggered"] is expected_triggered
-        assert properties["reason"] == expected_reason
 
     def test_can_create_dashboard_subscription_with_dashboard_export_insights(self):
         self.dashboard.tiles.create(insight=self.insight)

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -209,28 +209,13 @@ class TestSubscriptionTemporal(APILicensedTest):
 
     # Each setup builds a subscription and returns (sub_id, patch_payload) for the parameterized
     # delivery test below. Cases vary only in fixtures and payload; the fire/no-fire assertion is shared.
-    def _setup_frequency_edit(self) -> tuple[int, dict]:
-        return self._create_subscription(invite_message=None).json()["id"], {"frequency": "daily"}
+    # Reusable builders for the inline case factories below. Anything a lambda can't express (multi-row
+    # ORM setup, the verbose dashboard POST, tile side effects) lives here; the per-case payload stays inline.
+    def _basic_sub(self) -> int:
+        return self._create_subscription(invite_message=None).json()["id"]
 
-    def _setup_interval_edit(self) -> tuple[int, dict]:
-        return self._create_subscription(invite_message=None).json()["id"], {"interval": 3}
-
-    def _setup_title_edit(self) -> tuple[int, dict]:
-        return self._create_subscription(invite_message=None).json()["id"], {"title": "Renamed"}
-
-    def _setup_target_value_edit(self) -> tuple[int, dict]:
-        sub_id = self._create_subscription(invite_message=None).json()["id"]
-        return sub_id, {"target_value": "test@posthog.com,extra@posthog.com"}
-
-    def _setup_target_type_change(self) -> tuple[int, dict]:
-        # Switching channel routes delivery elsewhere — needs a Slack integration to land on.
-        integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        sub_id = self._create_subscription(invite_message=None).json()["id"]
-        return sub_id, {"target_type": "slack", "target_value": "#general", "integration_id": integration.id}
-
-    def _setup_re_enable(self) -> tuple[int, dict]:
-        # disabled → enabled: no delivery field changes, but the re-enable carve-out must still fire.
-        subscription = Subscription.objects.create(
+    def _disabled_email_sub(self) -> int:
+        return Subscription.objects.create(
             team=self.team,
             target_type="email",
             target_value="vasco@posthog.com",
@@ -239,36 +224,18 @@ class TestSubscriptionTemporal(APILicensedTest):
             insight=self.insight,
             title="t",
             enabled=False,
-        )
-        return subscription.id, {"enabled": True}
+        ).id
 
-    def _setup_integration_swap(self) -> tuple[int, dict]:
-        # Slack routing depends on the connected workspace, not just target_value — swapping the
-        # integration while target_type/target_value stay the same must still fire.
-        old_integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        new_integration = Integration.objects.create(team=self.team, kind="slack", config={})
-        subscription = Subscription.objects.create(
-            team=self.team,
-            target_type="slack",
-            target_value="#general",
-            integration=old_integration,
-            frequency="daily",
-            start_date=timezone.now(),
-            insight=self.insight,
-            title="t",
-        )
-        return subscription.id, {"integration_id": new_integration.id}
-
-    def _setup_dashboard_export_change(self) -> tuple[int, dict]:
-        # Changing which insights a dashboard subscription exports is delivery-relevant (the M2M branch).
-        self.dashboard.tiles.create(insight=self.insight)
-        other_insight = Insight.objects.create(team=self.team, name="other")
-        self.dashboard.tiles.create(insight=other_insight)
-        sub_id = self.client.post(
+    def _dashboard_sub(self, tile_insights: list[Insight], export_insights: list[Insight]) -> int:
+        # Dashboard subscriptions can only export insights that are dashboard tiles, so add a tile per
+        # insight before posting. export_insights is the initial selection a case then patches.
+        for insight in tile_insights:
+            self.dashboard.tiles.create(insight=insight)
+        return self.client.post(
             f"/api/projects/{self.team.id}/subscriptions",
             {
                 "dashboard": self.dashboard.id,
-                "dashboard_export_insights": [self.insight.id],
+                "dashboard_export_insights": [insight.id for insight in export_insights],
                 "target_type": "email",
                 "target_value": "test@posthog.com",
                 "frequency": "weekly",
@@ -277,48 +244,74 @@ class TestSubscriptionTemporal(APILicensedTest):
                 "title": "Dash",
             },
         ).json()["id"]
-        return sub_id, {"dashboard_export_insights": [self.insight.id, other_insight.id]}
 
-    def _setup_dashboard_export_resubmit_same(self) -> tuple[int, dict]:
-        # Re-submitting the identical export set (alongside a meta edit) is not a change — must short-circuit.
-        self.dashboard.tiles.create(insight=self.insight)
-        sub_id = self.client.post(
-            f"/api/projects/{self.team.id}/subscriptions",
-            {
-                "dashboard": self.dashboard.id,
-                "dashboard_export_insights": [self.insight.id],
-                "target_type": "email",
-                "target_value": "test@posthog.com",
-                "frequency": "weekly",
-                "interval": 1,
-                "start_date": "2022-01-01T00:00:00",
-                "title": "Dash",
-            },
-        ).json()["id"]
-        return sub_id, {"dashboard_export_insights": [self.insight.id], "title": "Renamed"}
-
+    # Each case is (name, build, should_fire); build(test) -> (sub_id, patch_payload). The inline factory
+    # keeps each case's setup next to its expected outcome.
     @parameterized.expand(
         [
-            # Schedule/meta-only edits must NOT re-fire a delivery — guards against an enabled
-            # subscription emitting a full delivery on every frequency/title tweak.
-            ("frequency", _setup_frequency_edit, False),
-            ("interval", _setup_interval_edit, False),
-            ("title", _setup_title_edit, False),
+            # Schedule/meta-only edits must NOT re-fire a delivery.
+            ("frequency", lambda t: (t._basic_sub(), {"frequency": "daily"}), False),
+            ("interval", lambda t: (t._basic_sub(), {"interval": 3}), False),
+            ("title", lambda t: (t._basic_sub(), {"title": "Renamed"}), False),
             # Delivery-relevant edits MUST fire a confirmation — what (or where) gets delivered changed,
             # or the subscription was re-enabled.
-            ("target_value", _setup_target_value_edit, True),
-            ("target_type", _setup_target_type_change, True),
-            ("re_enable", _setup_re_enable, True),
-            ("integration_swap", _setup_integration_swap, True),
-            ("dashboard_export_change", _setup_dashboard_export_change, True),
+            ("target_value", lambda t: (t._basic_sub(), {"target_value": "test@posthog.com,extra@posthog.com"}), True),
+            (
+                "target_type",  # switching channel routes delivery elsewhere — needs a Slack integration
+                lambda t: (
+                    t._basic_sub(),
+                    {
+                        "target_type": "slack",
+                        "target_value": "#general",
+                        "integration_id": Integration.objects.create(team=t.team, kind="slack", config={}).id,
+                    },
+                ),
+                True,
+            ),
+            ("re_enable", lambda t: (t._disabled_email_sub(), {"enabled": True}), True),
+            (
+                "integration_swap",  # Slack routing depends on the workspace, not just target_value
+                lambda t: (
+                    Subscription.objects.create(
+                        team=t.team,
+                        target_type="slack",
+                        target_value="#general",
+                        integration=Integration.objects.create(team=t.team, kind="slack", config={}),
+                        frequency="daily",
+                        start_date=timezone.now(),
+                        insight=t.insight,
+                        title="t",
+                    ).id,
+                    {"integration_id": Integration.objects.create(team=t.team, kind="slack", config={}).id},
+                ),
+                True,
+            ),
+            (
+                "dashboard_export_change",  # changing the exported insight set hits the M2M branch
+                lambda t: (
+                    t._dashboard_sub(
+                        [t.insight, (other := Insight.objects.create(team=t.team, name="other"))],
+                        [t.insight],
+                    ),
+                    {"dashboard_export_insights": [t.insight.id, other.id]},
+                ),
+                True,
+            ),
             # ...except re-submitting the identical export set, which changes nothing.
-            ("dashboard_export_resubmit_same", _setup_dashboard_export_resubmit_same, False),
+            (
+                "dashboard_export_resubmit_same",
+                lambda t: (
+                    t._dashboard_sub([t.insight], [t.insight]),
+                    {"dashboard_export_insights": [t.insight.id], "title": "Renamed"},
+                ),
+                False,
+            ),
         ]
     )
     def test_update_fires_delivery_only_when_delivery_relevant_field_changes(
-        self, _name: str, setup: Callable[["TestSubscriptionTemporal"], tuple[int, dict]], should_fire: bool
+        self, _name: str, build: Callable[["TestSubscriptionTemporal"], tuple[int, dict]], should_fire: bool
     ):
-        sub_id, patch_payload = setup(self)
+        sub_id, patch_payload = build(self)
         self.mock_temporal_client.start_workflow.reset_mock()
 
         response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
@@ -351,21 +344,31 @@ class TestSubscriptionTemporal(APILicensedTest):
 
     @parameterized.expand(
         [
-            ("delivery_field_changed", _setup_target_value_edit, True, "delivery_field_changed"),
-            ("meta_only_edit", _setup_frequency_edit, False, "no_delivery_relevant_change"),
-            ("re_enable", _setup_re_enable, True, "re_enabled"),
+            (
+                "delivery_field_changed",
+                lambda t: (t._basic_sub(), {"target_value": "test@posthog.com,extra@posthog.com"}),
+                True,
+                "delivery_field_changed",
+            ),
+            (
+                "meta_only_edit",
+                lambda t: (t._basic_sub(), {"frequency": "daily"}),
+                False,
+                "no_delivery_relevant_change",
+            ),
+            ("re_enable", lambda t: (t._disabled_email_sub(), {"enabled": True}), True, "re_enabled"),
         ]
     )
     def test_update_emits_delivery_decision_event(
         self,
         _name: str,
-        setup: Callable[["TestSubscriptionTemporal"], tuple[int, dict]],
+        build: Callable[["TestSubscriptionTemporal"], tuple[int, dict]],
         expected_triggered: bool,
         expected_reason: str,
     ):
         # The decision must be observable so a regression that silently suppresses deliveries is caught
         # — the "<kind> subscription updated" event fires pre-decision and can't carry this signal.
-        sub_id, patch_payload = setup(self)
+        sub_id, patch_payload = build(self)
         with patch("ee.api.subscription.posthoganalytics.capture") as mock_capture:
             response = self.client.patch(f"/api/projects/{self.team.id}/subscriptions/{sub_id}", patch_payload)
             assert response.status_code == status.HTTP_200_OK, response.content

--- a/ee/api/test/test_subscription.py
+++ b/ee/api/test/test_subscription.py
@@ -248,6 +248,7 @@ class TestSubscriptionTemporal(APILicensedTest):
         self.mock_temporal_client.start_workflow.assert_not_called()
         after = Subscription.objects.get(id=sub_id).next_delivery_date
         # Daily cadence brings the next delivery strictly earlier than the weekly one.
+        assert before is not None
         assert after is not None
         assert after < before
 

--- a/posthog/models/activity_logging/activity_log.py
+++ b/posthog/models/activity_logging/activity_log.py
@@ -395,6 +395,10 @@ field_exclusions: dict[AuditableScope, list[str]] = {
         # Scheduler-derived field; keep it out of user-facing change diffs even when another
         # field changes in the same save (signal_exclusions only governs whether the signal fires).
         "next_delivery_date",
+        # FK to a connected Slack integration. The generic field-diff captures the related object,
+        # which isn't JSON-serializable for the change detail (same reason FeatureFlag/Experiment
+        # exclude their FK relations) — without this, editing a subscription's integration 500s the save.
+        "integration",
     ],
     "Cohort": [
         "version",


### PR DESCRIPTION
## Problem

Editing an enabled subscription sent an immediate confirmation delivery on **any** save — including when only schedule or metadata changed (e.g. switching frequency from weekly to daily, renaming the title, toggling a summary setting). `SubscriptionSerializer.update` started the `handle-subscription-value-change` Temporal workflow (`trigger_type=TARGET_CHANGE`) unconditionally for every edit of an enabled subscription, never checking which field actually changed. So a user tweaking their cadence got an unexpected report blast.

## Changes

`update` now snapshots delivery-relevant values before `super().update()` and only starts the TARGET_CHANGE workflow when one of them actually changed, or when the subscription is being re-enabled.

- **Delivery-relevant** (fire on change): `target_value`, `target_type`, `prompt`, `insight`/`insight_id`, `dashboard`/`dashboard_id`, and the `dashboard_export_insights` set.
- **Schedule/meta** (never fire): `frequency`, `interval`, `byweekday`, `bysetpos`, `count`, `start_date`, `until_date`, `title`, `summary_enabled`, `summary_prompt_guide`.
- **Re-enable** (`enabled: false → true`) still fires the confirmation delivery — that carve-out is preserved explicitly so it doesn't get swallowed by the new "only fire on delivery-field change" short-circuit.
- A schedule-only edit still recomputes `next_delivery_date` via the model's `save()`; only the workflow trigger is gated.

```mermaid
flowchart TD
    A[update] --> B{deleted?}
    B -- yes --> Z[save, no workflow]
    B -- no --> C["super().update() + set export insights"]
    C --> D{re-enabling?}
    D -- yes --> E[reset next_delivery_date]
    D -- no --> F
    E --> F{resulting state disabled?}
    F -- yes --> Z2[return, no workflow]
    F -- no --> G{re-enabling OR delivery-relevant field changed?}
    G -- yes --> H[start TARGET_CHANGE workflow]
    G -- no --> I[return, no workflow]
```

## How did you test this code?

I'm an agent (PostHog Code). I added automated tests in `ee/api/test/test_subscription.py`:

- A parameterized `test_update_fires_delivery_only_when_delivery_relevant_field_changes` — frequency/interval/title edits assert the workflow is **not** started; a `target_value` change asserts it **is**. Catches the core regression: an enabled subscription re-firing a delivery on a schedule/meta-only edit.
- `test_schedule_only_update_still_recomputes_next_delivery_date` — a frequency change doesn't fire the workflow but the next delivery date still moves. Guards against the no-fire short-circuit accidentally skipping the reschedule.
- `test_update_target_type_change_fires_delivery` and the `target_value`/`prompt` cases — confirm genuine delivery-target changes still fire (the latter extends the existing `test_can_update_ai_subscription_prompt`).
- `test_re_enable_fires_delivery_even_without_delivery_field_change` — disabled→enabled still fires even with no delivery-field change. Guards the re-enable carve-out.

I could not execute the suite locally: this worktree's shared test database has drifted (a `delivery_config NOT NULL` column from an unrelated branch's migration that doesn't exist on `master`), so subscription `create()` fails at the DB layer before any of this code runs — an unmodified `master` test fails the same way. The new tests collect cleanly (parameterized cases enumerated correctly); relying on CI to run them against a correctly-migrated DB. Ruff lint/format and the pre-commit type check (`ty check`) pass.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus).
- Skills invoked: `/improving-drf-endpoints` (serializer change) and `/writing-tests` (new tests).
- Approach: rather than diffing `validated_data` keys (which map awkwardly through FK serializer fields and the popped M2M), the change snapshots the relevant instance attributes before the write and compares them after — robust to how DRF names write fields, and reads the live `dashboard_export_insights` set after `.set()` so it reflects the post-update value. The re-enable path is kept as an explicit OR condition so the existing confirmation-on-re-enable behavior is unchanged.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*


