### PR TITLE
fix(settings): guard project move by target org admin level

### DIFF
--- a/frontend/src/scenes/settings/project/ProjectMove.test.tsx
+++ b/frontend/src/scenes/settings/project/ProjectMove.test.tsx
@@ -1,0 +1,90 @@
+import { MOCK_DEFAULT_ORGANIZATION, MOCK_DEFAULT_TEAM, MOCK_DEFAULT_USER } from 'lib/api.mock'
+
+import '@testing-library/jest-dom'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import { OrganizationMembershipLevel } from 'lib/constants'
+import { projectLogic } from 'scenes/projectLogic'
+import { teamLogic } from 'scenes/teamLogic'
+import { userLogic } from 'scenes/userLogic'
+
+import { initKeaTests } from '~/test/init'
+import { OrganizationBasicType } from '~/types'
+
+import { ProjectMove } from './ProjectMove'
+
+// Render LemonSelect as a native <select> so each option's disabled state is assertable from the DOM
+// without driving the (portal-rendered) popover. We only override LemonSelect; the other Lemon components stay real.
+jest.mock('@posthog/lemon-ui', () => ({
+    ...jest.requireActual('@posthog/lemon-ui'),
+    LemonSelect: ({ options, value, onChange, placeholder }: any): JSX.Element => (
+        <select
+            aria-label="target organization"
+            value={value === undefined ? '' : String(value)}
+            onChange={(e) => onChange?.(options.find((o: any) => String(o.value) === e.target.value)?.value)}
+        >
+            <option value="">{placeholder}</option>
+            {options.map((o: any) => (
+                <option key={String(o.value)} value={String(o.value)} disabled={!!o.disabledReason}>
+                    {o.label}
+                </option>
+            ))}
+        </select>
+    ),
+}))
+
+const targetOrg = (overrides: Partial<OrganizationBasicType>): OrganizationBasicType => ({
+    ...MOCK_DEFAULT_ORGANIZATION,
+    ...overrides,
+})
+
+describe('<ProjectMove />', () => {
+    const adminTargetOrg = targetOrg({
+        id: 'org-admin',
+        name: 'Admin Target Org',
+        membership_level: OrganizationMembershipLevel.Admin,
+    })
+    const memberTargetOrg = targetOrg({
+        id: 'org-member',
+        name: 'Member Target Org',
+        membership_level: OrganizationMembershipLevel.Member,
+    })
+
+    beforeEach(() => {
+        initKeaTests()
+        userLogic.mount()
+        teamLogic.mount()
+        projectLogic.mount()
+        // Admin of the current team so the source-org guard (`restrictedReason`) passes and the target guard is what's under test.
+        teamLogic.actions.loadCurrentTeamSuccess({
+            ...MOCK_DEFAULT_TEAM,
+            effective_membership_level: OrganizationMembershipLevel.Admin,
+        })
+        userLogic.actions.loadUserSuccess({
+            ...MOCK_DEFAULT_USER,
+            organization: MOCK_DEFAULT_ORGANIZATION,
+            organizations: [MOCK_DEFAULT_ORGANIZATION, adminTargetOrg, memberTargetOrg],
+        })
+        projectLogic.actions.loadCurrentProjectSuccess({ id: 1, name: 'Source Project' } as any)
+    })
+
+    afterEach(() => {
+        cleanup()
+    })
+
+    it('disables target organizations the user is not an admin of', () => {
+        const { container } = render(<ProjectMove />)
+        expect(screen.getByRole('option', { name: 'Admin Target Org' })).toBeEnabled()
+        expect(screen.getByRole('option', { name: 'Member Target Org' })).toBeDisabled()
+        // No org picked yet, so the Move button is blocked.
+        expect(container.querySelector('[data-attr="move-project-button"]')).toHaveAttribute('aria-disabled', 'true')
+    })
+
+    it('enables the Move button once an admin-eligible target org is selected', async () => {
+        const { container } = render(<ProjectMove />)
+        await userEvent.selectOptions(screen.getByLabelText('target organization'), 'org-admin')
+        expect(container.querySelector('[data-attr="move-project-button"]')).toHaveAttribute('aria-disabled', 'false')
+    })
+})

--- a/frontend/src/scenes/settings/project/ProjectMove.tsx
+++ b/frontend/src/scenes/settings/project/ProjectMove.tsx
@@ -129,7 +129,7 @@ export function ProjectMove(): JSX.Element {
                         moveProjectDisabledReason ??
                         (targetOrganization === null
                             ? 'Please select the target organization'
-                            : targetOrgRestrictionReason ?? undefined)
+                            : (targetOrgRestrictionReason ?? undefined))
                     }
                 >
                     Move {currentProject?.name || 'the current project'}

--- a/frontend/src/scenes/settings/project/ProjectMove.tsx
+++ b/frontend/src/scenes/settings/project/ProjectMove.tsx
@@ -71,6 +71,12 @@ export function MoveProjectModal({
     )
 }
 
+const NOT_ADMIN_OF_TARGET_REASON = 'You need to be an admin or owner of this organization to move a project into it'
+
+function notAdminOfOrg(organization: OrganizationBasicType): boolean {
+    return (organization.membership_level ?? OrganizationMembershipLevel.Member) < OrganizationMembershipLevel.Admin
+}
+
 export function ProjectMove(): JSX.Element {
     const { currentProject } = useValues(projectLogic)
     const { otherOrganizations } = useValues(userLogic)
@@ -84,6 +90,12 @@ export function ProjectMove(): JSX.Element {
     })
     const { moveProjectDisabledReason } = useValues(projectLogic)
 
+    // Moving a project requires admin (or owner) on BOTH organizations — the API enforces this. The source org is
+    // covered by `restrictedReason` above; guard the target org here so a member of the target org gets a clear
+    // message instead of a failed request.
+    const targetOrgRestrictionReason =
+        targetOrganization && notAdminOfOrg(targetOrganization) ? NOT_ADMIN_OF_TARGET_REASON : null
+
     return (
         <>
             <p>
@@ -95,6 +107,7 @@ export function ProjectMove(): JSX.Element {
                     options={otherOrganizations.map((o) => ({
                         label: o.name,
                         value: o.id,
+                        disabledReason: notAdminOfOrg(o) ? NOT_ADMIN_OF_TARGET_REASON : undefined,
                     }))}
                     placeholder="Select target organization"
                     onChange={(value) => {
@@ -114,7 +127,9 @@ export function ProjectMove(): JSX.Element {
                     disabledReason={
                         restrictedReason ??
                         moveProjectDisabledReason ??
-                        (targetOrganization === null && 'Please select the target organization')
+                        (targetOrganization === null
+                            ? 'Please select the target organization'
+                            : targetOrgRestrictionReason ?? undefined)
                     }
                 >
                     Move {currentProject?.name || 'the current project'}


### PR DESCRIPTION
## Problem

Moving a project between organizations requires the user to be an admin (or owner) of **both** the source and target orgs — `change_organization` (`posthog/api/project.py`) enforces this. But the move UI only guarded the source side (`useRestrictedArea` with the `Project` scope) and the "you're not in any other org" case. A user who's an admin of the source org but only a **member** of the target org saw an enabled org picker and Move button, clicked through, and got a raw `400` surfaced as an uncaught exception + error toast — with no hint at what was wrong.

## Changes

- Disable target organizations the user isn't an admin/owner of in the destination `LemonSelect`, with a clear `disabledReason`.
- Give the **Move** button a matching disabled reason when the selected target org isn't one the user can move into.
- Add a Jest component test covering both states.

`OrganizationBasicType.membership_level` is already present on `otherOrganizations`, so the guard itself is purely a frontend change — no API or type changes.

## Background

The admin-of-both-orgs rule this surfaces isn't new — it's been the enforced backend behavior since self-service moving shipped in #28187 (2025-02-04), and the `change_organization` permission logic is unchanged since launch (covered by `test_cant_change_organization_if_not_admin_of_target_org` / `..._source_org`). The UI simply never reflected the *target* side: the only client-side gate is `moveProjectDisabledReason` (added in #42648, 2025-12-04), which checks "you're not in any other org." This PR closes that gap.

(Tangent worth noting from the same dig: the docs claimed a "source org must have ≥2 projects" rule that the product has never enforced — a pickaxe across full history finds that wording only in the docs. Corrected in PostHog/posthog.com#18025.)

## How did you test this code?

**Automated.** Added a Jest component test, `frontend/src/scenes/settings/project/ProjectMove.test.tsx`, run with `hogli test frontend/src/scenes/settings/project/ProjectMove.test.tsx` (2 passing). It mounts `userLogic` / `teamLogic` / `projectLogic` with a user who is an admin of the source team plus two target orgs (one where they are an Admin, one where they are only a Member), renders `ProjectMove`, and asserts:

- the member-only target org is disabled in the destination picker, while the admin org is selectable;
- the **Move** button stays blocked until an admin-eligible target org is picked, then unblocks.

I also confirmed the test goes red if the new `disabledReason` guard on the picker options is removed, so it locks in the fix rather than passing vacuously. To keep the assertion on each option's disabled state out of the portal-rendered popover, the test stubs `LemonSelect` with a native `<select>` (mirroring the existing `scenes/debug/Modifiers.test.tsx` precedent) and leaves the other Lemon components real.

**Manual (local dev stack).** Verified both paths end to end:

1. Created a second org and demoted myself to member-only there (`OrganizationMembership.Level.MEMBER`), staying owner of the source org.
2. **Blocked path:** in the source project's **Move project** section, the member-only target org is disabled in the picker with the tooltip *"You need to be an admin or owner of this organization to move a project into it"*, and the **Move** button is disabled.
3. **Happy path:** promoted myself back to admin of the target org — the target org becomes selectable and the **Move** button enables once it's picked.

I did not run the full TypeScript check or app build locally (whole-monorepo passes); CI covers those.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Matching docs fix: PostHog/posthog.com#18025 — the docs also overstated the move requirements.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

A support engineer investigating a ticket — a free-plan user who couldn't move their only project to another org — asked whether the underlying friction was fixable. Tracing the move path surfaced two issues: the docs overstated the requirements (fixed in posthog.com#18025), and the move UI doesn't reflect the API's admin-of-both-orgs rule, producing a confusing failed request instead of inline guidance.

- Tool: Claude Code (PostHog Code), via the support MCP + GitHub.
- Skills: `/writing-tests` was invoked before adding the Jest test (which gated it as worth keeping — it catches removal of the new guard, a path with no prior coverage). No DRF/serializer, migration, or generated-API-type changes.
- Decision: put the guard in the component (mirroring the existing `restrictedReason` pattern) rather than `projectLogic`, since the selected target org is local component state. Considered gating only the button, but disabling ineligible options too gives clearer feedback.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*