### PR TITLE
fix(batch-exports): Close async write client in BigQuery

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/bigquery_batch_export.py
@@ -1167,7 +1167,8 @@ _RETRYABLE_STATUS = {
 _RETRYABLE_CODES = {s.value[0] for s in _RETRYABLE_STATUS}
 
 
-def get_bigquery_write_async_client(credentials) -> BigQueryWriteAsyncClient:
+@contextlib.asynccontextmanager
+async def bigquery_write_async_client(credentials) -> collections.abc.AsyncIterator[BigQueryWriteAsyncClient]:
     """Create a new BigQuery storage write async client."""
     channel = BigQueryWriteGrpcAsyncIOTransport.create_channel(
         credentials=credentials,
@@ -1177,7 +1178,11 @@ def get_bigquery_write_async_client(credentials) -> BigQueryWriteAsyncClient:
     client = BigQueryWriteAsyncClient(
         transport=transport,
     )
-    return client
+
+    try:
+        yield client
+    finally:
+        await transport.close()
 
 
 class BigQueryStorageConsumer(Consumer):
@@ -1681,13 +1686,6 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                     # while testing.
                     # TODO: Remove this or the else block after we have tested out whether multiple
                     # consumers are viable.
-                    consumer: Consumer = BigQueryConsumer(
-                        client=bq_client,
-                        table=bigquery_consumer_table,
-                        file_format=file_format,
-                        model=model.name if isinstance(model, BatchExportModel) else "events",
-                    )
-
                     if use_storage_stream:
                         serialized = SerializedStreamTransformer()
                         transformer: ChunkTransformerProtocol = PipelineTransformer(
@@ -1713,14 +1711,31 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                             )
                         )
 
-                        write_client = get_bigquery_write_async_client(bq_client.sync_client._credentials)
-                        consumer = BigQueryStorageConsumer(
-                            client=write_client,
+                        async with bigquery_write_async_client(bq_client.sync_client._credentials) as write_client:
+                            consumer: Consumer = BigQueryStorageConsumer(
+                                client=write_client,
+                                table=bigquery_consumer_table,
+                                transformer=serialized,
+                                model=model.name if isinstance(model, BatchExportModel) else "events",
+                            )
+
+                            result = await run_consumer_from_stage(
+                                queue=queue,
+                                producer_task=producer_task,
+                                consumer=consumer,
+                                transformer=transformer,
+                                json_columns=(),
+                                records_total=inputs.records_total,
+                            )
+
+                    else:
+                        consumer = BigQueryConsumer(
+                            client=bq_client,
                             table=bigquery_consumer_table,
-                            transformer=serialized,
+                            file_format=file_format,
                             model=model.name if isinstance(model, BatchExportModel) else "events",
                         )
-                    else:
+
                         if can_perform_merge:
                             transformer = PipelineTransformer(
                                 transformers=(
@@ -1745,26 +1760,26 @@ async def insert_into_bigquery_activity_from_stage(inputs: BigQueryInsertInputs)
                                 )
                             )
 
-                    result = await run_consumer_from_stage(
-                        queue=queue,
-                        producer_task=producer_task,
-                        consumer=consumer,
-                        transformer=transformer,
-                        json_columns=(),
-                        records_total=inputs.records_total,
-                    )
+                        result = await run_consumer_from_stage(
+                            queue=queue,
+                            producer_task=producer_task,
+                            consumer=consumer,
+                            transformer=transformer,
+                            json_columns=(),
+                            records_total=inputs.records_total,
+                        )
 
                 else:
                     if use_storage_stream:
-                        write_client = get_bigquery_write_async_client(bq_client.sync_client._credentials)
-                        result = await run_storage_stream_consumers(
-                            client=write_client,
-                            table=bigquery_consumer_table,
-                            producer_task=producer_task,
-                            queue=queue,
-                            max_consumers=settings.BATCH_EXPORT_BIGQUERY_MAX_CONSUMERS,
-                            model=model.name if isinstance(model, BatchExportModel) else "events",
-                        )
+                        async with bigquery_write_async_client(bq_client.sync_client._credentials) as write_client:
+                            result = await run_storage_stream_consumers(
+                                client=write_client,
+                                table=bigquery_consumer_table,
+                                producer_task=producer_task,
+                                queue=queue,
+                                max_consumers=settings.BATCH_EXPORT_BIGQUERY_MAX_CONSUMERS,
+                                model=model.name if isinstance(model, BatchExportModel) else "events",
+                            )
                     else:
                         result = await run_consumers(
                             client=bq_client,

--- a/products/batch_exports/backend/temporal/pipeline/transformer.py
+++ b/products/batch_exports/backend/temporal/pipeline/transformer.py
@@ -754,10 +754,8 @@ class SerializedStreamTransformer:
                 log_attributes={"num_records": record_batch.num_rows},
             ) as recorder:
                 recorder.add_bytes_processed(record_batch.nbytes)
-                # The entire Arrow C++ call is not GIL-free, but enough of it
-                # seems to be for it to be worth to spawn a thread here, based
-                # on tests with 64MiB batches.
-                buf = await asyncio.to_thread(record_batch.select(self.schema.names).serialize)
+
+                buf = record_batch.select(self.schema.names).serialize()
                 chunk = buf.to_pybytes()  # We need bytes downstream
                 del buf  # Free buf on the next gc run
 


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

We do not clean up the async write client in Bigquery. This should be cleaned up by the garbage collector, but let's just close it regardless.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

Close the write client using a context manager.

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

Ran tests, all good.

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State that you're an agent and list only the automated tests you actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Just don't duplicate info already present in preceding sections. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->
<!-- Rules for agent-authored PRs:
     - When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
     - If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
     - Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
     - Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
     - Agent-authored PRs always require human review — do not self-merge or auto-approve.
     - Do NOT claim manual testing you haven't done.
     - GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
     - Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. Always stay professional.
     - For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
