### PR TITLE
feat(funnels): refine compare-to-previous step visualization

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -564,10 +564,18 @@ snapshots:
         hash: v1.k794b7964.23536e5a2ab3d8bce7331e71b383b4bb7731540c1b7c12bf5b2f5c0dff99f549.YTAdBcwHbe9fmAoGrhasYXk8eOoyQseHQPfTaNHriE4
     components-hogcharts-barchart--stacked-mixed-sign--light:
         hash: v1.k794b7964.54ea51777cd1be48ada08afc6d9652348e58c55b4578259834125c1586df772a.puvvq3HL5w9hHEpev9dP2fRTzvd42bW7BZ-F7WiOIks
+    components-hogcharts-barchart--stacked-with-track-ceiling--dark:
+        hash: v1.k794b7964.1f85d679741bd81ee3e7ab488ce82596c1e9f29f396295d863ed51a53f5a3a55.Q0JUJARVeJV8GdQs-EpptVEuOCgB0zYkwCApvNmEc7A
+    components-hogcharts-barchart--stacked-with-track-ceiling--light:
+        hash: v1.k794b7964.eb413728e33e4274883d8126d1634e408b221e6c9b3d880f6feaae458b891e09.55R7ZeVRnWxZjkWcMuLk_k8ZLPvrFXLxRqC8xOzYtAo
     components-hogcharts-barchart--with-bar-track--dark:
         hash: v1.k794b7964.459993a07b1a8d239b43e5700fda3de963173c7c62792c3ca73ca7d26d3e967e.3i1wOTz8MkiBSViwUvFmF0H-bkd_5Yeu3YpGa4l5jP4
     components-hogcharts-barchart--with-bar-track--light:
         hash: v1.k794b7964.ba635da9134368b50adcd9ef7f0918d3c586f9282554e5395db438f04c1b9828.4CvwEAEAL4UT_K-Fs7S-laUq9wf3MMmOG2jnRIkffo4
+    components-hogcharts-barchart--with-bar-track-ceiling--dark:
+        hash: v1.k794b7964.3326668de4a2d7d75de261b264de264a7a60113b703e67f687a8ef8a42f36109.2lqjmeix3iZwdrVjXi8ZpxMk9tuHmyV0LWVEIdaPJJ4
+    components-hogcharts-barchart--with-bar-track-ceiling--light:
+        hash: v1.k794b7964.e9accba1ecd78df7cf201f4eccdb1879ff90a450c7052c10940b1406892dcd65.fu8AiHQlPz_QXbMIH-RxgXyBXyhX9x365WS4pFWbKA4
     components-hogcharts-barchart--with-reference-line--dark:
         hash: v1.k794b7964.da4e7911b8847da4a178564ba146bcc41c61036ce36b332c6a9615b7d3d43df4.WtDqIa4IKDYz7LljgNREGiso0w4-6JVJZHPTFlWDrMc
     components-hogcharts-barchart--with-reference-line--light:
@@ -2469,13 +2477,13 @@ snapshots:
     insights-funnelbarhorizontalchart--default-narrow--light:
         hash: v1.k794b7964.b6543758ca04b2e970af5d54a370ba18ced44e9ae8fc75814f19392942db7abc.y9qjx5SS8j1iMTyUqdHLGqjEZuGfzS23ao2GcioBRUc
     insights-funnelbarhorizontalchart--funnel-top-to-bottom-breakdown-compare--dark:
-        hash: v1.k794b7964.e796992fbefdd3191e1ba79e60c77736a44741800bcf1449be26e6a13f7553c3.W-5yUtMfns_MAz8EcRrzSYEaJEKAttc_lzSc2fVESLE
+        hash: v1.k794b7964.eb479a84b636e03317606fce52cea935e6de48952d11fd691c42b13549869efd.2eMSpsP3yDXNFIgHD2By8EeD1TabFKSeMMCQC8ruPs4
     insights-funnelbarhorizontalchart--funnel-top-to-bottom-breakdown-compare--light:
-        hash: v1.k794b7964.75ef16cea8a014fe7cd3a01b8962c91de81ba9d4b3bc7378e090caa2047ad4dc.R_kwF04YcEG0ODevUS8jJb1jDAng3JWl3_RbuT0kURk
+        hash: v1.k794b7964.d3a574096970494a064ece19dc2ccb7e87ae4e6d11b32e8a95113efa54502aa4.SOAuVY10b_EoDBE4kngDdaLXbpc5YQ2hSt5GaV02vsY
     insights-funnelbarhorizontalchart--funnel-top-to-bottom-compare--dark:
-        hash: v1.k794b7964.72d237b21ff6966313ce6117b09181395d56a21f3826cd06eb7de95d118389d4.aTEfL9HGvWY3WO-TKr-bs8nvdEuVWauwCh3BWg4n7iU
+        hash: v1.k794b7964.5ce2f4ec8a61d61a1f94928d052ad786c79677b6f2de7d87335e654675338925.ZOxo83II5vBuKBTcrmyXnN0aPlHRJjb1WiF-HuYHjRY
     insights-funnelbarhorizontalchart--funnel-top-to-bottom-compare--light:
-        hash: v1.k794b7964.8faec9e7852253456408ac542e54813dca156da131c8a9a3f3be2abce804e8c5.H71T2F5dlR2cNdBQ2EhRysiy-c0VzNWUiiaHDxHC7Co
+        hash: v1.k794b7964.d0d07f01bc19a506cd477621ecc413c3a828370af2eb911a612f4de6a313dde1.8ZZ9IsGnPTTB9dIJvIELaCyjppVcNDTaBDXhuzlwY0w
     insights-funnelcorrelationtable--default--dark:
         hash: v1.k794b7964.0c70fac4deda9be64c8b0c0d06eb0149e9d11176c31ab5861f6657fa80714836.YqZL0Grf9CN71TbXgR_pGO23EfnukP5X-Doi0-Xy48A
     insights-funnelcorrelationtable--default--light:
@@ -2517,13 +2525,13 @@ snapshots:
     insights-funnelstepsbarchart--breakdown--light:
         hash: v1.k794b7964.ef5b8d25d48688261cfaa80a3fc0eb72591947c058b608785e0b82ff0f9a789f.Ew5iFWL3G7CoqIph640J4EcyQkv7EMC__wX_42-3yME
     insights-funnelstepsbarchart--breakdown-and-compare--dark:
-        hash: v1.k794b7964.88ae974582c9dcba3100f28eb688af198cfd7480a56375eee40d42e4839c233a.CEFZgymiNhpGlXdyaHivgzWQ8u0Anj0u72yq4ulch9A
+        hash: v1.k794b7964.7350467709d4650cf71e064ea55b39d31d779f85c4e473d85b5f470aa6f4838a.xgIOFyhWCh8uwVbUQJu1TEkCwuEO-YmHH_14GYir2yk
     insights-funnelstepsbarchart--breakdown-and-compare--light:
-        hash: v1.k794b7964.9f202e1484c79485c02ddf726b822bccaa4f208f6663ff287dae0245bb3b4a5e.FbEco_G_czhBhk9FIXa5xVQ1aP6_Hi8ndmheuCgvPaI
+        hash: v1.k794b7964.64ae5f7f33d528b3d6796e61b4bebbd46b6395f6c1313b9c8f9b9771aed12dfd.pkZgbPRunP-ImmqKR91IhlSZzxA3_SrYjpNTAjXHprw
     insights-funnelstepsbarchart--compare--dark:
-        hash: v1.k794b7964.4b63e733bb826606ac813e27b2c259007c1c37f790fed33baf77d5069048bbf3.0_oTFagU6uG6SHNAfgui8JXZxijxgS2PtPF_lPCo4JY
+        hash: v1.k794b7964.bb56d814937bc56a8f9b315571b227511c2b51c43d6cad0d3c367a81b4a0185f.xi3342BT2p-FNZerZZdfZx7dlk1XdMTw9gK51SdudX4
     insights-funnelstepsbarchart--compare--light:
-        hash: v1.k794b7964.e7b47f099f0ae984c8bcc5f251e1eee8edbb20b3c4b10b504c3ee58d0a3d479d.5giqurdSr41CHswwkeVaNjraBs1OS2m5z_M0mt97QOI
+        hash: v1.k794b7964.837931443f7ced23d24066f0faa223b94700e48a50931af7ccdcc2f32a7b0a21.Y7xvlht0gaI3-y1u7o6wRueG8VC9vTJg93Lw0C3NbRc
     insights-funnelstepsbarchart--default--dark:
         hash: v1.k794b7964.5317f73d42180be586139ca1ee35001cb08f764246dc98d9a1421949c796f235.6kheIKEWojErjDJhqIIyLd6JPoj9uopMYZ2q1qxKlRg
     insights-funnelstepsbarchart--default--light:
@@ -5757,9 +5765,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
         hash: v1.k794b7964.7ea36b6183af10b29a7294f85bfcff4a09590b90558904c7065018b77cfc35ef.jcwzdxAwnJjku6Nfe2HPb2IRClfbpiG3SFnh2EpSqXI
     scenes-app-insights-funnels--funnel-left-to-right-compare--dark:
-        hash: v1.k794b7964.e2b87a572d6503c8ebfbe7adf54031db98fda2b30d97b933c63fd094ef330ab4.GeSi46whIPeDDDWAO_Ow8pWiaDWnTg7VgQ5GJMdVBNE
+        hash: v1.k794b7964.7aa805f983ffd9a22957da8897abb9042ff85a8a7e53fc559ee5bf58ce60d932.YpPfgMNcecM0qO9eZ6KCWLqeyfVj27aOf-K40SIBJ7o
     scenes-app-insights-funnels--funnel-left-to-right-compare--light:
-        hash: v1.k794b7964.0a836d6b292fbfcccb587e3de3996e87a3b9933657642b4aee882a592da20008.3SxlWfNeYtsnARocwkgnRA43UgJECOkgM7e6rVSxnjE
+        hash: v1.k794b7964.529ba6a17ec80fec238a36bb9338b7c903356161df33471127bada959c4b55c7.4LJW1G8kS3MvdH3kVOx51dMGK8NAqcofqezIXRGxYes
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
         hash: v1.k794b7964.19e87533e1bdb4761c1a9f973894c8732e54fc65c230a4f675c0d71be67a01a0.WZPWNrUf1ZmNmJCLpgck7R_7RTWMaiuufEIDvKP08nk
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1653,18 +1653,19 @@ describe('funnelDataLogic', () => {
             expect(steps[1].count).toBe(70) // 50 Chrome + 20 Safari
         })
 
-        it('scales each breakdown value against its own larger period', async () => {
+        it('shares each period’s height across its breakdown values at the first step (larger period fills)', async () => {
             await loadBreakdownCompare(funnelResultStepsBreakdownCompare.result)
 
             const [chromeCur, chromePrev, safariCur, safariPrev] =
                 logic.values.visibleStepsWithConversionMetrics[0].nested_breakdown!
 
-            // Chrome basis = max(100, 80); Safari basis = max(40, 25). Each value's leader fills its
-            // bar — Safari current is full despite being far smaller than Chrome (not 40/100).
+            // At the first step every value converts 100% of its own entrants, so a period's values all
+            // share one height — the period's share of the larger baseline: current (140) fills, previous
+            // (105) → 105/140. Chrome and Safari read identically within each period.
             expect(chromeCur.conversionRates.fromBasisStep).toBe(1)
-            expect(chromePrev.conversionRates.fromBasisStep).toBe(80 / 100)
+            expect(chromePrev.conversionRates.fromBasisStep).toBe(105 / 140)
             expect(safariCur.conversionRates.fromBasisStep).toBe(1)
-            expect(safariPrev.conversionRates.fromBasisStep).toBe(25 / 40)
+            expect(safariPrev.conversionRates.fromBasisStep).toBe(105 / 140)
         })
 
         it('colors each breakdown value distinctly and desaturates its previous-period bar', async () => {

--- a/frontend/src/scenes/funnels/funnelDataLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelDataLogic.test.ts
@@ -1653,6 +1653,20 @@ describe('funnelDataLogic', () => {
             expect(steps[1].count).toBe(70) // 50 Chrome + 20 Safari
         })
 
+        it('scales each breakdown value against its own larger period', async () => {
+            await loadBreakdownCompare(funnelResultStepsBreakdownCompare.result)
+
+            const [chromeCur, chromePrev, safariCur, safariPrev] =
+                logic.values.visibleStepsWithConversionMetrics[0].nested_breakdown!
+
+            // Chrome basis = max(100, 80); Safari basis = max(40, 25). Each value's leader fills its
+            // bar — Safari current is full despite being far smaller than Chrome (not 40/100).
+            expect(chromeCur.conversionRates.fromBasisStep).toBe(1)
+            expect(chromePrev.conversionRates.fromBasisStep).toBe(80 / 100)
+            expect(safariCur.conversionRates.fromBasisStep).toBe(1)
+            expect(safariPrev.conversionRates.fromBasisStep).toBe(25 / 40)
+        })
+
         it('colors each breakdown value distinctly and desaturates its previous-period bar', async () => {
             await loadBreakdownCompare(funnelResultStepsBreakdownCompare.result)
 

--- a/frontend/src/scenes/funnels/funnelPersonsModalLogic.test.ts
+++ b/frontend/src/scenes/funnels/funnelPersonsModalLogic.test.ts
@@ -188,8 +188,8 @@ describe('funnelPersonsModalLogic', () => {
         })
 
         // There is no "dropped off before step 1": funnelStep would be -1, which the backend rejects
-        // with a ValueError. In compare mode the rescaled first bar can expose a clickable drop-off
-        // track, so this path is reachable and must no-op.
+        // with a ValueError. No UI exposes a first-step drop-off, but the listener guards against an
+        // invalid call defensively, so these must no-op rather than fire a query.
         test('openPersonsModalForSeries no-ops on the first step drop-off', async () => {
             logic.actions.openPersonsModalForSeries({
                 series: makeSeries({ order: 0, compare_label: 'current' }),

--- a/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
+++ b/frontend/src/scenes/funnels/funnelPersonsModalLogic.ts
@@ -106,9 +106,9 @@ export const funnelPersonsModalLogic = kea<funnelPersonsModalLogicType>([
         openPersonsModalForStep: ({ step, stepIndex, converted }) => {
             // Note - when in a legend the step.order is always 0 so we use stepIndex instead
             const stepNo = typeof stepIndex === 'number' ? stepIndex + 1 : step.order + 1
-            // There is no drop-off before the first step — funnelStep -1 is invalid and the backend
-            // rejects it. In compare mode the rescaled first bar can expose a clickable drop-off track,
-            // so ignore that click instead of firing a query that 500s.
+            // A first-step drop-off (funnelStep -1) is invalid — the backend rejects it with a 500. No UI
+            // exposes one (the footer/legend hide the drop-off control on step 1, and compare's first-step
+            // volume gap is non-interactive), but guard the listener so any invalid call opens nothing.
             if (!converted && stepNo === 1) {
                 return
             }

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -757,7 +757,7 @@ describe('stepsWithConversionMetrics', () => {
         expect(Number.isNaN(result[1].nested_breakdown![1].conversionRates.total)).toBe(false)
     })
 
-    it('breakdown + compare — each value scales against its own larger period, not a global max', () => {
+    it('breakdown + compare — every value shares its period’s height at the first step (larger period fills)', () => {
         // Chrome current 100 / previous 80; Safari current 40 / previous 25. nested_breakdown pairs
         // current+previous per value: [Chrome-cur, Chrome-prev, Safari-cur, Safari-prev].
         const steps: FunnelStepWithNestedBreakdown[] = [
@@ -799,11 +799,13 @@ describe('stepsWithConversionMetrics', () => {
         const result = stepsWithConversionMetrics(steps, FunnelStepReference.total)
         const nb = result[0].nested_breakdown!
 
-        // Chrome basis = max(100, 80) = 100; Safari basis = max(40, 25) = 40 — its own leader, NOT 100.
-        expect(nb[0].conversionRates.fromBasisStep).toBe(1) // Chrome current 100/100
-        expect(nb[1].conversionRates.fromBasisStep).toBe(80 / 100) // Chrome previous
-        expect(nb[2].conversionRates.fromBasisStep).toBe(1) // Safari current 40/40 — leader fills the bar
-        expect(nb[3].conversionRates.fromBasisStep).toBe(25 / 40) // Safari previous
+        // At the first step every value converts 100% of its own entrants, so within a period all values
+        // share one height: the period's share of the larger baseline. Current is larger (140 vs 105) →
+        // 100%; previous → 105/140. Chrome and Safari read the same height within each period.
+        expect(nb[0].conversionRates.fromBasisStep).toBe(1) // Chrome current
+        expect(nb[1].conversionRates.fromBasisStep).toBe(105 / 140) // Chrome previous
+        expect(nb[2].conversionRates.fromBasisStep).toBe(1) // Safari current — same as Chrome current
+        expect(nb[3].conversionRates.fromBasisStep).toBe(105 / 140) // Safari previous — same as Chrome previous
     })
 
     it('nested breakdowns with outlier detection — divergent breakdown gets significant: true', () => {

--- a/frontend/src/scenes/funnels/funnelUtils.test.ts
+++ b/frontend/src/scenes/funnels/funnelUtils.test.ts
@@ -757,6 +757,55 @@ describe('stepsWithConversionMetrics', () => {
         expect(Number.isNaN(result[1].nested_breakdown![1].conversionRates.total)).toBe(false)
     })
 
+    it('breakdown + compare — each value scales against its own larger period, not a global max', () => {
+        // Chrome current 100 / previous 80; Safari current 40 / previous 25. nested_breakdown pairs
+        // current+previous per value: [Chrome-cur, Chrome-prev, Safari-cur, Safari-prev].
+        const steps: FunnelStepWithNestedBreakdown[] = [
+            makeNestedStep({
+                count: 140,
+                order: 0,
+                nested_breakdown: [
+                    makeStep({
+                        count: 100,
+                        order: 0,
+                        breakdown: '$browser',
+                        breakdown_value: 'Chrome',
+                        compare_label: 'current',
+                    }),
+                    makeStep({
+                        count: 80,
+                        order: 0,
+                        breakdown: '$browser',
+                        breakdown_value: 'Chrome',
+                        compare_label: 'previous',
+                    }),
+                    makeStep({
+                        count: 40,
+                        order: 0,
+                        breakdown: '$browser',
+                        breakdown_value: 'Safari',
+                        compare_label: 'current',
+                    }),
+                    makeStep({
+                        count: 25,
+                        order: 0,
+                        breakdown: '$browser',
+                        breakdown_value: 'Safari',
+                        compare_label: 'previous',
+                    }),
+                ],
+            }),
+        ]
+        const result = stepsWithConversionMetrics(steps, FunnelStepReference.total)
+        const nb = result[0].nested_breakdown!
+
+        // Chrome basis = max(100, 80) = 100; Safari basis = max(40, 25) = 40 — its own leader, NOT 100.
+        expect(nb[0].conversionRates.fromBasisStep).toBe(1) // Chrome current 100/100
+        expect(nb[1].conversionRates.fromBasisStep).toBe(80 / 100) // Chrome previous
+        expect(nb[2].conversionRates.fromBasisStep).toBe(1) // Safari current 40/40 — leader fills the bar
+        expect(nb[3].conversionRates.fromBasisStep).toBe(25 / 40) // Safari previous
+    })
+
     it('nested breakdowns with outlier detection — divergent breakdown gets significant: true', () => {
         // Create 5 breakdowns where one is an outlier
         const breakdownCounts = [

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -502,20 +502,25 @@ export function stepsWithConversionMetrics(
 ): FunnelStepWithConversionMetrics[] {
     const compareBars = steps[0]?.nested_breakdown
     const isCompare = compareBars?.some((b) => b.compare_label != null) ?? false
-    // Each breakdown value's two periods share one baseline — that value's larger period's first
-    // step — so the value's leader period fills the bar and its other period shows real volume below
-    // it. Pure compare has a single value, so both periods group together (one global baseline);
-    // breakdown + compare groups per value, so a small value is never shrunk to a larger value's scale.
-    const compareBasisByIndex: number[] = []
+    // Compare bars are sized per period, not per breakdown value. Within a period every value keeps its
+    // own conversion from its own first step — so at the first step all of a period's values share one
+    // height — and the whole period is then scaled by its share of the larger period's total entrants.
+    // The larger period fills the bar (100%); the smaller one is proportionally shorter, its missing
+    // volume left as a blank gap above. Applied below as (count * periodTotal) / (firstStep * basis) —
+    // a single division so the exact ratios stay clean. Pure compare has one value whose first step is
+    // the period total, so it collapses to count / max(current, previous).
+    let currentTotal = 0
+    let previousTotal = 0
+    let compareBasis = 0
     if (isCompare && compareBars) {
-        const maxCountByValue = new Map<string, number>()
         for (const bar of compareBars) {
-            const key = getVisibilityKey(bar.breakdown_value)
-            maxCountByValue.set(key, Math.max(maxCountByValue.get(key) ?? 0, bar.count))
+            if (bar.compare_label === 'previous') {
+                previousTotal += bar.count
+            } else {
+                currentTotal += bar.count
+            }
         }
-        compareBars.forEach((bar, index) => {
-            compareBasisByIndex[index] = maxCountByValue.get(getVisibilityKey(bar.breakdown_value)) ?? 0
-        })
+        compareBasis = Math.max(currentTotal, previousTotal, 0)
     }
 
     let lastNonOptionalStep = 0
@@ -542,8 +547,10 @@ export function stepsWithConversionMetrics(
                 conversionRates: {
                     ...conversionRates,
                     fromBasisStep: isCompare
-                        ? compareBasisByIndex[breakdownIndex]
-                            ? breakdown.count / compareBasisByIndex[breakdownIndex]
+                        ? firstBreakdownCount > 0 && compareBasis > 0
+                            ? (breakdown.count *
+                                  (breakdown.compare_label === 'previous' ? previousTotal : currentTotal)) /
+                              (firstBreakdownCount * compareBasis)
                             : 0
                         : stepReference === FunnelStepReference.total
                           ? conversionRates.total

--- a/frontend/src/scenes/funnels/funnelUtils.tsx
+++ b/frontend/src/scenes/funnels/funnelUtils.tsx
@@ -502,10 +502,21 @@ export function stepsWithConversionMetrics(
 ): FunnelStepWithConversionMetrics[] {
     const compareBars = steps[0]?.nested_breakdown
     const isCompare = compareBars?.some((b) => b.compare_label != null) ?? false
-    // Compare bars share one baseline (the larger period's first step) so both periods sit on a
-    // common scale: the previous bar shows its real volume instead of always starting full height,
-    // and the tallest bar never exceeds the column.
-    const compareBasisCount = isCompare ? Math.max(...(compareBars?.map((b) => b.count) ?? [0])) : 0
+    // Each breakdown value's two periods share one baseline — that value's larger period's first
+    // step — so the value's leader period fills the bar and its other period shows real volume below
+    // it. Pure compare has a single value, so both periods group together (one global baseline);
+    // breakdown + compare groups per value, so a small value is never shrunk to a larger value's scale.
+    const compareBasisByIndex: number[] = []
+    if (isCompare && compareBars) {
+        const maxCountByValue = new Map<string, number>()
+        for (const bar of compareBars) {
+            const key = getVisibilityKey(bar.breakdown_value)
+            maxCountByValue.set(key, Math.max(maxCountByValue.get(key) ?? 0, bar.count))
+        }
+        compareBars.forEach((bar, index) => {
+            compareBasisByIndex[index] = maxCountByValue.get(getVisibilityKey(bar.breakdown_value)) ?? 0
+        })
+    }
 
     let lastNonOptionalStep = 0
     const stepsWithConversionMetrics = steps.map((step, i) => {
@@ -531,9 +542,9 @@ export function stepsWithConversionMetrics(
                 conversionRates: {
                     ...conversionRates,
                     fromBasisStep: isCompare
-                        ? compareBasisCount === 0
-                            ? 0
-                            : breakdown.count / compareBasisCount
+                        ? compareBasisByIndex[breakdownIndex]
+                            ? breakdown.count / compareBasisByIndex[breakdownIndex]
+                            : 0
                         : stepReference === FunnelStepReference.total
                           ? conversionRates.total
                           : conversionRates.fromPrevious,

--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -43,6 +43,7 @@ const series: Series[] = [
 
 - `key` (React key + stacking identity), `label` (legend/tooltip), `data` are required.
 - Line-only options: `points`, `stroke.pattern` (dashes/projections), `fill.opacity` / `fill.gradient` (area), `fill.lowerData` (ribbon).
+- Bar-only options: `bars` (per-bar `color`/`label`/`meta` overrides); `trackData` (grouped + `bars.track` only) caps each bar's "share of a whole" track at a per-bar ceiling in value units — the track fills only to `trackData[i]` and the region beyond is a blank, non-interactive gap (no track highlight, no click). Funnel compare uses it to draw a shorter period's volume gap as empty space rather than drop-off.
 - `yAxisId` scales a series against a second axis; `meta` carries arbitrary data into tooltips.
 
 ## Sizing

--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -43,7 +43,7 @@ const series: Series[] = [
 
 - `key` (React key + stacking identity), `label` (legend/tooltip), `data` are required.
 - Line-only options: `points`, `stroke.pattern` (dashes/projections), `fill.opacity` / `fill.gradient` (area), `fill.lowerData` (ribbon).
-- Bar-only options: `bars` (per-bar `color`/`label`/`meta` overrides); `trackData` (grouped + `bars.track` only) caps each bar's "share of a whole" track at a per-bar ceiling in value units — the track fills only to `trackData[i]` and the region beyond is a fully inert gap: no hover, tooltip, pointer cursor, highlight, or click (the chart vetoes the hover there via `resolveHoverIndex`). Funnel compare uses it to draw a shorter period's volume gap as empty space rather than drop-off.
+- Bar-only options: `bars` (per-bar `color`/`label`/`meta` overrides); `trackData` caps each bar's interactive extent at a per-bar ceiling in value units — the region beyond `trackData[i]` is a fully inert gap: no hover, tooltip, pointer cursor, highlight, or click (the chart vetoes the hover there via `resolveHoverIndex`). On grouped charts with `bars.track` the hatched "share of a whole" track also fills only to the ceiling; on stacked charts no track is drawn — the ceiling only bounds interactivity. Funnel compare uses it to draw a shorter period's volume gap as empty space rather than drop-off, in both its grouped (left-to-right) and stacked (top-to-bottom) charts.
 - `yAxisId` scales a series against a second axis; `meta` carries arbitrary data into tooltips.
 
 ## Sizing

--- a/packages/quill/packages/charts/AGENTS.md
+++ b/packages/quill/packages/charts/AGENTS.md
@@ -43,7 +43,7 @@ const series: Series[] = [
 
 - `key` (React key + stacking identity), `label` (legend/tooltip), `data` are required.
 - Line-only options: `points`, `stroke.pattern` (dashes/projections), `fill.opacity` / `fill.gradient` (area), `fill.lowerData` (ribbon).
-- Bar-only options: `bars` (per-bar `color`/`label`/`meta` overrides); `trackData` (grouped + `bars.track` only) caps each bar's "share of a whole" track at a per-bar ceiling in value units — the track fills only to `trackData[i]` and the region beyond is a blank, non-interactive gap (no track highlight, no click). Funnel compare uses it to draw a shorter period's volume gap as empty space rather than drop-off.
+- Bar-only options: `bars` (per-bar `color`/`label`/`meta` overrides); `trackData` (grouped + `bars.track` only) caps each bar's "share of a whole" track at a per-bar ceiling in value units — the track fills only to `trackData[i]` and the region beyond is a fully inert gap: no hover, tooltip, pointer cursor, highlight, or click (the chart vetoes the hover there via `resolveHoverIndex`). Funnel compare uses it to draw a shorter period's volume gap as empty space rather than drop-off.
 - `yAxisId` scales a series against a second axis; `meta` carries arbitrary data into tooltips.
 
 ## Sizing

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
@@ -82,6 +82,31 @@ export const WithBarTrackCeiling: Story = {
     },
 }
 
+export const StackedWithTrackCeiling: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        // Stacked counterpart of WithBarTrackCeiling — the shape of a top-to-bottom funnel compare bar.
+        // The stack (converted + drop-off) sums to the period's entry level (70), and `trackData` on the
+        // drop-off declares that ceiling: the region beyond it is fully inert (no tooltip, pointer
+        // cursor, or highlight when hovered), with no track drawn.
+        const series: Series[] = [
+            { key: 'converted', label: 'Converted', color: '', data: [45] },
+            { key: 'drop-off', label: 'Drop-off', color: '', data: [25], trackData: [70] },
+        ]
+        const config: BarChartConfig = {
+            barLayout: 'stacked',
+            axisOrientation: 'horizontal',
+            showGrid: true,
+            bars: { cornerRadius: 6, valueDomain: [0, 100] },
+        }
+        return (
+            <Stage height={120}>
+                <BarChart series={series} labels={['Step 1']} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
 export const Percent: Story = {
     render: () => {
         const theme = useReactiveTheme()

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.stories.tsx
@@ -59,6 +59,29 @@ export const WithBarTrack: Story = {
     },
 }
 
+export const WithBarTrackCeiling: Story = {
+    render: () => {
+        const theme = useReactiveTheme()
+        // Per-bar `trackData` caps each track at a ceiling (funnel compare's entry level): the "previous"
+        // series fills its track only up to 70, leaving the region above blank — the volume gap — instead
+        // of drawing it as drop-off. "Current" has no ceiling, so its track spans the full axis.
+        const series: Series[] = [
+            { key: 'current', label: 'Current', color: '', data: [100, 60, 40] },
+            { key: 'previous', label: 'Previous', color: '', data: [70, 45, 30], trackData: [70, 70, 70] },
+        ]
+        const config: BarChartConfig = {
+            barLayout: 'grouped',
+            showGrid: true,
+            bars: { track: true, cornerRadius: 6, valueDomain: [0, 100] },
+        }
+        return (
+            <Stage>
+                <BarChart series={series} labels={['Step 1', 'Step 2', 'Step 3']} config={config} theme={theme} />
+            </Stage>
+        )
+    },
+}
+
 export const Percent: Story = {
     render: () => {
         const theme = useReactiveTheme()

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -34,7 +34,7 @@ import type {
 } from '../../core/types'
 import { BarTooltip } from './BarTooltip'
 import { computeWrapperMinHeight, HORIZONTAL_MIN_BAND_SIZE_DEFAULT } from './utils/bar-config'
-import { groupedBandSlotAtCursor } from './utils/bars-under-cursor'
+import { cursorInInertTrackGap, groupedBandSlotAtCursor } from './utils/bars-under-cursor'
 import { drawBarChartStatic, drawBarHoverItems } from './utils/draw-bar-chart'
 import { resolveBarHoverItems } from './utils/resolve-bar-hover'
 import { resolveClickedBarSeries } from './utils/resolve-clicked-bar-series'
@@ -374,6 +374,36 @@ function BarChartInner<Meta = unknown>({
         [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
     )
 
+    // A capped track's blank volume gap (funnel compare) is inert: veto the hover there so the tooltip,
+    // pointer cursor, highlight, and click are all suppressed. Only wired when a series caps its track.
+    const seriesHasTrackCeiling = useMemo(
+        () => barTrack && barLayout === 'grouped' && visibleSeries.some((s) => Array.isArray(s.trackData)),
+        [barTrack, barLayout, visibleSeries]
+    )
+
+    const resolveHoverIndex = useCallback(
+        (index: number, cursor: { x: number; y: number }, scales: ChartScales): number => {
+            const d3Scales = (scales._private as BarChartPrivate | undefined)?.__barChart
+            if (!d3Scales) {
+                return index
+            }
+            return cursorInInertTrackGap({
+                series: seriesRef.current,
+                label: labelsRef.current[index],
+                dataIndex: index,
+                scales: d3Scales,
+                layout: barLayout,
+                isHorizontal,
+                stackedData,
+                topStackedKeyByAxis,
+                cursor,
+            })
+                ? -1
+                : index
+        },
+        [barLayout, isHorizontal, stackedData, topStackedKeyByAxis, seriesRef, labelsRef]
+    )
+
     const chart = (
         <Chart
             series={visibleSeries}
@@ -397,6 +427,7 @@ function BarChartInner<Meta = unknown>({
             )}
             onPointClick={onPointClick}
             wrapClickData={onPointClick ? wrapClickData : undefined}
+            resolveHoverIndex={seriesHasTrackCeiling ? resolveHoverIndex : undefined}
             className={className}
             dataAttr={dataAttr}
             resolveValue={resolveValue}

--- a/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
+++ b/packages/quill/packages/charts/src/charts/BarChart/BarChart.tsx
@@ -375,11 +375,10 @@ function BarChartInner<Meta = unknown>({
     )
 
     // A capped track's blank volume gap (funnel compare) is inert: veto the hover there so the tooltip,
-    // pointer cursor, highlight, and click are all suppressed. Only wired when a series caps its track.
-    const seriesHasTrackCeiling = useMemo(
-        () => barTrack && barLayout === 'grouped' && visibleSeries.some((s) => Array.isArray(s.trackData)),
-        [barTrack, barLayout, visibleSeries]
-    )
+    // pointer cursor, highlight, and click are all suppressed. Only wired when a series declares a
+    // `trackData` ceiling — with or without a drawn track (stacked funnel bars cap their interactive
+    // extent without one).
+    const seriesHasTrackCeiling = useMemo(() => visibleSeries.some((s) => Array.isArray(s.trackData)), [visibleSeries])
 
     const resolveHoverIndex = useCallback(
         (index: number, cursor: { x: number; y: number }, scales: ChartScales): number => {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -215,13 +215,13 @@ describe('cursorInInertTrackGap', () => {
     const subBandCenterX = (key: string): number =>
         scales.band('x')! + scales.group!(key)! + scales.group!.bandwidth() / 2
 
-    const inGap = (key: string, value: number, layout: 'grouped' | 'stacked' = 'grouped'): boolean =>
+    const inGap = (key: string, value: number): boolean =>
         cursorInInertTrackGap({
             series,
             label: 'x',
             dataIndex: 0,
             scales,
-            layout,
+            layout: 'grouped',
             isHorizontal: false,
             topStackedKeyByAxis: new Map(),
             cursor: { x: subBandCenterX(key), y: scales.value(value) },
@@ -236,7 +236,51 @@ describe('cursorInInertTrackGap', () => {
         expect(inGap(key, value)).toBe(expected)
     })
 
-    it('is false for non-grouped layouts (no capped track)', () => {
-        expect(inGap('b', 80, 'stacked')).toBe(false)
+    describe('stacked layout (a top-to-bottom funnel compare bar)', () => {
+        // One horizontal stacked bar shaped like a funnel compare period: converted (45) + drop-off
+        // (25) sum to the period's 70% entry level, with the drop-off declaring that ceiling via
+        // `trackData` — the 70–100 region is the blank volume gap.
+        const cappedStack: Series[] = [
+            { key: 'converted', label: 'Converted', data: [45] },
+            { key: 'drop-off', label: 'Drop-off', data: [25], trackData: [70] },
+        ]
+        // The same stack without a ceiling — a plain stacked chart, where the space beyond the stack
+        // must keep its ordinary band hover.
+        const uncappedStack: Series[] = [
+            { key: 'converted', label: 'Converted', data: [45] },
+            { key: 'drop-off', label: 'Drop-off', data: [25] },
+        ]
+
+        const stackedInGap = (stack: Series[], value: number): boolean => {
+            const labels = ['0']
+            const stackedScales = createBarScales(stack, labels, dimensions, {
+                barLayout: 'stacked',
+                axisOrientation: 'horizontal',
+                valueDomain: [0, 100],
+            })
+            return cursorInInertTrackGap({
+                series: stack,
+                label: '0',
+                dataIndex: 0,
+                scales: stackedScales,
+                layout: 'stacked',
+                isHorizontal: true,
+                stackedData: computeStackData(stack, labels),
+                topStackedKeyByAxis: new Map(),
+                cursor: {
+                    x: stackedScales.value(value),
+                    y: (stackedScales.band('0') ?? 0) + stackedScales.band.bandwidth() / 2,
+                },
+            })
+        }
+
+        it.each<[string, Series[], number, boolean]>([
+            ['beyond the ceiling (the blank volume gap)', cappedStack, 85, true],
+            ['inside the drop-off segment below the ceiling', cappedStack, 55, false],
+            ['inside the converted segment fill', cappedStack, 20, false],
+            ['beyond an uncapped stack (plain stacked chart keeps band hover)', uncappedStack, 85, false],
+        ])('%s', (_desc, stack, value, expected) => {
+            expect(stackedInGap(stack, value)).toBe(expected)
+        })
     })
 })

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.test.ts
@@ -5,6 +5,7 @@ import { dimensions } from '../../../testing/jsdom'
 import {
     barContainsPoint,
     barContainsPointOnBandAxis,
+    cursorInInertTrackGap,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     groupedBandSlotAtCursor,
@@ -197,5 +198,45 @@ describe('groupedBandSlotAtCursor', () => {
     it('returns undefined when there is no group scale (non-grouped layout)', () => {
         const stacked = createBarScales(series, labels, dimensions, { barLayout: 'stacked' })
         expect(groupedBandSlotAtCursor(stacked, 'x', start)).toBeUndefined()
+    })
+})
+
+describe('cursorInInertTrackGap', () => {
+    const labels = ['x']
+    // `a` is the tallest (domain max, uncapped); `b` fills to 20 with its track capped at 60, so above
+    // 60 is the blank volume gap (funnel compare) and 20–60 is ordinary drop-off; `c` is short and
+    // uncapped, so its track spans the whole axis.
+    const series: Series[] = [
+        { key: 'a', label: 'A', data: [100] },
+        { key: 'b', label: 'B', data: [20], trackData: [60] },
+        { key: 'c', label: 'C', data: [30] },
+    ]
+    const scales = createBarScales(series, labels, dimensions, { barLayout: 'grouped', axisOrientation: 'vertical' })
+    const subBandCenterX = (key: string): number =>
+        scales.band('x')! + scales.group!(key)! + scales.group!.bandwidth() / 2
+
+    const inGap = (key: string, value: number, layout: 'grouped' | 'stacked' = 'grouped'): boolean =>
+        cursorInInertTrackGap({
+            series,
+            label: 'x',
+            dataIndex: 0,
+            scales,
+            layout,
+            isHorizontal: false,
+            topStackedKeyByAxis: new Map(),
+            cursor: { x: subBandCenterX(key), y: scales.value(value) },
+        })
+
+    it.each<[string, string, number, boolean]>([
+        ['above a capped ceiling (the blank volume gap)', 'b', 80, true],
+        ['in the drop-off band below the ceiling', 'b', 40, false],
+        ['inside the bar fill', 'b', 10, false],
+        ['above an uncapped bar (track spans the axis)', 'c', 80, false],
+    ])('%s', (_desc, key, value, expected) => {
+        expect(inGap(key, value)).toBe(expected)
+    })
+
+    it('is false for non-grouped layouts (no capped track)', () => {
+        expect(inGap('b', 80, 'stacked')).toBe(false)
     })
 })

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -1,4 +1,4 @@
-import { computeBarAtIndex } from '../../../core/bar-layout'
+import { computeBarAtIndex, computeBarTrackRect } from '../../../core/bar-layout'
 import type { BarRect } from '../../../core/canvas-renderer'
 import { type BarScaleSet, groupedBandSlot, type StackedBand } from '../../../core/scales'
 import type { BandSlot, Series } from '../../../core/types'
@@ -44,6 +44,30 @@ export function cursorOutsideBarFillExtent(
     return isHorizontal
         ? point.x < bar.x || point.x > bar.x + bar.width
         : point.y < bar.y || point.y > bar.y + bar.height
+}
+
+/** True when the cursor sits beyond a series' per-bar track ceiling — the blank, inert region above a
+ *  capped `trackData` track (a funnel compare bar's volume gap). False when the series has no ceiling
+ *  at this bar (the track spans the whole axis). Callers establish band-axis containment and that the
+ *  cursor is already outside the bar's own fill before calling. */
+export function cursorBeyondTrackCeiling(
+    series: { trackData?: number[] },
+    bar: BarRect,
+    scales: BarScaleSet,
+    point: { x: number; y: number },
+    isHorizontal: boolean
+): boolean {
+    const ceiling = series.trackData?.[bar.dataIndex]
+    if (ceiling == null) {
+        return false
+    }
+    const ceilingPixel = scales.value(ceiling)
+    if (!isFinite(ceilingPixel)) {
+        return false
+    }
+    // Track grows from the value baseline (range start) to the ceiling; beyond it is the blank gap.
+    const [axisBaseline = 0] = scales.value.range()
+    return !barContainsPoint(computeBarTrackRect(bar, axisBaseline, ceilingPixel, isHorizontal), point)
 }
 
 export interface BarsAtCursorArgs {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -116,10 +116,12 @@ export function* barsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAx
     }
 }
 
-/** True when the cursor sits in a grouped bar's inert volume gap — lined up on the band axis with a bar
+/** True when the cursor sits in a bar's inert volume gap — lined up on the band axis with a bar
  *  whose capped `trackData` ceiling it has passed (a funnel compare period's blank space above its
- *  track). Such a position takes no hover, tooltip, highlight, or click. Non-grouped layouts, and bars
- *  whose track spans the full axis, are never a gap. */
+ *  track). Such a position takes no hover, tooltip, highlight, or click. Bars whose track spans the
+ *  full axis are never a gap. A grouped cursor lines up with a single column of the group; stacked
+ *  segments all share their band slot, so the cursor must clear every segment's fill before a
+ *  segment's ceiling can declare the position a gap. */
 export function cursorInInertTrackGap(
     args: Omit<BarsAtCursorArgs, 'series'> & {
         // `trackData` beyond the base pick so the ceiling check sees each series' cap.
@@ -127,22 +129,21 @@ export function cursorInInertTrackGap(
         cursor: { x: number; y: number }
     }
 ): boolean {
-    const { cursor, isHorizontal, layout, scales } = args
-    if (layout !== 'grouped') {
-        return false
-    }
+    const { cursor, isHorizontal, scales } = args
+    let beyondACeiling = false
     for (const { series: s, bar } of barsAtCursor(args)) {
         if (!barContainsPointOnBandAxis(bar, cursor, isHorizontal)) {
             continue
         }
-        // The cursor lines up with this bar's column — it's in the gap only when it's both outside the
-        // bar's own fill and beyond that bar's track ceiling.
-        return (
-            cursorOutsideBarFillExtent(bar, cursor, isHorizontal) &&
-            cursorBeyondTrackCeiling(s, bar, scales, cursor, isHorizontal)
-        )
+        // The cursor is over this bar's own fill — an actual segment, never a gap.
+        if (!cursorOutsideBarFillExtent(bar, cursor, isHorizontal)) {
+            return false
+        }
+        if (cursorBeyondTrackCeiling(s, bar, scales, cursor, isHorizontal)) {
+            beyondACeiling = true
+        }
     }
-    return false
+    return beyondACeiling
 }
 
 export interface ResolveBarsAtCursorResult {

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/bars-under-cursor.ts
@@ -116,6 +116,35 @@ export function* barsAtCursor<S extends Pick<Series, 'key' | 'visibility' | 'yAx
     }
 }
 
+/** True when the cursor sits in a grouped bar's inert volume gap — lined up on the band axis with a bar
+ *  whose capped `trackData` ceiling it has passed (a funnel compare period's blank space above its
+ *  track). Such a position takes no hover, tooltip, highlight, or click. Non-grouped layouts, and bars
+ *  whose track spans the full axis, are never a gap. */
+export function cursorInInertTrackGap(
+    args: Omit<BarsAtCursorArgs, 'series'> & {
+        // `trackData` beyond the base pick so the ceiling check sees each series' cap.
+        series: readonly Pick<Series, 'key' | 'visibility' | 'yAxisId' | 'data' | 'trackData'>[]
+        cursor: { x: number; y: number }
+    }
+): boolean {
+    const { cursor, isHorizontal, layout, scales } = args
+    if (layout !== 'grouped') {
+        return false
+    }
+    for (const { series: s, bar } of barsAtCursor(args)) {
+        if (!barContainsPointOnBandAxis(bar, cursor, isHorizontal)) {
+            continue
+        }
+        // The cursor lines up with this bar's column — it's in the gap only when it's both outside the
+        // bar's own fill and beyond that bar's track ceiling.
+        return (
+            cursorOutsideBarFillExtent(bar, cursor, isHorizontal) &&
+            cursorBeyondTrackCeiling(s, bar, scales, cursor, isHorizontal)
+        )
+    }
+    return false
+}
+
 export interface ResolveBarsAtCursorResult {
     /** Series keys whose bar slot contains the cursor on the band axis (every stacked segment). */
     hits: Set<string>

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/draw-bar-chart.ts
@@ -157,7 +157,13 @@ export function drawBarChartStatic(
     if (barTrack && barLayout === 'grouped') {
         const [axisStart = 0, axisEnd = 0] = d3Scales.value.range()
         for (const { series: s, bars } of seriesBars) {
-            const tracks = bars.map((b) => computeBarTrackRect(b, axisStart, axisEnd, isHorizontal))
+            const tracks = bars.map((b) => {
+                // `trackData` caps the track at a per-bar ceiling (funnel compare's entry level); the
+                // region beyond is left blank rather than drawn as track.
+                const ceiling = s.trackData?.[b.dataIndex]
+                const farEnd = ceiling != null && isFinite(d3Scales.value(ceiling)) ? d3Scales.value(ceiling) : axisEnd
+                return computeBarTrackRect(b, axisStart, farEnd, isHorizontal)
+            })
             drawBarTracks(baseDrawCtx, s, tracks, barCornerRadius)
         }
     }
@@ -211,9 +217,12 @@ export function drawBarHoverItems(
             } else {
                 trackColor = `rgba(0,0,0,${BAR_TRACK_HOVER_ALPHA})`
             }
+            const ceiling = s.trackData?.[bar.dataIndex]
+            const trackFarEnd =
+                ceiling != null && isFinite(d3Scales.value(ceiling)) ? d3Scales.value(ceiling) : trackAxisEnd
             drawBarHighlight(
                 ctx,
-                computeBarTrackRect(bar, trackAxisStart, trackAxisEnd, isHorizontal),
+                computeBarTrackRect(bar, trackAxisStart, trackFarEnd, isHorizontal),
                 trackColor,
                 highlightRadius
             )

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-bar-hover.ts
@@ -5,6 +5,7 @@ import {
     type BarLayout,
     barContainsPointOnBandAxis,
     barsAtCursor,
+    cursorBeyondTrackCeiling,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
     isStackedLayout,
@@ -43,14 +44,7 @@ export interface ResolveBarHoverArgs {
 export function resolveBarHoverItems(
     { series: coloredSeries, labels: drawLabels, hoverIndex, hoverPosition }: ChartDrawArgs,
     d3Scales: BarScaleSet,
-    {
-        barLayout,
-        isHorizontal,
-        stackedData,
-        topStackedKeyByAxis,
-        roundStackEnds,
-        barTrackHover,
-    }: ResolveBarHoverArgs
+    { barLayout, isHorizontal, stackedData, topStackedKeyByAxis, roundStackEnds, barTrackHover }: ResolveBarHoverArgs
 ): ResolvedBarHover | null {
     const hoveredLabel = drawLabels[hoverIndex]
     const items: BarHoverItem[] = []
@@ -99,7 +93,9 @@ export function resolveBarHoverItems(
                 barTrackHover &&
                 barLayout === 'grouped' &&
                 hoverPosition != null &&
-                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal)
+                cursorOutsideBarFillExtent(bar, hoverPosition, isHorizontal) &&
+                // Don't highlight the blank gap above a capped track (funnel compare's volume gap).
+                !cursorBeyondTrackCeiling(s, bar, d3Scales, hoverPosition, isHorizontal)
             items.push({ series: s, bar, isTrackHighlight })
             composition += isTrackHighlight ? 't' : 'b'
         }

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.test.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.test.ts
@@ -90,6 +90,43 @@ describe('resolveClickedBarSeries', () => {
         })
     })
 
+    describe('grouped layout with a per-bar track ceiling', () => {
+        const labels = ['x']
+        // `b` fills to 20 with its track capped at 60: above 60 is the blank volume gap (inert).
+        const series: Series[] = [
+            { key: 'a', label: 'A', data: [100] },
+            { key: 'b', label: 'B', data: [20], trackData: [60] },
+        ]
+        const scales = createBarScales(series, labels, dimensions, {
+            barLayout: 'grouped',
+            axisOrientation: 'vertical',
+        })
+        const subBandCenterX = (key: string): number =>
+            scales.band('x')! + scales.group!(key)! + scales.group!.bandwidth() / 2
+
+        const resolve = (cursor: { x: number; y: number }): PointClickData | null =>
+            resolveClickedBarSeries({
+                clickData: baseClickData(series, 0, 'x', cursor),
+                scales,
+                barLayout: 'grouped',
+                isHorizontal: false,
+                stackedData: undefined,
+                topStackedKeyByAxis: new Map(),
+                series,
+                labels,
+            })
+
+        it('flags inTrackArea between the bar fill and the ceiling', () => {
+            const result = resolve({ x: subBandCenterX('b'), y: scales.value(40) })
+            expect(result?.series.key).toBe('b')
+            expect(result?.inTrackArea).toBe(true)
+        })
+
+        it('returns null above the ceiling — the blank volume gap is non-interactive', () => {
+            expect(resolve({ x: subBandCenterX('b'), y: scales.value(80) })).toBeNull()
+        })
+    })
+
     describe('stacked layout', () => {
         const labels = ['Mon']
         const series: Series[] = [

--- a/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.ts
+++ b/packages/quill/packages/charts/src/charts/BarChart/utils/resolve-clicked-bar-series.ts
@@ -4,6 +4,7 @@ import {
     type BarLayout,
     barContainsPointOnBandAxis,
     barsAtCursor,
+    cursorBeyondTrackCeiling,
     cursorOutsideBarFillExtent,
     findVisibleStackedSegment,
 } from './bars-under-cursor'
@@ -70,6 +71,11 @@ export function resolveClickedBarSeries<Meta>({
                 return null
             }
             const inTrackArea = cursorOutsideBarFillExtent(bar, cursor, isHorizontal)
+            // Beyond a per-bar track ceiling the cursor is in the blank volume gap (funnel compare) —
+            // pass the click through so it opens nothing.
+            if (inTrackArea && cursorBeyondTrackCeiling(s, bar, scales, cursor, isHorizontal)) {
+                return null
+            }
             return { ...rewrite(hit.series, hit.value, dataIndex), inTrackArea }
         }
         return null

--- a/packages/quill/packages/charts/src/core/Chart.tsx
+++ b/packages/quill/packages/charts/src/core/Chart.tsx
@@ -92,6 +92,10 @@ export interface ChartProps<Meta = unknown> {
      *  cursor) before it reaches `onPointClick`, using the committed `scales` from this render.
      *  Chart-type adapters provide this; consumers do not. */
     wrapClickData?: (data: PointClickData<Meta>, scales: ChartScales) => PointClickData<Meta>
+    /** Chart-type seam: given the nearest band index and cursor, return the effective hover index — or
+     *  -1 to make the position a dead zone (no tooltip, pointer cursor, highlight, or click). Chart-type
+     *  adapters provide this; BarChart uses it for a capped track's blank volume gap. */
+    resolveHoverIndex?: (index: number, cursor: { x: number; y: number }, scales: ChartScales) => number
 }
 
 export function Chart<Meta = unknown>({
@@ -114,6 +118,7 @@ export function Chart<Meta = unknown>({
     labelToCoord,
     valueRangeSeries,
     wrapClickData,
+    resolveHoverIndex,
 }: ChartProps<Meta>): React.ReactElement {
     const {
         xTickFormatter,
@@ -226,6 +231,7 @@ export function Chart<Meta = unknown>({
         interactionAxis,
         labelToCoord,
         wrapClickData,
+        resolveHoverIndex,
     })
 
     // ref keeps composedDrawHover stable across drawHover identity changes

--- a/packages/quill/packages/charts/src/core/hooks/useChartInteraction.test.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useChartInteraction.test.ts
@@ -138,6 +138,31 @@ describe('useChartInteraction — tooltip pinning', () => {
         expect(result.current.hoverIndex).toBeGreaterThanOrEqual(0)
     })
 
+    it('treats a resolveHoverIndex veto (-1) as a dead zone — no hover index, no tooltip', () => {
+        const { result } = renderHook(() =>
+            useChartInteraction({
+                scales,
+                dimensions,
+                labels,
+                series,
+                canvasRef: refs.canvasRef,
+                wrapperRef: refs.wrapperRef,
+                showTooltip: true,
+                pinnable: false,
+                resolveValue: (s, i) => s.data[i],
+                // Chart-type seam vetoes every position (e.g. a funnel compare bar's blank volume gap).
+                resolveHoverIndex: () => -1,
+            })
+        )
+
+        act(() => {
+            simulateMouseMove(result.current.handlers, refs, 200, 100)
+        })
+
+        expect(result.current.hoverIndex).toBe(-1)
+        expect(result.current.tooltipCtx).toBeNull()
+    })
+
     it('pins tooltip on click when pinnable and multiple series', () => {
         const { result } = renderInteraction()
         hoverAndPin(result)

--- a/packages/quill/packages/charts/src/core/hooks/useChartInteraction.ts
+++ b/packages/quill/packages/charts/src/core/hooks/useChartInteraction.ts
@@ -50,6 +50,10 @@ interface UseChartInteractionOptions<Meta> {
      *  cursor) before it reaches `onPointClick`, using the committed `scales` from this render.
      *  Chart-type adapters provide this; consumers do not. */
     wrapClickData?: (data: PointClickData<Meta>, scales: ChartScales) => PointClickData<Meta>
+    /** Chart-type seam: given the nearest band index and the cursor, return the effective hover index —
+     *  or -1 to treat the position as a dead zone (no tooltip, pointer cursor, highlight, or click).
+     *  BarChart uses it to make a capped track's blank volume gap inert. Adapters provide this. */
+    resolveHoverIndex?: (index: number, cursor: { x: number; y: number }, scales: ChartScales) => number
 }
 
 /** Resolves a click on a pinnable multi-series chart to whichever series is nearest the cursor,
@@ -113,6 +117,7 @@ export function useChartInteraction<Meta = unknown>({
     interactionAxis = 'x',
     labelToCoord,
     wrapClickData,
+    resolveHoverIndex,
 }: UseChartInteractionOptions<Meta>): UseChartInteractionResult<Meta> {
     // Falls back to the value resolver when the chart doesn't distinguish position from
     // value (i.e. non-stacked charts, where the two are identical).
@@ -225,10 +230,20 @@ export function useChartInteraction<Meta = unknown>({
             }
 
             const probe = interactionAxis === 'y' ? mouseY : mouseX
-            const index = findNearestIndexFromPositions(probe, labelPositions)
+            const nearestIndex = findNearestIndexFromPositions(probe, labelPositions)
+            // Chart-type dead-zone veto (e.g. a funnel compare bar's blank volume gap): treat as
+            // no-hover so tooltip, pointer cursor, highlight, and click are all suppressed there.
+            const index =
+                nearestIndex >= 0 && resolveHoverIndex
+                    ? resolveHoverIndex(nearestIndex, { x: mouseX, y: mouseY }, scales)
+                    : nearestIndex
+            if (index < 0) {
+                clearTooltip()
+                return
+            }
             setHover(index, { x: mouseX, y: mouseY })
 
-            if (index >= 0 && showTooltip) {
+            if (showTooltip) {
                 const canvasBounds = canvasRef.current?.getBoundingClientRect() ?? new DOMRect()
                 // Always propagate the result (including null) so tooltipCtx stays in sync with hoverIndex.
                 setTooltipCtx(
@@ -269,6 +284,7 @@ export function useChartInteraction<Meta = unknown>({
             setHover,
             setTooltipCtx,
             resolveBottomValue,
+            resolveHoverIndex,
         ]
     )
 

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -46,6 +46,13 @@ export interface Series<Meta = unknown> {
      *  one bar per breakdown value) instead of paying the O(n²) cost of one series per bar. Read by
      *  bar fill, hover highlight, and the tooltip; not by track decorations (`drawBarTracks`). */
     bars?: { color?: string; label?: string; meta?: Meta }[]
+    /** Grouped bar charts with `bars.track` only: per-bar ceiling (in value-axis units) for the
+     *  "share of a whole" track. The hatched track fills only up to `trackData[i]` instead of the
+     *  whole axis, and the region beyond it is a blank, non-interactive gap — no track highlight, no
+     *  click (`onPointClick` passes through). Used by funnel compare to show a shorter period's
+     *  volume gap as empty space rather than drop-off. Omit (or leave an entry undefined) for the
+     *  default full-axis track. */
+    trackData?: number[]
     /** Which y-axis this series is scaled against. Defaults to {@link DEFAULT_Y_AXIS_ID}. */
     yAxisId?: string
     /** Mixed-type charts ({@link ComboChart}) read this to draw the series as a bar, line, or

--- a/packages/quill/packages/charts/src/core/types.ts
+++ b/packages/quill/packages/charts/src/core/types.ts
@@ -46,12 +46,13 @@ export interface Series<Meta = unknown> {
      *  one bar per breakdown value) instead of paying the O(n²) cost of one series per bar. Read by
      *  bar fill, hover highlight, and the tooltip; not by track decorations (`drawBarTracks`). */
     bars?: { color?: string; label?: string; meta?: Meta }[]
-    /** Grouped bar charts with `bars.track` only: per-bar ceiling (in value-axis units) for the
-     *  "share of a whole" track. The hatched track fills only up to `trackData[i]` instead of the
-     *  whole axis, and the region beyond it is a blank, non-interactive gap — no track highlight, no
-     *  click (`onPointClick` passes through). Used by funnel compare to show a shorter period's
-     *  volume gap as empty space rather than drop-off. Omit (or leave an entry undefined) for the
-     *  default full-axis track. */
+    /** Bar charts only: per-bar ceiling (in value-axis units) of the bar's interactive extent. The
+     *  region beyond the ceiling is a blank, fully inert gap — no hover, tooltip, highlight, or
+     *  click (`onPointClick` passes through). On grouped charts with `bars.track`, the hatched
+     *  "share of a whole" track also fills only up to `trackData[i]` instead of the whole axis; on
+     *  stacked charts no track is drawn — the ceiling only bounds interactivity. Used by funnel
+     *  compare to show a shorter period's volume gap as empty space rather than drop-off. Omit (or
+     *  leave an entry undefined) for the default full-axis extent. */
     trackData?: number[]
     /** Which y-axis this series is scaled against. Defaults to {@link DEFAULT_Y_AXIS_ID}. */
     yAxisId?: string

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalChart.tsx
@@ -102,6 +102,12 @@ export function FunnelBarHorizontalChart({
                     const isOptional = isStepOptional(stepIndex + 1)
 
                     const onSegmentClick = (meta: FunnelBarHorizontalSegmentMeta): void => {
+                        // Stacked breakdown + compare: the drop-off band aggregates every value for the
+                        // period, so it can't be scoped to one value and isn't clickable. Pure compare tags
+                        // each drop-off with its period's breakdownIndex, so it stays interactive.
+                        if (isComparedFunnel && meta.isDropOff && meta.breakdownIndex == null) {
+                            return
+                        }
                         // Compare: both the bar and its drop-off filler carry a period breakdownIndex, so
                         // route the matching period series (converted vs. dropped-off) — handled before the
                         // generic drop-off branch, which would otherwise open the aggregate step.

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -327,6 +327,10 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(result.map((s) => s.bars[1].series[0].data[0])).toEqual([80, 40])
             expect(result.map((s) => s.bars[1].series[1].data[0])).toEqual([0, 40])
             expect(result.map((s) => s.bars[1].series[0].data[0] + s.bars[1].series[1].data[0])).toEqual([80, 80])
+            // Each drop-off declares its period's entry level as the bar's interactive ceiling, so the
+            // chart treats the blank gap above it as inert (no hover, tooltip, pointer cursor, or click).
+            expect(result.map((s) => s.bars[0].series[1].trackData)).toEqual([[100], [100]])
+            expect(result.map((s) => s.bars[1].series[1].trackData)).toEqual([[80], [80]])
         })
 
         // At the first step every bar sits exactly at its own entry level, so drop-off is always 0 —
@@ -480,6 +484,10 @@ describe('buildFunnelBarHorizontalData', () => {
                 expect(result[1].bars[0].series.map((s) => s.data[0])).toEqual([30, 20, 50])
                 // Step 1 previous: 15 + 15 segments, aggregate drop-off 45 → reaches its 75 entry; 25 blank.
                 expect(result[1].bars[1].series.map((s) => s.data[0])).toEqual([15, 15, 45])
+                // The aggregate drop-off declares each period's entry total as the interactive ceiling,
+                // so the blank 25 above the previous stack is inert.
+                expect(result[0].bars[0].series[2].trackData).toEqual([100])
+                expect(result[0].bars[1].series[2].trackData).toEqual([75])
             })
 
             it('tags the aggregate drop-off so it isn’t attributed to a single value (breakdownIndex null)', () => {

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.test.ts
@@ -54,6 +54,11 @@ function dataAcross(steps: FunnelBarHorizontalStepData[], seriesIndex: number): 
     return steps.map((s) => s.series[seriesIndex].data[0])
 }
 
+/** Sum of a stacked bar's segment values (how far it fills the shared 0–100 axis). */
+function stackTotal(bar: FunnelBarHorizontalStepData): number {
+    return bar.series.reduce((sum, s) => sum + s.data[0], 0)
+}
+
 describe('buildFunnelBarHorizontalData', () => {
     it('returns no steps when given no steps', () => {
         expect(buildFunnelBarHorizontalData([], options)).toEqual([])
@@ -311,16 +316,21 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(result.every((step) => step.bars.every((bar) => bar.series.length === 2))).toBe(true)
         })
 
-        it('scales each bar to the shared baseline via fromBasisStep, each track summing segment + filler to 100', () => {
+        it('stops each period’s drop-off at its own entry level, leaving the volume gap blank', () => {
             const result = buildFunnelBarHorizontalCompareData(compareSteps, options)
 
-            // current: 100% then 50%; previous: 80% then 40% — each on its own 0–100 track
+            // Current is the leader (entry 100%): segment + drop-off fill the track to 100.
             expect(result.map((s) => s.bars[0].series[0].data[0])).toEqual([100, 50])
             expect(result.map((s) => s.bars[0].series[1].data[0])).toEqual([0, 50])
+            // Previous entry level is 80%, so its bars sum to 80, never 100 — the 20 above is the blank
+            // volume gap (fewer entrants), not drop-off, so it's left as whitespace (no segment).
             expect(result.map((s) => s.bars[1].series[0].data[0])).toEqual([80, 40])
-            expect(result.map((s) => s.bars[1].series[1].data[0])).toEqual([20, 60])
+            expect(result.map((s) => s.bars[1].series[1].data[0])).toEqual([0, 40])
+            expect(result.map((s) => s.bars[1].series[0].data[0] + s.bars[1].series[1].data[0])).toEqual([80, 80])
         })
 
+        // At the first step every bar sits exactly at its own entry level, so drop-off is always 0 —
+        // the shorter period's remainder to 100 is the blank volume gap (whitespace), not drop-off.
         it.each([
             {
                 description: 'does not force the current step-0 bar to 100 when the previous period is larger',
@@ -328,27 +338,27 @@ describe('buildFunnelBarHorizontalData', () => {
                     makeStep({ count: 80, fromBasisStep: 0.8, compare_label: 'current' }),
                     makeStep({ count: 100, fromBasisStep: 1, compare_label: 'previous' }),
                 ],
-                // current sits below the shared baseline; previous fills the track
+                // current sits below the shared baseline — its 20 to the top is blank, not drop-off
                 expectedBars: [
-                    { segment: [80], filler: [20], breakdownIndex: 0 },
-                    { segment: [100], filler: [0], breakdownIndex: 1 },
+                    { segment: [80], dropOff: [0], breakdownIndex: 0 },
+                    { segment: [100], dropOff: [0], breakdownIndex: 1 },
                 ],
             },
             {
-                description: 'renders a zeroed previous period as an empty track without error',
+                description: 'renders a zeroed previous period as an all-blank bar (no phantom drop-off)',
                 nested_breakdown: [
                     makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' }),
                     makeStep({ count: 0, fromBasisStep: 0, compare_label: 'previous' }),
                 ],
                 expectedBars: [
-                    { segment: [100], filler: [0], breakdownIndex: 0 },
-                    { segment: [0], filler: [100], breakdownIndex: 1 },
+                    { segment: [100], dropOff: [0], breakdownIndex: 0 },
+                    { segment: [0], dropOff: [0], breakdownIndex: 1 },
                 ],
             },
             {
                 description: 'renders a single bar when the step has no previous-period series',
                 nested_breakdown: [makeStep({ count: 100, fromBasisStep: 1, compare_label: 'current' })],
-                expectedBars: [{ segment: [100], filler: [0], breakdownIndex: 0 }],
+                expectedBars: [{ segment: [100], dropOff: [0], breakdownIndex: 0 }],
             },
         ])('$description', ({ nested_breakdown, expectedBars }) => {
             const steps: FunnelStepWithConversionMetrics[] = [
@@ -359,7 +369,7 @@ describe('buildFunnelBarHorizontalData', () => {
             expect(step.bars).toHaveLength(expectedBars.length)
             expectedBars.forEach((expected, barIndex) => {
                 expect(step.bars[barIndex].series[0].data).toEqual(expected.segment)
-                expect(step.bars[barIndex].series[1].data).toEqual(expected.filler)
+                expect(step.bars[barIndex].series[1].data).toEqual(expected.dropOff)
                 expect(step.bars[barIndex].series[0].meta?.breakdownIndex).toBe(expected.breakdownIndex)
             })
         })
@@ -387,31 +397,53 @@ describe('buildFunnelBarHorizontalData', () => {
         })
 
         describe('with breakdown', () => {
-            // Breakdown + compare: nested_breakdown is paired [value0 current, value0 previous, …], so each
-            // (value, period) gets its own full-track bar — no overflow from stacking variants scaled to the
-            // grouped-bar baseline — and bars read paired by breakdown value with the previous one dimmed.
+            // Breakdown + compare: two stacks per step (current, then previous), each split into the same
+            // breakdown-value segments and scaled to whichever period had more total entrants. nested_breakdown
+            // is paired [value0 current, value0 previous, …]; fromBasisStep is unused here (the stacks scale by
+            // raw count / max-period-total, not per-value).
             const breakdownCompareSteps: FunnelStepWithConversionMetrics[] = [
                 makeStep({
-                    count: 140,
+                    count: 100,
                     fromBasisStep: 1,
                     compare_label: 'current',
                     nested_breakdown: [
-                        makeStep({ count: 100, fromBasisStep: 1, breakdown_value: 'mobile', compare_label: 'current' }),
+                        makeStep({ count: 60, fromBasisStep: 1, breakdown_value: 'mobile', compare_label: 'current' }),
+                        makeStep({ count: 45, fromBasisStep: 1, breakdown_value: 'mobile', compare_label: 'previous' }),
+                        makeStep({ count: 40, fromBasisStep: 1, breakdown_value: 'desktop', compare_label: 'current' }),
                         makeStep({
-                            count: 80,
-                            fromBasisStep: 0.8,
+                            count: 30,
+                            fromBasisStep: 1,
+                            breakdown_value: 'desktop',
+                            compare_label: 'previous',
+                        }),
+                    ],
+                }),
+                makeStep({
+                    count: 50,
+                    fromBasisStep: 0.5,
+                    compare_label: 'current',
+                    nested_breakdown: [
+                        makeStep({
+                            count: 30,
+                            fromBasisStep: 0.5,
+                            breakdown_value: 'mobile',
+                            compare_label: 'current',
+                        }),
+                        makeStep({
+                            count: 15,
+                            fromBasisStep: 0.5,
                             breakdown_value: 'mobile',
                             compare_label: 'previous',
                         }),
                         makeStep({
-                            count: 40,
-                            fromBasisStep: 0.4,
+                            count: 20,
+                            fromBasisStep: 0.5,
                             breakdown_value: 'desktop',
                             compare_label: 'current',
                         }),
                         makeStep({
-                            count: 25,
-                            fromBasisStep: 0.25,
+                            count: 15,
+                            fromBasisStep: 0.5,
                             breakdown_value: 'desktop',
                             compare_label: 'previous',
                         }),
@@ -419,21 +451,59 @@ describe('buildFunnelBarHorizontalData', () => {
                 }),
             ]
 
-            it('renders one full-track bar per (breakdown value, period)', () => {
-                const [step] = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, options)
+            it('renders two stacks per step (current, then previous), each split by breakdown value', () => {
+                const result = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, options)
 
-                expect(step.bars).toHaveLength(4)
-                expect(step.bars.map((bar) => bar.series[0].data[0])).toEqual([100, 80, 40, 25])
-                expect(step.bars.map((bar) => bar.series[0].meta?.breakdownIndex)).toEqual([0, 1, 2, 3])
+                expect(result).toHaveLength(2)
+                expect(result.every((step) => step.bars.length === 2)).toBe(true)
+
+                // Current stack carries the current-period value segments (nested indices 0, 2); previous
+                // stack carries the previous-period segments (1, 3) — each keyed to its nested index so a
+                // click resolves the right (value, period).
+                const [step0] = result
+                expect(
+                    step0.bars[0].series.filter((s) => !s.meta?.isDropOff).map((s) => s.meta?.breakdownIndex)
+                ).toEqual([0, 2])
+                expect(
+                    step0.bars[1].series.filter((s) => !s.meta?.isDropOff).map((s) => s.meta?.breakdownIndex)
+                ).toEqual([1, 3])
             })
 
-            it('dims each breakdown value’s previous-period bar', () => {
+            it('shares the larger period’s total as the scale; the smaller stack is shorter with a blank gap', () => {
+                const result = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, options)
+
+                // basis = max(current total 100, previous total 75) = 100.
+                // Step 0 current (leader) fills to 100; previous reaches its 75 entry total, 25 blank above.
+                expect(stackTotal(result[0].bars[0])).toBe(100)
+                expect(stackTotal(result[0].bars[1])).toBe(75)
+                // Step 1 current: 30 + 20 segments, aggregate drop-off 50 → fills to 100.
+                expect(result[1].bars[0].series.map((s) => s.data[0])).toEqual([30, 20, 50])
+                // Step 1 previous: 15 + 15 segments, aggregate drop-off 45 → reaches its 75 entry; 25 blank.
+                expect(result[1].bars[1].series.map((s) => s.data[0])).toEqual([15, 15, 45])
+            })
+
+            it('tags the aggregate drop-off so it isn’t attributed to a single value (breakdownIndex null)', () => {
+                const [step0] = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, options)
+                const currentDropOff = step0.bars[0].series.find((s) => s.meta?.isDropOff)
+
+                expect(currentDropOff?.meta?.breakdownIndex).toBeNull()
+                expect(currentDropOff?.visibility?.tooltip).toBe(false)
+            })
+
+            it('dims each breakdown value’s previous-period segment', () => {
                 const getColor = jest.fn((v: FunnelStepWithConversionMetrics) =>
                     v.compare_label === 'previous' ? '#dimmed' : '#solid'
                 )
-                const [step] = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, { ...options, getColor })
+                const [step0] = buildFunnelBarHorizontalCompareData(breakdownCompareSteps, { ...options, getColor })
 
-                expect(step.bars.map((bar) => bar.series[0].color)).toEqual(['#solid', '#dimmed', '#solid', '#dimmed'])
+                expect(step0.bars[0].series.filter((s) => !s.meta?.isDropOff).map((s) => s.color)).toEqual([
+                    '#solid',
+                    '#solid',
+                ])
+                expect(step0.bars[1].series.filter((s) => !s.meta?.isDropOff).map((s) => s.color)).toEqual([
+                    '#dimmed',
+                    '#dimmed',
+                ])
             })
         })
     })

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/funnelBarHorizontalTransforms.ts
@@ -1,11 +1,12 @@
 import type { Series, TooltipContext } from '@posthog/quill-charts'
 
-import { getReferenceStep, getStepBreakdownSeries } from 'scenes/funnels/funnelUtils'
+import { getReferenceStep, getStepBreakdownSeries, hasBreakdown } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import { FunnelStepReference, type FunnelStepWithConversionMetrics } from '~/types'
 
 import {
+    buildFunnelBarHorizontalDropOff,
     buildFunnelBarHorizontalFiller,
     FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
     FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX,
@@ -86,9 +87,10 @@ function buildBreakdownSegments(
     return [...segments, buildFunnelBarHorizontalFiller(segments, options.fillerColor)]
 }
 
-/** One step in compare mode: two stacked bars (current, then previous), each a full 0–100 track
- *  rather than two segments sharing one track. `bars[0]` is current, `bars[1]` previous; previous is
- *  omitted only when the backend sent no previous-period series for the step. */
+/** One step in compare mode: two stacked bars (current, then previous) on a shared 0–100 axis.
+ *  `bars[0]` is current, `bars[1]` previous; previous is omitted only when the backend sent no
+ *  previous-period series for the step. A shorter period's bar sums to its own entry level, leaving
+ *  the volume gap above as blank whitespace. */
 export interface FunnelBarHorizontalCompareStep {
     bars: FunnelBarHorizontalStepData[]
 }
@@ -96,12 +98,23 @@ export interface FunnelBarHorizontalCompareStep {
 /** Builds the top-to-bottom compare layout: one bar per period, per step. Each bar is scaled to the
  *  shared baseline already baked into `conversionRates.fromBasisStep` (so the larger period's first
  *  step fills the track and the other is proportional), and takes its color from the *current step's*
- *  variant — both periods share step i's color, with `getColor` dimming the `previous` series. This is
- *  the key difference from `buildBreakdownSegments`, whose representative comes from step 0. */
+ *  variant — both periods share step i's color, with `getColor` dimming the `previous` series. Drop-off
+ *  stops at each period's entry level (its first-step share of the shared baseline); the space above is
+ *  the blank volume gap, left as whitespace rather than rendered as drop-off. */
 export function buildFunnelBarHorizontalCompareData(
     steps: FunnelStepWithConversionMetrics[],
     options: BuildOptions
 ): FunnelBarHorizontalCompareStep[] {
+    const firstNested = steps[0]?.nested_breakdown ?? []
+    // Breakdown + compare draws two stacks per step (one per period), each split by breakdown value;
+    // pure compare draws one bar per period. A value's series carries both a real breakdown value and a
+    // compare label, whereas pure compare carries only the label.
+    if (firstNested.some((variant) => variant.compare_label != null && hasBreakdown(variant.breakdown_value))) {
+        return buildBreakdownCompareStacks(steps, options)
+    }
+
+    // Each period's entry level on the shared axis, indexed to match nested_breakdown order.
+    const entryLevels = firstNested.map((variant) => variant.conversionRates.fromBasisStep * RATE_TO_PERCENT)
     return steps.map((step, stepIndex) => {
         const bars = (step.nested_breakdown ?? []).map((variant, breakdownIndex) => {
             const segment: Series<FunnelBarHorizontalSegmentMeta> = {
@@ -113,7 +126,15 @@ export function buildFunnelBarHorizontalCompareData(
             }
             return {
                 label: String(stepIndex),
-                series: [segment, buildFunnelBarHorizontalFiller([segment], options.fillerColor, breakdownIndex)],
+                series: [
+                    segment,
+                    buildFunnelBarHorizontalDropOff(
+                        [segment],
+                        entryLevels[breakdownIndex] ?? 0,
+                        options.fillerColor,
+                        breakdownIndex
+                    ),
+                ],
             }
         })
         return { bars }
@@ -181,6 +202,66 @@ export function resolveFunnelBarHorizontalHover(
     const isDropOffHover =
         stepIndex > 0 && context.hoverPosition != null && entry.yPixel != null && context.hoverPosition.x > entry.yPixel
     return { series: variantAt(entry.series.meta?.breakdownIndex), isDropOffHover, color: entry.color }
+}
+
+/** Builds the breakdown + compare layout: two stacks per step (current, then previous), each split into
+ *  breakdown-value segments and scaled to whichever period had more total entrants at the first step. The
+ *  smaller period's stack is shorter, its volume gap left blank. The aggregate drop-off band spans all
+ *  values for the period, so it's tagged `breakdownIndex: null` — the chart leaves it non-clickable. */
+function buildBreakdownCompareStacks(
+    steps: FunnelStepWithConversionMetrics[],
+    options: BuildOptions
+): FunnelBarHorizontalCompareStep[] {
+    const firstStep = periodTotals(steps[0])
+    // Both stacks share the larger period's first-step total, so the smaller stack sits proportionally short.
+    const basis = Math.max(firstStep.current, firstStep.previous, 0)
+    const toPercent = (count: number): number => (basis > 0 ? (count / basis) * RATE_TO_PERCENT : 0)
+    const currentEntry = toPercent(firstStep.current)
+    const previousEntry = toPercent(firstStep.previous)
+
+    return steps.map((step, stepIndex) => {
+        const current: Series<FunnelBarHorizontalSegmentMeta>[] = []
+        const previous: Series<FunnelBarHorizontalSegmentMeta>[] = []
+        ;(step.nested_breakdown ?? []).forEach((variant, breakdownIndex) => {
+            const segment: Series<FunnelBarHorizontalSegmentMeta> = {
+                key: `${FUNNEL_BAR_HORIZONTAL_SEGMENT_KEY_PREFIX}${breakdownIndex}`,
+                label: options.getLabel(variant),
+                data: [toPercent(variant.count)],
+                color: options.getColor(variant),
+                meta: { isDropOff: false, breakdownIndex },
+            }
+            ;(variant.compare_label === 'previous' ? previous : current).push(segment)
+        })
+        return {
+            bars: [
+                {
+                    label: String(stepIndex),
+                    series: [...current, buildFunnelBarHorizontalDropOff(current, currentEntry, options.fillerColor)],
+                },
+                {
+                    label: String(stepIndex),
+                    series: [
+                        ...previous,
+                        buildFunnelBarHorizontalDropOff(previous, previousEntry, options.fillerColor),
+                    ],
+                },
+            ],
+        }
+    })
+}
+
+/** Sums a period's first-step counts split by compare label — the basis for the shared stack scale. */
+function periodTotals(step: FunnelStepWithConversionMetrics | undefined): { current: number; previous: number } {
+    let current = 0
+    let previous = 0
+    for (const variant of step?.nested_breakdown ?? []) {
+        if (variant.compare_label === 'previous') {
+            previous += variant.count
+        } else {
+            current += variant.count
+        }
+    }
+    return { current, previous }
 }
 
 function buildSingleSegment(

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
@@ -2,6 +2,7 @@ import { Meta, StoryObj } from '@storybook/react'
 import { BindLogic } from 'kea'
 import { useState } from 'react'
 
+import { FEATURE_FLAGS } from 'lib/constants'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import funnelTopToBottomFixture from '~/mocks/fixtures/api/projects/team_id/insights/funnelTopToBottom.json'
@@ -70,10 +71,16 @@ export const Breakdown: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownFixture} />,
 }
 
+// Compare to previous: each step shows the periods as side-by-side columns (previous left of current),
+// each capped at its period's entry level so a shorter period leaves a blank volume gap above its track.
 export const Compare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomCompareFixture} />,
+    parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }
 
+// Breakdown + compare: each breakdown value's current+previous columns are paired and scaled to that
+// value's own larger period, so every value's leader column fills the chart.
 export const BreakdownAndCompare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownCompareFixture} />,
+    parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.stories.tsx
@@ -78,8 +78,9 @@ export const Compare: Story = {
     parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },
 }
 
-// Breakdown + compare: each breakdown value's current+previous columns are paired and scaled to that
-// value's own larger period, so every value's leader column fills the chart.
+// Breakdown + compare: each breakdown value shows its own conversion within its period, and the two
+// periods are scaled against each other — at the first step every value shares its period's height, the
+// larger period filling the column and the smaller one proportionally short, leaving a blank gap above.
 export const BreakdownAndCompare: Story = {
     render: () => <StoryRender insightFixture={funnelTopToBottomBreakdownCompareFixture} />,
     parameters: { featureFlags: [FEATURE_FLAGS.PRODUCT_ANALYTICS_FUNNELS_COMPARE] },

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -12,7 +12,6 @@ import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { StepLegend } from 'scenes/funnels/FunnelBarVertical/StepLegend'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
-import { hasBreakdown } from 'scenes/funnels/funnelUtils'
 import { insightLogic } from 'scenes/insights/insightLogic'
 
 import { groupsModel } from '~/models/groupsModel'
@@ -66,26 +65,14 @@ export function FunnelStepsBarChart({
         () =>
             buildFunnelStepsBarData(steps, {
                 getColor: getFunnelsColor,
-                // Breakdown + compare bars share a breakdown value across periods, so the legend
-                // must also name the period; plain breakdown/compare bars keep their single label.
-                getLabel: (variant) =>
-                    variant.compare_label && hasBreakdown(variant.breakdown_value)
-                        ? `${String(variant.breakdown_value)} · ${
-                              variant.compare_label === 'current' ? 'Current' : 'Previous'
-                          }`
-                        : String(variant.breakdown_value ?? variant.name ?? ''),
+                getLabel: (variant) => String(variant.breakdown_value ?? variant.name ?? ''),
             }),
         [steps, getFunnelsColor]
     )
 
-    // Only breakdown + compare needs a legend mapping color → breakdown value (and period); plain
-    // breakdown reads off the results table and pure compare is self-evident, so neither regresses.
-    const isBreakdownCompare = steps[0]?.nested_breakdown?.some(
-        (variant) => variant.compare_label != null && hasBreakdown(variant.breakdown_value)
-    )
     const config = useChartConfig(
-        () => withFunnelStepsBarInteraction(chartConfig, { isBreakdownCompare, quillTooltipEnabled }),
-        [isBreakdownCompare, quillTooltipEnabled]
+        () => withFunnelStepsBarInteraction(chartConfig, { quillTooltipEnabled }),
+        [quillTooltipEnabled]
     )
 
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
@@ -264,13 +264,4 @@ describe('withFunnelStepsBarInteraction', () => {
 
         expect(config.tooltip).toEqual({ pinnable: true, resolveClickToNearestSeries: true, placement: 'cursor' })
     })
-
-    it('adds a static legend for breakdown + compare, independent of the tooltip flag', () => {
-        const config = withFunnelStepsBarInteraction(baseConfig, {
-            isBreakdownCompare: true,
-            quillTooltipEnabled: false,
-        })
-
-        expect(config.legend).toEqual({ show: true, interactive: false })
-    })
 })

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
@@ -70,7 +70,9 @@ const compareSteps: FunnelStepWithConversionMetrics[] = [
     }),
 ]
 
-// Breakdown + compare: nested_breakdown pairs current+previous per value.
+// Breakdown + compare: nested_breakdown pairs current+previous per value. At the first step every value
+// converts 100% of its own entrants, so a period's values all read the same height — the larger period
+// fills the bar (1) and the smaller one is proportionally shorter (0.8 here); the gap above is blank.
 const breakdownCompareSteps: FunnelStepWithConversionMetrics[] = [
     makeStep({
         fromBasisStep: 1,
@@ -78,7 +80,7 @@ const breakdownCompareSteps: FunnelStepWithConversionMetrics[] = [
             makeStep({ fromBasisStep: 1, breakdown_value: 'Chrome', compare_label: 'current' }),
             makeStep({ fromBasisStep: 0.8, breakdown_value: 'Chrome', compare_label: 'previous' }),
             makeStep({ fromBasisStep: 1, breakdown_value: 'Safari', compare_label: 'current' }),
-            makeStep({ fromBasisStep: 0.625, breakdown_value: 'Safari', compare_label: 'previous' }),
+            makeStep({ fromBasisStep: 0.8, breakdown_value: 'Safari', compare_label: 'previous' }),
         ],
     }),
 ]

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.test.ts
@@ -52,6 +52,37 @@ const breakdownSteps: FunnelStepWithConversionMetrics[] = [
     }),
 ]
 
+// Pure compare: nested_breakdown is [current, previous] sharing the step's order.
+const compareSteps: FunnelStepWithConversionMetrics[] = [
+    makeStep({
+        fromBasisStep: 1,
+        nested_breakdown: [
+            makeStep({ fromBasisStep: 1, compare_label: 'current' }),
+            makeStep({ fromBasisStep: 0.8, compare_label: 'previous' }),
+        ],
+    }),
+    makeStep({
+        fromBasisStep: 0.5,
+        nested_breakdown: [
+            makeStep({ fromBasisStep: 0.5, compare_label: 'current' }),
+            makeStep({ fromBasisStep: 0.3, compare_label: 'previous' }),
+        ],
+    }),
+]
+
+// Breakdown + compare: nested_breakdown pairs current+previous per value.
+const breakdownCompareSteps: FunnelStepWithConversionMetrics[] = [
+    makeStep({
+        fromBasisStep: 1,
+        nested_breakdown: [
+            makeStep({ fromBasisStep: 1, breakdown_value: 'Chrome', compare_label: 'current' }),
+            makeStep({ fromBasisStep: 0.8, breakdown_value: 'Chrome', compare_label: 'previous' }),
+            makeStep({ fromBasisStep: 1, breakdown_value: 'Safari', compare_label: 'current' }),
+            makeStep({ fromBasisStep: 0.625, breakdown_value: 'Safari', compare_label: 'previous' }),
+        ],
+    }),
+]
+
 const options = {
     getColor: () => '#1d4aff',
     getLabel: (variant: FunnelStepWithConversionMetrics) => String(variant.breakdown_value ?? variant.name),
@@ -118,6 +149,54 @@ describe('buildFunnelStepsBarData', () => {
 
         expect(series).toEqual([])
         expect(labels).toEqual([])
+    })
+
+    it('emits the previous-period series before the current one so it renders to the left', () => {
+        const { series } = buildFunnelStepsBarData(compareSteps, options)
+
+        expect(series.map((s) => s.meta?.compareLabel)).toEqual(['previous', 'current'])
+    })
+
+    it('keeps each value’s pair grouped with previous before current (breakdown + compare)', () => {
+        const { series } = buildFunnelStepsBarData(breakdownCompareSteps, options)
+
+        expect(series.map((s) => [s.meta?.breakdownValue, s.meta?.compareLabel])).toEqual([
+            ['Chrome', 'previous'],
+            ['Chrome', 'current'],
+            ['Safari', 'previous'],
+            ['Safari', 'current'],
+        ])
+    })
+
+    it('caps each compare series’ track at its period entry level (trackData) so drop-off stops there', () => {
+        const { series } = buildFunnelStepsBarData(compareSteps, options)
+
+        // Previous entry level is 80% of the shared basis, so its drop-off track stops at 80 every step;
+        // current is the leader (100%). The blank space above each ceiling is the volume gap.
+        const previous = series.find((s) => s.meta?.compareLabel === 'previous')
+        const current = series.find((s) => s.meta?.compareLabel === 'current')
+        expect(previous?.trackData).toEqual([80, 80])
+        expect(current?.trackData).toEqual([100, 100])
+    })
+
+    it('leaves a non-compare series without trackData (full-height track)', () => {
+        const { series } = buildFunnelStepsBarData(breakdownSteps, options)
+
+        expect(series.every((s) => s.trackData === undefined)).toBe(true)
+    })
+
+    it('reorders the series array but keeps each series’ original breakdownIndex for click mapping', () => {
+        const { series } = buildFunnelStepsBarData(compareSteps, options)
+
+        // series[0] is the previous bar (now leftmost); its meta still points at nested index 1, so a
+        // click resolves to the previous variant rather than the current one.
+        const target = resolveFunnelStepClick(compareSteps, {
+            dataIndex: 0,
+            series: series[0],
+            inTrackArea: false,
+        })
+        expect(target?.series).toBe(compareSteps[0].nested_breakdown?.[1])
+        expect(target?.series.compare_label).toBe('previous')
     })
 })
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
@@ -1,6 +1,8 @@
 import type { BarChartConfig, PointClickData } from '@posthog/quill-charts'
 
-import type { FunnelStepWithConversionMetrics } from '~/types'
+import { getVisibilityKey } from 'scenes/funnels/funnelUtils'
+
+import type { BreakdownKeyType, FunnelStepWithConversionMetrics } from '~/types'
 
 import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { RATE_TO_PERCENT } from '../shared/funnelBarHorizontalShared'
@@ -13,9 +15,13 @@ import {
 export const FUNNEL_STEPS_SERIES_KEY_PREFIX = 'funnel-step-series-'
 
 /** Identifies which breakdown variant a hog-charts series maps back to, so click and
- *  tooltip handlers can recover the original `FunnelStepWithConversionMetrics`. */
+ *  tooltip handlers can recover the original `FunnelStepWithConversionMetrics`. `breakdownIndex` is
+ *  the original nested-array index even when compare reorders the visual series, so click/tooltip
+ *  routing stays correct; `compareLabel`/`breakdownValue` describe the series for ordering and tests. */
 export interface FunnelStepsBarSeriesMeta {
     breakdownIndex: number
+    compareLabel?: 'current' | 'previous'
+    breakdownValue?: BreakdownKeyType
 }
 
 interface BuildOptions {
@@ -56,21 +62,56 @@ export function buildFunnelStepsBarData(
 
     const isBreakdown = steps[0].nested_breakdown != null
     const breakdownCount = isBreakdown ? steps[0].nested_breakdown!.length : 1
+    const isCompare = steps[0].nested_breakdown?.some((variant) => variant.compare_label != null) ?? false
     const seriesVariants: FunnelStepsBarVariant<FunnelStepsBarSeriesMeta>[] = []
 
     for (let breakdownIndex = 0; breakdownIndex < breakdownCount; breakdownIndex++) {
         const variants = steps.map((step) => variantAtStep(step, breakdownIndex, isBreakdown))
         const representative = variants[0]
+        // A period's entry level (its first-step share of the shared basis) is constant across steps;
+        // it caps the drop-off track so the volume gap above is blank. Only meaningful in compare mode.
+        const entryLevel = (representative?.conversionRates.fromBasisStep ?? 0) * RATE_TO_PERCENT
         seriesVariants.push({
             key: `${FUNNEL_STEPS_SERIES_KEY_PREFIX}${breakdownIndex}`,
             label: representative ? options.getLabel(representative) : '',
             data: variants.map((variant) => variant.conversionRates.fromBasisStep * RATE_TO_PERCENT),
             color: representative ? options.getColor(representative) : undefined,
-            meta: { breakdownIndex },
+            meta: {
+                breakdownIndex,
+                compareLabel: representative?.compare_label,
+                breakdownValue: representative?.breakdown_value,
+            },
+            ...(isCompare ? { trackData: steps.map(() => entryLevel) } : {}),
         })
     }
 
-    return buildFunnelStepsBars(steps, seriesVariants)
+    // Grouped-bar slots render in series-array order, so reorder (not relabel) to put each value's
+    // previous-period bar left of its current one. Each series keeps its original breakdownIndex, so
+    // `resolveFunnelStepClick` and the tooltip still recover the right variant after the swap.
+    return buildFunnelStepsBars(steps, isCompare ? orderCompareSeriesPreviousFirst(seriesVariants) : seriesVariants)
+}
+
+/** Reorders compare series so each breakdown value's previous-period bar precedes its current one,
+ *  preserving the values' incoming order. Pure compare has a single value, so it just swaps the
+ *  current/previous pair. */
+function orderCompareSeriesPreviousFirst(
+    series: FunnelStepsBarVariant<FunnelStepsBarSeriesMeta>[]
+): FunnelStepsBarVariant<FunnelStepsBarSeriesMeta>[] {
+    const valueOrder: string[] = []
+    const byValue = new Map<string, FunnelStepsBarVariant<FunnelStepsBarSeriesMeta>[]>()
+    for (const variant of series) {
+        const key = getVisibilityKey(variant.meta?.breakdownValue)
+        if (!byValue.has(key)) {
+            byValue.set(key, [])
+            valueOrder.push(key)
+        }
+        byValue.get(key)!.push(variant)
+    }
+    return valueOrder.flatMap((key) =>
+        [...byValue.get(key)!].sort(
+            (a, b) => Number(a.meta?.compareLabel === 'current') - Number(b.meta?.compareLabel === 'current')
+        )
+    )
 }
 
 /** Derives the chart config from the base config plus the two things that vary per render:

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
@@ -114,23 +114,21 @@ function orderCompareSeriesPreviousFirst(
     )
 }
 
-/** Derives the chart config from the base config plus the two things that vary per render:
- *  whether the legend is needed (breakdown + compare) and whether the new pinnable tooltip is
+/** Derives the chart config from the base config plus whether the new pinnable tooltip is
  *  enabled. A breakdown always puts one series per breakdown value at each step, so a pinnable
  *  tooltip here always covers multiple series — `resolveClickToNearestSeries` resolves the
  *  click to the nearest one and opens its persons modal directly instead of pinning first. */
 export function withFunnelStepsBarInteraction(
     baseConfig: BarChartConfig,
-    options: { isBreakdownCompare?: boolean; quillTooltipEnabled: boolean }
+    options: { quillTooltipEnabled: boolean }
 ): BarChartConfig {
-    const base = options.isBreakdownCompare ? { ...baseConfig, legend: { show: true, interactive: false } } : baseConfig
     if (options.quillTooltipEnabled) {
         return {
-            ...base,
+            ...baseConfig,
             tooltip: { ...INSIGHT_TOOLTIP_CONFIG, resolveClickToNearestSeries: true },
         }
     }
-    return base
+    return baseConfig
 }
 
 export interface FunnelStepClickTarget {

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/funnelStepsBarTransforms.ts
@@ -68,8 +68,8 @@ export function buildFunnelStepsBarData(
     for (let breakdownIndex = 0; breakdownIndex < breakdownCount; breakdownIndex++) {
         const variants = steps.map((step) => variantAtStep(step, breakdownIndex, isBreakdown))
         const representative = variants[0]
-        // A period's entry level (its first-step share of the shared basis) is constant across steps;
-        // it caps the drop-off track so the volume gap above is blank. Only meaningful in compare mode.
+        // A period's entry level (its share of the larger baseline, shared by all its values) is constant
+        // across steps; it caps the drop-off track so the volume gap above is blank. Compare mode only.
         const entryLevel = (representative?.conversionRates.fromBasisStep ?? 0) * RATE_TO_PERCENT
         seriesVariants.push({
             key: `${FUNNEL_STEPS_SERIES_KEY_PREFIX}${breakdownIndex}`,

--- a/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
+++ b/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
@@ -55,8 +55,10 @@ export function buildFunnelBarHorizontalFiller(
 /** Compare-mode drop-off band: fills from the converted segments up to a period's own entry level
  *  (its first-step share of the shared baseline) rather than to 100%. The space above the entry level
  *  is the volume gap — this period simply had fewer entrants — and is left as blank axis whitespace,
- *  visually distinct from drop-off and non-interactive. The leader period's entry level is 100, so it
- *  fills the track exactly like the non-compare filler. */
+ *  visually distinct from drop-off and non-interactive: `trackData` declares the entry level as the
+ *  bar's interactive ceiling, so the chart suppresses hover, tooltip, pointer cursor, and click in
+ *  the gap. The leader period's entry level is 100, so it fills the track exactly like the
+ *  non-compare filler. */
 export function buildFunnelBarHorizontalDropOff(
     segments: Series<FunnelBarHorizontalSegmentMeta>[],
     entryLevelPercent: number,
@@ -71,6 +73,7 @@ export function buildFunnelBarHorizontalDropOff(
         color,
         visibility: { tooltip: false },
         meta: { isDropOff: true, breakdownIndex },
+        trackData: [entryLevelPercent],
     }
 }
 

--- a/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
+++ b/products/product_analytics/frontend/insights/funnels/shared/funnelBarHorizontalShared.ts
@@ -52,6 +52,28 @@ export function buildFunnelBarHorizontalFiller(
     }
 }
 
+/** Compare-mode drop-off band: fills from the converted segments up to a period's own entry level
+ *  (its first-step share of the shared baseline) rather than to 100%. The space above the entry level
+ *  is the volume gap — this period simply had fewer entrants — and is left as blank axis whitespace,
+ *  visually distinct from drop-off and non-interactive. The leader period's entry level is 100, so it
+ *  fills the track exactly like the non-compare filler. */
+export function buildFunnelBarHorizontalDropOff(
+    segments: Series<FunnelBarHorizontalSegmentMeta>[],
+    entryLevelPercent: number,
+    color: string,
+    breakdownIndex: number | null = null
+): Series<FunnelBarHorizontalSegmentMeta> {
+    const covered = segments.reduce((sum, s) => sum + (s.data[0] ?? 0), 0)
+    return {
+        key: FUNNEL_BAR_HORIZONTAL_FILLER_KEY,
+        label: 'Drop-off',
+        data: [Math.max(0, entryLevelPercent - covered)],
+        color,
+        visibility: { tooltip: false },
+        meta: { isDropOff: true, breakdownIndex },
+    }
+}
+
 /** Everything the MCP funnel view needs to render one step — all conversion math precomputed so the
  *  view stays presentational. */
 export interface FunnelBarRow {

--- a/products/product_analytics/frontend/insights/funnels/shared/funnelStepsBarShared.ts
+++ b/products/product_analytics/frontend/insights/funnels/shared/funnelStepsBarShared.ts
@@ -68,6 +68,9 @@ export interface FunnelStepsBarVariant<TMeta = unknown> {
     /** `data[stepIndex]` is the conversion from the first step, as a percent (0–100). The `track: true`
      *  bar config draws the drop-off remainder up to 100%. */
     data: number[]
+    /** Compare only: per-step track ceiling (percent) — caps the drop-off track at this period's entry
+     *  level so the volume gap above it is left blank. Omit for the default full-height track. */
+    trackData?: number[]
 }
 
 export interface FunnelStepsBarsModel<TMeta = unknown> {
@@ -104,6 +107,7 @@ export function buildFunnelStepsBars<TMeta = unknown>(
         data: variant.data,
         color: variant.color,
         meta: variant.meta,
+        ...(variant.trackData ? { trackData: variant.trackData } : {}),
     }))
     return {
         series,


### PR DESCRIPTION
## Problem

Funnel "compare to previous period" for the steps viz (behind `PRODUCT_ANALYTICS_FUNNELS_COMPARE`) didn't yet match the intended behavior. Three things were off:

- Breakdown comparisons were sized per breakdown value (each value against its own larger period), so a small value filled its bar just like a large one, and the two periods weren't read against a common per-period baseline.
- The empty "fewer entrants" space above a shorter period's bars was drawn — and clickable — as drop-off, conflating "this period had fewer people" with "people dropped off here".
- Left-to-right column order didn't match the intended previous-before-current.

## Changes

- **Per-period scaling (breakdown + compare):** each breakdown value shows its own conversion from its own first step, and the two periods are scaled against each other by their baselines. So at the first step every value in a period reads the **same height** — the larger period fills the bar (100%) and the smaller one is proportionally shorter, its missing volume left as a blank gap above. `fromBasisStep = (count × periodTotal) / (firstStep × basis)` where `basis = max(currentTotal, previousTotal)`; this collapses to the unchanged `count / max(current, previous)` for pure compare. The horizontal (stacked) layout already scaled to the larger period's total, so both layouts now agree at the period level.
- **Volume gap vs drop-off (the key rule):** a shorter period's drop-off now stops at that period's own entry level; the space above (the volume gap) is blank and non-interactive — no tooltip, no click, no pointer routing. Top-to-bottom renders the gap as axis whitespace; left-to-right uses a new per-bar track ceiling in `BarChart`.
- **Order:** left-to-right shows the previous-period column before the current one (top-to-bottom already shows current above previous).
- **Top-to-bottom breakdown + compare** renders two stacks per step (current, then previous), each split by breakdown value and scaled to whichever period had more total entrants; the aggregate drop-off band isn't clickable.
- **quill-charts:** `Series.trackData` adds an optional per-bar track ceiling for grouped bars — the track fills only to the ceiling and the region above is blank and non-interactive. Backward compatible (absent `trackData` keeps the full-height track).

Compare only changes how bars are **sized** and what is **interactive** — counts and percentages everywhere (tooltips, the per-step footer, the persons modals) stay exact and period-accurate.

Frontend changes; I'm an agent and can't attach screenshots. The compare Storybook stories (gated on the flag) were updated/added so visual-regression covers the new behavior.

## How did you test this code?

I'm an agent — I did not click through the UI manually. Built test-first; the automated suites pass:

- `funnelUtils.test.ts` — per-period compare sizing (at the first step every value in a period shares one height; the larger period fills, the smaller is proportional; pure compare stays `count / max(current, previous)`)
- `funnelDataLogic.test.ts` — breakdown + compare `fromBasisStep` end to end
- `funnelStepsBarTransforms.test.ts` — column order + the `trackData` ceiling
- `funnelBarHorizontalTransforms.test.ts` — entry-level drop-off + the two-stack breakdown layout
- `funnelPersonsModalLogic.test.ts` — first-step drop-off guard
- quill `resolve-clicked-bar-series.test.ts`, `bars-under-cursor.test.ts`, `bar-layout.test.ts` — track-ceiling click/hover

What each group catches: the per-period sizing tests catch a value being sized against the wrong reference (its own cross-period max, so small and large values look equally tall) instead of sharing its period's baseline height; the entry-level and two-stack tests catch the gap being drawn as drop-off and the old 4-bars-instead-of-2-stacks layout; the quill track-ceiling tests catch a click landing in the blank gap.

The Storybook compare stories will need their visual-regression snapshots regenerated in CI (the bar sizing and gap rendering changed — the grouped `BreakdownAndCompare` story most of all).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — the feature is still behind `PRODUCT_ANALYTICS_FUNNELS_COMPARE`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code (Claude Opus). Decisions worth a reviewer's attention:

- **Sizing is per period, not per breakdown value:** each value keeps its own conversion from its own first step, then the whole period is scaled by its share of the larger period's total entrants (`max(currentTotal, previousTotal)`). Because every value converts 100% of itself at the first step, a period's values all share one height there — which is what makes "larger period = 100%, smaller = proportional" read cleanly. Pure compare has a single value whose first step is the period total, so the formula collapses to the previous `count / max(current, previous)` and that path is unchanged.
- **Single-division form for precision:** computed as `(count × periodTotal) / (firstStep × basis)` rather than `(count/firstStep) × (periodTotal/basis)` — the two-step product introduces 1-ULP float drift (e.g. `0.4 × 0.75 → 0.30000000000000004`) that broke exact pure-compare assertions; the single division keeps the clean ratios exact. `significant.fromBasisStep` recomputes under the new sizing but is unused for display, so no percentage or significance readout shifts.
- **No axis pin needed:** the larger period reaches 100% at the first step, so the grouped steps-bar axis auto-scales to 100 and the smaller period's blank gap renders against it — no `valueDomain` override required.
- **Where the gap lives per layout:** the stacked (top-to-bottom) layout gets the blank gap for free as axis whitespace, but the grouped (left-to-right) layout's track is a real chart feature that always spanned the full axis, so `Series.trackData` was added to quill-charts rather than hacking the gap in at the product layer.
- **Kept the persons-modal first-step guard** as defense-in-depth — a silent no-op beats a 500 if anything ever re-exposes that path.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
