### PR TITLE
fix(google_search_console): retry transient DB pool timeouts when fetching integration

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/google_search_console.py
@@ -7,7 +7,7 @@ from typing import Any
 from urllib.parse import parse_qs, quote, unquote, urlparse, urlunparse
 
 from django.conf import settings
-from django.db import close_old_connections
+from django.db import OperationalError, close_old_connections
 
 import requests
 import structlog
@@ -166,13 +166,42 @@ def suggest_registered_site(site_url: str, registered: collections.abc.Iterable[
     return None
 
 
+def _backoff_sleep(attempt: int) -> None:
+    """Sleep before the next retry: linear growth capped at 30s (2s, 4s, 6s, ...)."""
+    time.sleep(min(2 * attempt, 30))
+
+
+_MAX_INTEGRATION_FETCH_ATTEMPTS = 4
+
+
+def _get_integration(integration_id: int, team_id: int) -> Integration:
+    """Fetch the OAuth ``Integration`` row, retrying a transient DB failure with backoff.
+
+    Temporal activities run in a long-lived worker outside Django's request cycle, and this
+    read happens lazily inside `get_rows` after the connection has often sat idle for minutes.
+    A pooled Postgres connection can be closed server-side while idle, or the connection pooler
+    can reject the query with a wait timeout (`query_wait_timeout`) when the pool is saturated.
+    Both surface as a transient ``OperationalError`` that clears once a healthy connection is
+    used. ``close_old_connections()`` evicts connections already known to be stale (and, after a
+    failed query marks one unusable, drops it), so each attempt runs on a fresh connection; the
+    short backoff also gives a saturated pool time to drain rather than retrying straight back
+    into the same wait timeout. This read is idempotent, so repeating it is safe.
+    ``Integration.DoesNotExist`` is left to propagate.
+    """
+    attempt = 0
+    while True:
+        close_old_connections()
+        try:
+            return Integration.objects.get(id=integration_id, team_id=team_id)
+        except OperationalError:
+            attempt += 1
+            if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
+                raise
+            _backoff_sleep(attempt)
+
+
 def _credentials(integration_id: int, team_id: int) -> OAuthCredentials:
-    # Temporal activities run in a thread pool where Django DB connections can go
-    # stale between uses (Postgres closes the connection server-side). This is
-    # invoked lazily from inside `get_rows`, so the connection has often been idle
-    # for minutes by the time we reach it — drop any stale connection first.
-    close_old_connections()
-    integration = Integration.objects.get(id=integration_id, team_id=team_id)
+    integration = _get_integration(integration_id, team_id)
     return OAuthCredentials(
         token=None,
         refresh_token=integration.refresh_token,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_search_console/tests/test_google_search_console.py
@@ -3,6 +3,8 @@ import datetime as dt
 import pytest
 from unittest import mock
 
+from django.db import OperationalError
+
 import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
@@ -18,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_sea
     GoogleSearchConsoleQuotaExceededError,
     GoogleSearchConsoleResumeConfig,
     _credentials,
+    _get_integration,
     _initial_start_date,
     _is_daily_quota_error,
     _is_quota_error,
@@ -138,6 +141,46 @@ def test_credentials_refreshes_stale_db_connection_before_query(monkeypatch):
 
     assert calls == ["close_old_connections", "Integration.objects.get"]
     assert creds.refresh_token == "refresh-token"
+
+
+def test_get_integration_rides_out_pool_wait_timeout_then_succeeds(monkeypatch):
+    # A saturated connection pooler rejects the query with `query_wait_timeout`; the short
+    # backoff lets the pool drain so a later attempt on a fresh connection succeeds.
+    integration = mock.MagicMock()
+    get = mock.Mock(
+        side_effect=[
+            OperationalError("query_wait_timeout"),
+            OperationalError("query_wait_timeout"),
+            integration,
+        ]
+    )
+
+    monkeypatch.setattr(gsc, "close_old_connections", lambda: None)
+    monkeypatch.setattr(gsc.Integration.objects, "get", get)
+    sleeps: list[float] = []
+    monkeypatch.setattr(gsc.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    result = _get_integration(integration_id=1, team_id=2)
+
+    assert result is integration
+    assert get.call_count == 3
+    assert sleeps == [2, 4]
+
+
+def test_get_integration_reraises_after_exhausting_attempts(monkeypatch):
+    get = mock.Mock(side_effect=OperationalError("query_wait_timeout"))
+
+    monkeypatch.setattr(gsc, "close_old_connections", lambda: None)
+    monkeypatch.setattr(gsc.Integration.objects, "get", get)
+    sleeps: list[float] = []
+    monkeypatch.setattr(gsc.time, "sleep", lambda seconds: sleeps.append(seconds))
+
+    with pytest.raises(OperationalError):
+        _get_integration(integration_id=1, team_id=2)
+
+    # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry the activity.
+    assert get.call_count == 4
+    assert sleeps == [2, 4, 6]
 
 
 def _make_response(config: GoogleSearchConsoleSourceConfig, rows_per_call: list[list[dict]]):


### PR DESCRIPTION
## Problem

Error tracking surfaced a transient DB failure in the Google Search Console import source: a connection-pooler **wait timeout** (`query_wait_timeout`, surfaced as a psycopg `ProtocolViolation` / `OperationalError`) raised while fetching the OAuth integration row in `_credentials`. The top in-app frame is `_credentials` in `google_search_console.py`, where the lazy `Integration.objects.get()` runs inside `get_rows` during the sync.

Issue: https://us.posthog.com/project/2/error_tracking/019f1614-70df-7921-9222-8c8ae54e6336

This is a **transient infrastructure error** — our own Postgres pooler was saturated and couldn't hand the query a server connection in time — not a credential or config problem. So it must stay retryable (it is **not** added to `NonRetryableErrors`). The fragility is in our retry shape: `_credentials` did a single `Integration.objects.get()` with no in-process retry, so a brief pool saturation crashes the whole activity on the first blip.

## Changes

Wrap the integration read in a `_get_integration` helper with bounded exponential backoff (up to 4 attempts, `min(2 * attempt, 30)`s between them). This mirrors the resilience pattern already in the sibling `google_ads` and `linkedin_ads` sources for the exact same error. `close_old_connections()` still evicts stale connections before each attempt, and the short backoff gives a saturated pool time to drain rather than retrying straight back into the timeout. After the bounded attempts it re-raises, leaving Temporal to retry the activity (the resumable source picks up from the last saved date).

Behavior preserved:
- `Integration.DoesNotExist` still propagates unchanged.
- The connection is still refreshed via `close_old_connections()` before each query.

## How did you test this code?

I'm an agent. I added and ran automated unit tests; I did not perform manual testing.

- `test_get_integration_rides_out_pool_wait_timeout_then_succeeds` — two `query_wait_timeout` failures then success; asserts the read is retried and backs off (2s, 4s). Catches the regression where a single transient pool timeout crashed the sync.
- `test_get_integration_reraises_after_exhausting_attempts` — persistent failure re-raises after a **bounded** number of attempts (4, sleeping 2s/4s/6s), so it can't loop forever and hands control back to Temporal.
- Existing `test_credentials_refreshes_stale_db_connection_before_query` still passes (connection eviction order unchanged).

Ran the full source test dir: 97 passed. `ruff check` and `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Investigated the issue via the PostHog error-tracking MCP tools: confirmed the full stack trace originates in this source's `_credentials` (`Integration.objects.get()` → psycopg `ProtocolViolation: query_wait_timeout`), a one-off transient pooler saturation.

Decision: transient infra error, not user/upstream — kept it retryable rather than extending `NonRetryableErrors` (which would permanently fail a sync on a brief DB blip). Chose to harden the read in-process to match the established `_get_integration` pattern in the `google_ads` (PR #66446) and `linkedin_ads` sources rather than invent a new abstraction. Scoped strictly to this source.
