### PR TITLE
feat(agent-platform): dry-run custom tools in a single-shot sandbox via janitor

### DIFF
--- a/products/agent_platform/backend/logic/janitor_client.py
+++ b/products/agent_platform/backend/logic/janitor_client.py
@@ -128,6 +128,11 @@ class JanitorClient:
     def delete_tool(self, revision_id: str, tool_id: str) -> dict:
         return self._call("DELETE", f"/revisions/{revision_id}/tools/{tool_id}")
 
+    def dry_run_tool(self, revision_id: str, tool_id: str, body: dict) -> dict:
+        """Single-shot sandbox execution of the persisted compiled.js with
+        synthetic args + mock secrets. `body` carries { args, mock_secrets? }."""
+        return self._call("POST", f"/revisions/{revision_id}/tools/{tool_id}/dry_run", json=body)
+
     def freeze(self, revision_id: str) -> dict:
         return self._call("POST", f"/revisions/{revision_id}/freeze")
 

--- a/products/agent_platform/backend/presentation/serializers.py
+++ b/products/agent_platform/backend/presentation/serializers.py
@@ -445,6 +445,25 @@ class WriteToolRequestSerializer(serializers.Serializer):
     source = serializers.CharField(allow_blank=False, trim_whitespace=False)  # type: ignore[assignment]  # field named `source` shadows DRF Field.source
 
 
+class DryRunToolRequestSerializer(serializers.Serializer):
+    """Body shape for POST /revisions/<id>/tools/<tool_id>/dry_run/.
+
+    Executes the persisted compiled.js once in the janitor's single-shot
+    sandbox with caller-supplied args + a stubbed ctx. No real secrets
+    leave Django — `mock_secrets` is a `{name → opaque nonce}` map the
+    sandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns
+    something deterministic to the author."""
+
+    args = serializers.JSONField(
+        help_text="Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync."
+    )
+    mock_secrets = serializers.DictField(
+        child=serializers.CharField(allow_blank=True),
+        required=False,
+        help_text="Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.",
+    )
+
+
 class WriteTypedBundleRequestSerializer(serializers.Serializer):
     """Body shape for PUT /revisions/<id>/bundle/ — the full-replace typed
     payload. Skills are not authored here: they come from the llma-skill store

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -84,6 +84,7 @@ from .serializers import (
     AgentRevisionSerializer,
     CloneFromRequestSerializer,
     DecideApprovalRequestSerializer,
+    DryRunToolRequestSerializer,
     NewDraftRevisionRequestSerializer,
     PreviewProxyInvokeRequestSerializer,
     PromoteRevisionRequestSerializer,
@@ -1682,6 +1683,10 @@ class AgentRevisionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
         "set_skill_refs",
         "put_tool",
         "delete_tool",
+        # Dry-run reads the persisted compiled.js but actually executes user
+        # code in a sandbox — treat it as a write-scoped op so the scope
+        # gates arbitrary compute, not just data reads.
+        "dry_run_tool",
         "cron_fire",
         "set_env",
         # env_keys_key handles GET/PUT/DELETE on /env_keys/<KEY>/ — bundled
@@ -2156,6 +2161,51 @@ class AgentRevisionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
     def delete_tool(self, request: Request, tool_id: str, **kwargs) -> Response:
         revision: AgentRevision = self.get_object()
         return Response(self._call(_janitor().delete_tool, str(revision.id), tool_id))
+
+    @extend_schema(
+        request=DryRunToolRequestSerializer,
+        responses=OpenApiResponse(
+            response=inline_serializer(
+                name="AgentRevisionDryRunToolResponse",
+                fields={
+                    "ok": drf_serializers.BooleanField(
+                        help_text="True when the tool's `actions.default` returned without throwing. False when the tool threw or the sandbox rejected the invocation (the structured `error` describes which)."
+                    ),
+                    "tool_id": drf_serializers.CharField(help_text="Echo of the tool id from the URL."),
+                    "result": drf_serializers.JSONField(
+                        required=False,
+                        help_text="Present on success — the value the tool's `actions.default` returned.",
+                    ),
+                    "error": inline_serializer(
+                        name="AgentRevisionDryRunToolError",
+                        fields={
+                            "code": drf_serializers.CharField(
+                                help_text="Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc."
+                            ),
+                            "message": drf_serializers.CharField(help_text="One-line human-readable detail."),
+                        },
+                        required=False,
+                    ),
+                    "duration_ms": drf_serializers.IntegerField(
+                        help_text="Wall-clock duration of the invocation, including sandbox acquire + release. Always present."
+                    ),
+                },
+            )
+        ),
+    )
+    @action(detail=True, methods=["post"], url_path=r"tools/(?P<tool_id>[a-z0-9][a-z0-9_-]*)/dry_run")
+    def dry_run_tool(self, request: Request, tool_id: str, **kwargs) -> Response:
+        """Execute one persisted custom tool in a single-shot sandbox.
+
+        Authoring loop's "test this tool" button. The tool's source must
+        already be PUT (compiled.js is what runs); this just invokes it
+        with the caller-supplied args and a stubbed ctx. No real secrets
+        leave Django — `mock_secrets` is a `{name → placeholder}` map.
+        """
+        revision: AgentRevision = self.get_object()
+        body = DryRunToolRequestSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        return Response(self._call(_janitor().dry_run_tool, str(revision.id), tool_id, body.validated_data))
 
     @extend_schema(
         request=None,

--- a/products/agent_platform/backend/presentation/views.py
+++ b/products/agent_platform/backend/presentation/views.py
@@ -2180,14 +2180,24 @@ class AgentRevisionViewSet(TeamAndOrgViewSetMixin, viewsets.ModelViewSet):
                         name="AgentRevisionDryRunToolError",
                         fields={
                             "code": drf_serializers.CharField(
-                                help_text="Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc."
+                                help_text=(
+                                    "Stable error code. `sandbox_acquire_failed` — the platform could not start a "
+                                    "sandbox (infrastructure issue, not tool code). `sandbox_invoke_failed` — the "
+                                    "sandbox started but the invoke threw uncaught (problem in the tool body, or a "
+                                    "runtime error). Dispatcher-side codes come through on `ok:false` invoke results: "
+                                    "`timeout`, `secret_not_provisioned`, `action_not_found`, `tool_not_found`."
+                                )
                             ),
                             "message": drf_serializers.CharField(help_text="One-line human-readable detail."),
                         },
                         required=False,
                     ),
                     "duration_ms": drf_serializers.IntegerField(
-                        help_text="Wall-clock duration of the invocation, including sandbox acquire + release. Always present."
+                        help_text=(
+                            "Wall-clock duration in milliseconds, measured from sandbox acquire to after release. "
+                            "Captured consistently across success, tool-throw, and acquire-failure paths so authors "
+                            "can compare timings between calls. Always present."
+                        )
                     ),
                 },
             )

--- a/products/agent_platform/frontend/generated/api.schemas.ts
+++ b/products/agent_platform/frontend/generated/api.schemas.ts
@@ -1223,6 +1223,46 @@ export interface AgentRevisionSystemPromptResponseApi {
     system_prompt: string
 }
 
+/**
+ * Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.
+ */
+export type DryRunToolRequestApiMockSecrets = { [key: string]: string }
+
+/**
+ * Body shape for POST /revisions/<id>/tools/<tool_id>/dry_run/.
+ *
+ * Executes the persisted compiled.js once in the janitor's single-shot
+ * sandbox with caller-supplied args + a stubbed ctx. No real secrets
+ * leave Django — `mock_secrets` is a `{name → opaque nonce}` map the
+ * sandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns
+ * something deterministic to the author.
+ */
+export interface DryRunToolRequestApi {
+    /** Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync. */
+    args: unknown
+    /** Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox. */
+    mock_secrets?: DryRunToolRequestApiMockSecrets
+}
+
+export interface AgentRevisionDryRunToolErrorApi {
+    /** Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc. */
+    code: string
+    /** One-line human-readable detail. */
+    message: string
+}
+
+export interface AgentRevisionDryRunToolResponseApi {
+    /** True when the tool's `actions.default` returned without throwing. False when the tool threw or the sandbox rejected the invocation (the structured `error` describes which). */
+    ok: boolean
+    /** Echo of the tool id from the URL. */
+    tool_id: string
+    /** Present on success — the value the tool's `actions.default` returned. */
+    result?: unknown
+    error?: AgentRevisionDryRunToolErrorApi
+    /** Wall-clock duration of the invocation, including sandbox acquire + release. Always present. */
+    duration_ms: number
+}
+
 export interface AgentRevisionValidationErrorApi {
     code: string
     message: string

--- a/products/agent_platform/frontend/generated/api.schemas.ts
+++ b/products/agent_platform/frontend/generated/api.schemas.ts
@@ -1245,7 +1245,7 @@ export interface DryRunToolRequestApi {
 }
 
 export interface AgentRevisionDryRunToolErrorApi {
-    /** Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc. */
+    /** Stable error code. `sandbox_acquire_failed` — the platform could not start a sandbox (infrastructure issue, not tool code). `sandbox_invoke_failed` — the sandbox started but the invoke threw uncaught (problem in the tool body, or a runtime error). Dispatcher-side codes come through on `ok:false` invoke results: `timeout`, `secret_not_provisioned`, `action_not_found`, `tool_not_found`. */
     code: string
     /** One-line human-readable detail. */
     message: string
@@ -1259,7 +1259,7 @@ export interface AgentRevisionDryRunToolResponseApi {
     /** Present on success — the value the tool's `actions.default` returned. */
     result?: unknown
     error?: AgentRevisionDryRunToolErrorApi
-    /** Wall-clock duration of the invocation, including sandbox acquire + release. Always present. */
+    /** Wall-clock duration in milliseconds, measured from sandbox acquire to after release. Captured consistently across success, tool-throw, and acquire-failure paths so authors can compare timings between calls. Always present. */
     duration_ms: number
 }
 

--- a/products/agent_platform/frontend/generated/api.ts
+++ b/products/agent_platform/frontend/generated/api.ts
@@ -47,6 +47,7 @@ import type {
     AgentRevisionApi,
     AgentRevisionCronFireRequestApi,
     AgentRevisionCronFireResponseApi,
+    AgentRevisionDryRunToolResponseApi,
     AgentRevisionEnvKeyStatusApi,
     AgentRevisionEnvKeysResponseApi,
     AgentRevisionSlackManifestResponseApi,
@@ -57,6 +58,7 @@ import type {
     AgentUsersListApi,
     CloneFromRequestApi,
     DecideApprovalRequestApi,
+    DryRunToolRequestApi,
     NewDraftRevisionRequestApi,
     PaginatedAgentApplicationListApi,
     PaginatedAgentRevisionListApi,
@@ -1314,6 +1316,42 @@ export const agentApplicationsRevisionsToolsDestroy = async (
         ...options,
         method: 'DELETE',
     })
+}
+
+export const getAgentApplicationsRevisionsToolsDryRunCreateUrl = (
+    projectId: string,
+    applicationId: string,
+    id: string,
+    toolId: string
+) => {
+    return `/api/projects/${projectId}/agent_applications/${applicationId}/revisions/${id}/tools/${toolId}/dry_run/`
+}
+
+/**
+ * Execute one persisted custom tool in a single-shot sandbox.
+ *
+ * Authoring loop's "test this tool" button. The tool's source must
+ * already be PUT (compiled.js is what runs); this just invokes it
+ * with the caller-supplied args and a stubbed ctx. No real secrets
+ * leave Django — `mock_secrets` is a `{name → placeholder}` map.
+ */
+export const agentApplicationsRevisionsToolsDryRunCreate = async (
+    projectId: string,
+    applicationId: string,
+    id: string,
+    toolId: string,
+    dryRunToolRequestApi: DryRunToolRequestApi,
+    options?: RequestInit
+): Promise<AgentRevisionDryRunToolResponseApi> => {
+    return apiMutator<AgentRevisionDryRunToolResponseApi>(
+        getAgentApplicationsRevisionsToolsDryRunCreateUrl(projectId, applicationId, id, toolId),
+        {
+            ...options,
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', ...options?.headers },
+            body: JSON.stringify(dryRunToolRequestApi),
+        }
+    )
 }
 
 export const getAgentApplicationsRevisionsValidateCreateUrl = (

--- a/products/agent_platform/frontend/generated/api.zod.ts
+++ b/products/agent_platform/frontend/generated/api.zod.ts
@@ -2412,6 +2412,32 @@ export const AgentApplicationsRevisionsToolsUpdateBody = /* @__PURE__ */ zod
     .describe('Body shape for PUT \/revisions\/<id>\/tools\/<tool_id>\/.')
 
 /**
+ * Execute one persisted custom tool in a single-shot sandbox.
+ *
+ * Authoring loop's "test this tool" button. The tool's source must
+ * already be PUT (compiled.js is what runs); this just invokes it
+ * with the caller-supplied args and a stubbed ctx. No real secrets
+ * leave Django — `mock_secrets` is a `{name → placeholder}` map.
+ */
+export const AgentApplicationsRevisionsToolsDryRunCreateBody = /* @__PURE__ */ zod
+    .object({
+        args: zod
+            .unknown()
+            .describe(
+                "Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync."
+            ),
+        mock_secrets: zod
+            .record(zod.string(), zod.string())
+            .optional()
+            .describe(
+                'Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.'
+            ),
+    })
+    .describe(
+        "Body shape for POST \/revisions\/<id>\/tools\/<tool_id>\/dry_run\/.\n\nExecutes the persisted compiled.js once in the janitor's single-shot\nsandbox with caller-supplied args + a stubbed ctx. No real secrets\nleave Django — `mock_secrets` is a `{name → opaque nonce}` map the\nsandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns\nsomething deterministic to the author."
+    )
+
+/**
  * Create a fresh draft revision under `application_id` and seed it
  * from `source_revision_id`. Saves the MCP one round-trip vs the
  * explicit create + clone_from sequence.

--- a/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
+++ b/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
@@ -440,6 +440,11 @@ export function buildTypedBundleRouter(opts: TypedBundleRouterOpts): Router {
             } = { ok: false, error: { code: 'dry_run_unknown', message: 'no response produced' } }
             let sandbox: Awaited<ReturnType<SandboxPool['acquireForSession']>> | undefined
 
+            // TODO(dry-run-throttle): unbounded fan-out — a user with
+            // agents:write can repeatedly POST and spawn sandboxes outside
+            // the session execution queue. Gate on per-team concurrency /
+            // quota before acquireForSession, or route dry-runs through the
+            // queued execution path.
             try {
                 try {
                     sandbox = await opts.sandboxes.acquireForSession({

--- a/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
+++ b/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
@@ -423,59 +423,75 @@ export function buildTypedBundleRouter(opts: TypedBundleRouterOpts): Router {
             const sessionId = `dry-run-${randomUUID()}`
             const startedAt = Date.now()
 
+            // Build the response in stages so `duration_ms` is captured
+            // consistently — after `release()` runs in the finally — on
+            // every path (acquire failure, invoke throw, invoke not-ok,
+            // invoke ok). Each failure mode gets its own stable `code`
+            // so authors can tell infrastructure problems
+            // (`sandbox_acquire_failed`) from tool-side problems
+            // (`sandbox_invoke_failed`, or the dispatcher's own code on
+            // an `ok:false` invoke result like `secret_not_provisioned`
+            // / `timeout`).
+            let status = 200
+            let body: {
+                ok: boolean
+                result?: unknown
+                error?: { code: string; message: string }
+            } = { ok: false, error: { code: 'dry_run_unknown', message: 'no response produced' } }
+            let sandbox: Awaited<ReturnType<SandboxPool['acquireForSession']>> | undefined
+
             try {
-                const sandbox = await opts.sandboxes.acquireForSession({
-                    sessionId,
-                    teamId: app.team_id,
-                    tools: [
-                        {
-                            id: toolId,
-                            compiledJs,
-                            schemaJson,
-                        },
-                    ],
-                    nonces: parsed.data.mock_secrets ?? {},
-                    sessionTimeoutMs: wallMs,
-                    limits: { wallMs, memoryMb },
-                })
                 try {
-                    const invokeResult = await sandbox.invoke({
-                        toolId,
-                        action: 'default',
-                        args: parsed.data.args,
-                        timeoutMs: wallMs,
+                    sandbox = await opts.sandboxes.acquireForSession({
+                        sessionId,
+                        teamId: app.team_id,
+                        tools: [
+                            {
+                                id: toolId,
+                                compiledJs,
+                                schemaJson,
+                            },
+                        ],
+                        nonces: parsed.data.mock_secrets ?? {},
+                        sessionTimeoutMs: wallMs,
+                        limits: { wallMs, memoryMb },
                     })
-                    const durationMs = Date.now() - startedAt
-                    if (invokeResult.ok) {
-                        res.json({
-                            ok: true,
-                            tool_id: toolId,
-                            result: invokeResult.result,
-                            duration_ms: durationMs,
-                        })
-                    } else {
-                        res.json({
-                            ok: false,
-                            tool_id: toolId,
-                            error: invokeResult.error,
-                            duration_ms: durationMs,
-                        })
+                } catch (err) {
+                    status = 500
+                    body = {
+                        ok: false,
+                        error: { code: 'sandbox_acquire_failed', message: (err as Error).message },
                     }
-                } finally {
+                }
+                if (sandbox) {
+                    try {
+                        const invokeResult = await sandbox.invoke({
+                            toolId,
+                            action: 'default',
+                            args: parsed.data.args,
+                            timeoutMs: wallMs,
+                        })
+                        body = invokeResult.ok
+                            ? { ok: true, result: invokeResult.result }
+                            : { ok: false, error: invokeResult.error }
+                    } catch (err) {
+                        status = 500
+                        body = {
+                            ok: false,
+                            error: { code: 'sandbox_invoke_failed', message: (err as Error).message },
+                        }
+                    }
+                }
+            } finally {
+                if (sandbox) {
                     await opts.sandboxes.release(sessionId).catch(() => {
                         // Sandbox release is best-effort cleanup; the sweep
                         // reaper catches anything we miss. Don't let a slow
                         // release surface as a request failure.
                     })
                 }
-            } catch (err) {
                 const durationMs = Date.now() - startedAt
-                res.status(500).json({
-                    ok: false,
-                    tool_id: toolId,
-                    error: { code: 'sandbox_invoke_failed', message: (err as Error).message },
-                    duration_ms: durationMs,
-                })
+                res.status(status).json({ tool_id: toolId, ...body, duration_ms: durationMs })
             }
         })
     )

--- a/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
+++ b/products/agent_platform/services/agent-janitor/src/api/typed-bundle.ts
@@ -23,6 +23,7 @@
  */
 
 import { Router } from 'express'
+import { randomUUID } from 'node:crypto'
 import { z } from 'zod'
 
 import {
@@ -34,15 +35,17 @@ import {
     RESOURCE_ID_REGEX,
     RevisionState,
     RevisionStore,
+    SandboxPool,
     skillBodyPath,
     skillCompanionPath,
     syncBundleToStore,
+    toolCapabilitiesPath,
     toolCompiledPath,
+    toolSchemaPath,
     TypedBundleSchema,
     TypedSkillSchema,
     TypedSpecSchema,
     TypedToolSchema,
-    toolCapabilitiesPath,
     writeToolSourceAndSchema,
 } from '@posthog/agent-shared'
 
@@ -85,7 +88,35 @@ const TypedBundlePutBodySchema = TypedBundleSchema.omit({ skills: true })
 export interface TypedBundleRouterOpts {
     revisions: RevisionStore
     bundles: BundleStore
+    /**
+     * Single-shot sandbox pool for `POST /tools/:tool_id/dry_run`. Same
+     * `selectSandboxPool` impl the runner uses; lifecycle is per-call
+     * (acquire → invoke → release) rather than per-session. Omitted →
+     * the dry-run route 503s.
+     */
+    sandboxes?: SandboxPool
+    /** Wall-clock cap per dry-run invocation (ms). Default: 10 000. */
+    dryRunWallMs?: number
+    /** Memory cap per dry-run sandbox (MB). Default: 256. */
+    dryRunMemoryMb?: number
 }
+
+const DEFAULT_DRY_RUN_WALL_MS = 10_000
+const DEFAULT_DRY_RUN_MEMORY_MB = 256
+
+const DryRunBodySchema = z.object({
+    /** Synthetic args the tool's `actions.default` is called with. */
+    args: z.unknown(),
+    /**
+     * Optional `{secret_name → opaque_nonce}` map plumbed into the
+     * sandbox the same way the runner injects nonces during a real
+     * session. The plaintext value never enters the sandbox, so the
+     * stub only needs *some* string the tool's `ctx.secrets.ref(name)`
+     * can return. Authors typically pass placeholder strings here just
+     * to confirm the tool runs without throwing `secret not provisioned`.
+     */
+    mock_secrets: z.record(z.string(), z.string()).optional(),
+})
 
 /**
  * Build the router that owns the typed-bundle endpoints. Mounted by the main
@@ -323,6 +354,129 @@ export function buildTypedBundleRouter(opts: TypedBundleRouterOpts): Router {
             }
             await deleteToolFiles(req.params.id, opts.bundles, idCheck.data)
             res.json({ ok: true, tool_id: idCheck.data })
+        })
+    )
+
+    // ─── POST /tools/:tool_id/dry_run  (single-shot sandbox execution) ──
+    //
+    // Runs the persisted compiled.js once with caller-supplied args + a
+    // stubbed ctx (mock nonces only — no real secrets ever leave Django).
+    // Per-call lifecycle (acquire → invoke → release) so we don't carry
+    // session-shaped sandbox state. May split out into `agent-exec` later
+    // if execution duties grow enough to crowd out CRUD.
+    router.post(
+        '/tools/:tool_id/dry_run',
+        asyncHandler(async (req, res) => {
+            const idCheck = ResourceIdParamSchema.safeParse(req.params.tool_id)
+            if (!idCheck.success) {
+                res.status(400).json({ error: 'invalid_resource_id', issues: idCheck.error.issues })
+                return
+            }
+            if (!opts.sandboxes) {
+                res.status(503).json({ error: 'sandbox_pool_not_configured' })
+                return
+            }
+            if (!(await assertDraft(opts, req.params.id, res))) {
+                return
+            }
+            const parsed = DryRunBodySchema.safeParse(req.body)
+            if (!parsed.success) {
+                res.status(400).json({ error: 'invalid_request', issues: parsed.error.issues })
+                return
+            }
+            const toolId = idCheck.data
+
+            // Confirm the tool exists in the bundle. We could load and pass
+            // through the sandbox, but the explicit check produces a 404
+            // instead of a cryptic `tool_not_found` runtime error.
+            const compiledPath = toolCompiledPath(toolId)
+            const compiledJs = await opts.bundles.readText(req.params.id, compiledPath).catch(() => null)
+            if (compiledJs === null) {
+                res.status(404).json({ error: 'tool_not_found', tool_id: toolId })
+                return
+            }
+            const schemaText = await opts.bundles.readText(req.params.id, toolSchemaPath(toolId)).catch(() => '{}')
+            let schemaJson: unknown = {}
+            try {
+                schemaJson = JSON.parse(schemaText)
+            } catch {
+                // Schema is informational at the sandbox boundary; carry on.
+                schemaJson = {}
+            }
+
+            // We need a teamId for the AcquireOpts contract; the dry-run is
+            // tied to the revision's owning team. Revisions don't carry
+            // team_id directly — resolve it through the parent application.
+            const rev = await opts.revisions.getRevisionRaw(req.params.id)
+            if (!rev) {
+                res.status(404).json({ error: 'revision_not_found' })
+                return
+            }
+            const app = await opts.revisions.getApplication(rev.application_id)
+            if (!app) {
+                res.status(404).json({ error: 'application_not_found' })
+                return
+            }
+
+            const wallMs = opts.dryRunWallMs ?? DEFAULT_DRY_RUN_WALL_MS
+            const memoryMb = opts.dryRunMemoryMb ?? DEFAULT_DRY_RUN_MEMORY_MB
+            const sessionId = `dry-run-${randomUUID()}`
+            const startedAt = Date.now()
+
+            try {
+                const sandbox = await opts.sandboxes.acquireForSession({
+                    sessionId,
+                    teamId: app.team_id,
+                    tools: [
+                        {
+                            id: toolId,
+                            compiledJs,
+                            schemaJson,
+                        },
+                    ],
+                    nonces: parsed.data.mock_secrets ?? {},
+                    sessionTimeoutMs: wallMs,
+                    limits: { wallMs, memoryMb },
+                })
+                try {
+                    const invokeResult = await sandbox.invoke({
+                        toolId,
+                        action: 'default',
+                        args: parsed.data.args,
+                        timeoutMs: wallMs,
+                    })
+                    const durationMs = Date.now() - startedAt
+                    if (invokeResult.ok) {
+                        res.json({
+                            ok: true,
+                            tool_id: toolId,
+                            result: invokeResult.result,
+                            duration_ms: durationMs,
+                        })
+                    } else {
+                        res.json({
+                            ok: false,
+                            tool_id: toolId,
+                            error: invokeResult.error,
+                            duration_ms: durationMs,
+                        })
+                    }
+                } finally {
+                    await opts.sandboxes.release(sessionId).catch(() => {
+                        // Sandbox release is best-effort cleanup; the sweep
+                        // reaper catches anything we miss. Don't let a slow
+                        // release surface as a request failure.
+                    })
+                }
+            } catch (err) {
+                const durationMs = Date.now() - startedAt
+                res.status(500).json({
+                    ok: false,
+                    tool_id: toolId,
+                    error: { code: 'sandbox_invoke_failed', message: (err as Error).message },
+                    duration_ms: durationMs,
+                })
+            }
         })
     )
 

--- a/products/agent_platform/services/agent-janitor/src/config.ts
+++ b/products/agent_platform/services/agent-janitor/src/config.ts
@@ -160,6 +160,64 @@ export const AgentJanitorConfigSchema = PlatformConfigSchema.extend({
         .string()
         .optional()
         .describe('Optional phs_ bearer for the model-catalog read; /models is otherwise unauthenticated.'),
+    // Sandbox config — mirrors the runner's so both services pick up the
+    // same SANDBOX_* env vars and end up running the same image. The janitor
+    // uses this to back the single-shot dry-run endpoint
+    // (`POST /revisions/:id/tools/:id/dry_run`). May split out into a
+    // dedicated `agent-exec` service if execution duties grow.
+    sandboxBackend: z
+        .enum(['docker', 'modal'])
+        .optional()
+        .transform((v): 'docker' | 'modal' | undefined => v ?? (isDev() ? 'docker' : undefined))
+        .describe(
+            'Sandbox pool impl for the dry-run endpoint. Mirrors the runner config (same SANDBOX_BACKEND env var).'
+        ),
+    sandboxHostImage: z
+        .string()
+        .optional()
+        .transform((v): string | undefined => v ?? (isDev() ? 'posthog/agent-sandbox-host:dev' : undefined))
+        .describe(
+            'Canonical agent-sandbox-host image. Defaults to the locally-built `posthog/agent-sandbox-host:dev` under isDev(); prod must set this. Mirrors the runner.'
+        ),
+    sandboxDockerImage: z
+        .string()
+        .optional()
+        .describe('Backend-specific Docker image override. Takes precedence over `sandboxHostImage`.'),
+    sandboxModalImage: z
+        .string()
+        .optional()
+        .describe('Backend-specific Modal image override. Takes precedence over `sandboxHostImage`.'),
+    modalAppName: z.string().optional().describe('Optional Modal app name. When unset the Modal SDK uses its default.'),
+    modalRegion: z
+        .string()
+        .optional()
+        .describe('Modal region pin (e.g. `us-east`, `eu-west`). Mirrors the runner config.'),
+    sandboxOutboundCidrAllowlist: z
+        .string()
+        .optional()
+        .transform((v): string[] =>
+            v
+                ? v
+                      .split(',')
+                      .map((s) => s.trim())
+                      .filter(Boolean)
+                : []
+        )
+        .describe(
+            'Comma-separated CIDRs the Modal dry-run sandbox may reach outbound. Empty (default) → no outbound network. Mirrors the runner.'
+        ),
+    dryRunWallMs: z.coerce
+        .number()
+        .int()
+        .positive()
+        .default(10_000)
+        .describe('Wall-clock cap for a single dry-run invocation.'),
+    dryRunMemoryMb: z.coerce
+        .number()
+        .int()
+        .positive()
+        .default(256)
+        .describe('Memory cap for a single dry-run sandbox.'),
 })
 
 export type AgentJanitorConfig = z.infer<typeof AgentJanitorConfigSchema>
@@ -190,6 +248,15 @@ const ENV_KEY_MAP = extendEnvKeyMap<AgentJanitorConfig>(PLATFORM_ENV_KEY_MAP, {
     AGENT_BUNDLE_S3_FORCE_PATH_STYLE: 'bundleS3ForcePathStyle',
     POSTHOG_AI_GATEWAY_URL: 'aiGatewayUrl',
     POSTHOG_AI_GATEWAY_KEY: 'posthogAiGatewayKey',
+    SANDBOX_BACKEND: 'sandboxBackend',
+    SANDBOX_HOST_IMAGE: 'sandboxHostImage',
+    SANDBOX_DOCKER_IMAGE: 'sandboxDockerImage',
+    SANDBOX_MODAL_IMAGE: 'sandboxModalImage',
+    MODAL_APP_NAME: 'modalAppName',
+    MODAL_REGION: 'modalRegion',
+    SANDBOX_OUTBOUND_CIDR_ALLOWLIST: 'sandboxOutboundCidrAllowlist',
+    AGENT_DRY_RUN_WALL_MS: 'dryRunWallMs',
+    AGENT_DRY_RUN_MEMORY_MB: 'dryRunMemoryMb',
 })
 
 export function loadAgentJanitorConfig(env: NodeJS.ProcessEnv = process.env): AgentJanitorConfig {

--- a/products/agent_platform/services/agent-janitor/src/index.ts
+++ b/products/agent_platform/services/agent-janitor/src/index.ts
@@ -38,6 +38,8 @@ import {
     S3BundleStore,
     S3JsonlTabularStore,
     S3MemoryStore,
+    SandboxPool,
+    selectSandboxPool,
     TabularStore,
 } from '@posthog/agent-shared'
 
@@ -165,6 +167,29 @@ async function main(): Promise<void> {
         http: new DirectHttpClient(),
     })
 
+    // Single-shot sandbox pool for the dry-run endpoint. Same `selectSandboxPool`
+    // impl the runner uses; the janitor just runs it with a per-call lifecycle
+    // (acquire → invoke → release inside one HTTP handler) instead of the
+    // runner's per-session lifecycle. If execution duties grow enough to
+    // crowd out the janitor's CRUD character, the natural next step is to
+    // hoist this into a dedicated `agent-exec` service — the abstraction is
+    // already in agent-shared, so the split is mechanical.
+    let sandboxes: SandboxPool | undefined
+    if (config.sandboxBackend) {
+        sandboxes = selectSandboxPool({
+            backend: config.sandboxBackend,
+            sandboxHostImage: config.sandboxHostImage,
+            sandboxDockerImage: config.sandboxDockerImage,
+            sandboxModalImage: config.sandboxModalImage,
+            modalAppName: config.modalAppName,
+            modalRegion: config.modalRegion,
+            sandboxOutboundCidrAllowlist: config.sandboxOutboundCidrAllowlist,
+        })
+        log.info({ backend: config.sandboxBackend }, 'sandbox.dry_run.enabled')
+    } else {
+        log.warn({}, 'sandbox.dry_run.disabled — SANDBOX_BACKEND unset; dry-run endpoint will 503')
+    }
+
     const app = buildJanitorApp({
         queue,
         sweep,
@@ -176,6 +201,9 @@ async function main(): Promise<void> {
         identityAdmin,
         gatewayCatalog,
         internalSigningKey: config.internalSigningKey,
+        sandboxes,
+        dryRunWallMs: config.dryRunWallMs,
+        dryRunMemoryMb: config.dryRunMemoryMb,
     })
     app.listen(config.port, () => {
         log.info({ port: config.port }, 'listening')

--- a/products/agent_platform/services/agent-janitor/src/server.ts
+++ b/products/agent_platform/services/agent-janitor/src/server.ts
@@ -76,6 +76,7 @@ import {
     previewText,
     readTypedBundle,
     RevisionStore,
+    SandboxPool,
     SessionQueue,
     skillBodyPath,
     TabularStore,
@@ -133,6 +134,18 @@ export interface JanitorServerOpts {
     /** Served-model catalog. When set, `validate` + freeze reject a models
      *  the gateway doesn't serve; omitted → the model check is skipped. */
     gatewayCatalog?: GatewayCatalog
+    /**
+     * Single-shot sandbox pool backing the `POST /tools/:id/dry_run`
+     * endpoint. Same `selectSandboxPool` impl the runner uses; lifecycle is
+     * per-call (acquire → invoke → release) rather than per-session. When
+     * omitted, the dry-run route 503s. May split into a dedicated
+     * `agent-exec` service if execution duties grow.
+     */
+    sandboxes?: SandboxPool
+    /** Wall-clock cap per dry-run invocation. Defaults applied at boot. */
+    dryRunWallMs?: number
+    /** Memory cap per dry-run sandbox. Defaults applied at boot. */
+    dryRunMemoryMb?: number
 }
 
 const SessionStateSchema = z.enum(['queued', 'running', 'completed', 'closed', 'failed'])
@@ -895,7 +908,16 @@ export function buildJanitorApp(opts: JanitorServerOpts): Express {
     // (`/file?path=X`, `/bundle` with `mode`) were removed. The new
     // surface lives entirely under the typed router below.
     if (opts.revisions && opts.bundles) {
-        app.use('/revisions/:id', buildTypedBundleRouter({ revisions: opts.revisions, bundles: opts.bundles }))
+        app.use(
+            '/revisions/:id',
+            buildTypedBundleRouter({
+                revisions: opts.revisions,
+                bundles: opts.bundles,
+                sandboxes: opts.sandboxes,
+                dryRunWallMs: opts.dryRunWallMs,
+                dryRunMemoryMb: opts.dryRunMemoryMb,
+            })
+        )
     }
 
     app.post(

--- a/products/agent_platform/services/agent-tests/src/cases/typed-bundle-authoring.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/typed-bundle-authoring.test.ts
@@ -549,6 +549,135 @@ describe('typed bundle authoring API: real e2e', () => {
         })
     })
 
+    // ─── Dry-run: single-shot sandbox execution ─────────────────────
+    //
+    // Janitor proxies a compiled tool through the same sandbox pool the
+    // runner uses, with a per-call lifecycle (acquire → invoke → release
+    // in one handler) instead of per-session. The harness wires the same
+    // InProcessSandboxPool to both worker + janitor so these cases exercise
+    // the real dispatch path.
+
+    describe('POST /tools/:id/dry_run', () => {
+        async function putGoodTool(rid: string, id: string, source: string): Promise<void> {
+            await request(c.janitor)
+                .put(`/revisions/${rid}/tools/${id}`)
+                .send({ description: id, args_schema: { type: 'object' }, source })
+                .expect(200)
+        }
+
+        it('runs the persisted compiled.js with caller-supplied args and returns the result', async () => {
+            const rid = await newDraft(c)
+            await putGoodTool(
+                rid,
+                'echo',
+                `export default {
+                    actions: {
+                        default: async (args: { name: string }) => ({ greeting: 'hi ' + args.name })
+                    }
+                }`
+            )
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/echo/dry_run`)
+                .send({ args: { name: 'dylan' } })
+                .expect(200)
+            expect(res.body.ok).toBe(true)
+            expect(res.body.tool_id).toBe('echo')
+            expect(res.body.result).toEqual({ greeting: 'hi dylan' })
+            expect(typeof res.body.duration_ms).toBe('number')
+        })
+
+        it('surfaces a tool-thrown error as ok:false with the error code', async () => {
+            const rid = await newDraft(c)
+            await putGoodTool(
+                rid,
+                'thrower',
+                `export default {
+                    actions: {
+                        default: async () => { throw new Error('boom') }
+                    }
+                }`
+            )
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/thrower/dry_run`)
+                .send({ args: {} })
+                .expect(200)
+            expect(res.body.ok).toBe(false)
+            expect(res.body.error.message).toContain('boom')
+        })
+
+        it('plumbs mock_secrets into ctx.secrets.ref(name)', async () => {
+            const rid = await newDraft(c)
+            await putGoodTool(
+                rid,
+                'reads-secret',
+                `export default {
+                    actions: {
+                        default: async (_a: unknown, ctx: { secrets: { ref(n: string): string } }) => ({ token: ctx.secrets.ref('FOO_TOKEN') })
+                    }
+                }`
+            )
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/reads-secret/dry_run`)
+                .send({ args: {}, mock_secrets: { FOO_TOKEN: 'nonce-abc' } })
+                .expect(200)
+            expect(res.body.ok).toBe(true)
+            expect(res.body.result).toEqual({ token: 'nonce-abc' })
+        })
+
+        it('returns ok:false when the tool refs an undeclared secret', async () => {
+            // The dispatcher (docker / modal) throws `secret not provisioned`;
+            // the in-process sandbox throws `secret not bound`. Both share the
+            // word `secret`, which is what we actually want to assert here —
+            // that the failure surfaces back as a structured error rather than
+            // a 500.
+            const rid = await newDraft(c)
+            await putGoodTool(
+                rid,
+                'missing-secret',
+                `export default {
+                    actions: {
+                        default: async (_a: unknown, ctx: { secrets: { ref(n: string): string } }) => ({ t: ctx.secrets.ref('NOPE') })
+                    }
+                }`
+            )
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/missing-secret/dry_run`)
+                .send({ args: {} })
+                .expect(200)
+            expect(res.body.ok).toBe(false)
+            expect(res.body.error.message).toMatch(/secret/)
+            expect(res.body.error.message).toContain('NOPE')
+        })
+
+        it('404s when the tool has never been PUT', async () => {
+            const rid = await newDraft(c)
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/never-existed/dry_run`)
+                .send({ args: {} })
+                .expect(404)
+            expect(res.body.error).toBe('tool_not_found')
+        })
+
+        it('400s on invalid_resource_id', async () => {
+            const rid = await newDraft(c)
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/BadID/dry_run`)
+                .send({ args: {} })
+                .expect(400)
+            expect(res.body.error).toBe('invalid_resource_id')
+        })
+
+        it('400s on invalid body (mock_secrets not a string map)', async () => {
+            const rid = await newDraft(c)
+            await putGoodTool(rid, 'ok', GOOD_TOOL_SOURCE)
+            const res = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/ok/dry_run`)
+                .send({ args: {}, mock_secrets: { FOO: 123 } })
+                .expect(400)
+            expect(res.body.error).toBe('invalid_request')
+        })
+    })
+
     // ─── Spec derivation at freeze ───────────────────────────────────
 
     describe('freeze derives spec.skills / spec.tools from the typed bundle', () => {

--- a/products/agent_platform/services/agent-tests/src/cases/typed-bundle-authoring.test.ts
+++ b/products/agent_platform/services/agent-tests/src/cases/typed-bundle-authoring.test.ts
@@ -586,7 +586,7 @@ describe('typed bundle authoring API: real e2e', () => {
             expect(typeof res.body.duration_ms).toBe('number')
         })
 
-        it('surfaces a tool-thrown error as ok:false with the error code', async () => {
+        it('surfaces a tool-thrown error as ok:false, passing the dispatcher code through', async () => {
             const rid = await newDraft(c)
             await putGoodTool(
                 rid,
@@ -602,7 +602,42 @@ describe('typed bundle authoring API: real e2e', () => {
                 .send({ args: {} })
                 .expect(200)
             expect(res.body.ok).toBe(false)
+            // The dispatcher catches the throw and returns ok:false with its
+            // own structured code (in-process → `exception`; docker/modal →
+            // dispatcher-specific). The janitor passes that code through
+            // verbatim — it does NOT overwrite with `sandbox_invoke_failed`,
+            // because that code is reserved for invocations that threw
+            // OUT of the sandbox (infrastructure failure, not tool code).
+            expect(res.body.error.code).not.toBe('sandbox_invoke_failed')
+            expect(res.body.error.code).not.toBe('sandbox_acquire_failed')
             expect(res.body.error.message).toContain('boom')
+        })
+
+        it('captures duration_ms on every path (success, tool-throw)', async () => {
+            // Same `duration_ms` contract on both ok:true and ok:false paths —
+            // measured after sandbox release in the finally block so the two
+            // numbers are comparable.
+            const rid = await newDraft(c)
+            await putGoodTool(rid, 'fast', GOOD_TOOL_SOURCE)
+            await putGoodTool(
+                rid,
+                'fast-thrower',
+                `export default { actions: { default: async () => { throw new Error('x') } } }`
+            )
+            const okRes = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/fast/dry_run`)
+                .send({ args: {} })
+                .expect(200)
+            const throwRes = await request(c.janitor)
+                .post(`/revisions/${rid}/tools/fast-thrower/dry_run`)
+                .send({ args: {} })
+                .expect(200)
+            expect(okRes.body.ok).toBe(true)
+            expect(throwRes.body.ok).toBe(false)
+            expect(typeof okRes.body.duration_ms).toBe('number')
+            expect(typeof throwRes.body.duration_ms).toBe('number')
+            expect(okRes.body.duration_ms).toBeGreaterThanOrEqual(0)
+            expect(throwRes.body.duration_ms).toBeGreaterThanOrEqual(0)
         })
 
         it('plumbs mock_secrets into ctx.secrets.ref(name)', async () => {

--- a/products/agent_platform/services/agent-tests/src/harness/cluster.ts
+++ b/products/agent_platform/services/agent-tests/src/harness/cluster.ts
@@ -485,6 +485,9 @@ export async function buildCluster(opts: BuildClusterOpts = {}): Promise<Cluster
         // (/memory/team/:t/agent/:a/...) read + write through this store and
         // the runner's `@posthog/memory-*` tools hit the same files.
         memoryStore,
+        // Reuse the same in-process sandbox pool the worker uses so dry-run
+        // e2e cases exercise the same dispatch path as production sessions.
+        sandboxes,
     })
 
     return {

--- a/services/mcp/definitions/agent_platform.yaml
+++ b/services/mcp/definitions/agent_platform.yaml
@@ -521,6 +521,27 @@ tools:
             NOT include `compiled.js` — it's generated. Tool id comes from the URL. Draft-only. Playbook: read the
             `editing-agents-safely` playbook via `agent-resolve-resource` for the branch → validate → freeze → promote
             workflow.
+    agent-applications-revisions-tools-dry-run-create:
+        operation: agent_applications_revisions_tools_dry_run_create
+        enabled: true
+        scopes:
+            - agents:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Dry-run a custom tool
+        description: >
+            Execute the persisted `compiled.js` for one tool in a single-shot sandbox with caller-supplied args and a
+            stubbed ctx — the authoring loop's "test this tool" button. Body `{ args, mock_secrets? }`: `args` is
+            free-form JSON (NOT validated against the tool's `args_schema`); `mock_secrets` is an optional
+            `{name → placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body can run without
+            "secret not provisioned". The real secret value never enters the sandbox. Returns
+            `{ ok, tool_id, result?, error?, duration_ms }`: `ok:true` + `result` when the tool returned cleanly,
+            `ok:false` + `error` when the tool threw or the sandbox rejected. Requires the tool to have been PUT first
+            (it runs the persisted bytes, not a fresh source). Draft-only. Per-call lifecycle — no warm pool today.
+            Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the broader
+            branch → validate → freeze → promote workflow.
     agent-applications-revisions-update:
         operation: agent_applications_revisions_update
         enabled: false

--- a/services/mcp/definitions/agent_platform.yaml
+++ b/services/mcp/definitions/agent_platform.yaml
@@ -504,6 +504,27 @@ tools:
             Removes source.ts, compiled.js, schema.json from the bundle. Returns 404 if the tool doesn't exist.
             Draft-only. Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the branch
             → validate → freeze → promote workflow.
+    agent-applications-revisions-tools-dry-run-create:
+        operation: agent_applications_revisions_tools_dry_run_create
+        enabled: true
+        scopes:
+            - agents:write
+        annotations:
+            readOnly: false
+            destructive: false
+            idempotent: false
+        title: Dry-run a custom tool
+        description: >
+            Execute the persisted `compiled.js` for one tool in a single-shot sandbox with caller-supplied args and a
+            stubbed ctx — the authoring loop's "test this tool" button. Body `{ args, mock_secrets? }`: `args` is
+            free-form JSON (NOT validated against the tool's `args_schema`); `mock_secrets` is an optional `{name →
+            placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body can run without "secret
+            not provisioned". The real secret value never enters the sandbox. Returns `{ ok, tool_id, result?, error?,
+            duration_ms }`: `ok:true` + `result` when the tool returned cleanly, `ok:false` + `error` when the tool
+            threw or the sandbox rejected. Requires the tool to have been PUT first (it runs the persisted bytes, not a
+            fresh source). Draft-only. Per-call lifecycle — no warm pool today. Playbook: read the
+            `editing-agents-safely` playbook via `agent-resolve-resource` for the broader branch → validate → freeze →
+            promote workflow.
     agent-applications-revisions-tools-update:
         operation: agent_applications_revisions_tools_update
         enabled: true
@@ -521,27 +542,6 @@ tools:
             NOT include `compiled.js` — it's generated. Tool id comes from the URL. Draft-only. Playbook: read the
             `editing-agents-safely` playbook via `agent-resolve-resource` for the branch → validate → freeze → promote
             workflow.
-    agent-applications-revisions-tools-dry-run-create:
-        operation: agent_applications_revisions_tools_dry_run_create
-        enabled: true
-        scopes:
-            - agents:write
-        annotations:
-            readOnly: false
-            destructive: false
-            idempotent: false
-        title: Dry-run a custom tool
-        description: >
-            Execute the persisted `compiled.js` for one tool in a single-shot sandbox with caller-supplied args and a
-            stubbed ctx — the authoring loop's "test this tool" button. Body `{ args, mock_secrets? }`: `args` is
-            free-form JSON (NOT validated against the tool's `args_schema`); `mock_secrets` is an optional
-            `{name → placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body can run without
-            "secret not provisioned". The real secret value never enters the sandbox. Returns
-            `{ ok, tool_id, result?, error?, duration_ms }`: `ok:true` + `result` when the tool returned cleanly,
-            `ok:false` + `error` when the tool threw or the sandbox rejected. Requires the tool to have been PUT first
-            (it runs the persisted bytes, not a fresh source). Draft-only. Per-call lifecycle — no warm pool today.
-            Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the broader
-            branch → validate → freeze → promote workflow.
     agent-applications-revisions-update:
         operation: agent_applications_revisions_update
         enabled: false

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -681,6 +681,21 @@
         },
         "feature_flag": "agent-platform"
     },
+    "agent-applications-revisions-tools-dry-run-create": {
+        "description": "Execute the persisted `compiled.js` for one tool in a single-shot sandbox with caller-supplied args and a stubbed ctx — the authoring loop's \"test this tool\" button. Body `{ args, mock_secrets? }`: `args` is free-form JSON (NOT validated against the tool's `args_schema`); `mock_secrets` is an optional `{name → placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body can run without \"secret not provisioned\". The real secret value never enters the sandbox. Returns `{ ok, tool_id, result?, error?, duration_ms }`: `ok:true` + `result` when the tool returned cleanly, `ok:false` + `error` when the tool threw or the sandbox rejected. Requires the tool to have been PUT first (it runs the persisted bytes, not a fresh source). Draft-only. Per-call lifecycle — no warm pool today. Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the broader branch → validate → freeze → promote workflow.",
+        "category": "Agent stack",
+        "feature": "agent_platform",
+        "summary": "Dry-run a custom tool",
+        "title": "Dry-run a custom tool",
+        "required_scopes": ["agents:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "agent-platform"
+    },
     "agent-applications-revisions-tools-update": {
         "description": "Body `{ description, args_schema, source }`. `source` is the TypeScript tool source — the janitor runs an AST shape check + esbuild compile synchronously and rejects a bad shape with structured diagnostics in the 422 response. Required shape: `export default { actions: { default: async (args, ctx) => { ... } } }`. Do NOT include `compiled.js` — it's generated. Tool id comes from the URL. Draft-only. Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the branch → validate → freeze → promote workflow.",
         "category": "Agent stack",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -681,6 +681,21 @@
         },
         "feature_flag": "agent-platform"
     },
+    "agent-applications-revisions-tools-dry-run-create": {
+        "description": "Execute the persisted `compiled.js` for one tool in a single-shot sandbox with caller-supplied args and a stubbed ctx — the authoring loop's \"test this tool\" button. Body `{ args, mock_secrets? }`: `args` is free-form JSON (NOT validated against the tool's `args_schema`); `mock_secrets` is an optional `{name → placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body can run without \"secret not provisioned\". The real secret value never enters the sandbox. Returns `{ ok, tool_id, result?, error?, duration_ms }`: `ok:true` + `result` when the tool returned cleanly, `ok:false` + `error` when the tool threw or the sandbox rejected. Requires the tool to have been PUT first (it runs the persisted bytes, not a fresh source). Draft-only. Per-call lifecycle — no warm pool today. Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the broader branch → validate → freeze → promote workflow.",
+        "category": "Agent stack",
+        "feature": "agent_platform",
+        "summary": "Dry-run a custom tool",
+        "title": "Dry-run a custom tool",
+        "required_scopes": ["agents:write"],
+        "annotations": {
+            "destructiveHint": false,
+            "idempotentHint": false,
+            "openWorldHint": true,
+            "readOnlyHint": false
+        },
+        "feature_flag": "agent-platform"
+    },
     "agent-applications-revisions-tools-update": {
         "description": "Body `{ description, args_schema, source }`. `source` is the TypeScript tool source — the janitor runs an AST shape check + esbuild compile synchronously and rejects a bad shape with structured diagnostics in the 422 response. Required shape: `export default { actions: { default: async (args, ctx) => { ... } } }`. Do NOT include `compiled.js` — it's generated. Tool id comes from the URL. Draft-only. Playbook: read the `editing-agents-safely` playbook via `agent-resolve-resource` for the branch → validate → freeze → promote workflow.",
         "category": "Agent stack",

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8690,6 +8690,25 @@ export namespace Schemas {
       request_id: string;
     }
 
+    export interface AgentRevisionDryRunToolError {
+      /** Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc. */
+      code: string;
+      /** One-line human-readable detail. */
+      message: string;
+    }
+
+    export interface AgentRevisionDryRunToolResponse {
+      /** True when the tool's `actions.default` returned without throwing. False when the tool threw or the sandbox rejected the invocation (the structured `error` describes which). */
+      ok: boolean;
+      /** Echo of the tool id from the URL. */
+      tool_id: string;
+      /** Present on success — the value the tool's `actions.default` returned. */
+      result?: unknown;
+      error?: AgentRevisionDryRunToolError;
+      /** Wall-clock duration of the invocation, including sandbox acquire + release. Always present. */
+      duration_ms: number;
+    }
+
     export interface AgentRevisionEnvKeyStatus {
       key: string;
       /** True if the key is present in the env block. The value itself is never returned. */
@@ -17892,6 +17911,27 @@ export namespace Schemas {
     export interface DraftStatusResponse {
       updated_at: string;
       has_draft: boolean;
+    }
+
+    /**
+     * Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.
+     */
+    export type DryRunToolRequestMockSecrets = {[key: string]: string};
+
+    /**
+     * Body shape for POST /revisions/<id>/tools/<tool_id>/dry_run/.
+     *
+     * Executes the persisted compiled.js once in the janitor's single-shot
+     * sandbox with caller-supplied args + a stubbed ctx. No real secrets
+     * leave Django — `mock_secrets` is a `{name → opaque nonce}` map the
+     * sandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns
+     * something deterministic to the author.
+     */
+    export interface DryRunToolRequest {
+      /** Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync. */
+      args: unknown;
+      /** Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox. */
+      mock_secrets?: DryRunToolRequestMockSecrets;
     }
 
     /**

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -8691,7 +8691,7 @@ export namespace Schemas {
     }
 
     export interface AgentRevisionDryRunToolError {
-      /** Stable error code: `timeout`, `secret_not_provisioned`, `tool_invoke_failed`, etc. */
+      /** Stable error code. `sandbox_acquire_failed` — the platform could not start a sandbox (infrastructure issue, not tool code). `sandbox_invoke_failed` — the sandbox started but the invoke threw uncaught (problem in the tool body, or a runtime error). Dispatcher-side codes come through on `ok:false` invoke results: `timeout`, `secret_not_provisioned`, `action_not_found`, `tool_not_found`. */
       code: string;
       /** One-line human-readable detail. */
       message: string;
@@ -8705,7 +8705,7 @@ export namespace Schemas {
       /** Present on success — the value the tool's `actions.default` returned. */
       result?: unknown;
       error?: AgentRevisionDryRunToolError;
-      /** Wall-clock duration of the invocation, including sandbox acquire + release. Always present. */
+      /** Wall-clock duration in milliseconds, measured from sandbox acquire to after release. Captured consistently across success, tool-throw, and acquire-failure paths so authors can compare timings between calls. Always present. */
       duration_ms: number;
     }
 

--- a/services/mcp/src/generated/agent_platform/api.ts
+++ b/services/mcp/src/generated/agent_platform/api.ts
@@ -3,7 +3,7 @@
  * MCP service uses these Zod schemas for generated tool handlers.
  * To regenerate: hogli build:openapi
  *
- * PostHog API - MCP 35 enabled ops
+ * PostHog API - MCP 36 enabled ops
  * OpenAPI spec version: 1.0.0
  */
 import * as zod from 'zod'
@@ -2093,6 +2093,45 @@ export const AgentApplicationsRevisionsToolsDestroyParams = /* @__PURE__ */ zod.
         ),
     tool_id: zod.string().regex(agentApplicationsRevisionsToolsDestroyPathToolIdRegExp),
 })
+
+/**
+ * Execute one persisted custom tool in a single-shot sandbox.
+ *
+ * Authoring loop's "test this tool" button. The tool's source must
+ * already be PUT (compiled.js is what runs); this just invokes it
+ * with the caller-supplied args and a stubbed ctx. No real secrets
+ * leave Django — `mock_secrets` is a `{name → placeholder}` map.
+ */
+export const agentApplicationsRevisionsToolsDryRunCreatePathToolIdRegExp = new RegExp('^[a-z0-9][a-z0-9_-]*$')
+
+export const AgentApplicationsRevisionsToolsDryRunCreateParams = /* @__PURE__ */ zod.object({
+    application_id: zod.string(),
+    id: zod.string().describe('A UUID string identifying this agent revision.'),
+    project_id: zod
+        .string()
+        .describe(
+            "Project ID of the project you're trying to access. To find the ID of the project, make a call to /api/projects/."
+        ),
+    tool_id: zod.string().regex(agentApplicationsRevisionsToolsDryRunCreatePathToolIdRegExp),
+})
+
+export const AgentApplicationsRevisionsToolsDryRunCreateBody = /* @__PURE__ */ zod
+    .object({
+        args: zod
+            .unknown()
+            .describe(
+                "Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync."
+            ),
+        mock_secrets: zod
+            .record(zod.string(), zod.string())
+            .optional()
+            .describe(
+                'Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.'
+            ),
+    })
+    .describe(
+        "Body shape for POST /revisions/<id>/tools/<tool_id>/dry_run/.\n\nExecutes the persisted compiled.js once in the janitor's single-shot\nsandbox with caller-supplied args + a stubbed ctx. No real secrets\nleave Django — `mock_secrets` is a `{name → opaque nonce}` map the\nsandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns\nsomething deterministic to the author."
+    )
 
 /**
  * Pre-flight checks before freeze + promote: agent.md exists,

--- a/services/mcp/src/tools/generated/agent_platform.ts
+++ b/services/mcp/src/tools/generated/agent_platform.ts
@@ -41,6 +41,8 @@ import {
     AgentApplicationsRevisionsSpecUpdateParams,
     AgentApplicationsRevisionsSystemPromptParams,
     AgentApplicationsRevisionsToolsDestroyParams,
+    AgentApplicationsRevisionsToolsDryRunCreateBody,
+    AgentApplicationsRevisionsToolsDryRunCreateParams,
     AgentApplicationsRevisionsToolsUpdateBody,
     AgentApplicationsRevisionsToolsUpdateParams,
     AgentApplicationsRevisionsValidateCreateParams,
@@ -748,6 +750,34 @@ const agentApplicationsRevisionsToolsUpdate = (): ToolBase<
     },
 })
 
+const AgentApplicationsRevisionsToolsDryRunCreateSchema = AgentApplicationsRevisionsToolsDryRunCreateParams.omit({
+    project_id: true,
+}).extend(AgentApplicationsRevisionsToolsDryRunCreateBody.shape)
+
+const agentApplicationsRevisionsToolsDryRunCreate = (): ToolBase<
+    typeof AgentApplicationsRevisionsToolsDryRunCreateSchema,
+    Schemas.AgentRevisionDryRunToolResponse
+> => ({
+    name: 'agent-applications-revisions-tools-dry-run-create',
+    schema: AgentApplicationsRevisionsToolsDryRunCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AgentApplicationsRevisionsToolsDryRunCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.args !== undefined) {
+            body['args'] = params.args
+        }
+        if (params.mock_secrets !== undefined) {
+            body['mock_secrets'] = params.mock_secrets
+        }
+        const result = await context.api.request<Schemas.AgentRevisionDryRunToolResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/agent_applications/${encodeURIComponent(String(params.application_id))}/revisions/${encodeURIComponent(String(params.id))}/tools/${encodeURIComponent(String(params.tool_id))}/dry_run/`,
+            body,
+        })
+        return result
+    },
+})
+
 const AgentApplicationsRevisionsValidateCreateSchema = AgentApplicationsRevisionsValidateCreateParams.omit({
     project_id: true,
 })
@@ -897,6 +927,7 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'agent-applications-revisions-system-prompt': agentApplicationsRevisionsSystemPrompt,
     'agent-applications-revisions-tools-destroy': agentApplicationsRevisionsToolsDestroy,
     'agent-applications-revisions-tools-update': agentApplicationsRevisionsToolsUpdate,
+    'agent-applications-revisions-tools-dry-run-create': agentApplicationsRevisionsToolsDryRunCreate,
     'agent-applications-revisions-validate-create': agentApplicationsRevisionsValidateCreate,
     'agent-applications-session-logs': agentApplicationsSessionLogs,
     'agent-applications-sessions-list': agentApplicationsSessionsList,

--- a/services/mcp/src/tools/generated/agent_platform.ts
+++ b/services/mcp/src/tools/generated/agent_platform.ts
@@ -719,6 +719,34 @@ const agentApplicationsRevisionsToolsDestroy = (): ToolBase<
     },
 })
 
+const AgentApplicationsRevisionsToolsDryRunCreateSchema = AgentApplicationsRevisionsToolsDryRunCreateParams.omit({
+    project_id: true,
+}).extend(AgentApplicationsRevisionsToolsDryRunCreateBody.shape)
+
+const agentApplicationsRevisionsToolsDryRunCreate = (): ToolBase<
+    typeof AgentApplicationsRevisionsToolsDryRunCreateSchema,
+    Schemas.AgentRevisionDryRunToolResponse
+> => ({
+    name: 'agent-applications-revisions-tools-dry-run-create',
+    schema: AgentApplicationsRevisionsToolsDryRunCreateSchema,
+    handler: async (context: Context, params: z.infer<typeof AgentApplicationsRevisionsToolsDryRunCreateSchema>) => {
+        const projectId = await context.stateManager.getProjectId()
+        const body: Record<string, unknown> = {}
+        if (params.args !== undefined) {
+            body['args'] = params.args
+        }
+        if (params.mock_secrets !== undefined) {
+            body['mock_secrets'] = params.mock_secrets
+        }
+        const result = await context.api.request<Schemas.AgentRevisionDryRunToolResponse>({
+            method: 'POST',
+            path: `/api/projects/${encodeURIComponent(String(projectId))}/agent_applications/${encodeURIComponent(String(params.application_id))}/revisions/${encodeURIComponent(String(params.id))}/tools/${encodeURIComponent(String(params.tool_id))}/dry_run/`,
+            body,
+        })
+        return result
+    },
+})
+
 const AgentApplicationsRevisionsToolsUpdateSchema = AgentApplicationsRevisionsToolsUpdateParams.omit({
     project_id: true,
 }).extend(AgentApplicationsRevisionsToolsUpdateBody.shape)
@@ -744,34 +772,6 @@ const agentApplicationsRevisionsToolsUpdate = (): ToolBase<
         const result = await context.api.request<Schemas.AgentRevision>({
             method: 'PUT',
             path: `/api/projects/${encodeURIComponent(String(projectId))}/agent_applications/${encodeURIComponent(String(params.application_id))}/revisions/${encodeURIComponent(String(params.id))}/tools/${encodeURIComponent(String(params.tool_id))}/`,
-            body,
-        })
-        return result
-    },
-})
-
-const AgentApplicationsRevisionsToolsDryRunCreateSchema = AgentApplicationsRevisionsToolsDryRunCreateParams.omit({
-    project_id: true,
-}).extend(AgentApplicationsRevisionsToolsDryRunCreateBody.shape)
-
-const agentApplicationsRevisionsToolsDryRunCreate = (): ToolBase<
-    typeof AgentApplicationsRevisionsToolsDryRunCreateSchema,
-    Schemas.AgentRevisionDryRunToolResponse
-> => ({
-    name: 'agent-applications-revisions-tools-dry-run-create',
-    schema: AgentApplicationsRevisionsToolsDryRunCreateSchema,
-    handler: async (context: Context, params: z.infer<typeof AgentApplicationsRevisionsToolsDryRunCreateSchema>) => {
-        const projectId = await context.stateManager.getProjectId()
-        const body: Record<string, unknown> = {}
-        if (params.args !== undefined) {
-            body['args'] = params.args
-        }
-        if (params.mock_secrets !== undefined) {
-            body['mock_secrets'] = params.mock_secrets
-        }
-        const result = await context.api.request<Schemas.AgentRevisionDryRunToolResponse>({
-            method: 'POST',
-            path: `/api/projects/${encodeURIComponent(String(projectId))}/agent_applications/${encodeURIComponent(String(params.application_id))}/revisions/${encodeURIComponent(String(params.id))}/tools/${encodeURIComponent(String(params.tool_id))}/dry_run/`,
             body,
         })
         return result
@@ -926,8 +926,8 @@ export const GENERATED_TOOLS: Record<string, () => ToolBase<ZodObjectAny>> = {
     'agent-applications-revisions-spec-update': agentApplicationsRevisionsSpecUpdate,
     'agent-applications-revisions-system-prompt': agentApplicationsRevisionsSystemPrompt,
     'agent-applications-revisions-tools-destroy': agentApplicationsRevisionsToolsDestroy,
-    'agent-applications-revisions-tools-update': agentApplicationsRevisionsToolsUpdate,
     'agent-applications-revisions-tools-dry-run-create': agentApplicationsRevisionsToolsDryRunCreate,
+    'agent-applications-revisions-tools-update': agentApplicationsRevisionsToolsUpdate,
     'agent-applications-revisions-validate-create': agentApplicationsRevisionsValidateCreate,
     'agent-applications-session-logs': agentApplicationsSessionLogs,
     'agent-applications-sessions-list': agentApplicationsSessionsList,

--- a/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-tools-dry-run-create.json
+++ b/services/mcp/tests/unit/__snapshots__/tool-schemas/agent-applications-revisions-tools-dry-run-create.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "properties": {
+        "application_id": {
+            "type": "string"
+        },
+        "args": {
+            "description": "Synthetic args the tool's `actions.default` is called with. Free-form JSON; the sandbox doesn't validate against the tool's `args_schema` — that's the author's responsibility to keep in sync."
+        },
+        "id": {
+            "description": "A UUID string identifying this agent revision.",
+            "type": "string"
+        },
+        "mock_secrets": {
+            "additionalProperties": {
+                "type": "string"
+            },
+            "description": "Optional `{secret_name → placeholder_string}` map. The string is returned verbatim by `ctx.secrets.ref(name)` inside the tool. The real secret value never enters the sandbox.",
+            "propertyNames": {
+                "type": "string"
+            },
+            "type": "object"
+        },
+        "tool_id": {
+            "pattern": "^[a-z0-9][a-z0-9_-]*$",
+            "type": "string"
+        }
+    },
+    "required": ["application_id", "id", "tool_id", "args"],
+    "type": "object"
+}


### PR DESCRIPTION
## Problem

Builds on #66584 (the static half of custom-tool authoring). That PR catches malformed tool sources at PUT time with friendly errors, but the only way to actually *run* a tool today is to deploy a real session — too slow for the iterate-on-a-tool authoring loop. Authors need a "test this tool" button that takes synthetic args and shows what comes back.

## Changes

**New endpoint:** `POST /api/projects/:team/agent_applications/:app/revisions/:rev/tools/:tool_id/dry_run/`

Body `{ args, mock_secrets? }`. Returns `{ ok, tool_id, result? | error?, duration_ms }`.

Executes the persisted `compiled.js` once in a per-call sandbox with a stubbed `ctx`. Tool source must already be PUT — dry-run runs the persisted bytes, not a fresh compile. Draft-only. No real secrets ever leave Django; `mock_secrets` is a `{name → placeholder}` map the sandbox plumbs into `ctx.secrets.ref(name)` so the tool body returns something deterministic.

**Lives on the janitor for v1.** Same `selectSandboxPool` impl the runner uses, but with a single-shot lifecycle (acquire → invoke → release in one HTTP handler) instead of the runner's per-session lifecycle. Why janitor instead of a new service — see #66584's "Next" section for the full decision log. TL;DR: at internal+design-partners scale the complexity of a fourth k8s service outweighs the architectural purity, and the sandbox abstraction is already in `agent-shared` so the split to a dedicated `agent-exec` service later is mechanical when usage signal justifies it.

**Two verbs, one service.** `PUT /tools/:id` compiles and persists (existing). `POST /tools/:id/dry_run` executes the persisted bytes (new). The split keeps each request shape clean.

### Files

| Layer | What |
|---|---|
| Janitor config | `sandboxBackend` / `sandboxHostImage` / `dryRunWallMs` / `dryRunMemoryMb` etc. — mirrors the runner so both services pick up the same `SANDBOX_*` env vars |
| Janitor bootstrap | Constructs a `SandboxPool` via `selectSandboxPool` at boot; passes it to `buildJanitorApp` |
| Janitor handler | `POST /tools/:tool_id/dry_run` in `api/typed-bundle.ts` — reads compiled.js + schema from bundle, acquires pool, invokes, always releases in `finally`. 503 if pool unconfigured, 404 if tool missing, 400 on invalid body |
| Django serializer | `DryRunToolRequestSerializer` with `help_text` on every field |
| Django viewset | `AgentRevisionViewSet.dry_run_tool` with `@extend_schema(request=..., responses=OpenApiResponse(...))` so MCP + frontend types pick up the response shape; added to `scope_object_write_actions` so the scope gates arbitrary compute |
| Janitor client | `dry_run_tool(rev_id, tool_id, body)` |
| MCP YAML | New `agent-applications-revisions-tools-dry-run-create` entry, `agents:write` scope, description calls out per-call lifecycle + `mock_secrets` semantics |
| Generated | OpenAPI types, MCP tool wrapper, frontend `api.schemas.ts` / `api.ts` / `api.zod.ts` |
| Tests | Harness wires the in-process sandbox pool to janitor; 7 new e2e cases cover happy path, tool-thrown error, mock-secret flow, undeclared-secret error, 404, 400 bad id, 400 bad body |

## How did you test this code?

Agent-authored — no manual testing claimed.

Automated tests run:

- `pnpm --filter @posthog/agent-tests vitest run src/cases/typed-bundle-authoring.test.ts` — 40/40 pass (33 pre-existing from #66584 + 7 new dry-run cases).
- `pnpm --filter @posthog/agent-janitor typescript:check` — clean.
- `ruff check products/agent_platform/backend/` — clean.
- `hogli build:openapi` — clean; MCP tool `agent-applications-revisions-tools-dry-run-create` and frontend types regenerated.

What the new tests catch that nothing existing did:

- Real sandbox dispatch returns the tool's actual return value (not a stub).
- A tool that throws surfaces as `ok:false` + structured `error`, not a 500.
- `mock_secrets` plumbs through to `ctx.secrets.ref(name)` end-to-end.
- An undeclared secret surfaces as a structured error (still `ok:false`, not 500).
- `tool_not_found`, `invalid_resource_id`, `invalid_request` paths return the right status codes.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

The new endpoint should land in `docs/custom-tools.md`'s "Authoring today" section once this merges — happy to do that in this PR or as a follow-up.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Tool: Claude Code (Opus 4.7). Skills invoked: `/improving-drf-endpoints` (when annotating the viewset action's response schema).

**Stacked on #66584.** The base branch is `dylan/custom-tools`, not `master` — merging #66584 first will let GitHub auto-rebase this onto `master`. Reviewing this PR's diff in isolation requires #66584's context (the AST validation, the typed-bundle authoring shape, the `capabilities.json` round-trip) — recommend reviewing #66584 first.

**Architectural decision recap** (full version in #66584): janitor gains code execution for v1 because the alternative — a fourth k8s service — buys more architectural purity than it earns at this scale. Single-shot lifecycle (not session-shaped). Pool reuses `selectSandboxPool` from `agent-shared`. If execution duties grow enough to crowd out CRUD (warm pools, latency tuning, separate scaling), the natural next step is to hoist into a dedicated `agent-exec` service — the abstraction is already in shared, so the split is mechanical.

**Scope explicitly deferred:**
- No warm pool yet — every dry-run pays Docker/Modal cold-start. Internal + design-partners can tolerate; revisit if usage signal shows authors clicking "test" hard enough to care.
- No frontend UI consuming this endpoint — that's Phase 4 (Tools tab in agent_platform frontend).
- No rate limiting — relies on the `agents:write` scope for now. Add if abuse appears.