### PR TITLE
chore(web-analytics): mark eager precompute warming deprecated

### DIFF
--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -313,7 +313,7 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             # precompute read, not fall through to raw. `preComputeStrategy == LAZY_PRECOMPUTE` is only
             # True when the read passed the lazy executor's TTL freshness filter
             # (`created_at + TTL >= now`, TTL = 2h today … 14d old), so True is a
-            # guarantee the precomputed value is well within the today TTL. A tile
+            # guarantee the precomputed value is well within the current 2h TTL. A tile
             # that comes back `not True` warmed nothing useful — surface it loudly so a
             # stale/missing precompute or a non-precomputable breakdown can't hide.
             if getattr(response, "preComputeStrategy", None) != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE:

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -312,7 +312,8 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             # Self-check the warm actually did its job: the tile must resolve to a
             # precompute read, not fall through to raw. `preComputeStrategy == LAZY_PRECOMPUTE` is only
             # True when the read passed the lazy executor's TTL freshness filter
-            # (`created_at + TTL >= now`, TTL = 2h today … 14d old), so True is a
+            # (`created_at + TTL >= now`; per LAZY_TTL_SECONDS the TTL ranges from 2h for
+            # today's window up to 14d for the oldest windows), so True is a
             # guarantee the precomputed value is well within the current 2h TTL. A tile
             # that comes back `not True` warmed nothing useful — surface it loudly so a
             # stale/missing precompute or a non-precomputable breakdown can't hide.

--- a/products/web_analytics/dags/eager_web_analytics_precompute.py
+++ b/products/web_analytics/dags/eager_web_analytics_precompute.py
@@ -1,5 +1,24 @@
 """Eager web analytics precompute — hourly baseline warming.
 
+.. deprecated::
+    Being wound down — prefer the lazy-on-read path, do not extend this matrix.
+
+    This warmer only covers a *single* point in query-param space (unfiltered
+    `properties=[]`, `filterTestAccounts=True`, `limit=10`, the fixed
+    `BASELINE_BREAKDOWNS`, trailing 31 days). Real dashboards roam the rest of
+    that space — a `$host`/path filter, test-accounts-off, a re-sort, or a
+    larger limit each hashes to a *different* lazy job the warm never builds, so
+    those loads stay cold regardless of how often this runs. Pre-warming the
+    full cross-product is combinatorially impossible.
+
+    The bet has shifted from "warm the baseline" to "make a cold first read
+    cheap": insert-time path cleaning (#65660, collapses path cardinality) and
+    the top-k store cap (#65664) bound the per-read build cost, so reactive
+    lazy-on-read is fast enough on its own. New teams are being enrolled on the
+    lazy path *without* this warmer to validate that. Once that holds, this
+    job + schedule should be deleted outright. Invest in the lazy path, not
+    here.
+
 A single Dagster job that pre-warms the lazy precompute cache for the
 Web analytics dashboard's main tile matrix over the trailing 31 days,
 for every team in the `WEB_ANALYTICS_LAZY_PRECOMPUTE_TEAM_IDS` setting.
@@ -13,7 +32,7 @@ source of truth for freshness.
 
 Force-refresh is used deliberately. The DEFAULT execution mode gates on the
 HogQL query result cache (6h staleness), which is the wrong clock for a
-precompute warmer whose buckets expire on a much shorter TTL (15min for
+precompute warmer whose buckets expire on a much shorter TTL (2h for
 today's bucket) — it would skip tiles whose Redis result is still "fresh"
 while the precompute they feed has gone cold. Force-refresh always recomputes,
 so every tick re-enters the precompute path. Crucially it goes through `run()`
@@ -293,8 +312,8 @@ def _warm_baseline_for_team(context: dagster.OpExecutionContext, team: Team) -> 
             # Self-check the warm actually did its job: the tile must resolve to a
             # precompute read, not fall through to raw. `preComputeStrategy == LAZY_PRECOMPUTE` is only
             # True when the read passed the lazy executor's TTL freshness filter
-            # (`created_at + TTL >= now`, TTL = 15min today … 7d old), so True is a
-            # guarantee the precomputed value is well within the 2h threshold. A tile
+            # (`created_at + TTL >= now`, TTL = 2h today … 14d old), so True is a
+            # guarantee the precomputed value is well within the today TTL. A tile
             # that comes back `not True` warmed nothing useful — surface it loudly so a
             # stale/missing precompute or a non-precomputable breakdown can't hide.
             if getattr(response, "preComputeStrategy", None) != WebAnalyticsPreComputeStrategy.LAZY_PRECOMPUTE:
@@ -499,11 +518,19 @@ def warm_eager_baseline_op(context: dagster.OpExecutionContext) -> dict[str, int
         "dagster/max_runtime": str(90 * 60),
     },
 )
+# DEPRECATED: winding down in favor of the lazy-on-read path — see module
+# docstring. Don't extend the tile matrix here; if you're tempted to warm a new
+# variant, that's the signal the lazy path's cold-read cost is the thing to fix.
 def web_analytics_eager_baseline_warming_job():
     warm_eager_baseline_op()
 
 
 @dagster.schedule(
+    # DEPRECATED: being wound down — see module docstring. The plan is to stop
+    # this schedule and validate teams on the lazy-on-read path alone; once that
+    # holds, delete this schedule + job. Left running (not `default_status`
+    # STOPPED) so the stop is an explicit operational toggle, not a silent
+    # code-deploy behavior change.
     # Hourly. The lazy cache's 2h TTL absorbs a single missed cycle, so
     # there's no need to align with shorter cadences. Offset by 5 min from
     # the top of the hour to avoid colliding with the existing


### PR DESCRIPTION
## Problem

The eager precompute warmer only pre-warms a single point in query-param space (unfiltered baseline, a fixed breakdown set, trailing 31 days). Real dashboards roam the rest — a host/path filter, test-accounts-off, a re-sort, a larger limit each hash to a *different* lazy job the warm never builds, so those loads stay cold regardless of how often it runs. With the lazy path's cold-read cost now bounded (insert-time path cleaning #65660, top-k store cap #65664), reactive lazy-on-read is fast enough on its own.

## Changes

- Deprecation markers: a module-docstring `.. deprecated::` block plus inline `# DEPRECATED` notes on the job and schedule, explaining the wind-down toward lazy-on-read.
- De-staled two outdated TTL comments (today's bucket has been 2h since #64063, not 15min).

No behavior change — the schedule still runs. Stopping it stays an explicit operational toggle (called out in the schedule comment) rather than a silent code-deploy change.

## How did you test this code?

Agent-authored. Comment-only change; ran ruff format and check (clean). No functional change, no tests.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Documents the decision to stop relying on eager warming and validate enrolled teams on the lazy-on-read path. Markers only, ahead of stopping the schedule operationally.
