### PR TITLE
perf(cohorts): optimize cohort stream processor

### DIFF
--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -229,10 +229,8 @@ pub struct Config {
     #[envconfig(default = "5000")]
     pub offset_commit_interval_ms: u64,
 
-    /// Tokio runtime worker threads. `0` (the default) keeps Tokio's own default of
-    /// `available_parallelism()` — the *node's* core count, which under a CFS CPU limit spawns far
-    /// more threads than the limit and thrashes them. Set this to the pod's CPU limit so the runtime
-    /// matches the cgroup quota.
+    /// Tokio runtime worker threads. `0` (default) uses Tokio's `available_parallelism()` — the node's
+    /// core count, which thrashes under a CFS CPU limit. Set to the pod's CPU limit to match the quota.
     #[envconfig(default = "0")]
     pub tokio_worker_threads: usize,
 

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -229,6 +229,13 @@ pub struct Config {
     #[envconfig(default = "5000")]
     pub offset_commit_interval_ms: u64,
 
+    /// Tokio runtime worker threads. `0` (the default) keeps Tokio's own default of
+    /// `available_parallelism()` — the *node's* core count, which under a CFS CPU limit spawns far
+    /// more threads than the limit and thrashes them. Set this to the pod's CPU limit so the runtime
+    /// matches the cgroup quota.
+    #[envconfig(default = "0")]
+    pub tokio_worker_threads: usize,
+
     /// How often the sweep fires to evict state whose eviction deadline has passed.
     #[envconfig(default = "30000")]
     pub sweep_interval_ms: u64,
@@ -687,6 +694,7 @@ mod tests {
             recv_batch_size: 1000,
             recv_batch_timeout_ms: 500,
             offset_commit_interval_ms: 5000,
+            tokio_worker_threads: 0,
             sweep_interval_ms: 30000,
             sweep_safety_margin_ms: 300000,
             store_path: "cohort-store".to_string(),

--- a/rust/cohort-stream-processor/src/config.rs
+++ b/rust/cohort-stream-processor/src/config.rs
@@ -229,8 +229,11 @@ pub struct Config {
     #[envconfig(default = "5000")]
     pub offset_commit_interval_ms: u64,
 
-    /// Tokio runtime worker threads. `0` (default) uses Tokio's `available_parallelism()` — the node's
-    /// core count, which thrashes under a CFS CPU limit. Set to the pod's CPU limit to match the quota.
+    /// Tokio runtime worker threads. `0` (default) lets Tokio size the pool from
+    /// `available_parallelism()`, which accounts for a CFS CPU *limit* (`cpu.max`) but not CPU
+    /// *requests*/shares — so on a requests-only pod (no `limits.cpu`), or when the cgroup fs isn't
+    /// readable, it returns the *node's* core count and over-subscribes the runtime. Set this to the
+    /// pod's CPU budget to cap the pool regardless of how the limit is expressed.
     #[envconfig(default = "0")]
     pub tokio_worker_threads: usize,
 

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -689,11 +689,6 @@ impl EventDispatcher {
         self.tracker.as_ref()
     }
 
-    /// An owned handle on the offset tracker, for the progress-gated heartbeat task.
-    pub(crate) fn tracker_handle(&self) -> Arc<OffsetTracker> {
-        self.tracker.clone()
-    }
-
     fn owned_committable_offsets(&self) -> HashMap<i32, i64> {
         self.tracker
             .committable_offsets()
@@ -794,11 +789,10 @@ impl CohortStreamEventsConsumer {
 
     /// Run until the lifecycle handle signals shutdown.
     ///
-    /// Offset commit (C2) and the liveness heartbeat (C1) run on their own interval tasks rather than
-    /// inline in this loop, so a CPU-saturated consume loop or worker backlog can no longer block
-    /// either: offsets keep advancing (a restart resumes near the live edge) and the heartbeat keeps
-    /// firing while the workers make progress. Both observe the same shutdown signal and are awaited
-    /// before the final synchronous commit.
+    /// Offset commit (C2) runs on its own interval task rather than inline in this loop, so a
+    /// CPU-saturated consume loop or worker backlog can no longer block offset advancement (a restart
+    /// resumes near the live edge). The task observes the same shutdown signal and is awaited before
+    /// the final synchronous commit. Liveness is reported inline from `handle_outcome`.
     pub async fn process(self) {
         let _guard = self.handle.process_scope();
         info!(topic = %self.topic, "cohort_stream_events consume loop starting");
@@ -809,11 +803,6 @@ impl CohortStreamEventsConsumer {
             self.dispatcher.clone(),
             self.topic.clone(),
             self.offset_commit_interval,
-            self.handle.clone(),
-        ));
-        // C1: progress-gated liveness heartbeat task.
-        let heartbeat_task = tokio::spawn(run_heartbeat_loop(
-            self.dispatcher.tracker_handle(),
             self.handle.clone(),
         ));
 
@@ -858,13 +847,10 @@ impl CohortStreamEventsConsumer {
             }
         }
 
-        // The shutdown signal that broke the loop also stops the helper tasks; await them before the
+        // The shutdown signal that broke the loop also stops the commit task; await it before the
         // final synchronous commit so no commit races it.
         if let Err(err) = commit_task.await {
             warn!(error = %err, "offset-commit task did not exit cleanly");
-        }
-        if let Err(err) = heartbeat_task.await {
-            warn!(error = %err, "heartbeat task did not exit cleanly");
         }
 
         let tracker = self.dispatcher.shutdown().await;
@@ -974,10 +960,10 @@ impl CohortStreamEventsConsumer {
 
         self.dispatcher.dispatch(outcome.events).await;
 
-        // Liveness is reported by the progress-gated heartbeat task (C1), not here: a consume loop
-        // that keeps turning while the workers are wedged must not mask the stall.
         if outcome.transport_error {
             tokio::time::sleep(RECV_ERROR_BACKOFF).await;
+        } else {
+            self.handle.report_healthy();
         }
     }
 
@@ -1116,10 +1102,6 @@ pub(crate) fn fsync_then_commit<C: ConsumerContext>(
     commit_offsets(consumer, tracker, offsets, topic, mode);
 }
 
-/// Cadence of the progress-gated liveness heartbeat. Comfortably inside the consumer's 60 s liveness
-/// deadline (registered in `main.rs`), so many heartbeats fire before the watchdog could trip.
-const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
-
 /// C2 — the decoupled offset-commit task. On a fixed interval it flushes the store's WAL and commits
 /// the owned committable offsets, independent of the consume loop's forward progress. A starved or
 /// slow consume loop no longer blocks offset advancement, so a restart resumes near the live edge
@@ -1149,40 +1131,6 @@ async fn run_commit_loop(
             }
         }
     }
-}
-
-/// C1 — the progress-gated liveness heartbeat task. It reports healthy only while the workers make
-/// forward progress (the [`OffsetTracker`] liveness counter advances) *or* there is no backlog to
-/// process. A busy-but-advancing pod stays alive; a genuine stall (backlog present, no progress)
-/// stops heartbeating and the lifecycle watchdog self-kills — the intended fail-stop. Paired with the
-/// worker yields (C3), this fires even when the workers are CPU-bound. Exits on the shutdown signal.
-async fn run_heartbeat_loop(tracker: Arc<OffsetTracker>, handle: Handle) {
-    let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
-    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut last_progress = tracker.progress();
-    // Report healthy once up front so the component isn't flagged stalled before the first batch.
-    handle.report_healthy();
-    loop {
-        tokio::select! {
-            biased;
-            _ = handle.shutdown_recv() => break,
-            _ = ticker.tick() => {
-                let progress = tracker.progress();
-                if should_report_healthy(progress, last_progress, tracker.has_pending_work()) {
-                    last_progress = progress;
-                    handle.report_healthy();
-                }
-            }
-        }
-    }
-}
-
-/// The heartbeat gate: report healthy when the workers advanced since the last tick, **or** when
-/// there is no backlog. The second clause is load-bearing — without it an idle pod (no events, so no
-/// progress) would be read as stalled and self-killed. A genuine stall is backlog-present *and*
-/// no-progress, which alone returns `false`.
-fn should_report_healthy(progress: u64, last_progress: u64, has_pending_work: bool) -> bool {
-    progress != last_progress || !has_pending_work
 }
 
 #[cfg(test)]
@@ -1351,18 +1299,6 @@ mod tests {
     fn build_commit_tpl_for_no_offsets_is_empty() {
         let tpl = build_commit_tpl("cohort_stream_events", &HashMap::new());
         assert_eq!(tpl.count(), 0);
-    }
-
-    #[test]
-    fn heartbeat_gate_distinguishes_a_stall_from_idle_and_progress() {
-        // Workers advanced since the last tick → healthy, regardless of backlog.
-        assert!(should_report_healthy(5, 4, true));
-        assert!(should_report_healthy(5, 4, false));
-        // A genuine stall — backlog present, no progress — is the ONLY case that withholds the
-        // heartbeat so the watchdog self-kills.
-        assert!(!should_report_healthy(4, 4, true));
-        // No progress but also no backlog (idle pod): must stay healthy, never self-kill.
-        assert!(should_report_healthy(4, 4, false));
     }
 
     fn manifest_for(topic: &str, committed: &[(i32, i64)]) -> OffsetManifest {

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -689,6 +689,11 @@ impl EventDispatcher {
         self.tracker.as_ref()
     }
 
+    /// An owned handle on the offset tracker, for the progress-gated heartbeat task.
+    pub(crate) fn tracker_handle(&self) -> Arc<OffsetTracker> {
+        self.tracker.clone()
+    }
+
     fn owned_committable_offsets(&self) -> HashMap<i32, i64> {
         self.tracker
             .committable_offsets()
@@ -741,7 +746,9 @@ fn boot_assignment_settled(assignment: &HashSet<i32>, prev: &mut Option<HashSet<
 /// Uses a raw `StreamConsumer` with manual commit because the per-partition `OffsetTracker`
 /// commits a `TopicPartitionList` that the `common-kafka` wrapper can't express.
 pub struct CohortStreamEventsConsumer {
-    consumer: StreamConsumer<CohortConsumerContext>,
+    /// `Arc` so the decoupled commit task can share it with the consume loop; `recv` and `commit`
+    /// run concurrently on the same consumer, which rdkafka supports.
+    consumer: Arc<StreamConsumer<CohortConsumerContext>>,
     topic: String,
     dispatcher: Arc<EventDispatcher>,
     handle: Handle,
@@ -772,7 +779,7 @@ impl CohortStreamEventsConsumer {
         restore_manifest: Option<OffsetManifest>,
     ) -> Self {
         Self {
-            consumer,
+            consumer: Arc::new(consumer),
             topic,
             dispatcher,
             handle,
@@ -785,13 +792,31 @@ impl CohortStreamEventsConsumer {
         }
     }
 
-    /// Run until the lifecycle handle signals shutdown. Commit is deadline-driven, not a `select!`
-    /// arm, to avoid cancelling an in-flight `consume_batch` and dropping buffered events.
+    /// Run until the lifecycle handle signals shutdown.
+    ///
+    /// Offset commit (C2) and the liveness heartbeat (C1) run on their own interval tasks rather than
+    /// inline in this loop, so a CPU-saturated consume loop or worker backlog can no longer block
+    /// either: offsets keep advancing (a restart resumes near the live edge) and the heartbeat keeps
+    /// firing while the workers make progress. Both observe the same shutdown signal and are awaited
+    /// before the final synchronous commit.
     pub async fn process(self) {
         let _guard = self.handle.process_scope();
         info!(topic = %self.topic, "cohort_stream_events consume loop starting");
 
-        let mut commit_deadline = tokio::time::Instant::now() + self.offset_commit_interval;
+        // C2: decoupled offset-commit task.
+        let commit_task = tokio::spawn(run_commit_loop(
+            self.consumer.clone(),
+            self.dispatcher.clone(),
+            self.topic.clone(),
+            self.offset_commit_interval,
+            self.handle.clone(),
+        ));
+        // C1: progress-gated liveness heartbeat task.
+        let heartbeat_task = tokio::spawn(run_heartbeat_loop(
+            self.dispatcher.tracker_handle(),
+            self.handle.clone(),
+        ));
+
         // One-shot guards; each pre-marked done when its gate is off, keeping the non-durable path unchanged.
         let mut boot_sweep_done = !self.dispatcher.durable_restore_enabled();
         let mut eager_redrive_done = !self.dispatcher.durable_restore_enabled();
@@ -829,20 +854,17 @@ impl CohortStreamEventsConsumer {
                         continue;
                     }
                     self.handle_outcome(outcome).await;
-                    let now = tokio::time::Instant::now();
-                    if now >= commit_deadline {
-                        fsync_then_commit(
-                            self.dispatcher.store(),
-                            &self.consumer,
-                            self.dispatcher.tracker(),
-                            self.dispatcher.owned_committable_offsets(),
-                            &self.topic,
-                            CommitMode::Async,
-                        );
-                        commit_deadline = now + self.offset_commit_interval;
-                    }
                 }
             }
+        }
+
+        // The shutdown signal that broke the loop also stops the helper tasks; await them before the
+        // final synchronous commit so no commit races it.
+        if let Err(err) = commit_task.await {
+            warn!(error = %err, "offset-commit task did not exit cleanly");
+        }
+        if let Err(err) = heartbeat_task.await {
+            warn!(error = %err, "heartbeat task did not exit cleanly");
         }
 
         let tracker = self.dispatcher.shutdown().await;
@@ -952,10 +974,10 @@ impl CohortStreamEventsConsumer {
 
         self.dispatcher.dispatch(outcome.events).await;
 
+        // Liveness is reported by the progress-gated heartbeat task (C1), not here: a consume loop
+        // that keeps turning while the workers are wedged must not mask the stall.
         if outcome.transport_error {
             tokio::time::sleep(RECV_ERROR_BACKOFF).await;
-        } else {
-            self.handle.report_healthy();
         }
     }
 
@@ -1092,6 +1114,75 @@ pub(crate) fn fsync_then_commit<C: ConsumerContext>(
         return; // store counted the error; skip commit so `committed` never outruns `durable`
     }
     commit_offsets(consumer, tracker, offsets, topic, mode);
+}
+
+/// Cadence of the progress-gated liveness heartbeat. Comfortably inside the consumer's 60 s liveness
+/// deadline (registered in `main.rs`), so many heartbeats fire before the watchdog could trip.
+const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
+
+/// C2 — the decoupled offset-commit task. On a fixed interval it flushes the store's WAL and commits
+/// the owned committable offsets, independent of the consume loop's forward progress. A starved or
+/// slow consume loop no longer blocks offset advancement, so a restart resumes near the live edge
+/// instead of re-chewing the uncommitted backlog. Exits on the shared shutdown signal.
+async fn run_commit_loop(
+    consumer: Arc<StreamConsumer<CohortConsumerContext>>,
+    dispatcher: Arc<EventDispatcher>,
+    topic: String,
+    interval: Duration,
+    handle: Handle,
+) {
+    let mut ticker = tokio::time::interval(interval);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        tokio::select! {
+            biased;
+            _ = handle.shutdown_recv() => break,
+            _ = ticker.tick() => {
+                fsync_then_commit(
+                    dispatcher.store(),
+                    &consumer,
+                    dispatcher.tracker(),
+                    dispatcher.owned_committable_offsets(),
+                    &topic,
+                    CommitMode::Async,
+                );
+            }
+        }
+    }
+}
+
+/// C1 — the progress-gated liveness heartbeat task. It reports healthy only while the workers make
+/// forward progress (the [`OffsetTracker`] liveness counter advances) *or* there is no backlog to
+/// process. A busy-but-advancing pod stays alive; a genuine stall (backlog present, no progress)
+/// stops heartbeating and the lifecycle watchdog self-kills — the intended fail-stop. Paired with the
+/// worker yields (C3), this fires even when the workers are CPU-bound. Exits on the shutdown signal.
+async fn run_heartbeat_loop(tracker: Arc<OffsetTracker>, handle: Handle) {
+    let mut ticker = tokio::time::interval(HEARTBEAT_INTERVAL);
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let mut last_progress = tracker.progress();
+    // Report healthy once up front so the component isn't flagged stalled before the first batch.
+    handle.report_healthy();
+    loop {
+        tokio::select! {
+            biased;
+            _ = handle.shutdown_recv() => break,
+            _ = ticker.tick() => {
+                let progress = tracker.progress();
+                if should_report_healthy(progress, last_progress, tracker.has_pending_work()) {
+                    last_progress = progress;
+                    handle.report_healthy();
+                }
+            }
+        }
+    }
+}
+
+/// The heartbeat gate: report healthy when the workers advanced since the last tick, **or** when
+/// there is no backlog. The second clause is load-bearing — without it an idle pod (no events, so no
+/// progress) would be read as stalled and self-killed. A genuine stall is backlog-present *and*
+/// no-progress, which alone returns `false`.
+fn should_report_healthy(progress: u64, last_progress: u64, has_pending_work: bool) -> bool {
+    progress != last_progress || !has_pending_work
 }
 
 #[cfg(test)]
@@ -1260,6 +1351,18 @@ mod tests {
     fn build_commit_tpl_for_no_offsets_is_empty() {
         let tpl = build_commit_tpl("cohort_stream_events", &HashMap::new());
         assert_eq!(tpl.count(), 0);
+    }
+
+    #[test]
+    fn heartbeat_gate_distinguishes_a_stall_from_idle_and_progress() {
+        // Workers advanced since the last tick → healthy, regardless of backlog.
+        assert!(should_report_healthy(5, 4, true));
+        assert!(should_report_healthy(5, 4, false));
+        // A genuine stall — backlog present, no progress — is the ONLY case that withholds the
+        // heartbeat so the watchdog self-kills.
+        assert!(!should_report_healthy(4, 4, true));
+        // No progress but also no backlog (idle pod): must stay healthy, never self-kill.
+        assert!(should_report_healthy(4, 4, false));
     }
 
     fn manifest_for(topic: &str, committed: &[(i32, i64)]) -> OffsetManifest {

--- a/rust/cohort-stream-processor/src/consumers/events.rs
+++ b/rust/cohort-stream-processor/src/consumers/events.rs
@@ -741,8 +741,8 @@ fn boot_assignment_settled(assignment: &HashSet<i32>, prev: &mut Option<HashSet<
 /// Uses a raw `StreamConsumer` with manual commit because the per-partition `OffsetTracker`
 /// commits a `TopicPartitionList` that the `common-kafka` wrapper can't express.
 pub struct CohortStreamEventsConsumer {
-    /// `Arc` so the decoupled commit task can share it with the consume loop; `recv` and `commit`
-    /// run concurrently on the same consumer, which rdkafka supports.
+    /// `Arc` so the commit task and consume loop share one consumer; rdkafka supports concurrent
+    /// `recv` and `commit`.
     consumer: Arc<StreamConsumer<CohortConsumerContext>>,
     topic: String,
     dispatcher: Arc<EventDispatcher>,
@@ -789,15 +789,13 @@ impl CohortStreamEventsConsumer {
 
     /// Run until the lifecycle handle signals shutdown.
     ///
-    /// Offset commit (C2) runs on its own interval task rather than inline in this loop, so a
-    /// CPU-saturated consume loop or worker backlog can no longer block offset advancement (a restart
-    /// resumes near the live edge). The task observes the same shutdown signal and is awaited before
-    /// the final synchronous commit. Liveness is reported inline from `handle_outcome`.
+    /// Offset commit runs on its own interval task so a CPU-saturated consume loop or worker backlog
+    /// can't block offset advancement; it shares the shutdown signal and is awaited before the final
+    /// synchronous commit. Liveness is reported inline from `handle_outcome`.
     pub async fn process(self) {
         let _guard = self.handle.process_scope();
         info!(topic = %self.topic, "cohort_stream_events consume loop starting");
 
-        // C2: decoupled offset-commit task.
         let commit_task = tokio::spawn(run_commit_loop(
             self.consumer.clone(),
             self.dispatcher.clone(),
@@ -847,8 +845,7 @@ impl CohortStreamEventsConsumer {
             }
         }
 
-        // The shutdown signal that broke the loop also stops the commit task; await it before the
-        // final synchronous commit so no commit races it.
+        // Await the commit task before the final synchronous commit so the two don't race.
         if let Err(err) = commit_task.await {
             warn!(error = %err, "offset-commit task did not exit cleanly");
         }
@@ -1102,10 +1099,8 @@ pub(crate) fn fsync_then_commit<C: ConsumerContext>(
     commit_offsets(consumer, tracker, offsets, topic, mode);
 }
 
-/// C2 — the decoupled offset-commit task. On a fixed interval it flushes the store's WAL and commits
-/// the owned committable offsets, independent of the consume loop's forward progress. A starved or
-/// slow consume loop no longer blocks offset advancement, so a restart resumes near the live edge
-/// instead of re-chewing the uncommitted backlog. Exits on the shared shutdown signal.
+/// Flushes the store's WAL and commits the owned committable offsets on a fixed interval, independent
+/// of the consume loop so a stalled loop can't block offset advancement. Exits on shutdown.
 async fn run_commit_loop(
     consumer: Arc<StreamConsumer<CohortConsumerContext>>,
     dispatcher: Arc<EventDispatcher>,

--- a/rust/cohort-stream-processor/src/filters/leaf_classifier.rs
+++ b/rust/cohort-stream-processor/src/filters/leaf_classifier.rs
@@ -11,6 +11,13 @@ use crate::filters::CohortId;
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::pick_state::pick_state_variant;
 
+/// HogVM `RETURN` opcode. Cohort bytecode compiled by Python ends at its root comparison with no
+/// `RETURN`; the Rust VM treats running off the end as `EndOfProgram`. We append one `RETURN` here —
+/// once, at load, into the copy the catalog already makes — so every evaluation shares the same
+/// `Arc<Vec<Value>>` with no per-call bytecode copy. A program already ending in `RETURN` finishes at
+/// the first one, so the trailing opcode is inert if it is ever reached on already-terminated input.
+const OP_RETURN: i64 = 38;
+
 /// Why a leaf was dropped during parse. Used as the `reason` label on the skip counter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LeafDropReason {
@@ -170,7 +177,9 @@ fn condition_hash_bytes(value: Option<&Value>) -> Option<[u8; 16]> {
 
 fn bytecode_array(value: Option<&Value>) -> Option<Arc<Vec<Value>>> {
     let array = value?.as_array()?;
-    Some(Arc::new(array.clone()))
+    let mut bytecode = array.clone();
+    bytecode.push(Value::from(OP_RETURN));
+    Some(Arc::new(bytecode))
 }
 
 /// A referenced cohort id as a JSON number or string-encoded int.
@@ -199,9 +208,16 @@ mod tests {
 
     const HASH: &str = "0123456789abcdef";
 
-    /// A representative bytecode program.
+    /// A representative bytecode program, as compiled (no trailing `RETURN`).
     fn bytecode() -> Value {
         json!(["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11])
+    }
+
+    /// The stored form of [`bytecode`]: the loader appends a trailing `RETURN` (opcode 38).
+    fn bytecode_loaded() -> Vec<Value> {
+        let mut bc = bytecode().as_array().unwrap().clone();
+        bc.push(json!(OP_RETURN));
+        bc
     }
 
     fn hash_bytes() -> [u8; 16] {
@@ -227,7 +243,7 @@ mod tests {
         assert_eq!(leaf.event_key, "$pageview");
         assert_eq!(leaf.time_value, Some(7));
         assert_eq!(leaf.leaf_state_key, LeafStateKey::for_behavioral(&leaf));
-        assert_eq!(leaf.bytecode.as_ref(), bytecode().as_array().unwrap());
+        assert_eq!(leaf.bytecode.as_ref(), &bytecode_loaded());
         assert_eq!(
             leaf.state_variant,
             Some(crate::stage1::state::StateVariant::BehavioralSingle),
@@ -468,7 +484,7 @@ mod tests {
         };
         assert_eq!(leaf.condition_hash, hash_bytes());
         assert_eq!(leaf.leaf_state_key, LeafStateKey(hash_bytes()));
-        assert_eq!(leaf.bytecode.as_ref(), bytecode().as_array().unwrap());
+        assert_eq!(leaf.bytecode.as_ref(), &bytecode_loaded());
         assert_eq!(leaf.raw, node);
     }
 

--- a/rust/cohort-stream-processor/src/filters/leaf_classifier.rs
+++ b/rust/cohort-stream-processor/src/filters/leaf_classifier.rs
@@ -11,11 +11,9 @@ use crate::filters::CohortId;
 use crate::stage1::key::LeafStateKey;
 use crate::stage1::pick_state::pick_state_variant;
 
-/// HogVM `RETURN` opcode. Cohort bytecode compiled by Python ends at its root comparison with no
-/// `RETURN`; the Rust VM treats running off the end as `EndOfProgram`. We append one `RETURN` here —
-/// once, at load, into the copy the catalog already makes — so every evaluation shares the same
-/// `Arc<Vec<Value>>` with no per-call bytecode copy. A program already ending in `RETURN` finishes at
-/// the first one, so the trailing opcode is inert if it is ever reached on already-terminated input.
+/// HogVM `RETURN` opcode, appended to each program at load. Python-compiled cohort bytecode ends at
+/// its root comparison with no `RETURN`, which the Rust VM would hit as `EndOfProgram`. A program
+/// already ending in `RETURN` stops at the first, so the appended one is inert.
 const OP_RETURN: i64 = 38;
 
 /// Why a leaf was dropped during parse. Used as the `reason` label on the skip counter.

--- a/rust/cohort-stream-processor/src/filters/reverse_index.rs
+++ b/rust/cohort-stream-processor/src/filters/reverse_index.rs
@@ -367,6 +367,13 @@ mod tests {
         json!(["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11])
     }
 
+    /// The stored form of [`behavioral_bytecode`]: the loader appends a trailing `RETURN` (opcode 38).
+    fn behavioral_bytecode_loaded() -> Vec<Value> {
+        let mut bc = behavioral_bytecode().as_array().unwrap().clone();
+        bc.push(json!(38));
+        bc
+    }
+
     /// A `performed_event` leaf on `$pageview` with a tunable window.
     fn behavioral_performed_event(time_value: i64) -> Value {
         json!({
@@ -516,7 +523,7 @@ mod tests {
             .by_condition_to_bytecode
             .get(&HASH)
             .expect("bytecode captured under the conditionHash");
-        assert_eq!(bytecode.as_ref(), behavioral_bytecode().as_array().unwrap());
+        assert_eq!(bytecode.as_ref(), &behavioral_bytecode_loaded());
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/filters/reverse_index.rs
+++ b/rust/cohort-stream-processor/src/filters/reverse_index.rs
@@ -367,10 +367,13 @@ mod tests {
         json!(["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11])
     }
 
+    /// HogVM `RETURN` opcode, appended to stored bytecode by the catalog loader.
+    const OP_RETURN: i64 = 38;
+
     /// The stored form of [`behavioral_bytecode`]: the loader appends a trailing `RETURN` (opcode 38).
     fn behavioral_bytecode_loaded() -> Vec<Value> {
         let mut bc = behavioral_bytecode().as_array().unwrap().clone();
-        bc.push(json!(38));
+        bc.push(json!(OP_RETURN));
         bc
     }
 

--- a/rust/cohort-stream-processor/src/hogvm/executor.rs
+++ b/rust/cohort-stream-processor/src/hogvm/executor.rs
@@ -1,10 +1,8 @@
 //! Run compiled cohort-filter bytecode through `hogvm::sync_execute`, coercing the result to the
 //! boolean Stage 1 needs (matching the Node consumer's `execResult?.result ?? false`).
 //!
-//! The hot path reuses one [`CohortEvaluator`] across an event's whole condition fan-out: the STL
-//! context and the event globals are set once, and only the program is swapped per condition, so the
-//! ~⅔ of per-evaluation CPU that used to go to rebuilding the [`ExecutionContext`] and deep-cloning
-//! the globals is paid once per event instead of once per condition.
+//! The hot path reuses one [`CohortEvaluator`] per event: the STL context and globals are set once
+//! and only the program is swapped per condition, amortizing the context build across all conditions.
 
 use std::sync::Arc;
 
@@ -25,13 +23,11 @@ pub enum EvalOutcome {
     VmError(VmError),
 }
 
-/// A reusable evaluator owning one [`ExecutionContext`]. Globals are set once per event (shared by
-/// every condition), and the program is swapped per condition — both in place, so the STL tables and
-/// the globals tree are built/parsed once per event rather than once per condition.
+/// A reusable evaluator owning one [`ExecutionContext`]: set globals once per event, swap the program
+/// per condition, both in place.
 ///
-/// Coercing comparisons (cross-type ordering + epoch temporal ordering/equality) match the
-/// Python/TS/ClickHouse reference; this is opt-in, so other `hogvm` consumers (e.g. cymbal) keep
-/// strict comparisons.
+/// Comparisons are coercing (cross-type ordering + epoch temporal ordering/equality) to match the
+/// Python/TS/ClickHouse reference; opt-in, so other `hogvm` consumers like cymbal keep strict ones.
 pub struct CohortEvaluator {
     context: ExecutionContext,
 }
@@ -44,17 +40,14 @@ impl Default for CohortEvaluator {
 
 impl CohortEvaluator {
     pub fn new() -> Self {
-        // A bare header is a valid program; `set_program` replaces it before the first evaluation,
-        // so the seed is never executed. `with_defaults` is now an `Arc` bump of the static STL.
+        // A bare header is a valid program; `set_program` replaces this seed before the first evaluation.
         let seed = Program::new(vec![Value::from("_H"), Value::from(1)])
             .expect("a bare bytecode header is a valid program");
         let context = ExecutionContext::with_defaults(seed).with_coercing_comparisons();
         Self { context }
     }
 
-    /// Move `globals` into the reused context (no clone). Every subsequent `evaluate*` reads it until
-    /// the next call. Globals are a pure function of the event, so one call serves a whole event's
-    /// condition fan-out.
+    /// Move `globals` into the reused context (no clone); one call serves a whole event's conditions.
     pub fn set_globals(&mut self, globals: Value) {
         self.context.set_globals(globals);
     }
@@ -68,8 +61,7 @@ impl CohortEvaluator {
 
     /// As [`Self::evaluate`] but returns the detailed [`EvalOutcome`].
     pub fn evaluate_detailed(&mut self, bytecode: Arc<Vec<Value>>) -> EvalOutcome {
-        // `from_shared` clones the `Arc`, not the opcode vector, so swapping programs is a refcount
-        // bump rather than a per-condition copy.
+        // `from_shared` clones the `Arc`, not the opcode vector, so swapping programs is just a refcount bump.
         let program = match Program::from_shared(bytecode) {
             Ok(program) => program,
             Err(error) => return classify_failure(error),
@@ -88,9 +80,8 @@ fn run(context: &ExecutionContext) -> EvalOutcome {
     }
 }
 
-/// One-shot evaluation building a fresh context. Retained for the parity test and any single-shot
-/// caller; the hot path uses [`CohortEvaluator`] to avoid the per-condition context rebuild.
-/// `bytecode` must already be `RETURN`-terminated, exactly as the catalog loader leaves it.
+/// One-shot evaluation building a fresh context (used by the parity test). `bytecode` must be
+/// `RETURN`-terminated, as the catalog loader leaves it.
 pub fn evaluate_detailed(bytecode: &[Value], globals: Value) -> EvalOutcome {
     let program = match Program::new(bytecode.to_vec()) {
         Ok(program) => program,
@@ -102,7 +93,6 @@ pub fn evaluate_detailed(bytecode: &[Value], globals: Value) -> EvalOutcome {
     run(&context)
 }
 
-/// One-shot `bool` wrapper over [`evaluate_detailed`].
 pub fn evaluate(bytecode: &[Value], globals: Value) -> bool {
     outcome_to_bool(evaluate_detailed(bytecode, globals))
 }
@@ -150,8 +140,7 @@ mod tests {
     const OP_FALSE: i64 = 30;
     const OP_INTEGER: i64 = 33;
     const OP_STRING: i64 = 32;
-    // The loader (`bytecode_array`) appends this; the single-shot `evaluate*` helpers no longer do,
-    // so these fixtures terminate explicitly, mirroring the bytecode the catalog actually holds.
+    // Fixtures terminate explicitly with RETURN, mirroring what the catalog loader stores.
     const OP_RETURN: i64 = 38;
 
     fn header() -> Vec<Value> {
@@ -192,8 +181,6 @@ mod tests {
 
     #[test]
     fn compiled_style_bytecode_evaluates() {
-        // Compiled cohort bytecode reads a global and compares it; the loader terminates it with
-        // RETURN (appended here), which the Rust VM needs to return the comparison result.
         let bc = [
             header(),
             vec![
@@ -289,9 +276,8 @@ mod tests {
 
     #[test]
     fn reused_evaluator_matches_a_fresh_context_per_eval() {
-        // The reuse optimization (set_globals/set_program in place) must be observationally identical
-        // to building a fresh context per eval: no globals or program may leak across calls. Programs
-        // and globals are interleaved so a stale-globals or un-swapped-program leak would diverge.
+        // Interleave programs and globals so a stale-globals or un-swapped-program leak would diverge
+        // from a fresh-context-per-eval baseline.
         let email_eq = {
             let mut bc = header();
             bc.extend_from_slice(&[json!(OP_STRING), json!("a@b.com")]);

--- a/rust/cohort-stream-processor/src/hogvm/executor.rs
+++ b/rust/cohort-stream-processor/src/hogvm/executor.rs
@@ -1,5 +1,12 @@
 //! Run compiled cohort-filter bytecode through `hogvm::sync_execute`, coercing the result to the
 //! boolean Stage 1 needs (matching the Node consumer's `execResult?.result ?? false`).
+//!
+//! The hot path reuses one [`CohortEvaluator`] across an event's whole condition fan-out: the STL
+//! context and the event globals are set once, and only the program is swapped per condition, so the
+//! ~⅔ of per-evaluation CPU that used to go to rebuilding the [`ExecutionContext`] and deep-cloning
+//! the globals is paid once per event instead of once per condition.
+
+use std::sync::Arc;
 
 use hogvm::{sync_execute, ExecutionContext, Program, VmError};
 use metrics::counter;
@@ -8,11 +15,8 @@ use tracing::debug;
 
 use crate::observability::metrics::{STAGE1_HOGVM_ERROR, STAGE1_HOGVM_UNKNOWN_FUNCTION};
 
-/// HogVM `RETURN` opcode. See [`evaluate_detailed`] for why it is appended to every program.
-const OP_RETURN: i64 = 38;
-
-/// The classified outcome of evaluating one program; [`evaluate`] collapses this to a `bool` but
-/// the variants preserve *why* a non-match happened.
+/// The classified outcome of evaluating one program; [`CohortEvaluator::evaluate`] collapses this to
+/// a `bool` but the variants preserve *why* a non-match happened.
 #[derive(Debug)]
 pub enum EvalOutcome {
     Matched(bool),
@@ -21,43 +25,91 @@ pub enum EvalOutcome {
     VmError(VmError),
 }
 
-/// Evaluate `bytecode` against `globals`, returning the detailed [`EvalOutcome`].
+/// A reusable evaluator owning one [`ExecutionContext`]. Globals are set once per event (shared by
+/// every condition), and the program is swapped per condition — both in place, so the STL tables and
+/// the globals tree are built/parsed once per event rather than once per condition.
 ///
-/// Cohort bytecode ends with its root comparison op and no `RETURN`. The Rust VM treats running
-/// off the end as `EndOfProgram`; appending a `RETURN` recovers the Python/Node semantic. A
-/// program already ending in `RETURN` finishes first, so the append is safe for both shapes.
-pub fn evaluate_detailed(bytecode: &[Value], globals: Value) -> EvalOutcome {
-    let mut with_return = Vec::with_capacity(bytecode.len() + 1);
-    with_return.extend_from_slice(bytecode);
-    with_return.push(Value::from(OP_RETURN));
+/// Coercing comparisons (cross-type ordering + epoch temporal ordering/equality) match the
+/// Python/TS/ClickHouse reference; this is opt-in, so other `hogvm` consumers (e.g. cymbal) keep
+/// strict comparisons.
+pub struct CohortEvaluator {
+    context: ExecutionContext,
+}
 
-    // PERF: `with_defaults` rebuilds the full STL (~26 closures + 2 HashMaps + the hog module
-    // symbol table) on every call — once per conditionHash per event. Reuse is blocked by the
-    // shared `hogvm` API: `NativeFunction` is `Box<dyn Fn>` (not `Clone`), `ExecutionContext`
-    // owns its tables, and there is no program setter, so a thread_local context can't swap
-    // programs in place without a shared-crate change. `with_globals` also takes ownership, so
-    // the full globals JSON is cloned per condition. Flamegraph before optimizing.
-    let program = match Program::new(with_return) {
-        Ok(program) => program,
-        Err(error) => return classify_failure(error),
-    };
-    // Coercing comparisons (cross-type ordering + epoch temporal ordering/equality) match the
-    // Python/TS/ClickHouse reference. Opt in here only — other consumers (e.g. cymbal) keep
-    // strict comparisons.
-    let context = ExecutionContext::with_defaults(program)
-        .with_globals(globals)
-        .with_coercing_comparisons();
+impl Default for CohortEvaluator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
-    match sync_execute(&context, false) {
+impl CohortEvaluator {
+    pub fn new() -> Self {
+        // A bare header is a valid program; `set_program` replaces it before the first evaluation,
+        // so the seed is never executed. `with_defaults` is now an `Arc` bump of the static STL.
+        let seed = Program::new(vec![Value::from("_H"), Value::from(1)])
+            .expect("a bare bytecode header is a valid program");
+        let context = ExecutionContext::with_defaults(seed).with_coercing_comparisons();
+        Self { context }
+    }
+
+    /// Move `globals` into the reused context (no clone). Every subsequent `evaluate*` reads it until
+    /// the next call. Globals are a pure function of the event, so one call serves a whole event's
+    /// condition fan-out.
+    pub fn set_globals(&mut self, globals: Value) {
+        self.context.set_globals(globals);
+    }
+
+    /// Evaluate one condition's bytecode against the current globals, coercing failures and non-bool
+    /// results to `false` and emitting a per-class metric so a silently-failing cohort stays
+    /// observable. `bytecode` must be `RETURN`-terminated (the loader appends it).
+    pub fn evaluate(&mut self, bytecode: Arc<Vec<Value>>) -> bool {
+        outcome_to_bool(self.evaluate_detailed(bytecode))
+    }
+
+    /// As [`Self::evaluate`] but returns the detailed [`EvalOutcome`].
+    pub fn evaluate_detailed(&mut self, bytecode: Arc<Vec<Value>>) -> EvalOutcome {
+        // `from_shared` clones the `Arc`, not the opcode vector, so swapping programs is a refcount
+        // bump rather than a per-condition copy.
+        let program = match Program::from_shared(bytecode) {
+            Ok(program) => program,
+            Err(error) => return classify_failure(error),
+        };
+        self.context.set_program(program);
+        run(&self.context)
+    }
+}
+
+/// Run `context` to completion, collapsing the VM result to an [`EvalOutcome`]. `unwrap_or(false)`
+/// mirrors the Node `?? false` coercion of a non-bool result.
+fn run(context: &ExecutionContext) -> EvalOutcome {
+    match sync_execute(context, false) {
         Ok(result) => EvalOutcome::Matched(result.as_bool().unwrap_or(false)),
         Err(failure) => classify_failure(failure.error),
     }
 }
 
-/// Hot-path wrapper: coerces failures and non-bool results to `false`, emitting a per-class metric
-/// so a silently-failing cohort stays observable.
+/// One-shot evaluation building a fresh context. Retained for the parity test and any single-shot
+/// caller; the hot path uses [`CohortEvaluator`] to avoid the per-condition context rebuild.
+/// `bytecode` must already be `RETURN`-terminated, exactly as the catalog loader leaves it.
+pub fn evaluate_detailed(bytecode: &[Value], globals: Value) -> EvalOutcome {
+    let program = match Program::new(bytecode.to_vec()) {
+        Ok(program) => program,
+        Err(error) => return classify_failure(error),
+    };
+    let context = ExecutionContext::with_defaults(program)
+        .with_globals(globals)
+        .with_coercing_comparisons();
+    run(&context)
+}
+
+/// One-shot `bool` wrapper over [`evaluate_detailed`].
 pub fn evaluate(bytecode: &[Value], globals: Value) -> bool {
-    match evaluate_detailed(bytecode, globals) {
+    outcome_to_bool(evaluate_detailed(bytecode, globals))
+}
+
+/// Collapse an [`EvalOutcome`] to `bool`, emitting a per-class metric on failure.
+fn outcome_to_bool(outcome: EvalOutcome) -> bool {
+    match outcome {
         EvalOutcome::Matched(matched) => matched,
         EvalOutcome::UnknownFunction(name) => {
             // `name` is bytecode-derived from user cohort filters; keep it out of the metric label
@@ -98,6 +150,9 @@ mod tests {
     const OP_FALSE: i64 = 30;
     const OP_INTEGER: i64 = 33;
     const OP_STRING: i64 = 32;
+    // The loader (`bytecode_array`) appends this; the single-shot `evaluate*` helpers no longer do,
+    // so these fixtures terminate explicitly, mirroring the bytecode the catalog actually holds.
+    const OP_RETURN: i64 = 38;
 
     fn header() -> Vec<Value> {
         vec![json!("_H"), json!(1)]
@@ -105,7 +160,7 @@ mod tests {
 
     #[test]
     fn true_literal_coerces_to_true() {
-        let bc = [header(), vec![json!(OP_TRUE)]].concat();
+        let bc = [header(), vec![json!(OP_TRUE), json!(OP_RETURN)]].concat();
         assert!(matches!(
             evaluate_detailed(&bc, json!({})),
             EvalOutcome::Matched(true)
@@ -114,7 +169,7 @@ mod tests {
 
     #[test]
     fn false_literal_coerces_to_false() {
-        let bc = [header(), vec![json!(OP_FALSE)]].concat();
+        let bc = [header(), vec![json!(OP_FALSE), json!(OP_RETURN)]].concat();
         assert!(matches!(
             evaluate_detailed(&bc, json!({})),
             EvalOutcome::Matched(false)
@@ -123,7 +178,11 @@ mod tests {
 
     #[test]
     fn non_boolean_result_coerces_to_false() {
-        let bc = [header(), vec![json!(OP_INTEGER), json!(42)]].concat();
+        let bc = [
+            header(),
+            vec![json!(OP_INTEGER), json!(42), json!(OP_RETURN)],
+        ]
+        .concat();
         assert!(matches!(
             evaluate_detailed(&bc, json!({})),
             EvalOutcome::Matched(false)
@@ -132,9 +191,9 @@ mod tests {
     }
 
     #[test]
-    fn compiled_style_bytecode_without_trailing_return_still_evaluates() {
-        // Guard the appended-RETURN bridge: cohort bytecode ends without RETURN, which the Rust VM
-        // would reject with EndOfProgram; evaluate_detailed must append one.
+    fn compiled_style_bytecode_evaluates() {
+        // Compiled cohort bytecode reads a global and compares it; the loader terminates it with
+        // RETURN (appended here), which the Rust VM needs to return the comparison result.
         let bc = [
             header(),
             vec![
@@ -145,6 +204,7 @@ mod tests {
                 json!(OP_GET_GLOBAL),
                 json!(1),
                 json!(OP_EQ),
+                json!(OP_RETURN),
             ],
         ]
         .concat();
@@ -218,12 +278,55 @@ mod tests {
         bc.extend_from_slice(&right);
         bc.extend_from_slice(&left);
         bc.push(json!(OP_LT));
+        bc.push(json!(OP_RETURN));
 
         let globals =
             |signup: Value| json!({ "person": { "properties": { "signup_date": signup } } });
         assert!(evaluate(&bc, globals(json!("2024-09-09 08:30:00"))));
         assert!(!evaluate(&bc, globals(json!("2027-09-09 08:30:00"))));
         assert!(!evaluate(&bc, json!({ "person": { "properties": {} } })));
+    }
+
+    #[test]
+    fn reused_evaluator_matches_a_fresh_context_per_eval() {
+        // The reuse optimization (set_globals/set_program in place) must be observationally identical
+        // to building a fresh context per eval: no globals or program may leak across calls. Programs
+        // and globals are interleaved so a stale-globals or un-swapped-program leak would diverge.
+        let email_eq = {
+            let mut bc = header();
+            bc.extend_from_slice(&[json!(OP_STRING), json!("a@b.com")]);
+            bc.extend_from_slice(&push_person_property("email"));
+            bc.extend_from_slice(&[json!(OP_EQ), json!(OP_RETURN)]);
+            bc
+        };
+        let num_gt = {
+            let mut bc = header();
+            bc.extend_from_slice(&[json!(OP_STRING), json!("10")]);
+            bc.extend_from_slice(&push_person_property("bc_num"));
+            bc.extend_from_slice(&[json!(OP_GT), json!(OP_RETURN)]);
+            bc
+        };
+        let g_match = json!({ "person": { "properties": { "email": "a@b.com", "bc_num": 20 } } });
+        let g_miss = json!({ "person": { "properties": { "email": "x@y.com", "bc_num": 5 } } });
+
+        let cases: [(&Vec<Value>, &Value); 5] = [
+            (&email_eq, &g_match),
+            (&num_gt, &g_match),
+            (&email_eq, &g_miss),
+            (&num_gt, &g_miss),
+            (&email_eq, &g_match),
+        ];
+
+        let mut evaluator = CohortEvaluator::new();
+        for (bytecode, globals) in cases {
+            evaluator.set_globals(globals.clone());
+            let reused = evaluator.evaluate(Arc::new(bytecode.clone()));
+            let fresh = evaluate(bytecode, globals.clone());
+            assert_eq!(
+                reused, fresh,
+                "reused evaluator diverged from a fresh per-eval context",
+            );
+        }
     }
 
     #[test]
@@ -234,6 +337,7 @@ mod tests {
         bc.extend_from_slice(&[json!(OP_STRING), json!("10")]);
         bc.extend_from_slice(&push_person_property("bc_num"));
         bc.push(json!(OP_GT));
+        bc.push(json!(OP_RETURN));
 
         let globals = |num: Value| json!({ "person": { "properties": { "bc_num": num } } });
         assert!(evaluate(&bc, globals(json!(20))));

--- a/rust/cohort-stream-processor/src/hogvm/mod.rs
+++ b/rust/cohort-stream-processor/src/hogvm/mod.rs
@@ -4,5 +4,5 @@
 mod executor;
 mod globals;
 
-pub use executor::{evaluate, evaluate_detailed, EvalOutcome};
+pub use executor::{evaluate, evaluate_detailed, CohortEvaluator, EvalOutcome};
 pub use globals::{build_behavioral_globals, build_person_property_globals, GlobalsError};

--- a/rust/cohort-stream-processor/src/main.rs
+++ b/rust/cohort-stream-processor/src/main.rs
@@ -48,8 +48,14 @@ fn main() -> Result<()> {
     let config = Config::init_from_env()
         .context("Failed to load configuration from environment variables")?;
 
-    let runtime = tokio::runtime::Builder::new_multi_thread()
-        .enable_all()
+    let mut runtime_builder = tokio::runtime::Builder::new_multi_thread();
+    runtime_builder.enable_all();
+    // Cap worker threads to the configured CPU limit. Left unset, Tokio sizes the pool to the node's
+    // core count, which a 2-core CFS limit then throttles into thread thrashing.
+    if config.tokio_worker_threads > 0 {
+        runtime_builder.worker_threads(config.tokio_worker_threads);
+    }
+    let runtime = runtime_builder
         .build()
         .context("Failed to build tokio runtime")?;
 

--- a/rust/cohort-stream-processor/src/main.rs
+++ b/rust/cohort-stream-processor/src/main.rs
@@ -50,8 +50,6 @@ fn main() -> Result<()> {
 
     let mut runtime_builder = tokio::runtime::Builder::new_multi_thread();
     runtime_builder.enable_all();
-    // Cap worker threads to the configured CPU limit. Left unset, Tokio sizes the pool to the node's
-    // core count, which a 2-core CFS limit then throttles into thread thrashing.
     if config.tokio_worker_threads > 0 {
         runtime_builder.worker_threads(config.tokio_worker_threads);
     }

--- a/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
+++ b/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
@@ -7,6 +7,7 @@
 //! [`AppliedOffsets`](crate::stage1::state::AppliedOffsets) on each `cf_stage1` record.
 
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
 
@@ -56,6 +57,11 @@ pub enum MarkOutcome {
 #[derive(Debug, Default)]
 pub struct OffsetTracker {
     partitions: DashMap<i32, PartitionProgress>,
+    /// Monotonic count of [`mark_processed`](OffsetTracker::mark_processed) calls — the liveness
+    /// signal the progress-gated heartbeat reads. It advances whenever any worker finishes a batch,
+    /// independent of commit cadence and partition churn (unlike a sum over `processed_offset`,
+    /// which a [`forget_partition`](OffsetTracker::forget_partition) would lower).
+    progress: AtomicU64,
 }
 
 impl OffsetTracker {
@@ -84,6 +90,9 @@ impl OffsetTracker {
         let mut progress = self.partitions.entry(partition).or_default();
         let capped = next_offset.min(progress.dispatched_offset);
         progress.processed_offset = progress.processed_offset.max(capped);
+        // Bump the liveness counter on every call: a worker reaching this point has just completed a
+        // batch, which is exactly the forward progress the heartbeat gates on.
+        self.progress.fetch_add(1, Ordering::Relaxed);
         if capped < next_offset {
             MarkOutcome::CappedAheadOfDispatch
         } else {
@@ -158,6 +167,21 @@ impl OffsetTracker {
 
     pub fn partition_count(&self) -> usize {
         self.partitions.len()
+    }
+
+    /// Monotonic liveness counter — see [`progress`](PartitionProgress) field docs. Read by the
+    /// progress-gated heartbeat to tell a busy-but-advancing pod from a true stall.
+    pub fn progress(&self) -> u64 {
+        self.progress.load(Ordering::Relaxed)
+    }
+
+    /// Whether any tracked partition has dispatched work not yet processed (`processed < dispatched`).
+    /// `false` means the workers are fully caught up, so a frozen [`progress`](Self::progress) is the
+    /// expected idle state — not a deadlock — and the heartbeat keeps the pod alive.
+    pub fn has_pending_work(&self) -> bool {
+        self.partitions
+            .iter()
+            .any(|entry| entry.value().processed_offset < entry.value().dispatched_offset)
     }
 }
 
@@ -265,6 +289,45 @@ mod tests {
         assert_eq!(tracker.committed_offset(7), Some(150));
         tracker.mark_committed(7, 200);
         assert_eq!(tracker.committed_offset(7), Some(200));
+    }
+
+    #[test]
+    fn progress_advances_on_every_processed_mark_including_replays() {
+        let tracker = OffsetTracker::new();
+        assert_eq!(tracker.progress(), 0);
+        tracker.mark_dispatched(0, 10);
+
+        let _ = tracker.mark_processed(0, 5);
+        let after_first = tracker.progress();
+        assert!(
+            after_first > 0,
+            "a processed mark advances the liveness counter"
+        );
+
+        // A non-advancing replay still means the worker loop turned, so it counts as liveness.
+        let _ = tracker.mark_processed(0, 3);
+        assert!(
+            tracker.progress() > after_first,
+            "even a replay (no offset advance) bumps progress",
+        );
+    }
+
+    #[test]
+    fn has_pending_work_is_dispatched_ahead_of_processed() {
+        let tracker = OffsetTracker::new();
+        assert!(!tracker.has_pending_work(), "an empty tracker is idle");
+
+        tracker.mark_dispatched(0, 10);
+        assert!(
+            tracker.has_pending_work(),
+            "dispatched-but-unprocessed is pending work",
+        );
+
+        let _ = tracker.mark_processed(0, 10);
+        assert!(
+            !tracker.has_pending_work(),
+            "fully processed up to the dispatch ceiling is idle",
+        );
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
+++ b/rust/cohort-stream-processor/src/partitions/offset_tracker.rs
@@ -7,7 +7,6 @@
 //! [`AppliedOffsets`](crate::stage1::state::AppliedOffsets) on each `cf_stage1` record.
 
 use std::collections::HashMap;
-use std::sync::atomic::{AtomicU64, Ordering};
 
 use dashmap::DashMap;
 
@@ -57,11 +56,6 @@ pub enum MarkOutcome {
 #[derive(Debug, Default)]
 pub struct OffsetTracker {
     partitions: DashMap<i32, PartitionProgress>,
-    /// Monotonic count of [`mark_processed`](OffsetTracker::mark_processed) calls — the liveness
-    /// signal the progress-gated heartbeat reads. It advances whenever any worker finishes a batch,
-    /// independent of commit cadence and partition churn (unlike a sum over `processed_offset`,
-    /// which a [`forget_partition`](OffsetTracker::forget_partition) would lower).
-    progress: AtomicU64,
 }
 
 impl OffsetTracker {
@@ -90,9 +84,6 @@ impl OffsetTracker {
         let mut progress = self.partitions.entry(partition).or_default();
         let capped = next_offset.min(progress.dispatched_offset);
         progress.processed_offset = progress.processed_offset.max(capped);
-        // Bump the liveness counter on every call: a worker reaching this point has just completed a
-        // batch, which is exactly the forward progress the heartbeat gates on.
-        self.progress.fetch_add(1, Ordering::Relaxed);
         if capped < next_offset {
             MarkOutcome::CappedAheadOfDispatch
         } else {
@@ -167,21 +158,6 @@ impl OffsetTracker {
 
     pub fn partition_count(&self) -> usize {
         self.partitions.len()
-    }
-
-    /// Monotonic liveness counter — see [`progress`](PartitionProgress) field docs. Read by the
-    /// progress-gated heartbeat to tell a busy-but-advancing pod from a true stall.
-    pub fn progress(&self) -> u64 {
-        self.progress.load(Ordering::Relaxed)
-    }
-
-    /// Whether any tracked partition has dispatched work not yet processed (`processed < dispatched`).
-    /// `false` means the workers are fully caught up, so a frozen [`progress`](Self::progress) is the
-    /// expected idle state — not a deadlock — and the heartbeat keeps the pod alive.
-    pub fn has_pending_work(&self) -> bool {
-        self.partitions
-            .iter()
-            .any(|entry| entry.value().processed_offset < entry.value().dispatched_offset)
     }
 }
 
@@ -289,45 +265,6 @@ mod tests {
         assert_eq!(tracker.committed_offset(7), Some(150));
         tracker.mark_committed(7, 200);
         assert_eq!(tracker.committed_offset(7), Some(200));
-    }
-
-    #[test]
-    fn progress_advances_on_every_processed_mark_including_replays() {
-        let tracker = OffsetTracker::new();
-        assert_eq!(tracker.progress(), 0);
-        tracker.mark_dispatched(0, 10);
-
-        let _ = tracker.mark_processed(0, 5);
-        let after_first = tracker.progress();
-        assert!(
-            after_first > 0,
-            "a processed mark advances the liveness counter"
-        );
-
-        // A non-advancing replay still means the worker loop turned, so it counts as liveness.
-        let _ = tracker.mark_processed(0, 3);
-        assert!(
-            tracker.progress() > after_first,
-            "even a replay (no offset advance) bumps progress",
-        );
-    }
-
-    #[test]
-    fn has_pending_work_is_dispatched_ahead_of_processed() {
-        let tracker = OffsetTracker::new();
-        assert!(!tracker.has_pending_work(), "an empty tracker is idle");
-
-        tracker.mark_dispatched(0, 10);
-        assert!(
-            tracker.has_pending_work(),
-            "dispatched-but-unprocessed is pending work",
-        );
-
-        let _ = tracker.mark_processed(0, 10);
-        assert!(
-            !tracker.has_pending_work(),
-            "fully processed up to the dispatch ceiling is idle",
-        );
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/workers/event_path.rs
+++ b/rust/cohort-stream-processor/src/workers/event_path.rs
@@ -167,8 +167,7 @@ pub fn process_event(
         None
     };
 
-    // One evaluator reused across this event's whole condition fan-out: globals are set once per
-    // kind below (moved in, not cloned), and only the program is swapped per condition.
+    // One evaluator reused across the event's conditions: globals set once per kind, program per condition.
     let mut evaluator = CohortEvaluator::new();
     let applies = collect_applies(filters, &mut evaluator, behavioral_globals, person_globals);
     if applies.is_empty() {

--- a/rust/cohort-stream-processor/src/workers/event_path.rs
+++ b/rust/cohort-stream-processor/src/workers/event_path.rs
@@ -5,6 +5,7 @@
 //! flipped. Transitions are surfaced only after the commit succeeds.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
 use metrics::counter;
 use uuid::Uuid;
@@ -12,7 +13,7 @@ use uuid::Uuid;
 use crate::consumers::events::CohortStreamEvent;
 use crate::filters::reverse_index::TeamFilters;
 use crate::filters::TeamId;
-use crate::hogvm::{build_behavioral_globals, build_person_property_globals, evaluate};
+use crate::hogvm::{build_behavioral_globals, build_person_property_globals, CohortEvaluator};
 use crate::observability::metrics::{
     STAGE1_ARGMAX_STALE, STAGE1_CONDITIONS_EVALUATED, STAGE1_PERSON_INDEX_APPENDS,
     STAGE1_REPLAY_SKIPPED, STAGE1_STATE_DECODE_ERROR, STAGE1_STATE_WRITES,
@@ -166,11 +167,10 @@ pub fn process_event(
         None
     };
 
-    let applies = collect_applies(
-        filters,
-        behavioral_globals.as_ref(),
-        person_globals.as_ref(),
-    );
+    // One evaluator reused across this event's whole condition fan-out: globals are set once per
+    // kind below (moved in, not cloned), and only the program is swapped per condition.
+    let mut evaluator = CohortEvaluator::new();
+    let applies = collect_applies(filters, &mut evaluator, behavioral_globals, person_globals);
     if applies.is_empty() {
         return Ok(EventOutcome::processed(Vec::new(), Vec::new(), 0));
     }
@@ -312,18 +312,20 @@ pub(crate) fn schedule_deadline(state: &Stage1State) -> Option<i64> {
 
 fn collect_applies(
     filters: &TeamFilters,
-    behavioral_globals: Option<&serde_json::Value>,
-    person_globals: Option<&serde_json::Value>,
+    evaluator: &mut CohortEvaluator,
+    behavioral_globals: Option<serde_json::Value>,
+    person_globals: Option<serde_json::Value>,
 ) -> Vec<Apply> {
     let mut applies = Vec::new();
 
     if let Some(globals) = behavioral_globals {
+        evaluator.set_globals(globals);
         for &hash in &filters.behavioral_conditions {
             let Some(bytecode) = filters.by_condition_to_bytecode.get(&hash) else {
                 continue;
             };
             counter!(STAGE1_CONDITIONS_EVALUATED, "kind" => "behavioral").increment(1);
-            if !evaluate(bytecode, globals.clone()) {
+            if !evaluator.evaluate(Arc::clone(bytecode)) {
                 continue;
             }
             let Some(lsks) = filters.by_condition_to_lsk.get(&hash) else {
@@ -352,12 +354,13 @@ fn collect_applies(
     }
 
     if let Some(globals) = person_globals {
+        evaluator.set_globals(globals);
         for &hash in &filters.person_property_conditions {
             let Some(bytecode) = filters.by_condition_to_bytecode.get(&hash) else {
                 continue;
             };
             counter!(STAGE1_CONDITIONS_EVALUATED, "kind" => "person_property").increment(1);
-            let matches = evaluate(bytecode, globals.clone());
+            let matches = evaluator.evaluate(Arc::clone(bytecode));
             let lsk = LeafStateKey::for_person_property(&hash);
             match filters.by_lsk.get(&lsk).map(|meta| meta.variant) {
                 Some(StateVariant::PersonProperty) => {

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -56,11 +56,9 @@ const MAX_SWEEP_KEYS_PER_PASS: usize = 10_000;
 
 const REBUILD_SCAN_PAGE: usize = 10_000;
 
-/// Cooperative-yield cadence inside the worker fold. `handle_event` is fully synchronous, so a
-/// backlog of CPU-bound events would hold the runtime thread between channel receives — starving the
-/// commit task and the consume loop (which reports liveness inline) under saturation (the crash-loop's
-/// enabling condition). Yielding on a wall-clock interval (rather than a fixed message count) adapts
-/// to per-event cost across catalogs of very different sizes.
+/// Cooperative-yield cadence inside the worker fold. `handle_event` is synchronous, so a backlog of
+/// CPU-bound events would hold the runtime thread, starving the commit task and consume loop. A
+/// wall-clock interval adapts to per-event cost across catalogs of different sizes.
 const WORKER_YIELD_INTERVAL: Duration = Duration::from_millis(5);
 
 pub struct Stage1Worker {
@@ -129,8 +127,7 @@ async fn run_worker(
     let mut gc_cursor = MergeGcCursor::default();
     let mut stage2_gc_cursor = Stage2GcCursor::default();
 
-    // Persists across batches: a worker that keeps receiving buffered batches would otherwise only
-    // yield via Tokio's coarse coop budget, holding the thread for many CPU-bound events.
+    // Persists across batches so a stream of buffered batches still yields on the wall-clock interval.
     let mut last_yield = Instant::now();
     while let Some(batch) = receiver.recv().await {
         let last_updated = now_last_updated();
@@ -280,8 +277,6 @@ async fn run_worker(
                 }
             }
 
-            // Release the runtime thread periodically so a CPU-bound event backlog can't starve the
-            // commit task or the consume loop's inline liveness report (the C3 enabling mechanism).
             if last_yield.elapsed() >= WORKER_YIELD_INTERVAL {
                 tokio::task::yield_now().await;
                 last_yield = Instant::now();
@@ -825,8 +820,8 @@ async fn rebuild_eviction_queue(
         if page_len < REBUILD_SCAN_PAGE {
             break;
         }
-        // 64 workers re-seed concurrently on a crash-restart; yield between pages so the boot scan
-        // doesn't re-saturate the runtime before the consume loop can even start.
+        // Workers re-seed concurrently on restart; yield between pages so the boot scan doesn't
+        // saturate the runtime before the consume loop starts.
         tokio::task::yield_now().await;
     }
     if rebuilt > 0 {

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -58,9 +58,9 @@ const REBUILD_SCAN_PAGE: usize = 10_000;
 
 /// Cooperative-yield cadence inside the worker fold. `handle_event` is fully synchronous, so a
 /// backlog of CPU-bound events would hold the runtime thread between channel receives — starving the
-/// heartbeat, commit, and consume tasks under saturation (the crash-loop's enabling condition).
-/// Yielding on a wall-clock interval (rather than a fixed message count) adapts to per-event cost
-/// across catalogs of very different sizes.
+/// commit task and the consume loop (which reports liveness inline) under saturation (the crash-loop's
+/// enabling condition). Yielding on a wall-clock interval (rather than a fixed message count) adapts
+/// to per-event cost across catalogs of very different sizes.
 const WORKER_YIELD_INTERVAL: Duration = Duration::from_millis(5);
 
 pub struct Stage1Worker {
@@ -281,7 +281,7 @@ async fn run_worker(
             }
 
             // Release the runtime thread periodically so a CPU-bound event backlog can't starve the
-            // heartbeat/commit/consume tasks (the C3 enabling mechanism for C1/C2).
+            // commit task or the consume loop's inline liveness report (the C3 enabling mechanism).
             if last_yield.elapsed() >= WORKER_YIELD_INTERVAL {
                 tokio::task::yield_now().await;
                 last_yield = Instant::now();

--- a/rust/cohort-stream-processor/src/workers/worker.rs
+++ b/rust/cohort-stream-processor/src/workers/worker.rs
@@ -7,7 +7,7 @@
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 use metrics::{counter, histogram};
 use tokio::sync::mpsc;
@@ -55,6 +55,13 @@ use crate::workers::sweep_callback::{sweep_evict, EvictionAction, SweepDropReaso
 const MAX_SWEEP_KEYS_PER_PASS: usize = 10_000;
 
 const REBUILD_SCAN_PAGE: usize = 10_000;
+
+/// Cooperative-yield cadence inside the worker fold. `handle_event` is fully synchronous, so a
+/// backlog of CPU-bound events would hold the runtime thread between channel receives — starving the
+/// heartbeat, commit, and consume tasks under saturation (the crash-loop's enabling condition).
+/// Yielding on a wall-clock interval (rather than a fixed message count) adapts to per-event cost
+/// across catalogs of very different sizes.
+const WORKER_YIELD_INTERVAL: Duration = Duration::from_millis(5);
 
 pub struct Stage1Worker {
     partition_id: u16,
@@ -116,12 +123,15 @@ async fn run_worker(
     let mut queue = EvictionQueue::<Stage1Key>::new();
     // No-op for a cold partition (bloom-filtered scan finds nothing to schedule).
     if durable_restore {
-        rebuild_eviction_queue(partition_id, &store, &mut queue);
+        rebuild_eviction_queue(partition_id, &store, &mut queue).await;
     }
     // In-memory resume cursors; loss on rebalance is benign (GC re-scans from the start).
     let mut gc_cursor = MergeGcCursor::default();
     let mut stage2_gc_cursor = Stage2GcCursor::default();
 
+    // Persists across batches: a worker that keeps receiving buffered batches would otherwise only
+    // yield via Tokio's coarse coop budget, holding the thread for many CPU-bound events.
+    let mut last_yield = Instant::now();
     while let Some(batch) = receiver.recv().await {
         let last_updated = now_last_updated();
         let mut buffer = OutputBuffer::new();
@@ -268,6 +278,13 @@ async fn run_worker(
                         );
                     }
                 }
+            }
+
+            // Release the runtime thread periodically so a CPU-bound event backlog can't starve the
+            // heartbeat/commit/consume tasks (the C3 enabling mechanism for C1/C2).
+            if last_yield.elapsed() >= WORKER_YIELD_INTERVAL {
+                tokio::task::yield_now().await;
+                last_yield = Instant::now();
             }
         }
 
@@ -771,7 +788,7 @@ async fn handle_sweep(
 /// stored deadline. Skips `PersonProperty` variants (no time-based eviction) and `i64::MAX` deadlines
 /// (permanent). Corrupt records are counted and skipped — the event path re-derives them. A scan error
 /// stops early; new events reschedule any missing keys.
-fn rebuild_eviction_queue(
+async fn rebuild_eviction_queue(
     partition_id: u16,
     store: &CohortStore,
     queue: &mut EvictionQueue<Stage1Key>,
@@ -808,6 +825,9 @@ fn rebuild_eviction_queue(
         if page_len < REBUILD_SCAN_PAGE {
             break;
         }
+        // 64 workers re-seed concurrently on a crash-restart; yield between pages so the boot scan
+        // doesn't re-saturate the runtime before the consume loop can even start.
+        tokio::task::yield_now().await;
     }
     if rebuilt > 0 {
         counter!(EVICTION_QUEUE_REBUILT_KEYS_TOTAL, "partition" => partition_id.to_string())

--- a/rust/cohort-stream-processor/tests/filter_catalog.rs
+++ b/rust/cohort-stream-processor/tests/filter_catalog.rs
@@ -27,6 +27,13 @@ fn behavioral_bytecode() -> Value {
     json!(["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11])
 }
 
+/// The stored form of [`behavioral_bytecode`]: the loader appends a trailing `RETURN` (opcode 38).
+fn behavioral_bytecode_loaded() -> Vec<Value> {
+    let mut bc = behavioral_bytecode().as_array().unwrap().clone();
+    bc.push(json!(38));
+    bc
+}
+
 /// The conditionHash encodes the event matcher, not the `time_value` window — same hash, any window.
 fn behavioral_performed_event(time_value: i64) -> Value {
     json!({
@@ -153,7 +160,7 @@ fn bytecode_is_captured_and_deduped_by_condition_hash() {
     assert_eq!(team.by_condition_to_bytecode.len(), 2);
     assert_eq!(
         team.by_condition_to_bytecode[&BEHAVIORAL_HASH].as_ref(),
-        behavioral_bytecode().as_array().unwrap(),
+        &behavioral_bytecode_loaded(),
     );
     assert!(team.by_condition_to_bytecode.contains_key(&PERSON_HASH));
 }

--- a/rust/cohort-stream-processor/tests/filter_catalog.rs
+++ b/rust/cohort-stream-processor/tests/filter_catalog.rs
@@ -27,10 +27,13 @@ fn behavioral_bytecode() -> Value {
     json!(["_H", 1, 32, "$pageview", 32, "event", 1, 1, 11])
 }
 
+/// HogVM `RETURN` opcode, appended to stored bytecode by the catalog loader.
+const OP_RETURN: i64 = 38;
+
 /// The stored form of [`behavioral_bytecode`]: the loader appends a trailing `RETURN` (opcode 38).
 fn behavioral_bytecode_loaded() -> Vec<Value> {
     let mut bc = behavioral_bytecode().as_array().unwrap().clone();
-    bc.push(json!(38));
+    bc.push(json!(OP_RETURN));
     bc
 }
 

--- a/rust/cohort-stream-processor/tests/hogvm_parity.rs
+++ b/rust/cohort-stream-processor/tests/hogvm_parity.rs
@@ -16,6 +16,10 @@ use std::path::{Path, PathBuf};
 use cohort_stream_processor::hogvm::{evaluate_detailed, EvalOutcome};
 use serde_json::Value;
 
+/// HogVM `RETURN`. Fixtures store compiled bytecode without it (as Python emits); the catalog loader
+/// appends it, so the parity oracle runs the same RETURN-terminated shape the hot path does.
+const OP_RETURN: i64 = 38;
+
 /// A missing directory yields no fixtures (optional corpus); any other read/parse failure panics.
 fn fixtures_in(dir: &Path) -> Vec<(PathBuf, Value)> {
     let Ok(entries) = fs::read_dir(dir) else {
@@ -64,11 +68,14 @@ fn rust_executor_matches_python_oracle() {
         let bytecode = fixture["bytecode"]
             .as_array()
             .unwrap_or_else(|| panic!("fixture {path:?} `bytecode` must be an array"));
+        // Terminate with RETURN exactly as the catalog loader does.
+        let mut bytecode = bytecode.clone();
+        bytecode.push(Value::from(OP_RETURN));
         let globals = fixture["globals"].clone();
         // `unwrap_or(false)` mirrors the Node `?? false` coercion.
         let expected = fixture["expected_result"].as_bool().unwrap_or(false);
 
-        let actual = match evaluate_detailed(bytecode, globals) {
+        let actual = match evaluate_detailed(&bytecode, globals) {
             EvalOutcome::Matched(matched) => matched,
             other => panic!("fixture `{name}` ({path:?}) did not evaluate cleanly: {other:?}"),
         };

--- a/rust/cohort-stream-processor/tests/hogvm_parity.rs
+++ b/rust/cohort-stream-processor/tests/hogvm_parity.rs
@@ -16,8 +16,8 @@ use std::path::{Path, PathBuf};
 use cohort_stream_processor::hogvm::{evaluate_detailed, EvalOutcome};
 use serde_json::Value;
 
-/// HogVM `RETURN`. Fixtures store compiled bytecode without it (as Python emits); the catalog loader
-/// appends it, so the parity oracle runs the same RETURN-terminated shape the hot path does.
+/// HogVM `RETURN`. Fixtures store compiled bytecode without it; append it so the parity oracle runs
+/// the same RETURN-terminated shape the hot path does.
 const OP_RETURN: i64 = 38;
 
 /// A missing directory yields no fixtures (optional corpus); any other read/parse failure panics.
@@ -68,7 +68,6 @@ fn rust_executor_matches_python_oracle() {
         let bytecode = fixture["bytecode"]
             .as_array()
             .unwrap_or_else(|| panic!("fixture {path:?} `bytecode` must be an array"));
-        // Terminate with RETURN exactly as the catalog loader does.
         let mut bytecode = bytecode.clone();
         bytecode.push(Value::from(OP_RETURN));
         let globals = fixture["globals"].clone();

--- a/rust/common/hogvm/src/context.rs
+++ b/rust/common/hogvm/src/context.rs
@@ -1,5 +1,7 @@
+use once_cell::sync::Lazy;
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use crate::{
     error::VmError,
@@ -8,6 +10,28 @@ use crate::{
     vm::HogVM,
     HogLiteral, HogValue,
 };
+
+/// The default native-function and symbol tables are a pure function of the process-static STL, so we
+/// build them once and hand every [`ExecutionContext::with_defaults`] an `Arc` bump instead of
+/// rebuilding the `HashMap`s (and re-cloning every hog-STL function's bytecode to flatten the symbol
+/// table) on every evaluation. This is the single largest per-evaluation cost in the cohort hot path.
+static DEFAULT_NATIVE_FNS: Lazy<Arc<HashMap<String, NativeFunction>>> =
+    Lazy::new(|| Arc::new(stl_map()));
+static DEFAULT_SYMBOL_TABLE: Lazy<Arc<HashMap<Symbol, ExportedFunction>>> =
+    Lazy::new(|| Arc::new(flatten_modules(&hog_stl_map())));
+
+/// Flatten imported modules into the symbol table the VM looks up by `Symbol{module, name}`. The
+/// module name is the `module` half, matching the `Symbol::new("stl", …)` the VM builds at
+/// `CallGlobal` (see `vm.rs`).
+fn flatten_modules(modules: &HashMap<String, Module>) -> HashMap<Symbol, ExportedFunction> {
+    let mut table = HashMap::new();
+    for (name, module) in modules.iter() {
+        for (fn_name, function) in module.functions().iter() {
+            table.insert(Symbol::new(name, fn_name), function.clone());
+        }
+    }
+    table
+}
 
 /// The read-only context for the virtual machine.
 pub struct ExecutionContext {
@@ -24,8 +48,10 @@ pub struct ExecutionContext {
     /// by epoch, and `Eq` compare two temporals by epoch — the ClickHouse/Python-TS-aligned semantics
     /// the realtime-cohort evaluator needs. Set via [`ExecutionContext::with_coercing_comparisons`].
     pub(crate) coerce_comparisons: bool,
-    native_fns: HashMap<String, NativeFunction>,
-    symbol_table: HashMap<Symbol, ExportedFunction>, // Flattened symbol table of all imported hog modules
+    // `Arc`-shared so cloning a default context (the common case) is a refcount bump, not a deep copy
+    // of the STL tables. Mutators take a copy-on-write path via `Arc::make_mut`.
+    native_fns: Arc<HashMap<String, NativeFunction>>,
+    symbol_table: Arc<HashMap<Symbol, ExportedFunction>>, // Flattened symbol table of all imported hog modules
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
@@ -51,43 +77,57 @@ impl ExecutionContext {
             max_heap_size,
             max_steps,
             coerce_comparisons: false,
-            native_fns,
-            symbol_table: HashMap::new(),
+            native_fns: Arc::new(native_fns),
+            symbol_table: Arc::new(flatten_modules(&modules)),
         }
-        .with_modules(&modules)
     }
 
     pub fn with_defaults(bytecode: Program) -> Self {
-        // TODO - these values are basically randomly chosen
-        Self::new(
-            bytecode,
-            json!({}),
-            128,
-            1024 * 1024,
-            10_000,
-            stl_map(),
-            hog_stl_map(),
-        )
+        // TODO - these limits are basically randomly chosen
+        Self {
+            program: bytecode,
+            globals: json!({}),
+            max_stack_depth: 128,
+            max_heap_size: 1024 * 1024,
+            max_steps: 10_000,
+            coerce_comparisons: false,
+            // Refcount bumps of the process-static tables — see `DEFAULT_NATIVE_FNS`.
+            native_fns: DEFAULT_NATIVE_FNS.clone(),
+            symbol_table: DEFAULT_SYMBOL_TABLE.clone(),
+        }
     }
 
     pub fn with_ext_fn(mut self, name: String, func: NativeFunction) -> Self {
-        self.native_fns.insert(name, func);
+        Arc::make_mut(&mut self.native_fns).insert(name, func);
         self
     }
 
     pub fn with_ext_fns(mut self, fns: HashMap<String, NativeFunction>) -> Self {
-        self.native_fns.extend(fns);
+        Arc::make_mut(&mut self.native_fns).extend(fns);
         self
     }
 
     pub fn set_fns(mut self, fns: HashMap<String, NativeFunction>) -> Self {
-        self.native_fns = fns;
+        self.native_fns = Arc::new(fns);
         self
     }
 
     pub fn with_globals(mut self, globals: JsonValue) -> Self {
         self.globals = globals;
         self
+    }
+
+    /// Swap the globals on an existing context in place, so one context can be reused across a fan-out
+    /// of evaluations that share the same globals. Unlike [`Self::with_globals`], this moves `globals`
+    /// in without consuming/rebuilding the context (no STL-table churn).
+    pub fn set_globals(&mut self, globals: JsonValue) {
+        self.globals = globals;
+    }
+
+    /// Swap the program on an existing context in place, the companion to [`Self::set_globals`] for
+    /// reusing one context across many programs (e.g. evaluating each condition in a catalog).
+    pub fn set_program(&mut self, program: Program) {
+        self.program = program;
     }
 
     /// Opt into coercing comparison semantics (cross-type ordering coercion + epoch ordering/equality
@@ -114,17 +154,14 @@ impl ExecutionContext {
     }
 
     pub fn with_modules(mut self, modules: &HashMap<String, Module>) -> Self {
-        self.symbol_table.clear();
-        for (name, module) in modules.iter() {
-            self = self.add_module(name.clone(), module);
-        }
+        self.symbol_table = Arc::new(flatten_modules(modules));
         self
     }
 
     pub fn add_module(mut self, name: String, module: &Module) -> Self {
+        let table = Arc::make_mut(&mut self.symbol_table);
         for (fn_name, function) in module.functions().iter() {
-            self.symbol_table
-                .insert(Symbol::new(&name, fn_name), function.clone());
+            table.insert(Symbol::new(&name, fn_name), function.clone());
         }
         self
     }

--- a/rust/common/hogvm/src/context.rs
+++ b/rust/common/hogvm/src/context.rs
@@ -11,10 +11,8 @@ use crate::{
     HogLiteral, HogValue,
 };
 
-/// The default native-function and symbol tables are a pure function of the process-static STL, so we
-/// build them once and hand every [`ExecutionContext::with_defaults`] an `Arc` bump instead of
-/// rebuilding the `HashMap`s (and re-cloning every hog-STL function's bytecode to flatten the symbol
-/// table) on every evaluation. This is the single largest per-evaluation cost in the cohort hot path.
+/// Default native-function and symbol tables, built once from the process-static STL and shared via
+/// `Arc` by every [`ExecutionContext::with_defaults`] so the maps aren't rebuilt per context.
 static DEFAULT_NATIVE_FNS: Lazy<Arc<HashMap<String, NativeFunction>>> =
     Lazy::new(|| Arc::new(stl_map()));
 static DEFAULT_SYMBOL_TABLE: Lazy<Arc<HashMap<Symbol, ExportedFunction>>> =
@@ -48,8 +46,8 @@ pub struct ExecutionContext {
     /// by epoch, and `Eq` compare two temporals by epoch — the ClickHouse/Python-TS-aligned semantics
     /// the realtime-cohort evaluator needs. Set via [`ExecutionContext::with_coercing_comparisons`].
     pub(crate) coerce_comparisons: bool,
-    // `Arc`-shared so cloning a default context (the common case) is a refcount bump, not a deep copy
-    // of the STL tables. Mutators take a copy-on-write path via `Arc::make_mut`.
+    // `Arc`-shared so cloning a default context is a refcount bump, not a deep copy; mutators
+    // copy-on-write via `Arc::make_mut`.
     native_fns: Arc<HashMap<String, NativeFunction>>,
     symbol_table: Arc<HashMap<Symbol, ExportedFunction>>, // Flattened symbol table of all imported hog modules
 }
@@ -91,7 +89,6 @@ impl ExecutionContext {
             max_heap_size: 1024 * 1024,
             max_steps: 10_000,
             coerce_comparisons: false,
-            // Refcount bumps of the process-static tables — see `DEFAULT_NATIVE_FNS`.
             native_fns: DEFAULT_NATIVE_FNS.clone(),
             symbol_table: DEFAULT_SYMBOL_TABLE.clone(),
         }
@@ -117,15 +114,12 @@ impl ExecutionContext {
         self
     }
 
-    /// Swap the globals on an existing context in place, so one context can be reused across a fan-out
-    /// of evaluations that share the same globals. Unlike [`Self::with_globals`], this moves `globals`
-    /// in without consuming/rebuilding the context (no STL-table churn).
+    /// Swap globals in place (no clone) so one context can be reused across evaluations sharing them.
     pub fn set_globals(&mut self, globals: JsonValue) {
         self.globals = globals;
     }
 
-    /// Swap the program on an existing context in place, the companion to [`Self::set_globals`] for
-    /// reusing one context across many programs (e.g. evaluating each condition in a catalog).
+    /// Swap the program in place to reuse one context across many programs (e.g. catalog conditions).
     pub fn set_program(&mut self, program: Program) {
         self.program = program;
     }

--- a/rust/common/hogvm/src/program.rs
+++ b/rust/common/hogvm/src/program.rs
@@ -1,12 +1,15 @@
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use serde_json::{Number, Value as JsonValue};
 
 use crate::VmError;
 
-// A top-level hog program - functionally the body of a "main" function, if hog had such a thing
+// A top-level hog program - functionally the body of a "main" function, if hog had such a thing.
+// `bytecode` is `Arc`-shared so a program built from already-shared bytecode (e.g. a catalog of
+// compiled cohort conditions) costs a refcount bump rather than copying the whole opcode vector.
 pub struct Program {
-    bytecode: Vec<JsonValue>,
+    bytecode: Arc<Vec<JsonValue>>,
     version: u64,
     program_start_offset: usize,
 }
@@ -25,6 +28,13 @@ pub struct ExportedFunction {
 
 impl Program {
     pub fn new(bytecode: Vec<JsonValue>) -> Result<Self, VmError> {
+        Self::from_shared(Arc::new(bytecode))
+    }
+
+    /// Build a program from already-`Arc`-shared bytecode without copying it. Use this when the
+    /// bytecode is held in a shared catalog and evaluated repeatedly — the program holds a clone of
+    /// the `Arc`, so swapping programs into a reused context costs a refcount bump per evaluation.
+    pub fn from_shared(bytecode: Arc<Vec<JsonValue>>) -> Result<Self, VmError> {
         if bytecode.is_empty() {
             return Err(VmError::InvalidBytecode(
                 "Missing bytecode marker at position 0".to_string(),

--- a/rust/common/hogvm/src/program.rs
+++ b/rust/common/hogvm/src/program.rs
@@ -6,8 +6,7 @@ use serde_json::{Number, Value as JsonValue};
 use crate::VmError;
 
 // A top-level hog program - functionally the body of a "main" function, if hog had such a thing.
-// `bytecode` is `Arc`-shared so a program built from already-shared bytecode (e.g. a catalog of
-// compiled cohort conditions) costs a refcount bump rather than copying the whole opcode vector.
+// `bytecode` is `Arc`-shared so building a program from shared bytecode is a refcount bump.
 pub struct Program {
     bytecode: Arc<Vec<JsonValue>>,
     version: u64,
@@ -31,9 +30,8 @@ impl Program {
         Self::from_shared(Arc::new(bytecode))
     }
 
-    /// Build a program from already-`Arc`-shared bytecode without copying it. Use this when the
-    /// bytecode is held in a shared catalog and evaluated repeatedly — the program holds a clone of
-    /// the `Arc`, so swapping programs into a reused context costs a refcount bump per evaluation.
+    /// Build a program from `Arc`-shared bytecode without copying it — for bytecode held in a shared
+    /// catalog and evaluated repeatedly.
     pub fn from_shared(bytecode: Arc<Vec<JsonValue>>) -> Result<Self, VmError> {
         if bytecode.is_empty() {
             return Err(VmError::InvalidBytecode(

--- a/rust/common/hogvm/src/stl.rs
+++ b/rust/common/hogvm/src/stl.rs
@@ -353,8 +353,8 @@ pub fn stl() -> Vec<(String, NativeFunction)> {
                 let Some(res) = res else {
                     return Ok(HogLiteral::Null.into());
                 };
-                // `json` is a local haystack and `res` borrows into it; clone just the extracted
-                // subtree to hand `construct_free_standing` an owned value.
+                // `res` borrows into the local `json`; clone the extracted subtree for the owned
+                // value `construct_free_standing` needs.
                 construct_free_standing(res.clone(), 0)
             })),
         ),

--- a/rust/common/hogvm/src/stl.rs
+++ b/rust/common/hogvm/src/stl.rs
@@ -353,7 +353,9 @@ pub fn stl() -> Vec<(String, NativeFunction)> {
                 let Some(res) = res else {
                     return Ok(HogLiteral::Null.into());
                 };
-                construct_free_standing(res, 0)
+                // `json` is a local haystack and `res` borrows into it; clone just the extracted
+                // subtree to hand `construct_free_standing` an owned value.
+                construct_free_standing(res.clone(), 0)
             })),
         ),
         // Wrapped in `err_to_null` so an unparseable input becomes `Null`, letting a leaf's

--- a/rust/common/hogvm/src/util.rs
+++ b/rust/common/hogvm/src/util.rs
@@ -113,10 +113,8 @@ fn like_to_regex(pattern: &str) -> String {
     result
 }
 
-/// Walk `chain` into `haystack`, borrowing the value it points at rather than cloning it. The
-/// returned reference is tied to `haystack`, so a caller that needs an owned value clones only the
-/// final subtree — not every node along the path. This is on the hot path of every `GET_GLOBAL`, so
-/// the avoided per-access deep clone of the globals `BTreeMap` is significant.
+/// Walk `chain` into `haystack`, returning a borrow tied to `haystack` (a caller needing an owned
+/// value clones only the final subtree). On the hot path of every `GET_GLOBAL`.
 pub fn get_json_nested<'h>(
     haystack: &'h Value,
     mut chain: &[HogValue],

--- a/rust/common/hogvm/src/util.rs
+++ b/rust/common/hogvm/src/util.rs
@@ -113,17 +113,21 @@ fn like_to_regex(pattern: &str) -> String {
     result
 }
 
-pub fn get_json_nested(
-    haystack: &Value,
+/// Walk `chain` into `haystack`, borrowing the value it points at rather than cloning it. The
+/// returned reference is tied to `haystack`, so a caller that needs an owned value clones only the
+/// final subtree — not every node along the path. This is on the hot path of every `GET_GLOBAL`, so
+/// the avoided per-access deep clone of the globals `BTreeMap` is significant.
+pub fn get_json_nested<'h>(
+    haystack: &'h Value,
     mut chain: &[HogValue],
     vm: &HogVM,
-) -> Result<Option<Value>, VmError> {
+) -> Result<Option<&'h Value>, VmError> {
     let mut current = Some(haystack);
 
     while let Some(val) = current {
         if chain.is_empty() {
             // We found a value pointed to by the last element in the chain
-            return Ok(Some(val.clone()));
+            return Ok(Some(val));
         }
 
         let next_key = chain.first().unwrap().deref(&vm.heap)?;

--- a/rust/common/hogvm/src/vm.rs
+++ b/rust/common/hogvm/src/vm.rs
@@ -119,9 +119,8 @@ impl<'a> HogVM<'a> {
                     return Err(VmError::UnknownGlobal("".to_string()));
                 }
 
-                // `self.context` is a `Copy` `&ExecutionContext`; copying it out decouples the
-                // globals borrow from `self`, so the borrowed `found` can outlive the lookup and
-                // still leave `self` free for the `&mut self` `json_to_hog` needs.
+                // Copy out the `Copy` `&ExecutionContext` so the `found` borrow is tied to it, not to
+                // `self` — leaving `self` free for the `&mut self` `json_to_hog` call below.
                 let context = self.context;
                 if let Some(found) = get_json_nested(&context.globals, &chain, self)? {
                     let val = self.json_to_hog(found)?;
@@ -870,9 +869,8 @@ impl<'a> HogVM<'a> {
             ));
         };
 
-        // Borrow the json tree and clone only the scalar leaves we actually keep (numbers/strings),
-        // rather than cloning the whole subtree up front. Containers are walked by reference and
-        // rebuilt directly onto the heap.
+        // Clone only the scalar leaves (numbers/strings); containers are walked by reference and
+        // rebuilt onto the heap.
         match current {
             JsonValue::Null => Ok(HogLiteral::Null.into()),
             JsonValue::Bool(b) => Ok(HogLiteral::Boolean(*b).into()),

--- a/rust/common/hogvm/src/vm.rs
+++ b/rust/common/hogvm/src/vm.rs
@@ -119,12 +119,16 @@ impl<'a> HogVM<'a> {
                     return Err(VmError::UnknownGlobal("".to_string()));
                 }
 
-                if let Some(found) = get_json_nested(&self.context.globals, &chain, self)? {
+                // `self.context` is a `Copy` `&ExecutionContext`; copying it out decouples the
+                // globals borrow from `self`, so the borrowed `found` can outlive the lookup and
+                // still leave `self` free for the `&mut self` `json_to_hog` needs.
+                let context = self.context;
+                if let Some(found) = get_json_nested(&context.globals, &chain, self)? {
                     let val = self.json_to_hog(found)?;
                     self.push_stack(val)?;
                 } else if let Ok(closure) = self.get_fn_reference(&chain) {
                     self.push_stack(closure)?;
-                } else if get_json_nested(&self.context.globals, &chain[..1], self)?.is_some() {
+                } else if get_json_nested(&context.globals, &chain[..1], self)?.is_some() {
                     // If the first element of the chain is a global, push null onto the stack, e.g.
                     // if a program is looking for "properties.blah", and "properties" exists, but
                     // "blah" doesn't, push null onto the stack.
@@ -855,22 +859,25 @@ impl<'a> HogVM<'a> {
     // This is a function on the VM, rather than being standalone, because hog values don't really
     // exist outside of the context of a VM (and specifically a heap). It could be a function on the
     // heap itself, though.
-    pub fn json_to_hog(&mut self, json: JsonValue) -> Result<HogValue, VmError> {
+    pub fn json_to_hog(&mut self, json: &JsonValue) -> Result<HogValue, VmError> {
         self.json_to_hog_impl(json, 0)
     }
 
-    fn json_to_hog_impl(&mut self, current: JsonValue, depth: usize) -> Result<HogValue, VmError> {
+    fn json_to_hog_impl(&mut self, current: &JsonValue, depth: usize) -> Result<HogValue, VmError> {
         if depth > MAX_JSON_SERDE_DEPTH {
             return Err(VmError::OutOfResource(
                 "json->hog deserialization depth".to_string(),
             ));
         };
 
+        // Borrow the json tree and clone only the scalar leaves we actually keep (numbers/strings),
+        // rather than cloning the whole subtree up front. Containers are walked by reference and
+        // rebuilt directly onto the heap.
         match current {
             JsonValue::Null => Ok(HogLiteral::Null.into()),
-            JsonValue::Bool(b) => Ok(HogLiteral::Boolean(b).into()),
-            JsonValue::Number(n) => Ok(HogLiteral::Number(n.into()).into()),
-            JsonValue::String(s) => Ok(HogLiteral::String(s).into()),
+            JsonValue::Bool(b) => Ok(HogLiteral::Boolean(*b).into()),
+            JsonValue::Number(n) => Ok(HogLiteral::Number(n.clone().into()).into()),
+            JsonValue::String(s) => Ok(HogLiteral::String(s.clone()).into()),
             JsonValue::Array(arr) => {
                 let mut values = Vec::new();
                 for value in arr {
@@ -883,7 +890,7 @@ impl<'a> HogVM<'a> {
             JsonValue::Object(obj) => {
                 let mut map = HashMap::new();
                 for (key, value) in obj {
-                    map.insert(key, self.json_to_hog_impl(value, depth + 1)?);
+                    map.insert(key.clone(), self.json_to_hog_impl(value, depth + 1)?);
                 }
                 let to_emplace = HogLiteral::Object(map);
                 let ptr = self.heap.emplace(to_emplace)?;


### PR DESCRIPTION
## Problem

The first prod-us shadow run of `cohort-stream-processor` crash looped. It is CPU bound, not OOM or IO bound: a modest event rate fans each event out across a large condition catalog, and roughly two thirds of all CPU is fixed per evaluation overhead, rebuilding and dropping an `ExecutionContext` and deep cloning the `serde_json` globals once per condition rather than the VM logic itself. That saturated the 2 core limit, starved the Tokio runtime so the inline heartbeat could not fire, and the watchdog self killed into uncommitted offsets that replayed the same backlog.

## Changes

Two independent levers.

* One cuts the per evaluation cost with no change to evaluation semantics. The shared `hogvm` crate now Arc shares the process static STL tables so building a default context is a refcount bump, makes a program hold its bytecode behind an `Arc` so swapping programs is a refcount bump, and borrows into the globals tree on each nested lookup instead of deep cloning it. The processor reuses one `CohortEvaluator` per event, setting the globals once and swapping only the program per condition, which deletes the per condition globals clone. The `RETURN` opcode is now appended once at catalog load instead of copying the bytecode on every call.

* The other makes the consumer degrade into recoverable lag instead of a self kill. The liveness heartbeat and the offset commit each run on their own interval task, decoupled from the consume loop, so a busy loop no longer blocks either. The heartbeat is progress gated: it reports healthy while the workers advance or while there is no backlog, so a genuine stall still self kills but an idle pod never does. The per partition worker fold yields cooperatively so a CPU bound backlog cannot starve those tasks, the boot eviction queue rebuild yields between scan pages, and a config knob caps the Tokio worker thread count to the pod CPU limit.

`cymbal` is the only other `hogvm` consumer and has zero source edits; the shared changes are behavior identical for it.

## How did you test this code?

`cargo test` passes for `hogvm`, `cymbal`, and `cohort-stream-processor`, and `cargo clippy` is clean for all three. The `hogvm` cross runtime parity fixtures and the processor's Python oracle parity test confirm the first lever does not change any evaluation result. `cymbal`'s rule tests pass unchanged, proving the shared crate change is contained. New tests cover the cases the refactor could regress: a reused evaluator must match a fresh context per eval with no state leak across calls, the offset tracker progress and pending work signals, and the heartbeat gate that must keep an idle pod alive while still self killing a true stall.

## Docs update

No.