### PR TITLE
chore(devex): per-test resource-utilization profiler (test-waste finder)

### DIFF
--- a/.github/workflows/ci-backend.yml
+++ b/.github/workflows/ci-backend.yml
@@ -808,13 +808,28 @@ jobs:
                   # ClickHouse drop/create race conditions with ReplicatedMergeTree ZK metadata.
                   # --durations-path: turbo runs products from products/<name>/, so pytest-split
                   # needs an explicit path back to the repo-root durations file for balanced sharding.
+                  # -p tools.pytest_resource_profiler: report-only per-test resource profiler.
                   # On master, also collect timing data for pytest-split sharding.
                   PYTEST_ADDOPTS: >-
                       --reuse-db
                       --durations-path ../../.test_durations
+                      -p tools.pytest_resource_profiler
                       ${{ needs.detect-snapshot-mode.outputs.mode == 'update' && '--snapshot-update --snapshot-warn-unused' || '' }}
                       ${{ github.ref == 'refs/heads/master' && '--store-durations' || '' }}
+                  # PYTHONPATH so `tools` imports from the products/<name>/ CWD; absolute out path
+                  # so every product in the shard appends to one file. Both need turbo passThroughEnv.
+                  PYTHONPATH: ${{ github.workspace }}
+                  RESOURCE_PROFILE_OUT: ${{ github.workspace }}/resource-profile/profile.jsonl
               run: pnpm turbo run backend:test ${{ matrix.filters }} --concurrency=1 --output-logs=full --force --log-order=stream ${{ matrix.pytest_args }}
+
+            - name: Upload resource profile
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: resource-profile-product-${{ matrix.group }}
+                  path: resource-profile/
+                  if-no-files-found: ignore
+                  retention-days: 2
 
             - name: Upload timing data
               uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -2083,6 +2098,13 @@ jobs:
         # Runner type is performance-critical — consult #team-devex before changing
         runs-on: depot-ubuntu-latest
 
+        env:
+            # Per-test resource profiler (report-only): counts DB/CH usage to find wasted setup.
+            # PYTEST_ADDOPTS is read by pytest automatically; the plugin is passive.
+            PYTEST_ADDOPTS: -p tools.pytest_resource_profiler
+            PYTHONPATH: ${{ github.workspace }}
+            RESOURCE_PROFILE_OUT: ${{ github.workspace }}/resource-profile/profile.jsonl
+
         strategy:
             fail-fast: false
             matrix:
@@ -2624,6 +2646,15 @@ jobs:
               with:
                   name: junit-results-backend-${{ matrix.artifact_key }}
                   path: junit-*.xml
+
+            - name: Upload resource profile
+              uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+              if: always()
+              with:
+                  name: resource-profile-${{ matrix.artifact_key }}
+                  path: resource-profile/
+                  if-no-files-found: ignore
+                  retention-days: 2
 
     # Aggregate and commit snapshot changes from all matrix jobs
 

--- a/conftest.py
+++ b/conftest.py
@@ -1,3 +1,7 @@
+# NOTE (chore/devex-test-resource-profiler, DO NOT MERGE): this throwaway branch loads
+# tools/pytest_resource_profiler via PYTEST_ADDOPTS in ci-backend.yml to harvest a
+# full-suite resource profile. This one-line touch only exists to flip the `backend`
+# path filter true so the Django (Core/Temporal) matrix runs and uploads its profile.
 import gc
 import warnings
 

--- a/tools/pytest_resource_profiler.py
+++ b/tools/pytest_resource_profiler.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import os
 import json
 import time
+import inspect
 import contextlib
 from pathlib import Path
 
@@ -112,6 +113,12 @@ def _ch_provisioned(cls) -> bool:
     return any("Clickhouse" in a.__name__ or "ClickHouse" in a.__name__ for a in cls.__mro__)
 
 
+def _is_async(item: pytest.Item) -> bool:
+    """Async tests often need transaction=True for the async/sync ORM boundary — never a txn-downgrade."""
+    func = getattr(item, "function", None) or getattr(item, "obj", None)
+    return bool(func) and inspect.iscoroutinefunction(func)
+
+
 def _new_record(item: pytest.Item) -> dict:
     cls = getattr(item, "cls", None)
     return {
@@ -119,6 +126,7 @@ def _new_record(item: pytest.Item) -> dict:
         "file": str(item.path) if getattr(item, "path", None) else "",
         "base": _testcase_base(cls),
         "is_txn": _is_txn(item, cls),
+        "is_async": _is_async(item),
         "db_enabled": _db_enabled(item, cls),
         "declared_dbs": _declared_dbs(cls),
         "ch_provisioned": _ch_provisioned(cls),

--- a/tools/pytest_resource_profiler.py
+++ b/tools/pytest_resource_profiler.py
@@ -18,7 +18,7 @@ Signals captured per test:
   - base, status
 
 Derived waste buckets (computed by tools/test_resource_report.py):
-  - no-DB        : db_enabled & pg_total==0 & ch_call==0      -> SimpleTestCase
+  - no-DB        : db_enabled & pg_call==0 & ch_call==0 & not async -> SimpleTestCase (verify)
   - CH-unused    : ch_provisioned & ch_call==0               -> drop the CH mixin
   - txn-downgrade: TransactionTestCase base & no on_commit & no FOR UPDATE & single conn -> TestCase
   - multi-DB-trim: declared_dbs has aliases never queried     -> trim `databases`
@@ -37,6 +37,7 @@ import json
 import time
 import inspect
 import contextlib
+from collections import Counter
 from pathlib import Path
 
 import pytest
@@ -57,7 +58,7 @@ _KNOWN_BASES = {
 _records: dict[str, dict] = {}
 
 
-def _db_enabled(item: pytest.Item, cls) -> bool:
+def _db_enabled(item: pytest.Item, cls: type | None) -> bool:
     if item.get_closest_marker("django_db") is not None:
         return True
     if cls is None:
@@ -70,7 +71,7 @@ def _db_enabled(item: pytest.Item, cls) -> bool:
         return False
 
 
-def _is_txn(item: pytest.Item, cls) -> bool:
+def _is_txn(item: pytest.Item, cls: type | None) -> bool:
     """The *slow* TransactionTestCase (truncates tables), not Django's fast TestCase subclass of it."""
     marker = item.get_closest_marker("django_db")
     if marker is not None and marker.kwargs.get("transaction"):
@@ -85,7 +86,7 @@ def _is_txn(item: pytest.Item, cls) -> bool:
         return False
 
 
-def _testcase_base(cls) -> str:
+def _testcase_base(cls: type | None) -> str:
     if cls is None:
         return "function"
     for ancestor in cls.__mro__[1:]:
@@ -94,7 +95,7 @@ def _testcase_base(cls) -> str:
     return cls.__mro__[1].__name__ if len(cls.__mro__) > 1 else cls.__name__
 
 
-def _declared_dbs(cls):
+def _declared_dbs(cls: type | None) -> list[str] | str | None:
     """The `databases` the TestCase wraps in transactions; None for plain functions."""
     dbs = getattr(cls, "databases", None) if cls is not None else None
     if dbs is None:
@@ -107,7 +108,7 @@ def _declared_dbs(cls):
         return str(dbs)
 
 
-def _ch_provisioned(cls) -> bool:
+def _ch_provisioned(cls: type | None) -> bool:
     if cls is None:
         return False
     return any("Clickhouse" in a.__name__ or "ClickHouse" in a.__name__ for a in cls.__mro__)
@@ -142,8 +143,18 @@ def _new_record(item: pytest.Item) -> dict:
         # Redundancy in setup: distinct query shapes vs the single most-repeated shape (N+1 in fixtures).
         "setup_distinct": 0,
         "setup_max_dup": 0,
-        "_setup_shapes": {},
+        "_setup_shapes": Counter(),
     }
+
+
+def _reset_counters(rec: dict) -> None:
+    """Clear per-attempt accumulators so a rerun (pytest-rerunfailures, --count) keeps the last attempt, not the sum."""
+    rec["pg_setup"] = rec["pg_call"] = rec["pg_teardown"] = 0
+    rec["ch_call"] = rec["on_commit"] = 0
+    rec["for_update"] = False
+    rec["pg_alias"] = {}
+    rec["_setup_shapes"] = Counter()
+    rec["status"] = "unknown"
 
 
 def _record_for(item: pytest.Item) -> dict:
@@ -157,34 +168,33 @@ def _record_for(item: pytest.Item) -> dict:
 @contextlib.contextmanager
 def _wrap_pg(rec: dict, phase: str):
     """Count Postgres queries per connection alias and watch for SELECT ... FOR UPDATE."""
-    counts: dict[str, int] = {}
+    counts: Counter[str] = Counter()
+    es = contextlib.ExitStack()
     try:
         from django.db import connections  # noqa: PLC0415 — Django configured at runtime only
 
-        stack: contextlib.AbstractContextManager = contextlib.ExitStack()
-
         def make(alias: str):
             def wrapper(execute, sql, params, many, context):
-                counts[alias] = counts.get(alias, 0) + 1
+                counts[alias] += 1
                 if isinstance(sql, str):
-                    if not rec["for_update"] and "FOR UPDATE" in sql.upper():
+                    # Django emits the keyword uppercase; substring check avoids an upper() copy per query.
+                    if not rec["for_update"] and "FOR UPDATE" in sql:
                         rec["for_update"] = True
-                    # Count query shapes during setup only — that's where fixture N+1 lives.
-                    # sql already carries %s placeholders (params are separate), so it's the shape.
+                    # Count query shapes during setup only — that's where fixture N+1 lives. sql already
+                    # carries %s placeholders (params are separate), so key by it directly (no hash collisions).
                     if phase == "setup":
-                        shapes = rec["_setup_shapes"]
-                        h = hash(sql)
-                        shapes[h] = shapes.get(h, 0) + 1
+                        rec["_setup_shapes"][sql] += 1
                 return execute(sql, params, many, context)
 
             return wrapper
 
         for conn in connections.all():
-            stack.enter_context(conn.execute_wrapper(make(conn.alias)))
+            es.enter_context(conn.execute_wrapper(make(conn.alias)))
     except Exception:
-        stack = contextlib.nullcontext()
+        es.close()  # unwind any wrappers entered before the failure so none leak onto the connection
+        es = contextlib.ExitStack()
     try:
-        with stack:
+        with es:
             yield
     finally:
         rec[f"pg_{phase}"] += sum(counts.values())
@@ -239,7 +249,9 @@ def _wrap_on_commit(rec: dict):
 
 @pytest.hookimpl(hookwrapper=True)
 def pytest_runtest_setup(item):
-    with _wrap_pg(_record_for(item), "setup"):
+    rec = _record_for(item)
+    _reset_counters(rec)  # setup is the first phase of every attempt, including reruns
+    with _wrap_pg(rec, "setup"):
         yield
 
 
@@ -265,8 +277,10 @@ def pytest_runtest_makereport(item):
     rec = _record_for(item)
     if report.when == "call":
         rec["status"] = report.outcome
-    elif report.when == "setup" and report.outcome in {"skipped", "failed"} and rec["status"] == "unknown":
-        rec["status"] = report.outcome
+    if report.outcome == "failed":
+        rec["status"] = "failed"  # any-phase failure (incl. teardown) means the test isn't green
+    elif report.when == "setup" and report.outcome == "skipped":
+        rec["status"] = "skipped"
 
 
 def pytest_sessionfinish():

--- a/tools/pytest_resource_profiler.py
+++ b/tools/pytest_resource_profiler.py
@@ -139,6 +139,10 @@ def _new_record(item: pytest.Item) -> dict:
         "for_update": False,
         "duration_s": 0.0,
         "status": "unknown",
+        # Redundancy in setup: distinct query shapes vs the single most-repeated shape (N+1 in fixtures).
+        "setup_distinct": 0,
+        "setup_max_dup": 0,
+        "_setup_shapes": {},
     }
 
 
@@ -162,8 +166,15 @@ def _wrap_pg(rec: dict, phase: str):
         def make(alias: str):
             def wrapper(execute, sql, params, many, context):
                 counts[alias] = counts.get(alias, 0) + 1
-                if not rec["for_update"] and isinstance(sql, str) and "FOR UPDATE" in sql.upper():
-                    rec["for_update"] = True
+                if isinstance(sql, str):
+                    if not rec["for_update"] and "FOR UPDATE" in sql.upper():
+                        rec["for_update"] = True
+                    # Count query shapes during setup only — that's where fixture N+1 lives.
+                    # sql already carries %s placeholders (params are separate), so it's the shape.
+                    if phase == "setup":
+                        shapes = rec["_setup_shapes"]
+                        h = hash(sql)
+                        shapes[h] = shapes.get(h, 0) + 1
                 return execute(sql, params, many, context)
 
             return wrapper
@@ -264,4 +275,7 @@ def pytest_sessionfinish():
     with out.open("a") as fh:
         for rec in _records.values():
             rec["pg_total"] = rec["pg_setup"] + rec["pg_call"] + rec["pg_teardown"]
+            shapes = rec.pop("_setup_shapes", {})
+            rec["setup_distinct"] = len(shapes)
+            rec["setup_max_dup"] = max(shapes.values()) if shapes else 0
             fh.write(json.dumps(rec) + "\n")

--- a/tools/pytest_resource_profiler.py
+++ b/tools/pytest_resource_profiler.py
@@ -1,0 +1,259 @@
+"""Per-test resource-utilization profiler.
+
+A passive passenger on a normal test run: for every test it records what
+expensive resources the test *provisioned* versus what it actually *used*, so we
+can find tests paying setup cost for nothing. Self-sufficient — it records its
+own per-test wall time and status, so no junit or coverage correlation is needed.
+
+Signals captured per test:
+  - db_enabled        : Postgres set up (django_db marker or a Django TestCase base)
+  - pg_{setup,call,teardown} : Postgres queries per phase
+  - pg_alias          : Postgres queries per connection alias (multi-DB over-declaration)
+  - declared_dbs      : the TestCase.databases declaration (what got transaction-wrapped)
+  - ch_provisioned    : test uses a ClickHouse test mixin
+  - ch_call           : ClickHouse queries during the test body
+  - on_commit         : transaction.on_commit registrations (TransactionTestCase necessity)
+  - for_update        : issued SELECT ... FOR UPDATE (TransactionTestCase necessity)
+  - duration_s        : call-phase wall time (perf_counter)
+  - base, status
+
+Derived waste buckets (computed by tools/test_resource_report.py):
+  - no-DB        : db_enabled & pg_total==0 & ch_call==0      -> SimpleTestCase
+  - CH-unused    : ch_provisioned & ch_call==0               -> drop the CH mixin
+  - txn-downgrade: TransactionTestCase base & no on_commit & no FOR UPDATE & single conn -> TestCase
+  - multi-DB-trim: declared_dbs has aliases never queried     -> trim `databases`
+
+Load with:  pytest -p tools.pytest_resource_profiler ...
+Output:     JSONL at $RESOURCE_PROFILE_OUT (one row per test).
+
+Only Postgres/ClickHouse are counted — the two datastores whose per-test setup
+actually costs something here.
+"""
+
+from __future__ import annotations
+
+import os
+import json
+import time
+import contextlib
+from pathlib import Path
+
+import pytest
+
+_DEFAULT_OUT = "logs/resource_profile.jsonl"
+
+# Test base classes worth grouping by, cheapest to most expensive.
+_KNOWN_BASES = {
+    "SimpleTestCase",
+    "TestCase",
+    "APIBaseTest",
+    "BaseTest",
+    "QueryMatchingTest",
+    "TransactionTestCase",
+    "APITransactionBaseTest",
+}
+
+_records: dict[str, dict] = {}
+
+
+def _db_enabled(item: pytest.Item, cls) -> bool:
+    if item.get_closest_marker("django_db") is not None:
+        return True
+    if cls is None:
+        return False
+    try:
+        from django.test import TransactionTestCase  # noqa: PLC0415 — Django configured at runtime only
+
+        return issubclass(cls, TransactionTestCase)
+    except Exception:
+        return False
+
+
+def _is_txn(item: pytest.Item, cls) -> bool:
+    """The *slow* TransactionTestCase (truncates tables), not Django's fast TestCase subclass of it."""
+    marker = item.get_closest_marker("django_db")
+    if marker is not None and marker.kwargs.get("transaction"):
+        return True
+    if cls is None:
+        return False
+    try:
+        from django.test import TestCase, TransactionTestCase  # noqa: PLC0415 — Django configured at runtime only
+
+        return issubclass(cls, TransactionTestCase) and not issubclass(cls, TestCase)
+    except Exception:
+        return False
+
+
+def _testcase_base(cls) -> str:
+    if cls is None:
+        return "function"
+    for ancestor in cls.__mro__[1:]:
+        if ancestor.__name__ in _KNOWN_BASES:
+            return ancestor.__name__
+    return cls.__mro__[1].__name__ if len(cls.__mro__) > 1 else cls.__name__
+
+
+def _declared_dbs(cls):
+    """The `databases` the TestCase wraps in transactions; None for plain functions."""
+    dbs = getattr(cls, "databases", None) if cls is not None else None
+    if dbs is None:
+        return None
+    if dbs == "__all__":
+        return "__all__"
+    try:
+        return sorted(str(d) for d in dbs)
+    except TypeError:
+        return str(dbs)
+
+
+def _ch_provisioned(cls) -> bool:
+    if cls is None:
+        return False
+    return any("Clickhouse" in a.__name__ or "ClickHouse" in a.__name__ for a in cls.__mro__)
+
+
+def _new_record(item: pytest.Item) -> dict:
+    cls = getattr(item, "cls", None)
+    return {
+        "nodeid": item.nodeid,
+        "file": str(item.path) if getattr(item, "path", None) else "",
+        "base": _testcase_base(cls),
+        "is_txn": _is_txn(item, cls),
+        "db_enabled": _db_enabled(item, cls),
+        "declared_dbs": _declared_dbs(cls),
+        "ch_provisioned": _ch_provisioned(cls),
+        "pg_setup": 0,
+        "pg_call": 0,
+        "pg_teardown": 0,
+        "pg_alias": {},
+        "ch_call": 0,
+        "on_commit": 0,
+        "for_update": False,
+        "duration_s": 0.0,
+        "status": "unknown",
+    }
+
+
+def _record_for(item: pytest.Item) -> dict:
+    rec = _records.get(item.nodeid)
+    if rec is None:
+        rec = _new_record(item)
+        _records[item.nodeid] = rec
+    return rec
+
+
+@contextlib.contextmanager
+def _wrap_pg(rec: dict, phase: str):
+    """Count Postgres queries per connection alias and watch for SELECT ... FOR UPDATE."""
+    counts: dict[str, int] = {}
+    try:
+        from django.db import connections  # noqa: PLC0415 — Django configured at runtime only
+
+        stack: contextlib.AbstractContextManager = contextlib.ExitStack()
+
+        def make(alias: str):
+            def wrapper(execute, sql, params, many, context):
+                counts[alias] = counts.get(alias, 0) + 1
+                if not rec["for_update"] and isinstance(sql, str) and "FOR UPDATE" in sql.upper():
+                    rec["for_update"] = True
+                return execute(sql, params, many, context)
+
+            return wrapper
+
+        for conn in connections.all():
+            stack.enter_context(conn.execute_wrapper(make(conn.alias)))
+    except Exception:
+        stack = contextlib.nullcontext()
+    try:
+        with stack:
+            yield
+    finally:
+        rec[f"pg_{phase}"] += sum(counts.values())
+        for alias, n in counts.items():
+            rec["pg_alias"][alias] = rec["pg_alias"].get(alias, 0) + n
+
+
+@contextlib.contextmanager
+def _wrap_ch(rec: dict):
+    """Count ClickHouse queries during the test body (only for CH-provisioned tests)."""
+    if not rec["ch_provisioned"]:
+        yield
+        return
+    counter = {"n": 0}
+    try:
+        from posthog.test.base import patch_clickhouse_client_execute  # noqa: PLC0415 — heavy test-only dep
+
+        def chw(orig_execute, query, *args, **kwargs):
+            counter["n"] += 1
+            return orig_execute(query, *args, **kwargs)
+
+        cm: contextlib.AbstractContextManager = patch_clickhouse_client_execute(chw)
+    except Exception:
+        cm = contextlib.nullcontext()
+    try:
+        with cm:
+            yield
+    finally:
+        rec["ch_call"] += counter["n"]
+
+
+@contextlib.contextmanager
+def _wrap_on_commit(rec: dict):
+    """Count transaction.on_commit registrations (attribute-access form)."""
+    try:
+        from unittest import mock  # noqa: PLC0415 — test-only
+
+        from django.db import transaction  # noqa: PLC0415 — Django configured at runtime only
+
+        original = transaction.on_commit
+    except Exception:
+        yield
+        return
+
+    def counting(func, using=None, robust=False):
+        rec["on_commit"] += 1
+        return original(func, using=using, robust=robust)
+
+    with mock.patch("django.db.transaction.on_commit", side_effect=counting):
+        yield
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_setup(item):
+    with _wrap_pg(_record_for(item), "setup"):
+        yield
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_call(item):
+    rec = _record_for(item)
+    start = time.perf_counter()
+    with _wrap_pg(rec, "call"), _wrap_ch(rec), _wrap_on_commit(rec):
+        yield
+    rec["duration_s"] = time.perf_counter() - start
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_teardown(item):
+    with _wrap_pg(_record_for(item), "teardown"):
+        yield
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item):
+    out = yield
+    report = out.get_result()
+    rec = _record_for(item)
+    if report.when == "call":
+        rec["status"] = report.outcome
+    elif report.when == "setup" and report.outcome in {"skipped", "failed"} and rec["status"] == "unknown":
+        rec["status"] = report.outcome
+
+
+def pytest_sessionfinish():
+    out = Path(os.environ.get("RESOURCE_PROFILE_OUT", _DEFAULT_OUT))
+    out.parent.mkdir(parents=True, exist_ok=True)
+    with out.open("a") as fh:
+        for rec in _records.values():
+            rec["pg_total"] = rec["pg_setup"] + rec["pg_call"] + rec["pg_teardown"]
+            fh.write(json.dumps(rec) + "\n")

--- a/tools/test_resource_report.py
+++ b/tools/test_resource_report.py
@@ -1,19 +1,24 @@
-"""Turn the per-test resource profile into ranked test-waste reports.
+"""Turn the per-test resource profile into a rich test-waste report.
 
-Consumes the JSONL written by tools/pytest_resource_profiler (one row per test)
-and emits four "provisioned but unused" buckets, each ranked by where the time goes:
+Consumes the JSONL written by tools/pytest_resource_profiler (one row per test).
+Two kinds of finding:
 
+Conversion opportunities (binary candidates — verify before acting):
   - no-DB         : DB set up, zero Postgres + ClickHouse queries  -> SimpleTestCase
   - CH-unused     : ClickHouse mixin, zero ClickHouse queries      -> drop the mixin
-  - txn-downgrade : TransactionTestCase with no on_commit / FOR UPDATE / 2nd connection -> TestCase
+  - txn-downgrade : TransactionTestCase, no on_commit / FOR UPDATE / 2nd conn / async -> TestCase
   - multi-DB-trim : `databases` declares an alias the test never queries -> trim it
 
-Self-sufficient: the profile already carries per-test wall time and status, so no
-junit or coverage correlation is needed.
+Overuse & redundancy rankings (where setup cost concentrates):
+  - setup-heavy   : most of a test's queries are setup, not the test body
+  - redundant-setup (N+1): one query shape repeated many times during setup
+  - over-provisioned: very high total query count (heavy fixtures)
+
+Self-sufficient: per-test wall time and status come from the plugin, so no junit
+or coverage correlation is needed.
 
 Usage:
     python tools/test_resource_report.py --in logs/resource_profile.jsonl
-    python tools/test_resource_report.py --in logs/resource_profile.jsonl --out logs/test_waste.md
     python tools/test_resource_report.py --in logs/resource_profile.jsonl --out logs/test_waste.html
 """
 
@@ -26,11 +31,17 @@ import argparse
 from collections import Counter, defaultdict
 from pathlib import Path
 
-BUCKET_LABELS = {
-    "no_db": ("DB set up, 0 queries", "-> SimpleTestCase"),
-    "ch_unused": ("ClickHouse mixin, 0 CH queries", "-> drop CH mixin"),
-    "txn_downgrade": ("TransactionTestCase, no txn need", "-> TestCase"),
-    "multi_db_trim": ("`databases` over-declared", "-> trim databases"),
+# Thresholds for the ranked overuse buckets. Conservative so the lists stay actionable.
+SETUP_HEAVY_MIN_Q = 30
+SETUP_HEAVY_RATIO = 0.7
+REDUNDANT_DUP_MIN = 10
+OVERPROVISIONED_MIN_Q = 100
+
+CONVERSION_LABELS = {
+    "no_db": ("DB set up, 0 queries", "SimpleTestCase"),
+    "ch_unused": ("ClickHouse mixin, 0 CH queries", "drop CH mixin"),
+    "txn_downgrade": ("TransactionTestCase, no txn need", "TestCase"),
+    "multi_db_trim": ("`databases` over-declared", "trim databases"),
 }
 
 
@@ -51,6 +62,21 @@ def used_aliases(row: dict) -> set[str]:
 def is_passing(row: dict) -> bool:
     # Only propose conversions for tests that actually passed in this run.
     return row.get("status") in {"passed", "unknown"}
+
+
+def class_key(nodeid: str) -> str:
+    """file::Class for grouping (setUpTestData is class-level); falls back to the file."""
+    parts = nodeid.split("::")
+    if len(parts) >= 2:
+        return "::".join(parts[:2])
+    return parts[0]
+
+
+def short_path(path: str) -> str:
+    for marker in ("/posthog/", "/products/", "/ee/"):
+        if marker in path:
+            return marker.strip("/") + "/" + path.split(marker, 1)[-1]
+    return path
 
 
 def load_rows(path: Path) -> list[dict]:
@@ -112,12 +138,33 @@ def bucket_multi_db_trim(rows: list[dict]) -> list[dict]:
     return out
 
 
+def bucket_setup_heavy(rows: list[dict]) -> list[dict]:
+    out = []
+    for r in rows:
+        total = r.get("pg_total", 0)
+        setup = r.get("pg_setup", 0)
+        if setup >= SETUP_HEAVY_MIN_Q and total > 0 and setup / total >= SETUP_HEAVY_RATIO:
+            out.append(r)
+    return out
+
+
+def bucket_redundant_setup(rows: list[dict]) -> list[dict]:
+    return [r for r in rows if r.get("setup_max_dup", 0) >= REDUNDANT_DUP_MIN]
+
+
+def bucket_over_provisioned(rows: list[dict]) -> list[dict]:
+    return [r for r in rows if r.get("pg_total", 0) >= OVERPROVISIONED_MIN_Q]
+
+
 def summarize(rows: list[dict]) -> dict:
     return {
         "no_db": bucket_no_db(rows),
         "ch_unused": bucket_ch_unused(rows),
         "txn_downgrade": bucket_txn_downgrade(rows),
         "multi_db_trim": bucket_multi_db_trim(rows),
+        "setup_heavy": bucket_setup_heavy(rows),
+        "redundant_setup": bucket_redundant_setup(rows),
+        "over_provisioned": bucket_over_provisioned(rows),
     }
 
 
@@ -126,60 +173,202 @@ def bucket_time(bucket: list[dict]) -> float:
 
 
 def top_files(bucket: list[dict], n: int = 15) -> list[tuple[str, int, float]]:
-    by_file_count: Counter[str] = Counter()
-    by_file_time: dict[str, float] = defaultdict(float)
+    counts: Counter[str] = Counter()
+    times: dict[str, float] = defaultdict(float)
     for r in bucket:
         f = r["file"]
-        by_file_count[f] += 1
-        by_file_time[f] += r.get("duration_s", 0.0)
-    ranked = sorted(by_file_count.items(), key=lambda kv: -by_file_time[kv[0]])
-    return [(f, c, by_file_time[f]) for f, c in ranked[:n]]
+        counts[f] += 1
+        times[f] += r.get("duration_s", 0.0)
+    ranked = sorted(counts.items(), key=lambda kv: -times[kv[0]])
+    return [(f, c, times[f]) for f, c in ranked[:n]]
+
+
+def top_classes(bucket: list[dict], metric: str, n: int = 20) -> list[tuple[str, int, int, int]]:
+    """Group by file::Class. Returns (class_key, ntests, summed_metric, summed_setup)."""
+    agg: dict[str, dict] = defaultdict(lambda: {"n": 0, "metric": 0, "setup": 0})
+    for r in bucket:
+        k = class_key(r["nodeid"])
+        agg[k]["n"] += 1
+        agg[k]["metric"] += r.get(metric, 0)
+        agg[k]["setup"] += r.get("pg_setup", 0)
+    ranked = sorted(agg.items(), key=lambda kv: -kv[1]["metric"])
+    return [(k, v["n"], v["metric"], v["setup"]) for k, v in ranked[:n]]
+
+
+def stats(rows: list[dict]) -> dict:
+    db_rows = [r for r in rows if r.get("db_enabled")]
+    return {
+        "total": len(rows),
+        "db_enabled": len(db_rows),
+        "wall": sum(r.get("duration_s", 0.0) for r in rows),
+        "pg_total": sum(r.get("pg_total", 0) for r in rows),
+        "pg_setup": sum(r.get("pg_setup", 0) for r in rows),
+        "ch_total": sum(r.get("ch_call", 0) for r in rows),
+    }
+
+
+# ---------------------------------------------------------------- markdown
 
 
 def format_markdown(rows: list[dict], buckets: dict) -> str:
-    out: list[str] = []
-    out.append("# Test resource-waste report\n")
-    out.append(f"- Tests profiled: **{len(rows):,}**")
-    db_rows = [r for r in rows if r.get("db_enabled")]
-    out.append(f"- DB-enabled tests: **{len(db_rows):,}**")
-    out.append("- Call-phase wall time captured directly (no junit/coverage correlation)\n")
+    s = stats(rows)
+    out: list[str] = ["# Test resource-waste report\n"]
+    out.append(f"- Tests profiled: **{s['total']:,}** ({s['db_enabled']:,} DB-enabled)")
+    out.append(f"- Postgres queries: **{s['pg_total']:,}** ({s['pg_setup']:,} in setup)")
+    out.append(f"- ClickHouse queries: **{s['ch_total']:,}** · call wall-time **{fmt_dur(s['wall'])}**")
+    out.append("- No junit/coverage correlation — the profiler records timing + status itself\n")
 
-    out.append("## Buckets\n")
-    out.append("| bucket | tests | call wall-time | fix |")
+    out.append("## Conversion opportunities\n")
+    out.append("| candidate | tests | call wall-time | fix |")
     out.append("|---|---:|---:|---|")
-    for key, (desc, fix) in BUCKET_LABELS.items():
+    for key, (desc, fix) in CONVERSION_LABELS.items():
         b = buckets[key]
-        out.append(f"| {desc} | {len(b):,} | {fmt_dur(bucket_time(b))} | {fix} |")
-    out.append(
-        "\n_Wall-time = where these tests currently spend time; realizable saving is the per-test "
-        "DB/transaction overhead, a fraction of that. Counts are the actionable signal._\n"
-    )
+        out.append(f"| {desc} | {len(b):,} | {fmt_dur(bucket_time(b))} | -> {fix} |")
+    out.append("\n_Candidates only — confirm each (esp. txn-downgrade) by converting and re-running._\n")
 
-    for key, (desc, _fix) in BUCKET_LABELS.items():
+    for key, (desc, _fix) in CONVERSION_LABELS.items():
         b = buckets[key]
         if not b:
             continue
-        out.append(f"\n## {desc} ({len(b):,} tests, {fmt_dur(bucket_time(b))})\n")
-        by_base = Counter(r["base"] for r in b)
-        out.append("by base: " + ", ".join(f"{base}={n}" for base, n in by_base.most_common()))
-        out.append("\n### Top files by wall-time\n")
+        out.append(f"\n### {desc} — {len(b):,} tests\n")
+        out.append("by base: " + ", ".join(f"{base}={n}" for base, n in Counter(r["base"] for r in b).most_common()))
         for f, c, t in top_files(b):
-            short = f.split("/posthog/", 1)[-1] if "/posthog/" in f else f
             extra = ""
             if key == "multi_db_trim":
                 sample = next((r for r in b if r["file"] == f), {})
                 extra = f"  (unused: {','.join(sample.get('_unused_dbs', []))})"
-            out.append(f"- {c:3d} tests  {fmt_dur(t):>7}  {short}{extra}")
+            out.append(f"- {c:3d}  {fmt_dur(t):>7}  {short_path(f)}{extra}")
+
+    out.append("\n## Overuse & redundancy (setup cost)\n")
+    overuse = [
+        ("setup-heavy (setup >> body)", "setup_heavy", "pg_setup"),
+        ("redundant setup (N+1 fixtures)", "redundant_setup", "setup_max_dup"),
+        ("over-provisioned (heavy total)", "over_provisioned", "pg_total"),
+    ]
+    for title, key, metric in overuse:
+        b = buckets[key]
+        out.append(f"\n### {title} — {len(b):,} tests\n")
+        for k, n, m, setup in top_classes(b, metric):
+            out.append(f"- {n:3d} tests  {metric}={m:,} (setup {setup:,})  {short_path(k)}")
     return "\n".join(out) + "\n"
 
 
+# ---------------------------------------------------------------- html
+
+_CSS = """
+:root{--fg:#0f172a;--muted:#64748b;--line:#e2e8f0;--card:#fff;--bg:#f8fafc;--accent:#0ea5e9;--warn:#dc2626;--ok:#16a34a}
+*{box-sizing:border-box}
+body{font:14px/1.55 -apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;color:var(--fg);background:var(--bg);margin:0;padding:28px}
+.wrap{max-width:1180px;margin:0 auto}
+h1{font-size:24px;margin:0 0 4px}
+h2{font-size:18px;margin:34px 0 12px;padding-bottom:6px;border-bottom:1px solid var(--line)}
+h3{font-size:14px;margin:20px 0 8px;color:var(--muted);font-weight:600;text-transform:uppercase;letter-spacing:.03em}
+.sub{color:var(--muted);margin:0 0 22px}
+.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(150px,1fr));gap:12px;margin:18px 0 8px}
+.card{background:var(--card);border:1px solid var(--line);border-radius:8px;padding:14px 16px}
+.card .k{color:var(--muted);font-size:11px;text-transform:uppercase;letter-spacing:.05em}
+.card .v{font-size:22px;font-weight:650;margin-top:4px}
+table{width:100%;border-collapse:collapse;background:var(--card);border:1px solid var(--line);border-radius:8px;overflow:hidden;margin:8px 0 4px;font-size:13px}
+th,td{text-align:left;padding:7px 11px;border-bottom:1px solid var(--line)}
+th{background:#f1f5f9;font-weight:600;font-size:11px;text-transform:uppercase;letter-spacing:.03em;color:var(--muted)}
+tr:last-child td{border-bottom:none}
+td.n,th.n{text-align:right;font-variant-numeric:tabular-nums}
+code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;color:#334155}
+.pill{display:inline-block;padding:1px 8px;border-radius:999px;font-size:12px;font-weight:600}
+.pill.go{background:#dcfce7;color:#166534}
+.note{color:var(--muted);font-size:12.5px;margin:6px 0 0}
+"""
+
+
+def _esc(s: str) -> str:
+    return html.escape(str(s))
+
+
+def _table(headers: list[str], rows: list[list], aligns: list[str]) -> str:
+    th = "".join(f"<th class='{a}'>{_esc(h)}</th>" for h, a in zip(headers, aligns))
+    body = []
+    for row in rows:
+        tds = "".join(f"<td class='{a}'>{cell}</td>" for cell, a in zip(row, aligns))
+        body.append(f"<tr>{tds}</tr>")
+    return f"<table><thead><tr>{th}</tr></thead><tbody>{''.join(body)}</tbody></table>"
+
+
 def format_html(rows: list[dict], buckets: dict) -> str:
-    body = html.escape(format_markdown(rows, buckets))
-    return (
-        "<!doctype html><html><head><meta charset='utf-8'><title>Test resource-waste report</title>"
-        "<style>body{font:14px/1.5 -apple-system,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px}"
-        "pre{white-space:pre-wrap}</style></head><body><pre>" + body + "</pre></body></html>"
+    s = stats(rows)
+    parts: list[str] = []
+    parts.append("<!doctype html><html lang='en'><head><meta charset='utf-8'>")
+    parts.append("<meta name='viewport' content='width=device-width,initial-scale=1'>")
+    parts.append("<title>Test resource-waste report</title>")
+    parts.append(f"<style>{_CSS}</style></head><body><div class='wrap'>")
+    parts.append("<h1>Test resource-waste report</h1>")
+    parts.append(
+        "<p class='sub'>What each test provisioned vs. what it used. "
+        "Per-test timing and status captured directly &mdash; no junit or coverage correlation.</p>"
     )
+
+    cards = [
+        ("tests profiled", f"{s['total']:,}"),
+        ("DB-enabled", f"{s['db_enabled']:,}"),
+        ("postgres queries", f"{s['pg_total']:,}"),
+        ("of which setup", f"{s['pg_setup']:,}"),
+        ("clickhouse queries", f"{s['ch_total']:,}"),
+        ("call wall-time", fmt_dur(s["wall"])),
+    ]
+    parts.append("<div class='cards'>")
+    for k, v in cards:
+        parts.append(f"<div class='card'><div class='k'>{_esc(k)}</div><div class='v'>{_esc(v)}</div></div>")
+    parts.append("</div>")
+
+    # Conversion opportunities summary
+    parts.append("<h2>Conversion opportunities</h2>")
+    summ_rows = []
+    for key, (desc, fix) in CONVERSION_LABELS.items():
+        b = buckets[key]
+        summ_rows.append(
+            [desc, f"{len(b):,}", fmt_dur(bucket_time(b)), f"<span class='pill go'>&rarr; {_esc(fix)}</span>"]
+        )
+    parts.append(_table(["candidate", "tests", "call wall-time", "fix"], summ_rows, ["", "n", "n", ""]))
+    parts.append(
+        "<p class='note'>Candidates only. Confirm each &mdash; especially txn-downgrade &mdash; "
+        "by converting and re-running before changing anything.</p>"
+    )
+
+    for key, (desc, _fix) in CONVERSION_LABELS.items():
+        b = buckets[key]
+        if not b:
+            continue
+        by_base = ", ".join(f"{_esc(base)}={n}" for base, n in Counter(r["base"] for r in b).most_common())
+        parts.append(f"<h3>{_esc(desc)} &mdash; {len(b):,} tests <span class='note'>({by_base})</span></h3>")
+        file_rows = []
+        for f, c, t in top_files(b):
+            extra = ""
+            if key == "multi_db_trim":
+                sample = next((r for r in b if r["file"] == f), {})
+                extra = f" <code>unused: {_esc(','.join(sample.get('_unused_dbs', [])))}</code>"
+            file_rows.append([f"{c}", fmt_dur(t), f"<code>{_esc(short_path(f))}</code>{extra}"])
+        parts.append(_table(["tests", "wall", "file"], file_rows, ["n", "n", ""]))
+
+    # Overuse & redundancy
+    parts.append("<h2>Overuse &amp; redundancy (setup cost)</h2>")
+    overuse = [
+        ("Setup-heavy (setup &gt;&gt; body)", "setup_heavy", "pg_setup", "setup queries"),
+        ("Redundant setup (N+1 fixtures)", "redundant_setup", "setup_max_dup", "max repeats of one query"),
+        ("Over-provisioned (heavy total)", "over_provisioned", "pg_total", "total queries"),
+    ]
+    for title, key, metric, col in overuse:
+        b = buckets[key]
+        parts.append(f"<h3>{title} &mdash; {len(b):,} tests</h3>")
+        cls_rows = []
+        for k, n, m, setup in top_classes(b, metric):
+            cls_rows.append([f"{n}", f"{m:,}", f"{setup:,}", f"<code>{_esc(short_path(k))}</code>"])
+        parts.append(_table(["tests", col, "setup q", "class"], cls_rows, ["n", "n", "n", ""]))
+
+    parts.append(
+        "<p class='note'>Setup-heavy / redundant point at fixtures rebuilt per test "
+        "(move read-only data to setUpTestData) or N+1 in fixture creation.</p>"
+    )
+    parts.append("</div></body></html>")
+    return "".join(parts)
 
 
 def main(argv: list[str]) -> int:

--- a/tools/test_resource_report.py
+++ b/tools/test_resource_report.py
@@ -39,7 +39,7 @@ REDUNDANT_DUP_MIN = 10
 OVERPROVISIONED_MIN_Q = 100
 
 CONVERSION_LABELS = {
-    "no_db": ("DB set up, 0 queries", "SimpleTestCase"),
+    "no_db": ("DB set up, test body issues no query", "SimpleTestCase (verify fixtures)"),
     "ch_unused": ("ClickHouse mixin, 0 CH queries", "drop CH mixin"),
     "txn_downgrade": ("TransactionTestCase, no txn need", "TestCase"),
     "multi_db_trim": ("`databases` over-declared", "trim databases"),
@@ -80,34 +80,55 @@ def short_path(path: str) -> str:
     return path
 
 
+def _prefer(a: dict, b: dict) -> dict:
+    """Pick the row to keep when a nodeid appears twice (reruns/shards): a passing row always wins
+    over a failing one (so a flaky first attempt can't drop a green test); ties break on more activity."""
+    a_pass, b_pass = is_passing(a), is_passing(b)
+    if a_pass != b_pass:
+        return a if a_pass else b
+    return a if (a.get("pg_total", 0) + a.get("ch_call", 0)) >= (b.get("pg_total", 0) + b.get("ch_call", 0)) else b
+
+
 def load_rows(path: Path) -> list[dict]:
-    """Load JSONL, deduping by nodeid (shards/re-runs) keeping the most-exercised row."""
+    """Load JSONL, deduping by nodeid (shards/reruns). Tolerates torn lines from concurrent writers."""
     by_id: dict[str, dict] = {}
-    dupes = 0
-    for line in path.read_text().splitlines():
+    dupes = bad = 0
+    for line in path.open():  # stream — the merged file can be large
         line = line.strip()
         if not line:
             continue
-        r = json.loads(line)
-        nid = r["nodeid"]
+        try:
+            r = json.loads(line)
+            nid = r["nodeid"]
+        except (json.JSONDecodeError, KeyError):
+            bad += 1  # a torn/interleaved line from parallel appends — skip it, don't crash the report
+            continue
         prev = by_id.get(nid)
         if prev is None:
             by_id[nid] = r
         else:
             dupes += 1
-            # Keep whichever observed more datastore activity (a 0-query re-run must not mask a real one).
-            if (r.get("pg_total", 0) + r.get("ch_call", 0)) > (prev.get("pg_total", 0) + prev.get("ch_call", 0)):
-                by_id[nid] = r
+            by_id[nid] = _prefer(prev, r)
     if dupes:
         sys.stderr.write(f"note: collapsed {dupes} duplicate nodeids (multiple shards/runs)\n")
+    if bad:
+        sys.stderr.write(f"warning: skipped {bad} malformed lines (likely interleaved parallel writes)\n")
     return list(by_id.values())
 
 
 def bucket_no_db(rows: list[dict]) -> list[dict]:
+    # The test BODY never queries (pg_call==0), even though DB setup was paid for. Keyed on the call phase,
+    # not pg_total: a validation test still incurs APIBaseTest setUpTestData/savepoint queries in setup.
+    # Async excluded (needs transaction=True). These are SimpleTestCase candidates IF the body doesn't rely
+    # on the setUp fixtures — a rewrite-and-verify, not a mechanical swap.
     return [
         r
         for r in rows
-        if r.get("db_enabled") and r.get("pg_total", 0) == 0 and r.get("ch_call", 0) == 0 and is_passing(r)
+        if r.get("db_enabled")
+        and r.get("pg_call", 0) == 0
+        and r.get("ch_call", 0) == 0
+        and not r.get("is_async")
+        and is_passing(r)
     ]
 
 
@@ -140,21 +161,22 @@ def bucket_multi_db_trim(rows: list[dict]) -> list[dict]:
 
 
 def bucket_setup_heavy(rows: list[dict]) -> list[dict]:
+    # is_passing on all overuse buckets too: a failed partial run reports truncated, misleading counts.
     out = []
     for r in rows:
         total = r.get("pg_total", 0)
         setup = r.get("pg_setup", 0)
-        if setup >= SETUP_HEAVY_MIN_Q and total > 0 and setup / total >= SETUP_HEAVY_RATIO:
+        if setup >= SETUP_HEAVY_MIN_Q and total > 0 and setup / total >= SETUP_HEAVY_RATIO and is_passing(r):
             out.append(r)
     return out
 
 
 def bucket_redundant_setup(rows: list[dict]) -> list[dict]:
-    return [r for r in rows if r.get("setup_max_dup", 0) >= REDUNDANT_DUP_MIN]
+    return [r for r in rows if r.get("setup_max_dup", 0) >= REDUNDANT_DUP_MIN and is_passing(r)]
 
 
 def bucket_over_provisioned(rows: list[dict]) -> list[dict]:
-    return [r for r in rows if r.get("pg_total", 0) >= OVERPROVISIONED_MIN_Q]
+    return [r for r in rows if r.get("pg_total", 0) >= OVERPROVISIONED_MIN_Q and is_passing(r)]
 
 
 def summarize(rows: list[dict]) -> dict:
@@ -215,14 +237,15 @@ def key_findings(rows: list[dict], buckets: dict) -> list[str]:
     nodb, ch, txn = buckets["no_db"], buckets["ch_unused"], buckets["txn_downgrade"]
     red, heavy, over = buckets["redundant_setup"], buckets["setup_heavy"], buckets["over_provisioned"]
 
-    if not nodb:
+    if nodb:
+        setup_paid = sum(1 for r in nodb if r.get("pg_setup", 0) > 0)
         out.append(
-            f"**The no-DB vein is exhausted.** Of {s['db_enabled']:,} DB-enabled tests, none issue zero "
-            "Postgres+ClickHouse queries — the SimpleTestCase conversions already caught the easy wins. "
-            "The remaining waste is in ClickHouse over-provisioning and fixture setup, not in DB-marked tests."
+            f"**{len(nodb):,} DB-enabled tests never query in their body** (pg_call==0), {setup_paid:,} of which "
+            "still paid for Postgres setup → SimpleTestCase candidates. Note: many are integration tests that hit "
+            "the DB only via setUp fixtures or reach other layers, so each needs a rewrite-and-verify, not a blind swap."
         )
     else:
-        out.append(f"**{len(nodb):,} DB-enabled tests issue zero queries** → convert to SimpleTestCase.")
+        out.append(f"**No test bodies are query-free** across {s['db_enabled']:,} DB-enabled tests.")
     if ch:
         out.append(
             f"**{len(ch):,} tests provision a ClickHouse mixin but never query ClickHouse** "

--- a/tools/test_resource_report.py
+++ b/tools/test_resource_report.py
@@ -24,6 +24,7 @@ Usage:
 
 from __future__ import annotations
 
+import re
 import sys
 import html
 import json
@@ -207,6 +208,54 @@ def stats(rows: list[dict]) -> dict:
     }
 
 
+def key_findings(rows: list[dict], buckets: dict) -> list[str]:
+    """Auto-generated narrative — the few things worth acting on, in priority order."""
+    s = stats(rows)
+    out: list[str] = []
+    nodb, ch, txn = buckets["no_db"], buckets["ch_unused"], buckets["txn_downgrade"]
+    red, heavy, over = buckets["redundant_setup"], buckets["setup_heavy"], buckets["over_provisioned"]
+
+    if not nodb:
+        out.append(
+            f"**The no-DB vein is exhausted.** Of {s['db_enabled']:,} DB-enabled tests, none issue zero "
+            "Postgres+ClickHouse queries — the SimpleTestCase conversions already caught the easy wins. "
+            "The remaining waste is in ClickHouse over-provisioning and fixture setup, not in DB-marked tests."
+        )
+    else:
+        out.append(f"**{len(nodb):,} DB-enabled tests issue zero queries** → convert to SimpleTestCase.")
+    if ch:
+        out.append(
+            f"**{len(ch):,} tests provision a ClickHouse mixin but never query ClickHouse** "
+            f"({fmt_dur(bucket_time(ch))} of call time) → drop the mixin. The biggest conversion lever here."
+        )
+    if red:
+        dup_counts = Counter(r.get("setup_max_dup", 0) for r in red)
+        val, n = dup_counts.most_common(1)[0]
+        out.append(
+            f"**Systemic N+1 in a shared fixture:** {n} test classes each run one identical query **{val}×** "
+            "during setup (row-by-row inserts a bulk_create would collapse). One fixture fix, broad payoff."
+        )
+    if heavy:
+        out.append(
+            f"**{len(heavy):,} tests are setup-heavy** (≥70% of their queries are fixture setup, not the test "
+            "body) → hoist read-only data to setUpTestData or use lighter factories (build() over create())."
+        )
+    if over:
+        top = top_classes(over, "pg_total", 1)
+        if top:
+            k, n, m, _su = top[0]
+            out.append(
+                f"**{len(over):,} tests are over-provisioned** (≥{OVERPROVISIONED_MIN_Q} queries each); the "
+                f"heaviest class fires {m:,} queries across {n} tests — `{short_path(k)}`."
+            )
+    if txn:
+        out.append(
+            f"**{len(txn):,} TransactionTestCase tests** show no on_commit / FOR UPDATE / second connection → "
+            "likely downgradable to TestCase (verify each by swap-and-rerun)."
+        )
+    return out
+
+
 # ---------------------------------------------------------------- markdown
 
 
@@ -217,6 +266,12 @@ def format_markdown(rows: list[dict], buckets: dict) -> str:
     out.append(f"- Postgres queries: **{s['pg_total']:,}** ({s['pg_setup']:,} in setup)")
     out.append(f"- ClickHouse queries: **{s['ch_total']:,}** · call wall-time **{fmt_dur(s['wall'])}**")
     out.append("- No junit/coverage correlation — the profiler records timing + status itself\n")
+
+    findings = key_findings(rows, buckets)
+    if findings:
+        out.append("## Key findings\n")
+        out.extend(f"- {f}" for f in findings)
+        out.append("")
 
     out.append("## Conversion opportunities\n")
     out.append("| candidate | tests | call wall-time | fix |")
@@ -277,11 +332,28 @@ code{font:12px ui-monospace,SFMono-Regular,Menlo,monospace;color:#334155}
 .pill{display:inline-block;padding:1px 8px;border-radius:999px;font-size:12px;font-weight:600}
 .pill.go{background:#dcfce7;color:#166534}
 .note{color:var(--muted);font-size:12.5px;margin:6px 0 0}
+.findings{background:var(--card);border:1px solid var(--line);border-left:3px solid var(--accent);border-radius:8px;padding:4px 20px;margin:10px 0}
+.findings li{margin:9px 0}
 """
 
 
 def _esc(s: str) -> str:
     return html.escape(str(s))
+
+
+def _md_inline(s: str) -> str:
+    """Render the limited markdown used in findings (**bold**, `code`) to HTML, escaping the rest."""
+    parts: list[str] = []
+    pos = 0
+    for m in re.finditer(r"\*\*(.+?)\*\*|`(.+?)`", s):
+        parts.append(_esc(s[pos : m.start()]))
+        if m.group(1) is not None:
+            parts.append(f"<strong>{_esc(m.group(1))}</strong>")
+        else:
+            parts.append(f"<code>{_esc(m.group(2))}</code>")
+        pos = m.end()
+    parts.append(_esc(s[pos:]))
+    return "".join(parts)
 
 
 def _table(headers: list[str], rows: list[list], aligns: list[str]) -> str:
@@ -318,6 +390,13 @@ def format_html(rows: list[dict], buckets: dict) -> str:
     for k, v in cards:
         parts.append(f"<div class='card'><div class='k'>{_esc(k)}</div><div class='v'>{_esc(v)}</div></div>")
     parts.append("</div>")
+
+    findings = key_findings(rows, buckets)
+    if findings:
+        parts.append("<h2>Key findings</h2><ul class='findings'>")
+        for f in findings:
+            parts.append(f"<li>{_md_inline(f)}</li>")
+        parts.append("</ul>")
 
     # Conversion opportunities summary
     parts.append("<h2>Conversion opportunities</h2>")

--- a/tools/test_resource_report.py
+++ b/tools/test_resource_report.py
@@ -1,0 +1,203 @@
+"""Turn the per-test resource profile into ranked test-waste reports.
+
+Consumes the JSONL written by tools/pytest_resource_profiler (one row per test)
+and emits four "provisioned but unused" buckets, each ranked by where the time goes:
+
+  - no-DB         : DB set up, zero Postgres + ClickHouse queries  -> SimpleTestCase
+  - CH-unused     : ClickHouse mixin, zero ClickHouse queries      -> drop the mixin
+  - txn-downgrade : TransactionTestCase with no on_commit / FOR UPDATE / 2nd connection -> TestCase
+  - multi-DB-trim : `databases` declares an alias the test never queries -> trim it
+
+Self-sufficient: the profile already carries per-test wall time and status, so no
+junit or coverage correlation is needed.
+
+Usage:
+    python tools/test_resource_report.py --in logs/resource_profile.jsonl
+    python tools/test_resource_report.py --in logs/resource_profile.jsonl --out logs/test_waste.md
+    python tools/test_resource_report.py --in logs/resource_profile.jsonl --out logs/test_waste.html
+"""
+
+from __future__ import annotations
+
+import sys
+import html
+import json
+import argparse
+from collections import Counter, defaultdict
+from pathlib import Path
+
+BUCKET_LABELS = {
+    "no_db": ("DB set up, 0 queries", "-> SimpleTestCase"),
+    "ch_unused": ("ClickHouse mixin, 0 CH queries", "-> drop CH mixin"),
+    "txn_downgrade": ("TransactionTestCase, no txn need", "-> TestCase"),
+    "multi_db_trim": ("`databases` over-declared", "-> trim databases"),
+}
+
+
+def fmt_dur(seconds: float) -> str:
+    if seconds >= 3600:
+        return f"{seconds / 3600:.1f}h"
+    if seconds >= 60:
+        return f"{seconds / 60:.1f}m"
+    if seconds >= 1:
+        return f"{seconds:.1f}s"
+    return f"{seconds * 1000:.0f}ms"
+
+
+def used_aliases(row: dict) -> set[str]:
+    return {a for a, n in row.get("pg_alias", {}).items() if n > 0}
+
+
+def is_passing(row: dict) -> bool:
+    # Only propose conversions for tests that actually passed in this run.
+    return row.get("status") in {"passed", "unknown"}
+
+
+def load_rows(path: Path) -> list[dict]:
+    """Load JSONL, deduping by nodeid (shards/re-runs) keeping the most-exercised row."""
+    by_id: dict[str, dict] = {}
+    dupes = 0
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        r = json.loads(line)
+        nid = r["nodeid"]
+        prev = by_id.get(nid)
+        if prev is None:
+            by_id[nid] = r
+        else:
+            dupes += 1
+            # Keep whichever observed more datastore activity (a 0-query re-run must not mask a real one).
+            if (r.get("pg_total", 0) + r.get("ch_call", 0)) > (prev.get("pg_total", 0) + prev.get("ch_call", 0)):
+                by_id[nid] = r
+    if dupes:
+        sys.stderr.write(f"note: collapsed {dupes} duplicate nodeids (multiple shards/runs)\n")
+    return list(by_id.values())
+
+
+def bucket_no_db(rows: list[dict]) -> list[dict]:
+    return [
+        r
+        for r in rows
+        if r.get("db_enabled") and r.get("pg_total", 0) == 0 and r.get("ch_call", 0) == 0 and is_passing(r)
+    ]
+
+
+def bucket_ch_unused(rows: list[dict]) -> list[dict]:
+    return [r for r in rows if r.get("ch_provisioned") and r.get("ch_call", 0) == 0 and is_passing(r)]
+
+
+def bucket_txn_downgrade(rows: list[dict]) -> list[dict]:
+    out = []
+    for r in rows:
+        if not r.get("is_txn") or not is_passing(r):
+            continue
+        if r.get("on_commit", 0) == 0 and not r.get("for_update") and len(used_aliases(r)) <= 1:
+            out.append(r)
+    return out
+
+
+def bucket_multi_db_trim(rows: list[dict]) -> list[dict]:
+    out = []
+    for r in rows:
+        declared = r.get("declared_dbs")
+        if not isinstance(declared, list) or len(declared) <= 1:
+            continue  # "__all__", None, or single-DB: nothing to trim here
+        unused = [d for d in declared if d not in used_aliases(r)]
+        if unused:
+            out.append({**r, "_unused_dbs": unused})
+    return out
+
+
+def summarize(rows: list[dict]) -> dict:
+    return {
+        "no_db": bucket_no_db(rows),
+        "ch_unused": bucket_ch_unused(rows),
+        "txn_downgrade": bucket_txn_downgrade(rows),
+        "multi_db_trim": bucket_multi_db_trim(rows),
+    }
+
+
+def bucket_time(bucket: list[dict]) -> float:
+    return sum(r.get("duration_s", 0.0) for r in bucket)
+
+
+def top_files(bucket: list[dict], n: int = 15) -> list[tuple[str, int, float]]:
+    by_file_count: Counter[str] = Counter()
+    by_file_time: dict[str, float] = defaultdict(float)
+    for r in bucket:
+        f = r["file"]
+        by_file_count[f] += 1
+        by_file_time[f] += r.get("duration_s", 0.0)
+    ranked = sorted(by_file_count.items(), key=lambda kv: -by_file_time[kv[0]])
+    return [(f, c, by_file_time[f]) for f, c in ranked[:n]]
+
+
+def format_markdown(rows: list[dict], buckets: dict) -> str:
+    out: list[str] = []
+    out.append("# Test resource-waste report\n")
+    out.append(f"- Tests profiled: **{len(rows):,}**")
+    db_rows = [r for r in rows if r.get("db_enabled")]
+    out.append(f"- DB-enabled tests: **{len(db_rows):,}**")
+    out.append("- Call-phase wall time captured directly (no junit/coverage correlation)\n")
+
+    out.append("## Buckets\n")
+    out.append("| bucket | tests | call wall-time | fix |")
+    out.append("|---|---:|---:|---|")
+    for key, (desc, fix) in BUCKET_LABELS.items():
+        b = buckets[key]
+        out.append(f"| {desc} | {len(b):,} | {fmt_dur(bucket_time(b))} | {fix} |")
+    out.append(
+        "\n_Wall-time = where these tests currently spend time; realizable saving is the per-test "
+        "DB/transaction overhead, a fraction of that. Counts are the actionable signal._\n"
+    )
+
+    for key, (desc, _fix) in BUCKET_LABELS.items():
+        b = buckets[key]
+        if not b:
+            continue
+        out.append(f"\n## {desc} ({len(b):,} tests, {fmt_dur(bucket_time(b))})\n")
+        by_base = Counter(r["base"] for r in b)
+        out.append("by base: " + ", ".join(f"{base}={n}" for base, n in by_base.most_common()))
+        out.append("\n### Top files by wall-time\n")
+        for f, c, t in top_files(b):
+            short = f.split("/posthog/", 1)[-1] if "/posthog/" in f else f
+            extra = ""
+            if key == "multi_db_trim":
+                sample = next((r for r in b if r["file"] == f), {})
+                extra = f"  (unused: {','.join(sample.get('_unused_dbs', []))})"
+            out.append(f"- {c:3d} tests  {fmt_dur(t):>7}  {short}{extra}")
+    return "\n".join(out) + "\n"
+
+
+def format_html(rows: list[dict], buckets: dict) -> str:
+    body = html.escape(format_markdown(rows, buckets))
+    return (
+        "<!doctype html><html><head><meta charset='utf-8'><title>Test resource-waste report</title>"
+        "<style>body{font:14px/1.5 -apple-system,sans-serif;max-width:1100px;margin:24px auto;padding:0 16px}"
+        "pre{white-space:pre-wrap}</style></head><body><pre>" + body + "</pre></body></html>"
+    )
+
+
+def main(argv: list[str]) -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--in", dest="inp", type=Path, required=True)
+    ap.add_argument("--out", type=Path, default=None, help="write to file; .html renders HTML, else markdown")
+    args = ap.parse_args(argv)
+
+    rows = load_rows(args.inp)
+    buckets = summarize(rows)
+    text = format_html(rows, buckets) if (args.out and args.out.suffix == ".html") else format_markdown(rows, buckets)
+
+    if args.out:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(text)
+        sys.stdout.write(f"wrote {args.out}\n")
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/test_resource_report.py
+++ b/tools/test_resource_report.py
@@ -89,9 +89,11 @@ def bucket_ch_unused(rows: list[dict]) -> list[dict]:
 
 
 def bucket_txn_downgrade(rows: list[dict]) -> list[dict]:
+    # Heuristic only — async tests need transaction=True for the async/sync ORM boundary, so exclude them.
+    # Survivors are CANDIDATES; confirm each by swapping to TestCase and re-running before converting.
     out = []
     for r in rows:
-        if not r.get("is_txn") or not is_passing(r):
+        if not r.get("is_txn") or r.get("is_async") or not is_passing(r):
             continue
         if r.get("on_commit", 0) == 0 and not r.get("for_update") and len(used_aliases(r)) <= 1:
             out.append(r)

--- a/turbo.json
+++ b/turbo.json
@@ -24,7 +24,7 @@
             "outputs": [],
             "cache": true,
             "env": ["DATABASE_URL", "REDIS_URL", "CLICKHOUSE_HOST", "TEST"],
-            "passThroughEnv": ["PYTEST_ADDOPTS"]
+            "passThroughEnv": ["PYTEST_ADDOPTS", "PYTHONPATH", "RESOURCE_PROFILE_OUT"]
         },
         "backend:lint": {
             "inputs": ["backend/**/*.py", "!backend/**/__pycache__/**"],


### PR DESCRIPTION
> **DO NOT MERGE** — throwaway data-collection branch. It wires a report-only profiler into backend CI to harvest a full-suite resource profile, then gets closed. Kept off the per-product coverage PR (#59664) on purpose.

## Problem

We have no systematic view of tests that pay for expensive setup they never use — a test that spins up Postgres (or ClickHouse) and a per-test transaction but issues zero queries could run as a no-DB `SimpleTestCase`. Manual one-offs (#66707/#66708/#66712/#66765) found these by hand. This finds them across the whole suite, plus related overuse: `TransactionTestCase` that doesn't need transactions (3–10× per-test cost), over-declared `databases`, and N+1 in fixture creation.

## Changes

- `tools/pytest_resource_profiler.py` — a passive pytest plugin. Per test it records what was provisioned vs. used: Postgres queries (per connection alias), ClickHouse queries, `transaction.on_commit` registrations, `SELECT ... FOR UPDATE`, async flag, base class, setup-phase query-shape repetition (N+1), and call-phase wall time + status. Self-sufficient — no junit or coverage correlation needed.
- `tools/test_resource_report.py` — turns the JSONL into a rich HTML/markdown report: conversion candidates (no-DB, CH-unused, txn-downgrade, multi-DB-trim) and ranked overuse buckets (setup-heavy, redundant-setup, over-provisioned).
- CI wiring (this branch only): the `django` and `turbo-tests` jobs load the plugin via `PYTEST_ADDOPTS` and upload a per-shard `resource-profile` artifact. `turbo.json` adds `PYTHONPATH`/`RESOURCE_PROFILE_OUT` to `backend:test` `passThroughEnv` (turbo sandboxes env).

Everything is report-only — no test behavior changes.

## How did you test this code?

I'm an agent. Postgres was available locally, ClickHouse was not.

- Local PG sweeps (~640 tests): plugin loads and records correctly; the txn-downgrade detector caught 3 candidates that turned out to be async tests genuinely needing `transaction=True` → added an `is_async` exclusion. This is why the report frames txn-downgrade as **candidates to verify**, not safe auto-conversions.
- `ruff` + `ty` clean on both tools; `actionlint` clean on the workflow; verified `tools.pytest_resource_profiler` imports from a `products/<name>/` CWD with `PYTHONPATH` set (the turbo path).
- The CH-unused / multi-DB buckets and the full numbers come from **this PR's own CI run** (full matrix forced via `run-ci-backend`).

## Automatic notifications

- [ ] Publish to changelog? no
- [ ] Alert Sales and Marketing teams? no

## Docs update

No.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Julian directed this.

- Tool: Claude Code. No repo skills required (no DRF/migration/serializer surface; report-only tooling + CI config).
- Key decisions: chose direct per-test query-counting over coverage-context inference for the DB question (direct, exact, cheaper); kept this off PR #59664 (aggregate per-product coverage, different axis); made the plugin a passive passenger so it rides one normal CI run with negligible overhead; framed `TransactionTestCase` downgrades as verify-first candidates after a local false-positive (async ORM boundary).
- Not for merge — it exists to collect the artifact and produce the report.
