### PR TITLE
feat(batch-import-worker): label capture failures by reason

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "httpmock",
  "lifecycle",
  "metrics",
+ "metrics-util",
  "mockito",
  "moka",
  "natord",

--- a/rust/batch-import-worker/Cargo.toml
+++ b/rust/batch-import-worker/Cargo.toml
@@ -55,3 +55,4 @@ httpmock = { workspace = true }
 flate2 = { workspace = true }
 mockito = { workspace = true }
 tokio-util = { workspace = true }
+metrics-util = { workspace = true }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -9,7 +9,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use common_types::{InternallyCapturedEvent, RawEvent};
 use metrics::counter;
-use posthog_rs::{Client, Event};
+use posthog_rs::{Client, Error as PosthogError, Event};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -147,10 +147,11 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         // earlier ones were accepted, the offset rollback re-sends the whole chunk and
         // re-delivers the accepted events — bounded over-delivery we accept over skipping data.
         let batches = split_into_byte_limited_batches(events)?;
+        let num_batches = batches.len();
 
         info!(
             count,
-            batches = batches.len(),
+            batches = num_batches,
             ?txn_elapsed,
             ?min_duration,
             ?to_sleep,
@@ -160,19 +161,47 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         for batch in batches {
             let batch_count = batch.len();
             if let Err(e) = self.client.capture_batch(batch, true).await {
-                counter!("capture_batch_events_total", "outcome" => "failure")
+                // The worker is the only place that sees per-event loss attributed to a
+                // reason: capture counts requests, not events, and a failed import sub-batch
+                // can carry thousands of events. `reason` lets alerting exclude expected
+                // quota (402) drops and act on transport/server/bad_request failures.
+                let reason = failure_reason(&e);
+                counter!("capture_batch_events_total", "outcome" => "failure", "reason" => reason)
                     .increment(batch_count as u64);
+                counter!("capture_batch_requests_total", "outcome" => "failure", "reason" => reason)
+                    .increment(1);
                 return Err(Error::msg(format!("capture batch failed: {e}")));
             }
         }
 
         // Count success once per fully-committed chunk. A mid-chunk failure rolls the offset
         // back and re-sends the whole chunk on retry, so counting per sub-batch would inflate
-        // the success total across retries.
+        // the success total across retries. The request counter follows the same rule: only
+        // the fully-committed chunk's sub-batches are counted as successful requests.
         counter!("capture_batch_events_total", "outcome" => "success").increment(count as u64);
+        counter!("capture_batch_requests_total", "outcome" => "success")
+            .increment(num_batches as u64);
 
         info!(count, "successfully sent batch to capture");
         Ok(to_sleep)
+    }
+}
+
+/// Maps a posthog-rs capture error to a bounded `&'static str` failure reason for
+/// metrics. The split is what makes worker-side alerting actionable: `quota` (HTTP
+/// 402) is expected billing enforcement and is excluded from alerts, while
+/// transport / server / bad_request failures are real ingestion problems. The
+/// `_` arm is required because `posthog_rs::Error` is `#[non_exhaustive]`.
+fn failure_reason(err: &PosthogError) -> &'static str {
+    match err {
+        PosthogError::BillingLimitExceeded(_) => "quota", // 402
+        PosthogError::BadRequest(_) => "bad_request",     // 400 / 413 (malformed / oversize)
+        PosthogError::ServerError { .. } => "server_error", // 5xx
+        PosthogError::RateLimit => "rate_limited",        // 429
+        PosthogError::Unauthorized => "unauthorized",     // 401
+        PosthogError::Connection(_) => "transport",       // network / unexpected status
+        PosthogError::Serialization(_) => "serialization", // local encode failure
+        _ => "other",
     }
 }
 
@@ -696,5 +725,214 @@ mod tests {
 
         let events = txn.events.lock().unwrap();
         assert_eq!(events.len(), 2, "only the first event per uuid is kept");
+    }
+
+    // --- failure-reason labeling + per-request counters ---
+
+    #[test]
+    fn failure_reason_maps_every_variant() {
+        // The exact tag for each variant is a metric contract consumed by the
+        // dashboard/alerts (quota MUST be separable from actionable failures).
+        let cases: &[(PosthogError, &str)] = &[
+            (PosthogError::BillingLimitExceeded("x".into()), "quota"),
+            (PosthogError::BadRequest("x".into()), "bad_request"),
+            (
+                PosthogError::ServerError {
+                    status: 503,
+                    message: "x".into(),
+                },
+                "server_error",
+            ),
+            (PosthogError::RateLimit, "rate_limited"),
+            (PosthogError::Unauthorized, "unauthorized"),
+            (PosthogError::Connection("x".into()), "transport"),
+            (PosthogError::Serialization("x".into()), "serialization"),
+            // A variant capture_batch never returns still maps safely via the
+            // non_exhaustive catch-all rather than panicking.
+            (PosthogError::NotInitialized, "other"),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(failure_reason(err), *expected, "reason for {err:?}");
+        }
+    }
+
+    /// Runs `f` under a local metrics recorder and returns every counter that
+    /// fired, as (name, labels, value). current_thread flavor keeps the
+    /// thread-local recorder visible across awaits.
+    async fn counters_after<F, Fut>(
+        f: F,
+    ) -> Vec<(String, std::collections::HashMap<String, String>, u64)>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+        f().await;
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _, _, value)| match value {
+                DebugValue::Counter(c) => {
+                    let labels = key
+                        .key()
+                        .labels()
+                        .map(|l| (l.key().to_string(), l.value().to_string()))
+                        .collect();
+                    Some((key.key().name().to_string(), labels, c))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn counter_value(
+        snap: &[(String, std::collections::HashMap<String, String>, u64)],
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> Option<u64> {
+        snap.iter()
+            .find(|(n, got, _)| {
+                n == name
+                    && labels
+                        .iter()
+                        .all(|(k, v)| got.get(*k).map(String::as_str) == Some(*v))
+            })
+            .map(|(_, _, c)| *c)
+    }
+
+    async fn commit_against_status(
+        status: usize,
+        body: &str,
+    ) -> Vec<(String, std::collections::HashMap<String, String>, u64)> {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/i/v1/analytics/events")
+            .with_status(status)
+            .with_body(body)
+            .create();
+
+        counters_after(|| async {
+            let client = make_client(&server.url()).await;
+            let txn = make_transaction(&client);
+            assert!(
+                txn.commit_write().await.is_err(),
+                "status {status} must fail the commit"
+            );
+        })
+        .await
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bad_request_failure_labels_events_and_requests() {
+        // 400/413 -> bad_request on BOTH the per-event and per-request counters;
+        // events charged the full sub-batch (here 1), requests charged once.
+        let snap = commit_against_status(400, "bad request").await;
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            Some(1)
+        );
+        // No success was recorded for a failed chunk.
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "success")]
+            ),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn quota_failure_is_separable_from_actionable_failures() {
+        // The alerting-critical case: 402 must surface as reason="quota" so it
+        // can be excluded from actionable-failure alerts.
+        let snap = commit_against_status(402, "billing limit exceeded").await;
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "quota")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn success_counts_events_total_and_requests_per_subbatch() {
+        // A chunk that splits into >1 sub-batch must count success once per event
+        // (count) and once per sub-batch request (num_batches), not per event for
+        // both — proving the request counter tracks requests, not events.
+        let events: Vec<Event> = (0..5).map(|_| padded_event(2_500_000)).collect();
+        let expected_requests = split_into_byte_limited_batches(events.clone())
+            .unwrap()
+            .len();
+        assert!(
+            expected_requests > 1,
+            "test must exercise multiple requests"
+        );
+        let total = events.len() as u64;
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/i/v1/analytics/events")
+            .with_status(200)
+            .with_body(V1_OK_BODY)
+            .expect(expected_requests)
+            .create();
+
+        let snap = counters_after(|| async {
+            let client = make_client(&server.url()).await;
+            let txn = Box::new(CaptureTransaction {
+                client: &client,
+                send_rate: 10_000,
+                start: Instant::now(),
+                events: Mutex::new(events),
+                seen_uuids: Mutex::new(HashSet::new()),
+            });
+            txn.commit_write().await.unwrap();
+        })
+        .await;
+
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "success")]
+            ),
+            Some(total)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "success")]
+            ),
+            Some(expected_requests as u64)
+        );
     }
 }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -798,6 +798,9 @@ mod tests {
         snap.iter()
             .find(|(n, got, _)| {
                 n == name
+                    // Exact label-set match (not subset): a future stray label on a
+                    // counter must not silently satisfy a narrower query.
+                    && got.len() == labels.len()
                     && labels
                         .iter()
                         .all(|(k, v)| got.get(*k).map(String::as_str) == Some(*v))
@@ -864,6 +867,24 @@ mod tests {
         // The alerting-critical case: 402 must surface as reason="quota" so it
         // can be excluded from actionable-failure alerts.
         let snap = commit_against_status(402, "billing limit exceeded").await;
+        // capture_batch_events_total is the primary per-event-loss metric, so the
+        // quota split has to hold there too — not just on the request counter.
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "quota")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            None
+        );
         assert_eq!(
             counter_value(
                 &snap,


### PR DESCRIPTION
## Problem

When the batch-import worker posts events to capture v1, a failed sub-batch was counted only as `capture_batch_events_total{outcome="failure"}` with no reason. So an import that is simply hitting its billing quota (HTTP 402, expected) looked identical to capture being down (5xx / transport, actionable). The worker is the **only** place that can attribute per-event loss — capture counts *requests*, and a single failed import sub-batch can carry thousands of events — so this is where the actionable-vs-expected split has to live.

## Changes

- Derive a bounded `&'static str` reason from the typed `posthog_rs::Error` variant returned by `capture_batch`: `quota` (402), `bad_request` (400/413), `server_error` (5xx), `transport` (network/unexpected), `rate_limited` (429), `unauthorized` (401), `serialization`, and `other` (non-exhaustive catch-all).
- Tag the existing `capture_batch_events_total` failures with `reason`, and add a new per-request `capture_batch_requests_total{outcome[,reason]}` for request rate and failure ratio.
  - Success is counted once per fully-committed sub-batch (matching the existing once-per-chunk event-success rule that avoids retry inflation); failure once per failed request.
- No `posthog-rs` change and no response-body parsing: 0.13.3 already maps statuses to typed `Error` variants via `Error::from_http_response`, so the split is free.

## How did you test this code?

I am an agent. Automated tests only — no manual testing.

`cargo test -p batch-import-worker --lib emit::capture` (21 passed), `cargo fmt`, `cargo clippy -p batch-import-worker --lib --tests` clean. New tests:
- `failure_reason_maps_every_variant` — table test pinning the exact tag for every `posthog_rs::Error` variant (the metric contract; quota must stay separable).
- `bad_request_failure_labels_events_and_requests` — 400 tags both counters `reason=bad_request`, events charged the full sub-batch, requests charged once, and no success counter fires on a failed chunk.
- `quota_failure_is_separable_from_actionable_failures` — 402 surfaces `reason=quota` and not `bad_request` (the alerting-critical separation).
- `success_counts_events_total_and_requests_per_subbatch` — multi-sub-batch success counts events by total and requests by sub-batch count (proves the request counter tracks requests, not events).

## Docs update

N/A — internal metrics; the companion grafana-dashboards worker board consumes them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @eli-r-ph

Authored with Cursor (Claude Opus) as part of a two-plan effort to remove capture v1 / batch-import observability blind spots. Key finding during implementation: the plan had assumed worker errors were effectively stringly-typed and quota could not be separated worker-side without an upstream change. Reading `posthog-rs` 0.13.3 disproved that — `Error` is a clean typed enum — so the worker can label failures by reason for free, which removes the need for any capture-side import-attribution hacks. The `non_exhaustive` enum is handled with a catch-all `other` arm. No repo skills were required.
