### PR TITLE
feat(experiments): surface bytes/rows scanned in slowest queries

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -44,6 +44,21 @@ const METRIC_TYPE_OPTIONS = [
     { value: 'retention', label: 'Retention' },
 ]
 
+function QueryStats({
+    read_bytes,
+    read_rows,
+    memory_usage,
+    exception_code,
+}: Pick<SlowestQuery, 'read_bytes' | 'read_rows' | 'memory_usage' | 'exception_code'>): JSX.Element {
+    return (
+        <div className="font-mono text-xs text-muted">
+            Read {humanizeBytes(read_bytes)} · {read_rows.toLocaleString()} rows
+            {memory_usage ? ` · ${humanizeBytes(memory_usage)} peak memory` : ''}
+            {exception_code ? ` · exit code ${exception_code}` : ''}
+        </div>
+    )
+}
+
 export function QueryPerformance(): JSX.Element {
     const { user } = useValues(userLogic)
     const {
@@ -394,16 +409,7 @@ export function QueryPerformance(): JSX.Element {
                                         expandedRowRender: function ExpandedQuery(item) {
                                             return (
                                                 <div className="flex flex-col gap-2 p-2">
-                                                    <div className="font-mono text-xs text-muted">
-                                                        Read {humanizeBytes(item.read_bytes)} ·{' '}
-                                                        {item.read_rows.toLocaleString()} rows
-                                                        {item.memory_usage
-                                                            ? ` · ${humanizeBytes(item.memory_usage)} peak memory`
-                                                            : ''}
-                                                        {item.exception_code
-                                                            ? ` · exit code ${item.exception_code}`
-                                                            : ''}
-                                                    </div>
+                                                    <QueryStats {...item} />
                                                     {item.sub_queries && item.sub_queries.length > 0 && (
                                                         <div>
                                                             <h4 className="mb-1">Sub-queries (precompute builds)</h4>
@@ -415,19 +421,7 @@ export function QueryPerformance(): JSX.Element {
                                                                     expandedRowRender: function ExpandedSubQuery(sub) {
                                                                         return (
                                                                             <div className="flex flex-col gap-2 p-2">
-                                                                                <div className="font-mono text-xs text-muted">
-                                                                                    Read {humanizeBytes(sub.read_bytes)}{' '}
-                                                                                    · {sub.read_rows.toLocaleString()}{' '}
-                                                                                    rows
-                                                                                    {sub.memory_usage
-                                                                                        ? ` · ${humanizeBytes(
-                                                                                              sub.memory_usage
-                                                                                          )} peak memory`
-                                                                                        : ''}
-                                                                                    {sub.exception_code
-                                                                                        ? ` · exit code ${sub.exception_code}`
-                                                                                        : ''}
-                                                                                </div>
+                                                                                <QueryStats {...sub} />
                                                                                 <CodeSnippet
                                                                                     language={Language.SQL}
                                                                                     thing="query"

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -11,6 +11,7 @@ import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { LemonTag } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
+import { humanizeBytes } from 'lib/utils/numbers'
 import { SceneExport } from 'scenes/sceneTypes'
 import { userLogic } from 'scenes/userLogic'
 
@@ -393,6 +394,16 @@ export function QueryPerformance(): JSX.Element {
                                         expandedRowRender: function ExpandedQuery(item) {
                                             return (
                                                 <div className="flex flex-col gap-2 p-2">
+                                                    <div className="font-mono text-xs text-muted">
+                                                        Read {humanizeBytes(item.read_bytes)} ·{' '}
+                                                        {item.read_rows.toLocaleString()} rows
+                                                        {item.memory_usage
+                                                            ? ` · ${humanizeBytes(item.memory_usage)} peak memory`
+                                                            : ''}
+                                                        {item.exception_code
+                                                            ? ` · exit code ${item.exception_code}`
+                                                            : ''}
+                                                    </div>
                                                     {item.sub_queries && item.sub_queries.length > 0 && (
                                                         <div>
                                                             <h4 className="mb-1">Sub-queries (precompute builds)</h4>
@@ -403,13 +414,28 @@ export function QueryPerformance(): JSX.Element {
                                                                 expandable={{
                                                                     expandedRowRender: function ExpandedSubQuery(sub) {
                                                                         return (
-                                                                            <CodeSnippet
-                                                                                language={Language.SQL}
-                                                                                thing="query"
-                                                                                maxLinesWithoutExpansion={10}
-                                                                            >
-                                                                                {sub.query}
-                                                                            </CodeSnippet>
+                                                                            <div className="flex flex-col gap-2 p-2">
+                                                                                <div className="font-mono text-xs text-muted">
+                                                                                    Read {humanizeBytes(sub.read_bytes)}{' '}
+                                                                                    · {sub.read_rows.toLocaleString()}{' '}
+                                                                                    rows
+                                                                                    {sub.memory_usage
+                                                                                        ? ` · ${humanizeBytes(
+                                                                                              sub.memory_usage
+                                                                                          )} peak memory`
+                                                                                        : ''}
+                                                                                    {sub.exception_code
+                                                                                        ? ` · exit code ${sub.exception_code}`
+                                                                                        : ''}
+                                                                                </div>
+                                                                                <CodeSnippet
+                                                                                    language={Language.SQL}
+                                                                                    thing="query"
+                                                                                    maxLinesWithoutExpansion={10}
+                                                                                >
+                                                                                    {sub.query}
+                                                                                </CodeSnippet>
+                                                                            </div>
                                                                         )
                                                                     },
                                                                 }}

--- a/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
+++ b/frontend/src/scenes/instance/QueryPerformance/queryPerformanceLogic.ts
@@ -39,6 +39,10 @@ export interface SlowestQuery {
     experiment_funnel_order_type: string | null
     experiment_id: number | null
     total_duration_ms: number
+    read_bytes: number
+    read_rows: number
+    exception_code: number
+    memory_usage: number
     sub_queries: SlowestQuery[]
 }
 

--- a/posthog/api/debug_ch_queries.py
+++ b/posthog/api/debug_ch_queries.py
@@ -474,6 +474,10 @@ class DebugCHQueries(viewsets.ViewSet):
                     argMax(query_start_time, type) AS query_start_time,
                     argMax(query_duration_ms, type) AS query_duration_ms,
                     argMax(exception, type) AS exception,
+                    argMax(read_bytes, type) AS read_bytes,
+                    argMax(read_rows, type) AS read_rows,
+                    argMax(exception_code, type) AS exception_code,
+                    argMax(memory_usage, type) AS memory_usage,
                     max(type) AS status,
                     argMax(JSONExtractInt(log_comment, 'team_id'), type) AS team_id,
                     argMax(JSONExtractString(log_comment, 'query_type'), type) AS query_type,
@@ -491,6 +495,7 @@ class DebugCHQueries(viewsets.ViewSet):
                 FROM (
                     SELECT
                         query_id, query, query_start_time, query_duration_ms, exception,
+                        read_bytes, read_rows, exception_code, memory_usage,
                         toInt8(type) AS type, log_comment
                     FROM clusterAllReplicas(%(cluster)s, system, query_log)
                     WHERE
@@ -517,7 +522,8 @@ class DebugCHQueries(viewsets.ViewSet):
                 g.team_id, g.query_type, g.experiment_name, g.experiment_metric_name, g.experiment_execution_path,
                 g.experiment_metric_type, g.experiment_funnel_order_type, g.experiment_id, g.experiment_exposures_path,
                 g.experiment_metric_events_path, g.experiment_query_surface, g.experiment_precompute_table,
-                g.experiment_query_group_id, r.total_duration_ms
+                g.experiment_query_group_id, r.total_duration_ms,
+                g.read_bytes, g.read_rows, g.exception_code, g.memory_usage
             FROM grouped AS g
             INNER JOIN ranked AS r ON g.grp = r.grp
             ORDER BY
@@ -574,6 +580,10 @@ class DebugCHQueries(viewsets.ViewSet):
                 "experiment_precompute_table": row[17],
                 "experiment_query_group_id": row[18],
                 "total_duration_ms": row[19],
+                "read_bytes": row[20],
+                "read_rows": row[21],
+                "exception_code": row[22],
+                "memory_usage": row[23],
                 "sub_queries": [],
             }
 


### PR DESCRIPTION
Plumb `read_bytes`, `read_rows`, `exception_code`, and `memory_usage` from `system.query_log` through the staff-only `slowest_queries` endpoint and show them in the expanded row detail of the query-performance table. First of six PRs improving that table; foundation for the dedicated bytes column, outcome column, and exception-code filter.

## 🤖 Agent context

Implements PR 1 of `PR_PLAN_query-performance-table.md`. Internal staff-only tooling (`is_staff`-gated, schema-excluded); no new tests by design — data plumbing on internal tooling, covered by typecheck and existing auth tests.
