### PR TITLE
feat(oauth): extend first-party access token TTL to 7 days

### DIFF
--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3840,6 +3840,82 @@ class TestOAuthAPI(APIBaseTest):
         self.assertEqual(data["scoped_organizations"], [str(self.organization.id)])
         self.assertEqual(data["scoped_teams"], [self.team.pk])
 
+    @freeze_time("2025-01-01 00:00:00")
+    def test_first_party_app_gets_extended_token_expiry(self):
+        app = self._create_first_party_app(slug="first-party-ttl")
+        grant = OAuthGrant.objects.create(
+            application=app,
+            user=self.user,
+            code="first_party_ttl_code",
+            code_challenge=self.code_challenge,
+            code_challenge_method="S256",
+            redirect_uri="https://example.com/callback",
+            expires=timezone.now() + timedelta(minutes=5),
+            scoped_organizations=[str(self.organization.id)],
+            scoped_teams=[],
+        )
+
+        response = self.post(
+            "/oauth/token/",
+            {
+                **self.base_token_body,
+                "client_id": app.client_id,
+                "client_secret": "first_party_first-party-ttl_client_secret",
+                "code": grant.code,
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertEqual(data["expires_in"], 60 * 60 * 24 * 7)
+
+        access_token = OAuthAccessToken.objects.get(token=data["access_token"])
+        expected_expiry = timezone.now() + timedelta(days=7)
+        self.assertLess(abs((access_token.expires - expected_expiry).total_seconds()), 60)
+
+    @freeze_time("2025-01-01 00:00:00")
+    def test_first_party_app_refreshed_token_keeps_extended_expiry_and_rotates(self):
+        app = self._create_first_party_app(slug="first-party-refresh-ttl")
+        client_secret = "first_party_first-party-refresh-ttl_client_secret"
+        grant = OAuthGrant.objects.create(
+            application=app,
+            user=self.user,
+            code="first_party_refresh_ttl_code",
+            code_challenge=self.code_challenge,
+            code_challenge_method="S256",
+            redirect_uri="https://example.com/callback",
+            expires=timezone.now() + timedelta(minutes=5),
+            scoped_organizations=[str(self.organization.id)],
+            scoped_teams=[],
+        )
+
+        token_response = self.post(
+            "/oauth/token/",
+            {
+                **self.base_token_body,
+                "client_id": app.client_id,
+                "client_secret": client_secret,
+                "code": grant.code,
+            },
+        )
+        self.assertEqual(token_response.status_code, status.HTTP_200_OK)
+        original = token_response.json()
+
+        refresh_response = self.post(
+            "/oauth/token/",
+            {
+                "grant_type": "refresh_token",
+                "refresh_token": original["refresh_token"],
+                "client_id": app.client_id,
+                "client_secret": client_secret,
+            },
+        )
+
+        self.assertEqual(refresh_response.status_code, status.HTTP_200_OK)
+        refreshed = refresh_response.json()
+        self.assertNotEqual(refreshed["refresh_token"], original["refresh_token"])
+        self.assertEqual(refreshed["expires_in"], 60 * 60 * 24 * 7)
+
 
 class TestLocalhostLoopbackRedirectUri(APIBaseTest):
     """

--- a/posthog/api/oauth/test_views.py
+++ b/posthog/api/oauth/test_views.py
@@ -3916,6 +3916,10 @@ class TestOAuthAPI(APIBaseTest):
         self.assertNotEqual(refreshed["refresh_token"], original["refresh_token"])
         self.assertEqual(refreshed["expires_in"], 60 * 60 * 24 * 7)
 
+        refreshed_access_token = OAuthAccessToken.objects.get(token=refreshed["access_token"])
+        expected_expiry = timezone.now() + timedelta(days=7)
+        self.assertLess(abs((refreshed_access_token.expires - expected_expiry).total_seconds()), 60)
+
 
 class TestLocalhostLoopbackRedirectUri(APIBaseTest):
     """

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -69,10 +69,11 @@ from posthog.views import login_required
 logger = structlog.get_logger(__name__)
 
 
-# Extended access-token TTL for clients that re-authorize rarely: dynamically
+# Extended access-token TTL for clients that rarely re-authorize: dynamically
 # registered (DCR/CIMD) clients that don't reliably refresh, and first-party
-# PostHog apps. Safe to extend because these tokens stay opaque and DB-backed,
-# so OAuthApplication.sessions_revoked_at can still force-revoke them.
+# PostHog apps. Safe to extend because these tokens stay opaque and DB-backed:
+# every request revalidates the token against the DB, so revoking an app's
+# sessions deletes its token rows and takes effect immediately regardless of TTL.
 EXTENDED_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 * 24 * 7  # 7 days
 
 

--- a/posthog/api/oauth/views.py
+++ b/posthog/api/oauth/views.py
@@ -69,6 +69,13 @@ from posthog.views import login_required
 logger = structlog.get_logger(__name__)
 
 
+# Extended access-token TTL for clients that re-authorize rarely: dynamically
+# registered (DCR/CIMD) clients that don't reliably refresh, and first-party
+# PostHog apps. Safe to extend because these tokens stay opaque and DB-backed,
+# so OAuthApplication.sessions_revoked_at can still force-revoke them.
+EXTENDED_ACCESS_TOKEN_EXPIRE_SECONDS = 60 * 60 * 24 * 7  # 7 days
+
+
 # Clients for which we must NOT issue refresh tokens. The token response will omit
 # "refresh_token" and no OAuthRefreshToken row will be created. Entries are matched
 # against the app's cimd_metadata_url for CIMD clients, and against client_id otherwise.
@@ -280,6 +287,12 @@ class OAuthValidator(OAuth2Validator):
         """Check if the client was registered dynamically (DCR or CIMD)."""
         if hasattr(request, "client") and request.client:
             return getattr(request.client, "is_dcr_client", False) or getattr(request.client, "is_cimd_client", False)
+        return False
+
+    def _is_first_party_client(self, request) -> bool:
+        """Check if the client is a first-party PostHog application."""
+        if hasattr(request, "client") and request.client:
+            return bool(getattr(request.client, "is_first_party", False))
         return False
 
     def _should_skip_refresh_token(self, request) -> bool:
@@ -496,14 +509,17 @@ class OAuthValidator(OAuth2Validator):
     def _get_token_expires_in(self, request) -> int:
         """
         Returns access token expiry in seconds.
-        Dynamically registered (DCR/CIMD) clients get extended TTL since they
-        don't reliably refresh. Impersonation-minted tokens are capped to the
-        impersonation idle timeout so they can't outlive the admin's session.
+
+        Dynamically registered (DCR/CIMD) clients get an extended TTL since they
+        don't reliably refresh; first-party PostHog apps get the same extended TTL.
+        Impersonation-minted tokens are capped to the impersonation idle timeout so
+        they can't outlive the admin's session. That check comes first so an
+        impersonated first-party app can't inherit the longer window.
         """
         if self._get_impersonator_id(request) is not None:
             return settings.IMPERSONATION_IDLE_TIMEOUT_SECONDS
-        if self._is_dynamic_client(request):
-            return 60 * 60 * 24 * 7  # 7 days
+        if self._is_dynamic_client(request) or self._is_first_party_client(request):
+            return EXTENDED_ACCESS_TOKEN_EXPIRE_SECONDS
         return oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS
 
     def save_bearer_token(self, token, request, *args, **kwargs):
@@ -525,7 +541,8 @@ class OAuthValidator(OAuth2Validator):
         logger.info(
             "oauth_save_bearer_token",
             client_id_prefix=str(client_id)[:8] if client_id else "unknown",
-            is_dcr_client=expires_in != oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS,
+            is_dynamic_client=self._is_dynamic_client(request),
+            is_first_party=self._is_first_party_client(request),
             expires_in=expires_in,
             refresh_token_suppressed=skip_refresh,
             grant_type=getattr(request, "grant_type", "unknown"),

--- a/posthog/test/test_oauth_impersonation.py
+++ b/posthog/test/test_oauth_impersonation.py
@@ -109,14 +109,22 @@ class TestImpersonationOAuthTokenIssuance(APIBaseTest):
     `/oauth/authorize` for both read-only and read-write impersonation — so this
     test implicitly covers both modes."""
 
-    def test_code_exchange_caps_expiry_and_suppresses_refresh_for_impersonation_grants(self) -> None:
+    @parameterized.expand(
+        [
+            ("third_party", False),
+            ("first_party", True),
+        ]
+    )
+    def test_code_exchange_caps_expiry_and_suppresses_refresh_for_impersonation_grants(
+        self, _name: str, is_first_party: bool
+    ) -> None:
         admin = User.objects.create_user(email="admin@posthog.com", password="x", first_name="A")
         admin.is_staff = True
         admin.save()
 
         app = OAuthApplication.objects.create(
             name="App",
-            client_id="impersonation-test-client",
+            client_id=f"impersonation-test-client-{_name}",
             client_secret="impersonation-test-secret",
             client_type=OAuthApplication.CLIENT_CONFIDENTIAL,
             authorization_grant_type=OAuthApplication.GRANT_AUTHORIZATION_CODE,
@@ -124,6 +132,7 @@ class TestImpersonationOAuthTokenIssuance(APIBaseTest):
             user=self.user,
             hash_client_secret=True,
             algorithm="RS256",
+            is_first_party=is_first_party,
         )
 
         # PKCE bits — `S256` over a fixed verifier. The validator only checks the


### PR DESCRIPTION
## Problem

Long-running agents working in the PostHog codebase authenticate through first-party OAuth apps, and a 1-hour access token expires partway through a session.

The auth system in posthog code has enough rough edges right now that this churn is a real source of friction and a broader authentication refactor is on the way. Extending the first-party access-token TTL is a low-risk way to ease that churn in the meantime. Honestly worth doing on the long-running-agent point alone.

It also lines first-party apps up with dynamically registered clients (DCR/CIMD), which already get a 7-day access token because they don't reliably run the refresh flow. First-party apps re-authorize rarely, so there's no reason to hold them to a shorter window.

**NOTE:** Safe to extend: these tokens stay opaque and DB-backed, so an app's `sessions_revoked_at` can still force-revoke them at any time.

## Changes

- `_get_token_expires_in` now returns the extended TTL for first-party apps (`is_first_party`) in addition to dynamic clients.
- Extracted the shared value into a module constant `EXTENDED_ACCESS_TOKEN_EXPIRE_SECONDS` (7 days) so the dynamic and first-party paths can't drift apart.
- Added an `_is_first_party_client` helper mirroring `_is_dynamic_client`.
- The impersonation cap still takes precedence: an impersonated first-party app is capped to the impersonation idle timeout and can't inherit the longer window.
- First-party apps keep refresh-token rotation **on** (only dynamic clients disable rotation). Only the access-token lifetime changes here.
- Cleaned up a stale log field in `save_bearer_token`: it inferred `is_dcr_client` from `expires_in != default`, which is wrong now that first-party tokens also differ from the default. Replaced it with explicit `is_dynamic_client` and `is_first_party` flags.

No DRF request/response schema changed. This is internal to the oauthlib `OAuthValidator`, so generated API types are unaffected.

## How did you test this code?

Added two tests to `posthog/api/oauth/test_views.py`:

- `test_first_party_app_gets_extended_token_expiry` catches a first-party initial token mint silently falling back to the 1-hour default. It asserts both the response `expires_in` and the persisted token's `expires` are ~7 days out.
- `test_first_party_app_refreshed_token_keeps_extended_expiry_and_rotates` catches two regressions no existing test covered: (1) the refresh grant not re-applying the 7-day TTL (for example if `request.client` weren't populated at save time), and (2) first-party apps accidentally inheriting the dynamic-client behavior of *not* rotating refresh tokens. It asserts the refreshed token still expires in 7 days and that the refresh token actually rotated.

Ran these alongside the existing expiry coverage locally, all green:

```
test_first_party_app_gets_extended_token_expiry
test_first_party_app_refreshed_token_keeps_extended_expiry_and_rotates
test_dcr_client_gets_extended_token_expiry
test_dcr_client_refresh_token_is_not_rotated
test_non_dcr_client_gets_default_token_expiry
5 passed
```

ruff lint/format and the pre-commit `ty` type check also pass.
