### PR TITLE
fix(google_analytics): retry transient DB pool timeout when fetching integration

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/google_analytics.py
@@ -5,7 +5,7 @@ import collections.abc
 from typing import Any
 
 from django.conf import settings
-from django.db import close_old_connections
+from django.db import OperationalError, close_old_connections
 
 import requests
 import structlog
@@ -70,12 +70,41 @@ class GoogleAnalyticsResumeConfig:
     offset: int  # next row offset within that chunk
 
 
+def _backoff_sleep(attempt: int) -> None:
+    """Sleep before the next retry: linear growth capped at 30s (2s, 4s, 6s, ...)."""
+    time.sleep(min(2 * attempt, 30))
+
+
+_MAX_INTEGRATION_FETCH_ATTEMPTS = 4
+
+
+def _get_integration(integration_id: int, team_id: int) -> Integration:
+    """Fetch the OAuth ``Integration`` row, retrying a transient DB failure with backoff.
+
+    Temporal activities run in a long-lived worker that never goes through Django's request
+    cycle, so a pooled Postgres connection can be closed server-side while it sits idle, or the
+    connection pooler can reject the query with a wait timeout when the pool is saturated. Both
+    surface as a transient ``OperationalError`` and both clear once a healthy connection is used.
+    ``close_old_connections()`` evicts connections already known to be stale (and, after a failed
+    query marks one unusable, drops it), so each attempt runs on a fresh connection; the short
+    backoff also gives a saturated pool time to drain rather than retrying straight back into the
+    same wait timeout. This read is idempotent, so it is safe to repeat. ``Integration.DoesNotExist``
+    is left to propagate.
+    """
+    attempt = 0
+    while True:
+        close_old_connections()
+        try:
+            return Integration.objects.get(id=integration_id, team_id=team_id)
+        except OperationalError:
+            attempt += 1
+            if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
+                raise
+            _backoff_sleep(attempt)
+
+
 def _credentials(integration_id: int, team_id: int) -> OAuthCredentials:
-    # Invoked lazily from inside `get_rows` on a worker thread, so the pooled
-    # Django connection has often been idle long enough for Postgres to close it
-    # server-side — drop any stale connection before the ORM read.
-    close_old_connections()
-    integration = Integration.objects.get(id=integration_id, team_id=team_id)
+    integration = _get_integration(integration_id, team_id)
     return OAuthCredentials(
         token=None,
         refresh_token=integration.refresh_token,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_analytics/tests/test_google_analytics.py
@@ -5,7 +5,11 @@ from typing import Any, cast
 import pytest
 from unittest import mock
 
+from django.db import OperationalError
+
 import requests
+
+from posthog.models.integration import Integration
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import (
     GoogleAnalyticsSourceConfig,
@@ -20,6 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ana
     GoogleAnalyticsResumeConfig,
     _convert_metric_value,
     _credentials,
+    _get_integration,
     _initial_start_date,
     _is_quota_error,
     _is_retryable_server_error,
@@ -204,6 +209,67 @@ def test_credentials_refreshes_stale_db_connection_before_query(monkeypatch):
 
     assert calls == ["close_old_connections", "Integration.objects.get"]
     assert creds.refresh_token == "refresh-token"
+
+
+_INTEGRATION_GET_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.google_analytics."
+    "Integration.objects.get"
+)
+_CLOSE_CONNECTIONS_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.google_analytics."
+    "close_old_connections"
+)
+_SLEEP_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.google_analytics.google_analytics.time.sleep"
+)
+
+
+class TestGetIntegrationDbResilience:
+    def test_rides_out_pool_wait_timeout_then_succeeds(self):
+        integration = object()
+        get = mock.Mock(
+            side_effect=[
+                OperationalError("query_wait_timeout"),
+                OperationalError("query_wait_timeout"),
+                integration,
+            ]
+        )
+
+        with (
+            mock.patch(_INTEGRATION_GET_PATH, get),
+            mock.patch(_CLOSE_CONNECTIONS_PATH),
+            mock.patch(_SLEEP_PATH) as sleep,
+        ):
+            result = _get_integration(integration_id=1, team_id=2)
+
+        assert result is integration
+        assert get.call_count == 3
+        # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleep.call_args_list == [mock.call(2), mock.call(4)]
+
+    def test_reraises_after_exhausting_attempts(self):
+        get = mock.Mock(side_effect=OperationalError("query_wait_timeout"))
+
+        with (
+            mock.patch(_INTEGRATION_GET_PATH, get),
+            mock.patch(_CLOSE_CONNECTIONS_PATH),
+            mock.patch(_SLEEP_PATH),
+        ):
+            with pytest.raises(OperationalError):
+                _get_integration(integration_id=1, team_id=2)
+
+        # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry the activity.
+        assert get.call_count == 4
+
+    def test_missing_integration_is_not_retried(self):
+        get = mock.Mock(side_effect=Integration.DoesNotExist())
+
+        with mock.patch(_INTEGRATION_GET_PATH, get), mock.patch(_CLOSE_CONNECTIONS_PATH), mock.patch(_SLEEP_PATH):
+            with pytest.raises(Integration.DoesNotExist):
+                _get_integration(integration_id=1, team_id=2)
+
+        # A deleted integration row is non-retryable — don't mask it as a transient drop.
+        assert get.call_count == 1
 
 
 def _fake_response(status_code: int, json_body: dict | None = None, headers: dict | None = None):


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ProtocolViolation: query_wait_timeout` (issue [019f1623-0e1b-7810-ba8e-1a603833b848](https://us.posthog.com/project/2/error_tracking/019f1623-0e1b-7810-ba8e-1a603833b848)) from the Google Analytics import source. The top in-app frame is `_credentials` in `google_analytics.py:78` — the `Integration.objects.get(...)` ORM read, which runs lazily inside `get_rows` on a long-lived Temporal worker thread.

`query_wait_timeout` is the connection pooler's wait-timeout rejection (SQLSTATE `08P01`, raised as a psycopg `ProtocolViolation` and wrapped by Django as `OperationalError`): when the Postgres pool is saturated, the pooler drops a query that has been waiting in the queue too long. This is a transient infrastructure condition — it clears once the pool drains — but the current code only calls `close_old_connections()` once and does a single read, so one wait timeout fails the whole chunk read.

## Changes

This is **not** a non-retryable error — it must stay retryable, so it is deliberately not added to `get_non_retryable_errors`. Instead, harden the integration fetch the same way the sibling ad sources already do (`google_ads`, `linkedin_ads`, `meta_ads`):

- Extract `_get_integration`, which evicts stale connections with `close_old_connections()` and retries the idempotent read with bounded linear backoff (2s, 4s, 6s; 4 attempts) before giving up and letting Temporal retry the activity. The backoff gives a saturated pool time to drain instead of retrying straight back into the same wait timeout.
- `Integration.DoesNotExist` propagates immediately — a deleted integration row is non-retryable and must not be masked as a transient drop.

This mirrors the in-process retry pattern being rolled out across the other warehouse sources for the same class of transient pool timeout.

## How did you test this code?

I'm an agent. I added unit tests at the same layer as the fix and ran them — the full GA source suite passes (62 tests). New tests in `TestGetIntegrationDbResilience` cover the three behaviors that no existing test caught:

- rides out repeated `query_wait_timeout` failures and succeeds, backing off between attempts
- re-raises after exhausting the bounded attempt budget (so Temporal still takes over)
- does not retry `Integration.DoesNotExist`

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the GA import source. Confirmed via the error-tracking MCP tools that the failing frame genuinely originates in this source's `_credentials` (stack: `import_data_activity_sync` → pipeline `get_rows` → `google_analytics_session` → `_credentials` → ORM read), not just serialized log context.

Decision: classified `query_wait_timeout` as a transient infrastructure error (pool saturation), so it stays retryable rather than going into `NonRetryableErrors`. The fix hardens the integration fetch with in-process retry/backoff, matching the existing convention in `google_ads`/`linkedin_ads`/`meta_ads` (the LinkedIn Ads `_get_integration` is the closest reference, including its `query_wait_timeout` test). Checked open PRs first — the same fix is in flight for other sources but none existed for `google_analytics`.