### PR TITLE
feat(phai): add welcome header and suggestions to task composer

### DIFF
--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -874,7 +874,7 @@ export const QUESTION_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
                 content: 'Create a survey to collect NPS responses from users',
             },
             {
-                content: 'Create a survey to CSAT responses from users',
+                content: 'Create a survey to collect CSAT responses from users',
             },
             {
                 content: 'Create a survey to measure product market fit',

--- a/products/posthog_ai/frontend/api/primitives.ts
+++ b/products/posthog_ai/frontend/api/primitives.ts
@@ -19,6 +19,22 @@ export type {
     ComposerSubmitProps,
 } from '../components/composer/Composer'
 
+// Welcome header (logomark + headline + subheadline) and its overridable default headlines.
+export { Welcome } from '../components/welcome/Welcome'
+export type { WelcomeProps } from '../components/welcome/Welcome'
+export { DEFAULT_HEADLINES, pickHeadline } from '../components/welcome/welcomeDefaults'
+
+// Suggestions compound (the "Try PostHog AI for…" button row + in-input dropdown) and its default content.
+export { Suggestions } from '../components/suggestions/Suggestions'
+export type {
+    SuggestionItem,
+    SuggestionGroup,
+    SuggestionsRootProps,
+    SuggestionsButtonsProps,
+    SuggestionsDropdownProps,
+} from '../components/suggestions/Suggestions'
+export { DEFAULT_SUGGESTIONS_DATA } from '../components/suggestions/suggestionsDefaults'
+
 // `Thread` is the Radix-style compound (Root + Message/Markdown/Reasoning/Failure/Activity/ToolCall
 // atoms); `ThreadView` is the prepackaged virtualized presenter (also `Thread.Root`).
 export { Thread } from '../components/Thread'

--- a/products/posthog_ai/frontend/components/suggestions/Suggestions.scss
+++ b/products/posthog_ai/frontend/components/suggestions/Suggestions.scss
@@ -1,0 +1,30 @@
+.Suggestions__list {
+    opacity: 0;
+    transition:
+        opacity 150ms ease-out,
+        transform 150ms ease-out;
+    transform: scale(0.95) translateY(-0.5rem);
+
+    &--visible {
+        opacity: 1;
+        transform: scale(1) translateY(0);
+    }
+}
+
+.Suggestions__item {
+    opacity: 0;
+    animation: Suggestions__item__slide-in-fade-down 60ms ease-out forwards;
+    animation-delay: calc(var(--index) * 25ms);
+}
+
+@keyframes Suggestions__item__slide-in-fade-down {
+    from {
+        opacity: 0;
+        transform: translateY(-0.5rem);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}

--- a/products/posthog_ai/frontend/components/suggestions/Suggestions.stories.tsx
+++ b/products/posthog_ai/frontend/components/suggestions/Suggestions.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { useState } from 'react'
+
+import { Composer } from '../composer/Composer'
+import { type SuggestionGroup, type SuggestionItem, Suggestions } from './Suggestions'
+import { DEFAULT_SUGGESTIONS_DATA } from './suggestionsDefaults'
+
+// The Suggestions primitives are logic-free and controlled: the story owns the open-dropdown state and the
+// composer value, assembling the parts the way a real surface (the tasks composer) does. The dropdown
+// attaches to the bottom edge of <Composer.Root>.
+interface SuggestionsStoryArgs {
+    initialActiveGroupIndex: number | null
+}
+
+type Story = StoryObj<SuggestionsStoryArgs>
+
+const meta: Meta<SuggestionsStoryArgs> = {
+    title: 'Products/PostHog AI/Suggestions',
+    tags: ['autodocs'],
+    args: { initialActiveGroupIndex: null },
+    render: ({ initialActiveGroupIndex }) => {
+        const [value, setValue] = useState('')
+        const [activeGroup, setActiveGroup] = useState<SuggestionGroup | null>(
+            initialActiveGroupIndex !== null ? DEFAULT_SUGGESTIONS_DATA[initialActiveGroupIndex] : null
+        )
+        const onSelectSuggestion = (item: SuggestionItem): void => {
+            setValue(item.content)
+            setActiveGroup(null)
+        }
+        return (
+            <div className="max-w-2xl mx-auto p-4 flex flex-col gap-4">
+                <Suggestions.Root
+                    activeGroup={activeGroup}
+                    onActiveGroupChange={setActiveGroup}
+                    onSelectSuggestion={onSelectSuggestion}
+                >
+                    <Composer.Root value={value} onChange={setValue} onSubmit={() => setValue('')}>
+                        <Composer.Frame>
+                            <Composer.Field>
+                                <Composer.Placeholder>Describe the task…</Composer.Placeholder>
+                                <Composer.Textarea submitShortcut="cmd-enter" />
+                            </Composer.Field>
+                        </Composer.Frame>
+                        <Suggestions.Dropdown />
+                        <Composer.Submit />
+                    </Composer.Root>
+                    <Suggestions.Buttons data={DEFAULT_SUGGESTIONS_DATA} />
+                </Suggestions.Root>
+            </div>
+        )
+    },
+}
+export default meta
+
+/** Collapsed — the button row under the input; clicking a multi-suggestion category opens the dropdown. */
+export const Default: Story = {}
+
+/** Expanded — a category's suggestions shown in the in-input dropdown. */
+export const Expanded: Story = {
+    args: { initialActiveGroupIndex: 0 },
+    // The dropdown animates open via useAnimatedPresence, which the snapshot runner can catch mid-transition.
+    tags: ['test-skip'],
+}

--- a/products/posthog_ai/frontend/components/suggestions/Suggestions.tsx
+++ b/products/posthog_ai/frontend/components/suggestions/Suggestions.tsx
@@ -5,6 +5,7 @@ import { createContext, type ReactNode, useContext, useEffect, useRef } from 're
 import { LemonButton, Tooltip } from '@posthog/lemon-ui'
 
 import { useAnimatedPresence } from 'lib/hooks/useAnimatedPresence'
+import { useOutsideClickHandler } from 'lib/hooks/useOutsideClickHandler'
 import { cn } from 'lib/utils/css-classes'
 
 // Radix-style compound suggestions surface: a logic-free button row ("Try PostHog AI for…") plus an
@@ -87,9 +88,35 @@ function SuggestionsRoot({
         onActiveGroupChange(null)
     }
 
+    // The dropdown dismisses on Esc or a click anywhere outside the suggestions subtree. The `contents`
+    // wrapper is layout-transparent (it doesn't establish a box or positioning context, so the flex layout
+    // and the dropdown's absolute positioning are unchanged) but gives `useOutsideClickHandler` one node that
+    // spans every slot — so clicking another category button to switch groups doesn't count as "outside".
+    const rootRef = useRef<HTMLDivElement | null>(null)
+    useOutsideClickHandler([rootRef], () => {
+        if (activeGroup) {
+            onActiveGroupChange(null)
+        }
+    })
+
+    useEffect(() => {
+        if (!activeGroup) {
+            return
+        }
+        const handleKeyDown = (event: KeyboardEvent): void => {
+            if (event.key === 'Escape') {
+                onActiveGroupChange(null)
+            }
+        }
+        document.addEventListener('keydown', handleKeyDown)
+        return () => document.removeEventListener('keydown', handleKeyDown)
+    }, [activeGroup, onActiveGroupChange])
+
     return (
         <SuggestionsContext.Provider value={{ activeGroup, handleGroupClick, handleSelect, disabled, disabledReason }}>
-            {children}
+            <div ref={rootRef} className="contents">
+                {children}
+            </div>
         </SuggestionsContext.Provider>
     )
 }

--- a/products/posthog_ai/frontend/components/suggestions/Suggestions.tsx
+++ b/products/posthog_ai/frontend/components/suggestions/Suggestions.tsx
@@ -1,0 +1,205 @@
+import './Suggestions.scss'
+
+import { createContext, type ReactNode, useContext, useEffect, useRef } from 'react'
+
+import { LemonButton, Tooltip } from '@posthog/lemon-ui'
+
+import { useAnimatedPresence } from 'lib/hooks/useAnimatedPresence'
+import { cn } from 'lib/utils/css-classes'
+
+// Radix-style compound suggestions surface: a logic-free button row ("Try PostHog AI for…") plus an
+// in-input dropdown that opens when a multi-suggestion category is picked. Reproduces the look of
+// scenes/max's FloatingSuggestionsDisplay + SuggestionsList without any conversation logic — the caller owns
+// the open state and decides what a chosen suggestion does (fill, submit, navigate). The dropdown attaches
+// to the bottom edge of whatever positioned ancestor it's placed in (e.g. inside <Composer.Root>).
+
+export interface SuggestionItem {
+    content: string
+    /** When true the caller should fill the input and let the user finish typing; otherwise submit directly. */
+    requiresUserInput?: boolean
+}
+
+export interface SuggestionGroup {
+    label: string
+    icon: JSX.Element
+    suggestions: SuggestionItem[]
+    /** Optional product page to open when the group is clicked (handled by the caller's `onNavigate`). */
+    url?: string
+    tooltip?: string
+}
+
+interface SuggestionsContextValue {
+    activeGroup: SuggestionGroup | null
+    handleGroupClick: (group: SuggestionGroup) => void
+    handleSelect: (item: SuggestionItem) => void
+    disabled: boolean
+    disabledReason?: string | null
+}
+
+const SuggestionsContext = createContext<SuggestionsContextValue | null>(null)
+
+function useSuggestionsContext(): SuggestionsContextValue {
+    const ctx = useContext(SuggestionsContext)
+    if (!ctx) {
+        throw new Error('Suggestions.* components must be rendered inside <Suggestions.Root>')
+    }
+    return ctx
+}
+
+export interface SuggestionsRootProps {
+    /** Controlled open-dropdown state; `null` when no category is expanded. The caller owns it. */
+    activeGroup: SuggestionGroup | null
+    onActiveGroupChange: (group: SuggestionGroup | null) => void
+    /** Called when a concrete suggestion is chosen — from the dropdown or a single-suggestion group. */
+    onSelectSuggestion: (item: SuggestionItem) => void
+    /** Called (before the open/select logic) for groups carrying a `url`, e.g. to open the product page. */
+    onNavigate?: (url: string) => void
+    disabled?: boolean
+    disabledReason?: string | null
+    children: ReactNode
+}
+
+function SuggestionsRoot({
+    activeGroup,
+    onActiveGroupChange,
+    onSelectSuggestion,
+    onNavigate,
+    disabled = false,
+    disabledReason,
+    children,
+}: SuggestionsRootProps): JSX.Element {
+    const handleGroupClick = (group: SuggestionGroup): void => {
+        if (group.url) {
+            onNavigate?.(group.url)
+        }
+        // ≤1 suggestion: nothing to expand, apply it straight away. Otherwise open the dropdown.
+        if (group.suggestions.length <= 1) {
+            if (group.suggestions[0]) {
+                onSelectSuggestion(group.suggestions[0])
+            }
+        } else {
+            onActiveGroupChange(group)
+        }
+    }
+
+    const handleSelect = (item: SuggestionItem): void => {
+        onSelectSuggestion(item)
+        onActiveGroupChange(null)
+    }
+
+    return (
+        <SuggestionsContext.Provider value={{ activeGroup, handleGroupClick, handleSelect, disabled, disabledReason }}>
+            {children}
+        </SuggestionsContext.Provider>
+    )
+}
+
+export interface SuggestionsButtonsProps {
+    data: readonly SuggestionGroup[]
+    /** The label above the row. Defaults to the PostHog AI prompt; pass `null` to hide it. */
+    tip?: ReactNode
+    type?: 'primary' | 'secondary' | 'tertiary'
+    /** Extra buttons appended after the category buttons (e.g. a settings affordance). */
+    additionalSuggestions?: ReactNode[]
+    className?: string
+}
+
+function SuggestionsButtons({
+    data,
+    tip = 'Try PostHog AI for…',
+    type = 'secondary',
+    additionalSuggestions,
+    className,
+}: SuggestionsButtonsProps): JSX.Element {
+    const { activeGroup, handleGroupClick, disabled, disabledReason } = useSuggestionsContext()
+
+    return (
+        <div className={cn('flex flex-col items-center justify-center gap-y-2', className)}>
+            {tip && <h3 className="text-center text-xs font-medium mb-0 text-secondary">{tip}</h3>}
+            <Tooltip title={disabled ? disabledReason || undefined : undefined}>
+                <ul
+                    className={cn(
+                        'flex items-center justify-center flex-wrap gap-1.5 mb-0',
+                        activeGroup && 'fade-out pointer-events-none'
+                    )}
+                >
+                    {data.map((group) => (
+                        <li key={group.label}>
+                            <LemonButton
+                                onClick={() => handleGroupClick(group)}
+                                size="xsmall"
+                                type={type}
+                                icon={group.icon}
+                                tooltip={disabled ? undefined : group.tooltip}
+                                disabled={disabled}
+                            >
+                                {group.label}
+                            </LemonButton>
+                        </li>
+                    ))}
+                    {additionalSuggestions?.map((node, index) => (
+                        <li key={index}>{node}</li>
+                    ))}
+                </ul>
+            </Tooltip>
+        </div>
+    )
+}
+
+export interface SuggestionsDropdownProps {
+    className?: string
+}
+
+function SuggestionsDropdown({ className }: SuggestionsDropdownProps): JSX.Element | null {
+    const { activeGroup, handleSelect } = useSuggestionsContext()
+    const containerRef = useRef<HTMLDivElement | null>(null)
+    // Keep the last group around so its items stay rendered through the exit animation.
+    const previousGroup = useRef<SuggestionGroup | null>(null)
+    const { rendered, shown } = useAnimatedPresence(!!activeGroup, 150)
+
+    useEffect(() => {
+        if (activeGroup && containerRef.current) {
+            // Move focus into the dropdown so keyboard users can act on it immediately.
+            containerRef.current.querySelector<HTMLElement>('button')?.focus()
+        }
+        previousGroup.current = activeGroup
+    }, [activeGroup, rendered])
+
+    const group = activeGroup || previousGroup.current
+
+    if (!rendered) {
+        return null
+    }
+
+    return (
+        <div
+            ref={containerRef}
+            role="listbox"
+            className={cn(
+                'Suggestions__list absolute inset-x-2 top-full grid auto-rows-auto p-1 border-x border-b rounded-b-lg bg-surface-primary z-10',
+                shown && 'Suggestions__list--visible',
+                className
+            )}
+        >
+            {group?.suggestions.map((suggestion, index) => (
+                <LemonButton
+                    key={suggestion.content}
+                    className="Suggestions__item text-left"
+                    style={{ '--index': index } as React.CSSProperties}
+                    size="small"
+                    type="tertiary"
+                    fullWidth
+                    onClick={() => handleSelect(suggestion)}
+                >
+                    <span className="font-normal">{suggestion.content}</span>
+                </LemonButton>
+            ))}
+        </div>
+    )
+}
+
+export const Suggestions = Object.assign(SuggestionsRoot, {
+    Root: SuggestionsRoot,
+    Buttons: SuggestionsButtons,
+    Dropdown: SuggestionsDropdown,
+})

--- a/products/posthog_ai/frontend/components/suggestions/suggestionsDefaults.tsx
+++ b/products/posthog_ai/frontend/components/suggestions/suggestionsDefaults.tsx
@@ -163,7 +163,7 @@ export const DEFAULT_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
                 content: 'Create a survey to collect NPS responses from users',
             },
             {
-                content: 'Create a survey to CSAT responses from users',
+                content: 'Create a survey to collect CSAT responses from users',
             },
             {
                 content: 'Create a survey to measure product market fit',

--- a/products/posthog_ai/frontend/components/suggestions/suggestionsDefaults.tsx
+++ b/products/posthog_ai/frontend/components/suggestions/suggestionsDefaults.tsx
@@ -1,0 +1,200 @@
+import { IconBook, IconCode } from '@posthog/icons'
+
+import { urls } from 'scenes/urls'
+
+import { iconForType } from '~/layout/panel-layout/ProjectTree/defaultTree'
+import { productUrls } from '~/products'
+
+import { type SuggestionGroup } from './Suggestions'
+
+// Default, overridable suggestion content for the Suggestions primitive. The "Coding" group leads (this
+// surface drives an agent that writes code), followed by PostHog's analytics categories. Pass your own
+// array to override.
+export const DEFAULT_SUGGESTIONS_DATA: readonly SuggestionGroup[] = [
+    {
+        label: 'Coding',
+        icon: <IconCode />,
+        suggestions: [
+            {
+                content: 'Instrument an event/property',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Fix a bug for me',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Research how my codebase works',
+            },
+        ],
+        tooltip: 'PostHog AI can write code in your repository — instrument events, fix bugs, and explore code.',
+    },
+    {
+        label: 'Product analytics',
+        icon: iconForType('product_analytics'),
+        suggestions: [
+            {
+                content: 'Create a funnel of the Pirate Metrics (AARRR)',
+            },
+            {
+                content: 'What are the most popular pages or screens?',
+            },
+            {
+                content: 'What is the retention in the last two weeks?',
+            },
+            {
+                content: 'What are the top referring domains?',
+            },
+            {
+                content: 'Calculate a conversion rate for <events or actions>…',
+                requiresUserInput: true,
+            },
+        ],
+        tooltip: 'PostHog AI can generate insights from natural language and tweak existing ones.',
+    },
+    {
+        label: 'SQL',
+        icon: iconForType('insight/hog'),
+        suggestions: [
+            {
+                content: 'Write an SQL query to…',
+                requiresUserInput: true,
+            },
+        ],
+        url: urls.sqlEditor(),
+        tooltip: 'PostHog AI can generate SQL queries for your PostHog data, both analytics and the data warehouse.',
+    },
+    {
+        label: 'Session replay',
+        icon: iconForType('session_replay'),
+        suggestions: [
+            {
+                content: 'Find recordings for…',
+                requiresUserInput: true,
+            },
+        ],
+        url: productUrls.replay(),
+        tooltip: 'PostHog AI can find session recordings for you.',
+    },
+    {
+        label: 'SDK setup',
+        icon: iconForType('sql_editor'),
+        suggestions: [
+            {
+                content: 'How can I set up the session replay in <a framework or language>…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up the feature flags in…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up the experiments in…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up the data warehouse in…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up the error tracking in…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up AI observability in…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'How can I set up the product analytics in…',
+                requiresUserInput: true,
+            },
+        ],
+        tooltip: 'PostHog AI can help you set up PostHog SDKs in your stack.',
+    },
+    {
+        label: 'Feature flags',
+        icon: iconForType('feature_flag'),
+        url: urls.featureFlags(),
+        suggestions: [
+            {
+                content: 'Create a flag to gradually roll out…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Create a flag that starts at 10% rollout for…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Create a multivariate flag for…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Create a beta testing flag for…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Audit my feature flags for issues',
+            },
+        ],
+    },
+    {
+        label: 'Experiments',
+        icon: iconForType('experiment'),
+        url: urls.experiments(),
+        suggestions: [
+            {
+                content: 'Create an experiment to test…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Set up an A/B test with a 70/30 split between control and test for…',
+                requiresUserInput: true,
+            },
+            {
+                content: 'Check if my running experiments are set up correctly',
+            },
+        ],
+    },
+    {
+        label: 'Surveys',
+        icon: iconForType('survey'),
+        suggestions: [
+            {
+                content: 'Create a survey to collect NPS responses from users',
+            },
+            {
+                content: 'Create a survey to CSAT responses from users',
+            },
+            {
+                content: 'Create a survey to measure product market fit',
+            },
+            {
+                content: 'Analyze survey responses to prioritize key features our users are interested in',
+            },
+        ],
+        url: urls.surveys(),
+        tooltip: 'PostHog AI can help you create surveys to collect feedback from your users.',
+    },
+    {
+        label: 'Docs',
+        icon: <IconBook />,
+        suggestions: [
+            {
+                content: 'How can I create a feature flag?',
+            },
+            {
+                content: 'Where do I watch session replays?',
+            },
+            {
+                content: 'Help me set up an experiment',
+            },
+            {
+                content: 'Explain autocapture',
+            },
+            {
+                content: 'How can I capture an exception?',
+            },
+        ],
+        tooltip: 'PostHog AI has access to PostHog docs and can help you get the most out of PostHog.',
+    },
+]

--- a/products/posthog_ai/frontend/components/welcome/Welcome.stories.tsx
+++ b/products/posthog_ai/frontend/components/welcome/Welcome.stories.tsx
@@ -1,0 +1,32 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { Welcome } from './Welcome'
+import { DEFAULT_HEADLINES } from './welcomeDefaults'
+
+const meta: Meta<typeof Welcome> = {
+    title: 'Products/PostHog AI/Welcome',
+    component: Welcome,
+    tags: ['autodocs'],
+    args: { headline: DEFAULT_HEADLINES[1] },
+    render: (args) => (
+        <div className="flex flex-col items-center max-w-2xl mx-auto p-4">
+            <Welcome {...args} />
+        </div>
+    ),
+}
+export default meta
+
+type Story = StoryObj<typeof Welcome>
+
+/** Default — logomark, headline, and the PostHog AI tagline. */
+export const Default: Story = {}
+
+/** A caller-supplied subheadline replaces the default tagline. */
+export const CustomSubheadline: Story = {
+    args: { subheadline: 'Ship faster with PostHog AI.' },
+}
+
+/** Passing `null` hides the subheadline entirely. */
+export const NoSubheadline: Story = {
+    args: { subheadline: null },
+}

--- a/products/posthog_ai/frontend/components/welcome/Welcome.tsx
+++ b/products/posthog_ai/frontend/components/welcome/Welcome.tsx
@@ -1,0 +1,32 @@
+import { type ReactNode } from 'react'
+
+import { JumpingLogomark } from 'lib/brand/JumpingLogomark'
+
+// Logic-free welcome header: the jumping logomark, a headline, and a subheadline. Mirrors the look of
+// scenes/max/Intro.tsx without its conversation coupling — the caller passes the (already-chosen) headline
+// and may append extras (notices, changelog) via `children`.
+
+export interface WelcomeProps {
+    headline: string
+    /** Defaults to the PostHog AI tagline; pass `null` to hide it entirely. */
+    subheadline?: string | null
+    /** Rendered after the header — e.g. a liability notice or changelog the consumer owns. */
+    children?: ReactNode
+}
+
+export function Welcome({
+    headline,
+    subheadline = 'Build something people want.',
+    children,
+}: WelcomeProps): JSX.Element {
+    return (
+        <>
+            <JumpingLogomark className="flex *:h-full *:w-12 p-2" />
+            <div className="text-center mb-1">
+                <h2 className="text-xl @2xl/main-content:text-2xl font-bold mb-2 text-balance">{headline}</h2>
+                {subheadline && <div className="text-sm italic text-tertiary text-pretty py-0.5">{subheadline}</div>}
+            </div>
+            {children}
+        </>
+    )
+}

--- a/products/posthog_ai/frontend/components/welcome/welcomeDefaults.ts
+++ b/products/posthog_ai/frontend/components/welcome/welcomeDefaults.ts
@@ -1,0 +1,25 @@
+// Default, overridable content for the Welcome primitive. Shipped here so both consumers (the tasks
+// composer and the new PostHog AI welcome) share one source; pass your own list to override.
+
+export const DEFAULT_HEADLINES: readonly string[] = [
+    'How can I help you build?',
+    'What are you curious about?',
+    'How can I help you understand users?',
+    'What do you want to know today?',
+]
+
+/**
+ * Pick a headline from `headlines`. Forces the first one under Storybook so visual snapshots stay stable;
+ * with a `seed` it's deterministic, otherwise it rotates at random. Call once and hold the result (e.g. in a
+ * logic reducer) — calling it on every render would reshuffle the headline.
+ */
+export function pickHeadline(headlines: readonly string[] = DEFAULT_HEADLINES, seed?: number): string {
+    if (headlines.length === 0) {
+        return ''
+    }
+    if (process.env.STORYBOOK) {
+        return headlines[0]
+    }
+    const index = seed !== undefined ? seed % headlines.length : Math.floor(Math.random() * headlines.length)
+    return headlines[index]
+}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -16,9 +16,9 @@ import { ComposerModelEffortPickers } from './ComposerModelEffortPickers'
 import { RepositorySelector } from './RepositorySelector'
 
 export function TaskComposer(): JSX.Element {
-    const { submitTaskCreateForm, setTaskCreateFormValues, setActiveSuggestionGroup, applySuggestion } =
+    const { submitNewTask, setNewTaskData, setActiveSuggestionGroup, applySuggestion } =
         useActions(taskTrackerSceneLogic)
-    const { taskCreateForm, isTaskCreateFormSubmitting, activeSuggestionGroup, headline, sendDisabledReason } =
+    const { newTaskData, isSubmittingTask, activeSuggestionGroup, headline, sendDisabledReason } =
         useValues(taskTrackerSceneLogic)
 
     const textAreaRef = useRef<HTMLTextAreaElement>(null)
@@ -44,14 +44,14 @@ export function TaskComposer(): JSX.Element {
                     {/* Repo/branch picker sits 8px above the input it configures. */}
                     <div className="w-full flex flex-col gap-2">
                         <RepositorySelector
-                            value={taskCreateForm.repositoryConfig}
-                            onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
+                            value={newTaskData.repositoryConfig}
+                            onChange={(config) => setNewTaskData({ repositoryConfig: config })}
                         />
                         <Composer.Root
-                            value={taskCreateForm.description}
-                            onChange={(value) => setTaskCreateFormValues({ description: value })}
-                            onSubmit={submitTaskCreateForm}
-                            loading={isTaskCreateFormSubmitting}
+                            value={newTaskData.description}
+                            onChange={(value) => setNewTaskData({ description: value })}
+                            onSubmit={submitNewTask}
+                            loading={isSubmittingTask}
                             disabledReason={sendDisabledReason}
                             textAreaRef={textAreaRef}
                         >
@@ -66,18 +66,18 @@ export function TaskComposer(): JSX.Element {
                                 </Composer.Field>
                                 <Composer.Footer>
                                     <ComposerModelEffortPickers
-                                        selectedModel={taskCreateForm.model}
-                                        selectedEffort={taskCreateForm.reasoningEffort}
+                                        selectedModel={newTaskData.model}
+                                        selectedEffort={newTaskData.reasoningEffort}
                                         onModelChange={(model) =>
-                                            setTaskCreateFormValues({
+                                            setNewTaskData({
                                                 model,
                                                 reasoningEffort: resolveEffortForModel(
-                                                    taskCreateForm.reasoningEffort,
+                                                    newTaskData.reasoningEffort,
                                                     model
                                                 ),
                                             })
                                         }
-                                        onEffortChange={(reasoningEffort) => setTaskCreateFormValues({ reasoningEffort })}
+                                        onEffortChange={(reasoningEffort) => setNewTaskData({ reasoningEffort })}
                                     />
                                 </Composer.Footer>
                             </Composer.Frame>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -35,53 +35,56 @@ export function TaskComposer(): JSX.Element {
             <div className="w-full max-w-2xl flex flex-col items-center gap-4">
                 <Welcome headline={headline} />
 
-                <div className="w-full">
-                    <RepositorySelector
-                        value={taskCreateForm.repositoryConfig}
-                        onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
-                    />
-                </div>
-
                 <Suggestions.Root
                     activeGroup={activeSuggestionGroup}
                     onActiveGroupChange={setActiveSuggestionGroup}
                     onSelectSuggestion={handleSelectSuggestion}
                     onNavigate={(url) => router.actions.push(url)}
                 >
-                    <Composer.Root
-                        value={taskCreateForm.description}
-                        onChange={(value) => setTaskCreateFormValues({ description: value })}
-                        onSubmit={submitTaskCreateForm}
-                        loading={isTaskCreateFormSubmitting}
-                        disabledReason={sendDisabledReason}
-                        textAreaRef={textAreaRef}
-                    >
-                        <Composer.Frame>
-                            <Composer.Field>
-                                <Composer.Placeholder>Describe the task in detail…</Composer.Placeholder>
-                                <Composer.Textarea
-                                    submitShortcut="cmd-enter"
-                                    autoFocus
-                                    data-attr="task-composer-input"
-                                />
-                            </Composer.Field>
-                            <Composer.Footer>
-                                <ComposerModelEffortPickers
-                                    selectedModel={taskCreateForm.model}
-                                    selectedEffort={taskCreateForm.reasoningEffort}
-                                    onModelChange={(model) =>
-                                        setTaskCreateFormValues({
-                                            model,
-                                            reasoningEffort: resolveEffortForModel(taskCreateForm.reasoningEffort, model),
-                                        })
-                                    }
-                                    onEffortChange={(reasoningEffort) => setTaskCreateFormValues({ reasoningEffort })}
-                                />
-                            </Composer.Footer>
-                        </Composer.Frame>
-                        <Suggestions.Dropdown />
-                        <Composer.Submit data-attr="task-composer-send" />
-                    </Composer.Root>
+                    {/* Repo/branch picker sits 8px above the input it configures. */}
+                    <div className="w-full flex flex-col gap-2">
+                        <RepositorySelector
+                            value={taskCreateForm.repositoryConfig}
+                            onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
+                        />
+                        <Composer.Root
+                            value={taskCreateForm.description}
+                            onChange={(value) => setTaskCreateFormValues({ description: value })}
+                            onSubmit={submitTaskCreateForm}
+                            loading={isTaskCreateFormSubmitting}
+                            disabledReason={sendDisabledReason}
+                            textAreaRef={textAreaRef}
+                        >
+                            <Composer.Frame>
+                                <Composer.Field>
+                                    <Composer.Placeholder>Describe the task in detail…</Composer.Placeholder>
+                                    <Composer.Textarea
+                                        submitShortcut="cmd-enter"
+                                        autoFocus
+                                        data-attr="task-composer-input"
+                                    />
+                                </Composer.Field>
+                                <Composer.Footer>
+                                    <ComposerModelEffortPickers
+                                        selectedModel={taskCreateForm.model}
+                                        selectedEffort={taskCreateForm.reasoningEffort}
+                                        onModelChange={(model) =>
+                                            setTaskCreateFormValues({
+                                                model,
+                                                reasoningEffort: resolveEffortForModel(
+                                                    taskCreateForm.reasoningEffort,
+                                                    model
+                                                ),
+                                            })
+                                        }
+                                        onEffortChange={(reasoningEffort) => setTaskCreateFormValues({ reasoningEffort })}
+                                    />
+                                </Composer.Footer>
+                            </Composer.Frame>
+                            <Suggestions.Dropdown />
+                            <Composer.Submit data-attr="task-composer-send" />
+                        </Composer.Root>
+                    </div>
 
                     <Suggestions.Buttons data={DEFAULT_SUGGESTIONS_DATA} />
                 </Suggestions.Root>

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -1,6 +1,14 @@
 import { useActions, useValues } from 'kea'
+import { router } from 'kea-router'
+import { useRef } from 'react'
 
-import { Composer } from 'products/posthog_ai/frontend/api/primitives'
+import {
+    Composer,
+    DEFAULT_SUGGESTIONS_DATA,
+    type SuggestionItem,
+    Suggestions,
+    Welcome,
+} from 'products/posthog_ai/frontend/api/primitives'
 import { resolveEffortForModel } from 'products/posthog_ai/frontend/utils/composerModels'
 
 import { taskTrackerSceneLogic } from '../taskTrackerSceneLogic'
@@ -8,46 +16,73 @@ import { ComposerModelEffortPickers } from './ComposerModelEffortPickers'
 import { RepositorySelector } from './RepositorySelector'
 
 export function TaskComposer(): JSX.Element {
-    const { submitTaskCreateForm, setTaskCreateFormValues } = useActions(taskTrackerSceneLogic)
-    const { taskCreateForm, isTaskCreateFormSubmitting } = useValues(taskTrackerSceneLogic)
+    const { submitTaskCreateForm, setTaskCreateFormValues, setActiveSuggestionGroup, applySuggestion } =
+        useActions(taskTrackerSceneLogic)
+    const { taskCreateForm, isTaskCreateFormSubmitting, activeSuggestionGroup, headline, sendDisabledReason } =
+        useValues(taskTrackerSceneLogic)
+
+    const textAreaRef = useRef<HTMLTextAreaElement>(null)
+
+    const handleSelectSuggestion = (item: SuggestionItem): void => {
+        applySuggestion(item)
+        if (item.requiresUserInput) {
+            textAreaRef.current?.focus()
+        }
+    }
 
     return (
         <div className="flex flex-col h-full min-h-0 items-center justify-center overflow-y-auto p-4">
-            <div className="w-full max-w-2xl flex flex-col gap-4">
-                <h2 className="text-lg font-semibold text-center mb-0">What should the agent do?</h2>
+            <div className="w-full max-w-2xl flex flex-col items-center gap-4">
+                <Welcome headline={headline} />
 
                 <RepositorySelector
                     value={taskCreateForm.repositoryConfig}
                     onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
                 />
 
-                <Composer.Root
-                    value={taskCreateForm.description}
-                    onChange={(value) => setTaskCreateFormValues({ description: value })}
-                    onSubmit={submitTaskCreateForm}
-                    loading={isTaskCreateFormSubmitting}
+                <Suggestions.Root
+                    activeGroup={activeSuggestionGroup}
+                    onActiveGroupChange={setActiveSuggestionGroup}
+                    onSelectSuggestion={handleSelectSuggestion}
+                    onNavigate={(url) => router.actions.push(url)}
                 >
-                    <Composer.Frame>
-                        <Composer.Field>
-                            <Composer.Placeholder>Describe the task in detail…</Composer.Placeholder>
-                            <Composer.Textarea submitShortcut="cmd-enter" autoFocus data-attr="task-composer-input" />
-                        </Composer.Field>
-                        <Composer.Footer>
-                            <ComposerModelEffortPickers
-                                selectedModel={taskCreateForm.model}
-                                selectedEffort={taskCreateForm.reasoningEffort}
-                                onModelChange={(model) =>
-                                    setTaskCreateFormValues({
-                                        model,
-                                        reasoningEffort: resolveEffortForModel(taskCreateForm.reasoningEffort, model),
-                                    })
-                                }
-                                onEffortChange={(reasoningEffort) => setTaskCreateFormValues({ reasoningEffort })}
-                            />
-                        </Composer.Footer>
-                    </Composer.Frame>
-                    <Composer.Submit data-attr="task-composer-send" />
-                </Composer.Root>
+                    <Composer.Root
+                        value={taskCreateForm.description}
+                        onChange={(value) => setTaskCreateFormValues({ description: value })}
+                        onSubmit={submitTaskCreateForm}
+                        loading={isTaskCreateFormSubmitting}
+                        disabledReason={sendDisabledReason}
+                        textAreaRef={textAreaRef}
+                    >
+                        <Composer.Frame>
+                            <Composer.Field>
+                                <Composer.Placeholder>Describe the task in detail…</Composer.Placeholder>
+                                <Composer.Textarea
+                                    submitShortcut="cmd-enter"
+                                    autoFocus
+                                    data-attr="task-composer-input"
+                                />
+                            </Composer.Field>
+                            <Composer.Footer>
+                                <ComposerModelEffortPickers
+                                    selectedModel={taskCreateForm.model}
+                                    selectedEffort={taskCreateForm.reasoningEffort}
+                                    onModelChange={(model) =>
+                                        setTaskCreateFormValues({
+                                            model,
+                                            reasoningEffort: resolveEffortForModel(taskCreateForm.reasoningEffort, model),
+                                        })
+                                    }
+                                    onEffortChange={(reasoningEffort) => setTaskCreateFormValues({ reasoningEffort })}
+                                />
+                            </Composer.Footer>
+                        </Composer.Frame>
+                        <Suggestions.Dropdown />
+                        <Composer.Submit data-attr="task-composer-send" />
+                    </Composer.Root>
+
+                    <Suggestions.Buttons data={DEFAULT_SUGGESTIONS_DATA} />
+                </Suggestions.Root>
             </div>
         </div>
     )

--- a/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/components/TaskComposer.tsx
@@ -35,10 +35,12 @@ export function TaskComposer(): JSX.Element {
             <div className="w-full max-w-2xl flex flex-col items-center gap-4">
                 <Welcome headline={headline} />
 
-                <RepositorySelector
-                    value={taskCreateForm.repositoryConfig}
-                    onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
-                />
+                <div className="w-full">
+                    <RepositorySelector
+                        value={taskCreateForm.repositoryConfig}
+                        onChange={(config) => setTaskCreateFormValues({ repositoryConfig: config })}
+                    />
+                </div>
 
                 <Suggestions.Root
                     activeGroup={activeSuggestionGroup}

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.test.ts
@@ -4,6 +4,7 @@ import { expectLogic } from 'kea-test-utils'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
+import { OriginProduct } from '../../types/taskTypes'
 import { taskTrackerSceneLogic } from './taskTrackerSceneLogic'
 
 describe('taskTrackerSceneLogic', () => {
@@ -43,12 +44,17 @@ describe('taskTrackerSceneLogic', () => {
     // PostHog AI can run without a repo: a description-only submit must still create and run the task with a
     // null repository, not bail. Guards against re-adding a "Repository is required" gate on the send path.
     it('creates and runs a task with no repository selected', async () => {
-        logic.actions.setTaskCreateFormValues({ description: 'do the thing' })
-        logic.actions.submitTaskCreateForm()
+        logic.actions.setNewTaskData({ description: 'do the thing' })
+        logic.actions.submitNewTask()
 
         await expectLogic(logic).toFinishAllListeners()
 
-        expect(createBody).toMatchObject({ description: 'do the thing', repository: null, github_integration: null })
+        expect(createBody).toMatchObject({
+            description: 'do the thing',
+            origin_product: OriginProduct.POSTHOG_AI,
+            repository: null,
+            github_integration: null,
+        })
         expect(runCalled).toBe(true)
         expect(router.values.location.pathname).toContain('/tasks/new-task')
     })

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -1,5 +1,4 @@
 import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
-import { forms } from 'kea-forms'
 import { router } from 'kea-router'
 
 import { lemonToast } from '@posthog/lemon-ui'
@@ -54,14 +53,34 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
     })),
 
     actions({
-        maybeRestoreRepositoryConfig: true,
-        setPersistedRepositoryConfig: (config: PersistedRepositoryConfig) => ({ config }),
+        setNewTaskData: (data: Partial<TaskCreateForm>) => ({ data }),
+        resetNewTaskData: true,
+        submitNewTask: true,
+        submitNewTaskSuccess: true,
+        submitNewTaskFailure: (error: string) => ({ error }),
+        maybeAutoSelectIntegration: true,
         setActiveSuggestionGroup: (group: SuggestionGroup | null) => ({ group }),
         applySuggestion: (item: SuggestionItem) => ({ item }),
         setHeadline: (headline: string) => ({ headline }),
+        setPersistedRepositoryConfig: (config: PersistedRepositoryConfig) => ({ config }),
     }),
 
     reducers({
+        newTaskData: [
+            EMPTY_TASK_FORM as TaskCreateForm,
+            {
+                setNewTaskData: (state, { data }) => ({ ...state, ...data }),
+                resetNewTaskData: () => EMPTY_TASK_FORM,
+            },
+        ],
+        isSubmittingTask: [
+            false,
+            {
+                submitNewTask: () => true,
+                submitNewTaskSuccess: () => false,
+                submitNewTaskFailure: () => false,
+            },
+        ],
         // Last repo/integration the user picked, persisted to localStorage so the composer comes back pre-filled.
         persistedRepositoryConfig: [
             {} as PersistedRepositoryConfig,
@@ -75,9 +94,9 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
             {
                 setActiveSuggestionGroup: (_, { group }) => group,
                 // Clearing the description (e.g. after submit/reset) collapses any open dropdown.
-                setTaskCreateFormValues: (state, { values: formValues }) =>
-                    formValues.description !== undefined && !formValues.description ? null : state,
-                resetTaskCreateForm: () => null,
+                setNewTaskData: (state, { data }) =>
+                    data.description !== undefined && !data.description ? null : state,
+                resetNewTaskData: () => null,
             },
         ],
         headline: [
@@ -88,68 +107,26 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
         ],
     }),
 
-    forms(({ actions }) => ({
-        taskCreateForm: {
-            defaults: EMPTY_TASK_FORM,
-            // Only `description` is validated here. `repositoryConfig` is optional — PostHog AI can run without a
-            // repo, so the send button is never gated on it; when set, the task is scoped to that repo/branch.
-            errors: ({ description }) => ({
-                description: !description.trim() ? 'Description is required' : undefined,
-            }),
-            submit: async ({ description, repositoryConfig, model, reasoningEffort }) => {
-                try {
-                    const taskData: TaskUpsertProps = {
-                        title: '',
-                        description,
-                        origin_product: OriginProduct.USER_CREATED,
-                        repository: repositoryConfig.repository ?? null,
-                        github_integration: repositoryConfig.integrationId ?? null,
-                    }
-
-                    const newTask = await api.tasks.create(taskData)
-                    lemonToast.success('Task created successfully')
-
-                    // Auto-run the task after creation; the detail scene shows the latest run by default. The
-                    // run checks out the chosen branch (server falls back to the repo's default branch if unset)
-                    // and launches with the picked model / reasoning effort (clamped to one the model supports).
-                    await api.tasks.run(newTask.id, {
-                        branch: repositoryConfig.branch ?? null,
-                        runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
-                        model,
-                        reasoning_effort: resolveEffortForModel(reasoningEffort, model),
-                    })
-                    router.actions.push(`/tasks/${newTask.id}`)
-
-                    actions.resetTaskCreateForm()
-                    actions.loadTasks()
-                    actions.loadRepositories()
-                } catch {
-                    lemonToast.error('Failed to create task')
-                }
-            },
-        },
-    })),
-
     selectors({
         sendDisabledReason: [
-            (s) => [s.taskCreateForm],
-            (taskCreateForm): string | undefined =>
-                !taskCreateForm.description.trim() ? 'Describe the task first' : undefined,
+            (s) => [s.newTaskData],
+            (newTaskData): string | undefined =>
+                !newTaskData.description.trim() ? 'Describe the task first' : undefined,
         ],
     }),
 
     listeners(({ actions, values }) => ({
         // Remember the repo/integration whenever the picker changes it, so the next visit restores it.
-        setTaskCreateFormValues: ({ values: formValues }) => {
-            if (formValues.repositoryConfig) {
-                const { integrationId, repository } = formValues.repositoryConfig
+        setNewTaskData: ({ data }) => {
+            if (data.repositoryConfig) {
+                const { integrationId, repository } = data.repositoryConfig
                 actions.setPersistedRepositoryConfig({ integrationId, repository })
             }
         },
         // Restore the remembered repo (or fall back to the first connected GitHub integration) when nothing is
         // chosen yet. The IntegrationChoice picker that used to own this selection is no longer rendered.
-        maybeRestoreRepositoryConfig: () => {
-            if (values.taskCreateForm.repositoryConfig.integrationId) {
+        maybeAutoSelectIntegration: () => {
+            if (values.newTaskData.repositoryConfig.integrationId) {
                 return
             }
             const githubIntegrations = values.integrations?.filter((integration) => integration.kind === 'github') ?? []
@@ -160,39 +137,80 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
             // GitHubBranchCombobox re-selects the repo's actual default branch.
             const { integrationId, repository } = values.persistedRepositoryConfig
             if (integrationId && githubIntegrations.some((integration) => integration.id === integrationId)) {
-                actions.setTaskCreateFormValues({ repositoryConfig: { integrationId, repository } })
+                actions.setNewTaskData({ repositoryConfig: { integrationId, repository } })
                 return
             }
-            actions.setTaskCreateFormValues({
+            actions.setNewTaskData({
                 repositoryConfig: {
-                    ...values.taskCreateForm.repositoryConfig,
+                    ...values.newTaskData.repositoryConfig,
                     integrationId: githubIntegrations[0].id,
                 },
             })
         },
         loadIntegrationsSuccess: () => {
-            actions.maybeRestoreRepositoryConfig()
+            actions.maybeAutoSelectIntegration()
         },
         // Fill the composer with the suggestion; submit straight away unless it needs the user to finish
         // typing (the component focuses the textarea in that case).
         applySuggestion: ({ item }) => {
-            actions.setTaskCreateFormValues({ description: item.content })
+            actions.setNewTaskData({ description: item.content })
             if (!item.requiresUserInput) {
-                actions.submitTaskCreateForm()
+                actions.submitNewTask()
+            }
+        },
+        submitNewTask: async () => {
+            const { description, repositoryConfig, model, reasoningEffort } = values.newTaskData
+
+            if (!description.trim()) {
+                lemonToast.error('Description is required')
+                actions.submitNewTaskFailure('Description is required')
+                return
+            }
+
+            try {
+                const taskData: TaskUpsertProps = {
+                    title: '',
+                    description,
+                    origin_product: OriginProduct.POSTHOG_AI,
+                    // PostHog AI can run without a repo; null means the task is not scoped to any repository.
+                    repository: repositoryConfig.repository ?? null,
+                    github_integration: repositoryConfig.integrationId ?? null,
+                }
+
+                const newTask = await api.tasks.create(taskData)
+                lemonToast.success('Task created successfully')
+
+                // Auto-run the task after creation; the detail scene shows the latest run by default. The
+                // run checks out the chosen branch (server falls back to the repo's default branch if unset)
+                // and launches with the picked model / reasoning effort (clamped to one the model supports).
+                await api.tasks.run(newTask.id, {
+                    branch: repositoryConfig.branch ?? null,
+                    runtime_adapter: ClaudeRuntimeAdapterEnumApi.Claude,
+                    model,
+                    reasoning_effort: resolveEffortForModel(reasoningEffort, model),
+                })
+                router.actions.push(`/tasks/${newTask.id}`)
+
+                actions.submitNewTaskSuccess()
+                actions.resetNewTaskData()
+                tasksLogic.actions.loadTasks()
+            } catch (error) {
+                lemonToast.error('Failed to create task')
+                actions.submitNewTaskFailure(error instanceof Error ? error.message : 'Unknown error')
             }
         },
     })),
 
     events(({ actions }) => ({
         afterMount: () => {
-            actions.loadTasks()
-            actions.loadRepositories()
+            tasksLogic.actions.loadTasks()
+            tasksLogic.actions.loadRepositories()
             // Roll a headline once per mount (pickHeadline forces index 0 under Storybook for stable snapshots).
             actions.setHeadline(pickHeadline())
             // integrationsLogic loads on its own mount (triggered by the connect above), so we don't call
             // loadIntegrations ourselves. loadIntegrationsSuccess covers that first load; this call covers
             // integrations already cached by an earlier mount.
-            actions.maybeRestoreRepositoryConfig()
+            actions.maybeAutoSelectIntegration()
         },
     })),
 ])

--- a/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
+++ b/products/posthog_ai/frontend/scenes/TaskTracker/taskTrackerSceneLogic.ts
@@ -1,4 +1,4 @@
-import { actions, connect, events, kea, listeners, path, reducers } from 'kea'
+import { actions, connect, events, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { router } from 'kea-router'
 
@@ -9,13 +9,15 @@ import { integrationsLogic } from 'lib/integrations/integrationsLogic'
 
 import { ClaudeRuntimeAdapterEnumApi, ReasoningEffortEnumApi } from 'products/tasks/frontend/generated/api.schemas'
 
+import type { SuggestionGroup, SuggestionItem } from '../../api/primitives'
+import { DEFAULT_HEADLINES, pickHeadline } from '../../api/primitives'
 import { tasksLogic } from '../../logics/tasksLogic'
 import type { RepositoryConfig } from '../../types/taskTypes'
 import { OriginProduct, TaskUpsertProps } from '../../types/taskTypes'
 import { DEFAULT_COMPOSER_EFFORT, DEFAULT_COMPOSER_MODEL, resolveEffortForModel } from '../../utils/composerModels'
 import type { taskTrackerSceneLogicType } from './taskTrackerSceneLogicType'
 
-export type TaskCreateForm = {
+export interface TaskCreateForm {
     description: string
     repositoryConfig: RepositoryConfig
     model: string
@@ -24,7 +26,7 @@ export type TaskCreateForm = {
 
 // The slice of the repo picker we remember across visits. Branch is deliberately excluded — on restore we
 // want the branch picker to re-derive the repo's actual default branch (from the GitHub API), not pin a stale one.
-type PersistedRepositoryConfig = Pick<RepositoryConfig, 'integrationId' | 'repository'>
+export type PersistedRepositoryConfig = Pick<RepositoryConfig, 'integrationId' | 'repository'>
 
 const LAST_REPOSITORY_CONFIG_STORAGE_KEY = 'posthog_ai.tasks.lastRepositoryConfig'
 
@@ -54,6 +56,9 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
     actions({
         maybeRestoreRepositoryConfig: true,
         setPersistedRepositoryConfig: (config: PersistedRepositoryConfig) => ({ config }),
+        setActiveSuggestionGroup: (group: SuggestionGroup | null) => ({ group }),
+        applySuggestion: (item: SuggestionItem) => ({ item }),
+        setHeadline: (headline: string) => ({ headline }),
     }),
 
     reducers({
@@ -63,6 +68,22 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
             { persist: true, storageKey: LAST_REPOSITORY_CONFIG_STORAGE_KEY },
             {
                 setPersistedRepositoryConfig: (_, { config }) => config,
+            },
+        ],
+        activeSuggestionGroup: [
+            null as SuggestionGroup | null,
+            {
+                setActiveSuggestionGroup: (_, { group }) => group,
+                // Clearing the description (e.g. after submit/reset) collapses any open dropdown.
+                setTaskCreateFormValues: (state, { values: formValues }) =>
+                    formValues.description !== undefined && !formValues.description ? null : state,
+                resetTaskCreateForm: () => null,
+            },
+        ],
+        headline: [
+            DEFAULT_HEADLINES[0],
+            {
+                setHeadline: (_, { headline }) => headline,
             },
         ],
     }),
@@ -109,6 +130,14 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
         },
     })),
 
+    selectors({
+        sendDisabledReason: [
+            (s) => [s.taskCreateForm],
+            (taskCreateForm): string | undefined =>
+                !taskCreateForm.description.trim() ? 'Describe the task first' : undefined,
+        ],
+    }),
+
     listeners(({ actions, values }) => ({
         // Remember the repo/integration whenever the picker changes it, so the next visit restores it.
         setTaskCreateFormValues: ({ values: formValues }) => {
@@ -144,12 +173,22 @@ export const taskTrackerSceneLogic = kea<taskTrackerSceneLogicType>([
         loadIntegrationsSuccess: () => {
             actions.maybeRestoreRepositoryConfig()
         },
+        // Fill the composer with the suggestion; submit straight away unless it needs the user to finish
+        // typing (the component focuses the textarea in that case).
+        applySuggestion: ({ item }) => {
+            actions.setTaskCreateFormValues({ description: item.content })
+            if (!item.requiresUserInput) {
+                actions.submitTaskCreateForm()
+            }
+        },
     })),
 
     events(({ actions }) => ({
         afterMount: () => {
             actions.loadTasks()
             actions.loadRepositories()
+            // Roll a headline once per mount (pickHeadline forces index 0 under Storybook for stable snapshots).
+            actions.setHeadline(pickHeadline())
             // integrationsLogic loads on its own mount (triggered by the connect above), so we don't call
             // loadIntegrations ourselves. loadIntegrationsSuccess covers that first load; this call covers
             // integrations already cached by an earlier mount.

--- a/products/posthog_ai/frontend/types/taskTypes.ts
+++ b/products/posthog_ai/frontend/types/taskTypes.ts
@@ -19,6 +19,7 @@ export enum OriginProduct {
     SIGNAL_REPORT = 'signal_report',
     // Runs created by a Signals scout (automated agent) — no interactive context budget to surface.
     SIGNALS_SCOUT = 'signals_scout',
+    POSTHOG_AI = 'posthog_ai',
 }
 
 export enum TaskRunStatus {


### PR DESCRIPTION
## Problem

The TaskTracker `/new` task composer just showed a bare "What should the agent do?" heading. We want it to feel like the PostHog AI welcome screen — a logo, a rotating headline, a "Try PostHog AI for…" suggestion row, and an in-input dropdown for multi-suggestion categories.

These pieces also need to back the new PostHog AI welcome later (swapped against the current one behind a feature flag), so they can't be one-off copies living in the tasks scene.

## Changes

Adds two reusable, logic-free presentational primitives to the shared PostHog AI agent-run surface (`products/posthog_ai/frontend`), exposed via the Tier-2 `api/primitives` facade alongside the existing `Composer` compound:

- **`Welcome`** — logomark + headline + subheadline, with a `children` slot for consumer extras. Ships overridable `DEFAULT_HEADLINES` + a `pickHeadline` helper (Storybook-stable).
- **`Suggestions`** — a compound (`Root` / `Buttons` / `Dropdown`) following the same context model as `Composer`: the caller owns the open-dropdown state and decides what a chosen suggestion does, while the component owns the open/close mechanics. Ships overridable `DEFAULT_SUGGESTIONS_DATA` (PostHog's categories with a "Coding" group prepended) and a small SCSS for the staggered dropdown animation.

Wires both into the tasks composer: `Welcome` replaces the old heading, the suggestion button row sits under the input, and the dropdown attaches inside `Composer.Root`. The fill-vs-submit behavior per suggestion lives in `taskTrackerSceneLogic` (`applySuggestion`), matching the source behavior — suggestions needing more detail fill the box and focus it; the rest submit directly.

The shared surface stays free of any `scenes/max` import — types and content are re-declared here, so Max remains a consumer, not a dependency.

## How did you test this code?

I'm an agent (Claude Code). Against the changed files only:
- `pnpm --filter=@posthog/frontend typescript:check` — clean
- oxlint + oxfmt — clean
- the surface coupling grep gate (`scenes/max` imports) — clean

No manual click-through yet — the welcome/suggestions interaction at `/tasks/new` should be verified in a running stack. Storybook stories are included for both primitives.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code. Key decision: rather than copy the Max welcome components into the tasks scene, I lifted them into the shared surface as logic-free primitives (the `Composer` precedent) so the new PostHog AI welcome can consume the exact same pieces behind a flag. Dropped Radix `ToggleGroup` from the ported dropdown — it isn't resolvable from the surface and would have been the surface's first Radix dependency — in favor of plain `LemonButton`s.

One open question for the reviewer: the default suggestion data carries the source behavior where single-suggestion `url` groups (SQL, Session replay) navigate away from the composer. That may not be desired in a coding-task context — easy to trim from the default data if not.
