### PR TITLE
fix(replay): keep vision scanner table interactable while polling

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -475,4 +475,28 @@ describe('replayScannerLogic', () => {
             expect(observeSpy).not.toHaveBeenCalled()
         })
     })
+
+    describe('background polling', () => {
+        it('background reloads stay silent so the table stays interactable, foreground loads do not', () => {
+            const persisted = replayScannerLogic({ id: 'abc-123' })
+            persisted.mount()
+            try {
+                // The initial foreground load (also manual refresh, filter/sort/pagination) shows the overlay.
+                expect(persisted.values.observationsLoading).toBe(true)
+
+                persisted.actions.loadObservationsSuccess([], 0)
+                expect(persisted.values.observationsLoading).toBe(false)
+
+                // The 3s in-flight poll reloads in the background — no overlay, so rows update in place.
+                persisted.actions.loadObservations(true)
+                expect(persisted.values.observationsLoading).toBe(false)
+
+                // A foreground reload still shows it — proving the silent case isn't just a no-op action.
+                persisted.actions.loadObservations()
+                expect(persisted.values.observationsLoading).toBe(true)
+            } finally {
+                persisted.unmount()
+            }
+        })
+    })
 })

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -220,7 +220,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         loadScannerFailure: true,
         setScannerType: (scannerType: ScannerType) => ({ scannerType }),
         setSubmitIntent: (intent: 'save' | 'advance') => ({ intent }),
-        loadObservations: true,
+        loadObservations: (background = false) => ({ background }),
         loadObservationsSuccess: (observations: ReplayObservationApi[], total: number) => ({ observations, total }),
         loadObservationsFailure: true,
         setObservationsPage: (page: number) => ({ page }),
@@ -425,7 +425,9 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         observationsLoading: [
             false,
             {
-                loadObservations: () => true,
+                // Background polls reload silently so the table stays interactable; only foreground
+                // loads (initial paint, manual refresh, filter/sort/pagination) show the overlay.
+                loadObservations: (state, { background }) => (background ? state : true),
                 loadObservationsSuccess: () => false,
                 loadObservationsFailure: () => false,
             },
@@ -640,8 +642,8 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
     }),
 
     listeners(({ actions, props, values, cache }) => {
-        const reloadObservationsAndStats = (): void => {
-            actions.loadObservations()
+        const reloadObservationsAndStats = (background = false): void => {
+            actions.loadObservations(background)
             actions.loadObservationStats()
         }
         return {
@@ -885,7 +887,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 scheduleObservationPoll(
                     cache.disposables,
                     values.hasObservationsInFlight || Date.now() < values.pollUntil,
-                    reloadObservationsAndStats
+                    () => reloadObservationsAndStats(true)
                 )
             },
             // Reschedule on failure too — a transient API hiccup shouldn't permanently kill the polling cycle.
@@ -893,7 +895,7 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
                 scheduleObservationPoll(
                     cache.disposables,
                     values.hasObservationsInFlight || Date.now() < values.pollUntil,
-                    reloadObservationsAndStats
+                    () => reloadObservationsAndStats(true)
                 )
             },
         }


### PR DESCRIPTION
## Problem

On the Replay Vision scanner page, the observation history table auto-refreshes every 3 seconds whenever there are observations "in flight" (any `pending`/`running` observation). The problem: each poll tick dropped the **entire** `LemonTable` into its loading-overlay state — blanking the table and making it non-interactable for the duration of every request. While observations were running you couldn't read, sort, paginate, or click rows without it blinking out from under you.

## Changes

The poll callback dispatched a foreground `loadObservations`, which flipped `observationsLoading` to `true` and drove the table's `loading` overlay on every 3s tick.

- `loadObservations` now takes a `background` flag.
- The `observationsLoading` reducer only flips `true` for **foreground** loads — initial paint, manual refresh, filter/sort/pagination. Background polls reload silently.
- The in-flight poll passes `background = true`, so rows swap in place via `loadObservationsSuccess` without the overlay. `rowKey="id"` keeps row identity (and hover/sort state) stable across the swap.

Net effect: the table still refreshes on the same 3s cadence while observations are in flight, but it stays fully interactable instead of blanking each tick. The manual Refresh button spinner, the on-demand trigger overlay, and the initial-load/filter/sort/pagination loading feedback are all unchanged.

No change was needed in `ScannerObservationsTable.tsx` — its existing `loading={refreshing || triggeringOnDemandObservation || observationsLoading}` simply stops seeing `observationsLoading` go true during background polls.

## How did you test this code?

I'm an agent (Claude Code). I did **not** manually exercise the UI. Automated only:

- Added a regression test in `replayScannerLogic.test.ts` (`background polling`) asserting a background `loadObservations(true)` keeps `observationsLoading` false while a foreground `loadObservations()` sets it true — catches a regression to the old unconditional `() => true` reducer that no existing test covered.
- `jest replayScannerLogic.test.ts` → 44/44 pass.
- `oxfmt --check` clean; `oxlint` 0 errors; kea typegen regenerates cleanly.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @ksvat

Investigated and implemented with Claude Code. The user reported the aggressive 3s table refresh on the Replay Vision scanner page and asked for options. I traced the polling wiring (`observationPolling.ts` single-shot 3s `setTimeout` rescheduled from `loadObservationStatsSuccess`/`Failure` whenever `hasObservationsInFlight`), and presented three options: silent background refresh, longer poll interval, and surgical single-row merge. The user chose the silent-refresh approach.

Chosen design adds a `background` flag to `loadObservations` rather than gating the table's `loading` prop on `observations.length === 0` — this is more precise, preserving the loading overlay for all genuinely user-driven loads (filter/sort/pagination) while silencing only the poll. Interval bump and single-row merge were deliberately left out of scope.
