### PR TITLE
fix(vercel): don't auto-create resource on delete operations

### DIFF
--- a/ee/vercel/integration.py
+++ b/ee/vercel/integration.py
@@ -1280,7 +1280,9 @@ class VercelIntegration:
             capture_exception(e, {"team_id": team.id, "resource_id": setup_result.resource_id})
 
 
-def _safe_vercel_sync(operation_name: str, item_id: str | int, team: Team, sync_func: Callable[[], None]) -> None:
+def _safe_vercel_sync(
+    operation_name: str, item_id: str | int, team: Team, sync_func: Callable[[], None], *, is_delete: bool = False
+) -> None:
     """
     Safety wrapper for Vercel sync operations triggered by Django signals.
 
@@ -1290,8 +1292,15 @@ def _safe_vercel_sync(operation_name: str, item_id: str | int, team: Team, sync_
 
     Operations are silently skipped if Vercel integration is not configured and
     exceptions are caught and logged rather than bubbling up to the caller.
+
+    On delete (``is_delete=True``) we never auto-create a Vercel resource: with no existing resource there is
+    nothing to delete from Vercel, and creating one is actively harmful during team deletion. Signals run in the
+    caller's transaction, so the team-deletion cascade would re-insert an Integration row for a team being deleted
+    in that same transaction — orphaning it and failing the commit with an IntegrityError on the team FK.
     """
     if not VercelIntegration._get_vercel_resource_for_team(team):
+        if is_delete:
+            return
         installation = VercelIntegration._get_installation_for_organization(team.organization)
         if not installation:
             return
@@ -1342,6 +1351,7 @@ def sync_feature_flag_experimentation_item(sender, instance: FeatureFlag, create
             instance.pk,
             instance.team,
             lambda: VercelIntegration.delete_feature_flag_from_vercel(instance),
+            is_delete=True,
         )
     else:
         _safe_vercel_sync(
@@ -1359,6 +1369,7 @@ def delete_resource_experimentation_item(sender, instance: FeatureFlag, **kwargs
         instance.pk,
         instance.team,
         lambda: VercelIntegration.delete_feature_flag_from_vercel(instance),
+        is_delete=True,
     )
 
 
@@ -1370,6 +1381,7 @@ def sync_experiment_experimentation_item(sender, instance: Experiment, created, 
             instance.pk,
             instance.team,
             lambda: VercelIntegration.delete_experiment_from_vercel(instance),
+            is_delete=True,
         )
     else:
         _safe_vercel_sync(
@@ -1387,4 +1399,5 @@ def delete_experiment_experimentation_item(sender, instance: Experiment, **kwarg
         instance.pk,
         instance.team,
         lambda: VercelIntegration.delete_experiment_from_vercel(instance),
+        is_delete=True,
     )

--- a/ee/vercel/test/test_integration.py
+++ b/ee/vercel/test/test_integration.py
@@ -20,7 +20,7 @@ from products.experiments.backend.models.experiment import Experiment
 from products.feature_flags.backend.models.feature_flag import FeatureFlag
 
 from ee.api.vercel.types import VercelUserClaims
-from ee.vercel.integration import VercelIntegration
+from ee.vercel.integration import VercelIntegration, _safe_vercel_sync
 
 
 class TestVercelIntegration(TestCase):
@@ -869,6 +869,38 @@ class TestVercelIntegration(TestCase):
         experiment.save()
 
         mock_sync.assert_called_once_with(experiment, False)
+
+    @parameterized.expand(
+        [
+            ("delete_skips_autocreate", True, False, 0),
+            ("sync_autocreates", False, True, 1),
+        ]
+    )
+    def test_safe_vercel_sync_only_autocreates_resource_on_sync(
+        self, _name, is_delete, should_create, expected_sync_calls
+    ):
+        team = Team.objects.create(organization=self.organization, name="No Resource Team")
+        sync_func = Mock()
+
+        _safe_vercel_sync("op", "item_1", team, sync_func, is_delete=is_delete)
+
+        created = Integration.objects.filter(team=team, kind=Integration.IntegrationKind.VERCEL).exists()
+        assert created is should_create
+        assert sync_func.call_count == expected_sync_calls
+
+    @patch("ee.vercel.integration.VercelAPIClient")
+    def test_feature_flag_post_delete_does_not_recreate_vercel_resource(self, _mock_client):
+        # Regression: project deletion looped forever. During the team-deletion cascade the team's Vercel
+        # resource is deleted before its feature flags, so each flag's post_delete auto-created a connectable
+        # Integration row for the team being deleted in the same atomic transaction — orphaning it and failing
+        # COMMIT with an IntegrityError on the team FK. The delete path must never auto-create a resource.
+        team = Team.objects.create(organization=self.organization, name="Doomed Team")
+        flag = FeatureFlag.objects.create(team=team, key="doomed-flag")
+        Integration.objects.filter(team=team, kind=Integration.IntegrationKind.VERCEL).delete()
+
+        flag.delete()
+
+        assert not Integration.objects.filter(team=team, kind=Integration.IntegrationKind.VERCEL).exists()
 
 
 class TestVercelInstallationRegressions(TestCase):


### PR DESCRIPTION
## What changed?
- Added `is_delete` parameter to `_safe_vercel_sync()` function to distinguish between sync and delete operations
- Modified the function to skip auto-creation of Vercel resources when `is_delete=True` — with no existing resource there is nothing to delete from Vercel, and creating one during team deletion is harmful
- Updated all delete-path signal handlers (`sync_feature_flag_experimentation_item`, `delete_resource_experimentation_item`, `sync_experiment_experimentation_item`, `delete_experiment_experimentation_item`) to pass `is_delete=True`
- Added comprehensive test coverage:
  - `test_safe_vercel_sync_only_autocreates_resource_on_sync`: Verifies that resource auto-creation only happens on sync operations, not deletes
  - `test_feature_flag_post_delete_does_not_recreate_vercel_resource`: Regression test ensuring feature flag deletion doesn't recreate Vercel resources during team deletion cascades

## How did you test this code?
- Added parameterized unit test covering both sync and delete scenarios with mock verification
- Added regression test simulating the team deletion cascade scenario where the delete path previously caused IntegrityErrors
- Both tests verify that sync operations auto-create resources while delete operations do not

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*