### PR TITLE
fix(salesforce): retry transient token-request lock with in-process backoff

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/auth.py
@@ -1,3 +1,4 @@
+import time
 from datetime import UTC, datetime, timedelta
 from typing import Any, Optional
 
@@ -75,20 +76,38 @@ class SalesforceAuthRequestError(Exception):
         raise cls(error_message, response=response)
 
 
+# Salesforce serializes OAuth token requests per connected app: when a refresh for the same app
+# arrives while another is still in flight (parallel schema syncs sharing one connection commonly
+# do this), it rejects the duplicate with a 400 "token request is already being processed". The
+# lock clears in moments, so a short in-process backoff recovers without failing the whole import
+# activity — which would otherwise restart pagination and surface captured error-tracking noise.
+_TRANSIENT_TOKEN_REQUEST_ERROR = "token request is already being processed"
+_MAX_TOKEN_REFRESH_ATTEMPTS = 4
+
+
 def salesforce_refresh_access_token(refresh_token: str, instance_url: str) -> str:
-    res = make_tracked_session().post(
-        f"{instance_url}/services/oauth2/token",
-        data={
-            "grant_type": "refresh_token",
-            "client_id": settings.SALESFORCE_CONSUMER_KEY,
-            "client_secret": settings.SALESFORCE_CONSUMER_SECRET,
-            "refresh_token": refresh_token,
-        },
-    )
+    attempt = 0
+    while True:
+        res = make_tracked_session().post(
+            f"{instance_url}/services/oauth2/token",
+            data={
+                "grant_type": "refresh_token",
+                "client_id": settings.SALESFORCE_CONSUMER_KEY,
+                "client_secret": settings.SALESFORCE_CONSUMER_SECRET,
+                "refresh_token": refresh_token,
+            },
+        )
 
-    SalesforceAuthRequestError.raise_from_response(res)
+        try:
+            SalesforceAuthRequestError.raise_from_response(res)
+        except SalesforceAuthRequestError as err:
+            attempt += 1
+            if attempt >= _MAX_TOKEN_REFRESH_ATTEMPTS or _TRANSIENT_TOKEN_REQUEST_ERROR not in str(err):
+                raise
+            time.sleep(min(0.5 * attempt, 5))
+            continue
 
-    return res.json()["access_token"]
+        return res.json()["access_token"]
 
 
 def get_salesforce_access_token_from_code(code: str, redirect_uri: str, instance_url: str) -> tuple[str, str]:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
@@ -149,12 +149,13 @@ def test_refresh_raises_transient_token_request_after_exhausting_retries():
         ),
         unittest.mock.patch(
             "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
-        ),
+        ) as mock_sleep,
         pytest.raises(auth.SalesforceAuthRequestError) as exc,
     ):
         _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
 
     assert "token request is already being processed" in str(exc.value)
+    assert mock_sleep.call_count == auth._MAX_TOKEN_REFRESH_ATTEMPTS - 1
 
 
 def test_refresh_does_not_retry_non_transient_error():

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/salesforce/test/test_auth.py
@@ -100,6 +100,87 @@ def test_get_salesforce_access_token_from_code_raises_on_server_failure():
     assert response_body in str(exc.value)
 
 
+def _token_response(status_code: int, body: dict) -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = json.dumps(body).encode("utf-8")
+    return response
+
+
+def _session_returning(responses: list[requests.Response]):
+    it = iter(responses)
+    return type("_S", (), {"post": staticmethod(lambda *a, **k: next(it))})()
+
+
+def test_refresh_retries_transient_token_request_then_succeeds():
+    # Salesforce locks concurrent token requests with a 400 "token request is already being
+    # processed"; the lock clears, so a retry should recover instead of failing the sync.
+    responses = [
+        _token_response(400, {"error_description": "token request is already being processed"}),
+        _token_response(400, {"error_description": "token request is already being processed"}),
+        _token_response(200, {"access_token": "fresh-token"}),
+    ]
+
+    with (
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=_session_returning(responses),
+        ),
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
+        ) as mock_sleep,
+    ):
+        token = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    assert token == "fresh-token"
+    assert mock_sleep.call_count == 2
+
+
+def test_refresh_raises_transient_token_request_after_exhausting_retries():
+    responses = [
+        _token_response(400, {"error_description": "token request is already being processed"})
+        for _ in range(auth._MAX_TOKEN_REFRESH_ATTEMPTS)
+    ]
+
+    with (
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=_session_returning(responses),
+        ),
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
+        ),
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    assert "token request is already being processed" in str(exc.value)
+
+
+def test_refresh_does_not_retry_non_transient_error():
+    # A permanent auth failure must not be retried — it surfaces immediately for the
+    # non-retryable classifier to catch.
+    responses = [
+        _token_response(400, {"error_description": "expired access/refresh token"}),
+        _token_response(200, {"access_token": "should-not-be-reached"}),
+    ]
+
+    with (
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.make_tracked_session",
+            return_value=_session_returning(responses),
+        ),
+        unittest.mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.salesforce.auth.time.sleep"
+        ) as mock_sleep,
+        pytest.raises(auth.SalesforceAuthRequestError) as exc,
+    ):
+        _ = auth.salesforce_refresh_access_token("something", "https://login.salesforce.com")
+
+    assert "expired access/refresh token" in str(exc.value)
+    assert mock_sleep.call_count == 0
+
+
 @pytest.mark.parametrize(
     "error_description",
     [


### PR DESCRIPTION
## Problem

Salesforce data-warehouse imports surfaced a `SalesforceAuthRequestError` from the source's token-refresh path:

> `400 Client Error: Bad Request: token request is already being processed`

Error-tracking issue: https://us.posthog.com/project/2/error_tracking/019f153b-5373-7973-9acc-9f0ce8999551

Salesforce serializes OAuth token requests per connected app. When a refresh for the same app arrives while another is still in flight, it rejects the duplicate with this 400. Parallel schema syncs sharing one Salesforce connection each spin up their own auth and can refresh concurrently, which trips the lock. It's transient — the lock clears in moments and a retry succeeds.

The stack confirmed the failure originates in this source: `auth.py` `__call__` → `obtain_token` → `salesforce_refresh_access_token` → `raise_from_response`, driven from the import pipeline during pagination.

## Changes

`salesforce_refresh_access_token` now retries this specific transient response in-process with a short bounded backoff (up to 4 attempts) before giving up.

Why a retry and not `NonRetryableErrors`: this is a transient upstream condition, not a permanent credential/config failure, so it must stay retryable. And the token-refresh `POST` is not covered by the tracked session's default retry policy (POST and 400 are both excluded), so without this the transient blip failed the whole import activity — restarting pagination and surfacing captured error-tracking noise — even though the next attempt would have worked. A non-transient auth failure (e.g. an expired/revoked token) still raises on the first attempt so the existing non-retryable classifier catches it. This mirrors the in-process transient-retry pattern already used in other warehouse sources.

Matching is on the stable substring `token request is already being processed`, not any volatile per-request value.

## How did you test this code?

I'm an agent. I could not run the suite in this environment (Python deps/flox unavailable), so I:

- Validated the retry loop logic against a faithful standalone simulation of the same control flow (retry-then-succeed, exhaust-and-raise, non-transient-raises-immediately).
- Added unit tests in `test_auth.py` covering the three cases, with `time.sleep` patched.
- Ran `ruff check` and `ruff format --check` (both clean) and `py_compile` on both files.

New tests catch a regression no existing test covered: a transient token-request lock must be retried and recover, must eventually raise if it never clears, and a non-transient error must not be retried.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue and full stack trace via the PostHog error-tracking MCP tools, read the salesforce source and the shared HTTP transport / import-activity error handling to classify the failure, and checked open PRs (including the maintainer's) to rule out a duplicate.

Decision: transient upstream error, not a permanent user/upstream failure → in-process retry with backoff rather than extending `NonRetryableErrors` or changing any global retry policy. Scoped strictly to the token-refresh helper.
