### PR TITLE
chore(llma): fix flaky AssistantFailureMessage test

### DIFF
--- a/products/posthog_ai/frontend/messages/AssistantFailureMessage.test.tsx
+++ b/products/posthog_ai/frontend/messages/AssistantFailureMessage.test.tsx
@@ -4,6 +4,12 @@ import { cleanup, render, screen } from '@testing-library/react'
 
 import { AssistantFailureMessage } from './AssistantFailureMessage'
 
+// Render content verbatim instead of through the real marked/LemonMarkdown pipeline,
+// which is slow to mount and rewrites the markdown (e.g. strips emphasis asterisks).
+jest.mock('./MarkdownMessage', () => ({
+    MarkdownMessage: ({ content }: { content: string }) => <div data-attr="markdown">{content}</div>,
+}))
+
 describe('AssistantFailureMessage', () => {
     afterEach(cleanup)
 


### PR DESCRIPTION
## Problem

`AssistantFailureMessage.test.tsx` was flaky in CI — the Jest shard hit its 15-minute timeout and got cancelled. The test rendered the *real* `MarkdownMessage`, which mounts the full `marked` + `LemonMarkdown` + `CodeSnippet` pipeline (syntax highlighting lazy-loads). That's slow to mount and also rewrites the markdown, so the fallback assertion checking for `*PostHog AI has failed…*` couldn't reliably match the rendered output (emphasis asterisks get stripped).

## Changes

Mock `MarkdownMessage` in the test so content renders verbatim, isolating the component under test. This mirrors the existing pattern in the sibling `Approval.test.tsx`.

## How did you test this code?

I'm an agent. Jest isn't installed in my environment, so I couldn't execute the suite. The change copies the verbatim-render mock already used and passing in `products/posthog_ai/frontend/components/Approval.test.tsx`, so the three assertions now match the literal content (including the fallback message's asterisks). CI will run the suite.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a flaky/timed-out Jest job. Root cause was the test exercising the heavy real markdown renderer rather than the component's own logic. Chose to mock `MarkdownMessage` (consistent with `Approval.test.tsx`) over mocking deeper into `marked`/`LemonMarkdown`, since the unit under test only cares about which content string it forwards.

---
*Created with [PostHog](https://posthog.com?ref=pr)*
