### PR TITLE
fix(postgres): stop capturing expected connection errors from metadata probe

### DIFF
--- a/products/data_warehouse/backend/presentation/views/external_data_source.py
+++ b/products/data_warehouse/backend/presentation/views/external_data_source.py
@@ -395,7 +395,13 @@ def get_direct_connection_metadata(
     try:
         metadata = metadata_fetcher(source_config, team_id, require_ssl=require_ssl)
     except Exception as error:
-        capture_exception(error)
+        # Connection metadata is best-effort — we fall back below regardless. An expected
+        # user/upstream connection failure (unreachable or misconfigured host, refused connection,
+        # bad credentials) is the customer's to fix and is already surfaced by credential
+        # validation, so don't capture it as error-tracking noise. Mirrors `refresh_schemas`.
+        _, is_expected_source_error = _classify_refresh_schemas_error(source_impl, error)
+        if not is_expected_source_error:
+            capture_exception(error)
         return fallback or {}
 
     return metadata if isinstance(metadata, dict) else (fallback or {})

--- a/products/data_warehouse/backend/tests/api/test_external_data_source.py
+++ b/products/data_warehouse/backend/tests/api/test_external_data_source.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, Mock, PropertyMock, patch
 
 from django.conf import settings
 from django.db import connection
-from django.test import override_settings
+from django.test import SimpleTestCase, override_settings
 from django.utils import timezone
 
 import psycopg
@@ -38,6 +38,7 @@ from products.data_warehouse.backend.direct_postgres import DIRECT_POSTGRES_URL_
 from products.data_warehouse.backend.models.revenue_analytics_config import ExternalDataSourceRevenueAnalyticsConfig
 from products.data_warehouse.backend.presentation.views.external_data_schema import ExternalDataSchemaSerializer
 from products.data_warehouse.backend.presentation.views.external_data_source import (
+    get_direct_connection_metadata,
     get_nonsensitive_and_sensitive_field_names,
     strip_sensitive_from_dict,
 )
@@ -10142,3 +10143,35 @@ class TestExternalDataSourcePreviewAndCustomPayload(APIBaseTest):
         source = ExternalDataSource.objects.get(id=response.json()["id"])
         assert source.source_type == "Custom"
         assert source.created_via == ExternalDataSource.CreatedVia.MCP
+
+
+class TestGetDirectConnectionMetadata(SimpleTestCase):
+    def _source_impl(self, error: Exception, non_retryable: dict | None = None) -> Mock:
+        impl = Mock()
+        impl.get_connection_metadata.side_effect = error
+        impl.get_non_retryable_errors.return_value = non_retryable or {}
+        return impl
+
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    def test_expected_connection_error_is_not_captured(self, mock_capture):
+        # An unreachable customer host fails the best-effort metadata probe — already surfaced by
+        # credential validation, so it must degrade to the fallback without flooding error tracking.
+        impl = self._source_impl(
+            psycopg.OperationalError('connection to server at "192.0.2.1", port 5432 failed: Network is unreachable')
+        )
+        fallback = {"database": "existing"}
+
+        result = get_direct_connection_metadata(source_impl=impl, source_config=Mock(), team_id=1, fallback=fallback)
+
+        self.assertEqual(result, fallback)
+        mock_capture.assert_not_called()
+
+    @patch("products.data_warehouse.backend.presentation.views.external_data_source.capture_exception")
+    def test_unexpected_error_is_still_captured(self, mock_capture):
+        error = ValueError("unexpected bug in metadata probe")
+        impl = self._source_impl(error)
+
+        result = get_direct_connection_metadata(source_impl=impl, source_config=Mock(), team_id=1, fallback=None)
+
+        self.assertEqual(result, {})
+        mock_capture.assert_called_once_with(error)


### PR DESCRIPTION
## Problem

Error tracking surfaced an `OperationalError` originating in the Postgres source's connection-metadata code:

```
OperationalError: connection is bad: connection to server at "<redacted host>", port 5432 failed: Network is unreachable
	Is the server running on that host and accepting TCP/IP connections?
```

The stack runs through the best-effort connection-metadata probe used during data-warehouse source setup:

```
get_direct_connection_metadata (external_data_source.py)
  → PostgresSource.get_connection_metadata (sources/postgres/source.py)
    → get_connection_metadata / pg_connection / _connect_to_postgres (sources/postgres/postgres.py)
```

The customer's host resolved to a non-routable address, so PostHog couldn't reach it. That's a user/upstream condition — the customer's connection target is unreachable — not a PostHog bug. `get_direct_connection_metadata` already handles it gracefully (any failure falls back to existing/empty metadata), but it called `capture_exception` on **every** failure, so each unreachable/misconfigured host turned into error-tracking noise.

This is distinct from the Temporal sync path: `"Network is unreachable"` is already classified non-retryable there. The probe is a separate, synchronous, best-effort path that doesn't retry — the only defect was the unconditional capture.

## Changes

Gate the `capture_exception` in `get_direct_connection_metadata` on the existing expected-source-error classification (`_classify_refresh_schemas_error`), exactly mirroring the sibling `refresh_schemas` path in the same file. Expected user/upstream connection failures (unreachable/misconfigured host, refused connection, bad credentials) degrade to the fallback without being captured; genuine unexpected errors are still captured.

No retry/timeout behavior changes, and no new error strings were needed — `"Network is unreachable"` is already recognized by both the Postgres source's `get_non_retryable_errors()` and `REFRESH_SCHEMAS_EXPECTED_ERROR_MESSAGES`.

## How did you test this code?

I'm an agent. I added a DB-free unit test class `TestGetDirectConnectionMetadata` and ran it locally:

- `test_expected_connection_error_is_not_captured` — an unreachable-host `OperationalError` returns the fallback and is **not** captured. Verified this fails on `master` (capture is called) and passes with the fix.
- `test_unexpected_error_is_still_captured` — an unexpected error still returns the fallback **and** is captured.

Ran `ruff check` and `ruff format` on both changed files (clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking issue for the Postgres data-warehouse source. Confirmed via the PostHog error-tracking tools that the failure genuinely originates in the source's connection-metadata code (single occurrence, single team), then traced the call path to the best-effort metadata probe in the data-warehouse views layer.

Decision: this is a fixable bug (a missing graceful-skip), not a `NonRetryableErrors` change. The probe isn't on the Temporal retry path and already swallows the error; the fix is to stop emitting capture noise for expected connection failures. Chose to fix at the shared helper (where the capture lives and where the classification helper already exists) rather than in the source method, to avoid changing the source method's contract for other callers. Reused the established `_classify_refresh_schemas_error` classifier instead of introducing a new abstraction.

Checked open PRs for duplicates — #66705 ("show friendly connection error during schema discovery") is closely related but touches the `database_schema`/`setup` `get_schemas` path, not the metadata probe, so it doesn't address this error. No overlap.
