### PR TITLE
chore: clarify slack thread links are fine in PR copy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Pushes still trigger CI, which burns runner credits, so batch related commits an
 
 This repository is public and all commit messages, pull request titles, and pull request descriptions must be safe for public readers.
 
-- Never mention internal-only systems, private incidents, customer data, private Slack threads, unreleased roadmap details, or security-sensitive implementation details.
+- Never mention internal-only systems, private incidents, customer data, Slack thread contents, unreleased roadmap details, or security-sensitive implementation details. Slack thread links and channel references are fine to include — they sit behind PostHog auth and are useful as origin context — but do not quote or paraphrase what was said in the thread.
 - Use product-facing and code-facing context that a public OSS contributor could understand from this repository alone.
 - If context is sensitive, summarize it at a high level without naming internal tools, accounts, or people.
 - Avoid citing private operational scale or incident metrics (for example, exact affected team counts, internal row-volume anecdotes, or customer-specific performance numbers) unless that data is already public and linkable.
@@ -87,8 +87,10 @@ This repository is public and all commit messages, pull request titles, and pull
 Examples:
 
 - ✅ `fix(insights): handle missing series color in trend export`
+- ✅ A PR description that links to the originating Slack thread for context
 - ❌ `fix: patch issue found in acme-co prod workspace after sales escalation` — references internal customer
 - ❌ `fix: will run fine on our 12 million rows there now` — leaks private operational scale
+- ❌ A PR description that quotes verbatim what a coworker said in a Slack thread
 
 ## CI / GitHub Actions
 


### PR DESCRIPTION
## Problem

The "no private info in PR copy" bullet currently forbids Slack threads outright, but Slack thread links sit behind PostHog auth and are useful as origin context. Only the *contents* of a thread are sensitive.

## Changes

- Reword the bullet to allow Slack thread links and channel references, while still forbidding quoting or paraphrasing thread contents.
- Add a ✅ example (linking to the originating Slack thread) and a ❌ example (quoting a coworker verbatim).
- `CLAUDE.md` is a symlink to `AGENTS.md`, so the single edit covers both.

## How did you test this code?

Docs-only change. No automated tests; ran the repo's lint-staged markdown formatter via the commit hook.