### PR TITLE
feat(signals): opt the logs scout into the report channel

### DIFF
--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -3,14 +3,18 @@ name: signals-scout-logs
 description: >
   Focused Signals scout for PostHog projects using logs. Watches for volume bursts,
   severity-distribution shifts, service silence, fresh message patterns, and
-  trace-correlated bursts via the logs ingestion pipeline. Emits findings only when
-  they clear the confidence bar; otherwise writes durable memory and closes out empty.
-  Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
+  trace-correlated bursts via the logs ingestion pipeline. Authors reports directly into
+  the Signals inbox when a shift clears the bar; otherwise writes durable memory and closes
+  out empty. Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP tool family plus the logs tool family listed in the body's MCP
-  tools section.
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
+  read-only analytics plus signal_scout_internal:write (for scratchpad) +
+  signal_scout_report:write (for emit-report/edit-report, granted because this scout authors
+  reports directly via the report channel). Assumes the signals-scout MCP tool family plus the
+  logs tool family listed in the body's MCP tools section.
+allowed_tools:
+  - emit_report
+  - edit_report
 metadata:
   owner_team: signals
   scope: logs
@@ -19,10 +23,17 @@ metadata:
 # Signals scout: logs
 
 You are a focused logs scout. Spot meaningful changes in this team's log volume,
-severity distribution, service activity, and fresh message patterns — and emit findings
-only when they clear the confidence bar. Logs live in their own ingestion pipeline
+severity distribution, service activity, and fresh message patterns — and file them as
+reports in the inbox when they clear the bar. Logs live in their own ingestion pipeline
 distinct from `top_events`, so the project profile won't tell you whether logs are
 loud today; you have to ask.
+
+You author reports directly via the report channel (`signals-scout-emit-report` /
+`signals-scout-edit-report`): you've done the research, so you own each report 1:1
+end-to-end rather than firing weak signals for a pipeline to cluster. The bar is
+correspondingly high — file a report only for a localized, validated shift you'd stand
+behind as a standalone inbox item a human will act on. A recurring or worsening issue the
+inbox already covers is an **edit**, not a new report.
 
 ## The stream is a firehose — never count it unfiltered
 
@@ -69,9 +80,14 @@ Cycle between these moves; skip what's not useful, revisit what is.
 Three cheap reads cold-start a run:
 
 - `signals-scout-scratchpad-search` (`text=logs` or `text=service`) — durable team steering
-  from past logs-focused runs. **Entries with `pattern:`, `noise:`, `addressed:`, or
-  `dedupe:` key prefixes tell you what's normal, what's already surfaced, what to skip.**
+  from past logs-focused runs. **Entries with `pattern:`, `noise:`, `addressed:`, `dedupe:`,
+  `report:`, or `reviewer:` key prefixes tell you what's normal, what's already reported, what
+  to skip, which report covers a service, and who owns it.**
 - `signals-scout-runs-list` (last 7d) — what prior logs scouts found and ruled out.
+- `inbox-reports-list` (filter by `search`=service/message, `source_product`, `ordering=-updated_at`)
+  — the reports already in the inbox. A logs shift on a service you've reported before is an
+  **edit**, not a fresh report; pull the closest matches with `inbox-reports-retrieve` before
+  authoring.
 - **The cheap tripwire set** (runs in seconds, no firehose) — this is the
   is-anything-loud-today check, _not_ an unfiltered baseline diff:
   1. `logs-services-create` over `-1h` (read the `services` list, ignore the `sparkline`;
@@ -180,7 +196,8 @@ genuinely firing.)
 
 Memory is a continuous activity. Write a scratchpad entry whenever you observe something
 a future logs run should know. Encode the "category" in the key prefix — `pattern:`,
-`noise:`, `addressed:`, `dedupe:` — so future runs can find it with a single `text=` search:
+`noise:`, `addressed:`, `dedupe:`, `report:`, `reviewer:` — so future runs can find it with
+a single `text=` search:
 
 - key `pattern:logs:temporal-worker` — _"Service `temporal-worker` typical log volume:
   ~12k/hour with ~3% error severity. Anything > 10% error in the recent window is fresh
@@ -192,29 +209,54 @@ a future logs run should know. Encode the "category" in the key prefix — `patt
 - key `addressed:logs:cdp-worker-2026-04-30` — _"Service `cdp-worker` migrated to a new
   runtime on 2026-04-30 — log volume baseline shifted from 8k/hour to 14k/hour, treat new
   baseline as normal."_
+- key `report:logs:temporal-worker` — _"Authored report `019f0a96-…` for the temporal-worker
+  error-rate burst on 2026-06-30. Edit it (append_note) if the burst persists or worsens
+  rather than filing a new one."_
+- key `reviewer:logs:temporal-worker` — _"`temporal-worker` logs owned by `alice` (GitHub
+  login) — route its reports there."_
 
 By run #5 you'll know per-service volume and severity baselines, which alerts are
-intentional outliers, and only surface fresh shifts.
+intentional outliers, which open report covers a service, who owns it, and only file fresh
+shifts.
 
 ### Decide
 
-For each candidate finding:
+Search the inbox before you author — a report covering this service / message / shift may
+already exist (`inbox-reports-list` with `ordering=-updated_at`, then `inbox-reports-retrieve`
+the closest matches). Then, for each candidate finding:
 
-- **Emit** via `signals-scout-emit-signal` if it clears the confidence bar.
-  Strong scout findings: confidence ≥ 0.85, with concrete service /
-  message / time-range evidence.
-- **Remember** if below the bar but worth carrying forward.
-- **Skip** with a one-line note if a scratchpad entry with a `noise:` or `addressed:`
-  key prefix already covers it.
+- **Edit** the existing report via `signals-scout-edit-report` when the inbox already covers
+  the service or pattern. A logs shift is rarely brand-new — a service that's still degrading,
+  an alert that's flapping again, a burst that's worsening: `append_note` with the fresh
+  numbers and time range (or rewrite the title/summary on a report you authored). This is the
+  default when a match exists; don't mint a near-duplicate. The dedupe pull is real here — the
+  same service moving twice in two days is one report, not two.
+- **Author** a fresh report via `signals-scout-emit-report` when nothing in the inbox covers
+  it (or a known issue has new evidence that changes the verdict). The natural fit is a single,
+  localized, validated shift — one service's volume burst, one severity step, one silent
+  service, one fresh message firing at scale — with concrete service / message / time-range
+  evidence (the bar is confidence ≥ 0.85). Most logs reports are an investigation, not a
+  one-line code fix, so default to `requires_human_input`. **Always set `suggested_reviewers`**
+  — resolve the owning person's GitHub login with `org-member-get-github-login` (cache it under
+  a `reviewer:logs:<service>` key). It's how the report reaches a human; left empty, the report
+  is assigned to nobody and is likely missed. After authoring, write a `report:logs:<service>`
+  scratchpad entry with the `report_id` so the next run edits it instead of duplicating. The
+  full report channel — field schema, safety × actionability status mapping, reviewer routing,
+  dedupe (it is **not** idempotent), and the edit rules — lives in
+  [`references/report.md`](references/report.md).
+- **Remember** via `signals-scout-scratchpad-remember` if it's below the bar but worth
+  carrying forward, or to record what you ruled out and why.
+- **Skip** with a one-line note if a scratchpad entry with a `noise:` or `addressed:` key
+  prefix, or an existing inbox report, already covers it.
 
-If a prior run already covered the topic, default to skip + scratchpad refresh rather
-than re-emit. Same fact twice in the inbox degrades signal-to-noise more than missing
-one finding for one tick.
+If a prior run already covered the topic, default to edit-or-skip + scratchpad refresh rather
+than a fresh report. The same fact twice in the inbox degrades signal-to-noise more than
+missing one finding for one tick.
 
 ### Close out
 
-**Summarize the run** — one paragraph: looked at what, emitted what, remembered what,
-ruled out what. The harness writes this to the run row as searchable prose; future runs
+**Summarize the run** — one paragraph: looked at what, authored or edited which reports,
+remembered what, ruled out what. The harness writes this to the run row as searchable prose; future runs
 read it via `signals-scout-runs-list`. Do **not** write a separate "run metadata"
 scratchpad entry — the run summary already serves that role.
 
@@ -230,9 +272,9 @@ scratchpad entry — the run summary already serves that role.
 - **Logs alerts in muted / snoozed state** — explicit team decision; don't override.
 - **Log error already covered by error tracking** — if a log record correlates 1:1
   with an `$exception` issue already surfaced, that issue's finding (or a scratchpad
-  entry with `dedupe:` key prefix) governs. Don't double-emit.
+  entry with `dedupe:` key prefix) governs. Don't author a duplicate report.
 
-When in doubt, write a memory entry instead of emitting.
+When in doubt, write a memory entry instead of filing a report.
 
 ## MCP tools
 
@@ -256,7 +298,12 @@ Direct calls (read-only):
 - `logs-alerts-list` / `logs-alerts-retrieve` — configured alerts and current state.
 - `logs-alerts-events-list` — an alert's firing history (fires/resolves/flaps); tells a
   fresh fire from a chronically-firing misconfigured one. May 403 on a personal key.
-- `inbox-reports-list` — verify a finding isn't already in the inbox.
+- `inbox-reports-list` / `inbox-reports-retrieve` — the reports already in the inbox; check
+  before authoring so you edit instead of duplicating (`ordering=-updated_at`).
+- `inbox-report-artefacts-list` — a comparable report's artefact log, where the routed
+  `suggested_reviewers` live (the report record doesn't expose them) — reviewer precedent.
+- `org-members-list` / `org-member-get-github-login` — resolve a service's owner to a bare
+  GitHub login for `suggested_reviewers` (returns null when unlinked → try the next owner).
 - `query-error-tracking-issues-list` — cross-check whether a log error already has an issue;
   error tracking owns those findings.
 
@@ -264,13 +311,14 @@ Harness-level:
 
 - `signals-scout-project-profile-get` / `signals-scout-scratchpad-search` /
   `signals-scout-runs-list` / `signals-scout-runs-retrieve` — orientation + dedupe.
-- `signals-scout-emit-signal` / `signals-scout-scratchpad-remember` — emit / remember.
+- `signals-scout-emit-report` / `signals-scout-edit-report` / `signals-scout-scratchpad-remember`
+  — author a report / edit an existing one / remember.
 
 ## When to stop
 
 - Volume + severity at baseline, no fresh patterns → close out empty.
 - A candidate matches a scratchpad entry with `noise:` / `addressed:` / `dedupe:` key
   prefix → skip with a one-line note.
-- You've validated some hypotheses and emitted what's solid → close out.
+- You've validated some hypotheses and filed (or edited) reports for what's solid → close out.
 
 "Looked but found nothing meaningful" is a real outcome.

--- a/products/signals/skills/signals-scout-logs/references/report.md
+++ b/products/signals/skills/signals-scout-logs/references/report.md
@@ -1,0 +1,183 @@
+# The report channel: `emit-report` / `edit-report`
+
+The report channel is your output: you've already done the research, so you file a full
+`SignalReport` into the inbox directly — no weak signals, no pipeline clustering. This reference
+is the contract: the two tools, their fields, how to choose between authoring and editing, and the
+two behaviors that make this channel different (it isn't idempotent, and the pipeline may later
+rewrite what you authored).
+
+> Like every `signals-scout-*` tool, **both report tools require the current `run_id`** (the
+> run you're executing in) on every call — omitting it fails validation.
+
+## Author or edit
+
+| You have…                                                                                                       | Use           |
+| --------------------------------------------------------------------------------------------------------------- | ------------- |
+| A finished, well-formed finding nothing in the inbox covers — filed **1:1** with full control of title/summary. | `emit-report` |
+| New information about a report that already exists (one you authored last run, or a pipeline report).           | `edit-report` |
+
+**Always search the inbox first** (`inbox-reports-list` → `inbox-reports-retrieve`): edit an
+existing report rather than mint a near-duplicate. A logs shift is report-shaped when it's a
+single, localized, validated change — one service's volume burst, one severity-distribution step,
+one silent service, one fresh message pattern firing at scale — that you've corroborated and would
+stand behind as a standalone inbox item. A scatter of small, weakly-correlated wobbles across many
+services is not a report — it's a sign you haven't found the finding yet; keep investigating or
+record it in the scratchpad and move on.
+
+Filing a report is a **high bar**. Author one only for a finding you'd own end-to-end as an inbox
+item a human will act on. When you can't get there, a scratchpad note is the right home — never
+file a half-formed report to fill space.
+
+## `emit-report` — author a full report
+
+Judges the report for safety, then persists it at the judged status.
+
+| Field                       | Type                    | Notes                                                                                                                                                                                                                                              |
+| --------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_id`                    | string, required        | The current run's id — same as every `signals-scout-*` tool.                                                                                                                                                                                       |
+| `title`                     | string, ≤300, non-empty | The inbox headline. One specific, quantified line.                                                                                                                                                                                                 |
+| `summary`                   | string                  | The report body prose — hook → pattern → hypothesis → recommendation. See _Writing the summary_ below.                                                                                                                                             |
+| `evidence`                  | list, 1–50              | Each `{description, source_id}`. Becomes a bound signal row backing the report. `source_id` is the citable entity id. Hard cap of **50** — summarize/trim before calling; a longer list fails validation before the report is judged or persisted. |
+| `actionability_explanation` | string                  | One sentence justifying the actionability call below.                                                                                                                                                                                              |
+| `actionability`             | enum                    | `immediately_actionable` / `requires_human_input` / `not_actionable`. You make this call — the channel does not re-research it.                                                                                                                    |
+| `already_addressed`         | bool, default `false`   | Set when the underlying issue is already handled and you're filing for the record.                                                                                                                                                                 |
+
+**Status is decided for you, from safety × actionability:**
+
+| Safety judge | `actionability`          | Resulting status | Surfaces in inbox? |
+| ------------ | ------------------------ | ---------------- | ------------------ |
+| safe         | `immediately_actionable` | `READY`          | yes                |
+| safe         | `requires_human_input`   | `PENDING_INPUT`  | yes                |
+| safe         | `not_actionable`         | `SUPPRESSED`     | no                 |
+| unsafe       | (any)                    | `SUPPRESSED`     | no                 |
+
+Note the trap: `not_actionable` is **suppressed** (never surfaces). Reserve it for filing-for-the-record;
+if you want a human to see it, it must be `immediately_actionable` or `requires_human_input`.
+
+The result tells you what happened: `report_id` (always set when a report was persisted —
+**even when suppressed**, so you can edit or dedup against it), `report_status` (the birth status —
+`ready` / `pending_input` / `suppressed`), `emitted` (true only when it actually surfaced),
+`safety_explanation`, and `skipped_reason` (set only when a preflight gate — the team's
+AI-data-processing approval or the signals-scout source being enabled — stopped the call before any
+report was created).
+
+### Writing the `title` and `summary`
+
+The `title` is the inbox headline and the `summary` is the body a human reads to decide whether to
+act — write both for a busy reader scanning a feed of other reports.
+
+- **`title`** — one specific, quantified line. Lead with what's wrong, which service, and the blast
+  radius, not a vague category. _"`temporal-worker` error-log rate jumped from ~3% to 22% of its
+  volume after 14:00 UTC"_, not _"Log errors up"_.
+- **`summary`** — a tight few paragraphs following hook → pattern → hypothesis → recommendation:
+  1. **Hook** — what's happening, quantified ("`temporal-worker` error+fatal lines rose from
+     ~360/hr to ~2.6k/hr between 14:00 and 15:30 UTC, while its total volume held flat").
+  2. **Pattern** — the shape that makes this signal, not noise ("the rise is confined to one
+     service and one message signature, and `top_events` shows `$exception` flat over the same
+     window — a caught-and-logged failure error tracking won't surface").
+  3. **Hypothesis** — your best read of the cause.
+  4. **Recommendation** — the concrete action that would resolve it.
+
+Quantify ("~2.6k/hr") over qualitative ("a lot"), and cite entity ids (service names, message
+signatures, alert ids, time ranges, trace ids) inline so a reviewer can pivot straight from prose to
+source. Put the same citations in `evidence` so they back the report as bound signals.
+
+### Opening a draft PR (autostart)
+
+First, `suggested_reviewers` is **not** a PR field — set it whenever you can name a plausible owner,
+PR or not. It's the routing lever and is covered in its own section below; the three fields in this
+section are the **PR-only** ones.
+
+A surfaced, immediately-actionable report can open a draft PR automatically. It's opt-in per report
+via these fields; supply them only when the report is a concrete, fixable issue you'd want a PR for.
+
+| Field                  | Type      | Notes                                                                                                                                                                                                                                                    |
+| ---------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository`           | string    | `"owner/repo"` targets that repo; the `NO_REPO` sentinel opts out; **omitting it** falls back to free-form selection across the team's repos — the slow path on a many-repo team (it spawns a selection sandbox), so pass `owner/repo` when you know it. |
+| `priority`             | `P0`-`P4` | Required for a PR. Pair with `priority_explanation`.                                                                                                                                                                                                     |
+| `priority_explanation` | string    | Required when `priority` is set.                                                                                                                                                                                                                         |
+
+Repo selection only runs when you signal PR intent — an explicit `repository`, or both `priority`
+and `suggested_reviewers`. A report that supplies none of these just surfaces in the inbox (no repo
+sandbox, no PR). Autostart no-ops unless the report is `immediately_actionable`, has a repo +
+priority, and a reviewer qualifies — so these three PR fields are safe to omit for an informational
+report. `suggested_reviewers` is not: set it whenever you can name a plausible owner (see the next
+section), PR or not. A logs anomaly is usually a thing to investigate, not a one-line code fix, so
+most logs reports want `requires_human_input` and a reviewer, not a PR.
+
+## `suggested_reviewers` — set it on every report (this is how it reaches a human)
+
+`suggested_reviewers` is the **single most important routing field**. It is how a report reaches the
+right person: the inbox orders by `is_suggested_reviewer`, so a reviewer's own reports float to the
+top of _their_ inbox even when **no PR** is involved. **A report with an empty `suggested_reviewers`
+is assigned to nobody — it lands in the shared inbox and is very likely to be missed.** So resolve and
+set at least one reviewer on every report you author, including informational `requires_human_input`
+ones.
+
+Each entry must be a **bare, lowercase GitHub login** — no `@`, no display name (e.g. `octocat`, not
+`@OctoCat`). Assignment matches the login against each user's linked GitHub login by exact, lowercased
+comparison, so a mis-cased handle, an `@`-prefix, a display name, a team slug, or an email won't
+assign to anyone. You rarely know the login outright, so resolve it — cheapest first:
+
+1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a prior run) recorded — reuse it.
+   For logs, key by the owning service (`reviewer:logs:<service>`).
+2. **Inbox precedent.** `inbox-reports-list` (filter by `source_product` + a free-text `search`) for a
+   comparable report on the same service/surface, then `inbox-report-artefacts-list` on it — the
+   `suggested_reviewers` artefact is where the routed reviewer lives (the report record itself doesn't
+   expose it). Reuse that reviewer for the same area.
+3. **`org-member-get-github-login`** — the **canonical resolver, available on every run**. Identify the
+   owning **person** (by name/email via `org-members-list`, or `@me`), then pass their PostHog user
+   UUID to `org-member-get-github-login` to get their linked GitHub login. It returns null when the
+   person hasn't linked a GitHub account — then try the next plausible owner.
+
+**Never guess a handle** — a wrong login mis-assigns the report, which is worse than leaving it open.
+If you genuinely can't resolve any confident owner, author the report anyway (it still surfaces) but
+treat that as the exception, not the norm. Once you've tied a service to an owner, write a
+`reviewer:logs:<service>` scratchpad entry with the bare lowercase login so the next run routes
+instantly.
+
+**On `edit-report`:** reviewers are set at author time and `edit-report` can't change them — so the
+one chance to route a report is when you `emit-report` it. If you're editing a report that landed with
+no reviewer, `append_note` naming the owner you'd route it to so a human can pick it up; the durable
+fix is to get `suggested_reviewers` right at emit.
+
+## `edit-report` — update an existing report
+
+Rewrite `title`/`summary` and/or append a note to a report that already exists. Pass `run_id` and
+`report_id`, plus at least one of `title`, `summary`, `append_note`.
+
+`edit-report` can target **any** of the team's inbox reports — not just ones a scout authored. That
+makes it the right tool when a later run learns something about a report the pipeline (or another
+scout) created. Two rules of good behavior:
+
+- **Prefer `append_note` over rewriting** `title`/`summary` on a report you didn't author. A note is
+  additive and audit-friendly (it carries your scout as author); a rewrite silently overwrites a
+  human- or pipeline-authored headline.
+- **Don't fight an in-flight pipeline.** A report the summary/research workflow is mid-run on can have
+  its fields overwritten under you. If a report is actively being worked, append a note rather than
+  rewriting.
+
+## Dedup: the channel is NOT idempotent
+
+`emit-report` is **not idempotent** — a retried call authors a _second_ report. There is no
+server-side dedup key. The dedup story is two-sided and you own it:
+
+1. **Before authoring**, `inbox-reports-list` for a prior report on the same topic (filter by
+   `search` / `status` / `source_product`). Pass `ordering=-updated_at` — the default ordering buckets
+   by your own reviewer-match and status first, so without it the most recent duplicate can sort below
+   older rows and you'd miss it. Found one? `edit-report` it instead of authoring a new one.
+2. **After authoring**, write a `report:logs:<service>` scratchpad entry recording the `report_id`
+   so the next run finds it (via `inbox-reports-retrieve`) without a title-search guess.
+
+**Never retry an `emit-report` / `edit-report` call that may have succeeded** — a transport error
+after the write commits, retried, double-files. If unsure whether a call landed, `inbox-reports-list`
+to check before retrying.
+
+## The pipeline may rewrite what you authored (accepted)
+
+An authored report is a first-class report that coexists with pipeline reports. When future signals
+consolidate around the same topic, the pipeline may **re-promote and re-research the report,
+overwriting your authored `title`/`summary`**. This is accepted behavior, not a bug — there is no
+pin. Author the finding, and let the inbox stay the source of truth for how it's currently framed.
+Your durable record of "I filed this" is the `report:` scratchpad entry and the `report_id`, not the
+title text.

--- a/products/signals/skills/signals-scout-logs/references/report.md
+++ b/products/signals/skills/signals-scout-logs/references/report.md
@@ -41,6 +41,7 @@ Judges the report for safety, then persists it at the judged status.
 | `actionability_explanation` | string                  | One sentence justifying the actionability call below.                                                                                                                                                                                              |
 | `actionability`             | enum                    | `immediately_actionable` / `requires_human_input` / `not_actionable`. You make this call — the channel does not re-research it.                                                                                                                    |
 | `already_addressed`         | bool, default `false`   | Set when the underlying issue is already handled and you're filing for the record.                                                                                                                                                                 |
+| `suggested_reviewers`       | list of strings         | Bare, lowercase GitHub logins. The **single most important routing field** — set on every report (PR or not). See the _`suggested_reviewers`_ section below for resolution steps.                                                                  |
 
 **Status is decided for you, from safety × actionability:**
 


### PR DESCRIPTION
## Problem

We're retiring the scouts' weak `emit_signal` path fleet-wide: every canonical scout should author and edit full `SignalReport`s directly via the report channel, each with its own grouping/edit-vs-new guidance. The general scout was the first port ([#66923](https://github.com/PostHog/posthog/pull/66923)); this does the same for the logs scout.

## Changes

Ports `signals-scout-logs` to be report-only, mirroring the general scout:

- **Frontmatter** — adds `allowed_tools: [emit_report, edit_report]` (the channel opt-in that forks the harness into the report persona) and adds `signal_scout_report:write` to the compatibility scope line.
- **Body** — rewrites the intro and `Decide` section from emit-signal to author/edit-report. Orientation now reads `inbox-reports-list` so a shift on an already-reported service is an **edit**, not a duplicate. `Decide` searches the inbox first, edits before authoring a near-duplicate, and **always sets `suggested_reviewers`** (resolved via `org-member-get-github-login`). All the domain expertise — the firehose/`logs-count` 500 notes, the cheap tripwire set, and the explore patterns (volume burst, severity shift, service silence, fresh message, trace-correlated burst, alert-without-coverage) — is preserved unchanged.
- **Logs-specific report discipline** — the scratchpad vocabulary gains `report:logs:<service>` (the report a service maps to) and `reviewer:logs:<service>` (its owner). Because logs is a high-volume watcher where the same service moves repeatedly, the guidance leans hard on **edit-over-author** and defaults most reports to `requires_human_input` (a logs anomaly is an investigation, not a one-line PR fix).
- **Bundled `references/report.md`** — the report-channel contract, adapted from the general scout's copy (a scout only reads its own files at runtime, so each adopter bundles its own).

## How did you test this code?

I'm an agent (Claude Code). No manual scout runs — scouts fire on their own schedule. Automated check run:

- `products/posthog_ai/scripts/build_skills.py --lint` → **OK: 97 skills passed**. The one advisory warning is a pre-existing stale-ref in a different skill (`authoring-scouts`), unrelated to this change.
- Markdown formatted via oxfmt / `hogli format:markdown` (lint-staged on commit).

No backend/serializer/migration changes — this is a skill-content-only port. The channel mechanics (safety judge, scope gating, prompt fork on `allowed_tools`) already shipped; this only opts the logs skill in.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed the work; assigned as DRI.

- **Agent/tools:** Claude Code (Opus 4.8). Skills invoked: `/authoring-signals-scouts` (the canonical scout-authoring skill) and `/phs scouts-emit-reports` (the feature's tracking doc).
- **Decision:** the tracking doc's old §Per-scout port guidance flagged volume/anomaly watchers like logs as a poor fit for report-only (loses pipeline clustering). Andy clarified the current direction supersedes that — `emit_signal` is being retired fleet-wide and each scout carries its own grouping/edit guidance instead. This port reflects that: logs commits fully to the channel but leans on edit-over-author to get the consolidation the pipeline used to provide.
- Recipe followed the general-scout port exactly (report-only, bundle `report.md`, reviewer routing via `org-member-get-github-login`), retuned for the logs domain.

The tracking doc's §Per-scout port section still says "leave logs on emit_signal" — that guidance is now stale and should be updated to match the retire-`emit_signal` direction in a follow-up.
