### PR TITLE
fix(linkedin_ads): treat deleted integration as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/source.py
@@ -81,6 +81,11 @@ class LinkedInAdsSource(ResumableSource[LinkedinAdsSourceConfig, LinkedInAdsResu
             # never succeeds, so fail fast and tell the user to fix the configured Account ID. Match on
             # the stable prefix only — the offending value that follows varies per source.
             "Array parameter 'accounts' value 'urn:li:sponsoredAccount:": "The LinkedIn Ads Account ID is invalid. Please check the Account ID in your source configuration — it should be the numeric account ID from your LinkedIn Campaign Manager.",
+            # Integration.DoesNotExist raised by `_get_integration` when the stored OAuth integration
+            # row has been deleted/disconnected before the sync runs. Retrying cannot recover — the
+            # user must re-authorize. Model-specific so we don't swallow unrelated `DoesNotExist`
+            # errors from other models, which may be real bugs.
+            "Integration matching query does not exist": "Your LinkedIn Ads connection is no longer available — it may have been disconnected. Please re-authorize the LinkedIn Ads integration.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/linkedin_ads/tests/test_linkedin_source.py
@@ -25,6 +25,8 @@ class TestLinkedInAdsSource:
             "The token used in the request has expired",
             "Failed to refresh token for LinkedIn Ads integration. Please re-authorize the integration.",
             'LinkedIn API error (401): {"status":401,"serviceErrorCode":65608,"code":"RESTRICTED_MEMBER","message":"Member is restricted"}',
+            # Integration.DoesNotExist when the OAuth integration row was deleted/disconnected.
+            "Integration matching query does not exist.",
         ],
     )
     def test_non_retryable_errors_match_upstream_failures(self, observed_error):


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `Integration.DoesNotExist` ("Integration matching query does not exist.") from the LinkedIn Ads data-warehouse import source, raised in `_get_integration` at `linkedin_ads.py`. This happens when the OAuth integration row backing a source has been deleted or disconnected, but the import schedule keeps running.

The job-status path (`update_external_data_job_model`) already classifies this via the global `Any_Source_Errors` map, but the import-sync retry path (`import_data_sync._handle_import_error`) consults **only** the source's own `get_non_retryable_errors()` — which didn't list this error. So the activity kept retrying an error that can never recover, producing a tight burst of identical failures per affected source.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1489-d2d4-7b82-8a0e-78e82f85a12e

## Changes

Classify `Integration.DoesNotExist` as non-retryable for the LinkedIn Ads source by adding `"Integration matching query does not exist"` to `get_non_retryable_errors()`, with a user-facing message telling the customer to re-authorize.

This mirrors the existing `google_ads` source, which already handles the identical error the same way (and the same key already lives in the shared `Any_Source_Errors` map). The substring is model-specific, so it won't swallow unrelated `DoesNotExist` errors from other models that could be real bugs.

This is squarely a user/upstream condition — the connected account no longer exists — so retrying is pointless; failing fast and prompting re-authorization is the right behavior.

## How did you test this code?

I'm an agent. I extended the existing parameterized `test_non_retryable_errors_match_upstream_failures` with a case asserting the deleted-integration message is recognized as non-retryable (rather than adding a redundant new test). The regression it guards: if someone drops this key from the LinkedIn Ads non-retryable map, a deleted/disconnected integration would retry forever instead of failing fast.

I could not execute the Python suite in this sandbox (no flox/Django environment available). I verified the change with `ruff check` / `ruff format --check` (both pass) and by inspection: the matcher is a substring check and the new key is contained in Django's `Integration.DoesNotExist` message, identical to the already-tested `google_ads` handling.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a live error-tracking issue for the LinkedIn Ads import source. Confirmed the failing frame (`_get_integration`) genuinely originates in this source, traced both non-retryable-error consumption paths, and confirmed the import-sync retry path didn't recognize the deleted-integration error. Decided this is a user/upstream error (deleted/disconnected OAuth integration) rather than a fixable code bug, so the fix extends `NonRetryableErrors` rather than changing logic — matching the established `google_ads` precedent.

Skills invoked: `/writing-tests` (decided to extend the existing parameterized test rather than add a redundant one). Checked open PRs (including the maintainer's) for duplicates before opening.
