### PR TITLE
chore(signals): steer report scouts to resolve reviewer github logins

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -332,6 +332,13 @@ unactioned.
   recent authors on the relevant surface, the team that owns the product) to name
   the right GitHub logins. Treat "I couldn't find an owner" as a last resort, not
   a default.
+- **Resolve the GitHub login — never guess it.** Entries must be bare, lowercase
+  GitHub logins, and the inbox routes by matching them exactly, so a guessed,
+  mis-cased, or display-name handle reaches no one. The owner you identify is
+  usually a PostHog member, not a handle: call `org-member-get-github-login` with
+  their user UUID (from `org-members-list`, or `@me`) to turn that member into
+  their linked GitHub login. If you can't resolve a confident login, leave the
+  field empty rather than inventing one.
 - **Set `priority` + `priority_explanation`** when the issue is concrete and you
   can justify the urgency — autostart needs a priority to consider a draft PR.
 - **Set `repository`** (`owner/repo`) when you know where a fix would land — pass

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -217,6 +217,9 @@ class TestPromptBuilder(BaseTest):
         assert "inbox-reports-list" in prompt
         assert "Suggested reviewers route the report" in prompt
         assert "suggested_reviewers" in prompt
+        # Reviewer routing only works with a real GitHub login, so the prompt must point the scout
+        # at the resolver tool rather than letting it guess a handle.
+        assert "org-member-get-github-login" in prompt
         # The report channel teaches that the `report:` scratchpad entry is a pointer
         # into the inbox, not a copy of the report — the inbox stays the source of
         # truth, so the scout retrieves the live report before editing. Dropping this
@@ -262,6 +265,8 @@ class TestPromptBuilder(BaseTest):
         assert "Editing existing reports" in prompt
         assert "Suggested reviewers route the report" not in prompt
         assert "Writing the report" not in prompt
+        # The reviewer-resolution guidance rides the author-time section, so it drops with it.
+        assert "org-member-get-github-login" not in prompt
 
 
 # Orchestration tests run as plain pytest functions because the async runner uses

--- a/products/signals/skills/authoring-signals-scouts/references/report-contract.md
+++ b/products/signals/skills/authoring-signals-scouts/references/report-contract.md
@@ -116,12 +116,12 @@ resolve it, cheapest source first:
    login directly: CODEOWNERS entries are often **team** slugs (`@your-org/team-name`) and `git log`
    gives a name + email — both must be resolved to an **individual** GitHub login before you write
    the reviewer (a team slug or an email won't match any user).
-4. **`org-members-list`** — only where the run has organization scope. It needs
-   `organization_member:read`, which **headless scout runs scoped to a single team don't have**, so
-   the tool is typically **absent from a scout's toolset**; don't build a scout's reviewer recipe
-   around it. Where it _is_ available it confirms a person exists and gives their canonical name +
-   account email (useful to **disambiguate or spell** a name) — but it still does **not** return a
-   GitHub login, so treat it as a corroboration aid, never as the source of the handle.
+4. **`org-member-get-github-login`** — the canonical login resolver, available to every scout run
+   (it needs only `organization_member:read`, which scout tokens carry). Once you've identified the
+   owning **person** — by name/email via `org-members-list`, or `@me` for the current user — pass
+   their PostHog user UUID to this tool to get their linked GitHub login (it returns null when the
+   member has no GitHub identity linked). This is the one step that actually hands you a usable
+   handle, so prefer it over guessing when steps 1–3 only give you a person rather than a login.
 
 **If you can't resolve a confident login, leave `suggested_reviewers` empty** — the report still
 surfaces for a human to grab. **Never guess a handle**: a wrong login mis-assigns the report (or


### PR DESCRIPTION
## Problem

Report-emitting Signals scouts set `suggested_reviewers`, which is what actually routes a report to a human who can act on it. Entries must be bare, lowercase GitHub logins that the inbox matches exactly — but a scout usually identifies an *owner* (a PostHog member, a code-owner, a recent author), not a handle. The prompt told scouts to "name the right GitHub logins" without telling them how to resolve one, and the authoring reference actively claimed the org-member tools were "typically absent" from a scout's toolset — which is no longer true (scout tokens carry `organization_member:read`). The result is guessed or mis-cased handles that route to no one.

## Changes

- Harness report-authoring prompt (`_SUGGESTED_REVIEWERS_REPORT`): added a step telling emit-capable scouts to resolve the GitHub login via `org-member-get-github-login` (passing the member's user UUID from `org-members-list`, or `@me`) rather than guessing, and to leave the field empty when no confident login resolves.
- Authoring-scouts reviewer-resolution reference (`report-contract.md`): replaced the stale "`org-members-list` is typically absent" rung with `org-member-get-github-login` as the canonical login resolver available to every scout run.
- The guidance rides the author-time section only (reviewer routing is an emit-time concern — `edit_report` takes no `suggested_reviewers`), so it appears for emit/both scouts and is dropped for edit-only ones.

## How did you test this code?

I'm an agent. I added assertions to the existing prompt-builder tests in `test_scout_harness.py` covering that `org-member-get-github-login` appears in the report-channel and emit-only prompts and is absent from the edit-only prompt — guarding against the guidance drifting onto the wrong capability. I could not execute the DB-backed tests in this environment (no Postgres available); I verified the edited files compile and pass `ruff check`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by the PostHog Slack app at a maintainer's request. Before editing, confirmed via codebase exploration that report-channel scout tokens resolve to `MCP_READ_SCOPES`, which includes `organization_member:read` — so `org-member-get-github-login` is genuinely callable from a scout sandbox (this is what made the prior "tool absent" guidance stale and motivated the change). Also verified `edit_report` has no `suggested_reviewers` parameter, confirming the guidance belongs only on the emit-capable prompt path. No skills were invoked.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B89UWRJDP/p1782772624946109)*
