### PR TITLE
feat(llma): group consecutive tool calls into collapsible accordions

### DIFF
--- a/products/posthog_ai/frontend/components/ThreadView.tsx
+++ b/products/posthog_ai/frontend/components/ThreadView.tsx
@@ -1,19 +1,20 @@
-import { useValues } from 'kea'
+import { useActions, useValues } from 'kea'
 import { memo, useCallback, useMemo } from 'react'
 
 import { runStreamLogic } from '../logics/runStreamLogic'
+import type { ThreadRow as ThreadRowData } from '../logics/threadGroups'
 import { ReasoningAnswer } from '../messages/ReasoningAnswer'
-import type { ThreadItem } from '../types/streamTypes'
 import { getRandomThinkingMessage } from '../utils/thinkingMessages'
 import { ContextUsageBar } from './ContextUsageBar'
 import { PullRequestCard } from './PullRequestCard'
 import { RunContext } from './RunContext'
 import { ThreadRow } from './ThreadRow'
+import { ToolGroupChip } from './tool/ToolGroupChip'
 import { VirtualizedThread } from './VirtualizedThread'
 
 /** Stable row key — defined at module scope so `getItemKey` never changes identity across renders. */
-function getThreadItemKey(item: ThreadItem): string {
-    return item.id
+function getThreadRowKey(row: ThreadRowData): string {
+    return row.id
 }
 
 interface ThreadViewProps {
@@ -53,6 +54,7 @@ export function ThreadView({
 }: ThreadViewProps): JSX.Element {
     const {
         threadItems,
+        threadRows,
         toolInvocations,
         isThinking,
         streamPhase,
@@ -61,6 +63,7 @@ export function ThreadView({
         currentRunStatus,
         contextUsage,
     } = useValues(runStreamLogic)
+    const { setGroupOverride } = useActions(runStreamLogic)
     const turnCancelled = currentRunStatus === 'cancelled'
     const hasActiveProgressItem = threadItems.some(
         (item) => item.type === 'progress' && item.progressSteps?.some((step) => step.status === 'in_progress')
@@ -77,7 +80,7 @@ export function ThreadView({
                     <ThreadHeader branch={branch} baseBranch={baseBranch} repo={repo} />
                 </VirtualizedThread.Row>
             ) : undefined,
-        [branch, baseBranch, repo]
+        [branch, baseBranch, repo, rowClassName]
     )
 
     // `provisioning` (conversations/open POST + cold boot before run_started) also shows the indicator,
@@ -102,29 +105,53 @@ export function ThreadView({
                     />
                 </VirtualizedThread.Row>
             ) : undefined,
-        [showThinking, thinkingPhase, pullRequestUrl, branch, showContextUsageFooter]
+        [showThinking, thinkingPhase, pullRequestUrl, branch, showContextUsageFooter, rowClassName]
     )
 
     const renderItem = useCallback(
-        (item: ThreadItem, index: number): JSX.Element => (
+        (row: ThreadRowData, index: number): JSX.Element => (
             <VirtualizedThread.Row className={rowClassName}>
-                <ThreadRow
-                    item={item}
-                    isLast={index === threadItems.length - 1}
-                    isThinking={isThinking}
-                    toolInvocations={toolInvocations}
-                    turnComplete={turnComplete}
-                    turnCancelled={turnCancelled}
-                />
+                {row.kind === 'tool_group' ? (
+                    <ToolGroupChip
+                        summary={row.summary}
+                        expanded={row.expanded}
+                        turnComplete={row.turnComplete}
+                        onToggle={() => setGroupOverride(row.id, !row.expanded)}
+                    >
+                        {row.expanded
+                            ? row.items.map((it) => (
+                                  <div key={it.id} className="empty:hidden">
+                                      <ThreadRow
+                                          item={it}
+                                          isLast={false}
+                                          isThinking={isThinking}
+                                          toolInvocations={toolInvocations}
+                                          turnComplete={row.turnComplete}
+                                          turnCancelled={turnCancelled}
+                                      />
+                                  </div>
+                              ))
+                            : null}
+                    </ToolGroupChip>
+                ) : (
+                    <ThreadRow
+                        item={row.item}
+                        isLast={index === threadRows.length - 1}
+                        isThinking={isThinking}
+                        toolInvocations={toolInvocations}
+                        turnComplete={turnComplete}
+                        turnCancelled={turnCancelled}
+                    />
+                )}
             </VirtualizedThread.Row>
         ),
-        [threadItems.length, isThinking, toolInvocations, turnComplete, turnCancelled, rowClassName]
+        [threadRows.length, isThinking, toolInvocations, turnComplete, turnCancelled, rowClassName, setGroupOverride]
     )
 
     return (
         <VirtualizedThread.Root
-            items={threadItems}
-            getItemKey={getThreadItemKey}
+            items={threadRows}
+            getItemKey={getThreadRowKey}
             header={header}
             footer={footer}
             stickToBottom

--- a/products/posthog_ai/frontend/components/tool/ToolGroupChip.tsx
+++ b/products/posthog_ai/frontend/components/tool/ToolGroupChip.tsx
@@ -1,0 +1,132 @@
+import clsx from 'clsx'
+import { type ComponentType, type ReactNode, memo } from 'react'
+
+import {
+    IconChevronDown,
+    IconChevronRight,
+    IconDocument,
+    IconGlobe,
+    IconPencil,
+    IconSearch,
+    IconShuffle,
+    IconTerminal,
+    IconTrash,
+    IconWrench,
+    IconAI,
+} from '@posthog/icons'
+import { Spinner, Tooltip } from '@posthog/lemon-ui'
+
+import type { GroupIconKey, GroupSummary } from '../../logics/threadGroups'
+import { ActivityDetails } from '../ActivityPrimitives'
+
+/** Maps a chip icon key to its icon component. Falls back to a wrench for unrecognized kinds. */
+function iconForKey(key: GroupIconKey): ComponentType<{ className?: string }> {
+    switch (key) {
+        case 'subagent':
+            return IconAI
+        case 'kind:execute':
+            return IconTerminal
+        case 'kind:read':
+            return IconDocument
+        case 'kind:edit':
+            return IconPencil
+        case 'kind:delete':
+            return IconTrash
+        case 'kind:move':
+            return IconShuffle
+        case 'kind:search':
+            return IconSearch
+        case 'kind:fetch':
+            return IconGlobe
+        default:
+            return IconWrench
+    }
+}
+
+const ICON_KEY_LABELS: Partial<Record<GroupIconKey, string>> = {
+    subagent: 'Spawned a subagent',
+    'kind:execute': 'Ran terminal commands',
+    'kind:read': 'Read files',
+    'kind:edit': 'Edited files',
+    'kind:delete': 'Deleted files',
+    'kind:move': 'Moved files',
+    'kind:search': 'Searched the codebase',
+    'kind:fetch': 'Fetched a web page',
+}
+
+function labelForIconKey(key: GroupIconKey): string {
+    return ICON_KEY_LABELS[key] ?? 'Ran other tools'
+}
+
+export interface ToolGroupChipProps {
+    summary: GroupSummary
+    expanded: boolean
+    turnComplete: boolean
+    onToggle: () => void
+    /** Rendered group items, shown inside the body rail when expanded. */
+    children?: ReactNode
+}
+
+/**
+ * A collapsed tool-call group: a clickable summary header (caret + spinner + verb-led label + icon
+ * strip) standing in for a run of tool calls and reasoning. Controlled — the open state is owned by
+ * the stream logic's per-group override. While the turn runs it shows the live action; once complete
+ * it shows the verb-led summary.
+ */
+export const ToolGroupChip = memo(function ToolGroupChip({
+    summary,
+    expanded,
+    turnComplete,
+    onToggle,
+    children,
+}: ToolGroupChipProps): JSX.Element {
+    const Caret = expanded ? IconChevronDown : IconChevronRight
+    // Spin on THIS group's own in-flight tool, not the turn — a turn split across several chips
+    // (by messages) must not keep finished chips spinning.
+    const running = !turnComplete && summary.active && summary.liveLabel != null
+    // While running, show both what's happened so far and what's happening now, so a collapsed turn
+    // reads as actively-working rather than stalled.
+    const label = running
+        ? summary.hasCountableWork
+            ? `${summary.doneLabel} · ${summary.liveLabel}`
+            : (summary.liveLabel as string)
+        : summary.doneLabel
+
+    return (
+        <div className="flex flex-col rounded transition-all duration-500 w-full min-w-0 gap-1 text-xs">
+            <div
+                className="group/group-chip flex items-center gap-1 min-w-0 select-none cursor-pointer rounded px-1 -mx-1 hover:bg-fill-button-tertiary-hover text-default"
+                onClick={onToggle}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        onToggle()
+                    }
+                }}
+                role="button"
+                tabIndex={0}
+                aria-expanded={expanded}
+                aria-label={expanded ? 'Collapse tool activity' : 'Expand tool activity'}
+            >
+                <Caret className="size-4 shrink-0 text-muted transition-colors group-hover/group-chip:text-default" />
+                {running && <Spinner className="shrink-0 text-muted" />}
+                <span className={clsx('truncate min-w-0', running && 'text-muted')}>{label}</span>
+                {!expanded && summary.icons.length > 0 && (
+                    <span className="ml-1 flex shrink-0 items-center gap-1.5 text-muted">
+                        {summary.icons.map((key) => {
+                            const Icon = iconForKey(key)
+                            return (
+                                <Tooltip key={key} title={labelForIconKey(key)}>
+                                    <span className="flex items-center">
+                                        <Icon className="size-3.5" />
+                                    </span>
+                                </Tooltip>
+                            )
+                        })}
+                    </span>
+                )}
+            </div>
+            {expanded && <ActivityDetails hasIcon={true}>{children}</ActivityDetails>}
+        </div>
+    )
+})

--- a/products/posthog_ai/frontend/logics/runStreamLogic.ts
+++ b/products/posthog_ai/frontend/logics/runStreamLogic.ts
@@ -48,6 +48,7 @@ import {
     isTaskRunStateFrame,
 } from '../types/wireTypes'
 import type { runStreamLogicType } from './runStreamLogicType'
+import { type CollapseMode, COLLAPSE_MODE_DEFAULT, type ThreadRow, buildThreadGroups } from './threadGroups'
 
 export type RunSseStatus = 'idle' | 'connecting' | 'open' | 'reconnecting' | 'closed' | 'error'
 export type RunStatus = 'queued' | 'in_progress' | 'completed' | 'failed' | 'cancelled'
@@ -1208,6 +1209,12 @@ export const runStreamLogic = kea<runStreamLogicType>([
         setContextUsage: (usage: ContextUsage) => ({ usage }),
         /** Diagnostic `_posthog/sdk_session` plumbing — no UI. */
         setSdkSession: (session: SdkSession) => ({ session }),
+        /** How aggressively completed turns collapse into a tool-call group chip. */
+        setCollapseMode: (mode: CollapseMode) => ({ mode }),
+        /** Ephemeral per-group expand override (true=expanded, false=collapsed), keyed by group id. */
+        setGroupOverride: (groupId: string, expanded: boolean) => ({ groupId, expanded }),
+        /** Drop all per-group overrides (e.g. when the global collapse mode changes). */
+        clearGroupOverrides: true,
         reset: true,
     }),
     reducers({
@@ -1477,6 +1484,24 @@ export const runStreamLogic = kea<runStreamLogicType>([
                 reset: () => null,
             },
         ],
+        // How completed turns collapse into a tool-call group chip. Ephemeral view state, per stream.
+        collapseMode: [
+            COLLAPSE_MODE_DEFAULT,
+            {
+                setCollapseMode: (_, { mode }) => mode,
+                reset: () => COLLAPSE_MODE_DEFAULT,
+            },
+        ],
+        // Per-group expand overrides keyed by group id. `true` = expanded, `false` = collapsed, absent
+        // = follow the collapse mode. Not persisted; wiped when the mode changes (see listeners).
+        groupOverrides: [
+            {} as Record<string, boolean>,
+            {
+                setGroupOverride: (state, { groupId, expanded }) => ({ ...state, [groupId]: expanded }),
+                clearGroupOverrides: (state) => (Object.keys(state).length === 0 ? state : {}),
+                reset: () => ({}),
+            },
+        ],
     }),
     selectors({
         /**
@@ -1509,6 +1534,16 @@ export const runStreamLogic = kea<runStreamLogicType>([
         toolInvocations: [
             (s) => [s.foldedThread],
             (foldedThread): Map<string, ToolInvocation> => foldedThread.toolInvocations,
+        ],
+        /**
+         * The thread folded into rows for rendering: each maximal run of tool calls + reasoning
+         * collapses into a single `tool_group` chip per the collapse mode and per-group overrides,
+         * everything else passes through as its own row. Memoized on the projection + view state.
+         */
+        threadRows: [
+            (s) => [s.threadItems, s.toolInvocations, s.collapseMode, s.groupOverrides, s.turnComplete],
+            (threadItems, toolInvocations, collapseMode, groupOverrides, turnComplete): ThreadRow[] =>
+                buildThreadGroups(threadItems, toolInvocations, collapseMode, groupOverrides, turnComplete),
         ],
         /**
          * Whether the agent is actively working a turn — drives the thread's thinking indicator.
@@ -1629,6 +1664,10 @@ export const runStreamLogic = kea<runStreamLogicType>([
         ],
     }),
     listeners(({ values, actions, cache, props }) => ({
+        // Changing the global collapse mode wipes the ephemeral per-group overrides.
+        setCollapseMode: () => {
+            actions.clearGroupOverrides()
+        },
         bootstrapRun: async ({ taskId, runId, justCreatedRun }, breakpoint) => {
             const projectId = values.currentProjectId
             if (projectId === null) {

--- a/products/posthog_ai/frontend/logics/threadGroups.ts
+++ b/products/posthog_ai/frontend/logics/threadGroups.ts
@@ -1,0 +1,307 @@
+/**
+ * Folds a flat run of tool-call work into collapsible groups — the "tool-call accordion" behavior.
+ *
+ * Ported from PostHog Code's `buildThreadGroups` / `conversationThreadConfig`. A group is a *maximal
+ * consecutive run* of groupable items (tool calls + the reasoning thoughts between them); anything
+ * else (a human message, direct assistant prose, an error, a status / progress / compaction marker,
+ * a turn separator) flushes the run into a standalone row. Grouping is keyed on item type alone, so a
+ * run never spans a turn boundary here — the separator flushes it.
+ *
+ * Pure and deterministic: safe to run inside a kea selector on every projection. Completed-turn
+ * summaries are memoized by reference so a streamed token doesn't re-walk frozen groups.
+ */
+
+import { extractClaudeToolName } from '../components/tool/toolResolver'
+import type { ThreadItem, ToolInvocation } from '../types/streamTypes'
+
+/** How aggressively completed turns collapse into a tool-call group chip. */
+export type CollapseMode = 'all' | 'partial' | 'none'
+
+/** The in-flight turn streams expanded; completed turns collapse to a summary chip. */
+export const COLLAPSE_MODE_DEFAULT: CollapseMode = 'partial'
+
+export const grouping = {
+    /** Tool names (SDK `_meta.claudeCode.toolName`) that spawn a subagent — counted separately. */
+    subagentToolNames: new Set<string>(['Task', 'Agent']),
+    /** Max distinct tool icons shown in a collapsed chip's icon strip. */
+    maxIconsInChip: 10,
+} as const
+
+/** Per-action tallies for a collapsed group. */
+export interface GroupCounts {
+    execute: number
+    read: number
+    edit: number
+    delete: number
+    move: number
+    search: number
+    fetch: number
+    subagents: number
+    other: number
+}
+
+/** The closed set of icon keys a chip can carry; mapped to icon components in the chip component. */
+export type GroupIconKey = 'subagent' | `kind:${string}`
+
+export interface GroupSummary {
+    counts: GroupCounts
+    /** Distinct icon keys (deduped, capped at `maxIconsInChip`), in first-seen order. */
+    icons: GroupIconKey[]
+    /** Title of the most recent tool — "what's happening now" while running. */
+    liveLabel: string | null
+    /** Verb-led summary shown once the turn completes (e.g. "Ran 3 commands, read a file"). */
+    doneLabel: string
+    /** This group's last tool call is still pending/in_progress (drives the chip spinner). */
+    active: boolean
+    /** The group did countable tool work — lets the chip show the summary without the "Worked" fallback. */
+    hasCountableWork: boolean
+}
+
+/**
+ * One rendered row of the thread: either a passthrough item or a collapsed tool-call group standing
+ * in for a run of work items.
+ */
+export type ThreadRow =
+    | { kind: 'item'; id: string; item: ThreadItem }
+    | {
+          kind: 'tool_group'
+          id: string
+          items: ThreadItem[]
+          summary: GroupSummary
+          turnComplete: boolean
+          expanded: boolean
+      }
+
+/** Whether an item folds into a tool-call group rather than getting its own row. */
+export function isGroupableItem(item: ThreadItem): boolean {
+    return item.type === 'tool_invocation' || item.type === 'assistant_thought'
+}
+
+function plural(n: number, singular: string, pluralForm: string): string {
+    return `${n} ${n === 1 ? singular : pluralForm}`
+}
+
+function files(n: number): string {
+    return n === 1 ? 'a file' : `${n} files`
+}
+
+/** Verb-led "done" summary, e.g. "Ran 25 commands, read a file, edited a file". */
+export function buildDoneLabel(counts: GroupCounts): string {
+    const seg: string[] = []
+    if (counts.execute > 0) {
+        seg.push(`ran ${plural(counts.execute, 'command', 'commands')}`)
+    }
+    if (counts.read > 0) {
+        seg.push(`read ${files(counts.read)}`)
+    }
+    if (counts.edit > 0) {
+        seg.push(`edited ${files(counts.edit)}`)
+    }
+    if (counts.delete > 0) {
+        seg.push(`deleted ${files(counts.delete)}`)
+    }
+    if (counts.move > 0) {
+        seg.push(`moved ${files(counts.move)}`)
+    }
+    if (counts.search > 0) {
+        seg.push(`ran ${plural(counts.search, 'search', 'searches')}`)
+    }
+    if (counts.fetch > 0) {
+        seg.push(`fetched ${plural(counts.fetch, 'page', 'pages')}`)
+    }
+    if (counts.subagents > 0) {
+        seg.push(`spawned ${plural(counts.subagents, 'subagent', 'subagents')}`)
+    }
+    if (counts.other > 0) {
+        seg.push(`ran ${plural(counts.other, 'tool call', 'tool calls')}`)
+    }
+    if (seg.length === 0) {
+        return 'Worked'
+    }
+    const joined = seg.join(', ')
+    return joined.charAt(0).toUpperCase() + joined.slice(1)
+}
+
+function summarize(items: ThreadItem[], invocations: Map<string, ToolInvocation>): GroupSummary {
+    const counts: GroupCounts = {
+        execute: 0,
+        read: 0,
+        edit: 0,
+        delete: 0,
+        move: 0,
+        search: 0,
+        fetch: 0,
+        subagents: 0,
+        other: 0,
+    }
+    let liveLabel: string | null = null
+    let lastToolStatus: ToolInvocation['status'] | undefined
+    const icons: GroupIconKey[] = []
+    const seen = new Set<GroupIconKey>()
+
+    const addIcon = (key: GroupIconKey): void => {
+        if (seen.has(key) || icons.length >= grouping.maxIconsInChip) {
+            return
+        }
+        seen.add(key)
+        icons.push(key)
+    }
+
+    for (const item of items) {
+        if (item.type !== 'tool_invocation' || !item.toolCallId) {
+            continue
+        }
+        const invocation = invocations.get(item.toolCallId)
+        if (!invocation) {
+            continue
+        }
+        // Most recent tool's title — what the chip shows while still running.
+        if (invocation.title) {
+            liveLabel = invocation.title
+        }
+        lastToolStatus = invocation.status
+        const claudeToolName = extractClaudeToolName(invocation.meta)
+        if (claudeToolName && grouping.subagentToolNames.has(claudeToolName)) {
+            counts.subagents++
+            addIcon('subagent')
+            continue
+        }
+        const kind = invocation.kind ?? null
+        switch (kind) {
+            case 'execute':
+                counts.execute++
+                break
+            case 'read':
+                counts.read++
+                break
+            case 'edit':
+                counts.edit++
+                break
+            case 'delete':
+                counts.delete++
+                break
+            case 'move':
+                counts.move++
+                break
+            case 'search':
+                counts.search++
+                break
+            case 'fetch':
+                counts.fetch++
+                break
+            default:
+                counts.other++
+                break
+        }
+        addIcon(`kind:${kind ?? 'other'}`)
+    }
+
+    const active = lastToolStatus === 'pending' || lastToolStatus === 'in_progress'
+    const hasCountableWork =
+        counts.execute +
+            counts.read +
+            counts.edit +
+            counts.delete +
+            counts.move +
+            counts.search +
+            counts.fetch +
+            counts.subagents +
+            counts.other >
+        0
+    return { counts, icons, liveLabel, active, hasCountableWork, doneLabel: buildDoneLabel(counts) }
+}
+
+// Completed turns are stable by reference, so their summary never changes — cache it keyed on the
+// group's (stable) first item to avoid re-walking frozen groups on every streamed token. The active
+// (incomplete) turn is never cached, so its live label stays correct.
+const summaryCache = new WeakMap<ThreadItem, { len: number; summary: GroupSummary }>()
+
+function summarizeMemo(
+    leading: ThreadItem[],
+    invocations: Map<string, ToolInvocation>,
+    turnComplete: boolean
+): GroupSummary {
+    const key = leading[0]
+    if (turnComplete) {
+        const cached = summaryCache.get(key)
+        if (cached && cached.len === leading.length) {
+            return cached.summary
+        }
+    }
+    const summary = summarize(leading, invocations)
+    if (turnComplete) {
+        summaryCache.set(key, { len: leading.length, summary })
+    }
+    return summary
+}
+
+/**
+ * Fold the flat thread items into rows, collapsing each completed turn's tool-call work into a
+ * chip according to the collapse mode and any per-group overrides.
+ *
+ * Per-group turn completeness is derived from the projection's `turn_separator` items: a group whose
+ * items sit at/before the last separator belongs to a finished turn; the trailing group (the live
+ * turn) uses `currentTurnComplete`.
+ */
+export function buildThreadGroups(
+    items: ThreadItem[],
+    invocations: Map<string, ToolInvocation>,
+    mode: CollapseMode,
+    overrides: Record<string, boolean>,
+    currentTurnComplete: boolean
+): ThreadRow[] {
+    const lastSeparatorIndex = items.findLastIndex((item) => item.type === 'turn_separator')
+    const rows: ThreadRow[] = []
+    let buffer: { item: ThreadItem; index: number }[] = []
+
+    const pushItemRow = (item: ThreadItem): void => {
+        rows.push({ kind: 'item', id: item.id, item })
+    }
+
+    const flush = (): void => {
+        if (buffer.length === 0) {
+            return
+        }
+        const leading = buffer.map((b) => b.item)
+        const first = buffer[0]
+        // A group in a finished turn (its first item precedes the last turn separator) is always
+        // complete; only the live, trailing turn defers to the stream's current turn state.
+        const turnComplete = first.index <= lastSeparatorIndex || currentTurnComplete
+        const groupId = `group:${first.item.id}`
+
+        // Base behavior from the mode; a per-group override (true=expanded, false=collapsed) wins.
+        // A chip shows whenever the group is collapsible by the mode or the user explicitly collapsed it.
+        const baseCollapse = mode === 'all' || (mode === 'partial' && turnComplete)
+        const override = overrides[groupId]
+        const expanded = override ?? !baseCollapse
+        const chipPresent = baseCollapse || override === false
+
+        if (chipPresent) {
+            rows.push({
+                kind: 'tool_group',
+                id: groupId,
+                items: leading,
+                summary: summarizeMemo(leading, invocations, turnComplete),
+                turnComplete,
+                expanded,
+            })
+        } else {
+            for (const item of leading) {
+                pushItemRow(item)
+            }
+        }
+        buffer = []
+    }
+
+    items.forEach((item, index) => {
+        if (isGroupableItem(item)) {
+            buffer.push({ item, index })
+        } else {
+            flush()
+            pushItemRow(item)
+        }
+    })
+    flush()
+
+    return rows
+}


### PR DESCRIPTION
## Problem

The PostHog AI agent-run thread (`products/posthog_ai/frontend`) renders every tool call as its own flat card. A busy turn — a dozen reads, edits, and shell commands — produces a long wall of individual cards you have to scroll past to find the actual answer. The PostHog Code agent UI already solved this by folding a turn's tool activity into a single collapsible summary chip; this brings the same behavior to the shared agent-run surface (consumed by Max and the signals inbox).

## Changes

Each maximal consecutive run of tool calls (and the reasoning thoughts between them) folds into one **summary chip** — e.g. "Ran 3 commands, read a file" with an icon strip — that you click to expand into the individual cards. Direct assistant prose, errors, and status/progress/compaction markers always flush out to their own rows, so a collapsed turn never swallows something said to the user.

Default collapse mode is **partial**: the in-flight turn streams expanded (unchanged from today), and a turn collapses to a chip once it completes. Collapse is overridable per group.

Architecture mirrors PostHog Code's grouping, adapted to this surface's conventions:

- **`logics/threadGroups.ts`** (new, pure) — `buildThreadGroups` folds `threadItems` + the tool-invocation map into render rows; `summarize` builds the verb-led label, per-kind counts, and deduped icon strip. Completed-turn summaries are memoized by reference. Per-group turn completeness is derived from the projection's `turn_separator` items, since a group never straddles a separator.
- **`components/tool/ToolGroupChip.tsx`** (new) — the controlled accordion chip (caret, running spinner, label, tooltip'd icon strip), styled with the existing design system (`@posthog/icons`, lemon-ui, Tailwind) and reusing the `ActivityDetails` rail for the body.
- **`logics/runStreamLogic.ts`** — adds `collapseMode` / `groupOverrides` view state (ephemeral, per `streamKey`), the toggle actions, a listener that clears overrides on mode change, and a memoized `threadRows` selector. All grouping logic lives in the logic, per this folder's AGENTS.md §4.
- **`components/ThreadView.tsx`** — virtualizes `threadRows` (a group is a single row); group rows render `ToolGroupChip` with children fed back through the existing `ThreadRow`.

No new dependencies. The surface stays Max-agnostic — grouping is generic.

## How did you test this code?

I'm an agent (Claude Opus 4.8). I did **not** run the app manually. Automated checks I actually ran:

- `pnpm --filter=@posthog/frontend typescript:check` — the four touched/added files are clean. (Regenerated the kea `*LogicType.ts` via `typegen:file` first.)
- `pnpm --filter=@posthog/frontend format` (oxlint + oxfmt) on the changed files.

Manual verification still needed: drive a Max sandbox run (or the `/tasks` runner) with several tool calls and confirm the active turn streams expanded, completed turns collapse to a chip, and per-group expand/collapse works.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Assignee and reviewers intentionally left unset for now at the requester's direction; the human DRI will be set before review.

Built with Claude Code (Opus 4.8). The task was to research how the separate PostHog Code repo groups tool calls into accordions and port the exact behavior here. Approach: two parallel exploration passes (one over the Code repo's `sessions` feature, one over this surface), then a plan.

Decisions confirmed with the human during planning:
- **Collapse default = partial** (not Code's `all`), so the live turn stays expanded and only finished turns collapse — closer to the current always-expanded feel.
- **What folds in = tool calls + reasoning thoughts** (exact match to Code), while direct assistant prose always flushes to its own row.

Placement decision: Code does the grouping in a component `useMemo`, but this folder's AGENTS.md §4 mandates "logic in the logic," so `buildThreadGroups` is a pure function driven by a kea selector instead. Tool classification uses ACP `kind` for counts and the SDK tool name for subagents; MCP/uncategorized tools fall into a generic "other" bucket rather than depending on uncertain server-name semantics. No skills were invoked. Agent-authored — requires human review.