### PR TITLE
fix(replay-vision): wire vision actions into object-level access control

### DIFF
--- a/posthog/rbac/test/test_user_access_control.py
+++ b/posthog/rbac/test/test_user_access_control.py
@@ -18,9 +18,11 @@ from posthog.rbac.user_access_control import (
     get_effective_access_level_for_member,
     get_effective_access_level_for_role,
     get_field_access_control_map,
+    model_to_resource,
 )
 
 from products.dashboards.backend.models.dashboard import Dashboard
+from products.replay_vision.backend.models.vision_action import VisionAction, VisionActionRun
 
 try:
     from ee.models.rbac.access_control import AccessControl
@@ -83,6 +85,13 @@ class BaseUserAccessControlTest(BaseTest):
 
 @pytest.mark.ee
 class TestUserAccessControl(BaseUserAccessControlTest):
+    def test_vision_action_models_map_to_vision_action_resource(self):
+        # VisionAction/VisionActionRun's _meta.model_name (visionaction/visionactionrun) differs from the
+        # vision_action scope object, so without the explicit mapping they silently drop out of
+        # object-level access control and a per-action grant wouldn't be enforced.
+        assert model_to_resource(VisionAction()) == "vision_action"
+        assert model_to_resource(VisionActionRun()) == "vision_action"
+
     def test_no_organization_id_passed(self):
         # Create a user without an organization
         user_without_org = User.objects.create(email="no-org@posthog.com", password="testtest")

--- a/posthog/rbac/user_access_control.py
+++ b/posthog/rbac/user_access_control.py
@@ -316,6 +316,8 @@ def model_to_resource(model: Model) -> Optional[APIScopeObject]:
         return "customer_journey"
     if name in ("replayscanner", "replayobservation"):
         return "replay_scanner"
+    if name in ("visionaction", "visionactionrun"):
+        return "vision_action"
 
     if name not in API_SCOPE_OBJECTS or name in INTERNAL_API_SCOPE_OBJECTS:
         return None


### PR DESCRIPTION
## Problem

`VisionAction` and `VisionActionRun` were never wired into object-level access control. Their `_meta.model_name` (`visionaction` / `visionactionrun`) doesn't match the `vision_action` scope object (underscored), so `model_to_resource` fell through to its `return None` fallback and the models silently dropped out of the resource-level `AccessControl` system.

The practical gap: a user whose `vision_action` resource access is set to "none" but who holds a specific per-action grant could still pass the viewset's `check_object_permissions` and read another same-team action's run history. Surfaced in review on #65318 (by `veria-ai` and a human reviewer); the root cause lives in the API viewset shipped in #64702, which has already merged — hence this follow-up.

## Changes

- Map `visionaction` / `visionactionrun` → `vision_action` in `model_to_resource`, mirroring the existing `replayscanner` / `replayobservation` → `replay_scanner` sibling. That's the only missing piece — the `vision_action` scope object and the viewset's `scope_object` + `check_object_permissions` wiring already exist.

## How did you test this code?

I'm an agent (PostHog Code); listing only automated tests I actually ran:

- Added `test_vision_action_models_map_to_vision_action_resource` asserting both models map to `vision_action` — guards against silent removal of the mapping (the property-based suite only *drops* coverage if the mapping disappears, it doesn't fail). Passes.
- The access-control property test (`test_every_access_controlled_model_is_buildable`) now auto-discovers `vision_action` and exercises it through the full property suite; confirmed it still passes (no factory override needed — `VisionAction` builds generically).
- `ruff` clean on both touched files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Invoked the `/improving-drf-endpoints` skill while scoping the change. Verified the fix is complete by confirming the `replay_scanner` sibling needs nothing beyond the scope-object entry + the `model_to_resource` mapping, and that the PBT auto-discovers the newly-mapped resource. Chose an explicit unit test in addition to the PBT because the property suite silently loses coverage (rather than failing) if the mapping is ever removed.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*