### PR TITLE
fix: coordinator flag

### DIFF
--- a/products/conversations/backend/temporal/coordinator.py
+++ b/products/conversations/backend/temporal/coordinator.py
@@ -81,19 +81,28 @@ class CollectEligibleTicketsOutput:
 
 
 def _is_master_flag_enabled(team: Team) -> bool:
-    return bool(
-        posthoganalytics.feature_enabled(
-            MASTER_FLAG,
-            str(team.uuid),
-            groups={"organization": str(team.organization_id), "project": str(team.id)},
-            group_properties={
-                "organization": {"id": str(team.organization_id)},
-                "project": {"id": str(team.id)},
-            },
-            only_evaluate_locally=False,
-            send_feature_flag_events=False,
+    # The flag is targeted by project group; release conditions can match on the project's `uuid`,
+    # so it must be in group_properties — the headless worker only sends what's listed here (unlike
+    # posthog-js, which auto-attaches full group properties). Without it a uuid filter never matches.
+    try:
+        return bool(
+            posthoganalytics.feature_enabled(
+                MASTER_FLAG,
+                str(team.uuid),
+                groups={"organization": str(team.organization_id), "project": str(team.id)},
+                group_properties={
+                    "organization": {"id": str(team.organization_id)},
+                    "project": {"id": str(team.id), "uuid": str(team.uuid)},
+                },
+                only_evaluate_locally=False,
+                send_feature_flag_events=False,
+            )
         )
-    )
+    except Exception:
+        # A flag-service blip must skip the ticket, not throw inside the scan loop and fail the
+        # whole coordinator tick. Fail closed: treat as disabled.
+        logger.warning("support_reply coordinator: master flag eval failed", team_id=team.id, exc_info=True)
+        return False
 
 
 def _collect_eligible(lookback_minutes: int = TICKET_LOOKBACK_MINUTES) -> list[EligibleTicket]:

--- a/products/conversations/backend/temporal/tests/test_coordinator.py
+++ b/products/conversations/backend/temporal/tests/test_coordinator.py
@@ -88,7 +88,7 @@ class TestMasterFlagEnabled:
             },
             group_properties={
                 "organization": {"id": str(TEST_ORG_UUID)},
-                "project": {"id": "2"},
+                "project": {"id": "2", "uuid": str(TEST_TEAM_UUID)},
             },
             only_evaluate_locally=False,
             send_feature_flag_events=False,


### PR DESCRIPTION
What changed in coordinator.py:

- Added "uuid": str(team.uuid) to the project group properties so the flag's project.uuid filter can actually match in the headless worker.
- Wrapped the eval in try/except → False so a flag-service error skips the ticket instead of throwing inside the scan loop and failing the whole coordinator tick.