### PR TITLE
fix(meta_ads): retry transient DB pool timeout when fetching integration

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/meta_ads.py
@@ -1,11 +1,12 @@
 import json
+import time
 import typing
 import datetime as dt
 import collections.abc
 from dataclasses import dataclass
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from django.db import close_old_connections
+from django.db import OperationalError, close_old_connections
 
 from requests import Response
 
@@ -109,15 +110,42 @@ def _clean_account_id(s: str | None) -> str | None:
     return s
 
 
+def _backoff_sleep(attempt: int) -> None:
+    """Sleep before the next retry: linear growth capped at 30s (2s, 4s, 6s, ...)."""
+    time.sleep(min(2 * attempt, 30))
+
+
+_MAX_INTEGRATION_FETCH_ATTEMPTS = 4
+
+
+def _fetch_integration_row(integration_id: int, team_id: int) -> Integration:
+    """Fetch the OAuth ``Integration`` row, retrying a transient DB failure with backoff.
+
+    Temporal activities run in a long-lived worker outside Django's request cycle, so a pooled
+    Postgres connection can be closed server-side while it sits idle, or the connection pooler can
+    reject the query with a wait timeout when the pool is saturated. Both surface as a transient
+    ``OperationalError`` (e.g. ``the connection is closed``, ``query_wait_timeout``) and both clear
+    once a healthy connection is used. ``close_old_connections()`` evicts connections already known
+    to be stale (and, after a failed query marks one unusable, drops it), so each attempt runs on a
+    fresh connection; the short backoff also gives a saturated pool time to drain rather than
+    retrying straight back into the same wait timeout. This read is idempotent, so it is safe to
+    repeat. ``Integration.DoesNotExist`` is left to propagate.
+    """
+    attempt = 0
+    while True:
+        close_old_connections()
+        try:
+            return Integration.objects.get(id=integration_id, team_id=team_id)
+        except OperationalError:
+            attempt += 1
+            if attempt >= _MAX_INTEGRATION_FETCH_ATTEMPTS:
+                raise
+            _backoff_sleep(attempt)
+
+
 def get_integration(config: MetaAdsSourceConfig, team_id: int) -> Integration:
     """Get the Meta Ads integration."""
-    # Temporal activities run in a thread pool where Django DB connections can go
-    # stale between uses (Postgres closes the connection server-side). This is
-    # invoked lazily from inside `get_rows`, so the connection has often been idle
-    # for minutes by the time we reach it, surfacing as
-    # `OperationalError: the connection is closed` — drop any stale connection first.
-    close_old_connections()
-    integration = Integration.objects.get(id=config.meta_ads_integration_id, team_id=team_id)
+    integration = _fetch_integration_row(config.meta_ads_integration_id, team_id)
     meta_ads_integration = MetaAdsIntegration(integration)
     meta_ads_integration.refresh_access_token()
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/meta_ads/test_meta_ads.py
@@ -6,6 +6,8 @@ import pytest
 from freezegun import freeze_time
 from unittest import mock
 
+from django.db import OperationalError
+
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.resumable import ResumableSourceManager
 from products.warehouse_sources.backend.temporal.data_imports.sources.generated_configs import MetaAdsSourceConfig
 from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads import meta_ads as meta_ads_module
@@ -16,6 +18,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.meta_ads.m
     PAGE_LIMIT_FALLBACK_SIZES,
     MetaAdsResumeConfig,
     _earliest_supported_since,
+    _fetch_integration_row,
     _is_permanent_auth_error,
     _iter_simple_pagination,
     _iter_time_range_pagination,
@@ -1172,3 +1175,68 @@ class TestGetIntegration:
         assert calls == ["close_old_connections", "Integration.objects.get"]
         meta_ads_integration.refresh_access_token.assert_called_once()
         assert result is integration
+
+
+class TestFetchIntegrationRowDbResilience:
+    def test_retries_on_dropped_connection_then_succeeds(self, monkeypatch) -> None:
+        integration = object()
+        get = mock.Mock(side_effect=[OperationalError("server closed the connection unexpectedly"), integration])
+        close = mock.Mock()
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", get)
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", close)
+        monkeypatch.setattr(meta_ads_module.time, "sleep", lambda _s: None)
+
+        result = _fetch_integration_row(integration_id=1, team_id=2)
+
+        assert result is integration
+        assert get.call_count == 2
+        # Evicted up front, then again after the failed query marked the connection unusable.
+        assert close.call_count == 2
+
+    def test_rides_out_pool_wait_timeout_then_succeeds(self, monkeypatch) -> None:
+        integration = object()
+        get = mock.Mock(
+            side_effect=[
+                OperationalError("query_wait_timeout"),
+                OperationalError("query_wait_timeout"),
+                integration,
+            ]
+        )
+        sleeps: list[int] = []
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", get)
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", lambda: None)
+        monkeypatch.setattr(meta_ads_module.time, "sleep", lambda s: sleeps.append(s))
+
+        result = _fetch_integration_row(integration_id=1, team_id=2)
+
+        assert result is integration
+        assert get.call_count == 3
+        # Backoff grows per attempt per `min(2 * attempt, 30)`: 2s after the 1st failure, 4s after the 2nd.
+        assert sleeps == [2, 4]
+
+    def test_reraises_after_exhausting_attempts(self, monkeypatch) -> None:
+        get = mock.Mock(side_effect=OperationalError("query_wait_timeout"))
+        sleeps: list[int] = []
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", get)
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", lambda: None)
+        monkeypatch.setattr(meta_ads_module.time, "sleep", lambda s: sleeps.append(s))
+
+        with pytest.raises(OperationalError):
+            _fetch_integration_row(integration_id=1, team_id=2)
+
+        # Bounded attempts: it gives up rather than looping forever, leaving Temporal to retry the activity.
+        assert get.call_count == 4
+        # Backed off between each attempt (2s, 4s, 6s) but not after the final attempt that re-raises.
+        assert sleeps == [2, 4, 6]
+
+    def test_missing_integration_is_not_retried(self, monkeypatch) -> None:
+        get = mock.Mock(side_effect=meta_ads_module.Integration.DoesNotExist())
+        monkeypatch.setattr(meta_ads_module.Integration.objects, "get", get)
+        monkeypatch.setattr(meta_ads_module, "close_old_connections", lambda: None)
+        monkeypatch.setattr(meta_ads_module.time, "sleep", lambda _s: None)
+
+        with pytest.raises(meta_ads_module.Integration.DoesNotExist):
+            _fetch_integration_row(integration_id=1, team_id=2)
+
+        # A deleted integration row is non-retryable — don't mask it as a transient drop.
+        assert get.call_count == 1


### PR DESCRIPTION
## Problem

Error tracking surfaced a `ProtocolViolation: query_wait_timeout` (a `psycopg`/`django.db.OperationalError`) from the Meta Ads import source: [issue 019f1797-0ea2-7512-a0f4-931e7aa62fb4](https://us.posthog.com/project/2/error_tracking/019f1797-0ea2-7512-a0f4-931e7aa62fb4).

The stack ends in `get_integration` (`meta_ads.py`) at the `Integration.objects.get(...)` call. `query_wait_timeout` is raised by the connection pooler when a query waits too long for a server connection because the pool is saturated — a **transient** failure on our own Postgres, not the customer's credentials, config, or Meta's API. It clears on its own once a healthy connection is available.

The source fetched the integration row with a single ORM `.get()`, so this transient blip failed the import immediately instead of riding it out.

## Changes

Extract the DB read into a `_fetch_integration_row` helper that retries on `OperationalError` with bounded attempts and linear backoff (2s, 4s, 6s; max 4 attempts), evicting stale connections via `close_old_connections()` before each attempt. After exhausting attempts it re-raises, leaving Temporal to retry the activity. `Integration.DoesNotExist` is left to propagate (still non-retryable — already handled by `get_non_retryable_errors`).

This is **not** added to `NonRetryableErrors`: the error is transient and should remain retryable. The fix mirrors the existing resilience pattern in the LinkedIn Ads source (`_get_integration`), which the same class of error is being hardened against across sibling sources.

## How did you test this code?

I'm an agent. I added unit tests for `_fetch_integration_row` covering: retry-then-succeed on a dropped connection, riding out repeated `query_wait_timeout` with the expected backoff sequence, re-raising after exhausting attempts, and not retrying `Integration.DoesNotExist`. These catch the regression where a transient pool timeout fails the import on the first attempt — no existing test exercised the retry loop. Ran the full `test_meta_ads.py` suite (71 passed) plus `ruff check`/`ruff format`.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook for the `meta_ads` source. Confirmed the failing frame is in `meta_ads.py:get_integration` doing an ORM read whose deepest frame is `psycopg.cursor.execute` raising `query_wait_timeout`.
- Decision: transient infrastructure error (pooler wait timeout on our own DB), so it must stay retryable — ruled out extending `NonRetryableErrors`. Treated it as a fixable fragility in our code and mirrored the already-merged LinkedIn Ads `_get_integration` retry/backoff helper.
- Checked open PRs (including the maintainer's) — siblings like google_analytics, hubspot, google_search_console, and google_ads have the same fix, but none existed for meta_ads.