### PR TITLE
fix(data-modeling): drop leaking session advisory lock in sync_views

### DIFF
--- a/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
+++ b/products/data_modeling/backend/models/datawarehouse_managed_viewset.py
@@ -169,36 +169,29 @@ class DataWarehouseManagedViewSet(CreatedMetaFields, UpdatedMetaFields, UUIDTMod
         # on every sync — create, update, and resync. saved_queries_to_schedule is in expected_views
         # order (dependencies first), so edges resolve in a single pass.
         #
-        # Serialize concurrent sync_views for this team+kind with a SESSION-level advisory lock so two
-        # calls can't race on node/edge placement (one call's edge delete-and-recreate wiping
-        # another's). Deliberately NOT wrapped in a transaction: sync_saved_query_to_dag parses HogQL
-        # (builds a Database context + resolves view dependencies), and holding a Postgres transaction
-        # open across that is what starves the data-modeling connection pool. Each call commits in
-        # autocommit and is idempotent; the lock is released in a finally so it never leaks.
-        lock_key = f"{self.team_id}_sync_views_{self.kind}"
-        with connection.cursor() as cursor:
-            cursor.execute("SELECT pg_advisory_lock(hashtext(%s)::bigint)", [lock_key])
-        try:
-            managed_dag = DAG.get_or_create_revenue_analytics(self.team)
-            for saved_query in saved_queries_to_schedule:
-                try:
-                    sync_saved_query_to_dag(saved_query, dag=managed_dag, allow_managed=True)
-                    # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
-                    # unless something there still depends on it (don't orphan a dependent).
-                    for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):
-                        if not stale.outgoing_edges.exists():
-                            stale.delete()
-                except Exception as e:
-                    capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
-                    logger.warning(
-                        "failed_to_sync_managed_view_to_dag",
-                        team_id=self.team_id,
-                        view_name=saved_query.name,
-                        error=str(e),
-                    )
-        finally:
-            with connection.cursor() as cursor:
-                cursor.execute("SELECT pg_advisory_unlock(hashtext(%s)::bigint)", [lock_key])
+        # No cross-call advisory lock here on purpose: a SESSION-level pg_advisory_lock acquired and
+        # released across separate autocommit statements leaks under transaction-mode PgBouncer — the
+        # unlock can be routed to a different backend than the one that holds the lock, stranding it
+        # and eventually exhausting the connection pool. Concurrent sync_views for the same team+kind
+        # can therefore race on node/edge placement; that is tolerated for now, pending a pooling-safe
+        # guard. The transaction-scoped lock above still serializes the saved-query writes.
+        managed_dag = DAG.get_or_create_revenue_analytics(self.team)
+        for saved_query in saved_queries_to_schedule:
+            try:
+                sync_saved_query_to_dag(saved_query, dag=managed_dag, allow_managed=True)
+                # Drop any stale node left in another DAG (e.g. a legacy Default-DAG placement),
+                # unless something there still depends on it (don't orphan a dependent).
+                for stale in Node.objects.filter(team=self.team, saved_query=saved_query).exclude(dag=managed_dag):
+                    if not stale.outgoing_edges.exists():
+                        stale.delete()
+            except Exception as e:
+                capture_exception(e, {"managed_viewset_id": self.id, "view_name": saved_query.name})
+                logger.warning(
+                    "failed_to_sync_managed_view_to_dag",
+                    team_id=self.team_id,
+                    view_name=saved_query.name,
+                    error=str(e),
+                )
 
         for saved_query in saved_queries_to_schedule:
             try:


### PR DESCRIPTION
## Problem

`DataWarehouseManagedViewSet.sync_views()` took a **session-scoped** `pg_advisory_lock` (acquired, then released in a `finally`) to serialize concurrent syncs for the same team while it placed managed view nodes/edges in the DAG.

On databases behind **transaction-mode PgBouncer**, consecutive autocommit statements can land on different server backends. So the `pg_advisory_unlock` in the `finally` can be routed to a *different* backend than the one that acquired the lock — the lock is never released. Leaked locks accumulate on pooled backends and eventually exhaust the connection pool, which then starves every workload sharing that pool (e.g. data-import job creation).

This is the same hazard the warehouse-sources DB avoids by pinning its PgBouncer to session mode; this code path runs against a transaction-pooled DB, so a session-scoped advisory lock isn't safe here.

## Changes

- Remove the session-scoped `pg_advisory_lock` / `pg_advisory_unlock` around the managed-view DAG node/edge sync.
- Keep the transaction-scoped `pg_advisory_xact_lock` already guarding the saved-query writes — it auto-releases on commit and is pooling-safe.

Trade-off: concurrent `sync_views` for the same team+kind can now race on DAG node/edge placement. That's accepted for now to stop the pool leak; the follow-up is a pooling-safe guard (e.g. an xact-scoped lock around the DAG section, or pinning that section to a session-mode connection).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8). Automated/static only — no manual testing claimed:
- `ruff check` + `ruff format` clean; commit-time `ty` typecheck passed.
- No test referenced the removed advisory lock, so none needed updating. Existing `sync_views()` tests exercise the unchanged behavior (view + DAG creation) and run in CI.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Eric directed this fix after identifying that a recently-added session-scoped advisory lock in the managed-view DAG work was leaking under transaction-mode PgBouncer and exhausting the main DB connection pool. We chose the minimal change — drop the session lock rather than revert the broader feature it shipped with (#63600) — to keep rollout fast and low-risk, accepting a temporary loss of cross-call serialization on DAG node/edge placement. Converting the section to a transaction-scoped lock was considered and deferred to a follow-up so this PR stays minimal. No repo skills were required for this change.
