### PR TITLE
fix(data-warehouse): fix lineage panel refetch and stale last_run_at

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
@@ -1,4 +1,4 @@
-import { connect, kea, key, listeners, path, props, selectors } from 'kea'
+import { afterMount, connect, kea, key, path, propsChanged, props, selectors } from 'kea'
 
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
@@ -67,17 +67,14 @@ export const infoTabLogic = kea<infoTabLogicType>([
             },
         ],
     }),
-    listeners(({ actions, props }) => {
-        if (!props.viewId) {
-            return {}
+    afterMount(({ actions, props }) => {
+        if (props.viewId) {
+            actions.loadUpstream(props.viewId)
         }
-        const jobsLogic = materializationJobsLogic({ viewId: props.viewId })
-        return {
-            [jobsLogic.actionTypes.loadDataModelingJobsSuccess]: () => {
-                if (props.viewId) {
-                    actions.loadUpstream(props.viewId)
-                }
-            },
+    }),
+    propsChanged(({ actions, props }, oldProps) => {
+        if (props.viewId && props.viewId !== oldProps.viewId) {
+            actions.loadUpstream(props.viewId)
         }
     }),
 ])

--- a/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
+++ b/frontend/src/scenes/data-warehouse/editor/output-pane-tabs/infoTabLogic.ts
@@ -1,4 +1,4 @@
-import { afterMount, connect, kea, key, path, propsChanged, props, selectors } from 'kea'
+import { afterMount, connect, kea, key, path, props, selectors } from 'kea'
 
 import { databaseTableListLogic } from 'scenes/data-management/database/databaseTableListLogic'
 import { dataWarehouseViewsLogic } from 'scenes/data-warehouse/saved_queries/dataWarehouseViewsLogic'
@@ -69,11 +69,6 @@ export const infoTabLogic = kea<infoTabLogicType>([
     }),
     afterMount(({ actions, props }) => {
         if (props.viewId) {
-            actions.loadUpstream(props.viewId)
-        }
-    }),
-    propsChanged(({ actions, props }, oldProps) => {
-        if (props.viewId && props.viewId !== oldProps.viewId) {
             actions.loadUpstream(props.viewId)
         }
     }),

--- a/products/data_warehouse/backend/presentation/views/lineage.py
+++ b/products/data_warehouse/backend/presentation/views/lineage.py
@@ -132,8 +132,6 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                         "name": table.name if table else external_table,
                     }
 
-    # The v2 backend updates DataModelingJob but not DataWarehouseSavedQuery.last_run_at, so prefer
-    # the latest job's timestamp — one query for the whole DAG, matching the saved query serializer.
     view_names = [name for name, data in node_data.items() if data["type"] == "view"]
     latest_runs = dict(
         DataModelingJob.objects.filter(team_id=team_id, saved_query__name__in=view_names)

--- a/products/data_warehouse/backend/presentation/views/lineage.py
+++ b/products/data_warehouse/backend/presentation/views/lineage.py
@@ -67,7 +67,6 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
     dag: dict[str, list[Any]] = {"nodes": [], "edges": []}
     seen_nodes: set[str] = set()
     node_data: dict[str, dict] = {}
-    node_key_by_saved_query_id: dict[Any, str] = {}
 
     # root node and its external tables
     root_query = DataWarehouseSavedQuery.objects.filter(id=model_id, team_id=team_id).first()
@@ -82,7 +81,6 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
         "last_run_at": root_query.last_run_at,
         "status": root_query.status,
     }
-    node_key_by_saved_query_id[root_query.id] = root_query.name
     seen_nodes.add(root_query.name)
 
     # Recursively fetch all dependencies with a bfs
@@ -123,7 +121,6 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                         "last_run_at": saved_query.last_run_at,
                         "status": saved_query.status,
                     }
-                    node_key_by_saved_query_id[saved_query.id] = external_table
                     to_process.append((external_table, saved_query.external_tables))
                 else:
                     table = tables.get(external_table)
@@ -137,17 +134,15 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
 
     # The v2 backend updates DataModelingJob but not DataWarehouseSavedQuery.last_run_at, so prefer
     # the latest job's timestamp — one query for the whole DAG, matching the saved query serializer.
-    if node_key_by_saved_query_id:
-        latest_jobs = (
-            DataModelingJob.objects.filter(team_id=team_id, saved_query_id__in=node_key_by_saved_query_id.keys())
-            .order_by("saved_query_id", "-last_run_at")
-            .distinct("saved_query_id")
-            .values_list("saved_query_id", "last_run_at")
-        )
-        for saved_query_id, job_last_run_at in latest_jobs:
-            node_key = node_key_by_saved_query_id.get(saved_query_id)
-            if node_key is not None:
-                node_data[node_key]["last_run_at"] = job_last_run_at
+    view_names = [name for name, data in node_data.items() if data["type"] == "view"]
+    latest_runs = dict(
+        DataModelingJob.objects.filter(team_id=team_id, saved_query__name__in=view_names)
+        .order_by("saved_query__name", "-last_run_at")
+        .distinct("saved_query__name")
+        .values_list("saved_query__name", "last_run_at")
+    )
+    for name, last_run_at in latest_runs.items():
+        node_data[name]["last_run_at"] = last_run_at
 
     # Order nodes by dependency order
     ordered_nodes = topological_sort(list(node_data.keys()), dag["edges"])

--- a/products/data_warehouse/backend/presentation/views/lineage.py
+++ b/products/data_warehouse/backend/presentation/views/lineage.py
@@ -9,7 +9,7 @@ from rest_framework.response import Response
 from posthog.api.documentation import _FallbackSerializer
 from posthog.api.routing import TeamAndOrgViewSetMixin
 
-from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
 
@@ -67,6 +67,7 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
     dag: dict[str, list[Any]] = {"nodes": [], "edges": []}
     seen_nodes: set[str] = set()
     node_data: dict[str, dict] = {}
+    node_key_by_saved_query_id: dict[Any, str] = {}
 
     # root node and its external tables
     root_query = DataWarehouseSavedQuery.objects.filter(id=model_id, team_id=team_id).first()
@@ -81,6 +82,7 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
         "last_run_at": root_query.last_run_at,
         "status": root_query.status,
     }
+    node_key_by_saved_query_id[root_query.id] = root_query.name
     seen_nodes.add(root_query.name)
 
     # Recursively fetch all dependencies with a bfs
@@ -121,6 +123,7 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                         "last_run_at": saved_query.last_run_at,
                         "status": saved_query.status,
                     }
+                    node_key_by_saved_query_id[saved_query.id] = external_table
                     to_process.append((external_table, saved_query.external_tables))
                 else:
                     table = tables.get(external_table)
@@ -131,6 +134,20 @@ def get_upstream_dag(team_id: int, model_id: str) -> dict[str, list[Any]]:
                         "type": "table",
                         "name": table.name if table else external_table,
                     }
+
+    # The v2 backend updates DataModelingJob but not DataWarehouseSavedQuery.last_run_at, so prefer
+    # the latest job's timestamp — one query for the whole DAG, matching the saved query serializer.
+    if node_key_by_saved_query_id:
+        latest_jobs = (
+            DataModelingJob.objects.filter(team_id=team_id, saved_query_id__in=node_key_by_saved_query_id.keys())
+            .order_by("saved_query_id", "-last_run_at")
+            .distinct("saved_query_id")
+            .values_list("saved_query_id", "last_run_at")
+        )
+        for saved_query_id, job_last_run_at in latest_jobs:
+            node_key = node_key_by_saved_query_id.get(saved_query_id)
+            if node_key is not None:
+                node_data[node_key]["last_run_at"] = job_last_run_at
 
     # Order nodes by dependency order
     ordered_nodes = topological_sort(list(node_data.keys()), dag["edges"])

--- a/products/data_warehouse/backend/tests/api/test_lineage.py
+++ b/products/data_warehouse/backend/tests/api/test_lineage.py
@@ -69,7 +69,8 @@ class TestLineage(APIBaseTest):
             for q in context.captured_queries
             if "datawarehousesavedquery" in q["sql"].lower() or "datawarehousetable" in q["sql"].lower()
         ]
-        self.assertLessEqual(len(view_queries), 7, f"Expected 7 queries, got {len(view_queries)}")
+        # One extra over the BFS lookups for the batched latest-job query (joins the saved query table)
+        self.assertLessEqual(len(view_queries), 8, f"Expected at most 8 queries, got {len(view_queries)}")
 
     def test_get_upstream_with_datawarehouse_table(self):
         DataWarehouseTable.objects.create(

--- a/products/data_warehouse/backend/tests/api/test_lineage.py
+++ b/products/data_warehouse/backend/tests/api/test_lineage.py
@@ -69,7 +69,6 @@ class TestLineage(APIBaseTest):
             for q in context.captured_queries
             if "datawarehousesavedquery" in q["sql"].lower() or "datawarehousetable" in q["sql"].lower()
         ]
-        # One extra over the BFS lookups for the batched latest-job query (joins the saved query table)
         self.assertLessEqual(len(view_queries), 8, f"Expected at most 8 queries, got {len(view_queries)}")
 
     def test_get_upstream_with_datawarehouse_table(self):
@@ -234,9 +233,7 @@ class TestLineage(APIBaseTest):
             data = response.json()
 
         nodes = {node["id"]: node for node in data["nodes"]}
-        # latest job wins, not the May 1 job nor the stale model field
         self.assertTrue(nodes["final_q"]["last_run_at"].startswith("2026-06-30T10:00:00"))
-        # base_q has no job, so it falls back to the model field
         self.assertTrue(nodes["base_q"]["last_run_at"].startswith("2026-04-29T09:00:00"))
 
         job_queries = [q for q in context.captured_queries if "posthog_datamodelingjob" in q["sql"].lower()]

--- a/products/data_warehouse/backend/tests/api/test_lineage.py
+++ b/products/data_warehouse/backend/tests/api/test_lineage.py
@@ -1,8 +1,10 @@
+from datetime import UTC, datetime
+
 from posthog.test.base import APIBaseTest
 
 from posthog.test.db_context_capturing import capture_db_queries
 
-from products.data_modeling.backend.facade.models import DataWarehouseSavedQuery
+from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
 from products.data_warehouse.backend.presentation.views.lineage import topological_sort
 from products.warehouse_sources.backend.facade.models import DataWarehouseTable
 
@@ -191,6 +193,53 @@ class TestLineage(APIBaseTest):
 
         nodes = {node["id"]: node for node in data["nodes"]}
         self.assertEqual(nodes["test_query"]["type"], "view")
+
+    def test_get_upstream_last_run_at_uses_latest_job_not_stale_model_field(self):
+        stale = datetime(2026, 4, 29, 9, 0, 0, tzinfo=UTC)
+
+        DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="base_q",
+            query={"kind": "HogQLQuery", "query": "select * from postgres.supabase.users"},
+            external_tables=["postgres.supabase.users"],
+            last_run_at=stale,
+            status="Modified",
+        )
+        final_q = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="final_q",
+            query={"kind": "HogQLQuery", "query": "select * from base_q"},
+            external_tables=["base_q"],
+            last_run_at=stale,
+            status="Modified",
+        )
+
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=final_q,
+            status="Completed",
+            last_run_at=datetime(2026, 5, 1, 0, 0, 0, tzinfo=UTC),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=final_q,
+            status="Completed",
+            last_run_at=datetime(2026, 6, 30, 10, 0, 0, tzinfo=UTC),
+        )
+
+        with capture_db_queries() as context:
+            response = self.client.get(f"/api/environments/{self.team.id}/lineage/get_upstream/?model_id={final_q.id}")
+            self.assertEqual(response.status_code, 200)
+            data = response.json()
+
+        nodes = {node["id"]: node for node in data["nodes"]}
+        # latest job wins, not the May 1 job nor the stale model field
+        self.assertTrue(nodes["final_q"]["last_run_at"].startswith("2026-06-30T10:00:00"))
+        # base_q has no job, so it falls back to the model field
+        self.assertTrue(nodes["base_q"]["last_run_at"].startswith("2026-04-29T09:00:00"))
+
+        job_queries = [q for q in context.captured_queries if "posthog_datamodelingjob" in q["sql"].lower()]
+        self.assertEqual(len(job_queries), 1, "Latest job per saved query must be a single batched query")
 
     def test_topological_sort(self):
         nodes = ["A", "B", "C"]


### PR DESCRIPTION
## Problem

Two issues in the SQL-editor materialize modal's lineage panel (`QueryInfo` → `get_upstream`), both surfaced now that the `lineage-dependency-view` flag is rolling out:

1. **Lineage refetched on every job poll.** `loadUpstream` was chained to `loadDataModelingJobsSuccess`, and the materialization-runs table re-arms a poll timer after every success — so `get_upstream` fired again every few seconds for as long as the modal stayed open. Lineage is structural and static between polls.

2. **Stale `last_run_at` in the lineage.** `get_upstream_dag` read the denormalized `DataWarehouseSavedQuery.last_run_at` model field. That field is only written by the **v1** materialization workflow (`run_workflow.py`); the **v2 DAG backend** (which EU teams run) updates `DataModelingJob` instead and never bumps the saved-query field. Result: a node materialized successfully today showed a months-old "last run" in the lineage, even though the Materialization Runs table (which reads jobs) showed today. The rest of the app already avoids this — the saved-query serializer's `get_last_run_at` derives from the latest job.

## Changes

- **`infoTabLogic`**: load lineage once on mount (`afterMount`) instead of on every `loadDataModelingJobsSuccess`. Removed a `propsChanged` guard that was dead code (`viewId` is part of the logic key, so a change remounts the logic — `afterMount` already covers it).
- **`get_upstream_dag`**: override each view node's `last_run_at` with the latest `DataModelingJob` per saved query, falling back to the model field when there are no jobs — mirroring `get_last_run_at`. Done in **one batched `DISTINCT ON` query** for the whole DAG (no N+1).

`status` is intentionally left as the model field — the saved-query serializer also returns it raw, and the lineage table doesn't render it.

## How did you test this code?

I'm an agent (Claude Code). Added `test_get_upstream_last_run_at_uses_latest_job_not_stale_model_field` to `test_lineage.py` — it stamps a stale model-field `last_run_at`, adds a newer + an older `DataModelingJob`, and asserts the lineage returns the newest job's timestamp (not the stale field), that a node with no job falls back to the model field, and that the job lookup is a single batched query (N+1 guard). Full `TestLineage` class passes (6 tests). The `infoTabLogic` change is a kea-lifecycle rewiring with no rendered-data change; not separately unit-tested.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a report that the lineage/dependencies panel repeatedly hit `get_upstream` and showed a stale last-run for a query that materialized today. Root-caused the staleness to the v1-vs-v2 write-back split (v2 updates `DataModelingJob`, not the saved-query model field) and the refetch to a poll-coupled listener. Invoked the repo `/writing-tests` skill before adding the backend test.
