### PR TITLE
fix(google_ads): restart pagination on expired page token

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/google_ads.py
@@ -554,7 +554,7 @@ def _search_with_transient_retry(
     Each retry re-requests the same ``page_token``, so there is no partial state to reconcile. The
     transient status may itself arrive wrapped in a ``GoogleAdsException`` (see
     ``_is_transient_grpc_error``). Non-transient errors re-raise immediately so the caller's
-    ``INVALID_PAGE_TOKEN`` handling and Temporal's retry policy still apply.
+    stale-page-token handling and Temporal's retry policy still apply.
     """
     attempt = 0
     while True:
@@ -567,17 +567,26 @@ def _search_with_transient_retry(
             time.sleep(min(2 * attempt, 30))
 
 
-def _is_invalid_page_token_error(exc: GoogleAdsException) -> bool:
-    """Return True if a ``GoogleAdsException`` was caused by an expired/invalid page token.
+_STALE_PAGE_TOKEN_REQUEST_ERRORS = ("INVALID_PAGE_TOKEN", "EXPIRED_PAGE_TOKEN")
+
+
+def _is_stale_page_token_error(exc: GoogleAdsException) -> bool:
+    """Return True if a ``GoogleAdsException`` was caused by a stale page token.
 
     Google Ads search page tokens are ephemeral, but our resumption contract
     persists them (see ``_search_as_arrow_tables``). When a sync resumes from a
-    token Google has already expired, the API rejects the request with
-    ``request_error: INVALID_PAGE_TOKEN``. The proto text representation is the
-    same for proto-plus and raw protobuf failures, so we match on it directly.
+    token Google no longer accepts, the API rejects the request with either
+    ``request_error: INVALID_PAGE_TOKEN`` (malformed/unrecognised) or
+    ``request_error: EXPIRED_PAGE_TOKEN`` (a once-valid token aged out between
+    runs) — both mean the same thing for us: restart pagination from the first
+    page. The proto text representation is the same for proto-plus and raw
+    protobuf failures, so we match on it directly.
     """
     failure = getattr(exc, "failure", None)
-    return failure is not None and "INVALID_PAGE_TOKEN" in str(failure)
+    if failure is None:
+        return False
+    failure_text = str(failure)
+    return any(request_error in failure_text for request_error in _STALE_PAGE_TOKEN_REQUEST_ERRORS)
 
 
 def _search_as_arrow_tables(
@@ -596,9 +605,10 @@ def _search_as_arrow_tables(
       yielded but never acked by a save is simply re-yielded. Merge semantics
       over ``primary_keys`` dedupe those repeated rows.
     * A resumed token may have expired between runs (Google Ads page tokens are
-      short-lived). If Google rejects it with ``INVALID_PAGE_TOKEN`` we discard
-      the saved token and restart pagination from the first page — the same
-      merge semantics make re-yielding already-synced rows safe.
+      short-lived). If Google rejects it with ``INVALID_PAGE_TOKEN`` or
+      ``EXPIRED_PAGE_TOKEN`` we discard the saved token and restart pagination
+      from the first page — the same merge semantics make re-yielding
+      already-synced rows safe.
     """
     page_token = ""
     if resumable_source_manager.can_resume():
@@ -623,7 +633,7 @@ def _search_as_arrow_tables(
             # Only a non-empty (resumed or mid-stream) token can be stale; an empty
             # token always requests the first page, so the guard also prevents an
             # infinite restart loop if the first page itself were ever rejected.
-            if page_token and _is_invalid_page_token_error(e):
+            if page_token and _is_stale_page_token_error(e):
                 resumable_source_manager.save_state(GoogleAdsResumeConfig(page_token=""))
                 page_token = ""
                 continue

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -24,7 +24,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads
     GoogleAdsColumn,
     GoogleAdsTable,
     _get_integration,
-    _is_invalid_page_token_error,
+    _is_stale_page_token_error,
     _is_transient_client_init_error,
     _is_transient_grpc_error,
     _load_client_with_transient_retry,
@@ -430,23 +430,33 @@ class _FakeResumableManager:
         self.saved_states.append(data.page_token)
 
 
-class TestInvalidPageTokenDetection:
+class TestStalePageTokenDetection:
     @pytest.mark.parametrize(
         "exc, expected",
         [
             (_google_ads_exception(RequestErrorEnum.RequestError.INVALID_PAGE_TOKEN), True),
+            # Google returns a distinct EXPIRED_PAGE_TOKEN when a once-valid token aged out
+            # between runs — the resumption recovery must treat it the same as INVALID_PAGE_TOKEN.
+            (_google_ads_exception(RequestErrorEnum.RequestError.EXPIRED_PAGE_TOKEN), True),
             (_google_ads_exception(RequestErrorEnum.RequestError.RESOURCE_NAME_MISSING), False),
             # A non-``GoogleAdsException`` shape (no ``failure``) must not match.
             (SimpleNamespace(failure=None), False),
         ],
     )
-    def test_is_invalid_page_token_error(self, exc, expected):
-        assert _is_invalid_page_token_error(exc) is expected
+    def test_is_stale_page_token_error(self, exc, expected):
+        assert _is_stale_page_token_error(exc) is expected
 
 
 class TestSearchPageTokenResumption:
-    def test_restarts_pagination_when_saved_page_token_expired(self):
-        service = _FakeService(_single_page())
+    @pytest.mark.parametrize(
+        "request_error",
+        [
+            RequestErrorEnum.RequestError.INVALID_PAGE_TOKEN,
+            RequestErrorEnum.RequestError.EXPIRED_PAGE_TOKEN,
+        ],
+    )
+    def test_restarts_pagination_when_saved_page_token_stale(self, request_error):
+        service = _FakeService(_single_page(), error_on_token=_google_ads_exception(request_error))
         manager = _FakeResumableManager(saved_token="STALE_TOKEN")
 
         tables = list(


### PR DESCRIPTION
## Problem

A Google Ads data-warehouse import surfaced in error tracking as an unhandled `GoogleAdsException` carrying `request_error: EXPIRED_PAGE_TOKEN` ("Page token has expired."), failing the whole sync.

Google Ads search page tokens are short-lived. The resumable source persists the `page_token` between runs so a restart can pick up where it left off, and `_search_as_arrow_tables` is designed to recover when a resumed token is no longer accepted — it discards the stale token and restarts pagination from the first page (merge-by-primary-key makes re-yielding already-synced rows safe).

The catch: Google rejects a no-longer-accepted token with one of **two** distinct request errors — `INVALID_PAGE_TOKEN` (malformed/unrecognised) and `EXPIRED_PAGE_TOKEN` (a once-valid token that aged out between runs). The recovery only matched `INVALID_PAGE_TOKEN`, so an `EXPIRED_PAGE_TOKEN` — the more common one for a resumed sync — fell through to `raise` and failed the activity instead of being recovered.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1746-4e3d-70b3-8983-51960527775a

## Changes

- Treat both `INVALID_PAGE_TOKEN` and `EXPIRED_PAGE_TOKEN` as a stale page token in the resumption recovery, restarting pagination from the first page in either case.
- Renamed `_is_invalid_page_token_error` -> `_is_stale_page_token_error` to reflect that it now covers both, and corrected the docstring (it previously, incorrectly, claimed expired tokens come back as `INVALID_PAGE_TOKEN`).

This is scoped to the page-token resumption path only — it does not touch the global retry policy or any other error handling.

## How did you test this code?

I'm an agent. I ran the source's existing unit tests via the automated suite only (no manual sync against the live API):

- Parametrized `_is_stale_page_token_error` over `INVALID_PAGE_TOKEN` (true), `EXPIRED_PAGE_TOKEN` (true), `RESOURCE_NAME_MISSING` (false), and a non-`GoogleAdsException` shape (false).
- Parametrized the end-to-end resumption test (`test_restarts_pagination_when_saved_page_token_stale`) over both token errors, asserting the stale token is tried, rejected, cleared from saved state, pagination restarts from the first page, and rows are still yielded.
- Confirmed both new cases **fail** against the pre-fix code (the `EXPIRED_PAGE_TOKEN` case raised the same unhandled `GoogleAdsException` seen in production) and pass with the fix.
- Full file: `97 passed`. Ran `ruff check`/`ruff format` clean.

These catch the regression that no existing test did: an expired (vs. merely invalid) page token must also trigger a pagination restart rather than failing the sync.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Used PostHog error-tracking MCP tools to pull the issue, a representative event, and the full stack trace, confirming the failure originates in `google_ads.py` (`get_rows` -> `_search_as_arrow_tables` -> `_search_with_transient_retry`). Verified `EXPIRED_PAGE_TOKEN` (8) is a distinct enum value from `INVALID_PAGE_TOKEN` (7) in the installed `google-ads` SDK.

Decision: this is a fixable bug, not a user/upstream error — the resumption contract already intends to recover from stale tokens; it just missed one of the two stable error codes. Did not extend `NonRetryableErrors`, since the right behavior is to recover and continue, not to stop. Checked open PRs (including the maintainer's) for a duplicate — the other open `google_ads` fixes cover schema-discovery retries, DB pool timeouts, RESOURCE_EXHAUSTED, and `is_mcc_account` validation; none touch page-token resumption.