### PR TITLE
fix(streaming): release DB connections before SSE streams in summarize, mcp proxy, and observation progress

### DIFF
--- a/posthog/session_recordings/session_recording_api.py
+++ b/posthog/session_recordings/session_recording_api.py
@@ -58,6 +58,7 @@ from posthog.schema import (
 
 from posthog.api.person import MinimalPersonSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
+from posthog.api.streaming import _release_request_connections
 from posthog.api.utils import ServerTimingsGathered, action, safe_clickhouse_string
 from posthog.auth import (
     ExportRendererAuthentication,
@@ -1672,6 +1673,7 @@ class SessionRecordingViewSet(
             session_ids=[session_id],
             video_based=True,
         )
+        _release_request_connections()
         response = StreamingHttpResponse(
             self._generate_video_based_summary(
                 session_id, user, tracking_id, product_context, custom_tags, force_restart=force_restart

--- a/products/mcp_store/backend/proxy.py
+++ b/products/mcp_store/backend/proxy.py
@@ -8,6 +8,7 @@ from django.http import HttpResponse, StreamingHttpResponse
 import httpx
 import structlog
 
+from posthog.api.streaming import _release_request_connections
 from posthog.security.url_validation import is_url_allowed
 from posthog.settings import SERVER_GATEWAY_INTERFACE
 
@@ -403,6 +404,7 @@ def proxy_mcp_request(request: Any, installation: MCPServerInstallation) -> Http
     content_type = upstream_response.headers.get("content-type", "")
 
     if "text/event-stream" in content_type:
+        _release_request_connections()
         return _build_sse_response(upstream_response, client)
 
     # Read body then close to avoid memory leaks from buffered responses

--- a/products/replay_vision/backend/api/observations.py
+++ b/products/replay_vision/backend/api/observations.py
@@ -20,6 +20,7 @@ from rest_framework.response import Response
 
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
+from posthog.api.streaming import _release_request_connections
 from posthog.renderers import ServerSentEventRenderer
 
 from products.replay_vision.backend.api.filters import MultiChoiceFilter, OrderByFilter, ordering_enum
@@ -599,6 +600,7 @@ class SessionReplayObservationViewSet(ReplayObservationViewSet):
         if getattr(settings, "SERVER_GATEWAY_INTERFACE", "ASGI") != "ASGI":
             raise RuntimeError("observation progress stream requires ASGI.")
         observation = self.get_object()
+        _release_request_connections()
         response = StreamingHttpResponse(
             stream_observation_progress(observation),
             content_type=ServerSentEventRenderer.media_type,


### PR DESCRIPTION
## Problem

Three streaming endpoints constructed `StreamingHttpResponse` directly without calling `_release_request_connections()`, leaving DB connections opened during view setup (auth, `get_object()`, team lookup) pinned to pgbouncer slots for the full stream lifetime.

- **`session_recordings/summarize/`** — individual session recording AI summary. Each stream holds connections for the duration of a Temporal workflow (minutes). Active incident driver today: 3,800+ clients queued on a single saturated pgbouncer pod.
- **`mcp_server_installations/proxy/`** — MCP proxy SSE path. Doubly bad: holds both a DB connection and an upstream `httpx` streaming connection simultaneously.
- **`replay_vision/observations/progress/`** — observation progress stream.

These were the last three unfixed endpoints after PR #66282 (conversations, dashboards, notebooks, batch summaries) and PR #66506 (session metadata middleware).

## Changes

One line each — `_release_request_connections()` added immediately before `StreamingHttpResponse` in:

- `posthog/session_recordings/session_recording_api.py` — `summarize` action
- `products/mcp_store/backend/proxy.py` — SSE branch of `proxy_mcp_request`
- `products/replay_vision/backend/api/observations.py` — `progress` action

## How did you test this code?

Agent-authored. Type-checked with `uv run ty check` on all three files — clean. No automated tests added; these are one-line structural changes matching an existing well-tested pattern (`_release_request_connections` is tested via PR #66506's `TestUserAuthSessionActivityMiddleware`). The `stream_with_held_connections` diagnostic log (PR #66243) will confirm the fix once deployed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated an active production incident (pgbouncer pod `mdk6z` at 75/75 server connections, 3,800+ waiting clients). `stream_with_held_connections` Loki logs during the incident window identified `session_recordings/summarize/` and `mcp_server_installations/proxy/` as the dominant sources. `replay_vision/observations/progress/` also appeared. All three were missing `_release_request_connections()` in the view, which PR #66282 applied to the other four streaming endpoints last Friday.

Related: #66282 (original fix), #66243 (diagnostic log), #66506 (middleware fix).