### PR TITLE
fix(engineering-analytics): bypass warehouse acl in job-logs discovery

### DIFF
--- a/products/engineering_analytics/backend/logic/job_logs/coordinator.py
+++ b/products/engineering_analytics/backend/logic/job_logs/coordinator.py
@@ -23,6 +23,7 @@ from temporalio.common import RetryPolicy, WorkflowIDReusePolicy
 from temporalio.exceptions import WorkflowAlreadyStartedError
 
 from posthog.hogql import ast
+from posthog.hogql.errors import QueryError
 from posthog.hogql.parser import parse_select
 from posthog.hogql.query import execute_hogql_query
 
@@ -66,6 +67,10 @@ def _query_failed_jobs(team: Team, prefix: str, cutoff_iso: str) -> list[dict[st
             query=parse_select(sql, placeholders={"cutoff": ast.Constant(value=cutoff_iso)}),
             team=team,
             query_type="GithubJobLogsDiscovery",
+            # Trusted internal sweep with no request user: without this, HogQL's access-control build
+            # marks the team's own warehouse tables denied and the query raises "You don't have access
+            # to table" — so nothing is ever discovered. The query stays scoped to this team's table.
+            bypass_warehouse_access_control=True,
         )
     return [dict(zip(response.columns or [], row)) for row in response.results]
 
@@ -105,6 +110,8 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
         # the activity's fail-closed guard, but here it also skips the per-source warehouse queries.
         return []
     found: list[dict[str, Any]] = []
+    eligible_sources = 0
+    skipped_sources = 0
     sources = (
         ExternalDataSource.objects.filter(source_type=ExternalDataSourceType.GITHUB)
         .exclude(deleted=True)
@@ -115,6 +122,7 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
         prefix = source.prefix or ""
         if params is None or not _PREFIX.match(prefix):
             continue
+        eligible_sources += 1
         integration_id, repo = params
         try:
             # Row handling stays inside the try so a single bad row (e.g. a null job_id) skips this
@@ -139,11 +147,25 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
                 if len(found) >= MAX_DISCOVERED_JOBS:
                     logger.warning("github_job_logs_discovery_capped", cap=MAX_DISCOVERED_JOBS)
                     return found
-        except Exception:
-            # A source whose jobs table isn't synced (most teams don't enable the workflow_jobs
-            # schema) or a transient query error shouldn't fail the whole sweep — skip it.
-            logger.warning("github_job_logs_discovery_skipped_source", source_id=str(source.id), exc_info=True)
+        except Exception as e:
+            # A source whose jobs table isn't synced or a transient query error shouldn't fail the
+            # whole sweep — skip it. Most teams never enable the workflow_jobs schema, so a missing
+            # table is the expected common case (log at debug); anything else is a real error (warn).
+            skipped_sources += 1
+            if isinstance(e, QueryError) and "Unknown table" in str(e):
+                logger.debug("github_job_logs_discovery_source_not_synced", source_id=str(source.id))
+            else:
+                logger.warning("github_job_logs_discovery_skipped_source", source_id=str(source.id), exc_info=True)
             continue
+    # One summary line per tick so coverage stays observable even though per-source "not synced" skips
+    # log at debug: a sweep that suddenly skips everything (e.g. a mistyped prefix or a dropped table)
+    # is visible here instead of silently emitting nothing.
+    logger.info(
+        "github_job_logs_discovery_complete",
+        eligible_sources=eligible_sources,
+        skipped_sources=skipped_sources,
+        jobs_found=len(found),
+    )
     return found
 
 

--- a/products/engineering_analytics/backend/logic/job_logs/coordinator.py
+++ b/products/engineering_analytics/backend/logic/job_logs/coordinator.py
@@ -146,7 +146,7 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
                 )
                 if len(found) >= MAX_DISCOVERED_JOBS:
                     logger.warning("github_job_logs_discovery_capped", cap=MAX_DISCOVERED_JOBS)
-                    return found
+                    break  # inner loop only; the outer break below stops the sweep so the cap holds
         except Exception as e:
             # A source whose jobs table isn't synced or a transient query error shouldn't fail the
             # whole sweep — skip it. Most teams never enable the workflow_jobs schema, so a missing
@@ -157,6 +157,8 @@ def _discover_failed_jobs(cutoff_iso: str) -> list[dict[str, Any]]:
             else:
                 logger.warning("github_job_logs_discovery_skipped_source", source_id=str(source.id), exc_info=True)
             continue
+        if len(found) >= MAX_DISCOVERED_JOBS:
+            break  # stop the sweep at the cap, but fall through to the summary log below
     # One summary line per tick so coverage stays observable even though per-source "not synced" skips
     # log at debug: a sweep that suddenly skips everything (e.g. a mistyped prefix or a dropped table)
     # is visible here instead of silently emitting nothing.

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_coordinator.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_coordinator.py
@@ -1,10 +1,17 @@
+from types import SimpleNamespace
+
+from unittest.mock import patch
+
 from django.test import override_settings
 
 from parameterized import parameterized
 
+from posthog.models.team import Team
+
 from products.engineering_analytics.backend.logic.job_logs.coordinator import (
     _discover_failed_jobs,
     _github_source_params,
+    _query_failed_jobs,
 )
 
 
@@ -42,3 +49,15 @@ class TestDiscoverFailedJobs:
         # deployed: discovery returns [] (without querying the warehouse) so no child workflows fan
         # out. Drops the guard and this fails by hitting the DB and returning rows.
         assert _discover_failed_jobs("2026-06-29T00:00:00+00:00") == []
+
+
+class TestQueryFailedJobs:
+    @patch("products.engineering_analytics.backend.logic.job_logs.coordinator.execute_hogql_query")
+    def test_bypasses_warehouse_access_control(self, mock_execute):
+        # The sweep runs with no request user, so without bypass HogQL marks the team's own
+        # workflow_jobs warehouse table denied and the query raises "You don't have access to table" —
+        # the worker then silently emits nothing. Locks in the bypass that makes the trusted query work.
+        mock_execute.return_value = SimpleNamespace(columns=["job_id"], results=[])
+        _query_failed_jobs(Team(pk=1), "devex_", "2026-06-30T00:00:00+00:00")
+        mock_execute.assert_called_once()
+        assert mock_execute.call_args.kwargs["bypass_warehouse_access_control"] is True


### PR DESCRIPTION
## Problem

The GitHub CI job-logs coordinator (engineering analytics) runs as a trusted internal Temporal sweep with no request user. HogQL's access-control build treats a user-less query as fail-closed and marks the team's own data-warehouse tables as denied, so the discovery query against `{prefix}github_workflow_jobs` raised `You don't have access to table …`. The per-source error handler swallowed it, so the coordinator discovered nothing and emitted no logs in production even though the schedule was firing every 2 minutes.

## Changes

- Pass `bypass_warehouse_access_control=True` on the discovery query. This is the sanctioned flag for user-less internal callers (the product's own curated read layer already uses the same pattern); the query stays scoped to a single team's own table.
- Downgrade the expected "table not synced" skip to debug — most teams never enable the `workflow_jobs` schema, so warn-with-traceback per source every tick was just noise. Genuine errors still warn.
- Add a per-tick discovery summary log (eligible / skipped / found) so coverage stays observable even with the debug downgrade — a sweep that suddenly skips everything (e.g. a renamed or dropped table) shows up here instead of silently emitting nothing.

## How did you test this code?

I'm an agent (Claude Code) — automated tests only, no manual claims beyond the live observation below.

- Added `TestQueryFailedJobs.test_bypasses_warehouse_access_control`, which locks in the bypass kwarg on the discovery query — the exact regression that silently broke emission. Existing coordinator tests still pass (11 total).
- Ran the job-logs test suite + targeted mypy locally; both clean.
- The bug was found by smoke-testing the live schedule: the coordinator was firing in prod-us but every source skipped on the warehouse access error, which is how it surfaced.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored with Claude Code, directed by @webjunkie.
- Found via live smoke test after registering the coordinator schedule in prod-us: the schedule fired but discovery skipped every source on a warehouse access-control error. Traced through `posthog/hogql/query.py` → `database.py` to the `bypass_warehouse_access_control` flag.
- Ran `/code-review medium` before pushing. Correctness came back clean: the bypass is scoped to one team (no cross-team leak), system-table ACL is still enforced, and the precedent is the same product's curated read layer. The review's one finding — that the debug downgrade also hides a misconfigured/renamed source — is addressed by the per-tick summary log.
- Deferred to a follow-up: pre-filtering sources by a synced `workflow_jobs` schema so the sweep doesn't run a guaranteed-to-fail query per unsynced source each tick. Bounded cost; skipped here to keep the fix tight and avoid mis-filter risk.
