### PR TITLE
feat(cli): `posthog-cli agents` — deploy/pull/list code-level agents (experimental)

### DIFF
--- a/cli/src/agents/deploy.rs
+++ b/cli/src/agents/deploy.rs
@@ -5,13 +5,14 @@ use anyhow::{Context, Result};
 use colored::Colorize;
 use inquire::Confirm;
 use serde_json::{json, Value};
+use similar::{ChangeTag, TextDiff};
 
 use crate::invocation_context::context;
 
 use super::{
     apply_spec_overrides, build_typed_bundle, debug_error, debug_request, discover_bundles,
-    find_application, get_json, load_bundle, per_file_sha256, select_bundles, DeployArgs,
-    LoadedBundle,
+    find_application, get_json, get_typed_bundle, load_bundle, per_file_sha256, select_bundles,
+    DeployArgs, LoadedBundle,
 };
 
 /// Curated name + description per slug. Bundles not listed fall back to a
@@ -46,6 +47,14 @@ enum Action {
     Skip,
 }
 
+/// One changed artifact in the plan: live content (`from`) vs what we'd deploy
+/// (`to`). Empty `from` reads as added, empty `to` as removed.
+struct FileDiff {
+    label: String,
+    from: String,
+    to: String,
+}
+
 struct Planned {
     bundle: LoadedBundle,
     spec: Value,
@@ -55,6 +64,8 @@ struct Planned {
     live_rev: Option<String>,
     action: Action,
     reason: String,
+    /// Populated only with `--diff`: line-level diffs for the plan display.
+    diffs: Vec<FileDiff>,
 }
 
 pub fn deploy_agents(args: &DeployArgs) -> Result<()> {
@@ -118,6 +129,14 @@ pub fn deploy_agents(args: &DeployArgs) -> Result<()> {
                 p.bundle.slug,
                 p.reason.dimmed()
             ),
+        }
+        for d in &p.diffs {
+            println!("    {} {}", diff_sigil(d).bold(), d.label.bold());
+            // Line-level hunks for modifications; pure add/remove stays label-only
+            // (no point dumping an entire new prompt as one green block).
+            if !d.from.is_empty() && !d.to.is_empty() {
+                print_diff(&d.from, &d.to, "      ");
+            }
         }
     }
 
@@ -206,21 +225,37 @@ fn plan_bundle(root: &Path, host: &str, args: &DeployArgs) -> Result<Planned> {
     )?;
 
     let app_id = find_application(&bundle.slug, args.debug)?;
+    let mut live_spec: Option<Value> = None;
     let (action, reason, live_rev) = match &app_id {
         None => (Action::Create, "new application".to_string(), None),
         Some(id) => {
-            let (live_rev, live_manifest, live_spec) = get_live(id, args.debug);
+            let (rev, live_manifest, spec_live) = get_live(id, args.debug);
+            live_spec = spec_live;
             let target = per_file_sha256(&bundle.files);
-            if live_rev.is_none() {
+            if rev.is_none() {
                 (Action::Update, "no live revision yet".to_string(), None)
             } else if live_manifest.as_ref() == Some(&target) && live_spec.as_ref() == Some(&spec) {
-                (Action::Skip, "matches live".to_string(), live_rev)
+                (Action::Skip, "matches live".to_string(), rev)
             } else if live_manifest.as_ref() != Some(&target) {
-                (Action::Update, "bundle drifted".to_string(), live_rev)
+                (Action::Update, "bundle drifted".to_string(), rev)
             } else {
-                (Action::Update, "spec drifted".to_string(), live_rev)
+                (Action::Update, "spec drifted".to_string(), rev)
             }
         }
+    };
+
+    let diffs = if args.diff {
+        compute_plan_diffs(
+            &action,
+            &bundle,
+            &spec,
+            app_id.as_deref(),
+            live_rev.as_deref(),
+            live_spec.as_ref(),
+            args.debug,
+        )
+    } else {
+        Vec::new()
     };
 
     Ok(Planned {
@@ -230,7 +265,134 @@ fn plan_bundle(root: &Path, host: &str, args: &DeployArgs) -> Result<Planned> {
         live_rev,
         action,
         reason,
+        diffs,
     })
+}
+
+/// Best-effort line-level diffs for the plan: agent.md + skill bodies (live vs
+/// what we'd deploy) and a spec diff. Skips quietly if the live bundle can't be
+/// fetched — a diff is a nicety, not a gate.
+fn compute_plan_diffs(
+    action: &Action,
+    bundle: &LoadedBundle,
+    spec: &Value,
+    app_id: Option<&str>,
+    live_rev: Option<&str>,
+    live_spec: Option<&Value>,
+    debug: bool,
+) -> Vec<FileDiff> {
+    if matches!(action, Action::Skip) {
+        return Vec::new();
+    }
+    let local = build_typed_bundle(bundle, spec);
+    let local_md = local.get("agent_md").and_then(Value::as_str).unwrap_or("");
+    let local_skills = skill_bodies(&local);
+
+    // No live revision to compare against → list what will be added (labels only).
+    let (Some(app_id), Some(rev_id)) = (app_id, live_rev) else {
+        let mut out = vec![FileDiff {
+            label: "agent.md".into(),
+            from: String::new(),
+            to: local_md.to_string(),
+        }];
+        let mut ids: Vec<&String> = local_skills.keys().collect();
+        ids.sort();
+        for id in ids {
+            out.push(FileDiff {
+                label: format!("skills/{id}"),
+                from: String::new(),
+                to: local_skills[id].clone(),
+            });
+        }
+        return out;
+    };
+
+    let mut out: Vec<FileDiff> = Vec::new();
+    if let Ok(live) = get_typed_bundle(app_id, rev_id, debug) {
+        let live_md = live.get("agent_md").and_then(Value::as_str).unwrap_or("");
+        if local_md != live_md {
+            out.push(FileDiff {
+                label: "agent.md".into(),
+                from: live_md.into(),
+                to: local_md.into(),
+            });
+        }
+        let live_skills = skill_bodies(&live);
+        let mut ids: Vec<&String> = local_skills.keys().chain(live_skills.keys()).collect();
+        ids.sort();
+        ids.dedup();
+        for id in ids {
+            let l = local_skills.get(id).map(String::as_str).unwrap_or("");
+            let r = live_skills.get(id).map(String::as_str).unwrap_or("");
+            if l != r {
+                out.push(FileDiff {
+                    label: format!("skills/{id}"),
+                    from: r.into(),
+                    to: l.into(),
+                });
+            }
+        }
+    }
+    // Spec diff (frozen live spec vs the spec we'd patch). Normalization noise expected.
+    if let Some(live_spec) = live_spec {
+        if live_spec != spec {
+            out.push(FileDiff {
+                label: "spec (frozen ↔ local)".into(),
+                from: serde_json::to_string_pretty(live_spec).unwrap_or_default(),
+                to: serde_json::to_string_pretty(spec).unwrap_or_default(),
+            });
+        }
+    }
+    out
+}
+
+/// `{ skill_id: body }` from a typed bundle's `skills[]`.
+fn skill_bodies(typed: &Value) -> HashMap<String, String> {
+    typed
+        .get("skills")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|s| {
+                    Some((
+                        s.get("id").and_then(Value::as_str)?.to_string(),
+                        s.get("body")
+                            .and_then(Value::as_str)
+                            .unwrap_or("")
+                            .to_string(),
+                    ))
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+fn diff_sigil(d: &FileDiff) -> colored::ColoredString {
+    if d.from.is_empty() {
+        "+".green()
+    } else if d.to.is_empty() {
+        "-".red()
+    } else {
+        "~".yellow()
+    }
+}
+
+/// Unified line diff (mirrors `exp endpoints`' renderer) using `similar`.
+fn print_diff(from: &str, to: &str, indent: &str) {
+    let diff = TextDiff::from_lines(from, to);
+    for change in diff.iter_all_changes() {
+        let (sign, paint): (&str, fn(&str) -> colored::ColoredString) = match change.tag() {
+            ChangeTag::Delete => ("-", |s: &str| s.red()),
+            ChangeTag::Insert => ("+", |s: &str| s.green()),
+            ChangeTag::Equal => (" ", |s: &str| s.dimmed()),
+        };
+        let line = change.to_string_lossy();
+        println!(
+            "{indent}{} {}",
+            paint(sign),
+            paint(line.trim_end_matches('\n'))
+        );
+    }
 }
 
 /// Run the full deploy pipeline for one planned bundle. Returns the now-live revision id.

--- a/cli/src/agents/deploy.rs
+++ b/cli/src/agents/deploy.rs
@@ -1,0 +1,492 @@
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use inquire::Confirm;
+use serde_json::{json, Value};
+
+use crate::invocation_context::context;
+
+use super::{
+    apply_spec_overrides, build_typed_bundle, debug_error, debug_request, discover_bundles,
+    find_application, get_json, load_bundle, per_file_sha256, select_bundles, DeployArgs,
+    LoadedBundle,
+};
+
+/// Curated name + description per slug. Bundles not listed fall back to a
+/// title-cased slug + a generic description — new examples deploy with zero
+/// config; this just preserves nicer copy for the ones we care about.
+fn metadata(slug: &str) -> (String, String) {
+    match slug {
+        "agent-approval-demo" => (
+            "Approval demo agent".to_string(),
+            "Smallest possible agent that demonstrates approval-gated tool calls — chat with it and ask it to save a note.".to_string(),
+        ),
+        "agent-builder" => ("Agent Builder".to_string(), "Meta-agent for the platform.".to_string()),
+        _ => (capitalize(&slug.replace('-', " ")), format!("Example agent bundle: {slug}.")),
+    }
+}
+
+/// First char upper, the rest lower — matches Python's `str.capitalize()`.
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first
+            .to_uppercase()
+            .chain(chars.flat_map(char::to_lowercase))
+            .collect(),
+    }
+}
+
+enum Action {
+    Create,
+    Update,
+    Skip,
+}
+
+struct Planned {
+    bundle: LoadedBundle,
+    spec: Value,
+    /// Existing application id, or None when the application must be created.
+    app_id: Option<String>,
+    /// Live revision to branch from (parent of the new draft), if any.
+    live_rev: Option<String>,
+    action: Action,
+    reason: String,
+}
+
+pub fn deploy_agents(args: &DeployArgs) -> Result<()> {
+    context().capture_command_invoked("agents_deploy");
+    let host = context().client.get_host().clone();
+
+    let bundles = discover_bundles(Path::new(&args.dir))?;
+    if bundles.is_empty() {
+        anyhow::bail!("no bundles found under {}", args.dir);
+    }
+    let selected = select_bundles(&bundles, &args.names)?;
+
+    println!();
+    println!(
+        "Deploy target: {} — {}/{} bundle(s)",
+        host.bold(),
+        selected.len(),
+        bundles.len()
+    );
+    println!();
+
+    // ── plan ──────────────────────────────────────────────────────────────────
+    let mut planned: Vec<Planned> = Vec::new();
+    let mut failures: Vec<(String, String)> = Vec::new();
+    for root in &selected {
+        match plan_bundle(root, &host, args) {
+            Ok(p) => planned.push(p),
+            Err(e) => {
+                let slug = root
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                println!(
+                    "  {}   {} ({})",
+                    "ERROR".red().bold(),
+                    slug,
+                    format!("{e:#}").dimmed()
+                );
+                failures.push((slug, format!("{e:#}")));
+            }
+        }
+    }
+
+    for p in &planned {
+        match p.action {
+            Action::Create => println!(
+                "  {}  {} ({})",
+                "CREATE".green().bold(),
+                p.bundle.slug.bold(),
+                p.reason.dimmed()
+            ),
+            Action::Update => println!(
+                "  {}  {} ({})",
+                "UPDATE".yellow().bold(),
+                p.bundle.slug.bold(),
+                p.reason.dimmed()
+            ),
+            Action::Skip => println!(
+                "  {}    {} ({})",
+                "SKIP".dimmed(),
+                p.bundle.slug,
+                p.reason.dimmed()
+            ),
+        }
+    }
+
+    let to_apply = planned
+        .iter()
+        .filter(|p| !matches!(p.action, Action::Skip))
+        .count();
+
+    if to_apply == 0 {
+        println!();
+        println!("Nothing to deploy.");
+        return finish(&failures);
+    }
+
+    // ── dry-run stops after the plan ────────────────────────────────────────────
+    if args.dry_run {
+        println!();
+        println!("{}", "(dry-run, nothing deployed)".dimmed());
+        return finish(&failures);
+    }
+
+    // ── confirm ─────────────────────────────────────────────────────────────────
+    if !args.yes
+        && !matches!(
+            Confirm::new(&format!("Deploy {to_apply} bundle(s)?"))
+                .with_default(true)
+                .prompt(),
+            Ok(true)
+        )
+    {
+        println!("Cancelled.");
+        return Ok(());
+    }
+    println!();
+
+    // ── apply ─────────────────────────────────────────────────────────────────
+    let mut deployed = 0;
+    for p in planned {
+        if matches!(p.action, Action::Skip) {
+            continue;
+        }
+        let slug = p.bundle.slug.clone();
+        match apply_bundle(p, args) {
+            Ok(rev_id) => {
+                println!(
+                    "  {} {} live at {}",
+                    "✓".green(),
+                    slug.bold(),
+                    rev_id.dimmed()
+                );
+                deployed += 1;
+            }
+            Err(e) => {
+                println!("  {} {}: {}", "✗".red(), slug, format!("{e:#}").dimmed());
+                failures.push((slug, format!("{e:#}")));
+            }
+        }
+    }
+
+    println!();
+    println!("{deployed}/{to_apply} bundle(s) deployed.");
+    finish(&failures)
+}
+
+fn finish(failures: &[(String, String)]) -> Result<()> {
+    if failures.is_empty() {
+        return Ok(());
+    }
+    eprintln!();
+    eprintln!("{}", "Failed bundles:".red());
+    for (slug, msg) in failures {
+        eprintln!("  - {slug}: {}", msg.lines().next().unwrap_or(""));
+    }
+    anyhow::bail!("{} bundle(s) failed", failures.len());
+}
+
+/// Load a bundle, apply overrides, and classify it against the live revision —
+/// faithfully mirroring seed.py's loose manifest+spec comparison.
+fn plan_bundle(root: &Path, host: &str, args: &DeployArgs) -> Result<Planned> {
+    let bundle = load_bundle(root)?;
+    let spec = apply_spec_overrides(
+        &bundle.spec,
+        host,
+        args.auth_mode.as_deref(),
+        args.mcp_url.as_deref(),
+    )?;
+
+    let app_id = find_application(&bundle.slug, args.debug)?;
+    let (action, reason, live_rev) = match &app_id {
+        None => (Action::Create, "new application".to_string(), None),
+        Some(id) => {
+            let (live_rev, live_manifest, live_spec) = get_live(id, args.debug);
+            let target = per_file_sha256(&bundle.files);
+            if live_rev.is_none() {
+                (Action::Update, "no live revision yet".to_string(), None)
+            } else if live_manifest.as_ref() == Some(&target) && live_spec.as_ref() == Some(&spec) {
+                (Action::Skip, "matches live".to_string(), live_rev)
+            } else if live_manifest.as_ref() != Some(&target) {
+                (Action::Update, "bundle drifted".to_string(), live_rev)
+            } else {
+                (Action::Update, "spec drifted".to_string(), live_rev)
+            }
+        }
+    };
+
+    Ok(Planned {
+        bundle,
+        spec,
+        app_id,
+        live_rev,
+        action,
+        reason,
+    })
+}
+
+/// Run the full deploy pipeline for one planned bundle. Returns the now-live revision id.
+fn apply_bundle(p: Planned, args: &DeployArgs) -> Result<String> {
+    let slug = &p.bundle.slug;
+    let app_id = match p.app_id {
+        Some(id) => id,
+        None => create_application(slug, args.debug)?,
+    };
+
+    let rev_id = create_draft(slug, &app_id, p.live_rev.as_deref(), &p.spec, args.debug)?;
+    push_bundle(
+        &app_id,
+        &rev_id,
+        &build_typed_bundle(&p.bundle, &p.spec),
+        args.debug,
+    )?;
+    patch_spec(&app_id, &rev_id, &p.spec, args.debug)?;
+    if args.dummy_secrets {
+        ensure_dummy_secrets(slug, &app_id, &rev_id, &p.spec, args.debug)?;
+    }
+    validate(slug, &app_id, &rev_id, args.debug)?;
+    freeze(&app_id, &rev_id, args.debug)?;
+    promote(&app_id, &rev_id, args.debug)?;
+    Ok(rev_id)
+}
+
+// ── pipeline steps ──────────────────────────────────────────────────────────
+
+fn create_application(slug: &str, debug: bool) -> Result<String> {
+    let (name, description) = metadata(slug);
+    let body = json!({ "name": name, "slug": slug, "description": description, "archived": false });
+    let v = post_json("agent_applications/", &body, debug).context("create application")?;
+    v.get("id")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .context("create application: response missing id")
+}
+
+/// `(live_revision_id, {path: sha256}, spec)` for the live revision, or all-None.
+/// Read failures collapse to None (mirrors seed.py's status-based fallbacks).
+fn get_live(
+    app_id: &str,
+    debug: bool,
+) -> (
+    Option<String>,
+    Option<HashMap<String, String>>,
+    Option<Value>,
+) {
+    let Ok(app) = get_json(&format!("agent_applications/{app_id}/"), debug) else {
+        return (None, None, None);
+    };
+    let Some(rev_id) = app
+        .get("live_revision")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+    else {
+        return (None, None, None);
+    };
+    let spec = get_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/"),
+        debug,
+    )
+    .ok()
+    .and_then(|r| r.get("spec").cloned());
+    let manifest = match get_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/manifest/"),
+        debug,
+    ) {
+        Ok(m) => m,
+        Err(_) => return (Some(rev_id), None, spec),
+    };
+    let files = manifest.get("files").and_then(Value::as_array).map(|arr| {
+        arr.iter()
+            .filter_map(|f| {
+                Some((
+                    f.get("path").and_then(Value::as_str)?.to_string(),
+                    f.get("sha256").and_then(Value::as_str)?.to_string(),
+                ))
+            })
+            .collect::<HashMap<String, String>>()
+    });
+    (Some(rev_id), files, spec)
+}
+
+fn create_draft(
+    slug: &str,
+    app_id: &str,
+    parent: Option<&str>,
+    spec: &Value,
+    debug: bool,
+) -> Result<String> {
+    if let Some(parent) = parent {
+        // new_draft branches from the live revision, copying its bundle; we then
+        // overwrite the bundle + patch the spec to match what we want.
+        let body = json!({ "application_id": app_id, "source_revision_id": parent });
+        let v = post_json(
+            &format!("agent_applications/{app_id}/revisions/new_draft/"),
+            &body,
+            debug,
+        )
+        .with_context(|| format!("new_draft for {slug}"))?;
+        v.get("revision")
+            .and_then(|r| r.get("id"))
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .context("new_draft: response missing revision.id")
+    } else {
+        let body = json!({ "application_id": app_id, "bundle_uri": format!("local://{slug}/seed"), "spec": spec });
+        let v = post_json(
+            &format!("agent_applications/{app_id}/revisions/"),
+            &body,
+            debug,
+        )
+        .with_context(|| format!("draft create for {slug}"))?;
+        v.get("id")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .context("draft create: response missing id")
+    }
+}
+
+fn push_bundle(app_id: &str, rev_id: &str, typed: &Value, debug: bool) -> Result<()> {
+    let client = &context().client;
+    let path = format!("agent_applications/{app_id}/revisions/{rev_id}/bundle/");
+    debug_request(debug, "PUT", &path);
+    client
+        .send_put(client.project_url(&path)?, |req| req.json(typed))
+        .inspect_err(|e| debug_error(debug, e))
+        .context("bundle update")?;
+    Ok(())
+}
+
+fn patch_spec(app_id: &str, rev_id: &str, spec: &Value, debug: bool) -> Result<()> {
+    let client = &context().client;
+    let path = format!("agent_applications/{app_id}/revisions/{rev_id}/");
+    debug_request(debug, "PATCH", &path);
+    client
+        .send_request(reqwest::Method::PATCH, client.project_url(&path)?, |req| {
+            req.json(&json!({ "spec": spec }))
+        })
+        .inspect_err(|e| debug_error(debug, e))
+        .context("spec patch")?;
+    Ok(())
+}
+
+fn validate(slug: &str, app_id: &str, rev_id: &str, debug: bool) -> Result<()> {
+    let v = post_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/validate/"),
+        &json!({}),
+        debug,
+    )
+    .with_context(|| format!("validate for {slug}"))?;
+    if !v.get("ok").and_then(Value::as_bool).unwrap_or(false) {
+        anyhow::bail!(
+            "validate failed for {slug}: {}",
+            serde_json::to_string_pretty(&v).unwrap_or_default()
+        );
+    }
+    Ok(())
+}
+
+fn freeze(app_id: &str, rev_id: &str, debug: bool) -> Result<()> {
+    post_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/freeze/"),
+        &json!({}),
+        debug,
+    )
+    .context("freeze")?;
+    Ok(())
+}
+
+fn promote(app_id: &str, rev_id: &str, debug: bool) -> Result<()> {
+    post_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/promote/"),
+        &json!({}),
+        debug,
+    )
+    .context("promote")?;
+    Ok(())
+}
+
+/// Set placeholder values for any required secret not already set, so secret-gated
+/// agents can promote locally. Never overwrites an existing value.
+fn ensure_dummy_secrets(
+    slug: &str,
+    app_id: &str,
+    rev_id: &str,
+    spec: &Value,
+    debug: bool,
+) -> Result<()> {
+    let client = &context().client;
+    let mut set: Vec<String> = Vec::new();
+    for key in required_secret_keys(spec) {
+        let base = format!("agent_applications/{app_id}/revisions/{rev_id}/env_keys/{key}/");
+        let is_set = get_json(&base, debug)
+            .ok()
+            .and_then(|p| p.get("is_set").and_then(Value::as_bool))
+            .unwrap_or(false);
+        if is_set {
+            continue;
+        }
+        debug_request(debug, "PUT", &base);
+        client
+            .send_put(client.project_url(&base)?, |req| {
+                req.json(&json!({ "value": format!("placeholder-{key}") }))
+            })
+            .inspect_err(|e| debug_error(debug, e))
+            .with_context(|| format!("set placeholder secret {key}"))?;
+        set.push(key);
+    }
+    if !set.is_empty() {
+        println!(
+            "  {} {}: placeholder secrets {}",
+            "→".cyan(),
+            slug,
+            set.join(", ").dimmed()
+        );
+    }
+    Ok(())
+}
+
+/// Secret keys a bundle needs before promote: declared `spec.secrets[]` plus
+/// per-trigger required keys (slack). Order-preserving + de-duped.
+fn required_secret_keys(spec: &Value) -> Vec<String> {
+    let mut keys: Vec<String> = Vec::new();
+    if let Some(secrets) = spec.get("secrets").and_then(Value::as_array) {
+        for s in secrets {
+            if let Some(k) = s.get("key").and_then(Value::as_str).or_else(|| s.as_str()) {
+                if !keys.iter().any(|x| x == k) {
+                    keys.push(k.to_string());
+                }
+            }
+        }
+    }
+    if let Some(triggers) = spec.get("triggers").and_then(Value::as_array) {
+        for t in triggers {
+            if t.get("type").and_then(Value::as_str) == Some("slack") {
+                for k in ["SLACK_SIGNING_SECRET", "SLACK_BOT_TOKEN"] {
+                    if !keys.iter().any(|x| x == k) {
+                        keys.push(k.to_string());
+                    }
+                }
+            }
+        }
+    }
+    keys
+}
+
+/// POST a project-scoped path with a JSON body and parse the response. Non-2xx is an Err.
+fn post_json(path: &str, body: &Value, debug: bool) -> Result<Value> {
+    let client = &context().client;
+    debug_request(debug, "POST", path);
+    let resp = client
+        .send_post(client.project_url(path)?, |req| req.json(body))
+        .inspect_err(|e| debug_error(debug, e))?;
+    resp.json()
+        .with_context(|| format!("parsing response for {path}"))
+}

--- a/cli/src/agents/list.rs
+++ b/cli/src/agents/list.rs
@@ -1,0 +1,35 @@
+use std::path::Path;
+
+use anyhow::Result;
+use colored::Colorize;
+
+use crate::invocation_context::context;
+
+use super::{discover_bundles, slug_of, ListArgs};
+
+pub fn list_agents(args: &ListArgs) -> Result<()> {
+    context().capture_command_invoked("agents_list");
+
+    let bundles = discover_bundles(Path::new(&args.dir))?;
+
+    println!();
+    if bundles.is_empty() {
+        println!("No agent bundles found under {}.", args.dir.bold());
+        return Ok(());
+    }
+
+    println!("Agent bundles under {}:", args.dir.bold());
+    println!();
+    for b in &bundles {
+        if let Some(slug) = slug_of(b) {
+            println!("  {slug}");
+        }
+    }
+    println!();
+    println!(
+        "{} bundle{} total.",
+        bundles.len(),
+        if bundles.len() == 1 { "" } else { "s" }
+    );
+    Ok(())
+}

--- a/cli/src/agents/mod.rs
+++ b/cli/src/agents/mod.rs
@@ -74,6 +74,20 @@ pub(crate) fn find_application(slug: &str, debug: bool) -> Result<Option<String>
         .map(str::to_string))
 }
 
+/// A revision's typed bundle: `{ agent_md, skills:[{id,body}], tools:[{id,source}], spec }`.
+pub(crate) fn get_typed_bundle(app_id: &str, rev_id: &str, debug: bool) -> Result<Value> {
+    let payload = get_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/bundle/"),
+        debug,
+    )
+    .with_context(|| format!("read bundle for {rev_id}"))?;
+    payload
+        .get("bundle")
+        .filter(|b| b.is_object())
+        .cloned()
+        .with_context(|| format!("bundle read returned no bundle for {rev_id}"))
+}
+
 // ── command surface ──────────────────────────────────────────────────────────
 
 #[derive(Subcommand)]
@@ -116,6 +130,11 @@ pub struct DeployArgs {
     /// Rewrite every `mcps[].url` (local-dev / cross-region).
     #[arg(long)]
     pub mcp_url: Option<String>,
+
+    /// Show a line-level diff (agent.md, skills, spec) for each updated bundle
+    /// in the plan. Pairs well with `--dry-run`.
+    #[arg(long)]
+    pub diff: bool,
 
     /// Show API request/response detail.
     #[arg(long)]

--- a/cli/src/agents/mod.rs
+++ b/cli/src/agents/mod.rs
@@ -26,6 +26,8 @@ use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
+use crate::invocation_context::context;
+
 pub use deploy::deploy_agents;
 pub use list::list_agents;
 pub use pull::pull_agents;
@@ -44,6 +46,32 @@ pub(crate) fn debug_error<E: std::fmt::Display>(debug: bool, error: &E) {
     if debug {
         eprintln!("  {} {}", "Error:".red(), error);
     }
+}
+
+// ── platform reads (shared by deploy + pull) ─────────────────────────────────
+
+/// GET a project-scoped path and parse the JSON body. Non-2xx is already an Err.
+pub(crate) fn get_json(path: &str, debug: bool) -> Result<Value> {
+    let client = &context().client;
+    debug_request(debug, "GET", path);
+    let resp = client
+        .send_get(client.project_url(path)?, |req| req)
+        .inspect_err(|e| debug_error(debug, e))?;
+    resp.json()
+        .with_context(|| format!("parsing response for {path}"))
+}
+
+/// The application id whose slug matches, or None if no such application exists.
+pub(crate) fn find_application(slug: &str, debug: bool) -> Result<Option<String>> {
+    let payload = get_json("agent_applications/", debug).context("listing applications")?;
+    let Some(results) = payload.get("results").and_then(Value::as_array) else {
+        return Ok(None);
+    };
+    Ok(results
+        .iter()
+        .find(|a| a.get("slug").and_then(Value::as_str) == Some(slug))
+        .and_then(|a| a.get("id").and_then(Value::as_str))
+        .map(str::to_string))
 }
 
 // ── command surface ──────────────────────────────────────────────────────────
@@ -174,11 +202,18 @@ pub fn select_bundles(bundles: &[PathBuf], selectors: &[String]) -> Result<Vec<P
     for sel in selectors {
         let matches: Vec<&PathBuf> = bundles
             .iter()
-            .filter(|b| slug_of(b).map(|s| s == *sel || s.contains(sel)).unwrap_or(false))
+            .filter(|b| {
+                slug_of(b)
+                    .map(|s| s == *sel || s.contains(sel))
+                    .unwrap_or(false)
+            })
             .collect();
         if matches.is_empty() {
             let known: Vec<String> = bundles.iter().filter_map(|b| slug_of(b)).collect();
-            anyhow::bail!("no bundle matches selector \"{sel}\"; known: {}", known.join(", "));
+            anyhow::bail!(
+                "no bundle matches selector \"{sel}\"; known: {}",
+                known.join(", ")
+            );
         }
         for m in matches {
             if !chosen.contains(m) {
@@ -197,14 +232,16 @@ pub fn slug_of(root: &Path) -> Option<String> {
 pub fn load_bundle(root: &Path) -> Result<LoadedBundle> {
     let slug = slug_of(root).context("bundle has no directory name")?;
     let spec: Value = serde_json::from_str(
-        &std::fs::read_to_string(root.join("spec.json")).with_context(|| format!("reading spec.json for {slug}"))?,
+        &std::fs::read_to_string(root.join("spec.json"))
+            .with_context(|| format!("reading spec.json for {slug}"))?,
     )
     .with_context(|| format!("parsing spec.json for {slug}"))?;
 
     let mut files: HashMap<String, String> = HashMap::new();
     files.insert(
         "agent.md".to_string(),
-        std::fs::read_to_string(root.join("agent.md")).with_context(|| format!("reading agent.md for {slug}"))?,
+        std::fs::read_to_string(root.join("agent.md"))
+            .with_context(|| format!("reading agent.md for {slug}"))?,
     );
 
     let skills_dir = root.join("skills");
@@ -309,15 +346,24 @@ pub fn posthog_mcp_url_for_host(host: &str) -> String {
 /// Apply local-dev overrides to a clone of the spec: per-trigger auth modes and
 /// MCP URL rewrites. Production deploys pass no overrides (the spec is untouched
 /// except the region MCP rewrite for `posthog`-authed MCPs).
-pub fn apply_spec_overrides(raw: &Value, host: &str, auth_mode: Option<&str>, mcp_url: Option<&str>) -> Result<Value> {
+pub fn apply_spec_overrides(
+    raw: &Value,
+    host: &str,
+    auth_mode: Option<&str>,
+    mcp_url: Option<&str>,
+) -> Result<Value> {
     let mut spec = raw.clone();
 
     let auth_override: Option<Value> = match auth_mode {
         None => None,
         Some("shared_secret") => {
-            anyhow::bail!("--auth-mode shared_secret needs a header/secret_ref; use the bundle's modes")
+            anyhow::bail!(
+                "--auth-mode shared_secret needs a header/secret_ref; use the bundle's modes"
+            )
         }
-        Some("public") => Some(json!({ "modes": [{ "type": "public", "acknowledge_public_exposure": true }] })),
+        Some("public") => {
+            Some(json!({ "modes": [{ "type": "public", "acknowledge_public_exposure": true }] }))
+        }
         Some(other) => Some(json!({ "modes": [{ "type": other }] })),
     };
     if let Some(triggers) = spec.get_mut("triggers").and_then(Value::as_array_mut) {
@@ -326,12 +372,17 @@ pub fn apply_spec_overrides(raw: &Value, host: &str, auth_mode: Option<&str>, mc
                 .get("type")
                 .and_then(Value::as_str)
                 .is_some_and(|ty| DECLARATIVE_TRIGGERS.contains(&ty));
-            let Some(obj) = t.as_object_mut() else { continue };
+            let Some(obj) = t.as_object_mut() else {
+                continue;
+            };
             if is_declarative {
                 if let Some(o) = &auth_override {
                     obj.insert("auth".to_string(), o.clone());
                 } else if !obj.contains_key("auth") {
-                    obj.insert("auth".to_string(), json!({ "modes": [{ "type": "posthog_internal" }] }));
+                    obj.insert(
+                        "auth".to_string(),
+                        json!({ "modes": [{ "type": "posthog_internal" }] }),
+                    );
                 }
             } else {
                 obj.remove("auth");
@@ -342,9 +393,14 @@ pub fn apply_spec_overrides(raw: &Value, host: &str, auth_mode: Option<&str>, mc
     let region_mcp = posthog_mcp_url_for_host(host);
     if let Some(mcps) = spec.get_mut("mcps").and_then(Value::as_array_mut) {
         for m in mcps.iter_mut() {
-            let provider_is_posthog =
-                m.get("auth").and_then(|a| a.get("provider")).and_then(Value::as_str) == Some("posthog");
-            let Some(obj) = m.as_object_mut() else { continue };
+            let provider_is_posthog = m
+                .get("auth")
+                .and_then(|a| a.get("provider"))
+                .and_then(Value::as_str)
+                == Some("posthog");
+            let Some(obj) = m.as_object_mut() else {
+                continue;
+            };
             if let Some(url) = mcp_url {
                 obj.insert("url".to_string(), json!(url));
             } else if provider_is_posthog {

--- a/cli/src/agents/mod.rs
+++ b/cli/src/agents/mod.rs
@@ -104,7 +104,9 @@ pub enum AgentsCommand {
 
 #[derive(Args, Clone)]
 pub struct DeployArgs {
-    /// Directory of agent bundles (each a subdir with spec.json + agent.md).
+    /// Bundle directory: a single bundle (spec.json + agent.md) or a parent of
+    /// bundles. Defaults to the current directory.
+    #[arg(short = 'd', long, default_value = ".")]
     pub dir: String,
 
     /// Only deploy bundles whose slug equals or contains one of these.
@@ -143,7 +145,9 @@ pub struct DeployArgs {
 
 #[derive(Args, Clone)]
 pub struct PullArgs {
-    /// Directory of agent bundles to pull into.
+    /// Bundle directory: a single bundle (spec.json + agent.md) or a parent of
+    /// bundles. Defaults to the current directory.
+    #[arg(short = 'd', long, default_value = ".")]
     pub dir: String,
 
     /// Only pull bundles whose slug equals or contains one of these.
@@ -172,7 +176,9 @@ pub struct PullArgs {
 
 #[derive(Args, Clone)]
 pub struct ListArgs {
-    /// Directory of agent bundles.
+    /// Bundle directory: a single bundle (spec.json + agent.md) or a parent of
+    /// bundles. Defaults to the current directory.
+    #[arg(short = 'd', long, default_value = ".")]
     pub dir: String,
 }
 
@@ -196,13 +202,33 @@ pub struct LoadedBundle {
     pub files: HashMap<String, String>,
 }
 
-/// Every immediate subdir of `dir` that holds a deployable bundle (spec.json +
-/// agent.md), sorted by slug.
+/// Bundles to act on, resolved from `dir` (commonly the current directory):
+/// - `dir` is itself a bundle (`spec.json` + `agent.md`) → just that bundle;
+/// - otherwise every immediate subdir that is a bundle, sorted by slug.
+///
+/// Paths are canonicalized so a relative `dir` (e.g. `.`) yields a real slug.
+/// A half-formed bundle (one of the two files present) errors loudly rather
+/// than being silently treated as an empty parent.
 pub fn discover_bundles(dir: &Path) -> Result<Vec<PathBuf>> {
+    let dir = std::fs::canonicalize(dir).with_context(|| format!("resolving {}", dir.display()))?;
     if !dir.is_dir() {
         anyhow::bail!("not a directory: {}", dir.display());
     }
-    let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+
+    let has_spec = dir.join("spec.json").is_file();
+    let has_agent = dir.join("agent.md").is_file();
+    if has_spec && has_agent {
+        return Ok(vec![dir]);
+    }
+    if has_spec || has_agent {
+        anyhow::bail!(
+            "{} looks like a bundle but is missing {}",
+            dir.display(),
+            if has_spec { "agent.md" } else { "spec.json" }
+        );
+    }
+
+    let mut out: Vec<PathBuf> = std::fs::read_dir(&dir)
         .with_context(|| format!("reading {}", dir.display()))?
         .filter_map(|e| e.ok().map(|e| e.path()))
         .filter(|p| p.is_dir() && p.join("spec.json").is_file() && p.join("agent.md").is_file())
@@ -428,4 +454,60 @@ pub fn apply_spec_overrides(
         }
     }
     Ok(spec)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A unique scratch dir under the system temp dir for one test.
+    fn scratch(tag: &str) -> PathBuf {
+        let dir = std::env::temp_dir().join(format!("ph_agents_{}_{tag}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn write_bundle(dir: &Path) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join("spec.json"), "{}").unwrap();
+        std::fs::write(dir.join("agent.md"), "# agent").unwrap();
+    }
+
+    #[test]
+    fn discover_bundles_treats_a_bundle_dir_as_a_single_bundle() {
+        let dir = scratch("single");
+        write_bundle(&dir);
+        let found = discover_bundles(&dir).unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(
+            slug_of(&found[0]),
+            dir.file_name().map(|n| n.to_string_lossy().to_string())
+        );
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn discover_bundles_finds_child_bundles_under_a_parent() {
+        let parent = scratch("parent");
+        write_bundle(&parent.join("alpha"));
+        write_bundle(&parent.join("beta"));
+        std::fs::create_dir_all(parent.join("not-a-bundle")).unwrap(); // no spec/agent → ignored
+        let slugs: Vec<String> = discover_bundles(&parent)
+            .unwrap()
+            .iter()
+            .filter_map(|p| slug_of(p))
+            .collect();
+        assert_eq!(slugs, vec!["alpha".to_string(), "beta".to_string()]);
+        std::fs::remove_dir_all(&parent).unwrap();
+    }
+
+    #[test]
+    fn discover_bundles_errors_on_a_half_formed_bundle() {
+        let dir = scratch("partial");
+        std::fs::write(dir.join("spec.json"), "{}").unwrap(); // spec but no agent.md
+        let err = discover_bundles(&dir).unwrap_err().to_string();
+        assert!(err.contains("missing agent.md"), "unexpected error: {err}");
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
 }

--- a/cli/src/agents/mod.rs
+++ b/cli/src/agents/mod.rs
@@ -1,0 +1,356 @@
+//! `agents` — deploy + sync code-level PostHog agents.
+//!
+//! An agent *bundle* is a directory holding `spec.json` + `agent.md` (+ optional
+//! `skills/<id>/SKILL.md` and `tests/*.json`). `deploy` runs each bundle through
+//! the authoring API (create application → branch/create draft → push bundle →
+//! patch spec → validate → freeze → promote); `pull` syncs a live agent back to
+//! disk; `list` shows discoverable bundles.
+//!
+//! Auth + the project-scoped API client come from the shared invocation context
+//! (`posthog login` / `POSTHOG_CLI_*`), same as every other command. Experimental:
+//! gated behind the top-level `--experimental` flag.
+
+mod deploy;
+mod list;
+mod pull;
+
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+use clap::{Args, Subcommand};
+use colored::Colorize;
+use serde_json::{json, Map, Value};
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+pub use deploy::deploy_agents;
+pub use list::list_agents;
+pub use pull::pull_agents;
+
+// ── debug logging (mirrors exp endpoints) ───────────────────────────────────
+
+#[inline]
+pub(crate) fn debug_request(debug: bool, method: &str, path: &str) {
+    if debug {
+        eprintln!("  {} {} {}", "DEBUG".cyan().bold(), method, path);
+    }
+}
+
+#[inline]
+pub(crate) fn debug_error<E: std::fmt::Display>(debug: bool, error: &E) {
+    if debug {
+        eprintln!("  {} {}", "Error:".red(), error);
+    }
+}
+
+// ── command surface ──────────────────────────────────────────────────────────
+
+#[derive(Subcommand)]
+pub enum AgentsCommand {
+    /// Deploy bundle(s) to PostHog: create → validate → freeze → promote
+    Deploy(DeployArgs),
+
+    /// Pull a live agent's bundle (prompt, skills, custom tools) back to disk
+    Pull(PullArgs),
+
+    /// List discoverable agent bundles in a directory
+    List(ListArgs),
+}
+
+#[derive(Args, Clone)]
+pub struct DeployArgs {
+    /// Directory of agent bundles (each a subdir with spec.json + agent.md).
+    pub dir: String,
+
+    /// Only deploy bundles whose slug equals or contains one of these.
+    pub names: Vec<String>,
+
+    /// Preview the plan without mutating anything.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Skip the confirmation prompt.
+    #[arg(long, short = 'y')]
+    pub yes: bool,
+
+    /// Set obviously-fake placeholders for required secrets so secret-gated
+    /// agents can promote (local dev — the agents won't actually function).
+    #[arg(long)]
+    pub dummy_secrets: bool,
+
+    /// Override every declarative trigger's auth modes (e.g. `public`, `posthog`).
+    #[arg(long)]
+    pub auth_mode: Option<String>,
+
+    /// Rewrite every `mcps[].url` (local-dev / cross-region).
+    #[arg(long)]
+    pub mcp_url: Option<String>,
+
+    /// Show API request/response detail.
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct PullArgs {
+    /// Directory of agent bundles to pull into.
+    pub dir: String,
+
+    /// Only pull bundles whose slug equals or contains one of these.
+    pub names: Vec<String>,
+
+    /// Pull the newest revision even if it isn't promoted to live.
+    #[arg(long)]
+    pub latest: bool,
+
+    /// Also rewrite spec.json (the frozen/normalised spec).
+    #[arg(long)]
+    pub spec: bool,
+
+    /// Delete on-disk skills/tools the platform no longer has.
+    #[arg(long)]
+    pub prune: bool,
+
+    /// Preview without writing.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Show API request/response detail.
+    #[arg(long)]
+    pub debug: bool,
+}
+
+#[derive(Args, Clone)]
+pub struct ListArgs {
+    /// Directory of agent bundles.
+    pub dir: String,
+}
+
+impl AgentsCommand {
+    pub fn run(&self) -> Result<()> {
+        match self {
+            AgentsCommand::Deploy(args) => deploy_agents(args),
+            AgentsCommand::Pull(args) => pull_agents(args),
+            AgentsCommand::List(args) => list_agents(args),
+        }
+    }
+}
+
+// ── bundle loading ───────────────────────────────────────────────────────────
+
+pub struct LoadedBundle {
+    pub slug: String,
+    pub root: PathBuf,
+    pub spec: Value,
+    /// Bundle-relative path → content (agent.md, skills/<id>/SKILL.md, tests/*.json).
+    pub files: HashMap<String, String>,
+}
+
+/// Every immediate subdir of `dir` that holds a deployable bundle (spec.json +
+/// agent.md), sorted by slug.
+pub fn discover_bundles(dir: &Path) -> Result<Vec<PathBuf>> {
+    if !dir.is_dir() {
+        anyhow::bail!("not a directory: {}", dir.display());
+    }
+    let mut out: Vec<PathBuf> = std::fs::read_dir(dir)
+        .with_context(|| format!("reading {}", dir.display()))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_dir() && p.join("spec.json").is_file() && p.join("agent.md").is_file())
+        .collect();
+    out.sort();
+    Ok(out)
+}
+
+/// Filter bundle dirs by selector — a selector matches a bundle whose slug
+/// equals it or contains it. No selectors → all. Errors on an unknown selector.
+pub fn select_bundles(bundles: &[PathBuf], selectors: &[String]) -> Result<Vec<PathBuf>> {
+    if selectors.is_empty() {
+        return Ok(bundles.to_vec());
+    }
+    let mut chosen: Vec<PathBuf> = Vec::new();
+    for sel in selectors {
+        let matches: Vec<&PathBuf> = bundles
+            .iter()
+            .filter(|b| slug_of(b).map(|s| s == *sel || s.contains(sel)).unwrap_or(false))
+            .collect();
+        if matches.is_empty() {
+            let known: Vec<String> = bundles.iter().filter_map(|b| slug_of(b)).collect();
+            anyhow::bail!("no bundle matches selector \"{sel}\"; known: {}", known.join(", "));
+        }
+        for m in matches {
+            if !chosen.contains(m) {
+                chosen.push(m.clone());
+            }
+        }
+    }
+    Ok(chosen)
+}
+
+pub fn slug_of(root: &Path) -> Option<String> {
+    root.file_name().map(|n| n.to_string_lossy().to_string())
+}
+
+/// Load a bundle dir: spec.json + agent.md + skills/**.md + tests/*.json.
+pub fn load_bundle(root: &Path) -> Result<LoadedBundle> {
+    let slug = slug_of(root).context("bundle has no directory name")?;
+    let spec: Value = serde_json::from_str(
+        &std::fs::read_to_string(root.join("spec.json")).with_context(|| format!("reading spec.json for {slug}"))?,
+    )
+    .with_context(|| format!("parsing spec.json for {slug}"))?;
+
+    let mut files: HashMap<String, String> = HashMap::new();
+    files.insert(
+        "agent.md".to_string(),
+        std::fs::read_to_string(root.join("agent.md")).with_context(|| format!("reading agent.md for {slug}"))?,
+    );
+
+    let skills_dir = root.join("skills");
+    if skills_dir.is_dir() {
+        for entry in WalkDir::new(&skills_dir).sort_by_file_name() {
+            let entry = entry?;
+            let p = entry.path();
+            if p.is_file() && p.extension().is_some_and(|e| e == "md") {
+                let rel = p.strip_prefix(root)?.to_string_lossy().replace('\\', "/");
+                files.insert(rel, std::fs::read_to_string(p)?);
+            }
+        }
+    }
+    let tests_dir = root.join("tests");
+    if tests_dir.is_dir() {
+        let mut names: Vec<PathBuf> = std::fs::read_dir(&tests_dir)?
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.is_file() && p.extension().is_some_and(|e| e == "json"))
+            .collect();
+        names.sort();
+        for p in names {
+            let name = p.file_name().unwrap().to_string_lossy();
+            files.insert(format!("tests/{name}"), std::fs::read_to_string(&p)?);
+        }
+    }
+    Ok(LoadedBundle {
+        slug,
+        root: root.to_path_buf(),
+        spec,
+        files,
+    })
+}
+
+/// Shape for `PUT /bundle/`: `{ agent_md, skills:[{id,description,body}], tools:[], spec }`.
+/// The spec slice drops `skills`/`tools` (server-derived at freeze).
+pub fn build_typed_bundle(b: &LoadedBundle, spec: &Value) -> Value {
+    let mut skills: Vec<Value> = Vec::new();
+    if let Some(arr) = spec.get("skills").and_then(Value::as_array) {
+        for r in arr {
+            let Some(id) = r.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let path = r
+                .get("path")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+                .unwrap_or_else(|| format!("skills/{id}.md"));
+            skills.push(json!({
+                "id": id,
+                "description": r.get("description").and_then(Value::as_str).unwrap_or(""),
+                "body": b.files.get(&path).cloned().unwrap_or_default(),
+            }));
+        }
+    }
+    let mut author_spec = Map::new();
+    if let Some(obj) = spec.as_object() {
+        for (k, v) in obj {
+            if k != "skills" && k != "tools" {
+                author_spec.insert(k.clone(), v.clone());
+            }
+        }
+    }
+    json!({
+        "agent_md": b.files.get("agent.md").cloned().unwrap_or_default(),
+        "skills": skills,
+        "tools": [],
+        "spec": Value::Object(author_spec),
+    })
+}
+
+/// Per-file sha256 (hex), mirroring the janitor manifest — for idempotency diffs.
+pub fn per_file_sha256(files: &HashMap<String, String>) -> HashMap<String, String> {
+    files
+        .iter()
+        .map(|(p, c)| {
+            let mut h = Sha256::new();
+            h.update(c.as_bytes());
+            (p.clone(), format!("{:x}", h.finalize()))
+        })
+        .collect()
+}
+
+// ── spec overrides (local-dev / cross-region) ────────────────────────────────
+
+const DECLARATIVE_TRIGGERS: [&str; 3] = ["webhook", "chat", "mcp"];
+
+/// The PostHog MCP URL matching the target host (local → local MCP, us/eu → their
+/// region MCP, else the region-agnostic host).
+pub fn posthog_mcp_url_for_host(host: &str) -> String {
+    let host = host.to_lowercase();
+    if host.contains("localhost") || host.contains("127.0.0.1") {
+        "http://localhost:8787/mcp".to_string()
+    } else if host.contains("eu.posthog.com") {
+        "https://mcp.eu.posthog.com/mcp".to_string()
+    } else if host.contains("us.posthog.com") || host.contains("app.posthog.com") {
+        "https://mcp.us.posthog.com/mcp".to_string()
+    } else {
+        "https://mcp.posthog.com/mcp".to_string()
+    }
+}
+
+/// Apply local-dev overrides to a clone of the spec: per-trigger auth modes and
+/// MCP URL rewrites. Production deploys pass no overrides (the spec is untouched
+/// except the region MCP rewrite for `posthog`-authed MCPs).
+pub fn apply_spec_overrides(raw: &Value, host: &str, auth_mode: Option<&str>, mcp_url: Option<&str>) -> Result<Value> {
+    let mut spec = raw.clone();
+
+    let auth_override: Option<Value> = match auth_mode {
+        None => None,
+        Some("shared_secret") => {
+            anyhow::bail!("--auth-mode shared_secret needs a header/secret_ref; use the bundle's modes")
+        }
+        Some("public") => Some(json!({ "modes": [{ "type": "public", "acknowledge_public_exposure": true }] })),
+        Some(other) => Some(json!({ "modes": [{ "type": other }] })),
+    };
+    if let Some(triggers) = spec.get_mut("triggers").and_then(Value::as_array_mut) {
+        for t in triggers.iter_mut() {
+            let is_declarative = t
+                .get("type")
+                .and_then(Value::as_str)
+                .is_some_and(|ty| DECLARATIVE_TRIGGERS.contains(&ty));
+            let Some(obj) = t.as_object_mut() else { continue };
+            if is_declarative {
+                if let Some(o) = &auth_override {
+                    obj.insert("auth".to_string(), o.clone());
+                } else if !obj.contains_key("auth") {
+                    obj.insert("auth".to_string(), json!({ "modes": [{ "type": "posthog_internal" }] }));
+                }
+            } else {
+                obj.remove("auth");
+            }
+        }
+    }
+
+    let region_mcp = posthog_mcp_url_for_host(host);
+    if let Some(mcps) = spec.get_mut("mcps").and_then(Value::as_array_mut) {
+        for m in mcps.iter_mut() {
+            let provider_is_posthog =
+                m.get("auth").and_then(|a| a.get("provider")).and_then(Value::as_str) == Some("posthog");
+            let Some(obj) = m.as_object_mut() else { continue };
+            if let Some(url) = mcp_url {
+                obj.insert("url".to_string(), json!(url));
+            } else if provider_is_posthog {
+                obj.insert("url".to_string(), json!(region_mcp));
+            }
+        }
+    }
+    Ok(spec)
+}

--- a/cli/src/agents/pull.rs
+++ b/cli/src/agents/pull.rs
@@ -1,0 +1,339 @@
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+use colored::Colorize;
+use serde::Serialize;
+use serde_json::Value;
+use walkdir::WalkDir;
+
+use crate::invocation_context::context;
+
+use super::{discover_bundles, find_application, get_json, select_bundles, slug_of, PullArgs};
+
+/// Top-level spec keys deploy strips before upload, so the platform never stores
+/// them. Preserved from the on-disk `spec.json` when rewriting it.
+const LOCAL_ONLY_SPEC_KEYS: [&str; 1] = ["resume"];
+
+pub fn pull_agents(args: &PullArgs) -> Result<()> {
+    context().capture_command_invoked("agents_pull");
+
+    let bundles = discover_bundles(Path::new(&args.dir))?;
+    if bundles.is_empty() {
+        anyhow::bail!("no bundles found under {}", args.dir);
+    }
+    let selected = select_bundles(&bundles, &args.names)?;
+
+    println!();
+    println!(
+        "Pull source: {} — {}/{} bundle(s)",
+        context().client.get_host().bold(),
+        selected.len(),
+        bundles.len()
+    );
+    println!();
+
+    let mut failures: Vec<(String, String)> = Vec::new();
+    for root in &selected {
+        if let Err(e) = pull_bundle(root, args) {
+            let slug = slug_of(root).unwrap_or_default();
+            println!("  {} {}: {}", "✗".red(), slug, format!("{e:#}").dimmed());
+            failures.push((slug, format!("{e:#}")));
+        }
+    }
+
+    println!();
+    println!(
+        "{}/{} bundle(s) ok.",
+        selected.len() - failures.len(),
+        selected.len()
+    );
+    if !failures.is_empty() {
+        anyhow::bail!("{} bundle(s) failed", failures.len());
+    }
+    Ok(())
+}
+
+fn pull_bundle(root: &Path, args: &PullArgs) -> Result<()> {
+    let slug = slug_of(root).context("bundle has no directory name")?;
+    let Some(app_id) = find_application(&slug, args.debug)? else {
+        println!("  {slug}: no application on the platform — nothing to pull");
+        return Ok(());
+    };
+    let Some(rev_id) = pick_revision(&app_id, args.latest, args.debug)? else {
+        println!("  {slug}: no revision to pull (not promoted yet? try --latest)");
+        return Ok(());
+    };
+
+    let bundle = get_typed_bundle(&app_id, &rev_id, args.debug)?;
+    println!("  {slug}: pulling revision {rev_id}");
+
+    let mut changed = 0u32;
+
+    // agent.md — the system prompt.
+    let agent_md = bundle.get("agent_md").and_then(Value::as_str).unwrap_or("");
+    if write_if_changed(root, "agent.md", agent_md, args.dry_run)? {
+        changed += 1;
+    }
+
+    // Skills — one folder per skill at the platform-canonical path. Bodies
+    // round-trip exactly; this is the common case (Agent Builder prose edits).
+    let mut pulled_skills: HashSet<String> = HashSet::new();
+    if let Some(skills) = bundle.get("skills").and_then(Value::as_array) {
+        for s in skills {
+            let Some(sid) = s.get("id").and_then(Value::as_str) else {
+                continue;
+            };
+            let rel = format!("skills/{sid}/SKILL.md");
+            pulled_skills.insert(rel.clone());
+            let body = s.get("body").and_then(Value::as_str).unwrap_or("");
+            if write_if_changed(root, &rel, body, args.dry_run)? {
+                changed += 1;
+            }
+        }
+    }
+
+    // Custom tool sources (deploy doesn't push these, but the Agent Builder may
+    // have added one on the platform). `source` may be "" but not null.
+    let mut pulled_tools: HashSet<String> = HashSet::new();
+    if let Some(tools) = bundle.get("tools").and_then(Value::as_array) {
+        for t in tools {
+            let (Some(tid), Some(source)) = (
+                t.get("id").and_then(Value::as_str),
+                t.get("source").and_then(Value::as_str),
+            ) else {
+                continue;
+            };
+            pulled_tools.insert(format!("tools/{tid}"));
+            if write_if_changed(
+                root,
+                &format!("tools/{tid}/source.ts"),
+                source,
+                args.dry_run,
+            )? {
+                changed += 1;
+            }
+        }
+    }
+
+    // spec.json — opt-in. The platform stores the FROZEN spec (defaults filled,
+    // skill descriptions re-derived at freeze), so this rewrites spec.json into
+    // that normalised shape. Off by default; review the diff.
+    if args.spec {
+        let on_disk: Value = fs::read_to_string(root.join("spec.json"))
+            .ok()
+            .and_then(|s| serde_json::from_str(&s).ok())
+            .unwrap_or_else(|| Value::Object(Default::default()));
+        let full = get_full_spec(&app_id, &rev_id, args.debug)?;
+        let serialized = serialize_spec(&reconstruct_spec(&full, &on_disk))?;
+        if write_if_changed(root, "spec.json", &serialized, args.dry_run)? {
+            changed += 1;
+        }
+    } else {
+        println!(
+            "  {slug}: spec.json not pulled (pass --spec to also pull spec/trigger/tool changes)"
+        );
+    }
+
+    prune_orphans(
+        root,
+        &slug,
+        &pulled_skills,
+        &pulled_tools,
+        args.prune,
+        args.dry_run,
+    )?;
+
+    if changed == 0 {
+        println!("  {slug}: content up to date — nothing changed");
+    }
+    Ok(())
+}
+
+// ── platform reads ────────────────────────────────────────────────────────────
+
+/// The revision to pull: the live one by default, or the newest revision (any
+/// state) with `--latest`. None if there's nothing to pull.
+fn pick_revision(app_id: &str, latest: bool, debug: bool) -> Result<Option<String>> {
+    let app =
+        get_json(&format!("agent_applications/{app_id}/"), debug).context("read application")?;
+    let live = app
+        .get("live_revision")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    if !latest {
+        return Ok(live);
+    }
+    let payload = get_json(&format!("agent_applications/{app_id}/revisions/"), debug)
+        .context("list revisions")?;
+    let revs = payload
+        .get("results")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    if revs.is_empty() {
+        return Ok(live);
+    }
+    let newest = revs.iter().max_by(|a, b| {
+        let key = |r: &Value| {
+            r.get("created_at")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string()
+        };
+        key(a).cmp(&key(b))
+    });
+    Ok(newest
+        .and_then(|r| r.get("id").and_then(Value::as_str))
+        .map(str::to_string))
+}
+
+/// `{ agent_md, skills:[{id,body}], tools:[{id,source}], spec }`.
+fn get_typed_bundle(app_id: &str, rev_id: &str, debug: bool) -> Result<Value> {
+    let payload = get_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/bundle/"),
+        debug,
+    )
+    .with_context(|| format!("read bundle for {rev_id}"))?;
+    payload
+        .get("bundle")
+        .filter(|b| b.is_object())
+        .cloned()
+        .with_context(|| format!("bundle read returned no bundle for {rev_id}"))
+}
+
+/// The full frozen spec (includes derived `skills[]` + `tools[]`).
+fn get_full_spec(app_id: &str, rev_id: &str, debug: bool) -> Result<Value> {
+    let rev = get_json(
+        &format!("agent_applications/{app_id}/revisions/{rev_id}/"),
+        debug,
+    )
+    .with_context(|| format!("read revision {rev_id}"))?;
+    rev.get("spec")
+        .filter(|s| s.is_object())
+        .cloned()
+        .with_context(|| format!("revision {rev_id} has no spec"))
+}
+
+// ── disk writes ────────────────────────────────────────────────────────────────
+
+/// Write `content` to `rel` under the bundle only if it differs. Logs
+/// `+ added` / `~ updated` (silent when unchanged). Honors dry-run.
+fn write_if_changed(root: &Path, rel: &str, content: &str, dry_run: bool) -> Result<bool> {
+    let dest = root.join(rel);
+    let existed = dest.is_file();
+    if existed && fs::read_to_string(&dest).ok().as_deref() == Some(content) {
+        return Ok(false);
+    }
+    let verb = if existed { "~ updated" } else { "+ added" };
+    println!("    {verb} {rel}");
+    if !dry_run {
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&dest, content).with_context(|| format!("writing {rel}"))?;
+    }
+    Ok(true)
+}
+
+/// Match the on-disk bundle convention: 4-space indent, trailing newline,
+/// non-ASCII left intact (prompts use em-dashes etc.).
+fn serialize_spec(spec: &Value) -> Result<String> {
+    let mut buf = Vec::new();
+    let fmt = serde_json::ser::PrettyFormatter::with_indent(b"    ");
+    let mut ser = serde_json::Serializer::with_formatter(&mut buf, fmt);
+    spec.serialize(&mut ser).context("serialize spec")?;
+    let body = String::from_utf8(buf).context("spec is not valid UTF-8")?;
+    Ok(format!("{body}\n"))
+}
+
+/// The spec to write: the platform's frozen spec plus any local-only keys
+/// (`resume`) carried over from the existing file.
+// ponytail: serde_json::Value objects sort their keys (no `preserve_order`
+// feature), so the on-disk key order isn't preserved across a --spec pull.
+// Enable serde_json `preserve_order` if minimal --spec diffs ever matter.
+fn reconstruct_spec(platform_spec: &Value, on_disk: &Value) -> Value {
+    let mut merged = platform_spec.clone();
+    if let Some(obj) = merged.as_object_mut() {
+        for key in LOCAL_ONLY_SPEC_KEYS {
+            if !obj.contains_key(key) {
+                if let Some(v) = on_disk.get(key) {
+                    obj.insert(key.to_string(), v.clone());
+                }
+            }
+        }
+    }
+    merged
+}
+
+/// On-disk skills/tools the platform no longer has. With `--prune`, delete them;
+/// otherwise warn so a stale local file doesn't silently re-deploy.
+fn prune_orphans(
+    root: &Path,
+    slug: &str,
+    pulled_skills: &HashSet<String>,
+    pulled_tools: &HashSet<String>,
+    prune: bool,
+    dry_run: bool,
+) -> Result<()> {
+    let skills_dir = root.join("skills");
+    if skills_dir.is_dir() {
+        let mut files: Vec<PathBuf> = WalkDir::new(&skills_dir)
+            .sort_by_file_name()
+            .into_iter()
+            .filter_map(|e| e.ok().map(walkdir::DirEntry::into_path))
+            .filter(|p| p.is_file() && p.file_name().is_some_and(|n| n == "SKILL.md"))
+            .collect();
+        files.sort();
+        for f in files {
+            let rel = f.strip_prefix(root)?.to_string_lossy().replace('\\', "/");
+            if pulled_skills.contains(&rel) {
+                continue;
+            }
+            // Remove the skill's folder, unless the SKILL.md sits directly in skills/.
+            let target = match f.parent() {
+                Some(parent) if parent != skills_dir.as_path() => parent.to_path_buf(),
+                _ => f.clone(),
+            };
+            handle_orphan(slug, &target, &rel, prune, dry_run)?;
+        }
+    }
+
+    let tools_dir = root.join("tools");
+    if tools_dir.is_dir() {
+        let mut dirs: Vec<PathBuf> = fs::read_dir(&tools_dir)?
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.is_dir())
+            .collect();
+        dirs.sort();
+        for d in dirs {
+            let rel = d.strip_prefix(root)?.to_string_lossy().replace('\\', "/");
+            if pulled_tools.contains(&rel) {
+                continue;
+            }
+            handle_orphan(slug, &d, &rel, prune, dry_run)?;
+        }
+    }
+    Ok(())
+}
+
+fn handle_orphan(slug: &str, target: &Path, rel: &str, prune: bool, dry_run: bool) -> Result<()> {
+    if !prune {
+        println!(
+            "  {slug}: {} on disk but not on platform: {rel} (pass --prune to remove)",
+            "!".yellow()
+        );
+        return Ok(());
+    }
+    println!("  {slug}: - removed {rel}");
+    if dry_run {
+        return Ok(());
+    }
+    if target.is_dir() {
+        fs::remove_dir_all(target).with_context(|| format!("removing {rel}"))?;
+    } else if target.is_file() {
+        fs::remove_file(target).with_context(|| format!("removing {rel}"))?;
+    }
+    Ok(())
+}

--- a/cli/src/agents/pull.rs
+++ b/cli/src/agents/pull.rs
@@ -10,7 +10,10 @@ use walkdir::WalkDir;
 
 use crate::invocation_context::context;
 
-use super::{discover_bundles, find_application, get_json, select_bundles, slug_of, PullArgs};
+use super::{
+    discover_bundles, find_application, get_json, get_typed_bundle, select_bundles, slug_of,
+    PullArgs,
+};
 
 /// Top-level spec keys deploy strips before upload, so the platform never stores
 /// them. Preserved from the on-disk `spec.json` when rewriting it.
@@ -187,20 +190,6 @@ fn pick_revision(app_id: &str, latest: bool, debug: bool) -> Result<Option<Strin
     Ok(newest
         .and_then(|r| r.get("id").and_then(Value::as_str))
         .map(str::to_string))
-}
-
-/// `{ agent_md, skills:[{id,body}], tools:[{id,source}], spec }`.
-fn get_typed_bundle(app_id: &str, rev_id: &str, debug: bool) -> Result<Value> {
-    let payload = get_json(
-        &format!("agent_applications/{app_id}/revisions/{rev_id}/bundle/"),
-        debug,
-    )
-    .with_context(|| format!("read bundle for {rev_id}"))?;
-    payload
-        .get("bundle")
-        .filter(|b| b.is_object())
-        .cloned()
-        .with_context(|| format!("bundle read returned no bundle for {rev_id}"))
 }
 
 /// The full frozen spec (includes derived `skills[]` + `tools[]`).

--- a/cli/src/api/client.rs
+++ b/cli/src/api/client.rs
@@ -230,6 +230,10 @@ impl PHClient {
         &self.config.env_id
     }
 
+    pub fn get_host(&self) -> &String {
+        &self.config.host
+    }
+
     fn create_request(&self, method: Method, url: Url) -> RequestBuilder {
         let headers = self.build_headers();
         debug!("building request for {method} {url}");

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -594,21 +594,20 @@ mod tests {
     #[test]
     fn agents_is_off_by_default_and_gated_behind_experimental() {
         // Without the flag, `experimental` parses false — run_impl gates on this.
-        let cli = Cli::try_parse_from(["posthog-cli", "agents", "list", "dir"]).unwrap();
+        // `dir` defaults to cwd, so `agents list` takes no positional.
+        let cli = Cli::try_parse_from(["posthog-cli", "agents", "list"]).unwrap();
         assert!(!cli.experimental);
         assert!(matches!(cli.command, Commands::Agents { .. }));
 
         // The flag must precede the subcommand (it is not a clap global).
-        let cli = Cli::try_parse_from(["posthog-cli", "--experimental", "agents", "list", "dir"])
-            .unwrap();
+        let cli = Cli::try_parse_from(["posthog-cli", "--experimental", "agents", "list"]).unwrap();
         assert!(cli.experimental);
     }
 
     #[test]
     fn agents_deploy_dry_run_is_independent_of_top_level_flag() {
         // `agents deploy --dry-run` sets only the subcommand preview flag, like `exp endpoints`.
-        let cli =
-            Cli::try_parse_from(["posthog-cli", "agents", "deploy", "dir", "--dry-run"]).unwrap();
+        let cli = Cli::try_parse_from(["posthog-cli", "agents", "deploy", "--dry-run"]).unwrap();
         assert!(!cli.dry_run);
         assert_eq!(dry_run_skipped_command(&cli.command), None);
     }

--- a/cli/src/commands.rs
+++ b/cli/src/commands.rs
@@ -5,6 +5,7 @@ use clap::{Parser, Subcommand};
 use tracing::{debug, error, warn};
 
 use crate::{
+    agents::AgentsCommand,
     api_proxy,
     download::SymbolSetsSubcommand,
     dsym::DsymSubcommand,
@@ -25,6 +26,11 @@ pub struct Cli {
     /// Disable non-zero exit codes on errors. Use with caution.
     #[arg(long, default_value = "false")]
     no_fail: bool,
+
+    /// Enable experimental commands (currently `agents`). Pass before the subcommand
+    /// (`posthog-cli --experimental agents ...`) or set `POSTHOG_CLI_EXPERIMENTAL`.
+    #[arg(long, env = "POSTHOG_CLI_EXPERIMENTAL", default_value = "false")]
+    experimental: bool,
 
     /// Skip SSL certificate verification when talking to the PostHog API. Use only with
     /// self-signed certificates.
@@ -119,6 +125,12 @@ pub enum Commands {
     Exp {
         #[command(subcommand)]
         cmd: ExpCommand,
+    },
+
+    #[command(hide = true, about = "Deploy + sync code-level agents (experimental)")]
+    Agents {
+        #[command(subcommand)]
+        cmd: AgentsCommand,
     },
 
     #[command(about = "Upload a directory of bundled chunks to PostHog")]
@@ -266,6 +278,13 @@ impl Cli {
     }
 
     fn run_impl(self) -> Result<(), CapturedError> {
+        if matches!(self.command, Commands::Agents { .. }) && !self.experimental {
+            return Err(anyhow::anyhow!(
+                "`agents` is experimental — re-run with --experimental (or POSTHOG_CLI_EXPERIMENTAL=1)"
+            )
+            .into());
+        }
+
         if self.dry_run {
             if let Some(kind) = dry_run_skipped_command(&self.command) {
                 warn!(
@@ -413,6 +432,9 @@ impl Cli {
                     }
                 },
             },
+            Commands::Agents { cmd } => {
+                cmd.run()?;
+            }
         }
 
         if INVOCATION_CONTEXT.get().is_some() {
@@ -567,6 +589,28 @@ mod tests {
             &dry_run_args,
             |_| false
         ));
+    }
+
+    #[test]
+    fn agents_is_off_by_default_and_gated_behind_experimental() {
+        // Without the flag, `experimental` parses false — run_impl gates on this.
+        let cli = Cli::try_parse_from(["posthog-cli", "agents", "list", "dir"]).unwrap();
+        assert!(!cli.experimental);
+        assert!(matches!(cli.command, Commands::Agents { .. }));
+
+        // The flag must precede the subcommand (it is not a clap global).
+        let cli = Cli::try_parse_from(["posthog-cli", "--experimental", "agents", "list", "dir"])
+            .unwrap();
+        assert!(cli.experimental);
+    }
+
+    #[test]
+    fn agents_deploy_dry_run_is_independent_of_top_level_flag() {
+        // `agents deploy --dry-run` sets only the subcommand preview flag, like `exp endpoints`.
+        let cli =
+            Cli::try_parse_from(["posthog-cli", "agents", "deploy", "dir", "--dry-run"]).unwrap();
+        assert!(!cli.dry_run);
+        assert_eq!(dry_run_skipped_command(&cli.command), None);
     }
 
     #[test]

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod agents;
 pub mod api;
 pub mod api_proxy;
 pub mod commands;


### PR DESCRIPTION
Adds an experimental `agents` command group to **posthog-cli** for deploying and syncing code-level PostHog agents — a Rust port of the `seed.py` / `pull.py` scripts in `agent-tests`, reusing the existing CLI auth + API client (no new auth).

## Command surface

All gated behind a new global `--experimental` flag (or `POSTHOG_CLI_EXPERIMENTAL`); the `agents` command is hidden from `--help` until enabled. The gate fires *before* auth/context setup.

- `agents list` — list discoverable bundles
- `agents deploy [names...]` — create → validate → freeze → promote each bundle. Plan/confirm/apply shape (mirrors `exp endpoints push`): prints a `CREATE`/`UPDATE`/`SKIP` plan, then confirms (unless `--yes`/`--dry-run`), then applies. Continues past a failing bundle and exits non-zero if any failed. Flags: `--dry-run`, `--diff`, `-y/--yes`, `--dummy-secrets`, `--auth-mode`, `--mcp-url`, `--debug`.
- `agents pull [names...]` — sync a live agent's bundle back to disk (write-if-changed `agent.md`, skills, custom tools). Flags: `--latest`, `--spec`, `--prune`, `--dry-run`, `--debug`.

`dir` is a `-d/--dir` flag defaulting to the **current directory**, which can be a single bundle (`spec.json` + `agent.md`) or a parent of bundle subdirs. A half-formed bundle errors loudly. Selectors are positional.

## `--diff` (terraform-style)

`agents deploy --diff` fetches the live revision's typed bundle and renders unified line-level diffs (via `similar`, same renderer style as `exp endpoints`) for `agent.md`, each changed skill body, and the spec (frozen ↔ local) per `UPDATE` bundle. Pure add/remove shows label-only; modifications show the hunks. Best-effort — a failed live fetch just omits the content diff.

## Notes

- Idempotency mirrors `seed.py`'s deliberately loose manifest+spec comparison (don't "fix" it here).
- Auth/API client come from the shared invocation context (`posthog login` / `POSTHOG_CLI_*`), project-scoped (`project_url`).
- **Deferred** (first cut): embedding example bundles into the published CLI, moving bundles out of `agent-tests`, and the agent-tests rewire. Everything operates on a `--dir`.

## Test

- `cd cli && cargo build && cargo clippy --all-targets && cargo test` — clean; 126 tests pass (incl. 3 `discover_bundles` cases + 2 wiring tests).
- Manual: `phcli --experimental agents deploy -d products/agent_platform/services/agent-tests/src/examples --dry-run --diff` against a local stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)