### PR TITLE
fix(hubspot): retry transient DB pool timeout when fetching OAuth integration

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -187,16 +187,16 @@ class OAuthMixin:
         Postgres connection can be closed server-side while idle, or the connection pooler can
         reject the query with a wait timeout when the pool is saturated. Both surface as a transient
         ``OperationalError`` that clears on a healthy connection, so this idempotent lookup is
-        retried with backoff — ``close_old_connections()`` drops the stale connection between
-        attempts and the sleep lets a saturated pool drain — rather than failing the whole import on
-        a momentary blip. A genuinely missing integration raises ``ValueError`` and is not retried.
+        retried with backoff before failing the whole import on a momentary blip. A failed query
+        marks its connection unusable, so ``close_old_connections()`` evicts it between attempts and
+        the next attempt runs on a fresh one; the sleep lets a saturated pool drain. A genuinely
+        missing integration raises ``ValueError`` and is not retried.
         """
         if not integration_id:
             raise ValueError(f"Missing integration ID")
 
         attempt = 0
         while True:
-            close_old_connections()
             try:
                 if not Integration.objects.filter(id=integration_id, team_id=team_id).exists():
                     raise ValueError(f"Integration not found: {integration_id}")
@@ -206,6 +206,7 @@ class OAuthMixin:
                 attempt += 1
                 if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
                     raise
+                close_old_connections()
                 _integration_fetch_backoff_sleep(attempt)
 
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -190,7 +190,8 @@ class OAuthMixin:
         retried with backoff before failing the whole import on a momentary blip. A failed query
         marks its connection unusable, so ``close_old_connections()`` evicts it between attempts and
         the next attempt runs on a fresh one; the sleep lets a saturated pool drain. A genuinely
-        missing integration raises ``ValueError`` and is not retried.
+        missing integration is surfaced as the stable, non-retryable ``ValueError`` and is not
+        retried.
         """
         if not integration_id:
             raise ValueError(f"Missing integration ID")
@@ -198,10 +199,9 @@ class OAuthMixin:
         attempt = 0
         while True:
             try:
-                if not Integration.objects.filter(id=integration_id, team_id=team_id).exists():
-                    raise ValueError(f"Integration not found: {integration_id}")
-
                 return Integration.objects.get(id=integration_id, team_id=team_id)
+            except Integration.DoesNotExist:
+                raise ValueError(f"Integration not found: {integration_id}") from None
             except OperationalError:
                 attempt += 1
                 if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/mixins.py
@@ -1,6 +1,9 @@
+import time
 import socket
 from collections.abc import Callable, Generator
 from contextlib import _GeneratorContextManager, contextmanager
+
+from django.db import OperationalError, close_old_connections
 
 import structlog
 
@@ -166,18 +169,44 @@ class SSHTunnelMixin:
         return True, None
 
 
+_MAX_INTEGRATION_FETCH_ATTEMPTS = 4
+
+
+def _integration_fetch_backoff_sleep(attempt: int) -> None:
+    """Sleep before the next integration-fetch retry: linear growth capped at 30s (2s, 4s, 6s, ...)."""
+    time.sleep(min(2 * attempt, 30))
+
+
 class OAuthMixin:
     """Mixin for OAuth-based sources"""
 
     def get_oauth_integration(self, integration_id: int, team_id: int) -> Integration:
-        """Get OAuth integration from integration ID"""
+        """Get OAuth integration from integration ID.
+
+        Temporal activities run in a long-lived worker outside Django's request cycle, so a pooled
+        Postgres connection can be closed server-side while idle, or the connection pooler can
+        reject the query with a wait timeout when the pool is saturated. Both surface as a transient
+        ``OperationalError`` that clears on a healthy connection, so this idempotent lookup is
+        retried with backoff — ``close_old_connections()`` drops the stale connection between
+        attempts and the sleep lets a saturated pool drain — rather than failing the whole import on
+        a momentary blip. A genuinely missing integration raises ``ValueError`` and is not retried.
+        """
         if not integration_id:
             raise ValueError(f"Missing integration ID")
 
-        if not Integration.objects.filter(id=integration_id, team_id=team_id).exists():
-            raise ValueError(f"Integration not found: {integration_id}")
+        attempt = 0
+        while True:
+            close_old_connections()
+            try:
+                if not Integration.objects.filter(id=integration_id, team_id=team_id).exists():
+                    raise ValueError(f"Integration not found: {integration_id}")
 
-        return Integration.objects.get(id=integration_id, team_id=team_id)
+                return Integration.objects.get(id=integration_id, team_id=team_id)
+            except OperationalError:
+                attempt += 1
+                if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
+                    raise
+                _integration_fetch_backoff_sleep(attempt)
 
 
 class ValidateDatabaseHostMixin:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -9,6 +9,8 @@ from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
+from posthog.models.integration import Integration
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
     OAuthMixin,
     SSHTunnelMixin,
@@ -243,20 +245,17 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
     )
     def test_retries_transient_db_error_then_succeeds(self, _name: str, message: str):
         integration = object()
-        filter_qs = mock.Mock()
-        filter_qs.exists.side_effect = [OperationalError(message), OperationalError(message), True]
+        get = mock.Mock(side_effect=[OperationalError(message), OperationalError(message), integration])
 
         with (
-            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
-            patch(f"{_MIXINS_MODULE}.Integration.objects.get", return_value=integration) as get,
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", get),
             patch(f"{_MIXINS_MODULE}.close_old_connections") as close,
             patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
         ):
             result = OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
 
         assert result is integration
-        assert filter_qs.exists.call_count == 3
-        assert get.call_count == 1
+        assert get.call_count == 3
         # The poisoned connection is evicted before each retry, but not on the successful attempt.
         assert close.call_count == 2
         # Backoff grows per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
@@ -266,11 +265,8 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
         # Closing the connection on the happy path would tear down the caller's open transaction
         # (e.g. inside a transactional test), so eviction must only happen between retries.
         integration = object()
-        filter_qs = mock.Mock()
-        filter_qs.exists.return_value = True
 
         with (
-            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
             patch(f"{_MIXINS_MODULE}.Integration.objects.get", return_value=integration),
             patch(f"{_MIXINS_MODULE}.close_old_connections") as close,
             patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
@@ -282,11 +278,10 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
         sleep.assert_not_called()
 
     def test_reraises_after_exhausting_attempts(self):
-        filter_qs = mock.Mock()
-        filter_qs.exists.side_effect = OperationalError("query_wait_timeout")
+        get = mock.Mock(side_effect=OperationalError("query_wait_timeout"))
 
         with (
-            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", get),
             patch(f"{_MIXINS_MODULE}.close_old_connections"),
             patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
         ):
@@ -294,24 +289,37 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
                 OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
 
         # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry the activity.
-        assert filter_qs.exists.call_count == 4
+        assert get.call_count == 4
         # Backed off between attempts (2s, 4s, 6s) but not after the final attempt that re-raises.
         assert sleep.call_args_list == [mock.call(2), mock.call(4), mock.call(6)]
 
     def test_missing_integration_is_not_retried(self):
-        filter_qs = mock.Mock()
-        filter_qs.exists.return_value = False
+        get = mock.Mock(side_effect=Integration.DoesNotExist())
 
         with (
-            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
-            patch(f"{_MIXINS_MODULE}.Integration.objects.get") as get,
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", get),
             patch(f"{_MIXINS_MODULE}.close_old_connections"),
             patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
         ):
-            # A deleted integration row is non-retryable — raised as the stable "Integration not found"
+            # A deleted integration is non-retryable — surfaced as the stable "Integration not found"
             # message the sources classify as non-retryable, not masked as a transient drop.
             with pytest.raises(ValueError, match="Integration not found"):
                 OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
 
-        get.assert_not_called()
+        assert get.call_count == 1
         sleep.assert_not_called()
+
+    def test_deletion_during_retry_is_surfaced_as_not_found(self):
+        # The row vanishes after a transient failure: the retry must convert DoesNotExist into the
+        # stable non-retryable ValueError rather than letting raw DoesNotExist escape and be retried.
+        get = mock.Mock(side_effect=[OperationalError("query_wait_timeout"), Integration.DoesNotExist()])
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", get),
+            patch(f"{_MIXINS_MODULE}.close_old_connections"),
+            patch(f"{_MIXINS_MODULE}.time.sleep"),
+        ):
+            with pytest.raises(ValueError, match="Integration not found"):
+                OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
+
+        assert get.call_count == 2

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -1,16 +1,22 @@
 from dataclasses import dataclass
 
+import pytest
+from unittest import mock
 from unittest.mock import patch
 
+from django.db import OperationalError
 from django.test import SimpleTestCase, override_settings
 
 from parameterized import parameterized
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins import (
+    OAuthMixin,
     SSHTunnelMixin,
     ValidateDatabaseHostMixin,
     _is_host_safe,
 )
+
+_MIXINS_MODULE = "products.warehouse_sources.backend.temporal.data_imports.sources.common.mixins"
 
 
 class TestIsHostSafe(SimpleTestCase):
@@ -226,3 +232,67 @@ class TestSSHTunnelHostValidation(SimpleTestCase):
         config = FakeConfig(ssh_tunnel=FakeSSHTunnelConfig(enabled=True, host=host))
         valid, _ = mixin.ssh_tunnel_is_valid(config, team_id=999)
         assert not valid
+
+
+class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
+    @parameterized.expand(
+        [
+            ("pool_wait_timeout", "query_wait_timeout"),
+            ("dropped_connection", "server closed the connection unexpectedly"),
+        ]
+    )
+    def test_retries_transient_db_error_then_succeeds(self, _name: str, message: str):
+        integration = object()
+        filter_qs = mock.Mock()
+        filter_qs.exists.side_effect = [OperationalError(message), OperationalError(message), True]
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", return_value=integration) as get,
+            patch(f"{_MIXINS_MODULE}.close_old_connections") as close,
+            patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
+        ):
+            result = OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
+
+        assert result is integration
+        assert filter_qs.exists.call_count == 3
+        assert get.call_count == 1
+        # A fresh connection is acquired before each attempt.
+        assert close.call_count == 3
+        # Backoff grows per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_reraises_after_exhausting_attempts(self):
+        filter_qs = mock.Mock()
+        filter_qs.exists.side_effect = OperationalError("query_wait_timeout")
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
+            patch(f"{_MIXINS_MODULE}.close_old_connections"),
+            patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
+        ):
+            with pytest.raises(OperationalError):
+                OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
+
+        # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry the activity.
+        assert filter_qs.exists.call_count == 4
+        # Backed off between attempts (2s, 4s, 6s) but not after the final attempt that re-raises.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4), mock.call(6)]
+
+    def test_missing_integration_is_not_retried(self):
+        filter_qs = mock.Mock()
+        filter_qs.exists.return_value = False
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get") as get,
+            patch(f"{_MIXINS_MODULE}.close_old_connections"),
+            patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
+        ):
+            # A deleted integration row is non-retryable — raised as the stable "Integration not found"
+            # message the sources classify as non-retryable, not masked as a transient drop.
+            with pytest.raises(ValueError, match="Integration not found"):
+                OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
+
+        get.assert_not_called()
+        sleep.assert_not_called()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test_mixins.py
@@ -257,10 +257,29 @@ class TestOAuthMixinIntegrationFetchResilience(SimpleTestCase):
         assert result is integration
         assert filter_qs.exists.call_count == 3
         assert get.call_count == 1
-        # A fresh connection is acquired before each attempt.
-        assert close.call_count == 3
+        # The poisoned connection is evicted before each retry, but not on the successful attempt.
+        assert close.call_count == 2
         # Backoff grows per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
         assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_success_does_not_evict_connection(self):
+        # Closing the connection on the happy path would tear down the caller's open transaction
+        # (e.g. inside a transactional test), so eviction must only happen between retries.
+        integration = object()
+        filter_qs = mock.Mock()
+        filter_qs.exists.return_value = True
+
+        with (
+            patch(f"{_MIXINS_MODULE}.Integration.objects.filter", return_value=filter_qs),
+            patch(f"{_MIXINS_MODULE}.Integration.objects.get", return_value=integration),
+            patch(f"{_MIXINS_MODULE}.close_old_connections") as close,
+            patch(f"{_MIXINS_MODULE}.time.sleep") as sleep,
+        ):
+            result = OAuthMixin().get_oauth_integration(integration_id=1, team_id=2)
+
+        assert result is integration
+        close.assert_not_called()
+        sleep.assert_not_called()
 
     def test_reraises_after_exhausting_attempts(self):
         filter_qs = mock.Mock()


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ProtocolViolation: query_wait_timeout` failing the Hubspot data-warehouse import. The reported frame is `hubspot/source.py` → `source_for_pipeline`, which calls the shared `OAuthMixin.get_oauth_integration` to load the connected OAuth integration row before any data is fetched.

The deepest, coherent frames in the trace are:

```
hubspot/source.py:source_for_pipeline
  → common/mixins.py:get_oauth_integration
    → Django ORM .exists()
      → psycopg execute → query_wait_timeout  (OperationalError / ProtocolViolation)
```

`query_wait_timeout` is a connection-pooler error (PgBouncer returns SQLSTATE `08P01` when it can't assign a server connection within its wait window — i.e. the pool is briefly saturated). This is a **transient infrastructure error against our own Postgres**, not a Hubspot/credentials/upstream problem. It is low-frequency and self-clearing.

The lookup lives in the shared `OAuthMixin.get_oauth_integration`, which had no transient-error handling. So a momentary pool blip while reading the integration row failed the whole import activity and got captured as an exception, instead of being ridden out.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1613-5080-7242-81e1-5bf307d3ebe7

## Changes

Decision: this is a **fixable robustness gap**, not a non-retryable user/upstream error — so it must stay retryable, and it does not belong in `NonRetryableErrors`.

Wrap the idempotent integration lookup in an in-process retry: `close_old_connections()` before each attempt (drops a stale/poisoned connection so the retry runs on a healthy one) plus linear backoff (2s, 4s, 6s, capped at 30s) to let a saturated pool drain. Bounded at 4 attempts, after which it re-raises so Temporal's activity retry still applies. A genuinely missing integration continues to raise `ValueError("Integration not found")` — the stable signal the sources already classify as non-retryable — and is not retried.

The fix is applied at the shared `OAuthMixin` layer because that is the exact frame that threw, and ~15 OAuth sources share it. This mirrors the pattern the `google_ads` and `linkedin_ads` sources independently adopted for this same `query_wait_timeout` on their integration fetch (they have their own `_get_integration` helpers because they don't use the mixin).

## How did you test this code?

I'm an agent. I added unit tests at the same layer as the fix (`common/test_mixins.py`, `TestOAuthMixinIntegrationFetchResilience`) and ran them plus the surrounding suites with pytest:

- `retries_transient_db_error_then_succeeds` (parameterized over `query_wait_timeout` and a dropped-connection message) — the actual regression: a transient `OperationalError` must not fail the fetch; asserts the backoff sequence and that a fresh connection is acquired per attempt.
- `reraises_after_exhausting_attempts` — retries are bounded (no infinite loop) and the error eventually surfaces to Temporal; asserts the backoff stops before the final attempt.
- `missing_integration_is_not_retried` — a deleted integration raises `ValueError("Integration not found")` immediately and is never masked as a transient drop.

Ran `test_mixins.py` and the full `hubspot/` source suite: 168 passed. Ran `ruff check`/`ruff format` on the changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged the error-tracking issue via the PostHog MCP error-tracking tools, read the full stack trace, and traced the call path from the Hubspot source into the shared `OAuthMixin`.
- Considered the three buckets: user/upstream (→ `NonRetryableErrors`), transient infra, fixable bug. Classified `query_wait_timeout` as a transient Postgres/PgBouncer pool error, so explicitly **not** added to `NonRetryableErrors` (that would turn a momentary blip into a hard sync failure). Chose to harden the shared integration-fetch instead, following the existing `google_ads`/`linkedin_ads` precedent rather than inventing a new abstraction.
- Checked open PRs (including the maintainer's) to rule out a duplicate — the closest ones fix `google_ads`/`linkedin_ads` per-source modules; none touch the shared mixin or the Hubspot path.