### PR TITLE
fix(dashboards): abort dashboard SSE stream on unmount and restart

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -3570,7 +3570,9 @@ const api = {
                     }
                 },
                 onerror: (error) => {
-                    onError(error)
+                    // Throw so fetch-event-source stops instead of auto-reconnecting; the
+                    // rejection propagates to .catch(onError) below, reporting the error once.
+                    throw error
                 },
             }).catch(onError)
 

--- a/frontend/src/scenes/dashboard/dashboardLogic.test.ts
+++ b/frontend/src/scenes/dashboard/dashboardLogic.test.ts
@@ -2091,4 +2091,76 @@ describe('dashboardLogic', () => {
             })
         })
     })
+
+    describe('SSE streaming connection cleanup', () => {
+        let streamAbort: jest.Mock
+        let streamTilesSpy: jest.SpyInstance
+
+        beforeEach(async () => {
+            silenceKeaLoadersErrors()
+            streamAbort = jest.fn()
+            streamTilesSpy = jest.spyOn(api.dashboards, 'streamTiles').mockResolvedValue(streamAbort)
+            logic = dashboardLogic({ id: 5 })
+            logic.mount()
+            // drain the non-streaming auto-load so streaming runs against a quiet logic
+            await expectLogic(logic).toFinishAllListeners()
+        })
+
+        afterEach(() => {
+            resumeKeaLoadersErrors()
+        })
+
+        // streamTiles resolves the abort handle on a microtask after the loader's
+        // 200ms breakpoint; wait for the loader to settle, then flush microtasks.
+        async function startStreamAndSettle(action: DashboardLoadAction): Promise<void> {
+            logic.actions.loadDashboardStreaming({ action })
+            await expectLogic(logic).toFinishAllListeners()
+            await Promise.resolve()
+            await Promise.resolve()
+        }
+
+        it('aborts the SSE connection when the logic unmounts', async () => {
+            await startStreamAndSettle(DashboardLoadAction.InitialLoad)
+            expect(streamTilesSpy).toHaveBeenCalledTimes(1)
+            expect(streamAbort).not.toHaveBeenCalled()
+
+            logic.unmount()
+
+            expect(streamAbort).toHaveBeenCalledTimes(1)
+        })
+
+        it('aborts the previous stream before starting a new one on restart', async () => {
+            const firstAbort = jest.fn()
+            const secondAbort = jest.fn()
+            streamTilesSpy.mockResolvedValueOnce(firstAbort).mockResolvedValueOnce(secondAbort)
+
+            await startStreamAndSettle(DashboardLoadAction.InitialLoad)
+            await startStreamAndSettle(DashboardLoadAction.Update)
+
+            // re-adding the keyed disposable tears down the previous connection first
+            expect(firstAbort).toHaveBeenCalledTimes(1)
+            expect(secondAbort).not.toHaveBeenCalled()
+        })
+
+        it('aborts the handle even when disposed before streamTiles resolves', async () => {
+            const lateAbort = jest.fn()
+            let resolveStream: () => void = () => {}
+            streamTilesSpy.mockReturnValueOnce(
+                new Promise<() => void>((resolve) => {
+                    resolveStream = () => resolve(lateAbort)
+                })
+            )
+
+            logic.actions.loadDashboardStreaming({ action: DashboardLoadAction.InitialLoad })
+            await expectLogic(logic).toFinishAllListeners()
+
+            // unmount before the abort handle is available, then let streamTiles resolve
+            logic.unmount()
+            resolveStream()
+            await Promise.resolve()
+            await Promise.resolve()
+
+            expect(lateAbort).toHaveBeenCalledTimes(1)
+        })
+    })
 })

--- a/frontend/src/scenes/dashboard/dashboardLogic.tsx
+++ b/frontend/src/scenes/dashboard/dashboardLogic.tsx
@@ -458,33 +458,55 @@ export const dashboardLogic = kea<dashboardLogicType>([
                     await breakpoint(200)
                     actions.resetIntermittentFilters()
 
-                    // Start unified streaming - metadata followed by tiles
-                    api.dashboards.streamTiles(
-                        props.id,
-                        {
-                            layoutSize: values.currentLayoutSize,
-                            filtersOverride: values.filtersOverrideForLoad,
-                            variablesOverride: values.urlVariables,
-                        },
-                        // onMessage callback - handles both metadata and tiles
-                        (data) => {
-                            if (data.type === 'metadata') {
-                                actions.loadDashboardMetadataSuccess(
-                                    getQueryBasedDashboard(data.dashboard as DashboardType<InsightModel>)
+                    // Register via disposables so the SSE connection is aborted on unmount and
+                    // replaced (old one aborted first) on restart. The abort handle resolves
+                    // asynchronously, so hold it in a closure and abort once it's available.
+                    cache.disposables.add(
+                        () => {
+                            let abort: (() => void) | undefined
+                            let disposed = false
+                            api.dashboards
+                                .streamTiles(
+                                    props.id,
+                                    {
+                                        layoutSize: values.currentLayoutSize,
+                                        filtersOverride: values.filtersOverrideForLoad,
+                                        variablesOverride: values.urlVariables,
+                                    },
+                                    // onMessage callback - handles both metadata and tiles
+                                    (data) => {
+                                        if (data.type === 'metadata') {
+                                            actions.loadDashboardMetadataSuccess(
+                                                getQueryBasedDashboard(data.dashboard as DashboardType<InsightModel>)
+                                            )
+                                        } else if (data.type === 'tile') {
+                                            actions.receiveTileFromStream(data)
+                                        }
+                                    },
+                                    // onComplete callback
+                                    () => {
+                                        actions.tileStreamingComplete()
+                                    },
+                                    // onError callback
+                                    (error) => {
+                                        console.error('❌ Tile streaming error:', error)
+                                        actions.tileStreamingFailure(error)
+                                    }
                                 )
-                            } else if (data.type === 'tile') {
-                                actions.receiveTileFromStream(data)
+                                .then((abortFn) => {
+                                    if (disposed) {
+                                        abortFn()
+                                    } else {
+                                        abort = abortFn
+                                    }
+                                })
+                            return () => {
+                                disposed = true
+                                abort?.()
                             }
                         },
-                        // onComplete callback
-                        () => {
-                            actions.tileStreamingComplete()
-                        },
-                        // onError callback
-                        (error) => {
-                            console.error('❌ Tile streaming error:', error)
-                            actions.tileStreamingFailure(error)
-                        }
+                        'sseStream',
+                        { pauseOnPageHidden: false }
                     )
 
                     // Return null - metadata will update the dashboard


### PR DESCRIPTION
## Problem

Dashboards behind the `sse-dashboards` flag stream tiles over a Server-Sent Events connection (`loadDashboardStreaming` → `api.dashboards.streamTiles`). `streamTiles` returns an abort handle to close the connection — but the caller threw it away. Nothing could ever hang up.

Three leaks followed:

- **Unmount** — navigating away left the connection open (`beforeUnmount` only aborted the insight-refresh controller, not the stream).
- **Reload** — restarting opened a second connection without closing the first; the orphan kept firing tile actions at a reloading logic.
- **Transient errors** — `onerror` returned instead of throwing, so `fetch-event-source` auto-reconnected, stacking fresh backend streams.

The flag is live (100% for one org, ~10% of others), so this affects real traffic today — worth fixing before the rollout widens.

## Changes

- Register the stream through `cache.disposables` (key `sseStream`): aborts on unmount, and re-adding the key aborts the previous connection before opening a new one. The abort handle resolves asynchronously, so it's held in a closure and aborted once available — or immediately if disposal wins the race.
- `onerror` now throws, so `fetch-event-source` stops instead of reconnecting. The rejection flows to the existing `.catch(onError)`, reporting once. This matches the `onopen` path, which already aborts to prevent retries.
- No `beforeUnmount` change — the disposables plugin owns stream teardown.

## How did you test this code?

I'm an agent (Claude Code); a human directed this work. I **could not run the suite** — this environment has no `node_modules` — so the tests below need a green CI run to confirm.

Added three kea-logic tests in `dashboardLogic.test.ts` (`describe('SSE streaming connection cleanup')`), each targeting a regression this PR fixes:

| Test | Regression caught |
| --- | --- |
| aborts on unmount | discarded abort handle — pre-fix, unmount closed nothing |
| aborts previous stream on restart | reload orphaning the prior connection |
| aborts handle when disposed before `streamTiles` resolves | the `disposed`-flag race |

They mock `streamTiles` to resolve an abort spy and assert it fires on unmount / restart. Kept at the kea-logic level (no DOM render). Manual browser check — DevTools → Network → `stream_tiles` cancels on navigate/reload with the flag on — still wants a human.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by @MattPua. Started from a hunch that dashboard streams weren't closing; tracing `streaming.py`, `dashboard.py` (`stream_tiles`), `api.ts` (`streamTiles`), and `dashboardLogic.tsx` confirmed the discarded abort handle and the `onerror` auto-reconnect.

Skills invoked: `/using-kea-disposables` (chosen over a hand-rolled `beforeUnmount` + `cache` ref — repo convention and a lint rule both point at it) and `/writing-tests` (gated tests to named regressions, kept at the cheapest rung). The flag rollout was checked via the PostHog MCP.

**Out of scope (follow-up):** on the WSGI fallback path, `async_to_sync` spawns a non-daemon thread joined with a 1s timeout, which can linger on early disconnect. Separate and lower-frequency — left for later.
