### PR TITLE
chore(devex): add writing-tests path-rule for /writing-tests skill

### DIFF
--- a/.claude/rules/writing-tests.md
+++ b/.claude/rules/writing-tests.md
@@ -8,8 +8,16 @@ paths:
   - '**/*.spec.tsx'
 ---
 
-If this change adds a new test or substantially alters an existing one, invoke the
-`/writing-tests` skill before making changes. The skill carries the "what regression
-does this catch?" value gate, the "don't write it" decision tree, and the rule to
-parameterize near-duplicate cases. Touching a test file for an unrelated reason
-(rename, formatter, import sort) does not require the skill.
+Agents have a track record of shipping low-value tests here — change-detector
+assertions, redundant near-duplicate cases, sleep-laden waits, and zero-assertion
+mock choreography. Do not add to the pile.
+
+If this change adds a new test or substantially alters an existing one, you MUST
+invoke the `/writing-tests` skill before writing it. Every test earns its place:
+name the realistic regression it catches that no existing test already does — if
+you can't name one, do not write it. Collapse near-duplicates into parameterized
+cases, assert observable behavior through the public interface (never implementation
+details), and keep it deterministic and fast (no sleeps, no real network, cheapest
+level that catches the bug).
+
+Touching a test file for an unrelated reason (rename, formatter, import sort) is exempt.

--- a/.claude/rules/writing-tests.md
+++ b/.claude/rules/writing-tests.md
@@ -9,16 +9,13 @@ paths:
   - '**/*.spec.tsx'
 ---
 
-Agents have a track record of shipping low-value tests here — change-detector
-assertions, redundant near-duplicate cases, sleep-laden waits, and zero-assertion
-mock choreography. Do not add to the pile.
+Agents keep shipping low-value test bloat here — change-detector assertions,
+redundant near-duplicates, sleep-laden waits, zero-assertion mock choreography.
 
 If this change adds a new test or substantially alters an existing one, you MUST
-invoke the `/writing-tests` skill before writing it. Every test earns its place:
-name the realistic regression it catches that no existing test already does — if
-you can't name one, do not write it. Collapse near-duplicates into parameterized
-cases, assert observable behavior through the public interface (never implementation
-details), and keep it deterministic and fast (no sleeps, no real network, cheapest
-level that catches the bug).
+invoke the `/writing-tests` skill before writing it. It carries the value gate
+("what realistic regression does this catch that no existing test does?"), the
+"don't write it" decision tree, and the efficiency bar. Do not skip it because the
+change looks small.
 
 Touching a test file for an unrelated reason (rename, formatter, import sort) is exempt.

--- a/.claude/rules/writing-tests.md
+++ b/.claude/rules/writing-tests.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - '**/test_*.py'
+  - '**/*_test.py'
+  - '**/*.test.ts'
+  - '**/*.test.tsx'
+  - '**/*.spec.ts'
+  - '**/*.spec.tsx'
+---
+
+If this change adds a new test or substantially alters an existing one, invoke the
+`/writing-tests` skill before making changes. The skill carries the "what regression
+does this catch?" value gate, the "don't write it" decision tree, and the rule to
+parameterize near-duplicate cases. Touching a test file for an unrelated reason
+(rename, formatter, import sort) does not require the skill.

--- a/.claude/rules/writing-tests.md
+++ b/.claude/rules/writing-tests.md
@@ -2,6 +2,7 @@
 paths:
   - '**/test_*.py'
   - '**/*_test.py'
+  - '**/tests.py'
   - '**/*.test.ts'
   - '**/*.test.tsx'
   - '**/*.spec.ts'


### PR DESCRIPTION
## Problem

`/writing-tests` is marked "Always invoke" in AGENTS.md but is the only one of the 5 always-invoke skills with no companion `.claude/rules/*.md` path-trigger. Agents editing test files miss the path-gated prompt that DRF, Django/ClickHouse migrations, and generated-types changes get.

## Changes

One file: `.claude/rules/writing-tests.md`. Globs cover pytest, Jest, and Playwright tests repo-wide; the conditional body only signals intent when a test is added or substantially changed (not renames/formatters). Follows the skill+rule precedent of [kea-disposables](https://github.com/PostHog/posthog/pull/58371) and [storybook-feature-flags](https://github.com/PostHog/posthog/pull/60775).

## How did you test this code?

Agent-authored, no executable code. Verified the 9 existing rules share the same frontmatter, that `writing-tests` is the only always-invoke skill missing a rule, and that no lint-staged/CI check validates `.claude/rules/`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code. Broadened the Jest globs repo-wide (the originally-proposed scope missed ~700 test files outside `frontend/src` and `products/*/frontend`) and dropped an over-broad `**/tests/**/*.py` glob that would fire on conftest/fixtures.
