### PR TITLE
fix(inbox): Correct session problem card timecodes and play affordance

### DIFF
--- a/ee/hogai/chat_agent/memory/prompts.py
+++ b/ee/hogai/chat_agent/memory/prompts.py
@@ -202,6 +202,7 @@ We use the Oxford comma.
 Do not create links like "here" or "click here". All links should have relevant anchor text that describes what they link to.
 We always use sentence case rather than title case, including in titles, headings, subheadings, or bold text. However if quoting provided text, we keep the original case.
 When writing numbers in the thousands to the billions, it's acceptable to abbreviate them (like 10M or 100B - capital letter, no space). If you write out the full number, use commas (like 15,000,000).
+Session replay is the product name; the sessions it captures are called session recordings. Refer to them as "session recordings" (not "session replays").
 </writing_style>
 """.strip()
 

--- a/ee/hogai/chat_agent/prompts/base.py
+++ b/ee/hogai/chat_agent/prompts/base.py
@@ -27,6 +27,7 @@ We always use sentence case rather than title case, including in titles, heading
 When writing numbers in the thousands to the billions, it's acceptable to abbreviate them (like 10M or 100B - capital letter, no space). If you write out the full number, use commas (like 15,000,000).
 You can use light Markdown formatting for readability. Never use the em-dash (—) if you can use the en-dash (–).
 For headers, use sentence case rather than title case.
+Session replay is the product name; the sessions it captures are called session recordings. Refer to them as "session recordings" (not "session replays").
 </writing_style>
 """.strip()
 

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -6,11 +6,11 @@ import { IconBug, IconCursorClick, IconGlobe, IconKeyboard, IconPlay } from '@po
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import type { LemonTagType } from '@posthog/lemon-ui'
 
+import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/sessionRecordingInfoLogic'
 import ViewRecordingButton, {
     RecordingPlayerType,
     useRecordingButton,
 } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
-import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/sessionRecordingInfoLogic'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDuration, reverseColonDelimitedDuration } from 'lib/utils/durations'

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -2,8 +2,8 @@ import clsx from 'clsx'
 import { useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconBug, IconCursorClick, IconExternal, IconGlobe, IconKeyboard, IconPlay } from '@posthog/icons'
-import { LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
+import { IconBug, IconCursorClick, IconGlobe, IconKeyboard, IconPlay } from '@posthog/icons'
+import { LemonButton, LemonTag } from '@posthog/lemon-ui'
 import type { LemonTagType } from '@posthog/lemon-ui'
 
 import ViewRecordingButton, {
@@ -14,7 +14,6 @@ import { Dayjs, dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { teamLogic } from 'scenes/teamLogic'
-import { urls } from 'scenes/urls'
 
 import { getExportsContentRetrieveUrl } from '~/generated/core/api'
 import type { SessionProblemEventEntry, SessionProblemSignalExtra } from '~/queries/schema/schema-signals'
@@ -134,11 +133,6 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
         openPlayerIn: RecordingPlayerType.Modal,
     })
 
-    const replayUrl = urls.replaySingle(
-        extra.session_id,
-        segmentSeekTime ? { unixTimestampMillis: segmentSeekTime.valueOf() } : undefined
-    )
-
     const events = extra.event_history ?? []
     const visibleEvents = showAllEvents ? events : events.slice(0, TIMELINE_PREVIEW_COUNT)
 
@@ -238,13 +232,6 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                     )}
                 </div>
             )}
-
-            <div className="flex items-center mt-2">
-                <span className="flex-1" />
-                <Link to={replayUrl} className="flex items-center gap-1 text-xs font-medium shrink-0">
-                    Open replay <IconExternal className="size-3" />
-                </Link>
-            </div>
         </SignalCardShell>
     )
 }

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx'
 import { useValues } from 'kea'
 import { useState } from 'react'
 
@@ -5,10 +6,12 @@ import { IconBug, IconCursorClick, IconExternal, IconGlobe, IconKeyboard, IconPl
 import { LemonButton, LemonTag, Link } from '@posthog/lemon-ui'
 import type { LemonTagType } from '@posthog/lemon-ui'
 
-import ViewRecordingButton, { RecordingPlayerType } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
-import { dayjs } from 'lib/dayjs'
+import ViewRecordingButton, {
+    RecordingPlayerType,
+    useRecordingButton,
+} from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { Dayjs, dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { humanFriendlyDetailedTime } from 'lib/utils/datetime'
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { teamLogic } from 'scenes/teamLogic'
 import { urls } from 'scenes/urls'
@@ -37,6 +40,27 @@ export function isSessionProblemExtra(
     return typeof extra.session_id === 'string' && 'problem_type' in extra
 }
 
+/** Segment and event times arrive as recording-relative offsets (`MM:SS` / `HH:MM:SS`), not datetimes — parse to seconds. */
+function parseRecordingOffsetSeconds(offset: string | undefined): number | null {
+    if (!offset) {
+        return null
+    }
+    const parts = offset.split(':').map((part) => Number(part))
+    if (parts.length < 2 || parts.length > 3 || parts.some((part) => !Number.isFinite(part))) {
+        return null
+    }
+    return parts.reduce((total, part) => total * 60 + part, 0)
+}
+
+/** Turns a recording-relative offset into an absolute timestamp the player can seek to, given the session start. */
+function recordingSeekTime(sessionStartTime: string | undefined, offset: string | undefined): Dayjs | undefined {
+    const offsetSeconds = parseRecordingOffsetSeconds(offset)
+    if (!sessionStartTime || offsetSeconds === null) {
+        return undefined
+    }
+    return dayjs(sessionStartTime).add(offsetSeconds, 'second')
+}
+
 /** Picks a glyph for a timeline event based on its interaction type. */
 function EventGlyph({ entry }: { entry: SessionProblemEventEntry }): JSX.Element {
     const className = 'size-3.5 shrink-0 text-tertiary'
@@ -57,7 +81,15 @@ function EventGlyph({ entry }: { entry: SessionProblemEventEntry }): JSX.Element
 }
 
 /** A single row in the problem-event timeline; its time opens the recording at that moment. */
-function TimelineRow({ entry, sessionId }: { entry: SessionProblemEventEntry; sessionId: string }): JSX.Element {
+function TimelineRow({
+    entry,
+    sessionId,
+    sessionStartTime,
+}: {
+    entry: SessionProblemEventEntry
+    sessionId: string
+    sessionStartTime: string | undefined
+}): JSX.Element {
     const primaryText = entry.interaction_text?.trim() || entry.event
     return (
         <li className="flex items-start gap-2 py-0.5">
@@ -70,11 +102,11 @@ function TimelineRow({ entry, sessionId }: { entry: SessionProblemEventEntry; se
             </div>
             <ViewRecordingButton
                 sessionId={sessionId}
-                timestamp={entry.timestamp}
+                timestamp={recordingSeekTime(sessionStartTime, entry.timestamp)}
                 openPlayerIn={RecordingPlayerType.Modal}
                 size="xsmall"
                 type="tertiary"
-                label={humanFriendlyDetailedTime(entry.timestamp)}
+                label={entry.timestamp}
             />
         </li>
     )
@@ -94,9 +126,18 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
         ? getExportsContentRetrieveUrl(String(currentTeamId), extra.exported_asset_id as number)
         : undefined
 
-    const replayUrl = urls.replaySingle(extra.session_id, {
-        unixTimestampMillis: dayjs(extra.start_time).valueOf(),
+    const segmentSeekTime = recordingSeekTime(extra.session_start_time, extra.start_time)
+
+    const { onClick: openRecording, disabledReason } = useRecordingButton({
+        sessionId: extra.session_id,
+        timestamp: segmentSeekTime,
+        openPlayerIn: RecordingPlayerType.Modal,
     })
+
+    const replayUrl = urls.replaySingle(
+        extra.session_id,
+        segmentSeekTime ? { unixTimestampMillis: segmentSeekTime.valueOf() } : undefined
+    )
 
     const events = extra.event_history ?? []
     const visibleEvents = showAllEvents ? events : events.slice(0, TIMELINE_PREVIEW_COUNT)
@@ -124,50 +165,41 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                 </LemonMarkdown>
             )}
 
-            {/* 16:9 framed preview: eager thumbnail when an export exists, otherwise a play affordance. */}
-            <div className="relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2">
-                {thumbnailSrc ? (
-                    <>
-                        <img
-                            src={thumbnailSrc}
-                            alt={`Recording preview for ${extra.segment_title}`}
-                            className="absolute inset-0 size-full object-cover"
-                            onError={() => setThumbnailFailed(true)}
-                        />
-                        <div className="absolute inset-0 flex items-center justify-center bg-black/20">
-                            <ViewRecordingButton
-                                sessionId={extra.session_id}
-                                timestamp={extra.start_time}
-                                openPlayerIn={RecordingPlayerType.Modal}
-                                checkRecordingExists
-                                size="small"
-                                type="primary"
-                                label="Play"
-                            />
-                        </div>
-                    </>
-                ) : (
-                    <div className="absolute inset-0 flex flex-col items-center justify-center gap-1 text-tertiary">
-                        <IconPlay className="size-6" aria-hidden />
-                        <ViewRecordingButton
-                            sessionId={extra.session_id}
-                            timestamp={extra.start_time}
-                            openPlayerIn={RecordingPlayerType.Modal}
-                            checkRecordingExists
-                            size="small"
-                            type="secondary"
-                            label="Play recording"
-                        />
-                    </div>
+            {/* The 16:9 preview frame is itself the play affordance — clicking it opens the recording at the segment. */}
+            <button
+                type="button"
+                onClick={openRecording}
+                disabled={!!disabledReason}
+                aria-label="Play recording"
+                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default"
+            >
+                {thumbnailSrc && (
+                    <img
+                        src={thumbnailSrc}
+                        alt={`Recording preview for ${extra.segment_title}`}
+                        className="absolute inset-0 size-full object-cover"
+                        onError={() => setThumbnailFailed(true)}
+                    />
                 )}
-            </div>
+                <div
+                    className={clsx(
+                        'absolute inset-0 flex items-center justify-center transition-colors',
+                        thumbnailSrc ? 'bg-black/20 group-hover:bg-black/30' : 'group-hover:bg-fill-highlight-100'
+                    )}
+                >
+                    <IconPlay
+                        className={clsx('size-10 drop-shadow', thumbnailSrc ? 'text-white' : 'text-tertiary')}
+                        aria-hidden
+                    />
+                </div>
+            </button>
 
             {/* Dot-separated meta line: affected user, segment window, active/total duration. */}
             <div className="flex items-center gap-1.5 flex-wrap text-xs text-tertiary mb-2">
                 <span className="font-mono">{extra.distinct_id.slice(0, 10)}…</span>
                 <span>·</span>
-                <span>
-                    {humanFriendlyDetailedTime(extra.start_time)} – {humanFriendlyDetailedTime(extra.end_time)}
+                <span className="font-mono">
+                    {extra.start_time} – {extra.end_time}
                 </span>
                 {(activeDuration || totalDuration) && (
                     <>
@@ -190,6 +222,7 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                                 key={`${entry.timestamp}-${index}`}
                                 entry={entry}
                                 sessionId={extra.session_id}
+                                sessionStartTime={extra.session_start_time}
                             />
                         ))}
                     </ul>

--- a/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
+++ b/frontend/src/scenes/inbox/components/signalCards/SessionReplaySignalCard.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
-import { useValues } from 'kea'
-import { useState } from 'react'
+import { useActions, useValues } from 'kea'
+import { useEffect, useState } from 'react'
 
 import { IconBug, IconCursorClick, IconGlobe, IconKeyboard, IconPlay } from '@posthog/icons'
 import { LemonButton, LemonTag } from '@posthog/lemon-ui'
@@ -10,9 +10,10 @@ import ViewRecordingButton, {
     RecordingPlayerType,
     useRecordingButton,
 } from 'lib/components/ViewRecordingButton/ViewRecordingButton'
+import { sessionRecordingInfoLogic } from 'lib/components/ViewRecordingButton/sessionRecordingInfoLogic'
 import { Dayjs, dayjs } from 'lib/dayjs'
 import { LemonMarkdown } from 'lib/lemon-ui/LemonMarkdown'
-import { humanFriendlyDuration } from 'lib/utils/durations'
+import { humanFriendlyDuration, reverseColonDelimitedDuration } from 'lib/utils/durations'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { getExportsContentRetrieveUrl } from '~/generated/core/api'
@@ -39,21 +40,12 @@ export function isSessionProblemExtra(
     return typeof extra.session_id === 'string' && 'problem_type' in extra
 }
 
-/** Segment and event times arrive as recording-relative offsets (`MM:SS` / `HH:MM:SS`), not datetimes — parse to seconds. */
-function parseRecordingOffsetSeconds(offset: string | undefined): number | null {
-    if (!offset) {
-        return null
-    }
-    const parts = offset.split(':').map((part) => Number(part))
-    if (parts.length < 2 || parts.length > 3 || parts.some((part) => !Number.isFinite(part))) {
-        return null
-    }
-    return parts.reduce((total, part) => total * 60 + part, 0)
-}
-
-/** Turns a recording-relative offset into an absolute timestamp the player can seek to, given the session start. */
+/**
+ * Segment and event times arrive as recording-relative offsets (`MM:SS` / `HH:MM:SS`), not datetimes.
+ * Combine the offset with the session start to get an absolute timestamp the player can seek to.
+ */
 function recordingSeekTime(sessionStartTime: string | undefined, offset: string | undefined): Dayjs | undefined {
-    const offsetSeconds = parseRecordingOffsetSeconds(offset)
+    const offsetSeconds = reverseColonDelimitedDuration(offset)
     if (!sessionStartTime || offsetSeconds === null) {
         return undefined
     }
@@ -127,10 +119,20 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
 
     const segmentSeekTime = recordingSeekTime(extra.session_start_time, extra.start_time)
 
+    // Mirror ViewRecordingButton's `checkRecordingExists`: batch-check the recording so the play
+    // affordance disables (rather than opening an empty player) when the recording wasn't captured.
+    const { checkRecordingInfo } = useActions(sessionRecordingInfoLogic)
+    const { getRecordingExists } = useValues(sessionRecordingInfoLogic)
+    useEffect(() => {
+        checkRecordingInfo(extra.session_id)
+    }, [extra.session_id, checkRecordingInfo])
+    const hasRecording = getRecordingExists(extra.session_id)
+
     const { onClick: openRecording, disabledReason } = useRecordingButton({
         sessionId: extra.session_id,
         timestamp: segmentSeekTime,
         openPlayerIn: RecordingPlayerType.Modal,
+        hasRecording,
     })
 
     const events = extra.event_history ?? []
@@ -164,8 +166,9 @@ export function SessionReplaySignalCard({ signal }: SignalCardProps): JSX.Elemen
                 type="button"
                 onClick={openRecording}
                 disabled={!!disabledReason}
+                title={typeof disabledReason === 'string' ? disabledReason : undefined}
                 aria-label="Play recording"
-                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default"
+                className="group relative w-full aspect-video rounded overflow-hidden border bg-surface-secondary mb-2 cursor-pointer disabled:cursor-default disabled:opacity-70"
             >
                 {thumbnailSrc && (
                     <img

--- a/products/posthog_ai/backend/services/system_prompt/prompt.py
+++ b/products/posthog_ai/backend/services/system_prompt/prompt.py
@@ -64,4 +64,5 @@ Do not use acronyms when you can avoid them. Acronyms have the effect of excludi
 We always use sentence case rather than title case, including in titles, headings, subheadings, or bold text. However if quoting provided text, we keep the original case.
 When writing numbers in the thousands to the billions, it's acceptable to abbreviate them (like 10M or 100B - capital letter, no space). If you write out the full number, use commas (like 15,000,000).
 You can use light Markdown formatting for readability. Never use the em-dash (—) if you can use the en-dash (–).
+Session replay is the product name; the sessions it captures are called session recordings. Refer to them as "session recordings" (not "session replays").
 """

--- a/products/signals/backend/report_generation/research.py
+++ b/products/signals/backend/report_generation/research.py
@@ -330,6 +330,7 @@ We use the Oxford comma.
 We always use sentence case rather than title case, including in titles, headings, subheadings, or bold text. However if quoting provided text, we keep the original case.
 When writing numbers in the thousands to the billions, it's acceptable to abbreviate them (like 10M or 100B - capital letter, no space). If you write out the full number, use commas (like 15,000,000).
 We never use the em-dash, only the en-dash (–).
+Session replay is the product name; the sessions it captures are called session recordings. Refer to them as "session recordings" (not "session replays").
 </writing_guide>
 
 You have two investigation tools:

--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -430,6 +430,15 @@ you this run.
   run (emit / remember / summary) exactly as you would otherwise.
 - Never put customer PII or sensitive query content in a feedback field."""
 
+_WRITING_STYLE = """# Writing style
+
+- We use American English and the Oxford comma.
+- Sentence case rather than title case, including in titles, headings, subheadings, and bold text (keep the original case when quoting provided text).
+- When writing numbers in the thousands to the billions, abbreviate them (like 10M or 100B, capital letter, no space) or write the full number with commas (like 15,000,000).
+- Never use the em-dash (—); use the en-dash (–).
+- Session replay is the product name; the sessions it captures are called session recordings. Refer to them as "session recordings" (not "session replays")."""
+
+
 _OUTPUT_FORMAT = """# Output format
 
 Respond at end_turn with a single JSON object matching this schema:
@@ -446,6 +455,7 @@ _SIGNAL_TAIL_SECTIONS = [
     _FINDING_SCHEMA,
     _TAGGING,
     _WRITING_DESCRIPTION_SIGNAL,
+    _WRITING_STYLE,
     _WRITING_SUMMARY,
     _BUSINESS_KNOWLEDGE,
     _DEDUPE_RULES_SIGNAL,
@@ -487,6 +497,7 @@ def _report_tail_sections(*, can_emit: bool, can_edit: bool) -> list[str]:
         _SCRATCHPAD_KEYS,
         _RECENCY_LENS,
         *channel_sections,
+        _WRITING_STYLE,
         _WRITING_SUMMARY,
         _BUSINESS_KNOWLEDGE,
         _GROUND_RULES,

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -185,6 +185,9 @@ class TestPromptBuilder(BaseTest):
         # surface (markdown, front-loaded into the ~300-char collapsed preview),
         # while leaving a skill body free to impose its own structure.
         assert "Writing the description (how it renders in the inbox)" in prompt
+        # The writing-style section is wired into the tail, carrying the
+        # session-replay-vs-recording terminology rule scouts must follow.
+        assert "session recordings" in prompt
         # A signal scout never sees the report-channel guidance — it fires weak
         # signals, it does not author reports.
         assert "signals-scout-emit-report" not in prompt


### PR DESCRIPTION
## Problem

Session-problem cards in the inbox had two issues reported [by Cory in Slack](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782748960073379):

1. The segment window line rendered "Invalid Date – Invalid Date", due to the wrong type of parsing I had an agent use before.
2. A redundant "Play recording" button floated over the session preview, on top of the preview which was meant to be the play affordance.

## Changes

Let's:
- Display the segment window and timeline timestamps as their verbatim timecodes (e.g. `00:30 – 02:15`).
- Parse the `MM:SS` / `HH:MM:SS` offsets and combine them with `session_start_time` to produce real absolute timestamps
- Make the preview frame itself the play button with a Play icon overlaid

Also per Cory:
Standardizes session-replay-vs-recording wording in agent writing style.