### PR TITLE
chore(email): assign platform email infrastructure to team-platform-features

### DIFF
--- a/.github/CODEOWNERS-soft
+++ b/.github/CODEOWNERS-soft
@@ -35,6 +35,16 @@ posthog/temporal/messaging/ @PostHog/team-workflows
 frontend/src/scenes/data-pipelines/ @PostHog/team-workflows
 frontend/src/scenes/hog-functions/ @PostHog/team-workflows
 
+# Platform email infrastructure - owned by @PostHog/team-platform-features
+# The shared SMTP/HTTP send path, email settings, and platform-level emails (e.g. daily/weekly
+# project digests). Product-specific emails keep their own owners via more specific entries
+# (workflows messaging above; weekly digest temporal workflow and AI observability templates below).
+posthog/email.py @PostHog/team-platform-features
+posthog/settings/email.py @PostHog/team-platform-features
+posthog/tasks/email.py @PostHog/team-platform-features
+posthog/tasks/email_utils.py @PostHog/team-platform-features
+posthog/helpers/email_utils.py @PostHog/team-platform-features
+
 # Web Analytics - owned by @PostHog/team-web-analytics
 frontend/src/scenes/web-analytics/** @PostHog/team-web-analytics
 posthog/models/web_preaggregated/** @PostHog/team-web-analytics


### PR DESCRIPTION
## Problem

Platform-level emails (the daily/weekly project digests and other notifications) are sent through a shared email path that had **no owner** in `CODEOWNERS-soft`. A recent incident — silent SMTP send failures where a worker kept using stale credentials after a rotation — meant a large batch of these emails never went out, and there was no clear team on the hook for the send infrastructure. This assigns that ownership so future changes and regressions in the shared email path get the right reviewers.

## Changes

Adds a `CODEOWNERS-soft` section assigning the shared email infrastructure to `@PostHog/team-platform-features`:

- `posthog/email.py` — shared SMTP/HTTP send path
- `posthog/settings/email.py` — email/SMTP settings
- `posthog/tasks/email.py` — platform email + digest tasks
- `posthog/tasks/email_utils.py`
- `posthog/helpers/email_utils.py`

Product-specific emails keep their existing owners via more specific entries: workflows messaging (`@PostHog/team-workflows`), the weekly digest temporal workflow (`@PostHog/team-growth`), and AI observability templates (`@PostHog/team-ai-observability`).

These are non-blocking reviewer assignments (`CODEOWNERS-soft`), not required approvals.

## How did you test this code?

I'm an agent. No automated tests apply — this is a reviewer-assignment config change. Verified the listed paths exist and that none are claimed by a more specific entry elsewhere in the file.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested via Slack: route ownership of platform-level emails (daily digests etc.) to the platform team. The team handle was taken from existing `team-platform-features` entries in the same file. Scope was kept to the shared send infrastructure and generic email tasks rather than the email template directory, to avoid pinging the platform team on every product's template change and to leave product-owned emails with their current owners.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C06GG249PR6/p1782810580722529?thread_ts=1782810580.722529&cid=C06GG249PR6)*
