### PR TITLE
fix(google_ads): surface a retry prompt for transient validation errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/source.py
@@ -293,8 +293,9 @@ class GoogleAdsSource(
         team_id: int,
         schema_name: Optional[str] = None,
     ) -> tuple[bool, str | None]:
-        from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads import (
-            google_ads_client,  # noqa: PLC0415
+        from products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads import (  # noqa: PLC0415
+            _is_transient_grpc_error,
+            google_ads_client,
         )
 
         try:
@@ -336,5 +337,14 @@ class GoogleAdsSource(
                     False,
                     "Your Google Ads connection is no longer available — it may have been disconnected. "
                     "Please reconnect your Google Ads account.",
+                )
+            # A transient Google-side blip (INTERNAL / UNAVAILABLE) stringifies as a raw gRPC status and
+            # protobuf failure dump the user can't act on. The sync rides these out in-process; here on
+            # the interactive create path we surface a clean retry prompt instead of leaking the dump.
+            if _is_transient_grpc_error(e):
+                return (
+                    False,
+                    "Google Ads returned a temporary error while validating your credentials. This is "
+                    "usually a transient issue on Google's side — please try again in a moment.",
                 )
             return False, f"Error validating credentials: {error_message}"

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/google_ads/tests/test_google_ads_source.py
@@ -356,6 +356,24 @@ class TestValidateCredentials:
         assert ok is False
         assert "reconnect your Google Ads account" in (message or "")
 
+    def test_transient_google_side_error_returns_retry_message(self):
+        # A transient INTERNAL/UNAVAILABLE blip from Google stringifies as a raw gRPC status plus a
+        # protobuf failure dump. Surface a clean retry prompt instead of leaking that to the wizard.
+        config = GoogleAdsSourceConfig(customer_id="1234567890", google_ads_integration_id=1)
+        client = mock.Mock()
+        client.get_service.return_value.list_accessible_customers.side_effect = (
+            google_api_exceptions.InternalServerError("500 Internal error encountered.")
+        )
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.google_ads.google_ads.google_ads_client",
+            return_value=client,
+        ):
+            ok, message = GoogleAdsSource().validate_credentials(config, team_id=1)
+
+        assert ok is False
+        assert "try again" in (message or "")
+        assert "Internal error encountered" not in (message or "")
+
 
 def _google_ads_exception(request_error: int) -> GoogleAdsException:
     failure = GoogleAdsFailure(


### PR DESCRIPTION
## Problem

When connecting a new Google Ads source, a transient Google-side gRPC blip during credential validation (status `INTERNAL` / `UNAVAILABLE`) was caught by `validate_credentials`' catch-all and returned to the setup wizard as a raw gRPC status line plus a serialized protobuf `GoogleAdsFailure` dump — i.e. `Error validating credentials: 500 Internal error encountered. [type_url: ... value: ...]`. That gives the user nothing actionable for what is actually a momentary, self-clearing error on Google's side.

## Changes

`validate_credentials` now reuses the existing `_is_transient_grpc_error` predicate (the same one the sync path uses to ride these statuses out in-process). When the validation failure is one of those transient statuses, we return a clean, static "please try again in a moment" message instead of leaking the raw status/protobuf dump. All other error branches (scope insufficient, wrong customer ID, disconnected integration, etc.) are unchanged.

No schema/field changes — purely error-message handling on the create path.

## How did you test this code?

I'm an agent. I added one backend test (`test_transient_google_side_error_returns_retry_message`) that mocks the validation call to raise `InternalServerError` and asserts the friendly retry message is returned and the raw `Internal error encountered` text does not leak. Ran the `TestValidateCredentials` group locally (3 passed). `ruff check` / `ruff format` pass on both touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced while triaging data-warehouse new-source validation failures. Invoked `/improving-drf-endpoints` (confirmed no request/response schema is touched, so no codegen impact) and `/writing-tests` (kept it to a single regression-guarding test). Considered the most frequent Google Ads validation error in the same triage — an `ACCESS_TOKEN_SCOPE_INSUFFICIENT` message — but the OAuth flow already requests the correct `adwords` scope and that message is already clear and actionable, so it was left untouched. This transient-error leak was the one self-contained gap worth fixing.