### PR TITLE
fix(replay-vision): gate runs on delivery_config, not the vestigial hog_flow_id

### DIFF
--- a/products/replay_vision/backend/temporal/vision_actions/activities.py
+++ b/products/replay_vision/backend/temporal/vision_actions/activities.py
@@ -111,8 +111,8 @@ def _validate(inputs: ValidateVisionActionInputs) -> str | None:
         return "not_found"
     if not action.enabled:
         return "disabled"
-    if action.hog_flow_id is None:
-        return "no_delivery_flow"
+    if not action.delivery_config:
+        return "no_delivery"
     return None
 
 

--- a/products/replay_vision/backend/tests/test_vision_action_engine.py
+++ b/products/replay_vision/backend/tests/test_vision_action_engine.py
@@ -131,7 +131,7 @@ class TestEngineActivities(BaseTest):
         [
             ("not_found",),
             ("disabled",),
-            ("no_delivery_flow",),
+            ("no_delivery",),
         ]
     )
     def test_validate_reasons(self, case: str) -> None:
@@ -140,10 +140,21 @@ class TestEngineActivities(BaseTest):
         elif case == "disabled":
             action_id = _action(self.team, name="off", enabled=False).id
         else:
-            action_id = _action(self.team, name="noflow").id
+            # No delivery_config → nothing to deliver to → skip.
+            action_id = _action(self.team, name="nodelivery").id
         self.assertEqual(
             act._validate(ValidateVisionActionInputs(vision_action_id=action_id, team_id=self.team.id)), case
         )
+
+    def test_validate_passes_when_delivery_configured(self) -> None:
+        # Regression: the gate used to check the now-vestigial hog_flow_id (always null after the
+        # internal_destination rework), which skipped every action. It must pass when delivery_config is set.
+        action = _action(
+            self.team,
+            name="delivers",
+            delivery_config=[{"type": "slack", "integration_id": 1, "channel": "#general"}],
+        )
+        self.assertIsNone(act._validate(ValidateVisionActionInputs(vision_action_id=action.id, team_id=self.team.id)))
 
     def test_update_run(self) -> None:
         action = _action(self.team)
@@ -274,14 +285,14 @@ async def test_process_skips_when_validate_returns_reason() -> None:
     mocks = _Mocks(
         results={
             act.create_vision_action_run_activity: uuid.uuid4(),
-            act.validate_vision_action_activity: "no_delivery_flow",
+            act.validate_vision_action_activity: "no_delivery",
         }
     )
     await _run_process(_process_inputs(), mocks)
 
     assert act.emit_action_ready_activity not in mocks.calls()
     assert _final_status(mocks) == VisionActionRunStatus.SKIPPED.value
-    assert _final_error(mocks) == {"skip_reason": "no_delivery_flow"}
+    assert _final_error(mocks) == {"skip_reason": "no_delivery"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Every scheduled group-summary vision action was silently skipping — runs landed with `{"skip_reason": "no_delivery_flow"}` and **nothing ever delivered to Slack**. Found while testing a real action in prod.

Root cause: the delivery rework swapped the per-action **HogFlow** for **`internal_destination` HogFunctions** provisioned from `delivery_config` (`api/delivery.py`), which leaves `VisionAction.hog_flow_id` permanently null. But the engine's validate gate still checked it:

```python
if action.hog_flow_id is None:
    return "no_delivery_flow"
```

Since nothing populates `hog_flow_id` anymore, that gate fired for **100% of actions**, before any synthesis or delivery. The rework updated `_emit` and `delivery.py` but missed this `_validate` gate.

## Changes

- Gate on **`delivery_config`** (the field that actually drives provisioning) instead of the dead `hog_flow_id`. Empty config → nothing to deliver to → skip before spending an LLM call; non-empty → proceed. `perform_create` provisions the destination atomically with the action, so a non-empty config faithfully means a destination exists — this restores the gate's original pre-rework intent.
- Rename the skip reason `no_delivery_flow` → `no_delivery` (there are no flows anymore).

## How did you test this code?

I'm an agent (PostHog Code); automated tests only:

- Added `test_validate_passes_when_delivery_configured` — asserts `_validate` returns `None` when `delivery_config` is set. This is the regression that was missing: against the old `hog_flow_id` check it would have failed (always skipped), which is exactly the prod bug.
- Updated the existing `test_validate_reasons` parametrization (`no_delivery_flow` → `no_delivery`, set up via an action with empty `delivery_config`) and the workflow-level skip test's mocked reason.
- Full `test_vision_action_engine.py` suite passes (19), `ruff` clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude). Diagnosed from a real prod run that skipped with `no_delivery_flow`; traced it to the stale `hog_flow_id` gate left by the HogFlow → internal_destination delivery rework. Chose to gate on `delivery_config` (decoupled, trivially testable, faithful given atomic provisioning) rather than re-querying the provisioned HogFunction from the temporal activity, which would couple the engine to the CDP/api layer. Invoked `/improving-drf-endpoints` earlier in the session for adjacent serializer work; this change is engine-only.

Standalone fix off master (the engine PR already merged), independent of the open run-history stack.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*