### PR TITLE
fix(google_ads): handle non-dict is_mcc_account in config validation

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -252,8 +252,11 @@ class GoogleAdsSource(
             )
             is_valid = False
 
-        is_mcc_account = job_inputs.get("is_mcc_account", {})
-        if is_mcc_account.get("enabled"):
+        # The switch-group field is a dict (`{"enabled": ..., "mcc_client_id": ...}`) when
+        # sent from the setup form, but API callers may send a plain bool, so only treat it
+        # as enabled when it's the expected dict shape.
+        is_mcc_account = job_inputs.get("is_mcc_account")
+        if isinstance(is_mcc_account, dict) and is_mcc_account.get("enabled"):
             raw_mcc_client_id = is_mcc_account.get("mcc_client_id", "")
             if raw_mcc_client_id and not re.fullmatch(r"\d{10}", clean_customer_id(raw_mcc_client_id) or ""):
                 errors.append(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -98,6 +98,13 @@ class TestGoogleAdsValidateConfig:
         }
         assert len(self._manager_id_errors(job_inputs)) == 1
 
+    @pytest.mark.parametrize("is_mcc_account", [False, True, None])
+    def test_non_dict_is_mcc_account_does_not_crash(self, is_mcc_account):
+        # API callers may send is_mcc_account as a plain bool instead of the switch-group dict;
+        # validate_config must not crash trying to read `.get("enabled")` off it.
+        job_inputs = {"customer_id": "1234567890", "is_mcc_account": is_mcc_account}
+        assert self._manager_id_errors(job_inputs) == []
+
 
 class TestGoogleAdsNonRetryableErrors:
     def setup_method(self):


### PR DESCRIPTION
## Problem

Error tracking surfaced an unhandled `AttributeError: 'bool' object has no attribute 'get'` raised from the Google Ads source's `validate_config` ([issue](https://us.posthog.com/project/2/error_tracking/019f1504-b66a-7113-ae7d-26310b86bebe)).

The `is_mcc_account` field is a switch-group, so the setup form sends it as a dict (`{"enabled": ..., "mcc_client_id": ...}`). `validate_config` relied on that shape and called `is_mcc_account.get("enabled")`. An API caller creating a source sent `is_mcc_account` as a plain bool instead, so the `.get` call blew up and the request 500'd instead of returning a normal validation response.

## Changes

In `validate_config`, only treat `is_mcc_account` as enabled when it's actually the expected dict shape (`isinstance(is_mcc_account, dict) and is_mcc_account.get("enabled")`). A bool/`None`/absent value now falls through gracefully instead of crashing.

Scoped deliberately: this fixes the reported crash in the Google Ads source. The shared config layer's separate over-eager requirement of `mcc_client_id` when the field is present-but-disabled is pre-existing and untouched here.

## How did you test this code?

I'm an agent. Automated tests only — no manual testing.

Added a parameterized regression test (`bool`/`None` values) to `TestGoogleAdsValidateConfig`. It reproduces the exact `AttributeError` on the unpatched code (including the `False` case from the production event) and passes with the fix. Full `TestGoogleAdsValidateConfig` suite green (16 passed); `ruff check` and `ruff format --check` clean on both files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the failure originates in `google_ads/source.py:validate_config` via the issue's stack trace and event variables (the request payload carried `is_mcc_account` as a plain bool). Classified as a fixable bug rather than a user/upstream error: our code is fragile to a valid-looking request shape, not a credential/permission problem, so it does not belong in `NonRetryableErrors`.

Checked open PRs (including the maintainer's own) for an existing fix touching this code path — none found.

Tooling: Claude Code with the PostHog error-tracking MCP tools. No repo skills were required for this change.
