### PR TITLE
fix(taxonomic-filter): only disable explicitly inactive feature flags

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1266,15 +1266,16 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
                         getName: (featureFlag: FeatureFlagType) => {
                             const name = featureFlag.key || featureFlag.name
-                            const isInactive = !featureFlag.active
-                            return isInactive ? `${name} (disabled)` : name
+                            return featureFlag.active === false ? `${name} (disabled)` : name
                         },
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
                         getPopoverHeader: () => `Feature Flags`,
                         getIcon: (featureFlag: FeatureFlagType) => (
-                            <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
+                            <IconFlag
+                                className={clsx('size-4', featureFlag.active === false && 'text-muted-alt opacity-50')}
+                            />
                         ),
-                        getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
+                        getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
                         localItemsSearch: (items, query) => {
                             if (!query) {
                                 return items

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -818,15 +818,16 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
             getName: (featureFlag: FeatureFlagType) => {
                 const name = featureFlag.key || featureFlag.name
-                const isInactive = !featureFlag.active
-                return isInactive ? `${name} (disabled)` : name
+                return featureFlag.active === false ? `${name} (disabled)` : name
             },
             getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
             getPopoverHeader: () => `Feature Flags`,
             getIcon: (featureFlag: FeatureFlagType) => (
-                <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
+                <IconFlag
+                    className={clsx('size-4', featureFlag.active === false && 'text-muted-alt opacity-50')}
+                />
             ),
-            getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
+            getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
             localItemsSearch: (items: TaxonomicDefinitionTypes[], query: string): TaxonomicDefinitionTypes[] => {
                 // Note: This function doesn't have direct access to the current value
                 // The actual filtering logic needs to be implemented in the infinite list logic


### PR DESCRIPTION
## Problem

Feature flag entries in the TaxonomicFilter were treated as disabled whenever the `active` field was falsy. In recent-item flows, the stored item can omit `active`, which made selectable feature flags appear disabled.

Closes #66492

## Changes

- only mark feature flag entries as disabled when `active === false`
- mirror the change in both TaxonomicFilter implementations:
  - legacy `taxonomicFilterLogic`
  - rebuilt `buildTaxonomicGroups`

## How did you test this code?

- reviewed the affected TaxonomicFilter code paths for both implementations
- manually verified the release-conditions picker flow in local dev
- injected a recent `feature_flags` item into browser localStorage without an `active` field and confirmed it remained selectable in the picker
- verified explicitly inactive flags still render as disabled

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

This PR was prepared with Codex assistance in a local development session. The implementation focused on keeping behavior aligned across the legacy and rebuilt TaxonomicFilter feature flag groups.

We considered broader manual reproduction paths, but the most reliable validation path locally was the feature flag release-conditions picker. The chosen fix preserves disabled behavior for explicitly inactive flags while avoiding false-disabled state for recent items that omit the `active` field.