### PR TITLE
fix(bigquery): surface a clear error for an invalid dataset or project ID

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -107,6 +107,15 @@ BIGQUERY_DATASET_NOT_FOUND_ERROR = (
     "region in your source configuration if it isn't in the US."
 )
 
+# User-facing message for a syntactically invalid project/dataset ID (e.g. a value carrying
+# parentheses or other characters BigQuery forbids). Raised below and matched in
+# `BigQuerySource.get_non_retryable_errors`, so it must stay free of volatile data (the offending id).
+BIGQUERY_INVALID_IDENTIFIER_ERROR = (
+    "Your BigQuery Project ID or Dataset ID contains characters BigQuery doesn't allow — they may "
+    "only contain letters, numbers, dashes and underscores. Please check the Dataset ID in your "
+    "source configuration."
+)
+
 # BigQuery occasionally fails a query job with a transient `jobInternalError`, surfaced from the
 # `jobs.getQueryResults` REST call as a 400 BadRequest whose message ends "The job encountered an
 # error during execution. Retrying the job may solve the problem.". The client's default job-retry
@@ -133,6 +142,17 @@ class BigQueryDatasetNotFoundError(Exception):
     "404 Not found: Dataset ... was not found in location US ... Job ID: ..." — BigQuery job
     internals the user can't act on, which would otherwise leak straight to the create/validate
     response. We re-raise it with the same actionable wording we map this condition to during syncs.
+    """
+
+
+class BigQueryInvalidIdentifierError(Exception):
+    """Raised when schema discovery is given a syntactically invalid project/dataset ID.
+
+    `client.query()` raises a `google.api_core.exceptions.BadRequest` whose `str()` is a raw
+    `400 Invalid dataset ID "..."` / `Invalid project ID "..."` carrying the offending value plus
+    job internals (location, job id) — none of which the user can act on. A value like `(default)`
+    fails because parentheses aren't allowed. We re-raise it with actionable wording instead of
+    leaking the raw 400 to the create/validate response. Deterministic config error — non-retryable.
     """
 
 
@@ -805,6 +825,16 @@ class BigQueryImplementation(SQLSourceImplementation[BigQuerySourceConfig, bigqu
                 "BigQuery dataset '%s' not found during schema discovery: %s", config.dataset_id, e
             )
             raise BigQueryDatasetNotFoundError(BIGQUERY_DATASET_NOT_FOUND_ERROR) from e
+        except BadRequest as e:
+            # A bad project/dataset ID surfaces as "400 Invalid project ID ..." / "Invalid dataset ID
+            # ...". Convert it to an actionable message; anything else is a genuine BadRequest we leave
+            # to propagate (including the transient job-internal-error the query retry predicate covers).
+            if "Invalid dataset ID" not in str(e) and "Invalid project ID" not in str(e):
+                raise
+            structlog.get_logger().warning(
+                "BigQuery rejected an invalid project/dataset ID during schema discovery: %s", e
+            )
+            raise BigQueryInvalidIdentifierError(BIGQUERY_INVALID_IDENTIFIER_ERROR) from e
         except TypeError as e:
             # See `BigQueryTokenRefreshError`: google-auth raises an opaque
             # `TypeError: string indices must be integers` when the OAuth token endpoint

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -76,10 +76,12 @@ from products.warehouse_sources.backend.types import IncrementalFieldType, Parti
 
 __all__ = [
     "BIGQUERY_DATASET_NOT_FOUND_ERROR",
+    "BIGQUERY_INVALID_IDENTIFIER_ERROR",
     "BIGQUERY_TOKEN_RESPONSE_ERROR",
     "BigQueryCredentialsRejectedError",
     "BigQueryDatasetNotFoundError",
     "BigQueryImplementation",
+    "BigQueryInvalidIdentifierError",
     "BigQueryTokenRefreshError",
     "bigquery_client",
     "bigquery_storage_read_client",

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/bigquery.py
@@ -112,10 +112,13 @@ BIGQUERY_DATASET_NOT_FOUND_ERROR = (
 # User-facing message for a syntactically invalid project/dataset ID (e.g. a value carrying
 # parentheses or other characters BigQuery forbids). Raised below and matched in
 # `BigQuerySource.get_non_retryable_errors`, so it must stay free of volatile data (the offending id).
+# Kept generic across project vs dataset: the raw 400 can be either ("Invalid project ID" /
+# "Invalid dataset ID"), and the two have different allowed character sets (dataset IDs allow
+# underscores but not dashes; project IDs allow dashes but not underscores), so naming a specific
+# allowlist or only one field would mislead half the cases.
 BIGQUERY_INVALID_IDENTIFIER_ERROR = (
-    "Your BigQuery Project ID or Dataset ID contains characters BigQuery doesn't allow — they may "
-    "only contain letters, numbers, dashes and underscores. Please check the Dataset ID in your "
-    "source configuration."
+    "Your BigQuery Project ID or Dataset ID contains characters BigQuery doesn't allow. "
+    "Please check the Project ID and Dataset ID in your source configuration."
 )
 
 # BigQuery occasionally fails a query job with a transient `jobInternalError`, surfaced from the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/source.py
@@ -13,6 +13,7 @@ from posthog.schema import (
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
+    BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryImplementation,
     build_destination_table_prefix,
@@ -106,6 +107,14 @@ class BigQuerySource(SQLSource[BigQuerySourceConfig]):
             # carrying this exact wording (so the create/validate path shows it instead of the raw
             # 404). Match it here too so the discovery activity treats it as non-retryable.
             BIGQUERY_DATASET_NOT_FOUND_ERROR: BIGQUERY_DATASET_NOT_FOUND_ERROR,
+            # A syntactically invalid project/dataset ID (e.g. a value carrying parentheses like
+            # "(default)") is rejected as a 400 "Invalid dataset ID ..." / "Invalid project ID ...".
+            # Schema discovery re-raises it as `BigQueryInvalidIdentifierError` carrying the friendly
+            # wording, so match that here, plus the raw 400 phrasings for occurrences elsewhere in the
+            # sync. Deterministic config error — retrying never succeeds until the id is corrected.
+            BIGQUERY_INVALID_IDENTIFIER_ERROR: BIGQUERY_INVALID_IDENTIFIER_ERROR,
+            "Invalid dataset ID": BIGQUERY_INVALID_IDENTIFIER_ERROR,
+            "Invalid project ID": BIGQUERY_INVALID_IDENTIFIER_ERROR,
             # Raised as a 400 BadRequest from job creation (POST .../jobs) when the location the
             # client runs in — the custom region from the source form, or the dataset's own location
             # auto-detected in `connect` — isn't a region BigQuery can run query jobs in, e.g.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/bigquery/tests/test_source.py
@@ -12,11 +12,13 @@ from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery import bigquery as bq_module
 from products.warehouse_sources.backend.temporal.data_imports.sources.bigquery.bigquery import (
     BIGQUERY_DATASET_NOT_FOUND_ERROR,
+    BIGQUERY_INVALID_IDENTIFIER_ERROR,
     BIGQUERY_QUERY_JOB_RETRY,
     BIGQUERY_TOKEN_RESPONSE_ERROR,
     BigQueryCredentialsRejectedError,
     BigQueryDatasetNotFoundError,
     BigQueryImplementation,
+    BigQueryInvalidIdentifierError,
     BigQueryTokenRefreshError,
     _bq_select_clause,
     _get_primary_keys_for_table,
@@ -158,6 +160,36 @@ def test_bigquery_get_columns_raises_friendly_error_when_dataset_not_found():
     # The raw 404 (job id, location internals) must not survive into the message.
     assert "Job ID" not in str(exc_info.value)
     assert BIGQUERY_DATASET_NOT_FOUND_ERROR in BigQuerySource().get_non_retryable_errors()
+
+
+@pytest.mark.parametrize("phrase", ['Invalid dataset ID "(default)"', 'Invalid project ID "bad id"'])
+def test_bigquery_get_columns_raises_friendly_error_for_invalid_identifier(phrase):
+    """A syntactically invalid project/dataset ID surfaces as a raw 400 `BadRequest` from
+    `client.query()`. Schema discovery must re-raise it with actionable wording instead of leaking
+    the offending value and BigQuery job internals, and that wording must stay non-retryable."""
+    fake_client = mock.MagicMock()
+    fake_client.query.side_effect = BadRequest(
+        f"400 {phrase}. Dataset IDs must be alphanumeric. Location: US Job ID: f2bf3ba8-4c4b"
+    )
+
+    with pytest.raises(BigQueryInvalidIdentifierError) as exc_info:
+        BigQueryImplementation().get_columns(fake_client, _make_config(), names=None)
+
+    assert str(exc_info.value) == BIGQUERY_INVALID_IDENTIFIER_ERROR
+    # The raw 400 (offending id, job id) must not survive into the message.
+    assert "Job ID" not in str(exc_info.value)
+    assert "(default)" not in str(exc_info.value)
+    assert BIGQUERY_INVALID_IDENTIFIER_ERROR in BigQuerySource().get_non_retryable_errors()
+
+
+def test_bigquery_get_columns_propagates_unrelated_bad_request():
+    """A BadRequest that isn't an invalid-identifier error (e.g. a malformed query) must propagate
+    unchanged rather than being mislabeled as an invalid project/dataset ID."""
+    fake_client = mock.MagicMock()
+    fake_client.query.side_effect = BadRequest("400 Syntax error: Unexpected keyword SELECT")
+
+    with pytest.raises(BadRequest):
+        BigQueryImplementation().get_columns(fake_client, _make_config(), names=None)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Problem

When a BigQuery source is configured with a syntactically invalid Project ID or Dataset ID (a value containing characters BigQuery forbids, e.g. parentheses), BigQuery rejects schema-discovery queries with a raw `400 BadRequest` — `Invalid dataset ID "<value>". Dataset IDs must be alphanumeric ...` — carrying the offending value plus job internals (location, job id). `get_columns` caught `Forbidden` / `NotFound` / `TypeError` / `RefreshError`, but not `BadRequest`, so this raw 400 leaked straight into the source-creation wizard toast.

## Changes

`get_columns` now wraps the invalid-identifier `BadRequest` (matched on the stable `Invalid dataset ID` / `Invalid project ID` wording) as a new `BigQueryInvalidIdentifierError` carrying an actionable, value-free message — mirroring the existing `NotFound` → `BigQueryDatasetNotFoundError` handling. The friendly message and the raw 400 phrasings are registered in `get_non_retryable_errors` so a sync treats this deterministic config error as non-retryable rather than retrying forever. Any unrelated `BadRequest` (a malformed query, the transient job-internal-error the query retry predicate covers) propagates unchanged.

No schema/field changes — error-message handling only.

## How did you test this code?

I'm an agent. I added two backend tests: one (parametrized over an invalid dataset ID and an invalid project ID) asserting `get_columns` re-raises the friendly message, drops the offending value and job internals, and keeps the wording non-retryable; and one asserting an unrelated `BadRequest` still propagates. Ran the full BigQuery `test_source.py` suite locally (100 passed). `ruff check` / `ruff format` pass on all touched files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Produced while triaging data-warehouse new-source validation failures. Invoked `/improving-drf-endpoints` (confirmed no request/response schema is touched, so no codegen impact) and `/writing-tests`. The fix follows the connector's established pattern of converting raw Google API errors into curated, non-retryable messages; tests assert only on stable, non-sensitive substrings.