### PR TITLE
test(tasks): make facade state-metrics test isolation-proof

### DIFF
--- a/products/tasks/backend/tests/test_facade.py
+++ b/products/tasks/backend/tests/test_facade.py
@@ -239,24 +239,39 @@ class TestFacadeReadsAndMappers(TestCase):
         self.assertEqual(run.state.get("foo"), "bar")
 
     def test_collect_task_run_state_metrics(self):
+        def collect():
+            return facade.collect_task_run_state_metrics(
+                open_statuses=["queued", "in_progress"],
+                age_statuses=["queued", "in_progress"],
+                terminal_statuses=["completed", "failed", "cancelled"],
+                window_seconds=3600,
+            )
+
+        # These are global gauges (no team filter) bucketed by environment too, so other tests' rows can
+        # share a (status, origin_product) key across environments. Measure the delta this test contributes
+        # by summing matching rows across all environments, not an absolute count or a single bucket.
+        def status_total(rows, status, origin_product):
+            return sum(r.value for r in rows if r.status == status and r.origin_product == origin_product)
+
+        queued = (TaskRun.Status.QUEUED.value, Task.OriginProduct.USER_CREATED.value)
+        completed = (TaskRun.Status.COMPLETED.value, Task.OriginProduct.USER_CREATED.value)
+
+        before = collect()
+        created_before = sum(r.value for r in before.created_recently)
+        queued_before = status_total(before.runs_in_status, *queued)
+        terminal_before = status_total(before.terminal_recently, *completed)
+
         task = self._make_task()
         TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
         TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.QUEUED)
         TaskRun.objects.create(task=task, team=self.team, status=TaskRun.Status.COMPLETED)
 
-        metrics = facade.collect_task_run_state_metrics(
-            open_statuses=["queued", "in_progress"],
-            age_statuses=["queued", "in_progress"],
-            terminal_statuses=["completed", "failed", "cancelled"],
-            window_seconds=3600,
-        )
-        open_counts = {(r.status, r.origin_product): r.value for r in metrics.runs_in_status}
-        self.assertEqual(open_counts[(TaskRun.Status.QUEUED.value, Task.OriginProduct.USER_CREATED.value)], 2)
-        # COMPLETED is terminal, not open
-        self.assertNotIn((TaskRun.Status.COMPLETED.value, Task.OriginProduct.USER_CREATED.value), open_counts)
-        terminal_counts = {(r.status, r.origin_product): r.value for r in metrics.terminal_recently}
-        self.assertEqual(terminal_counts[(TaskRun.Status.COMPLETED.value, Task.OriginProduct.USER_CREATED.value)], 1)
-        self.assertEqual(sum(r.value for r in metrics.created_recently), 3)
+        metrics = collect()
+        self.assertEqual(status_total(metrics.runs_in_status, *queued) - queued_before, 2)
+        # COMPLETED is terminal, so it never appears in the open runs_in_status gauge
+        self.assertNotIn(completed, {(r.status, r.origin_product) for r in metrics.runs_in_status})
+        self.assertEqual(status_total(metrics.terminal_recently, *completed) - terminal_before, 1)
+        self.assertEqual(sum(r.value for r in metrics.created_recently) - created_before, 3)
         self.assertTrue(all(r.value >= 0 for r in metrics.oldest_open_age_seconds))
 
     def test_upsert_internal_sandbox_env(self):


### PR DESCRIPTION
## Problem

`test_collect_task_run_state_metrics` is failing on master with `AssertionError: 19.0 != 3` — red on several consecutive master commits, so it blocks every PR's `Product tests (signals, tasks)` shard.

The test asserts absolute counts against `facade.collect_task_run_state_metrics`. But `created_recently` and `terminal_recently` are intentionally **global** monitoring gauges — they aggregate `TaskRun` rows across all teams with no team filter (`products/tasks/backend/facade/api.py`). In a shared test database, rows created by sibling tests land in the same one-hour recency window, so the count drifts above the 3 this test created.

## Changes

Measure the **delta** this test contributes instead of an absolute count: snapshot `created_recently`, `terminal_recently`, and `runs_in_status` before creating the three runs, then assert the increase is exactly 3 / 1 / 2. This matches the behavior the gauges actually promise and is robust to any pre-existing rows. The `assertNotIn(completed_key, open_counts)` check was already isolation-proof and is unchanged.

No production code changes — the global gauge behavior is correct by design; only the test's assertions were fragile.

## How did you test this code?

I'm an agent. I confirmed the failure reproduces deterministically on master (identical `19.0 != 3` across four consecutive master commits) and that the diff is confined to the test. I could not run the test in my sandbox (no database/test tooling available), so CI will exercise it — `ruff`-relevant checks (line length ≤ 120, no `C408` from the `dict()` literal) were verified by inspection and the file parses cleanly.

This test catches a regression where `collect_task_run_state_metrics` stops counting newly created runs in its recency/status gauges; the delta assertions still fail if the aggregation breaks, now without depending on a pristine database.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul was adopting #66707 and asked to fix its failing CI. Investigation showed #66707's own failures were unrelated: a transient Temporal flake in batch-exports (cleared on re-run) and this pre-existing master-wide breakage in `products/tasks`. Split the tasks fix into this focused PR rather than widening #66707 (which only touches `test_team.py`). Considered scoping the production query to a team or weakening the assertion to `>=`; chose the delta approach because it preserves the gauges' intended global semantics while keeping the assertions exact.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
