### PR TITLE
feat(billing): add usage report run state observability

### DIFF
--- a/posthog/management/commands/send_usage_report.py
+++ b/posthog/management/commands/send_usage_report.py
@@ -34,18 +34,25 @@ class Command(BaseCommand):
         )
 
         if run_async:
-            send_all_org_usage_reports.delay(
+            async_result = send_all_org_usage_reports.delay(
                 dry_run=dry_run,
                 at=date,
                 skip_capture_event=skip_capture_event,
                 organization_ids=organization_ids,
+                run_source="manual",
+                execution_location="usage_report_worker",
+                execution_mode="celery",
             )
+            print(f"Started async usage report task {async_result.id}")  # noqa T201
         else:
             send_all_org_usage_reports(
                 dry_run=dry_run,
                 at=date,
                 skip_capture_event=skip_capture_event,
                 organization_ids=organization_ids,
+                run_source="manual",
+                execution_location="toolbox",
+                execution_mode="direct",
             )
 
             if dry_run:

--- a/posthog/management/commands/test/test_send_usage_report.py
+++ b/posthog/management/commands/test/test_send_usage_report.py
@@ -14,6 +14,9 @@ def test_send_usage_report_defaults_to_current_date() -> None:
         at="2026-06-02",
         skip_capture_event=None,
         organization_ids=None,
+        run_source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
     )
 
 
@@ -27,4 +30,28 @@ def test_send_usage_report_preserves_passed_date() -> None:
         at="2026-05-31",
         skip_capture_event=None,
         organization_ids=None,
+        run_source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
     )
+
+
+@freeze_time("2026-06-02T12:00:00Z")
+def test_send_usage_report_async_runs_on_usage_report_worker() -> None:
+    with (
+        patch("posthog.management.commands.send_usage_report.send_all_org_usage_reports") as mock_send_reports,
+        patch("builtins.print") as print_mock,
+    ):
+        mock_send_reports.delay.return_value.id = "usage-report-task-id"
+        call_command("send_usage_report", "--date=2026-05-31", "--async=1")
+
+    mock_send_reports.delay.assert_called_once_with(
+        dry_run=None,
+        at="2026-05-31",
+        skip_capture_event=None,
+        organization_ids=None,
+        run_source="manual",
+        execution_location="usage_report_worker",
+        execution_mode="celery",
+    )
+    print_mock.assert_any_call("Started async usage report task usage-report-task-id")

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -899,10 +899,15 @@ def clickhouse_materialize_columns() -> None:
 
 
 @shared_task(ignore_result=True, queue=CeleryQueue.USAGE_REPORTS.value)
-def send_org_usage_reports() -> None:
+def send_org_usage_reports(organization_ids: Optional[list[str]] = None) -> None:
     from posthog.tasks.usage_report import send_all_org_usage_reports
 
-    send_all_org_usage_reports.delay()
+    send_all_org_usage_reports.delay(
+        organization_ids=organization_ids,
+        run_source="scheduled",
+        execution_location="usage_report_worker",
+        execution_mode="celery",
+    )
 
 
 @shared_task(ignore_result=True, retries=3)

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -50,6 +50,7 @@ from posthog.models.group.util import create_group
 from posthog.models.scoping import team_scope
 from posthog.models.sharing_configuration import SharingConfiguration
 from posthog.session_recordings.queries.test.session_replay_sql import produce_replay_summary
+from posthog.tasks.tasks import send_org_usage_reports
 from posthog.tasks.usage_report import (
     OrgReport,
     UsageReportCounters,
@@ -432,8 +433,6 @@ def test_send_all_org_usage_reports_keeps_observability_failures_best_effort() -
 
 
 def test_scheduled_usage_report_wrapper_enqueues_scheduled_worker_context() -> None:
-    from posthog.tasks.tasks import send_org_usage_reports
-
     with patch("posthog.tasks.usage_report.send_all_org_usage_reports.delay") as send_reports_mock:
         send_org_usage_reports(organization_ids=["org-id"])
 

--- a/posthog/tasks/test/test_usage_report.py
+++ b/posthog/tasks/test/test_usage_report.py
@@ -2,6 +2,8 @@ import gzip
 import json
 import base64
 import dataclasses
+from collections.abc import Iterator
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 from typing import Any
 from uuid import uuid4
@@ -29,6 +31,7 @@ import structlog
 from dateutil.relativedelta import relativedelta
 from dateutil.tz import tzutc
 from parameterized import parameterized
+from prometheus_client import CollectorRegistry
 
 from posthog.schema import EventsQuery
 
@@ -64,6 +67,7 @@ from posthog.tasks.usage_report import (
     has_non_zero_usage,
     send_all_org_usage_reports,
 )
+from posthog.tasks.usage_report_observability import UsageReportCeleryMetadata
 from posthog.test.fixtures import create_app_metric2
 from posthog.test.test_utils import create_group_type_mapping_without_created_at
 from posthog.utils import get_previous_day
@@ -92,6 +96,353 @@ from ee.clickhouse.materialized_columns.columns import materialize
 from ee.models.license import License
 
 logger = structlog.get_logger(__name__)
+
+
+@contextmanager
+def _collect_usage_report_registry(registries: list[CollectorRegistry]) -> Iterator[CollectorRegistry]:
+    registry = CollectorRegistry()
+    registries.append(registry)
+    yield registry
+
+
+def _captured_usage_report_event_properties(mock_posthog: MagicMock, event: str) -> list[dict[str, Any]]:
+    return [call.kwargs["properties"] for call in mock_posthog.capture.call_args_list if call.kwargs["event"] == event]
+
+
+@freeze_time("2026-06-29T12:00:00Z")
+def test_send_all_org_usage_reports_pushes_querying_before_query_and_emits_existing_success_events() -> None:
+    registries: list[CollectorRegistry] = []
+    mock_posthog = MagicMock()
+    base_labels = {
+        "region": "US",
+        "source": "manual",
+        "execution_location": "toolbox",
+        "execution_mode": "direct",
+        "run_scope": "all_orgs",
+    }
+
+    def get_org_reports(_period_start: datetime, _period_end: datetime) -> dict[str, OrgReport]:
+        assert (
+            registries[0].get_sample_value(
+                "posthog_legacy_usage_report_current_stage",
+                {**base_labels, "stage": "querying"},
+            )
+            == 1
+        )
+        assert [call.kwargs["event"] for call in mock_posthog.capture.call_args_list] == ["usage reports querying"]
+        return {}
+
+    with (
+        patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+        patch("posthog.tasks.usage_report.get_ph_client", return_value=mock_posthog),
+        patch("posthog.tasks.usage_report.get_instance_metadata", return_value=MagicMock()),
+        patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=False),
+        patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+        ),
+        patch("posthog.tasks.usage_report._get_all_org_reports", side_effect=get_org_reports),
+        patch("posthog.tasks.usage_report.settings.EE_AVAILABLE", False),
+    ):
+        send_all_org_usage_reports(
+            at="2026-06-29",
+            run_source="manual",
+            execution_location="toolbox",
+            execution_mode="direct",
+        )
+
+    event_names = [call.kwargs["event"] for call in mock_posthog.capture.call_args_list]
+    assert event_names == ["usage reports querying", "usage reports starting", "usage reports complete"]
+    assert len(registries) == 5
+
+    event_properties = [call.kwargs["properties"] for call in mock_posthog.capture.call_args_list]
+    run_ids = {properties["run_id"] for properties in event_properties}
+    assert len(run_ids) == 1
+    complete_properties = event_properties[-1]
+    assert complete_properties["terminal_status"] == "completed"
+    assert complete_properties["source"] == "manual"
+    assert complete_properties["execution_location"] == "toolbox"
+    assert complete_properties["execution_mode"] == "direct"
+    assert complete_properties["run_scope"] == "all_orgs"
+
+
+@freeze_time("2026-06-29T12:00:00Z")
+def test_send_all_org_usage_reports_records_skipped_terminal_state_when_disabled() -> None:
+    registries: list[CollectorRegistry] = []
+    base_labels = {
+        "region": "US",
+        "source": "scheduled",
+        "execution_location": "usage_report_worker",
+        "execution_mode": "celery",
+        "run_scope": "all_orgs",
+    }
+
+    with (
+        patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+        patch("posthog.tasks.usage_report.get_ph_client") as get_ph_client_mock,
+        patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=True),
+        patch("posthog.tasks.usage_report.posthoganalytics.capture_exception"),
+        patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+        ),
+        patch("posthog.tasks.usage_report._get_all_org_reports") as get_org_reports_mock,
+    ):
+        send_all_org_usage_reports(
+            at="2026-06-29",
+            run_source="scheduled",
+            execution_location="usage_report_worker",
+            execution_mode="celery",
+        )
+
+    get_org_reports_mock.assert_not_called()
+    get_ph_client_mock.assert_not_called()
+    assert len(registries) == 2
+    assert (
+        registries[0].get_sample_value(
+            "posthog_legacy_usage_report_terminal_status",
+            {**base_labels, "terminal_status": "skipped"},
+        )
+        == 1
+    )
+
+
+def test_send_all_org_usage_reports_records_failed_terminal_state_before_reraising() -> None:
+    registries: list[CollectorRegistry] = []
+    base_labels = {
+        "region": "US",
+        "source": "scheduled",
+        "execution_location": "usage_report_worker",
+        "execution_mode": "celery",
+        "run_scope": "all_orgs",
+    }
+
+    with freeze_time("2026-06-29T12:00:00Z") as frozen_time:
+
+        def fail_after_query_work(_period_start: datetime, _period_end: datetime) -> dict[str, OrgReport]:
+            frozen_time.tick(delta=timedelta(seconds=42))
+            raise ValueError("query failed")
+
+        with (
+            patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+            patch("posthog.tasks.usage_report.get_ph_client") as get_ph_client_mock,
+            patch("posthog.tasks.usage_report.get_instance_metadata", return_value=MagicMock()),
+            patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=False),
+            patch(
+                "posthog.tasks.usage_report_observability._get_current_usage_report_celery_metadata",
+                return_value=UsageReportCeleryMetadata(task_id="usage-report-task-id", retries=3, max_retries=3),
+            ),
+            patch(
+                "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+                side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+            ),
+            patch("posthog.tasks.usage_report._get_all_org_reports", side_effect=fail_after_query_work),
+            patch("posthog.tasks.usage_report.settings.EE_AVAILABLE", False),
+        ):
+            with pytest.raises(ValueError, match="query failed"):
+                send_all_org_usage_reports(
+                    at="2026-06-29",
+                    run_source="scheduled",
+                    execution_location="usage_report_worker",
+                    execution_mode="celery",
+                )
+
+        get_ph_client_mock.assert_called_once_with(sync_mode=True)
+        event_names = [call.kwargs["event"] for call in get_ph_client_mock.return_value.capture.call_args_list]
+        assert event_names == ["usage reports querying", "usage reports failed"]
+        failed_properties = get_ph_client_mock.return_value.capture.call_args_list[-1].kwargs["properties"]
+        assert failed_properties["terminal_status"] == "failed"
+        assert failed_properties["query_time"] == 42
+        assert failed_properties["total_time"] == 42
+        assert failed_properties["total_duration_seconds"] == 42
+        assert failed_properties["celery_retries"] == 3
+        assert failed_properties["celery_max_retries"] == 3
+        assert failed_properties["celery_attempt"] == 4
+        assert failed_properties["celery_attempt_status"] == "final_retry"
+        assert "stage" not in failed_properties
+        assert (
+            registries[-2].get_sample_value(
+                "posthog_legacy_usage_report_terminal_status",
+                {**base_labels, "terminal_status": "failed"},
+            )
+            == 1
+        )
+        assert (
+            registries[-2].get_sample_value(
+                "posthog_legacy_usage_report_failures",
+                {**base_labels, "failure_type": "process"},
+            )
+            == 1
+        )
+        assert registries[-2].get_sample_value("posthog_legacy_usage_report_query_duration_seconds", base_labels) == 42
+
+
+@freeze_time("2026-06-29T12:00:00Z")
+def test_send_all_org_usage_reports_records_queue_failure_when_producer_returns_empty_response() -> None:
+    registries: list[CollectorRegistry] = []
+    mock_posthog = MagicMock()
+    producer = MagicMock()
+    producer.send_message.return_value = {}
+    org_report = MagicMock()
+    org_report.organization_id = "org-id"
+    base_labels = {
+        "region": "US",
+        "source": "manual",
+        "execution_location": "toolbox",
+        "execution_mode": "direct",
+        "run_scope": "all_orgs",
+    }
+
+    with (
+        patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+        patch("posthog.tasks.usage_report.get_ph_client", return_value=mock_posthog),
+        patch("posthog.tasks.usage_report.get_instance_metadata", return_value=MagicMock()),
+        patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=False),
+        patch("ee.sqs.SQSProducer.get_sqs_producer", return_value=producer),
+        patch("posthog.tasks.usage_report.settings.EE_AVAILABLE", True),
+        patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+        ),
+        patch("posthog.tasks.usage_report._get_all_org_reports", return_value={"org-id": org_report}),
+        patch("posthog.tasks.usage_report._get_full_org_usage_report", return_value=MagicMock()),
+        patch(
+            "posthog.tasks.usage_report._get_full_org_usage_report_as_dict", return_value={"has_non_zero_usage": True}
+        ),
+        patch("posthog.tasks.usage_report.has_non_zero_usage", return_value=True),
+    ):
+        send_all_org_usage_reports(
+            at="2026-06-29",
+            skip_capture_event=True,
+            run_source="manual",
+            execution_location="toolbox",
+            execution_mode="direct",
+        )
+
+    producer.send_message.assert_called_once()
+    complete_properties = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")[0]
+    assert complete_properties["terminal_status"] == "partial_success"
+    assert complete_properties["failure_counts"] == {"queue": 1}
+    assert complete_properties["total_orgs_sent"] == 0
+    assert (
+        registries[-2].get_sample_value(
+            "posthog_legacy_usage_report_terminal_status",
+            {**base_labels, "terminal_status": "partial_success"},
+        )
+        == 1
+    )
+    assert (
+        registries[-2].get_sample_value(
+            "posthog_legacy_usage_report_failures",
+            {**base_labels, "failure_type": "queue"},
+        )
+        == 1
+    )
+
+
+@freeze_time("2026-06-29T12:00:00Z")
+def test_send_all_org_usage_reports_records_producer_unavailable_as_partial_success() -> None:
+    registries: list[CollectorRegistry] = []
+    mock_posthog = MagicMock()
+    org_report = MagicMock()
+    org_report.organization_id = "org-id"
+    base_labels = {
+        "region": "US",
+        "source": "manual",
+        "execution_location": "toolbox",
+        "execution_mode": "direct",
+        "run_scope": "all_orgs",
+    }
+
+    with (
+        patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+        patch("posthog.tasks.usage_report.get_ph_client", return_value=mock_posthog),
+        patch("posthog.tasks.usage_report.get_instance_metadata", return_value=MagicMock()),
+        patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=False),
+        patch("ee.sqs.SQSProducer.get_sqs_producer", side_effect=RuntimeError("producer unavailable")),
+        patch("posthog.tasks.usage_report.settings.EE_AVAILABLE", True),
+        patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+        ),
+        patch("posthog.tasks.usage_report._get_all_org_reports", return_value={"org-id": org_report}),
+        patch("posthog.tasks.usage_report._get_full_org_usage_report", return_value=MagicMock()),
+        patch(
+            "posthog.tasks.usage_report._get_full_org_usage_report_as_dict", return_value={"has_non_zero_usage": True}
+        ),
+        patch("posthog.tasks.usage_report.has_non_zero_usage", return_value=True),
+    ):
+        send_all_org_usage_reports(
+            at="2026-06-29",
+            skip_capture_event=True,
+            run_source="manual",
+            execution_location="toolbox",
+            execution_mode="direct",
+        )
+
+    complete_properties = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")[0]
+    assert complete_properties["terminal_status"] == "partial_success"
+    assert complete_properties["failure_counts"] == {"producer_unavailable": 1}
+    assert complete_properties["total_orgs_sent"] == 0
+    assert (
+        registries[-2].get_sample_value(
+            "posthog_legacy_usage_report_failures",
+            {**base_labels, "failure_type": "producer_unavailable"},
+        )
+        == 1
+    )
+
+
+@freeze_time("2026-06-29T12:00:00Z")
+def test_send_all_org_usage_reports_keeps_observability_failures_best_effort() -> None:
+    mock_posthog = MagicMock()
+    mock_posthog.capture.side_effect = RuntimeError("posthog unavailable")
+    producer = MagicMock()
+    producer.send_message.return_value = {"MessageId": "message-id"}
+    org_report = MagicMock()
+    org_report.organization_id = "org-id"
+
+    with (
+        patch("posthog.tasks.usage_report.get_instance_region", return_value="US"),
+        patch("posthog.tasks.usage_report.get_ph_client", return_value=mock_posthog),
+        patch("posthog.tasks.usage_report.get_instance_metadata", return_value=MagicMock()),
+        patch("posthog.tasks.usage_report.posthoganalytics.feature_enabled", return_value=False),
+        patch("ee.sqs.SQSProducer.get_sqs_producer", return_value=producer),
+        patch("posthog.tasks.usage_report.settings.EE_AVAILABLE", True),
+        patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=RuntimeError("pushgateway unavailable"),
+        ),
+        patch("posthog.tasks.usage_report._get_all_org_reports", return_value={"org-id": org_report}),
+        patch("posthog.tasks.usage_report._get_full_org_usage_report", return_value=MagicMock()),
+        patch(
+            "posthog.tasks.usage_report._get_full_org_usage_report_as_dict", return_value={"has_non_zero_usage": True}
+        ),
+        patch("posthog.tasks.usage_report.has_non_zero_usage", return_value=True),
+    ):
+        send_all_org_usage_reports(
+            at="2026-06-29",
+            skip_capture_event=True,
+            run_source="manual",
+            execution_location="toolbox",
+            execution_mode="direct",
+        )
+
+    producer.send_message.assert_called_once()
+
+
+def test_scheduled_usage_report_wrapper_enqueues_scheduled_worker_context() -> None:
+    from posthog.tasks.tasks import send_org_usage_reports
+
+    with patch("posthog.tasks.usage_report.send_all_org_usage_reports.delay") as send_reports_mock:
+        send_org_usage_reports(organization_ids=["org-id"])
+
+    send_reports_mock.assert_called_once_with(
+        organization_ids=["org-id"],
+        run_source="scheduled",
+        execution_location="usage_report_worker",
+        execution_mode="celery",
+    )
 
 
 def _setup_replay_data(team_id: int, include_mobile_replay: bool, include_zero_duration: bool = False) -> None:
@@ -4963,11 +5314,9 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         assert data["organization_id"] == str(self.organization.id)
         assert data["usage_report"]["organization_id"] == str(self.organization.id)
 
-        capture_calls = [
-            call for call in mock_posthog.capture.call_args_list if call[1].get("event") == "usage reports complete"
-        ]
+        capture_calls = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")
         assert len(capture_calls) == 1
-        properties = capture_calls[0][1]["properties"]
+        properties = capture_calls[0]
         assert properties["filtered"] is True
         assert properties["requested_org_count"] == 1
         assert properties["total_orgs"] == 1
@@ -4997,10 +5346,8 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
 
         assert set(sent_org_ids) == set(org_ids)
 
-        capture_calls = [
-            call for call in mock_posthog.capture.call_args_list if call[1].get("event") == "usage reports complete"
-        ]
-        properties = capture_calls[0][1]["properties"]
+        capture_calls = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")
+        properties = capture_calls[0]
         assert properties["filtered"] is True
         assert properties["requested_org_count"] == 2
         assert properties["total_orgs"] == 2
@@ -5021,11 +5368,9 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         # Should not send any messages
         mock_producer.send_message.assert_not_called()
 
-        capture_calls = [
-            call for call in mock_posthog.capture.call_args_list if call[1].get("event") == "usage reports complete"
-        ]
+        capture_calls = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")
         assert len(capture_calls) == 1
-        properties = capture_calls[0][1]["properties"]
+        properties = capture_calls[0]
         assert properties["filtered"] is True
         assert properties["requested_org_count"] == 1
         assert properties["requested_missing_org_count"] == 1
@@ -5065,10 +5410,8 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
 
         assert set(sent_org_ids) == {str(self.organization.id), str(self.org2.id)}
 
-        capture_calls = [
-            call for call in mock_posthog.capture.call_args_list if call[1].get("event") == "usage reports complete"
-        ]
-        properties = capture_calls[0][1]["properties"]
+        capture_calls = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")
+        properties = capture_calls[0]
         assert properties["filtered"] is True
         assert properties["requested_org_count"] == 4
         assert properties["requested_missing_org_count"] == 2
@@ -5090,10 +5433,8 @@ class TestOrganizationFiltering(LicensedTestMixin, ClickhouseDestroyTablesMixin,
         assert mock_producer.send_message.call_count == 3
 
         # Verify telemetry shows unfiltered
-        capture_calls = [
-            call for call in mock_posthog.capture.call_args_list if call[1].get("event") == "usage reports complete"
-        ]
-        properties = capture_calls[0][1]["properties"]
+        capture_calls = _captured_usage_report_event_properties(mock_posthog, "usage reports complete")
+        properties = capture_calls[0]
         assert properties["filtered"] is False
         assert properties.get("requested_org_count") is None
         assert properties.get("requested_missing_org_count") is None

--- a/posthog/tasks/test/test_usage_report_observability.py
+++ b/posthog/tasks/test/test_usage_report_observability.py
@@ -173,6 +173,57 @@ def test_usage_report_run_state_sticky_timestamps_use_terminal_only_jobs() -> No
     )
 
 
+def test_usage_report_run_state_dry_runs_do_not_update_last_success_timestamp() -> None:
+    registries: list[CollectorRegistry] = []
+    job_names: list[str] = []
+    context = UsageReportRunContext(
+        run_id="run-123",
+        source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
+        run_scope="all_orgs",
+        requested_date="2026-06-29",
+        period_start=datetime(2026, 6, 29),
+        period_end=datetime(2026, 6, 30),
+        region="US",
+        celery_task_id=None,
+        celery_retries=None,
+        dry_run=True,
+    )
+
+    def collect_registry(job_name: str) -> AbstractContextManager[CollectorRegistry]:
+        job_names.append(job_name)
+        return _collect_usage_report_registry(registries)
+
+    with patch("posthog.tasks.usage_report_observability.pushed_metrics_registry", side_effect=collect_registry):
+        _push_usage_report_run_state(
+            UsageReportRunStateSnapshot(
+                context=context,
+                stage="terminal",
+                terminal_status="completed",
+                stage_timestamp=1_790_000_000,
+            )
+        )
+
+    assert job_names == [
+        "legacy_usage_report_run_state_us_manual_toolbox_direct_all_orgs",
+        "legacy_usage_report_run_terminal_timestamp_us_manual_toolbox_direct_all_orgs",
+    ]
+    assert (
+        registries[1].get_sample_value(
+            "posthog_legacy_usage_report_last_terminal_timestamp_seconds",
+            {
+                "region": "US",
+                "source": "manual",
+                "execution_location": "toolbox",
+                "execution_mode": "direct",
+                "run_scope": "all_orgs",
+            },
+        )
+        == 1_790_000_000
+    )
+
+
 def test_usage_report_run_state_job_name_distinguishes_filtered_runs() -> None:
     registries: list[CollectorRegistry] = []
     context = UsageReportRunContext(

--- a/posthog/tasks/test/test_usage_report_observability.py
+++ b/posthog/tasks/test/test_usage_report_observability.py
@@ -1,0 +1,237 @@
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
+from datetime import datetime, timedelta
+
+from freezegun import freeze_time
+from unittest.mock import MagicMock, patch
+
+from prometheus_client import CollectorRegistry
+
+from posthog.tasks.usage_report_observability import (
+    UsageReportRunContext,
+    UsageReportRunObserver,
+    UsageReportRunProgress,
+    UsageReportRunStateSnapshot,
+    _push_usage_report_run_state,
+)
+
+
+@contextmanager
+def _collect_usage_report_registry(registries: list[CollectorRegistry]) -> Iterator[CollectorRegistry]:
+    registry = CollectorRegistry()
+    registries.append(registry)
+    yield registry
+
+
+def test_usage_report_run_state_metrics_use_bounded_labels_and_bounded_job_name() -> None:
+    registries: list[CollectorRegistry] = []
+    context = UsageReportRunContext(
+        run_id="run-123",
+        source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
+        run_scope="all_orgs",
+        requested_date="2026-06-29",
+        period_start=datetime(2026, 6, 29),
+        period_end=datetime(2026, 6, 30),
+        region="US",
+        celery_task_id="celery-task-123",
+        celery_retries=2,
+    )
+    snapshot = UsageReportRunStateSnapshot(
+        context=context,
+        stage="sending",
+        terminal_status="none",
+        stage_timestamp=1_790_000_000,
+        total_orgs=3,
+        total_orgs_sent=1,
+        query_duration_seconds=12.5,
+        failure_counts={"queue": 2},
+    )
+
+    with patch(
+        "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+        side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+    ) as pushed_metrics_registry_mock:
+        _push_usage_report_run_state(snapshot)
+
+    pushed_metrics_registry_mock.assert_called_once_with(
+        "legacy_usage_report_run_state_us_manual_toolbox_direct_all_orgs"
+    )
+    registry = registries[0]
+    base_labels = {
+        "region": "US",
+        "source": "manual",
+        "execution_location": "toolbox",
+        "execution_mode": "direct",
+        "run_scope": "all_orgs",
+    }
+    assert (
+        registry.get_sample_value(
+            "posthog_legacy_usage_report_current_stage",
+            {**base_labels, "stage": "sending"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "posthog_legacy_usage_report_current_stage",
+            {**base_labels, "stage": "querying"},
+        )
+        == 0
+    )
+    assert (
+        registry.get_sample_value(
+            "posthog_legacy_usage_report_terminal_status",
+            {**base_labels, "terminal_status": "none"},
+        )
+        == 1
+    )
+    assert (
+        registry.get_sample_value(
+            "posthog_legacy_usage_report_failures",
+            {**base_labels, "failure_type": "queue"},
+        )
+        == 2
+    )
+    assert (
+        registry.get_sample_value(
+            "posthog_legacy_usage_report_failures",
+            {**base_labels, "failure_type": "capture"},
+        )
+        == 0
+    )
+
+    for metric in registry.collect():
+        for sample in metric.samples:
+            assert "run_id" not in sample.labels
+            assert "requested_date" not in sample.labels
+            assert "celery_task_id" not in sample.labels
+
+
+def test_usage_report_run_state_sticky_timestamps_use_terminal_only_jobs() -> None:
+    registries: list[CollectorRegistry] = []
+    job_names: list[str] = []
+    context = UsageReportRunContext(
+        run_id="run-123",
+        source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
+        run_scope="all_orgs",
+        requested_date="2026-06-29",
+        period_start=datetime(2026, 6, 29),
+        period_end=datetime(2026, 6, 30),
+        region="US",
+        celery_task_id=None,
+        celery_retries=None,
+    )
+    completed_snapshot = UsageReportRunStateSnapshot(
+        context=context,
+        stage="terminal",
+        terminal_status="completed",
+        stage_timestamp=1_790_000_000,
+    )
+    querying_snapshot = UsageReportRunStateSnapshot(
+        context=context,
+        stage="querying",
+        terminal_status="none",
+        stage_timestamp=1_790_000_100,
+    )
+
+    def collect_registry(job_name: str) -> AbstractContextManager[CollectorRegistry]:
+        job_names.append(job_name)
+        return _collect_usage_report_registry(registries)
+
+    with patch("posthog.tasks.usage_report_observability.pushed_metrics_registry", side_effect=collect_registry):
+        _push_usage_report_run_state(completed_snapshot)
+        _push_usage_report_run_state(querying_snapshot)
+
+    assert job_names == [
+        "legacy_usage_report_run_state_us_manual_toolbox_direct_all_orgs",
+        "legacy_usage_report_run_terminal_timestamp_us_manual_toolbox_direct_all_orgs",
+        "legacy_usage_report_run_success_timestamp_us_manual_toolbox_direct_all_orgs",
+        "legacy_usage_report_run_state_us_manual_toolbox_direct_all_orgs",
+    ]
+    base_labels = {
+        "region": "US",
+        "source": "manual",
+        "execution_location": "toolbox",
+        "execution_mode": "direct",
+        "run_scope": "all_orgs",
+    }
+    assert (
+        registries[1].get_sample_value("posthog_legacy_usage_report_last_terminal_timestamp_seconds", base_labels)
+        == 1_790_000_000
+    )
+    assert (
+        registries[2].get_sample_value("posthog_legacy_usage_report_last_success_timestamp_seconds", base_labels)
+        == 1_790_000_000
+    )
+    assert (
+        registries[3].get_sample_value("posthog_legacy_usage_report_last_success_timestamp_seconds", base_labels)
+        is None
+    )
+
+
+def test_usage_report_run_state_job_name_distinguishes_filtered_runs() -> None:
+    registries: list[CollectorRegistry] = []
+    context = UsageReportRunContext(
+        run_id="run-123",
+        source="scheduled",
+        execution_location="usage_report_worker",
+        execution_mode="celery",
+        run_scope="filtered_orgs",
+        requested_date="2026-06-29",
+        period_start=datetime(2026, 6, 29),
+        period_end=datetime(2026, 6, 30),
+        region="US",
+        celery_task_id="celery-task-123",
+        celery_retries=0,
+    )
+
+    with patch(
+        "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+        side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+    ) as pushed_metrics_registry_mock:
+        _push_usage_report_run_state(UsageReportRunStateSnapshot(context=context, stage="querying"))
+
+    pushed_metrics_registry_mock.assert_called_once_with(
+        "legacy_usage_report_run_state_us_scheduled_usage_report_worker_celery_filtered_orgs"
+    )
+
+
+def test_usage_report_terminal_properties_keep_total_time_compatible_with_phase_duration() -> None:
+    registries: list[CollectorRegistry] = []
+    context = UsageReportRunContext(
+        run_id="run-123",
+        source="manual",
+        execution_location="toolbox",
+        execution_mode="direct",
+        run_scope="all_orgs",
+        requested_date="2026-06-29",
+        period_start=datetime(2026, 6, 29),
+        period_end=datetime(2026, 6, 30),
+        region="US",
+        celery_task_id=None,
+        celery_retries=None,
+    )
+    observer = UsageReportRunObserver(context=context)
+    mock_posthog = MagicMock()
+
+    with freeze_time("2026-06-30T12:00:00Z") as frozen_time:
+        progress = UsageReportRunProgress.for_organizations(None)
+        progress.query_duration_seconds = 10.0
+        progress.queue_duration_seconds = 20.0
+        frozen_time.tick(delta=timedelta(seconds=45))
+
+        with patch(
+            "posthog.tasks.usage_report_observability.pushed_metrics_registry",
+            side_effect=lambda _job_name: _collect_usage_report_registry(registries),
+        ):
+            terminal_properties = observer.completed(mock_posthog, progress)
+
+    complete_properties = mock_posthog.capture.call_args.kwargs["properties"]
+    assert complete_properties["total_time"] == 30.0
+    assert complete_properties["total_duration_seconds"] == 45.0
+    assert terminal_properties["total_time"] == 30.0
+    assert terminal_properties["total_duration_seconds"] == 45.0

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -16,6 +16,7 @@ from django.db.models.functions import Coalesce
 
 import requests
 import structlog
+import posthoganalytics
 from cachetools import cached
 from celery import shared_task
 from dateutil import parser
@@ -41,6 +42,13 @@ from posthog.schema_enums import AIEventType
 from posthog.scoping_audit import skip_team_scope_audit
 from posthog.settings import CLICKHOUSE_CLUSTER, INSTANCE_TAG
 from posthog.tasks.report_utils import capture_event
+from posthog.tasks.usage_report_observability import (
+    UsageReportExecutionLocation,
+    UsageReportExecutionMode,
+    UsageReportRunObserver,
+    UsageReportRunProgress,
+    UsageReportRunSource,
+)
 from posthog.tasks.utils import CeleryQueue
 from posthog.utils import get_helm_info_env, get_instance_realm, get_instance_region, get_previous_day
 
@@ -2838,9 +2846,7 @@ def _queue_report(producer: Any, organization_id: str, full_report_dict: dict[st
     response = producer.send_message(message_body=compressed_b64, message_attributes=message_attributes)
 
     if not response:
-        logger.exception(f"Failed to send usage report for organization {organization_id}")
-
-    return
+        raise RuntimeError(f"Failed to send usage report for organization {organization_id}: empty producer response")
 
 
 @shared_task(**USAGE_REPORT_TASK_KWARGS, max_retries=3)
@@ -2849,136 +2855,198 @@ def send_all_org_usage_reports(
     at: Optional[str] = None,
     skip_capture_event: bool = False,
     organization_ids: Optional[list[str]] = None,
+    run_source: UsageReportRunSource = "unknown",
+    execution_location: UsageReportExecutionLocation = "unknown",
+    execution_mode: Optional[UsageReportExecutionMode] = None,
 ) -> None:
-    import posthoganalytics
-
-    are_usage_reports_disabled = posthoganalytics.feature_enabled("disable-usage-reports", "internal_billing_events")
-    if are_usage_reports_disabled:
-        posthoganalytics.capture_exception(Exception(f"Usage reports are disabled for {at}"))
-        return
-
     at_date = parser.parse(at) if at else None
     period = get_previous_day(at=at_date)
     period_start, period_end = period
+    observer = UsageReportRunObserver.from_current_task(
+        at=at,
+        period_start=period_start,
+        period_end=period_end,
+        run_source=run_source,
+        execution_location=execution_location,
+        execution_mode=execution_mode,
+        run_scope="filtered_orgs" if organization_ids is not None else "all_orgs",
+        region=get_instance_region() or "unknown",
+    )
+    progress = UsageReportRunProgress.for_organizations(organization_ids)
+    pha_client: Optional[PostHogClient] = None
+    log_context = observer.log_context
 
-    instance_metadata = get_instance_metadata(period)
+    entry_properties = {
+        "dry_run": dry_run,
+        "skip_capture_event": skip_capture_event,
+        **progress.filtering_properties,
+    }
+    logger.info("Legacy usage-report producer run started", **log_context, **entry_properties)
 
-    producer = None
     try:
-        if settings.EE_AVAILABLE:
-            from ee.sqs.SQSProducer import get_sqs_producer
-
-            producer = get_sqs_producer("usage_reports")
-    except Exception:
-        pass
-
-    pha_client = get_ph_client(sync_mode=True)
-
-    if organization_ids:
-        logger.info(
-            "Sending usage reports for specific organizations",
-            org_count=len(organization_ids),
-            organization_ids=organization_ids,
+        are_usage_reports_disabled = posthoganalytics.feature_enabled(
+            "disable-usage-reports", "internal_billing_events"
         )
+        if are_usage_reports_disabled:
+            try:
+                posthoganalytics.capture_exception(Exception(f"Usage reports are disabled for {at}"))
+            except Exception as capture_err:
+                logger.exception(
+                    "Failed to capture usage reports disabled exception",
+                    **log_context,
+                    error=capture_err,
+                )
+            terminal_properties = observer.skipped(progress)
+            logger.info(
+                "Legacy usage-report producer run skipped",
+                **log_context,
+                **terminal_properties,
+            )
+            return
 
-    logger.info("Querying usage report data")
-    query_time_start = datetime.now()
+        instance_metadata = get_instance_metadata(period)
 
-    org_reports = _get_all_org_reports(period_start, period_end)
-
-    if organization_ids:
-        original_count = len(org_reports)
-        org_reports = {org_id: report for org_id, report in org_reports.items() if org_id in organization_ids}
-        filtered_count = len(org_reports)
-        missing_orgs = set(organization_ids) - set(org_reports.keys())
-        logger.info(
-            f"Filtered org reports from {original_count} to {filtered_count} organizations",
-            requested_org_count=len(organization_ids),
-            found_org_count=filtered_count,
-            missing_orgs=missing_orgs or None,
-        )
-
-    filtering_properties: dict[str, Any] = {"filtered": organization_ids is not None}
-    if organization_ids:
-        filtering_properties["requested_org_count"] = len(organization_ids)
-        filtering_properties["requested_missing_org_count"] = len(missing_orgs) if missing_orgs else None
-
-    query_time_duration = (datetime.now() - query_time_start).total_seconds()
-    logger.info(f"Found {len(org_reports)} org reports. It took {query_time_duration} seconds.")
-
-    total_orgs = len(org_reports)
-    total_orgs_sent = 0
-
-    logger.info("Sending usage reports to billing")
-    queue_time_start = datetime.now()
-
-    pha_client.capture(
-        distinct_id="internal_billing_events",
-        event="usage reports starting",
-        properties={
-            "total_orgs": total_orgs,
-            "region": get_instance_region(),
-            **filtering_properties,
-        },
-        groups={"instance": settings.SITE_URL},
-    )
-
-    for org_report in org_reports.values():
+        producer = None
         try:
-            organization_id = org_report.organization_id
+            if settings.EE_AVAILABLE:
+                from ee.sqs.SQSProducer import get_sqs_producer  # noqa: PLC0415 - EE-only optional import
 
-            full_report = _get_full_org_usage_report(org_report, instance_metadata)
-            full_report_dict = _get_full_org_usage_report_as_dict(full_report)
+                producer = get_sqs_producer("usage_reports")
+        except Exception as producer_err:
+            logger.exception(
+                "Failed to initialize usage reports SQS producer",
+                **log_context,
+                error=producer_err,
+            )
 
-            if dry_run:
-                logger.info(f"Dry run, skipping sending for organization {organization_id}")
-                continue
+        if organization_ids:
+            logger.info(
+                "Sending usage reports for specific organizations",
+                **log_context,
+                org_count=len(organization_ids),
+                organization_ids=organization_ids,
+            )
 
-            # First capture the events to PostHog
-            if not skip_capture_event:
-                try:
-                    at_date_str = at_date.isoformat() if at_date else None
-                    capture_report.delay(
-                        organization_id=organization_id,
-                        full_report_dict=full_report_dict,
-                        at_date=at_date_str,
+        pha_client = get_ph_client(sync_mode=True)
+        querying_properties = {"stage": "querying", **progress.filtering_properties}
+        logger.info("Querying usage report data", **log_context, **querying_properties)
+        observer.querying(pha_client, progress)
+        progress.start_query_timer()
+
+        org_reports = _get_all_org_reports(period_start, period_end)
+
+        if organization_ids:
+            original_count = len(org_reports)
+            org_reports = {org_id: report for org_id, report in org_reports.items() if org_id in organization_ids}
+            filtered_count = len(org_reports)
+            missing_orgs = set(organization_ids) - set(org_reports.keys())
+            progress.filtering_properties["requested_missing_org_count"] = len(missing_orgs) if missing_orgs else None
+            logger.info(
+                f"Filtered org reports from {original_count} to {filtered_count} organizations",
+                **log_context,
+                requested_org_count=len(organization_ids),
+                found_org_count=filtered_count,
+                missing_orgs=missing_orgs or None,
+            )
+
+        progress.finish_query_timer()
+        progress.total_orgs = len(org_reports)
+        query_complete_properties = {
+            "stage": "query_complete",
+            "total_orgs": progress.total_orgs,
+            "query_time": progress.query_duration_seconds,
+            **progress.filtering_properties,
+        }
+        logger.info(
+            f"Found {progress.total_orgs} org reports. It took {progress.query_duration_seconds} seconds.",
+            **log_context,
+            **query_complete_properties,
+        )
+
+        sending_properties = {
+            "stage": "sending",
+            "total_orgs": progress.total_orgs,
+            "query_time": progress.query_duration_seconds,
+            **progress.filtering_properties,
+        }
+        logger.info("Sending usage reports to billing", **log_context, **sending_properties)
+        observer.sending(progress)
+        progress.start_queue_timer()
+        observer.starting(pha_client, progress)
+
+        for org_report in org_reports.values():
+            organization_id = None
+            try:
+                organization_id = org_report.organization_id
+
+                full_report = _get_full_org_usage_report(org_report, instance_metadata)
+                full_report_dict = _get_full_org_usage_report_as_dict(full_report)
+
+                if dry_run:
+                    logger.info(
+                        f"Dry run, skipping sending for organization {organization_id}",
+                        **log_context,
                     )
-                except Exception as capture_err:
-                    logger.exception(
-                        f"Failed to capture report for organization {organization_id}",
-                        error=capture_err,
-                    )
+                    continue
 
-            # Then send the reports to billing through SQS (only if the producer is available)
-            if has_non_zero_usage(full_report) and producer:
-                try:
-                    _queue_report(producer, organization_id, full_report_dict)
-                    total_orgs_sent += 1
-                except Exception as err:
-                    logger.exception(
-                        f"Failed to queue report for organization {organization_id}",
-                        error=err,
-                    )
+                # First capture the events to PostHog
+                if not skip_capture_event:
+                    try:
+                        at_date_str = at_date.isoformat() if at_date else None
+                        capture_report.delay(
+                            organization_id=organization_id,
+                            full_report_dict=full_report_dict,
+                            at_date=at_date_str,
+                        )
+                    except Exception as capture_err:
+                        progress.record_failure("capture")
+                        logger.exception(
+                            f"Failed to capture report for organization {organization_id}",
+                            **log_context,
+                            error=capture_err,
+                        )
 
-        except Exception as loop_err:
-            logger.exception(f"Failed to process organization {organization_id}", error=loop_err)
+                report_has_non_zero_usage = has_non_zero_usage(full_report)
+                if report_has_non_zero_usage and producer:
+                    try:
+                        _queue_report(producer, organization_id, full_report_dict)
+                        progress.total_orgs_sent += 1
+                    except Exception as err:
+                        progress.record_failure("queue")
+                        logger.exception(
+                            f"Failed to queue report for organization {organization_id}",
+                            **log_context,
+                            error=err,
+                        )
+                elif report_has_non_zero_usage and settings.EE_AVAILABLE:
+                    progress.record_failure("producer_unavailable")
 
-    queue_time_duration = (datetime.now() - queue_time_start).total_seconds()
-    pha_client.capture(
-        distinct_id="internal_billing_events",
-        event="usage reports complete",
-        properties={
-            "total_orgs": total_orgs,
-            "period_start": period_start.isoformat(),
-            "period_end": period_end.isoformat(),
-            "total_orgs_sent": total_orgs_sent,
-            "query_time": query_time_duration,
-            "queue_time": queue_time_duration,
-            "total_time": query_time_duration + queue_time_duration,
-            "region": get_instance_region(),
-            **filtering_properties,
-        },
-        groups={"instance": settings.SITE_URL},
-    )
+            except Exception as loop_err:
+                progress.record_failure("process")
+                logger.exception(
+                    f"Failed to process organization {organization_id}",
+                    **log_context,
+                    error=loop_err,
+                )
 
-    logger.info(f"Usage reports complete. Total orgs: {total_orgs}, total orgs sent: {total_orgs_sent}.")
+        progress.finish_queue_timer()
+
+        terminal_properties = observer.completed(pha_client, progress)
+
+        logger.info(
+            f"Usage reports complete. Total orgs: {progress.total_orgs}, total orgs sent: {progress.total_orgs_sent}.",
+            **log_context,
+            **terminal_properties,
+        )
+
+    except Exception as err:
+        progress.refresh_active_timers()
+        progress.record_failure("process")
+        terminal_properties = observer.failed(pha_client, progress)
+        logger.exception(
+            "Legacy usage-report producer run failed",
+            **log_context,
+            **terminal_properties,
+            error=err,
+        )
+        raise

--- a/posthog/tasks/usage_report.py
+++ b/posthog/tasks/usage_report.py
@@ -2871,13 +2871,13 @@ def send_all_org_usage_reports(
         execution_mode=execution_mode,
         run_scope="filtered_orgs" if organization_ids is not None else "all_orgs",
         region=get_instance_region() or "unknown",
+        dry_run=dry_run,
     )
     progress = UsageReportRunProgress.for_organizations(organization_ids)
     pha_client: Optional[PostHogClient] = None
     log_context = observer.log_context
 
     entry_properties = {
-        "dry_run": dry_run,
         "skip_capture_event": skip_capture_event,
         **progress.filtering_properties,
     }

--- a/posthog/tasks/usage_report_observability.py
+++ b/posthog/tasks/usage_report_observability.py
@@ -65,6 +65,7 @@ class UsageReportRunContext:
     celery_task_id: Optional[str]
     celery_retries: Optional[int]
     celery_max_retries: Optional[int] = None
+    dry_run: bool = False
 
 
 @dataclasses.dataclass(frozen=True)
@@ -157,6 +158,7 @@ class UsageReportRunObserver:
         execution_mode: Optional[UsageReportExecutionMode],
         run_scope: UsageReportRunScope,
         region: str,
+        dry_run: bool = False,
     ) -> "UsageReportRunObserver":
         celery_metadata = _get_current_usage_report_celery_metadata()
         resolved_execution_mode = execution_mode or ("celery" if celery_metadata.task_id else "direct")
@@ -178,6 +180,7 @@ class UsageReportRunObserver:
             celery_task_id=celery_metadata.task_id,
             celery_retries=celery_metadata.retries,
             celery_max_retries=celery_metadata.max_retries,
+            dry_run=dry_run,
         )
         return cls(context=context)
 
@@ -420,6 +423,7 @@ def _usage_report_run_log_context(context: UsageReportRunContext) -> dict[str, A
         "period_start": context.period_start.isoformat(),
         "period_end": context.period_end.isoformat(),
         "requested_date": context.requested_date,
+        "dry_run": context.dry_run,
         "celery_task_id": context.celery_task_id,
         "celery_retries": context.celery_retries,
         "celery_max_retries": context.celery_max_retries,
@@ -485,7 +489,7 @@ def _push_usage_report_sticky_timestamps(snapshot: UsageReportRunStateSnapshot) 
         )
         last_terminal_timestamp_gauge.labels(**base_labels).set(snapshot.stage_timestamp)
 
-    if snapshot.terminal_status == "completed":
+    if snapshot.terminal_status == "completed" and not snapshot.context.dry_run:
         with pushed_metrics_registry(_usage_report_success_timestamp_job_name(snapshot.context)) as registry:
             last_success_timestamp_gauge = Gauge(
                 "posthog_legacy_usage_report_last_success_timestamp_seconds",

--- a/posthog/tasks/usage_report_observability.py
+++ b/posthog/tasks/usage_report_observability.py
@@ -1,0 +1,582 @@
+import dataclasses
+from collections.abc import Mapping, Sequence
+from datetime import UTC, datetime
+from typing import Any, Literal, Optional
+from uuid import uuid4
+
+from django.conf import settings
+
+from celery import current_task
+from posthoganalytics.client import Client as PostHogClient
+from prometheus_client import Gauge
+from structlog import get_logger
+
+from posthog.metrics import pushed_metrics_registry
+
+logger = get_logger(__name__)
+
+UsageReportRunSource = Literal["scheduled", "manual", "unknown"]
+UsageReportExecutionLocation = Literal["usage_report_worker", "toolbox", "unknown"]
+UsageReportExecutionMode = Literal["celery", "direct"]
+UsageReportRunScope = Literal["all_orgs", "filtered_orgs"]
+UsageReportRunStage = Literal["querying", "sending", "terminal"]
+UsageReportTerminalStatus = Literal["completed", "partial_success", "skipped", "failed", "none"]
+UsageReportFailureType = Literal["capture", "process", "queue", "producer_unavailable"]
+UsageReportCeleryAttemptStatus = Literal["direct", "first_attempt", "retry_attempt", "final_retry", "unknown"]
+
+USAGE_REPORT_RUN_STAGES: tuple[UsageReportRunStage, ...] = ("querying", "sending", "terminal")
+USAGE_REPORT_TERMINAL_STATUSES: tuple[UsageReportTerminalStatus, ...] = (
+    "completed",
+    "partial_success",
+    "skipped",
+    "failed",
+    "none",
+)
+USAGE_REPORT_FAILURE_TYPES: tuple[UsageReportFailureType, ...] = (
+    "capture",
+    "process",
+    "queue",
+    "producer_unavailable",
+)
+USAGE_REPORT_RUN_STATE_JOB_NAME = "legacy_usage_report_run_state"
+USAGE_REPORT_RUN_TERMINAL_TIMESTAMP_JOB_NAME = "legacy_usage_report_run_terminal_timestamp"
+USAGE_REPORT_RUN_SUCCESS_TIMESTAMP_JOB_NAME = "legacy_usage_report_run_success_timestamp"
+USAGE_REPORT_RUN_METRIC_LABELS = ["region", "source", "execution_location", "execution_mode", "run_scope"]
+
+
+@dataclasses.dataclass(frozen=True)
+class UsageReportCeleryMetadata:
+    task_id: Optional[str]
+    retries: Optional[int]
+    max_retries: Optional[int]
+
+
+@dataclasses.dataclass(frozen=True)
+class UsageReportRunContext:
+    run_id: str
+    source: UsageReportRunSource
+    execution_location: UsageReportExecutionLocation
+    execution_mode: UsageReportExecutionMode
+    run_scope: UsageReportRunScope
+    requested_date: Optional[str]
+    period_start: datetime
+    period_end: datetime
+    region: str
+    celery_task_id: Optional[str]
+    celery_retries: Optional[int]
+    celery_max_retries: Optional[int] = None
+
+
+@dataclasses.dataclass(frozen=True)
+class UsageReportRunStateSnapshot:
+    context: UsageReportRunContext
+    stage: UsageReportRunStage
+    terminal_status: UsageReportTerminalStatus = "none"
+    stage_timestamp: float = dataclasses.field(default_factory=lambda: datetime.now(UTC).timestamp())
+    total_orgs: Optional[int] = None
+    total_orgs_sent: Optional[int] = None
+    query_duration_seconds: Optional[float] = None
+    total_duration_seconds: Optional[float] = None
+    failure_counts: dict[str, int] = dataclasses.field(default_factory=dict)
+
+
+@dataclasses.dataclass
+class UsageReportRunProgress:
+    filtering_properties: dict[str, Any]
+    started_at: datetime = dataclasses.field(default_factory=lambda: datetime.now(UTC))
+    query_started_at: Optional[datetime] = None
+    query_finished_at: Optional[datetime] = None
+    queue_started_at: Optional[datetime] = None
+    queue_finished_at: Optional[datetime] = None
+    failure_counts: dict[str, int] = dataclasses.field(default_factory=dict)
+    query_duration_seconds: float = 0.0
+    queue_duration_seconds: float = 0.0
+    total_orgs: int = 0
+    total_orgs_sent: int = 0
+
+    @classmethod
+    def for_organizations(cls, organization_ids: Optional[Sequence[str]]) -> "UsageReportRunProgress":
+        filtering_properties: dict[str, Any] = {"filtered": organization_ids is not None}
+        if organization_ids:
+            filtering_properties["requested_org_count"] = len(organization_ids)
+
+        return cls(filtering_properties=filtering_properties)
+
+    @property
+    def total_duration_seconds(self) -> float:
+        return (datetime.now(UTC) - self.started_at).total_seconds()
+
+    @property
+    def terminal_status(self) -> UsageReportTerminalStatus:
+        return "partial_success" if sum(self.failure_counts.values()) else "completed"
+
+    def start_query_timer(self) -> None:
+        self.query_started_at = datetime.now(UTC)
+
+    def finish_query_timer(self) -> None:
+        if not self.query_started_at:
+            return
+
+        self.query_finished_at = datetime.now(UTC)
+        self.query_duration_seconds = (self.query_finished_at - self.query_started_at).total_seconds()
+
+    def start_queue_timer(self) -> None:
+        self.queue_started_at = datetime.now(UTC)
+
+    def finish_queue_timer(self) -> None:
+        if not self.queue_started_at:
+            return
+
+        self.queue_finished_at = datetime.now(UTC)
+        self.queue_duration_seconds = (self.queue_finished_at - self.queue_started_at).total_seconds()
+
+    def refresh_active_timers(self) -> None:
+        now = datetime.now(UTC)
+        if self.query_started_at and not self.query_finished_at:
+            self.query_duration_seconds = (now - self.query_started_at).total_seconds()
+        if self.queue_started_at and not self.queue_finished_at:
+            self.queue_duration_seconds = (now - self.queue_started_at).total_seconds()
+
+    def record_failure(self, failure_type: UsageReportFailureType) -> None:
+        self.failure_counts[failure_type] = self.failure_counts.get(failure_type, 0) + 1
+
+
+@dataclasses.dataclass(frozen=True)
+class UsageReportRunObserver:
+    context: UsageReportRunContext
+
+    @classmethod
+    def from_current_task(
+        cls,
+        *,
+        at: Optional[str],
+        period_start: datetime,
+        period_end: datetime,
+        run_source: UsageReportRunSource,
+        execution_location: UsageReportExecutionLocation,
+        execution_mode: Optional[UsageReportExecutionMode],
+        run_scope: UsageReportRunScope,
+        region: str,
+    ) -> "UsageReportRunObserver":
+        celery_metadata = _get_current_usage_report_celery_metadata()
+        resolved_execution_mode = execution_mode or ("celery" if celery_metadata.task_id else "direct")
+        resolved_execution_location = execution_location
+
+        if resolved_execution_location == "unknown" and resolved_execution_mode == "celery":
+            resolved_execution_location = "usage_report_worker"
+
+        context = UsageReportRunContext(
+            run_id=celery_metadata.task_id or str(uuid4()),
+            source=run_source,
+            execution_location=resolved_execution_location,
+            execution_mode=resolved_execution_mode,
+            run_scope=run_scope,
+            requested_date=at,
+            period_start=period_start,
+            period_end=period_end,
+            region=region,
+            celery_task_id=celery_metadata.task_id,
+            celery_retries=celery_metadata.retries,
+            celery_max_retries=celery_metadata.max_retries,
+        )
+        return cls(context=context)
+
+    @property
+    def log_context(self) -> dict[str, Any]:
+        return _usage_report_run_log_context(self.context)
+
+    def querying(
+        self,
+        pha_client: PostHogClient,
+        progress: UsageReportRunProgress,
+    ) -> None:
+        self.push_state("querying", failure_counts=progress.failure_counts)
+        self.capture_event(pha_client, "usage reports querying", progress.filtering_properties)
+
+    def sending(self, progress: UsageReportRunProgress) -> None:
+        self.push_state(
+            "sending",
+            total_orgs=progress.total_orgs,
+            query_duration_seconds=progress.query_duration_seconds,
+            failure_counts=progress.failure_counts,
+        )
+
+    def starting(
+        self,
+        pha_client: PostHogClient,
+        progress: UsageReportRunProgress,
+    ) -> None:
+        self.capture_event(
+            pha_client,
+            "usage reports starting",
+            {
+                "total_orgs": progress.total_orgs,
+                **progress.filtering_properties,
+            },
+        )
+
+    def skipped(self, progress: UsageReportRunProgress) -> dict[str, Any]:
+        terminal_properties = {
+            "stage": "terminal",
+            "terminal_status": "skipped",
+            "total_orgs": progress.total_orgs,
+            "total_orgs_sent": progress.total_orgs_sent,
+            "total_duration_seconds": progress.total_duration_seconds,
+            "failure_counts": dict(progress.failure_counts),
+            **progress.filtering_properties,
+        }
+        self.push_state(
+            "terminal",
+            terminal_status="skipped",
+            total_orgs=progress.total_orgs,
+            total_orgs_sent=progress.total_orgs_sent,
+            total_duration_seconds=progress.total_duration_seconds,
+            failure_counts=progress.failure_counts,
+        )
+        return terminal_properties
+
+    def completed(
+        self,
+        pha_client: PostHogClient,
+        progress: UsageReportRunProgress,
+    ) -> dict[str, Any]:
+        terminal_status = progress.terminal_status
+        complete_event_properties = {
+            "total_orgs": progress.total_orgs,
+            "period_start": self.context.period_start.isoformat(),
+            "period_end": self.context.period_end.isoformat(),
+            "total_orgs_sent": progress.total_orgs_sent,
+            "query_time": progress.query_duration_seconds,
+            "queue_time": progress.queue_duration_seconds,
+            "total_time": progress.query_duration_seconds + progress.queue_duration_seconds,
+            "total_duration_seconds": progress.total_duration_seconds,
+            "terminal_status": terminal_status,
+            "failure_counts": dict(progress.failure_counts),
+            **progress.filtering_properties,
+        }
+        self.capture_event(pha_client, "usage reports complete", complete_event_properties)
+
+        terminal_properties = self._terminal_properties(
+            terminal_status=terminal_status,
+            progress=progress,
+        )
+        self.push_state(
+            "terminal",
+            terminal_status=terminal_status,
+            total_orgs=progress.total_orgs,
+            total_orgs_sent=progress.total_orgs_sent,
+            query_duration_seconds=progress.query_duration_seconds,
+            total_duration_seconds=progress.total_duration_seconds,
+            failure_counts=progress.failure_counts,
+        )
+        return terminal_properties
+
+    def failed(
+        self,
+        pha_client: Optional[PostHogClient],
+        progress: UsageReportRunProgress,
+    ) -> dict[str, Any]:
+        terminal_properties = self._terminal_properties(
+            terminal_status="failed",
+            progress=progress,
+        )
+        if pha_client:
+            failed_event_properties = {key: value for key, value in terminal_properties.items() if key != "stage"}
+            self.capture_event(pha_client, "usage reports failed", failed_event_properties)
+
+        self.push_state(
+            "terminal",
+            terminal_status="failed",
+            total_orgs=progress.total_orgs,
+            total_orgs_sent=progress.total_orgs_sent,
+            query_duration_seconds=progress.query_duration_seconds,
+            total_duration_seconds=progress.total_duration_seconds,
+            failure_counts=progress.failure_counts,
+        )
+        return terminal_properties
+
+    def push_state(
+        self,
+        stage: UsageReportRunStage,
+        *,
+        terminal_status: UsageReportTerminalStatus = "none",
+        total_orgs: Optional[int] = None,
+        total_orgs_sent: Optional[int] = None,
+        query_duration_seconds: Optional[float] = None,
+        total_duration_seconds: Optional[float] = None,
+        failure_counts: Optional[Mapping[str, int]] = None,
+    ) -> None:
+        _push_usage_report_run_state(
+            UsageReportRunStateSnapshot(
+                context=self.context,
+                stage=stage,
+                terminal_status=terminal_status,
+                total_orgs=total_orgs,
+                total_orgs_sent=total_orgs_sent,
+                query_duration_seconds=query_duration_seconds,
+                total_duration_seconds=total_duration_seconds,
+                failure_counts=dict(failure_counts or {}),
+            )
+        )
+
+    def capture_event(
+        self,
+        pha_client: PostHogClient,
+        event: str,
+        properties: Optional[Mapping[str, Any]] = None,
+    ) -> None:
+        try:
+            pha_client.capture(
+                distinct_id="internal_billing_events",
+                event=event,
+                properties=_usage_report_run_event_properties(self.context, properties),
+                groups={"instance": settings.SITE_URL},
+            )
+        except Exception as err:
+            logger.exception(
+                "Failed to capture usage report lifecycle event",
+                lifecycle_event=event,
+                run_id=self.context.run_id,
+                error=err,
+            )
+
+    def _terminal_properties(
+        self,
+        *,
+        terminal_status: UsageReportTerminalStatus,
+        progress: UsageReportRunProgress,
+    ) -> dict[str, Any]:
+        return {
+            "stage": "terminal",
+            "terminal_status": terminal_status,
+            "total_orgs": progress.total_orgs,
+            "total_orgs_sent": progress.total_orgs_sent,
+            "query_time": progress.query_duration_seconds,
+            "queue_time": progress.queue_duration_seconds,
+            "total_time": progress.query_duration_seconds + progress.queue_duration_seconds,
+            "total_duration_seconds": progress.total_duration_seconds,
+            "failure_counts": dict(progress.failure_counts),
+            **progress.filtering_properties,
+        }
+
+
+def _coerce_optional_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_current_usage_report_celery_metadata() -> UsageReportCeleryMetadata:
+    try:
+        task_request = getattr(current_task, "request", None)
+    except Exception:
+        return UsageReportCeleryMetadata(task_id=None, retries=None, max_retries=None)
+
+    task_id = getattr(task_request, "id", None)
+    retries = _coerce_optional_int(getattr(task_request, "retries", None))
+    max_retries = _coerce_optional_int(getattr(task_request, "max_retries", None))
+    if max_retries is None:
+        max_retries = _coerce_optional_int(getattr(current_task, "max_retries", None))
+
+    if task_id is not None:
+        task_id = str(task_id)
+    else:
+        retries = None
+        max_retries = None
+
+    return UsageReportCeleryMetadata(task_id=task_id, retries=retries, max_retries=max_retries)
+
+
+def _usage_report_celery_attempt(context: UsageReportRunContext) -> Optional[int]:
+    if context.execution_mode != "celery" or context.celery_retries is None:
+        return None
+    return context.celery_retries + 1
+
+
+def _usage_report_celery_attempt_status(context: UsageReportRunContext) -> UsageReportCeleryAttemptStatus:
+    if context.execution_mode != "celery":
+        return "direct"
+    if context.celery_retries is None:
+        return "unknown"
+    if context.celery_retries == 0:
+        return "first_attempt"
+    if context.celery_max_retries is not None and context.celery_retries >= context.celery_max_retries:
+        return "final_retry"
+    return "retry_attempt"
+
+
+def _usage_report_run_log_context(context: UsageReportRunContext) -> dict[str, Any]:
+    return {
+        "run_id": context.run_id,
+        "source": context.source,
+        "execution_location": context.execution_location,
+        "execution_mode": context.execution_mode,
+        "run_scope": context.run_scope,
+        "region": context.region,
+        "period_start": context.period_start.isoformat(),
+        "period_end": context.period_end.isoformat(),
+        "requested_date": context.requested_date,
+        "celery_task_id": context.celery_task_id,
+        "celery_retries": context.celery_retries,
+        "celery_max_retries": context.celery_max_retries,
+        "celery_attempt": _usage_report_celery_attempt(context),
+        "celery_attempt_status": _usage_report_celery_attempt_status(context),
+    }
+
+
+def _usage_report_run_event_properties(
+    context: UsageReportRunContext, properties: Optional[Mapping[str, Any]] = None
+) -> dict[str, Any]:
+    base_properties = _usage_report_run_log_context(context)
+    base_properties.update(properties or {})
+    return base_properties
+
+
+def _usage_report_metric_labels(context: UsageReportRunContext) -> dict[str, str]:
+    return {
+        "region": context.region,
+        "source": context.source,
+        "execution_location": context.execution_location,
+        "execution_mode": context.execution_mode,
+        "run_scope": context.run_scope,
+    }
+
+
+def _usage_report_pushgateway_job_name(base_job_name: str, context: UsageReportRunContext) -> str:
+    return "_".join(
+        [
+            base_job_name,
+            context.region.lower(),
+            context.source,
+            context.execution_location,
+            context.execution_mode,
+            context.run_scope,
+        ]
+    )
+
+
+def _usage_report_run_state_job_name(context: UsageReportRunContext) -> str:
+    return _usage_report_pushgateway_job_name(USAGE_REPORT_RUN_STATE_JOB_NAME, context)
+
+
+def _usage_report_terminal_timestamp_job_name(context: UsageReportRunContext) -> str:
+    return _usage_report_pushgateway_job_name(USAGE_REPORT_RUN_TERMINAL_TIMESTAMP_JOB_NAME, context)
+
+
+def _usage_report_success_timestamp_job_name(context: UsageReportRunContext) -> str:
+    return _usage_report_pushgateway_job_name(USAGE_REPORT_RUN_SUCCESS_TIMESTAMP_JOB_NAME, context)
+
+
+def _push_usage_report_sticky_timestamps(snapshot: UsageReportRunStateSnapshot) -> None:
+    if snapshot.terminal_status == "none":
+        return
+
+    base_labels = _usage_report_metric_labels(snapshot.context)
+    with pushed_metrics_registry(_usage_report_terminal_timestamp_job_name(snapshot.context)) as registry:
+        last_terminal_timestamp_gauge = Gauge(
+            "posthog_legacy_usage_report_last_terminal_timestamp_seconds",
+            "Unix timestamp for the latest legacy usage-report producer terminal state.",
+            registry=registry,
+            labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+        )
+        last_terminal_timestamp_gauge.labels(**base_labels).set(snapshot.stage_timestamp)
+
+    if snapshot.terminal_status == "completed":
+        with pushed_metrics_registry(_usage_report_success_timestamp_job_name(snapshot.context)) as registry:
+            last_success_timestamp_gauge = Gauge(
+                "posthog_legacy_usage_report_last_success_timestamp_seconds",
+                "Unix timestamp for the latest completed legacy usage-report producer run.",
+                registry=registry,
+                labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+            )
+            last_success_timestamp_gauge.labels(**base_labels).set(snapshot.stage_timestamp)
+
+
+def _push_usage_report_run_state(snapshot: UsageReportRunStateSnapshot) -> None:
+    try:
+        base_labels = _usage_report_metric_labels(snapshot.context)
+
+        with pushed_metrics_registry(_usage_report_run_state_job_name(snapshot.context)) as registry:
+            current_stage_gauge = Gauge(
+                "posthog_legacy_usage_report_current_stage",
+                "Latest legacy usage-report producer stage.",
+                registry=registry,
+                labelnames=[*USAGE_REPORT_RUN_METRIC_LABELS, "stage"],
+            )
+            stage_timestamp_gauge = Gauge(
+                "posthog_legacy_usage_report_stage_timestamp_seconds",
+                "Unix timestamp for the latest legacy usage-report producer stage transition.",
+                registry=registry,
+                labelnames=[*USAGE_REPORT_RUN_METRIC_LABELS, "stage"],
+            )
+            terminal_status_gauge = Gauge(
+                "posthog_legacy_usage_report_terminal_status",
+                "Latest legacy usage-report producer terminal status.",
+                registry=registry,
+                labelnames=[*USAGE_REPORT_RUN_METRIC_LABELS, "terminal_status"],
+            )
+            query_duration_gauge = Gauge(
+                "posthog_legacy_usage_report_query_duration_seconds",
+                "Duration of the usage-report producer query phase for the latest snapshot.",
+                registry=registry,
+                labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+            )
+            total_duration_gauge = Gauge(
+                "posthog_legacy_usage_report_total_duration_seconds",
+                "Total usage-report producer duration for the latest terminal snapshot.",
+                registry=registry,
+                labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+            )
+            total_orgs_gauge = Gauge(
+                "posthog_legacy_usage_report_total_orgs",
+                "Total organizations in the latest legacy usage-report producer run.",
+                registry=registry,
+                labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+            )
+            total_orgs_sent_gauge = Gauge(
+                "posthog_legacy_usage_report_total_orgs_sent",
+                "Organizations sent to Billing by the latest legacy usage-report producer run.",
+                registry=registry,
+                labelnames=USAGE_REPORT_RUN_METRIC_LABELS,
+            )
+            failures_gauge = Gauge(
+                "posthog_legacy_usage_report_failures",
+                "Failure counts for the latest legacy usage-report producer run.",
+                registry=registry,
+                labelnames=[*USAGE_REPORT_RUN_METRIC_LABELS, "failure_type"],
+            )
+
+            for stage in USAGE_REPORT_RUN_STAGES:
+                current_stage_gauge.labels(**base_labels, stage=stage).set(1 if snapshot.stage == stage else 0)
+                stage_timestamp_gauge.labels(**base_labels, stage=stage).set(
+                    snapshot.stage_timestamp if snapshot.stage == stage else 0
+                )
+
+            for terminal_status in USAGE_REPORT_TERMINAL_STATUSES:
+                terminal_status_gauge.labels(**base_labels, terminal_status=terminal_status).set(
+                    1 if snapshot.terminal_status == terminal_status else 0
+                )
+
+            query_duration_gauge.labels(**base_labels).set(snapshot.query_duration_seconds or 0)
+            total_duration_gauge.labels(**base_labels).set(snapshot.total_duration_seconds or 0)
+            total_orgs_gauge.labels(**base_labels).set(snapshot.total_orgs or 0)
+            total_orgs_sent_gauge.labels(**base_labels).set(snapshot.total_orgs_sent or 0)
+
+            for failure_type in USAGE_REPORT_FAILURE_TYPES:
+                failures_gauge.labels(**base_labels, failure_type=failure_type).set(
+                    snapshot.failure_counts.get(failure_type, 0)
+                )
+
+        _push_usage_report_sticky_timestamps(snapshot)
+    except Exception as err:
+        logger.exception(
+            "Failed to push usage report run state",
+            run_id=snapshot.context.run_id,
+            stage=snapshot.stage,
+            terminal_status=snapshot.terminal_status,
+            error=err,
+        )


### PR DESCRIPTION
## Problem

Legacy usage reporting is hard to debug while a run is in progress. Existing signals show sending started/completed, but not whether the producer is still querying, where it is running, whether a worker attempt is a retry, or whether the run reached a terminal state.

This PR adds a narrow observability bridge for the legacy path while usage reporting v2 moves this workflow to Temporal.

## Changes

- Add bounded run context for legacy usage-report producer runs: source, execution location, execution mode, run scope, region, requested date, run id, dry-run mode, and Celery retry metadata.
- Move lifecycle event, Pushgateway metric, and run-progress bookkeeping into `posthog.tasks.usage_report_observability` so `send_all_org_usage_reports` stays focused on the producer flow.
- Publish lightweight Pushgateway gauges for `querying`, `sending`, and `terminal` states, plus terminal status, timestamps, durations, org counts, and bounded failure counts.
- Keep scheduled all-org runs separate from filtered reruns with `run_scope`, and classify execution location as usage-report worker vs toolbox/direct.
- Emit `usage reports querying` before the expensive query starts, keep the existing start/complete events, and add failed terminal events with retry metadata.
- Preserve the existing `total_time` phase-duration meaning and add `total_duration_seconds` for wall-clock duration.
- Treat falsey producer responses and unavailable producers as bounded failures so affected runs become `partial_success` instead of looking fully successful.
- Keep observability best-effort so PostHog event capture or Pushgateway failures cannot fail the producer.

This is intentionally bounded: no per-org observability events, no run ids or retry counters in Prometheus labels, and only a few Pushgateway pushes per producer run. Overlapping runs with the exact same bounded identity are last-writer-wins, which is accepted for this temporary bridge. Dry-runs publish terminal timestamps but do not advance last-success timestamps.

## Plan beyond this

Usage reporting v2 should own durable run state, retries, and stage visibility through Temporal. These legacy-path signals can then be removed or folded into the v2 dashboard/alerts.

## How did you test this code?

- Added management command tests for direct toolbox runs, manual async worker runs, and printed async task ids.
- Added usage-report producer tests for querying-before-query, skipped/failed terminal states, retry metadata, failed-query duration, queue failures, unavailable producers, best-effort observability failures, and scheduled worker context forwarding.
- Added observability module tests for bounded metric identity, sticky timestamp jobs including dry-runs, and `total_time` vs `total_duration_seconds` semantics.
- Existing organization filtering tests cover manual rerun filtering and completion metadata.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.
