### PR TITLE
fix(data-warehouse): retry transient DB pool timeout when checking webhook status

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_webhook_s3.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/test/test_webhook_s3.py
@@ -5,9 +5,10 @@ import functools
 import contextlib
 
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from django.conf import settings
+from django.db import OperationalError
 from django.test import override_settings
 
 import orjson
@@ -16,7 +17,15 @@ import aioboto3
 import pyarrow.parquet as pq
 from parameterized import parameterized
 
-from products.warehouse_sources.backend.temporal.data_imports.sources.common.webhook_s3 import WebhookSourceManager
+from products.warehouse_sources.backend.temporal.data_imports.sources.common.webhook_s3 import (
+    WebhookSourceManager,
+    _db_read_with_retry,
+)
+
+_CLOSE_CONNECTIONS_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.common.webhook_s3.close_old_connections"
+)
+_SLEEP_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.common.webhook_s3.time.sleep"
 
 
 def _table_to_parquet_bytes(table: pa.Table) -> bytes:
@@ -339,6 +348,47 @@ class TestWebhookSourceManager:
             tables = [table async for table in manager.get_items()]
 
         assert tables == []
+
+
+class TestDbReadWithRetry:
+    def test_rides_out_pool_wait_timeout_then_succeeds(self):
+        sentinel = object()
+        fn = MagicMock(
+            side_effect=[
+                OperationalError("query_wait_timeout"),
+                OperationalError("query_wait_timeout"),
+                sentinel,
+            ]
+        )
+
+        with patch(_CLOSE_CONNECTIONS_PATH) as close, patch(_SLEEP_PATH) as sleep:
+            result = _db_read_with_retry(fn)
+
+        assert result is sentinel
+        assert fn.call_count == 3
+        # Connections evicted before every attempt, including the two that failed.
+        assert close.call_count == 3
+        # Backoff grows per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.call_args_list == [call(2), call(4)]
+
+    def test_reraises_after_exhausting_attempts(self):
+        fn = MagicMock(side_effect=OperationalError("query_wait_timeout"))
+
+        with patch(_CLOSE_CONNECTIONS_PATH), patch(_SLEEP_PATH):
+            with pytest.raises(OperationalError):
+                _db_read_with_retry(fn)
+
+        assert fn.call_count == 4
+
+    def test_non_operational_error_propagates_without_retry(self):
+        fn = MagicMock(side_effect=ValueError("not a connection problem"))
+
+        with patch(_CLOSE_CONNECTIONS_PATH), patch(_SLEEP_PATH) as sleep:
+            with pytest.raises(ValueError):
+                _db_read_with_retry(fn)
+
+        assert fn.call_count == 1
+        sleep.assert_not_called()
 
 
 # -- Integration tests using MinIO --

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/webhook_s3.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import time
 from collections.abc import AsyncGenerator, Callable
-from typing import Optional
+from typing import Optional, TypeVar
 
 from django.conf import settings
+from django.db import OperationalError, close_old_connections
 
 import orjson
 import pyarrow as pa
@@ -16,6 +18,35 @@ from posthog.sync import database_sync_to_async_pool
 from products.data_warehouse.backend.facade.api import aget_s3_client
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import SourceInputs
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.utils import table_from_py_list
+
+T = TypeVar("T")
+
+_MAX_DB_READ_ATTEMPTS = 4
+
+
+def _db_read_with_retry(fn: Callable[[], T]) -> T:
+    """Run an idempotent main-DB read, retrying a transient connection failure with backoff.
+
+    Temporal activities run in a long-lived worker that never goes through Django's request
+    cycle, so a pooled Postgres connection can be closed server-side while it sits idle, or the
+    connection pooler can reject the query with a wait timeout when the pool is saturated. Both
+    surface as a transient ``OperationalError`` and both clear once a healthy connection is used.
+    ``close_old_connections()`` evicts connections already known to be stale (and, after a failed
+    query marks one unusable, drops it), so each attempt runs on a fresh connection; the short
+    backoff also gives a saturated pool time to drain rather than retrying straight back into the
+    same wait timeout. Must run inside the ``database_sync_to_async_pool`` thread so the eviction
+    targets the same connection the query uses. ``DoesNotExist`` and other errors propagate.
+    """
+    attempt = 0
+    while True:
+        close_old_connections()
+        try:
+            return fn()
+        except OperationalError:
+            attempt += 1
+            if attempt >= _MAX_DB_READ_ATTEMPTS:
+                raise
+            time.sleep(min(2 * attempt, 30))
 
 
 class WebhookSourceManager:
@@ -36,8 +67,8 @@ class WebhookSourceManager:
         from products.cdp.backend.models.hog_functions.hog_function import HogFunction
         from products.warehouse_sources.backend.models.external_data_schema import ExternalDataSchema
 
-        schema = await database_sync_to_async_pool(ExternalDataSchema.objects.get)(
-            id=self._inputs.schema_id, team_id=self._inputs.team_id
+        schema = await database_sync_to_async_pool(_db_read_with_retry)(
+            lambda: ExternalDataSchema.objects.get(id=self._inputs.schema_id, team_id=self._inputs.team_id)
         )
 
         if (
@@ -50,15 +81,15 @@ class WebhookSourceManager:
             )
             return False
 
-        has_webhook_function = await database_sync_to_async_pool(
-            HogFunction.objects.filter(
+        has_webhook_function = await database_sync_to_async_pool(_db_read_with_retry)(
+            lambda: HogFunction.objects.filter(
                 inputs__source_id__value=self._inputs.source_id,
                 team_id=self._inputs.team_id,
                 type="warehouse_source_webhook",
                 enabled=True,
                 deleted=False,
-            ).exists
-        )()
+            ).exists()
+        )
 
         return has_webhook_function
 


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a recurring crash in the data-warehouse import pipeline: [`ProtocolViolation: query_wait_timeout`](https://us.posthog.com/project/2/error_tracking/019f1614-a16e-78f3-a338-11d56a8c0ac4) (also seen as `OperationalError: query_wait_timeout`), raised through the `customer_io` webhook source.

The stack trace's local variables are cross-contaminated by a concurrent activity sharing the worker's thread pool, but the actual resolved frame chain is clear:

```
import_data_activity_sync
 → customer_io/source.py source_for_pipeline → _webhook_source_response
   → common/webhook_s3.py webhook_enabled
     → ExternalDataSchema.objects.get(...)   # Django ORM SELECT
       → psycopg execute → query_wait_timeout
```

`query_wait_timeout` is a connection-pooler (PgBouncer) error: the client waited too long for a server connection from a momentarily saturated pool. It is **transient infrastructure**, not a Customer.io credential/config/data problem — so it must stay retryable and does **not** belong in any non-retryable list.

The fragility is that `WebhookSourceManager.webhook_enabled` runs two main-DB reads during pipeline setup with no resilience. Temporal activities run in a long-lived worker outside Django's request cycle, so a pooled connection can be closed server-side while idle, or the pool can reject the query under saturation — both crash the activity instead of riding it out.

## Changes

Wrap the two idempotent reads in `webhook_enabled` (`ExternalDataSchema.objects.get` and the `HogFunction` existence check) in `close_old_connections()` + bounded backoff retry, via a small `_db_read_with_retry` helper. The retry runs **inside** the `database_sync_to_async_pool` thread so the connection eviction targets the same connection the query uses.

This mirrors the existing `_get_integration` pattern already used by the `linkedin_ads` and `google_ads` sources for exactly this class of transient DB failure. The fix lives in the shared `webhook_s3.py` because that is where the queries run (and where `close_old_connections()` semantics are correct) — it benefits every webhook source, not just `customer_io`.

The error remains retryable end to end: non-`OperationalError` exceptions (e.g. `DoesNotExist`) propagate immediately, and after exhausting in-process attempts the error is re-raised so Temporal still retries the activity.

## How did you test this code?

I'm an agent. I added automated tests and ran them — no manual testing.

New `TestDbReadWithRetry` cases in `test_webhook_s3.py`:
- rides out repeated `OperationalError("query_wait_timeout")` then succeeds, asserting a connection eviction per attempt and growing backoff — catches a regression where the lookup had no retry and crashed the import on a momentary pool blip;
- re-raises after exhausting attempts (so Temporal-level retry is preserved);
- propagates a non-`OperationalError` immediately without retry or backoff (so real bugs aren't masked).

Ran the new tests plus the existing `test_webhook_enabled_conditions` — 8 passed. `ruff check`/`ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook alert. Used the PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, then read the `customer_io` source and the shared webhook manager.

Decision: the exception is a transient connection-pool wait timeout, not a user/upstream error, so adding it to `NonRetryableErrors` would be wrong (it would permanently fail imports on a momentary DB blip). Instead followed the established in-process-retry convention already present in sibling sources (`_get_integration` in `linkedin_ads`/`google_ads`) and applied it at the shared layer where the query actually runs. Kept the change minimal — no new abstractions beyond one small private helper, no change to global retry policy.
