### PR TITLE
fix(google_ads): retry transient gRPC errors during schema discovery

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -15,6 +15,10 @@ from google.ads.googleads.v23.common import types as ga_common
 from google.ads.googleads.v23.enums import types as ga_enums
 from google.ads.googleads.v23.resources import types as ga_resources
 from google.ads.googleads.v23.services import types as ga_services
+from google.ads.googleads.v23.services.services.google_ads_field_service import (
+    GoogleAdsFieldServiceClient,
+    pagers as field_pagers,
+)
 from google.ads.googleads.v23.services.services.google_ads_service import GoogleAdsServiceClient, pagers
 from google.api_core import exceptions as google_api_exceptions
 from google.auth import exceptions as google_auth_exceptions
@@ -372,8 +376,8 @@ def get_schemas(config: GoogleAdsSourceConfigUnion, team_id: int) -> TableSchema
     """
     client = google_ads_client(config, team_id)
     gaf_service = client.get_service("GoogleAdsFieldService", interceptors=tracked_interceptors(GOOGLE_ADS_HOST))
-    fields_query = gaf_service.search_google_ads_fields(
-        query=f"select name, data_type, is_repeated, type_url where selectable = true"
+    fields_query = _search_fields_with_transient_retry(
+        gaf_service, "select name, data_type, is_repeated, type_url where selectable = true"
     )
     fields_map = {field.name: field for field in fields_query.results}
     table_schemas = {}
@@ -560,6 +564,31 @@ def _search_with_transient_retry(
     while True:
         try:
             return service.search(request=request)
+        except Exception as e:
+            attempt += 1
+            if attempt >= max_attempts or not _is_transient_grpc_error(e):
+                raise
+            time.sleep(min(2 * attempt, 30))
+
+
+def _search_fields_with_transient_retry(
+    service: GoogleAdsFieldServiceClient,
+    query: str,
+    *,
+    max_attempts: int = _MAX_TRANSIENT_SEARCH_ATTEMPTS,
+) -> field_pagers.SearchGoogleAdsFieldsPager:
+    """Call ``GoogleAdsFieldService.search_google_ads_fields``, retrying a transient gRPC failure.
+
+    Schema discovery issues this one field-metadata query up front. A transient ``INTERNAL`` /
+    ``UNAVAILABLE`` blip (see ``_is_transient_grpc_error``) would otherwise fail the whole discovery
+    activity and surface as captured error-tracking noise — the same reason the data-fetch
+    ``search`` call rides these out via ``_search_with_transient_retry``. The query is idempotent,
+    so re-issuing it is safe; non-transient errors re-raise so Temporal's retry policy still applies.
+    """
+    attempt = 0
+    while True:
+        try:
+            return service.search_google_ads_fields(query=query)
         except Exception as e:
             attempt += 1
             if attempt >= max_attempts or not _is_transient_grpc_error(e):

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -529,6 +529,8 @@ _MAX_TRANSIENT_SEARCH_ATTEMPTS = 4
 
 _TRANSIENT_GRPC_STATUS_CODES = frozenset({grpc.StatusCode.UNAVAILABLE, grpc.StatusCode.INTERNAL})
 
+_T = typing.TypeVar("_T")
+
 
 def _is_transient_grpc_error(exc: BaseException) -> bool:
     """Return True for a transient gRPC failure Google's guidance says to retry.
@@ -547,6 +549,23 @@ def _is_transient_grpc_error(exc: BaseException) -> bool:
     return callable(code) and code() in _TRANSIENT_GRPC_STATUS_CODES
 
 
+def _with_transient_grpc_retry(fn: collections.abc.Callable[[], _T], *, max_attempts: int) -> _T:
+    """Run ``fn``, retrying a transient gRPC failure (see ``_is_transient_grpc_error``) with backoff.
+
+    Each retry re-issues the same request, so there is no partial state to reconcile. Non-transient
+    errors re-raise immediately so the caller's error handling and Temporal's retry policy still apply.
+    """
+    attempt = 0
+    while True:
+        try:
+            return fn()
+        except Exception as e:
+            attempt += 1
+            if attempt >= max_attempts or not _is_transient_grpc_error(e):
+                raise
+            time.sleep(min(2 * attempt, 30))
+
+
 def _search_with_transient_retry(
     service: GoogleAdsServiceClient,
     request: dict,
@@ -560,15 +579,7 @@ def _search_with_transient_retry(
     ``_is_transient_grpc_error``). Non-transient errors re-raise immediately so the caller's
     ``INVALID_PAGE_TOKEN`` handling and Temporal's retry policy still apply.
     """
-    attempt = 0
-    while True:
-        try:
-            return service.search(request=request)
-        except Exception as e:
-            attempt += 1
-            if attempt >= max_attempts or not _is_transient_grpc_error(e):
-                raise
-            time.sleep(min(2 * attempt, 30))
+    return _with_transient_grpc_retry(lambda: service.search(request=request), max_attempts=max_attempts)
 
 
 def _search_fields_with_transient_retry(
@@ -585,15 +596,7 @@ def _search_fields_with_transient_retry(
     ``search`` call rides these out via ``_search_with_transient_retry``. The query is idempotent,
     so re-issuing it is safe; non-transient errors re-raise so Temporal's retry policy still applies.
     """
-    attempt = 0
-    while True:
-        try:
-            return service.search_google_ads_fields(query=query)
-        except Exception as e:
-            attempt += 1
-            if attempt >= max_attempts or not _is_transient_grpc_error(e):
-                raise
-            time.sleep(min(2 * attempt, 30))
+    return _with_transient_grpc_retry(lambda: service.search_google_ads_fields(query=query), max_attempts=max_attempts)
 
 
 def _is_invalid_page_token_error(exc: GoogleAdsException) -> bool:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -673,19 +673,33 @@ class TestTransientGrpcErrorDetection:
         assert _is_transient_grpc_error(exc) is expected
 
 
-class _FlakyService:
-    """Raises a transient error for the first ``fail_times`` calls, then serves one page."""
+class _FlakyCalls:
+    """Raises a transient error for the first ``fail_times`` calls, then serves ``_success()``."""
 
-    def __init__(self, page: SimpleNamespace, error: BaseException, fail_times: int):
-        self.page = page
+    def __init__(self, error: BaseException, fail_times: int):
         self.error = error
         self.fail_times = fail_times
         self.calls = 0
 
-    def search(self, request: dict):
+    def _serve(self):
         self.calls += 1
         if self.calls <= self.fail_times:
             raise self.error
+        return self._success()
+
+    def _success(self):
+        raise NotImplementedError
+
+
+class _FlakyService(_FlakyCalls):
+    def __init__(self, page: SimpleNamespace, error: BaseException, fail_times: int):
+        super().__init__(error, fail_times)
+        self.page = page
+
+    def search(self, request: dict):
+        return self._serve()
+
+    def _success(self):
         return SimpleNamespace(pages=iter([self.page]))
 
 
@@ -771,19 +785,15 @@ class TestSearchTransientRetry:
         assert sleep.call_count == 0
 
 
-class _FlakyFieldService:
-    """Raises a transient error for the first ``fail_times`` calls, then returns a fields pager."""
-
+class _FlakyFieldService(_FlakyCalls):
     def __init__(self, pager: object, error: BaseException, fail_times: int):
+        super().__init__(error, fail_times)
         self.pager = pager
-        self.error = error
-        self.fail_times = fail_times
-        self.calls = 0
 
     def search_google_ads_fields(self, query: str):
-        self.calls += 1
-        if self.calls <= self.fail_times:
-            raise self.error
+        return self._serve()
+
+    def _success(self):
         return self.pager
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -29,6 +29,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads
     _is_transient_grpc_error,
     _load_client_with_transient_retry,
     _search_as_arrow_tables,
+    _search_fields_with_transient_retry,
 )
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.schemas import RESOURCE_SCHEMAS
 from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.source import GoogleAdsSource
@@ -766,6 +767,59 @@ class TestSearchTransientRetry:
                 )
 
         # First call raises and propagates immediately — no retry, no backoff.
+        assert service.calls == 1
+        assert sleep.call_count == 0
+
+
+class _FlakyFieldService:
+    """Raises a transient error for the first ``fail_times`` calls, then returns a fields pager."""
+
+    def __init__(self, pager: object, error: BaseException, fail_times: int):
+        self.pager = pager
+        self.error = error
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def search_google_ads_fields(self, query: str):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise self.error
+        return self.pager
+
+
+class TestSearchFieldsTransientRetry:
+    def test_rides_out_transient_internal_error(self):
+        pager = object()
+        service = _FlakyFieldService(pager, error=_grpc_internal_error(), fail_times=2)
+
+        with mock.patch(_SLEEP_PATH) as sleep:
+            result = _search_fields_with_transient_retry(service, "select name from x")  # type: ignore[arg-type]
+
+        # The reported INTERNAL blip on schema discovery is now ridden out in-process, not surfaced.
+        assert result is pager
+        assert service.calls == 3
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_persistent_internal_is_reraised_for_temporal_to_retry(self):
+        service = _FlakyFieldService(object(), error=_grpc_internal_error(), fail_times=99)
+
+        with mock.patch(_SLEEP_PATH) as sleep:
+            with pytest.raises(grpc.RpcError):
+                _search_fields_with_transient_retry(service, "select name from x")  # type: ignore[arg-type]
+
+        # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry.
+        assert service.calls == 4
+        assert sleep.call_args_list == [mock.call(2), mock.call(4), mock.call(6)]
+
+    def test_non_transient_error_is_not_retried(self):
+        service = _FlakyFieldService(
+            object(), error=google_api_exceptions.PermissionDenied("PERMISSION_DENIED"), fail_times=99
+        )
+
+        with mock.patch(_SLEEP_PATH) as sleep:
+            with pytest.raises(google_api_exceptions.PermissionDenied):
+                _search_fields_with_transient_retry(service, "select name from x")  # type: ignore[arg-type]
+
         assert service.calls == 1
         assert sleep.call_count == 0
 


### PR DESCRIPTION
## Problem

Error tracking surfaced a `_InactiveRpcError` (gRPC `StatusCode.INTERNAL`, status 13, "Internal error encountered.") raised from the Google Ads source's schema-discovery path — `get_schemas` in `google_ads.py`, on the `GoogleAdsFieldService.search_google_ads_fields` call. This is a transient server-side blip from Google's API, not a credential/config problem.

The module already treats gRPC `INTERNAL` / `UNAVAILABLE` as transient statuses to ride out in-process (`_is_transient_grpc_error` + `_search_with_transient_retry`), explicitly to avoid restarting the whole import activity and to avoid captured error-tracking noise. But that protection was only wired into the data-fetch `GoogleAdsService.search` call. The schema-discovery `search_google_ads_fields` call — the one that failed here — was the single Google Ads gRPC request left unwrapped, so a transient blip there propagated, failed the discovery activity, and showed up as an error-tracking issue.

## Changes

- Add `_search_fields_with_transient_retry`, mirroring the existing per-call-site retry helpers (`_search_with_transient_retry`, `_load_client_with_transient_retry`) and reusing the same `_is_transient_grpc_error` detector and backoff.
- Route the discovery `search_google_ads_fields` call through it.

Non-transient errors still re-raise immediately, so genuine credential/permission failures keep flowing through the existing non-retryable handling and Temporal's retry policy. This is not a change to retry policy or to `NonRetryableErrors` — a transient `INTERNAL` should stay retryable; the fix just rides the blip out in-process the same way the data path already does, instead of letting it crash discovery.

## How did you test this code?

I'm an agent. I added unit tests and ran them locally — no manual testing.

New `TestSearchFieldsTransientRetry` covers the discovery retry helper's own loop (a separate copy from the data-path helper):
- rides out a transient `INTERNAL` and returns the page without surfacing the error (the reported regression);
- bounded attempts — gives up and re-raises rather than looping forever, leaving Temporal to retry;
- a non-transient error (`PermissionDenied`) is not retried.

Ran `TestSearchFieldsTransientRetry`, `TestSearchTransientRetry`, and `TestTransientGrpcErrorDetection` — 18 passed. Ruff check + format clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue. Confirmed via the error-tracking tools that the failing stack frames are all in the `google_ads` source (`source.py` → `google_ads.py:get_schemas`), not just serialized log context. Decided this is a fixable gap rather than a `NonRetryableErrors` candidate: gRPC `INTERNAL` is a transient upstream status the codebase already classifies as retryable, so the right fix is extending the existing in-process transient-retry to the one call site that lacked it — not suppressing retries. Checked open PRs (including the maintainer's own) for the same fix; the nearest (#66774, RESOURCE_EXHAUSTED on the data-fetch path) is a different call site and status, so no duplicate.
