### PR TITLE
feat(batch-import-worker): count pre-sink event drops and chunk errors

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1305,6 +1305,7 @@ dependencies = [
  "httpmock",
  "lifecycle",
  "metrics",
+ "metrics-util",
  "mockito",
  "moka",
  "natord",

--- a/rust/batch-import-worker/Cargo.toml
+++ b/rust/batch-import-worker/Cargo.toml
@@ -55,3 +55,4 @@ httpmock = { workspace = true }
 flate2 = { workspace = true }
 mockito = { workspace = true }
 tokio-util = { workspace = true }
+metrics-util = { workspace = true }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -9,7 +9,7 @@ use anyhow::Error;
 use async_trait::async_trait;
 use common_types::{InternallyCapturedEvent, RawEvent};
 use metrics::counter;
-use posthog_rs::{Client, Event};
+use posthog_rs::{Client, Error as PosthogError, Event};
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -147,10 +147,11 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         // earlier ones were accepted, the offset rollback re-sends the whole chunk and
         // re-delivers the accepted events — bounded over-delivery we accept over skipping data.
         let batches = split_into_byte_limited_batches(events)?;
+        let num_batches = batches.len();
 
         info!(
             count,
-            batches = batches.len(),
+            batches = num_batches,
             ?txn_elapsed,
             ?min_duration,
             ?to_sleep,
@@ -160,19 +161,47 @@ impl<'a> Transaction<'a> for CaptureTransaction<'a> {
         for batch in batches {
             let batch_count = batch.len();
             if let Err(e) = self.client.capture_batch(batch, true).await {
-                counter!("capture_batch_events_total", "outcome" => "failure")
+                // The worker is the only place that sees per-event loss attributed to a
+                // reason: capture counts requests, not events, and a failed import sub-batch
+                // can carry thousands of events. `reason` lets alerting exclude expected
+                // quota (402) drops and act on transport/server/bad_request failures.
+                let reason = failure_reason(&e);
+                counter!("capture_batch_events_total", "outcome" => "failure", "reason" => reason)
                     .increment(batch_count as u64);
+                counter!("capture_batch_requests_total", "outcome" => "failure", "reason" => reason)
+                    .increment(1);
                 return Err(Error::msg(format!("capture batch failed: {e}")));
             }
         }
 
         // Count success once per fully-committed chunk. A mid-chunk failure rolls the offset
         // back and re-sends the whole chunk on retry, so counting per sub-batch would inflate
-        // the success total across retries.
+        // the success total across retries. The request counter follows the same rule: only
+        // the fully-committed chunk's sub-batches are counted as successful requests.
         counter!("capture_batch_events_total", "outcome" => "success").increment(count as u64);
+        counter!("capture_batch_requests_total", "outcome" => "success")
+            .increment(num_batches as u64);
 
         info!(count, "successfully sent batch to capture");
         Ok(to_sleep)
+    }
+}
+
+/// Maps a posthog-rs capture error to a bounded `&'static str` failure reason for
+/// metrics. The split is what makes worker-side alerting actionable: `quota` (HTTP
+/// 402) is expected billing enforcement and is excluded from alerts, while
+/// transport / server / bad_request failures are real ingestion problems. The
+/// `_` arm is required because `posthog_rs::Error` is `#[non_exhaustive]`.
+fn failure_reason(err: &PosthogError) -> &'static str {
+    match err {
+        PosthogError::BillingLimitExceeded(_) => "quota", // 402
+        PosthogError::BadRequest(_) => "bad_request",     // 400 / 413 (malformed / oversize)
+        PosthogError::ServerError { .. } => "server_error", // 5xx
+        PosthogError::RateLimit => "rate_limited",        // 429
+        PosthogError::Unauthorized => "unauthorized",     // 401
+        PosthogError::Connection(_) => "transport",       // network / unexpected status
+        PosthogError::Serialization(_) => "serialization", // local encode failure
+        _ => "other",
     }
 }
 
@@ -696,5 +725,214 @@ mod tests {
 
         let events = txn.events.lock().unwrap();
         assert_eq!(events.len(), 2, "only the first event per uuid is kept");
+    }
+
+    // --- failure-reason labeling + per-request counters ---
+
+    #[test]
+    fn failure_reason_maps_every_variant() {
+        // The exact tag for each variant is a metric contract consumed by the
+        // dashboard/alerts (quota MUST be separable from actionable failures).
+        let cases: &[(PosthogError, &str)] = &[
+            (PosthogError::BillingLimitExceeded("x".into()), "quota"),
+            (PosthogError::BadRequest("x".into()), "bad_request"),
+            (
+                PosthogError::ServerError {
+                    status: 503,
+                    message: "x".into(),
+                },
+                "server_error",
+            ),
+            (PosthogError::RateLimit, "rate_limited"),
+            (PosthogError::Unauthorized, "unauthorized"),
+            (PosthogError::Connection("x".into()), "transport"),
+            (PosthogError::Serialization("x".into()), "serialization"),
+            // A variant capture_batch never returns still maps safely via the
+            // non_exhaustive catch-all rather than panicking.
+            (PosthogError::NotInitialized, "other"),
+        ];
+        for (err, expected) in cases {
+            assert_eq!(failure_reason(err), *expected, "reason for {err:?}");
+        }
+    }
+
+    /// Runs `f` under a local metrics recorder and returns every counter that
+    /// fired, as (name, labels, value). current_thread flavor keeps the
+    /// thread-local recorder visible across awaits.
+    async fn counters_after<F, Fut>(
+        f: F,
+    ) -> Vec<(String, std::collections::HashMap<String, String>, u64)>
+    where
+        F: FnOnce() -> Fut,
+        Fut: std::future::Future<Output = ()>,
+    {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+        f().await;
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _, _, value)| match value {
+                DebugValue::Counter(c) => {
+                    let labels = key
+                        .key()
+                        .labels()
+                        .map(|l| (l.key().to_string(), l.value().to_string()))
+                        .collect();
+                    Some((key.key().name().to_string(), labels, c))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    fn counter_value(
+        snap: &[(String, std::collections::HashMap<String, String>, u64)],
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> Option<u64> {
+        snap.iter()
+            .find(|(n, got, _)| {
+                n == name
+                    && labels
+                        .iter()
+                        .all(|(k, v)| got.get(*k).map(String::as_str) == Some(*v))
+            })
+            .map(|(_, _, c)| *c)
+    }
+
+    async fn commit_against_status(
+        status: usize,
+        body: &str,
+    ) -> Vec<(String, std::collections::HashMap<String, String>, u64)> {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/i/v1/analytics/events")
+            .with_status(status)
+            .with_body(body)
+            .create();
+
+        counters_after(|| async {
+            let client = make_client(&server.url()).await;
+            let txn = make_transaction(&client);
+            assert!(
+                txn.commit_write().await.is_err(),
+                "status {status} must fail the commit"
+            );
+        })
+        .await
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn bad_request_failure_labels_events_and_requests() {
+        // 400/413 -> bad_request on BOTH the per-event and per-request counters;
+        // events charged the full sub-batch (here 1), requests charged once.
+        let snap = commit_against_status(400, "bad request").await;
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            Some(1)
+        );
+        // No success was recorded for a failed chunk.
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "success")]
+            ),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn quota_failure_is_separable_from_actionable_failures() {
+        // The alerting-critical case: 402 must surface as reason="quota" so it
+        // can be excluded from actionable-failure alerts.
+        let snap = commit_against_status(402, "billing limit exceeded").await;
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "quota")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            None
+        );
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn success_counts_events_total_and_requests_per_subbatch() {
+        // A chunk that splits into >1 sub-batch must count success once per event
+        // (count) and once per sub-batch request (num_batches), not per event for
+        // both — proving the request counter tracks requests, not events.
+        let events: Vec<Event> = (0..5).map(|_| padded_event(2_500_000)).collect();
+        let expected_requests = split_into_byte_limited_batches(events.clone())
+            .unwrap()
+            .len();
+        assert!(
+            expected_requests > 1,
+            "test must exercise multiple requests"
+        );
+        let total = events.len() as u64;
+
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("POST", "/i/v1/analytics/events")
+            .with_status(200)
+            .with_body(V1_OK_BODY)
+            .expect(expected_requests)
+            .create();
+
+        let snap = counters_after(|| async {
+            let client = make_client(&server.url()).await;
+            let txn = Box::new(CaptureTransaction {
+                client: &client,
+                send_rate: 10_000,
+                start: Instant::now(),
+                events: Mutex::new(events),
+                seen_uuids: Mutex::new(HashSet::new()),
+            });
+            txn.commit_write().await.unwrap();
+        })
+        .await;
+
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "success")]
+            ),
+            Some(total)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_requests_total",
+                &[("outcome", "success")]
+            ),
+            Some(expected_requests as u64)
+        );
     }
 }

--- a/rust/batch-import-worker/src/emit/capture.rs
+++ b/rust/batch-import-worker/src/emit/capture.rs
@@ -798,6 +798,9 @@ mod tests {
         snap.iter()
             .find(|(n, got, _)| {
                 n == name
+                    // Exact label-set match (not subset): a future stray label on a
+                    // counter must not silently satisfy a narrower query.
+                    && got.len() == labels.len()
                     && labels
                         .iter()
                         .all(|(k, v)| got.get(*k).map(String::as_str) == Some(*v))
@@ -864,6 +867,24 @@ mod tests {
         // The alerting-critical case: 402 must surface as reason="quota" so it
         // can be excluded from actionable-failure alerts.
         let snap = commit_against_status(402, "billing limit exceeded").await;
+        // capture_batch_events_total is the primary per-event-loss metric, so the
+        // quota split has to hold there too — not just on the request counter.
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "quota")]
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            counter_value(
+                &snap,
+                "capture_batch_events_total",
+                &[("outcome", "failure"), ("reason", "bad_request")]
+            ),
+            None
+        );
         assert_eq!(
             counter_value(
                 &snap,

--- a/rust/batch-import-worker/src/parse/format.rs
+++ b/rust/batch-import-worker/src/parse/format.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use anyhow::{Context, Error};
 use chrono::Duration;
 use common_types::{InternallyCapturedEvent, RawEvent};
+use metrics::counter;
 use rayon::iter::IntoParallelIterator;
 use rayon::prelude::*;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -29,6 +30,26 @@ pub enum FormatConfig {
 
 pub type ParserFn =
     Box<dyn Fn(Vec<u8>) -> Result<Parsed<Vec<InternallyCapturedEvent>>, Error> + Send + Sync>;
+
+/// Per-event drops the transform discards as `Ok(None)` (e.g. Mixpanel
+/// `skip_no_distinct_id`, geoip/filter skips) vanish through `filter_map` +
+/// `transpose` with no other signal. Count them so the worker board can see
+/// pre-sink silent loss — the worker is the only place this is observable.
+fn record_transform_drops(format: &'static str, input_len: usize, output_len: usize) {
+    let dropped = input_len.saturating_sub(output_len);
+    if dropped > 0 {
+        counter!("batch_import_events_dropped_total", "format" => format, "stage" => "transform")
+            .increment(dropped as u64);
+    }
+}
+
+/// A chunk that fails to parse or transform aborts the entire chunk and pauses
+/// the job; today that is only visible as a paused job. Count it by stage so a
+/// parse failure (malformed source bytes) is distinguishable from a transform
+/// failure (a record that cannot be mapped) on the board.
+fn record_chunk_error(format: &'static str, stage: &'static str) {
+    counter!("batch_import_chunk_errors_total", "format" => format, "stage" => stage).increment(1);
+}
 
 impl FormatConfig {
     pub async fn get_parser(
@@ -68,19 +89,31 @@ impl FormatConfig {
                 );
 
                 let parser = move |data| {
-                    let parsed: Parsed<Vec<MixpanelEvent>> = format_parse(data)?;
+                    let parsed: Parsed<Vec<MixpanelEvent>> = match format_parse(data) {
+                        Ok(parsed) => parsed,
+                        Err(e) => {
+                            record_chunk_error("mixpanel", "parse");
+                            return Err(e);
+                        }
+                    };
                     let consumed = parsed.consumed;
-                    let result: Result<_, Error> = parsed
+                    let input_len = parsed.data.len();
+                    let result: Result<Vec<_>, Error> = parsed
                         .data
                         .into_par_iter()
                         .map(&event_transform)
                         .filter_map(|x| x.transpose())
                         .collect();
+                    let data = match result {
+                        Ok(data) => data,
+                        Err(e) => {
+                            record_chunk_error("mixpanel", "transform");
+                            return Err(e);
+                        }
+                    };
+                    record_transform_drops("mixpanel", input_len, data.len());
 
-                    Ok(Parsed {
-                        data: result?,
-                        consumed,
-                    })
+                    Ok(Parsed { data, consumed })
                 };
 
                 Ok(Box::new(parser))
@@ -89,21 +122,32 @@ impl FormatConfig {
                 let format_parse = json_nd(*skip_blanks);
                 let event_transform = AmplitudeEvent::parse_fn(transform_context, skip_geoip());
                 let parser = move |data| {
-                    let parsed: Parsed<Vec<AmplitudeEvent>> = format_parse(data)?;
+                    let parsed: Parsed<Vec<AmplitudeEvent>> = match format_parse(data) {
+                        Ok(parsed) => parsed,
+                        Err(e) => {
+                            record_chunk_error("amplitude", "parse");
+                            return Err(e);
+                        }
+                    };
                     let consumed = parsed.consumed;
                     // Propagate the first transform error rather than silently
                     // dropping events (matches the Mixpanel/Captured paths).
                     // Each Amplitude input event may produce multiple output
                     // events (the event itself plus optional identify and group
                     // identify events), so we collect into Vec<Vec<_>> and
-                    // flatten after the error check.
+                    // flatten after the error check. There is no Ok(None) drop
+                    // path here, so no transform-drop count applies.
                     let result: Result<Vec<Vec<_>>, Error> =
                         parsed.data.into_par_iter().map(&event_transform).collect();
+                    let data = match result {
+                        Ok(rows) => rows.into_iter().flatten().collect(),
+                        Err(e) => {
+                            record_chunk_error("amplitude", "transform");
+                            return Err(e);
+                        }
+                    };
 
-                    Ok(Parsed {
-                        data: result?.into_iter().flatten().collect(),
-                        consumed,
-                    })
+                    Ok(Parsed { data, consumed })
                 };
 
                 Ok(Box::new(parser))
@@ -112,19 +156,31 @@ impl FormatConfig {
                 let format_parse = json_nd(*skip_blanks);
                 let event_transform = captured_parse_fn(transform_context, skip_geoip());
                 let parser = move |data| {
-                    let parsed: Parsed<Vec<RawEvent>> = format_parse(data)?;
+                    let parsed: Parsed<Vec<RawEvent>> = match format_parse(data) {
+                        Ok(parsed) => parsed,
+                        Err(e) => {
+                            record_chunk_error("captured", "parse");
+                            return Err(e);
+                        }
+                    };
                     let consumed = parsed.consumed;
-                    let result: Result<_, Error> = parsed
+                    let input_len = parsed.data.len();
+                    let result: Result<Vec<_>, Error> = parsed
                         .data
                         .into_par_iter()
                         .map(&event_transform)
                         .filter_map(|x| x.transpose())
                         .collect();
+                    let data = match result {
+                        Ok(data) => data,
+                        Err(e) => {
+                            record_chunk_error("captured", "transform");
+                            return Err(e);
+                        }
+                    };
+                    record_transform_drops("captured", input_len, data.len());
 
-                    Ok(Parsed {
-                        data: result?,
-                        consumed,
-                    })
+                    Ok(Parsed { data, consumed })
                 };
 
                 Ok(Box::new(parser))
@@ -509,5 +565,74 @@ mod tests {
             msg.contains("comma"),
             "Missing comma should be mentioned: {msg}"
         );
+    }
+
+    fn counter_snapshot<F: FnOnce()>(
+        f: F,
+    ) -> Vec<(String, std::collections::HashMap<String, String>, u64)> {
+        use metrics_util::debugging::{DebugValue, DebuggingRecorder};
+
+        let recorder = DebuggingRecorder::new();
+        let snapshotter = recorder.snapshotter();
+        let _guard = metrics::set_default_local_recorder(&recorder);
+        f();
+        snapshotter
+            .snapshot()
+            .into_vec()
+            .into_iter()
+            .filter_map(|(key, _, _, value)| match value {
+                DebugValue::Counter(c) => {
+                    let labels = key
+                        .key()
+                        .labels()
+                        .map(|l| (l.key().to_string(), l.value().to_string()))
+                        .collect();
+                    Some((key.key().name().to_string(), labels, c))
+                }
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn transform_drops_counted_by_format_and_stage() {
+        // 10 parsed, 7 kept -> the 3 events the transform discarded as Ok(None)
+        // must be counted (this is the silent pre-sink loss the board needs).
+        let snap = counter_snapshot(|| record_transform_drops("mixpanel", 10, 7));
+        let found = snap.iter().find(|(n, l, _)| {
+            n == "batch_import_events_dropped_total"
+                && l.get("format").map(String::as_str) == Some("mixpanel")
+                && l.get("stage").map(String::as_str) == Some("transform")
+        });
+        assert_eq!(found.map(|(_, _, c)| *c), Some(3));
+    }
+
+    #[test]
+    fn transform_drops_not_emitted_when_nothing_dropped() {
+        // No drop -> the series must not fire, so a healthy import does not
+        // create a permanent zero line on the board.
+        let snap = counter_snapshot(|| record_transform_drops("captured", 5, 5));
+        assert!(snap
+            .iter()
+            .all(|(n, _, _)| n != "batch_import_events_dropped_total"));
+    }
+
+    #[test]
+    fn chunk_error_counted_by_stage() {
+        // parse vs transform must stay distinguishable for the board.
+        let snap = counter_snapshot(|| {
+            record_chunk_error("mixpanel", "parse");
+            record_chunk_error("mixpanel", "transform");
+        });
+        let val = |stage: &str| {
+            snap.iter()
+                .find(|(n, l, _)| {
+                    n == "batch_import_chunk_errors_total"
+                        && l.get("stage").map(String::as_str) == Some(stage)
+                })
+                .map(|(_, _, c)| *c)
+        };
+        assert_eq!(val("parse"), Some(1));
+        assert_eq!(val("transform"), Some(1));
     }
 }


### PR DESCRIPTION
## Problem

Before the batch-import worker hands events to the capture sink, the parse/transform stage can lose them with **no metric at all**:

- Events the per-record transform discards as `Ok(None)` (e.g. Mixpanel `skip_no_distinct_id`, geoip/filter skips) vanish through `filter_map` + `transpose`. The worker reads N events and emits M < N, and the `N - M` gap was invisible to every metric and to both the capture-v1 and Batch Import Worker dashboards.
- A chunk that fails to parse or transform aborts the whole chunk and pauses the job — visible only as a paused job, with no counter to say *why* or *how often*.

This is purely worker-internal accounting (not blocked by `posthog-rs`), and the worker is the only place this pre-sink loss is observable.

## Changes

- Add `batch_import_events_dropped_total{format, stage="transform"}`, incremented by `input_len - output_len` in the Mixpanel and Captured parser closures. It only fires when something is actually dropped, so a healthy import does not draw a permanent zero line.
- Add `batch_import_chunk_errors_total{format, stage="parse"|"transform"}` at the chunk-failure boundaries.
- Amplitude expands 1 input into >= 1 outputs and never returns `Ok(None)`, so it has no transform-drop signal; only its chunk-error paths are counted (documented inline).

## How did you test this code?

I am an agent. Automated tests only.

`cargo test -p batch-import-worker --lib parse::format` (9 passed), `cargo fmt`, `cargo clippy` clean. New tests pin the metric name + `{format, stage}` label contract the dashboards depend on:

- `transform_drops_counted_by_format_and_stage` — input 10 / kept 7 -> dropped 3 on the right counter+labels.
- `transform_drops_not_emitted_when_nothing_dropped` — no drop -> no series (no zero baseline).
- `chunk_error_counted_by_stage` — parse vs transform stay distinguishable.

## Docs update

N/A — internal metrics; the companion grafana-dashboards Batch Import Worker board (PR #219) consumes them.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI: @eli-r-ph

Stacked on #66868. Part of the capture-v1 / batch-import observability effort. #66868 closed the *sink-side* failure-attribution gap (capture failures labeled by reason); this closes the *pre-sink* silent-drop gap. Granular per-reason transform-drop labels (e.g. `no_distinct_id` vs `filtered`) are deferred — they need a typed reason threaded out of the transforms; coarse `stage="transform"` covers the blind spot for now.
