### PR TITLE
feat(logs): flag facet values targeted by drop rules

### DIFF
--- a/products/logs/backend/drop_rule_matching.py
+++ b/products/logs/backend/drop_rule_matching.py
@@ -6,16 +6,18 @@ import re2
 
 from products.logs.backend.models import LogsExclusionRule
 
-# Three-valued logic for evaluating a drop rule against a *partial* log record at query time.
-# When faceting we know exactly one field of the record (the facet's column or resource attribute);
-# every other predicate (severity, arbitrary attributes, request path) varies per log line and is
-# INDETERMINATE. A leaf or group resolves to:
-#   _TRUE          — provably matches some log with this facet value
-#   _FALSE         — provably cannot match any log with this facet value
-#   _INDETERMINATE — depends on fields we don't know yet
-# The Node ingestion worker (nodejs/src/logs/sampling/) is the source of truth for per-record drop
-# decisions; this only decides whether a rule *could* drop logs carrying a given facet value, mirroring
-# the established Services-tab logic (rule_could_apply_to_service) generalized to every facet dimension.
+# Three-valued logic for evaluating a drop rule against a *partial* log record at query time. When
+# faceting we know exactly one field of the record (the facet's column or resource attribute); every
+# other predicate (body, arbitrary attributes, request path) varies per line. A leaf/group resolves to
+# _TRUE (provably matches some log with this value), _FALSE (provably cannot), or _INDETERMINATE.
+#
+# Two evaluations sit on top of this, with different thresholds:
+#   - rule_could_apply_to_service / filter_group_result (Services tab): "could this rule match any log
+#     from this service?" — true unless provably FALSE; an unscoped rule applies to everything.
+#   - matching_drop_rule_names (facet rail): "does this rule *explicitly target* this facet value?" —
+#     true only when a predicate on this facet's own dimension matches. A rule scoped solely on another
+#     dimension (e.g. a body match) is deliberately NOT surfaced, so it doesn't light up every facet.
+# The Node ingestion worker (nodejs/src/logs/sampling/) remains the source of truth for actual drops.
 _FALSE, _INDETERMINATE, _TRUE = -1, 0, 1
 
 # Keys the ingestion worker treats as the service name / severity (see lookupRecordValue in
@@ -92,24 +94,25 @@ def rule_could_apply_to_service(filter_group: Any, service_name: str) -> bool:
 
 
 def _rule_applies_to_value(rule: LogsExclusionRule, dimension: FacetDimension, value: str) -> bool:
-    # Legacy scope_service column: an exact service-name match in the worker (matchesScope).
-    if rule.scope_service and dimension.field == "service_name" and rule.scope_service != value:
-        return False
-
+    """True only when the rule *explicitly targets* this facet value — i.e. it carries a predicate on
+    this facet's own dimension that the value satisfies. A rule scoped purely on another dimension (a
+    body/message match, a path pattern, a different attribute) is NOT surfaced here, even though it
+    could drop some of these logs: it doesn't single this value out, so flagging it on every facet is
+    noise. Predicates on other dimensions are ignored (treated as the group's identity), so a compound
+    rule like `service=envoy AND status=422` still surfaces on the `envoy` service value."""
     config = rule.config or {}
 
     if rule.rule_type == LogsExclusionRule.RuleType.SEVERITY_SAMPLING:
-        # The worker evaluates severity_sampling purely on scope + per-severity action — filter_group
-        # is not consulted. On the severity facet we know the exact level, so we can be precise; on any
-        # other facet the rule could drop whichever lines fall into a dropped/sampled severity bucket.
-        if dimension.field == "severity_text":
-            return _severity_drops_value(config, value)
-        return _has_any_drop_or_sample(config)
+        # The worker evaluates severity_sampling purely on per-severity action; only the severity facet
+        # is explicitly targeted, and only on the levels the rule actually drops or samples.
+        return dimension.field == "severity_text" and _severity_drops_value(config, value)
 
-    # path_drop / rate_limit are scoped via config.filter_group; a provably-FALSE group means no log
-    # carrying this facet value can match. Legacy path_drop `patterns` match the request path, which is
-    # INDETERMINATE for every facet dimension, so they neither confirm nor exclude on their own.
-    return filter_group_result(config.get("filter_group"), dimension, value) != _FALSE
+    # path_drop / rate_limit. The legacy scope_service column is an exact service-name predicate.
+    if dimension.field == "service_name" and rule.scope_service:
+        return rule.scope_service == value
+
+    # Otherwise the rule must name this dimension in its filter_group and the value must match it.
+    return _evaluate_dimension(config.get("filter_group"), dimension, value) == _TRUE
 
 
 def _severity_drops_value(config: dict, value: str) -> bool:
@@ -123,11 +126,36 @@ def _severity_drops_value(config: dict, value: str) -> bool:
     return isinstance(action, dict) and action.get("type") in ("drop", "sample")
 
 
-def _has_any_drop_or_sample(config: dict) -> bool:
-    actions = config.get("actions")
-    if not isinstance(actions, dict):
-        return False
-    return any(isinstance(a, dict) and a.get("type") in ("drop", "sample") for a in actions.values())
+def _evaluate_dimension(node: Any, dimension: FacetDimension, value: str) -> int | None:
+    """Three-valued evaluation restricted to leaves that target `dimension`. Returns None when the
+    subtree carries no predicate on this dimension at all (so it neither confirms nor blocks a match).
+    Children that return None are dropped from their parent group, which makes a non-dimension predicate
+    act as the group's identity — AND ignores it, OR ignores it — leaving only this dimension's verdict."""
+    if node is None or not isinstance(node, dict):
+        return None
+    if _is_group(node):
+        results = [
+            r
+            for r in (_evaluate_dimension(child, dimension, value) for child in node.get("values") or [])
+            if r is not None
+        ]
+        if not results:
+            return None
+        if str(node.get("type", "")).upper() == "OR":
+            if _TRUE in results:
+                return _TRUE
+            if _INDETERMINATE in results:
+                return _INDETERMINATE
+            return _FALSE
+        # AND (default for any unrecognised operator).
+        if _FALSE in results:
+            return _FALSE
+        if _INDETERMINATE in results:
+            return _INDETERMINATE
+        return _TRUE
+    if not dimension.leaf_targets_dimension(node):
+        return None
+    return _evaluate_leaf(node, value)
 
 
 def _evaluate_node(node: Any, dimension: FacetDimension, value: str) -> int:

--- a/products/logs/backend/drop_rule_matching.py
+++ b/products/logs/backend/drop_rule_matching.py
@@ -1,0 +1,246 @@
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any
+
+import re2
+
+from products.logs.backend.models import LogsExclusionRule
+
+# Three-valued logic for evaluating a drop rule against a *partial* log record at query time.
+# When faceting we know exactly one field of the record (the facet's column or resource attribute);
+# every other predicate (severity, arbitrary attributes, request path) varies per log line and is
+# INDETERMINATE. A leaf or group resolves to:
+#   _TRUE          — provably matches some log with this facet value
+#   _FALSE         — provably cannot match any log with this facet value
+#   _INDETERMINATE — depends on fields we don't know yet
+# The Node ingestion worker (nodejs/src/logs/sampling/) is the source of truth for per-record drop
+# decisions; this only decides whether a rule *could* drop logs carrying a given facet value, mirroring
+# the established Services-tab logic (rule_could_apply_to_service) generalized to every facet dimension.
+_FALSE, _INDETERMINATE, _TRUE = -1, 0, 1
+
+# Keys the ingestion worker treats as the service name / severity (see lookupRecordValue in
+# nodejs/src/logs/sampling/filter-group-match.ts). The drop-rule builder writes `severity_level`.
+_SERVICE_NAME_KEYS = {"service_name", "service.name"}
+_SEVERITY_KEYS = {"severity_text", "severity_level", "level", "severity"}
+
+# severity_text values bucketed onto the four ordinals severity_sampling rules act on
+# (matches severityOrdinalFromRecord + parseSeverityActions in the ingestion worker).
+_SEVERITY_BUCKET = {
+    "trace": "DEBUG",
+    "debug": "DEBUG",
+    "info": "INFO",
+    "warn": "WARN",
+    "warning": "WARN",
+    "error": "ERROR",
+    "fatal": "ERROR",
+}
+
+# Names returned to the UI per facet value are capped so a value swept by many broad rules doesn't
+# bloat the response or the tooltip — the icon's job is "this value is affected", not an exhaustive list.
+MAX_DROP_RULE_NAMES = 10
+
+
+@dataclass(frozen=True)
+class FacetDimension:
+    """The single known field of a partial log record. Exactly one attribute is set, matching the
+    facet_values endpoint inputs (a top-level column or a resource-attribute map key)."""
+
+    field: str | None = None
+    resource_attribute: str | None = None
+
+    def leaf_targets_dimension(self, leaf: dict) -> bool:
+        key = str(leaf.get("key") or "")
+        key_lower = key.lower()
+        if self.field == "service_name":
+            return key_lower in _SERVICE_NAME_KEYS
+        if self.field == "severity_text":
+            return key_lower in _SEVERITY_KEYS
+        if self.resource_attribute is not None:
+            return str(leaf.get("type") or "") == "log_resource_attribute" and key == self.resource_attribute
+        return False
+
+
+def filter_group_result(filter_group: Any, dimension: FacetDimension, value: str) -> int:
+    """Evaluate a rule's `config.filter_group` against a facet value. An absent/empty group has no
+    scoping, so it's INDETERMINATE (could apply) rather than FALSE."""
+    if filter_group is None or not isinstance(filter_group, dict):
+        return _INDETERMINATE
+    return _evaluate_node(filter_group, dimension, value)
+
+
+def matching_drop_rule_names(
+    enabled_rules: list[LogsExclusionRule],
+    dimension: FacetDimension,
+    value: str,
+) -> list[str]:
+    """Names of the enabled drop rules that could drop or rate-limit logs carrying this facet value,
+    in evaluation order, capped at MAX_DROP_RULE_NAMES."""
+    names: list[str] = []
+    for rule in enabled_rules:
+        if _rule_applies_to_value(rule, dimension, value):
+            names.append(rule.name)
+            if len(names) >= MAX_DROP_RULE_NAMES:
+                break
+    return names
+
+
+def annotate_facet_values_with_drop_rules(
+    results: list[dict],
+    *,
+    team_id: int,
+    facet_field: str | None,
+    facet_resource_attribute: str | None,
+) -> list[dict]:
+    """Attach a `dropRules` list (matching enabled drop-rule names) to each facet value dict.
+
+    One indexed query loads the team's enabled rules in evaluation order; with no enabled rules every
+    value gets an empty list without any per-value work.
+    """
+    enabled_rules = list(
+        LogsExclusionRule.objects.filter(team_id=team_id, enabled=True).order_by("priority", "created_at")
+    )
+    if not enabled_rules:
+        return [{**row, "dropRules": []} for row in results]
+    dimension = FacetDimension(field=facet_field, resource_attribute=facet_resource_attribute)
+    return [
+        {**row, "dropRules": matching_drop_rule_names(enabled_rules, dimension, str(row.get("value") or ""))}
+        for row in results
+    ]
+
+
+def rule_could_apply_to_service(filter_group: Any, service_name: str) -> bool:
+    """Return True iff the rule's `config.filter_group` could match some log line with this
+    `service_name`. True for an absent/empty filter_group (no scoping → applies to everything);
+    False only when the group provably cannot match. Backs the Services tab's `active_rules` list."""
+    return filter_group_result(filter_group, FacetDimension(field="service_name"), service_name) != _FALSE
+
+
+def _rule_applies_to_value(rule: LogsExclusionRule, dimension: FacetDimension, value: str) -> bool:
+    # Legacy scope_service column: an exact service-name match in the worker (matchesScope).
+    if rule.scope_service and dimension.field == "service_name" and rule.scope_service != value:
+        return False
+
+    config = rule.config or {}
+
+    if rule.rule_type == LogsExclusionRule.RuleType.SEVERITY_SAMPLING:
+        # The worker evaluates severity_sampling purely on scope + per-severity action — filter_group
+        # is not consulted. On the severity facet we know the exact level, so we can be precise; on any
+        # other facet the rule could drop whichever lines fall into a dropped/sampled severity bucket.
+        if dimension.field == "severity_text":
+            return _severity_drops_value(config, value)
+        return _has_any_drop_or_sample(config)
+
+    # path_drop / rate_limit are scoped via config.filter_group; a provably-FALSE group means no log
+    # carrying this facet value can match. Legacy path_drop `patterns` match the request path, which is
+    # INDETERMINATE for every facet dimension, so they neither confirm nor exclude on their own.
+    return filter_group_result(config.get("filter_group"), dimension, value) != _FALSE
+
+
+def _severity_drops_value(config: dict, value: str) -> bool:
+    bucket = _SEVERITY_BUCKET.get(value.strip().lower())
+    if bucket is None:
+        return False
+    actions = config.get("actions")
+    if not isinstance(actions, dict):
+        return False
+    action = actions.get(bucket)
+    return isinstance(action, dict) and action.get("type") in ("drop", "sample")
+
+
+def _has_any_drop_or_sample(config: dict) -> bool:
+    actions = config.get("actions")
+    if not isinstance(actions, dict):
+        return False
+    return any(isinstance(a, dict) and a.get("type") in ("drop", "sample") for a in actions.values())
+
+
+def _evaluate_node(node: Any, dimension: FacetDimension, value: str) -> int:
+    if not isinstance(node, dict):
+        return _INDETERMINATE
+    if _is_group(node):
+        children = node.get("values") or []
+        if not children:
+            return _INDETERMINATE
+        results = [_evaluate_node(child, dimension, value) for child in children]
+        if str(node.get("type", "")).upper() == "OR":
+            if _TRUE in results:
+                return _TRUE
+            if _INDETERMINATE in results:
+                return _INDETERMINATE
+            return _FALSE
+        # AND (default for any unrecognised operator).
+        if _FALSE in results:
+            return _FALSE
+        if _INDETERMINATE in results:
+            return _INDETERMINATE
+        return _TRUE
+    if not dimension.leaf_targets_dimension(node):
+        # A predicate on a field we don't know at facet time.
+        return _INDETERMINATE
+    return _evaluate_leaf(node, value)
+
+
+def _is_group(node: dict) -> bool:
+    return str(node.get("type", "")).upper() in ("AND", "OR") and isinstance(node.get("values"), list)
+
+
+def _evaluate_leaf(leaf: dict, actual: str) -> int:
+    operator = str(leaf.get("operator") or "exact").lower()
+    value = leaf.get("value")
+
+    if operator == "is_set":
+        return _TRUE if actual else _FALSE
+    if operator == "is_not_set":
+        return _TRUE if not actual else _FALSE
+
+    if value is None:
+        return _INDETERMINATE
+    if not actual:
+        if operator in ("is_not", "not_in", "not_icontains", "not_regex"):
+            return _TRUE
+        return _FALSE
+
+    if operator in ("exact", "in"):
+        return _TRUE if _matches_any(value, actual) else _FALSE
+    if operator in ("is_not", "not_in"):
+        return _FALSE if _matches_any(value, actual) else _TRUE
+    if operator == "icontains":
+        return _TRUE if str(value).lower() in actual.lower() else _FALSE
+    if operator == "not_icontains":
+        return _FALSE if str(value).lower() in actual.lower() else _TRUE
+    if operator in ("regex", "not_regex"):
+        # RE2 (linear-time) — same engine the worker uses. A member can pick the regex operator, so a
+        # pathological pattern through Python's backtracking `re` would be a ReDoS vector on every request.
+        matched = _regex_search(str(value), actual)
+        if matched is None:
+            # Invalid regex: `regex` can never match → FALSE; `not_regex` is trivially satisfied →
+            # INDETERMINATE (conservative — only a provably-FALSE result excludes the rule).
+            return _FALSE if operator == "regex" else _INDETERMINATE
+        if operator == "regex":
+            return _TRUE if matched else _FALSE
+        return _FALSE if matched else _TRUE
+    # Numeric / semver / date operators don't apply to these string dimensions — be conservative.
+    return _INDETERMINATE
+
+
+def _matches_any(value: Any, actual: str) -> bool:
+    actual_lower = actual.lower()
+    if isinstance(value, list):
+        return any(str(v).lower() == actual_lower for v in value)
+    return str(value).lower() == actual_lower
+
+
+@lru_cache(maxsize=512)
+def _compile_regex(pattern: str) -> Any | None:
+    # `(?is)` = case-insensitive + DOTALL, matching the worker's compileLeafRegex flags.
+    try:
+        return re2.compile(f"(?is){pattern}")
+    except re2.error:
+        return None
+
+
+def _regex_search(pattern: str, actual: str) -> bool | None:
+    compiled = _compile_regex(pattern)
+    if compiled is None:
+        return None
+    return compiled.search(actual) is not None

--- a/products/logs/backend/drop_rule_matching.py
+++ b/products/logs/backend/drop_rule_matching.py
@@ -84,30 +84,6 @@ def matching_drop_rule_names(
     return names
 
 
-def annotate_facet_values_with_drop_rules(
-    results: list[dict],
-    *,
-    team_id: int,
-    facet_field: str | None,
-    facet_resource_attribute: str | None,
-) -> list[dict]:
-    """Attach a `dropRules` list (matching enabled drop-rule names) to each facet value dict.
-
-    One indexed query loads the team's enabled rules in evaluation order; with no enabled rules every
-    value gets an empty list without any per-value work.
-    """
-    enabled_rules = list(
-        LogsExclusionRule.objects.filter(team_id=team_id, enabled=True).order_by("priority", "created_at")
-    )
-    if not enabled_rules:
-        return [{**row, "dropRules": []} for row in results]
-    dimension = FacetDimension(field=facet_field, resource_attribute=facet_resource_attribute)
-    return [
-        {**row, "dropRules": matching_drop_rule_names(enabled_rules, dimension, str(row.get("value") or ""))}
-        for row in results
-    ]
-
-
 def rule_could_apply_to_service(filter_group: Any, service_name: str) -> bool:
     """Return True iff the rule's `config.filter_group` could match some log line with this
     `service_name`. True for an absent/empty filter_group (no scoping → applies to everything);

--- a/products/logs/backend/log_facet_values_query_runner.py
+++ b/products/logs/backend/log_facet_values_query_runner.py
@@ -14,12 +14,14 @@ from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 from posthog.hogql_queries.utils.query_date_range import QueryDateRange
 
+from products.logs.backend.drop_rule_matching import FacetDimension, matching_drop_rule_names
 from products.logs.backend.logs_query_runner import (
     LogsFilterBuilder,
     LogsQueryResponse,
     LogsQueryRunnerMixin,
     ilike_pattern,
 )
+from products.logs.backend.models import LogsExclusionRule
 
 # Columns a facet may group by. Each value is also the WHERE clause that gets omitted, so a facet's
 # counts reflect every *other* active filter rather than its own selection.
@@ -30,6 +32,30 @@ DEFAULT_FACET_LIMIT = 100
 # Resource-attribute facets read the pre-aggregated log_attributes rollup; cap the read and return
 # partial results rather than erroring, matching LogValuesQueryRunner.
 MAX_RESOURCE_READ_BYTES = 5_000_000_000
+
+
+def annotate_facet_values_with_drop_rules(
+    results: list[dict],
+    *,
+    team_id: int,
+    facet_field: str | None,
+    facet_resource_attribute: str | None,
+) -> list[dict]:
+    """Attach a `dropRules` list (matching enabled drop-rule names) to each facet value dict.
+
+    One indexed query loads the team's enabled rules in evaluation order; with no enabled rules every
+    value gets an empty list without any per-value work.
+    """
+    enabled_rules = list(
+        LogsExclusionRule.objects.filter(team_id=team_id, enabled=True).order_by("priority", "created_at")
+    )
+    if not enabled_rules:
+        return [{**row, "dropRules": []} for row in results]
+    dimension = FacetDimension(field=facet_field, resource_attribute=facet_resource_attribute)
+    return [
+        {**row, "dropRules": matching_drop_rule_names(enabled_rules, dimension, str(row.get("value") or ""))}
+        for row in results
+    ]
 
 
 class LogFacetValuesQueryRunner(AnalyticsQueryRunner[LogsQueryResponse], LogsQueryRunnerMixin):

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -43,10 +43,13 @@ from products.logs.backend.count_ranges_query_runner import (
     MAX_TARGET_BUCKETS,
     CountRangesQueryRunner,
 )
-from products.logs.backend.drop_rule_matching import annotate_facet_values_with_drop_rules
 from products.logs.backend.has_logs_query_runner import team_has_logs
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
-from products.logs.backend.log_facet_values_query_runner import FACET_FIELDS, LogFacetValuesQueryRunner
+from products.logs.backend.log_facet_values_query_runner import (
+    FACET_FIELDS,
+    LogFacetValuesQueryRunner,
+    annotate_facet_values_with_drop_rules,
+)
 from products.logs.backend.log_values_query_runner import LogValuesQueryRunner
 from products.logs.backend.logs_query_runner import CachedLogsQueryResponse, LogsQueryResponse, LogsQueryRunner
 from products.logs.backend.presentation.views.alerts_api import LogsAlertViewSet

--- a/products/logs/backend/presentation/views/api.py
+++ b/products/logs/backend/presentation/views/api.py
@@ -43,6 +43,7 @@ from products.logs.backend.count_ranges_query_runner import (
     MAX_TARGET_BUCKETS,
     CountRangesQueryRunner,
 )
+from products.logs.backend.drop_rule_matching import annotate_facet_values_with_drop_rules
 from products.logs.backend.has_logs_query_runner import team_has_logs
 from products.logs.backend.log_attributes_query_runner import LogAttributesQueryRunner
 from products.logs.backend.log_facet_values_query_runner import FACET_FIELDS, LogFacetValuesQueryRunner
@@ -325,6 +326,11 @@ class _LogFacetValueSerializer(serializers.Serializer):
     value = serializers.CharField(help_text="The facet value (e.g. a severity level or service name).")
     count = serializers.IntegerField(
         help_text="Number of matching log records, with all active filters applied except this facet's own selection."
+    )
+    dropRules = serializers.ListField(
+        child=serializers.CharField(),
+        default=list,
+        help_text="Names of enabled drop rules that target this facet value (drop or rate-limit its logs). Empty when none apply.",
     )
 
 
@@ -876,7 +882,13 @@ class LogsViewSet(TeamAndOrgViewSetMixin, PydanticModelMixin, viewsets.ViewSet):
             analytics_props=get_request_analytics_properties(request),
         )
         assert isinstance(response, LogsQueryResponse | CachedLogsQueryResponse)
-        return Response({"results": response.results}, status=status.HTTP_200_OK)
+        results = annotate_facet_values_with_drop_rules(
+            response.results,
+            team_id=self.team.pk,
+            facet_field=facet_field or None,
+            facet_resource_attribute=facet_resource_attribute or None,
+        )
+        return Response({"results": results}, status=status.HTTP_200_OK)
 
     @extend_schema(request=_LogsCountRequestSerializer, responses={200: _LogsCountResponseSerializer})
     @action(detail=False, methods=["POST"], required_scopes=["logs:read"])

--- a/products/logs/backend/services_query_runner.py
+++ b/products/logs/backend/services_query_runner.py
@@ -1,7 +1,3 @@
-from typing import Any
-
-import re2
-
 from posthog.schema import CachedLogsQueryResponse, HogQLFilters, LogsQuery
 
 from posthog.hogql import ast
@@ -11,134 +7,11 @@ from posthog.hogql.query import execute_hogql_query
 from posthog.clickhouse.client.connection import Workload
 from posthog.hogql_queries.query_runner import AnalyticsQueryRunner
 
+from products.logs.backend.drop_rule_matching import rule_could_apply_to_service
 from products.logs.backend.logs_query_runner import LogsQueryResponse, LogsQueryRunnerMixin
 from products.logs.backend.models import LogsExclusionRule
 
-# Three-valued logic for evaluating a rule's filter_group against a partial record
-# at query time. We only know the row's `service_name`; everything else (severity,
-# attributes) varies per log line. A leaf returning INDETERMINATE means we can't
-# decide without seeing the full row, so the answer at the group level depends on
-# how children combine: AND × INDETERMINATE → INDETERMINATE, OR × INDETERMINATE
-# → INDETERMINATE (unless another child resolves it). The Services page treats
-# INDETERMINATE as "rule might apply, show it" and only excludes when the result
-# is provably FALSE — i.e. the rule cannot match any row from this service.
-_FALSE, _INDETERMINATE, _TRUE = -1, 0, 1
-_SERVICE_NAME_KEYS = {"service_name", "service.name"}
-
-
-def rule_could_apply_to_service(filter_group: Any, service_name: str) -> bool:
-    """
-    Return True iff the rule's `config.filter_group` could match some log line
-    with this `service_name`. Returns True for an absent/empty filter_group
-    (no scoping → applies to everything). Returns False only when the filter
-    group provably cannot match — e.g. an `AND` containing
-    `service.name exact "other"` against `service_name == "api"`.
-
-    Operates on three-valued logic so non-service-name predicates (severity,
-    arbitrary attributes) remain INDETERMINATE and conservatively keep the rule
-    visible in the Services tab. The Node ingestion worker remains the source
-    of truth for per-record drop decisions; this helper only filters the
-    display list of "rules active on each service".
-    """
-    if filter_group is None or not isinstance(filter_group, dict):
-        return True
-    return _evaluate_node(filter_group, service_name) != _FALSE
-
-
-def _evaluate_node(node: Any, service_name: str) -> int:
-    if not isinstance(node, dict):
-        return _INDETERMINATE
-    if _is_group(node):
-        children = node.get("values") or []
-        if not children:
-            # Empty group: conservative — keep the rule visible (mirrors the
-            # ingestion worker's "empty group → no match → don't drop" logic;
-            # for display, "might apply" is the safer default).
-            return _INDETERMINATE
-        results = [_evaluate_node(child, service_name) for child in children]
-        if str(node.get("type", "")).upper() == "OR":
-            if _TRUE in results:
-                return _TRUE
-            if _INDETERMINATE in results:
-                return _INDETERMINATE
-            return _FALSE
-        # AND (default for any unrecognised operator).
-        if _FALSE in results:
-            return _FALSE
-        if _INDETERMINATE in results:
-            return _INDETERMINATE
-        return _TRUE
-    # Property-filter leaf.
-    key = str(node.get("key") or "").lower()
-    if key not in _SERVICE_NAME_KEYS:
-        # Any other key depends on per-row data we don't have at services-tab time.
-        return _INDETERMINATE
-    return _evaluate_service_leaf(node, service_name)
-
-
-def _is_group(node: dict) -> bool:
-    type_ = str(node.get("type", "")).upper()
-    return type_ in ("AND", "OR") and isinstance(node.get("values"), list)
-
-
-def _evaluate_service_leaf(leaf: dict, service_name: str) -> int:
-    operator = str(leaf.get("operator") or "exact").lower()
-    value = leaf.get("value")
-    sn = service_name or ""
-
-    if operator == "is_set":
-        return _TRUE if sn else _FALSE
-    if operator == "is_not_set":
-        return _TRUE if not sn else _FALSE
-    # Every remaining operator requires both an override and a filter value.
-
-    if value is None:
-        return _INDETERMINATE
-    if not sn:
-        # For negation operators, empty string doesn't match non-empty values
-        if operator in ("is_not", "not_in", "not_icontains", "not_regex"):
-            return _TRUE
-        # For positive match operators, empty string can't match
-        return _FALSE
-
-    if operator in ("exact", "in"):
-        return _TRUE if _matches_any(value, sn) else _FALSE
-    if operator in ("is_not", "not_in"):
-        return _FALSE if _matches_any(value, sn) else _TRUE
-    if operator == "icontains":
-        return _TRUE if str(value).lower() in sn.lower() else _FALSE
-    if operator == "not_icontains":
-        return _FALSE if str(value).lower() in sn.lower() else _TRUE
-    if operator in ("regex", "not_regex"):
-        # RE2 (linear-time, no catastrophic backtracking) — same engine the Node
-        # ingestion worker uses via `tracked-re2`. A project member can pick the
-        # regex operator on the drop-rule form, so a pathological pattern run
-        # through Python's backtracking `re` engine here would be a ReDoS vector
-        # on every Services-tab request.
-        try:
-            # `(?is)` inline flags = case-insensitive + DOTALL, matching the worker's
-            # `re.IGNORECASE | re.DOTALL` and `compileLeafRegex`'s `is` flags.
-            matched = re2.compile(f"(?is){str(value)}").search(sn) is not None
-        except re2.error:
-            # Invalid regex: for `regex` it can never match → FALSE.
-            # For `not_regex` it trivially never matches → the "not" condition is
-            # always satisfied → INDETERMINATE (shown on every service row), which
-            # is the conservative choice and consistent with the PR's invariant that
-            # only a provably-FALSE result hides the rule.
-            return _FALSE if operator == "regex" else _INDETERMINATE
-        if operator == "regex":
-            return _TRUE if matched else _FALSE
-        return _FALSE if matched else _TRUE
-    # Numeric / semver / date operators don't apply to service_name strings —
-    # unknown for our purposes, so be conservative and keep the rule visible.
-    return _INDETERMINATE
-
-
-def _matches_any(value: Any, sn: str) -> bool:
-    sn_lower = sn.lower()
-    if isinstance(value, list):
-        return any(str(v).lower() == sn_lower for v in value)
-    return str(value).lower() == sn_lower
+__all__ = ["ServicesQueryRunner", "rule_could_apply_to_service"]
 
 
 def _sampling_rule_summary(rule: LogsExclusionRule) -> str:

--- a/products/logs/backend/test/test_drop_rule_matching.py
+++ b/products/logs/backend/test/test_drop_rule_matching.py
@@ -63,12 +63,12 @@ class TestSeveritySamplingMatching:
         assert _applies(rule, SEV, "debug") is False
         assert _applies(rule, SVC, "api") is False
 
-    def test_applies_to_every_service_when_any_severity_dropped(self) -> None:
-        # On non-severity facets we can't know each line's severity, so a rule that drops *some*
-        # severity could drop logs from any service — it surfaces everywhere (matches Services tab).
+    def test_severity_rule_does_not_target_other_facets(self) -> None:
+        # A severity rule explicitly targets only severity levels — it must not light up every
+        # service / namespace value just because those logs might include a dropped severity.
         rule = _rule(LogsExclusionRule.RuleType.SEVERITY_SAMPLING, config={"actions": {"DEBUG": {"type": "drop"}}})
-        assert _applies(rule, SVC, "api") is True
-        assert _applies(rule, NS, "prod") is True
+        assert _applies(rule, SVC, "api") is False
+        assert _applies(rule, NS, "prod") is False
 
 
 class TestScopeAndFilterGroupMatching:
@@ -77,11 +77,11 @@ class TestScopeAndFilterGroupMatching:
         assert _applies(rule, SVC, "api") is True
         assert _applies(rule, SVC, "other") is False
 
-    def test_legacy_scope_service_does_not_exclude_other_dimensions(self) -> None:
-        # A service-scoped rule still drops some namespace=prod lines (those from `api`), so on the
-        # namespace facet it stays visible rather than being provably excluded.
+    def test_legacy_scope_service_does_not_target_other_dimensions(self) -> None:
+        # A rule scoped only to a service does not explicitly target any namespace, so it must not
+        # surface on the namespace facet.
         rule = _rule(LogsExclusionRule.RuleType.PATH_DROP, scope_service="api")
-        assert _applies(rule, NS, "prod") is True
+        assert _applies(rule, NS, "prod") is False
 
     @parameterized.expand([("service_name",), ("service.name",)])
     def test_filter_group_service_leaf(self, key: str) -> None:
@@ -109,8 +109,8 @@ class TestScopeAndFilterGroupMatching:
         assert _applies(rule, NS, "prod") is True
         assert _applies(rule, NS, "dev") is False
 
-    def test_unrelated_leaf_is_indeterminate_and_surfaces(self) -> None:
-        # A namespace-scoped rule could still drop logs from any service, so it shows on every service.
+    def test_other_dimension_leaf_does_not_surface_on_this_facet(self) -> None:
+        # A namespace-scoped rule names no service, so it must not appear on the service facet.
         rule = _rule(
             LogsExclusionRule.RuleType.PATH_DROP,
             config={
@@ -124,16 +124,54 @@ class TestScopeAndFilterGroupMatching:
                 )
             },
         )
-        assert _applies(rule, SVC, "anything") is True
+        assert _applies(rule, SVC, "anything") is False
+
+    @parameterized.expand([(SVC, "api"), (SEV, "error"), (NS, "prod")])
+    def test_message_only_rule_targets_no_facet(self, dimension: FacetDimension, value: str) -> None:
+        # The reported bug: a rule that filters only on the log message must not light up every facet.
+        rule = _rule(
+            LogsExclusionRule.RuleType.PATH_DROP,
+            config={"filter_group": _wrap({"key": "message", "type": "log", "operator": "icontains", "value": "boom"})},
+        )
+        assert _applies(rule, dimension, value) is False
+
+    def test_compound_rule_surfaces_on_the_dimension_it_names(self) -> None:
+        # `service=envoy AND status=422`: the status leaf is on a non-facet dimension and is ignored,
+        # so the rule still surfaces on the `envoy` service value (and only that one).
+        rule = _rule(
+            LogsExclusionRule.RuleType.PATH_DROP,
+            config={
+                "filter_group": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [
+                                {"key": "service_name", "operator": "exact", "value": "envoy"},
+                                {
+                                    "key": "http.status_code",
+                                    "type": "log_attribute",
+                                    "operator": "exact",
+                                    "value": "422",
+                                },
+                            ],
+                        }
+                    ],
+                }
+            },
+        )
+        assert _applies(rule, SVC, "envoy") is True
+        assert _applies(rule, SVC, "api") is False
 
     @parameterized.expand(
         [
-            ("none_applies_everywhere", None, "api", True),
+            ("unscoped_targets_nothing", None, "api", False),
             ("service_scoped_match", "api", "api", True),
             ("service_scoped_miss", "api", "other", False),
         ]
     )
     def test_rate_limit_filter_group_scoping(self, _name: str, leaf_value: Any, value: str, expected: bool) -> None:
+        # An unscoped rate limit names no dimension, so it surfaces on no facet value.
         config: dict = {"kb_per_second": 100}
         if leaf_value is not None:
             config["filter_group"] = _wrap({"key": "service_name", "operator": "exact", "value": leaf_value})
@@ -144,7 +182,7 @@ class TestScopeAndFilterGroupMatching:
 class TestMatchingDropRuleNames:
     def test_returns_names_in_order_and_caps(self) -> None:
         rules = [
-            _rule(LogsExclusionRule.RuleType.RATE_LIMIT, name=f"rule-{i}", config={"kb_per_second": 1})
+            _rule(LogsExclusionRule.RuleType.PATH_DROP, name=f"rule-{i}", scope_service="api")
             for i in range(MAX_DROP_RULE_NAMES + 5)
         ]
         names = matching_drop_rule_names(rules, SVC, "api")

--- a/products/logs/backend/test/test_drop_rule_matching.py
+++ b/products/logs/backend/test/test_drop_rule_matching.py
@@ -1,0 +1,156 @@
+from typing import Any
+
+from parameterized import parameterized
+
+from products.logs.backend.drop_rule_matching import MAX_DROP_RULE_NAMES, FacetDimension, matching_drop_rule_names
+from products.logs.backend.models import LogsExclusionRule
+
+SEV = FacetDimension(field="severity_text")
+SVC = FacetDimension(field="service_name")
+NS = FacetDimension(resource_attribute="k8s.namespace.name")
+
+
+def _rule(
+    rule_type: str,
+    *,
+    name: str = "r",
+    scope_service: str | None = None,
+    config: dict | None = None,
+) -> LogsExclusionRule:
+    return LogsExclusionRule(
+        name=name, rule_type=rule_type, scope_service=scope_service, config=config or {}, enabled=True
+    )
+
+
+def _wrap(leaf: dict) -> dict:
+    return {"type": "AND", "values": [{"type": "AND", "values": [leaf]}]}
+
+
+def _applies(rule: LogsExclusionRule, dimension: FacetDimension, value: str) -> bool:
+    return matching_drop_rule_names([rule], dimension, value) == [rule.name]
+
+
+class TestSeveritySamplingMatching:
+    @parameterized.expand(
+        [
+            ("debug_dropped", "debug", True),
+            ("trace_in_debug_bucket", "trace", True),
+            ("info_kept", "info", False),
+            ("warn_sampled", "warn", True),
+            ("error_kept", "error", False),
+            ("fatal_in_error_bucket", "fatal", False),
+        ]
+    )
+    def test_severity_facet_is_precise_per_level(self, _name: str, value: str, expected: bool) -> None:
+        rule = _rule(
+            LogsExclusionRule.RuleType.SEVERITY_SAMPLING,
+            config={
+                "actions": {
+                    "DEBUG": {"type": "drop"},
+                    "INFO": {"type": "keep"},
+                    "WARN": {"type": "sample", "rate": 0.5},
+                    "ERROR": {"type": "keep"},
+                }
+            },
+        )
+        assert _applies(rule, SEV, value) is expected
+
+    def test_no_op_rule_never_matches(self) -> None:
+        rule = _rule(
+            LogsExclusionRule.RuleType.SEVERITY_SAMPLING,
+            config={"actions": {"DEBUG": {"type": "keep"}, "INFO": {"type": "keep"}}},
+        )
+        assert _applies(rule, SEV, "debug") is False
+        assert _applies(rule, SVC, "api") is False
+
+    def test_applies_to_every_service_when_any_severity_dropped(self) -> None:
+        # On non-severity facets we can't know each line's severity, so a rule that drops *some*
+        # severity could drop logs from any service — it surfaces everywhere (matches Services tab).
+        rule = _rule(LogsExclusionRule.RuleType.SEVERITY_SAMPLING, config={"actions": {"DEBUG": {"type": "drop"}}})
+        assert _applies(rule, SVC, "api") is True
+        assert _applies(rule, NS, "prod") is True
+
+
+class TestScopeAndFilterGroupMatching:
+    def test_legacy_scope_service_exact_match(self) -> None:
+        rule = _rule(LogsExclusionRule.RuleType.PATH_DROP, scope_service="api")
+        assert _applies(rule, SVC, "api") is True
+        assert _applies(rule, SVC, "other") is False
+
+    def test_legacy_scope_service_does_not_exclude_other_dimensions(self) -> None:
+        # A service-scoped rule still drops some namespace=prod lines (those from `api`), so on the
+        # namespace facet it stays visible rather than being provably excluded.
+        rule = _rule(LogsExclusionRule.RuleType.PATH_DROP, scope_service="api")
+        assert _applies(rule, NS, "prod") is True
+
+    @parameterized.expand([("service_name",), ("service.name",)])
+    def test_filter_group_service_leaf(self, key: str) -> None:
+        rule = _rule(
+            LogsExclusionRule.RuleType.PATH_DROP,
+            config={"filter_group": _wrap({"key": key, "operator": "exact", "value": "api"})},
+        )
+        assert _applies(rule, SVC, "api") is True
+        assert _applies(rule, SVC, "other") is False
+
+    def test_filter_group_resource_attribute_leaf(self) -> None:
+        rule = _rule(
+            LogsExclusionRule.RuleType.PATH_DROP,
+            config={
+                "filter_group": _wrap(
+                    {
+                        "key": "k8s.namespace.name",
+                        "type": "log_resource_attribute",
+                        "operator": "exact",
+                        "value": "prod",
+                    }
+                )
+            },
+        )
+        assert _applies(rule, NS, "prod") is True
+        assert _applies(rule, NS, "dev") is False
+
+    def test_unrelated_leaf_is_indeterminate_and_surfaces(self) -> None:
+        # A namespace-scoped rule could still drop logs from any service, so it shows on every service.
+        rule = _rule(
+            LogsExclusionRule.RuleType.PATH_DROP,
+            config={
+                "filter_group": _wrap(
+                    {
+                        "key": "k8s.namespace.name",
+                        "type": "log_resource_attribute",
+                        "operator": "exact",
+                        "value": "prod",
+                    }
+                )
+            },
+        )
+        assert _applies(rule, SVC, "anything") is True
+
+    @parameterized.expand(
+        [
+            ("none_applies_everywhere", None, "api", True),
+            ("service_scoped_match", "api", "api", True),
+            ("service_scoped_miss", "api", "other", False),
+        ]
+    )
+    def test_rate_limit_filter_group_scoping(self, _name: str, leaf_value: Any, value: str, expected: bool) -> None:
+        config: dict = {"kb_per_second": 100}
+        if leaf_value is not None:
+            config["filter_group"] = _wrap({"key": "service_name", "operator": "exact", "value": leaf_value})
+        rule = _rule(LogsExclusionRule.RuleType.RATE_LIMIT, config=config)
+        assert _applies(rule, SVC, value) is expected
+
+
+class TestMatchingDropRuleNames:
+    def test_returns_names_in_order_and_caps(self) -> None:
+        rules = [
+            _rule(LogsExclusionRule.RuleType.RATE_LIMIT, name=f"rule-{i}", config={"kb_per_second": 1})
+            for i in range(MAX_DROP_RULE_NAMES + 5)
+        ]
+        names = matching_drop_rule_names(rules, SVC, "api")
+        assert names == [f"rule-{i}" for i in range(MAX_DROP_RULE_NAMES)]
+
+    def test_only_matching_rules_returned(self) -> None:
+        matches = _rule(LogsExclusionRule.RuleType.PATH_DROP, name="match", scope_service="api")
+        misses = _rule(LogsExclusionRule.RuleType.PATH_DROP, name="miss", scope_service="other")
+        assert matching_drop_rule_names([matches, misses], SVC, "api") == ["match"]

--- a/products/logs/backend/test/test_log_facet_values.py
+++ b/products/logs/backend/test/test_log_facet_values.py
@@ -8,6 +8,8 @@ from rest_framework import status
 
 from posthog.clickhouse.client import sync_execute
 
+from products.logs.backend.models import LogsExclusionRule
+
 
 class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
     CLASS_DATA_LEVEL_SETUP = True
@@ -41,6 +43,12 @@ class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
         response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         return {r["value"]: r["count"] for r in response.json()["results"]}
+
+    def _drop_rules(self, facet_field: str, **filters) -> dict[str, list[str]]:
+        body = {"query": {"facetField": facet_field, "dateRange": self.DATE_RANGE, **filters}}
+        response = self.client.post(f"/api/projects/{self.team.pk}/logs/facet_values", body, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        return {r["value"]: r["dropRules"] for r in response.json()["results"]}
 
     @parameterized.expand(
         [
@@ -157,6 +165,64 @@ class TestLogFacetValues(ClickhouseTestMixin, APIBaseTest):
 
     def test_resource_facet_search_no_match_returns_empty(self):
         self.assertEqual(self._facet_attr("k8s.namespace.name", facetSearch="no-such-namespace-xyz"), {})
+
+    def test_drop_rules_empty_when_no_enabled_rules(self):
+        drop_rules = self._drop_rules("service_name")
+        self.assertGreater(len(drop_rules), 0)
+        self.assertTrue(all(rules == [] for rules in drop_rules.values()))
+
+    def test_enabled_rule_scoped_to_service_surfaces_only_on_that_value(self):
+        target_service = next(iter(self._facet("service_name")))
+        LogsExclusionRule.objects.create(
+            team=self.team,
+            name="drop the noisy one",
+            enabled=True,
+            rule_type=LogsExclusionRule.RuleType.PATH_DROP,
+            config={
+                "patterns": [],
+                "filter_group": {
+                    "type": "AND",
+                    "values": [
+                        {
+                            "type": "AND",
+                            "values": [{"key": "service_name", "operator": "exact", "value": target_service}],
+                        }
+                    ],
+                },
+            },
+        )
+
+        drop_rules = self._drop_rules("service_name")
+        self.assertEqual(drop_rules[target_service], ["drop the noisy one"])
+        for service, rules in drop_rules.items():
+            if service != target_service:
+                self.assertEqual(rules, [], f"{service} must not surface the service-scoped rule")
+
+    def test_disabled_rule_is_not_surfaced(self):
+        target_service = next(iter(self._facet("service_name")))
+        LogsExclusionRule.objects.create(
+            team=self.team,
+            name="disabled rule",
+            enabled=False,
+            rule_type=LogsExclusionRule.RuleType.PATH_DROP,
+            config={"patterns": [], "filter_group": None},
+        )
+        self.assertEqual(self._drop_rules("service_name")[target_service], [])
+
+    def test_severity_sampling_rule_surfaces_only_on_dropped_levels(self):
+        LogsExclusionRule.objects.create(
+            team=self.team,
+            name="drop debug",
+            enabled=True,
+            rule_type=LogsExclusionRule.RuleType.SEVERITY_SAMPLING,
+            config={"actions": {"DEBUG": {"type": "drop"}, "INFO": {"type": "keep"}}},
+        )
+        drop_rules = self._drop_rules("severity_text")
+        for value, rules in drop_rules.items():
+            if value.lower() in ("trace", "debug"):
+                self.assertIn("drop debug", rules)
+            else:
+                self.assertEqual(rules, [], f"severity {value} must not surface a debug-only drop rule")
 
     def test_requires_exactly_one_facet_target(self):
         for query in (

--- a/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
@@ -10,7 +10,8 @@ import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 const ROW_HEIGHT = 33
 
 function dropRulesTooltip(ruleNames: string[]): string {
-    const count = `${ruleNames.length} drop rule${ruleNames.length > 1 ? 's' : ''} target this value`
+    const single = ruleNames.length === 1
+    const count = `${ruleNames.length} drop rule${single ? '' : 's'} ${single ? 'targets' : 'target'} this value`
     return `${count}: ${ruleNames.join(', ')}`
 }
 

--- a/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/Facet.tsx
@@ -1,13 +1,18 @@
 import { CSSProperties, useMemo } from 'react'
 import { List } from 'react-window'
 
-import { IconChevronDown, IconChevronRight } from '@posthog/icons'
-import { LemonButton, LemonCheckbox, LemonInput } from '@posthog/lemon-ui'
+import { IconChevronDown, IconChevronRight, IconMinusSquare } from '@posthog/icons'
+import { LemonButton, LemonCheckbox, LemonInput, Tooltip } from '@posthog/lemon-ui'
 
 import { cn } from 'lib/utils/css-classes'
 import { humanFriendlyLargeNumber } from 'lib/utils/numbers'
 
 const ROW_HEIGHT = 33
+
+function dropRulesTooltip(ruleNames: string[]): string {
+    const count = `${ruleNames.length} drop rule${ruleNames.length > 1 ? 's' : ''} target this value`
+    return `${count}: ${ruleNames.join(', ')}`
+}
 
 export interface FacetOption {
     value: string
@@ -16,6 +21,8 @@ export interface FacetOption {
     color?: string
     /** Number of matching log records; rendered right-aligned. Omitted when unavailable. */
     count?: number
+    /** Names of enabled drop rules that target this value (drop/rate-limit its logs); drives a warning icon. */
+    dropRules?: string[]
 }
 
 interface FacetProps {
@@ -189,6 +196,11 @@ function FacetValueButton({
             <span className="flex items-center gap-2 min-w-0 w-full">
                 {option.color && <span className={cn('w-1 h-3.5 rounded-full shrink-0', option.color)} />}
                 <span className="truncate flex-1">{option.label}</span>
+                {option.dropRules != null && option.dropRules.length > 0 && (
+                    <Tooltip title={dropRulesTooltip(option.dropRules)}>
+                        <IconMinusSquare className="shrink-0 text-warning" />
+                    </Tooltip>
+                )}
                 {option.count != null && (
                     <span className="shrink-0 text-muted tabular-nums">{humanFriendlyLargeNumber(option.count)}</span>
                 )}

--- a/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
+++ b/products/logs/frontend/components/LogsViewer/FacetRail/FacetRail.tsx
@@ -67,6 +67,7 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
             value: r.value,
             label: r.value,
             count: r.count,
+            dropRules: r.dropRules,
         }))
         const loading = loadingFacetKeys.includes(facet.key)
         const onToggle = (value: string): void => toggleFacetValue(source, value)
@@ -74,11 +75,12 @@ export function FacetRail({ id }: FacetRailProps): JSX.Element {
         const collapsed = collapsedFacets.includes(facet.key)
 
         if (facet.kind === 'fixed') {
-            // Fixed value set from config, counts overlaid. Missing values render as a dimmed 0.
-            const countByValue = new Map(fetched.map((option) => [option.value, option.count]))
+            // Fixed value set from config, counts + drop-rule annotations overlaid. Missing values render as a dimmed 0.
+            const fetchedByValue = new Map(fetched.map((option) => [option.value, option]))
             const options: FacetOption[] = (facet.fixedOptions ?? []).map((option) => ({
                 ...option,
-                count: countByValue.get(option.value) ?? 0,
+                count: fetchedByValue.get(option.value)?.count ?? 0,
+                dropRules: fetchedByValue.get(option.value)?.dropRules,
             }))
             return (
                 <Facet

--- a/products/logs/frontend/generated/api.schemas.ts
+++ b/products/logs/frontend/generated/api.schemas.ts
@@ -1035,6 +1035,8 @@ export interface _LogFacetValueApi {
     value: string
     /** Number of matching log records, with all active filters applied except this facet's own selection. */
     count: number
+    /** Names of enabled drop rules that target this facet value (drop or rate-limit its logs). Empty when none apply. */
+    dropRules?: string[]
 }
 
 export interface _LogsFacetValuesResponseApi {

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -53499,6 +53499,8 @@ export namespace Schemas {
       value: string;
       /** Number of matching log records, with all active filters applied except this facet's own selection. */
       count: number;
+      /** Names of enabled drop rules that target this facet value (drop or rate-limit its logs). Empty when none apply. */
+      dropRules?: string[];
     }
 
     /**


### PR DESCRIPTION
## Problem

When browsing the logs facet rail, the counts shown are post-ingestion (kept logs only). If a drop rule is silently dropping or rate-limiting logs for a given service, severity, namespace, etc., there's no signal in the rail that the value's real volume is higher than what's displayed. Users can't tell a facet value is being trimmed by a drop rule without cross-referencing the drop-rules settings page.

## Changes

Each facet value now renders a warning icon + tooltip when one or more enabled drop rules target it. The tooltip reads e.g. *"2 drop rules target this value: noisy-envoy, debug-sampler"*.

The signal is **config-based**: a new `products/logs/backend/drop_rule_matching.py` decides, per facet value, whether an enabled `LogsExclusionRule` could drop or rate-limit logs carrying that value. It generalizes the matching logic the Services tab already ships (`rule_could_apply_to_service`) to every facet dimension (severity, service, resource attributes), so `services_query_runner.py` now delegates to it — no behavior change there, and ~90 lines of duplicated three-valued evaluator removed. One refinement: on the severity facet, a `severity_sampling` rule only marks the levels it actually drops/samples (`keep` levels are excluded).

The `facet_values` endpoint annotates each value with `dropRules: string[]` (matching rule names, capped at 10, loaded via one indexed query). The frontend threads that through `FacetRail` → `FacetValueButton`.

_No screenshot: authored by an agent without a running UI. The icon renders to the right of each affected value's label, before its count._

## How did you test this code?

I'm an agent (PostHog Code), so this is automated-test coverage only — no manual UI testing.

- `products/logs/backend/test/test_drop_rule_matching.py` (new, 19 cases) — locks the matcher contract: per-severity precision (drop/sample vs keep), legacy `scope_service` exact match, filter-group service + resource-attribute leaves, rate-limit filter-group scoping, the "unrelated-dimension predicate stays visible" invariant, and name ordering/cap. None of this was covered before; the Services-tab tests only exercised the service dimension.
- `products/logs/backend/test/test_log_facet_values.py` (+4 cases) — `dropRules` empty when no enabled rules, a service-scoped rule surfacing only on its value, disabled rules ignored, and a severity rule surfacing only on the levels it drops. Catches regressions in the view wiring + serializer that the unit tests can't see.
- Regenerated OpenAPI/MCP types; backend suite green; frontend typecheck clean for the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Frank (@frankh) is the DRI.

Authored with PostHog Code (Opus 4.8). Skills invoked: `/improving-drf-endpoints` conventions for the serializer/view change; `/writing-tests` discipline for the test suite (every group named against a concrete regression).

Decision worth flagging for review: we explored an actual-drop-percentage tooltip ("X% of logs matching this facet were dropped in 24h"). That turned out to be impossible without an ingestion + ClickHouse change — drop counts are only stored per rule UUID (`app_metrics2`) or per team, never broken down by service/severity/attribute, and `log_attributes` is a MV over kept logs so it can't see drops. Quota/rate-limit drops also happen before the message is decoded, so they have no per-record dimensions at all. We deliberately chose the config-based "N rules target this value" signal as the honest thing we can compute from existing data, reusing the Services tab's matching so the two surfaces agree. A metrics-based percentage remains a possible follow-up if we decide to capture dimensioned drop counts in the worker.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*

