### PR TITLE
chore(signals): trim canonical scout descriptions to a sentence or two

### DIFF
--- a/products/signals/skills/authoring-scouts/SKILL.md
+++ b/products/signals/skills/authoring-scouts/SKILL.md
@@ -213,3 +213,7 @@ surfaces change.
 - **Save-memory** guidance using the scratchpad prefixes so the scout gets smarter each run.
 - A lean body (push depth into `references/`) — every line is a recurring token cost on
   every run.
+- A **tight frontmatter `description`** — a sentence or two naming the surface and the
+  shapes it watches. Every scout's description loads into the caller's AI plugin together,
+  so wordy descriptions waste token budget and get truncated; skip the fleet-wide
+  boilerplate (confidence bar, durable memory, self-contained peer).

--- a/products/signals/skills/authoring-scouts/references/scout-anatomy.md
+++ b/products/signals/skills/authoring-scouts/references/scout-anatomy.md
@@ -27,10 +27,11 @@ runs as a scout.
 ---
 name: signals-scout-<scope>
 description: >
-  One paragraph, third person. State the surface it watches, the specific shapes it
-  looks for (bursts, regressions, clusters, drops), that it emits only above the
-  confidence bar and otherwise writes memory and closes out empty, and that it's a
-  self-contained peer in the signals-scout-* fleet.
+  One or two sentences, third person: the surface it watches and the specific shapes it
+  looks for (bursts, regressions, clusters, drops). Keep it tight. Don't restate the
+  fleet-wide boilerplate every scout shares (emits above the confidence bar, writes
+  memory, closes out empty, self-contained peer) — that's assumed, and repeating it
+  across the fleet burns the caller's token budget and gets truncated in AI plugins.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit).
@@ -51,7 +52,10 @@ scout assumes; `metadata.scope` gives downstream tooling a short label.
 The `description` does double duty: beyond skill discovery, it is surfaced verbatim as the
 scout's `description` on the config API (`signals-scout-config-list` / `-create` / `-update`
 responses) — it's how the fleet roster reads to agents and the UI without opening each
-scout's body. Write it to stand alone in that listing.
+scout's body. Write it to stand alone in that listing, and keep it short: it's also loaded
+alongside every other scout's into a caller's AI plugin, where a wordy description wastes
+token budget and gets truncated. A sentence or two that names the surface and the shapes is
+the whole job.
 
 ## Body structure
 
@@ -139,10 +143,8 @@ files to a per-team scout with `posthog:skill-file-create`; in the repo, drop th
 ---
 name: signals-scout-<scope>
 description: >
-  Focused Signals scout for PostHog projects using <surface>. Watches <event/metric> for
-  <the shapes: bursts / regressions / clusters / drops>. Emits findings only when they
-  clear the confidence bar; otherwise writes durable memory and closes out empty.
-  Self-contained peer in the signals-scout-* fleet.
+  Signals scout for PostHog <surface>. Watches <event/metric> for <the shapes: bursts /
+  regressions / clusters / drops>.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write). Assumes the signals-scout MCP

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: signals-scout-ai-observability
 description: >
-  Focused Signals scout for PostHog projects using AI observability. Rotates through a set
-  of lenses — cost, latency, errors, volume, eval performance, eval/enrichment config,
-  clusters, and tool usage — watching each for trends and spikes sliced by the dimensions
-  it discovers over time. Leans on the sandbox's bundled `exploring-llm-*` deep-dive skills
-  for the actual queries. Emits findings only when they clear the confidence bar; otherwise
-  writes durable memory and closes out empty. Self-contained peer in the signals-scout-*
-  fleet — no dependencies on other scouts.
+  Signals scout for PostHog AI observability. Watches LLM traces for cost, latency, error,
+  volume, and eval-performance regressions, sliced by the dimensions it discovers over time.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
+++ b/products/signals/skills/signals-scout-anomaly-detection/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: signals-scout-anomaly-detection
 description: >
-  Signals scout that watches a PostHog project's most-viewed dashboards and insights for
-  recent anomalies — sudden bursts, drops, flat-lines, and trend breaks at the daily or
-  hourly level. It discovers what the team actually looks at (view counts, dashboard
-  access), curates a durable watchlist in the scratchpad, and balances re-checking known
-  high-value insights (exploit) against discovering new ones (explore) across runs, since
-  no single run can cover a busy project. Anomalies are scored by robust deviation from
-  each insight's own seasonality-matched baseline; it emits a finding only when a move
-  clears the confidence bar, otherwise it updates the baseline memory and closes out
-  empty. Self-contained peer in the signals-scout-* fleet.
+  Signals scout that watches a project's most-viewed dashboards and insights for recent
+  anomalies — bursts, drops, flat-lines, and trend breaks scored against each insight's own
+  seasonality-matched baseline.
 compatibility: >
   Runs as the PostHog Signals scout in a Claude sandbox with read-only analytics scopes
   plus signal_scout_internal:write (scratchpad + emit) and notebook:write (the notebook

--- a/products/signals/skills/signals-scout-apm/SKILL.md
+++ b/products/signals/skills/signals-scout-apm/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: signals-scout-apm
 description: >
-  Focused Signals scout for PostHog projects using the distributed tracing (APM /
-  OpenTelemetry spans) product. Watches RED metrics per (service, operation) — error rate,
-  p95 latency, and request volume — for regressions against each operation's own
-  seasonality-matched baseline (the same window 7 days ago), plus new error signatures,
-  failing downstream dependencies, and service traffic cliffs. Emits findings only when
-  they clear the confidence bar; otherwise writes durable memory and closes out empty.
-  Self-contained peer in the signals-scout-* fleet — not AI observability ($ai_* traces)
-  and not logs.
+  Signals scout for PostHog distributed tracing (APM / OpenTelemetry spans). Watches RED
+  metrics per (service, operation) — error rate, p95 latency, request volume — for
+  regressions, new error signatures, and traffic cliffs.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-csp-violations/SKILL.md
+++ b/products/signals/skills/signals-scout-csp-violations/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: signals-scout-csp-violations
 description: >
-  Focused Signals scout for PostHog projects collecting Content Security Policy (CSP)
-  violation reports. Watches `$csp_violation` events for fresh blocked-URL clusters,
-  per-directive bursts, page-scoped regressions after deploys, standing high-reach
-  enforced / first-party blocks, and suspicious third-party domains that may indicate a
-  compromised script. Emits aggregated
-  findings only when a cluster clears the confidence bar; otherwise writes durable
-  memory and closes out empty. Self-contained peer in the signals-scout-* fleet — no
-  dependencies on other skills.
+  Signals scout for Content Security Policy violation reports. Watches `$csp_violation` events
+  for blocked-URL clusters, per-directive bursts, post-deploy regressions, and suspicious
+  third-party domains.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-customer-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-customer-analytics/SKILL.md
@@ -1,19 +1,9 @@
 ---
 name: signals-scout-customer-analytics
 description: >
-  Focused Signals scout for PostHog projects using Customer analytics (the Accounts
-  product — `system.accounts`, where an account is a customer organization keyed by a
-  group). Watches per-account product engagement for churn-risk shapes — an engagement
-  cliff on a named account, dormancy onset, single-threaded champion departure — and the
-  positive inverse, an expansion signal worth an upsell, scoring each account against its
-  own trailing baseline and weighting by whether a human has staked commercial ownership
-  on it (assigned CSM / AE / owner, or a CRM link). Its discriminator is a per-account
-  engagement regression while the fleet holds: one staked account sliding is signal, the
-  whole fleet moving together is someone else's baseline problem. Curates a durable
-  watchlist of commercially-meaningful accounts and balances re-scoring known ones
-  (exploit) against discovering new ones (explore) across runs. Emits findings only when
-  they clear the confidence bar; otherwise writes durable memory and closes out empty.
-  Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for PostHog Customer analytics (Accounts). Watches per-account engagement for
+  churn-risk shapes — engagement cliffs, dormancy, champion departure — and the expansion
+  inverse, weighted by commercial ownership.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-data-pipelines/SKILL.md
+++ b/products/signals/skills/signals-scout-data-pipelines/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: signals-scout-data-pipelines
 description: >
-  Focused Signals scout for PostHog projects moving data through pipelines. Watches the
-  three delivery surfaces — CDP destinations and transformations (hog functions), batch
-  exports, and hog flows (workflows/messaging) — for contradictions between configured
-  state and actual delivery: functions the watcher quietly degraded or disabled, failure
-  rates stepping above a pipeline's own baseline, batch export runs failing or stalling
-  (a growing data gap), and active flows failing for the people they trigger on. Emits
-  findings only when they clear the confidence bar; otherwise writes durable memory and
-  closes out empty. Self-contained peer in the signals-scout-* fleet — no dependencies
-  on other skills.
+  Signals scout for PostHog data pipelines — CDP destinations and transformations, batch
+  exports, and hog flows. Watches for delivery failures, degraded functions, and stalled
+  exports against each pipeline's baseline.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-error-tracking/SKILL.md
+++ b/products/signals/skills/signals-scout-error-tracking/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: signals-scout-error-tracking
 description: >
-  Focused Signals scout for PostHog projects using error tracking. Watches `$exception`
-  bursts, stuck loops, multi-fingerprint clusters, status regressions, and stack-trace
-  activity-name patterns. Emits findings only when they clear the confidence bar;
-  otherwise writes durable memory and closes out empty. Self-contained peer in the
-  signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for PostHog error tracking. Watches `$exception` bursts, stuck loops,
+  multi-fingerprint clusters, and status regressions.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-experiments/SKILL.md
+++ b/products/signals/skills/signals-scout-experiments/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: signals-scout-experiments
 description: >
-  Focused Signals scout for PostHog projects running A/B experiments. Watches running
-  experiments for validity threats (sample ratio mismatch, multi-variant contamination,
-  exposure stalls, mid-run flag mutations) and lifecycle drift (zombie experiments running
-  long past their useful life, decided-but-still-running experiments, ended experiments
-  whose flags still serve multiple variants). Emits findings only when they clear the
-  confidence bar; otherwise writes durable memory and closes out empty. Self-contained
-  peer in the signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for PostHog A/B experiments. Watches running experiments for validity threats
+  (sample ratio mismatch, contamination, exposure stalls, mid-run flag mutations) and
+  lifecycle drift (zombies, decided-but-running).
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-feature-flags/SKILL.md
+++ b/products/signals/skills/signals-scout-feature-flags/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: signals-scout-feature-flags
 description: >
-  Focused Signals scout for PostHog projects using feature flags. Watches the flag roster
-  and the `$feature_flag_called` evaluation stream for contradictions between a flag's
-  configured state and its real traffic: evaluation cliffs on healthy flags, ghost flags
-  (code calling keys that no longer exist), response-distribution shifts with no
-  corresponding flag edit, and flag debt (stale, fully-rolled-out, or dead flags still
-  burning evaluations). Emits findings only when they clear the confidence bar; otherwise
-  writes durable memory and closes out empty. Self-contained peer in the signals-scout-*
-  fleet — no dependencies on other skills.
+  Signals scout for PostHog feature flags. Watches the flag roster and the
+  `$feature_flag_called` stream for evaluation cliffs, ghost flags, response-distribution
+  shifts, and flag debt.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-general/SKILL.md
+++ b/products/signals/skills/signals-scout-general/SKILL.md
@@ -1,12 +1,8 @@
 ---
 name: signals-scout-general
 description: >
-  General Signals scout for PostHog projects. Cross-product explorer that scans a
-  team's project and emits findings into the Signals inbox. Sibling signals-scout-*
-  specialists each watch a single product surface in depth; this scout looks for
-  cross-product correlations and explores the surfaces no specialist covers. Each
-  scout runs on its own schedule (default every 24 hours), so general fires independently
-  of the specialists over time.
+  Cross-product Signals scout. Looks for cross-product correlations and explores the surfaces
+  the per-product specialist scouts don't cover.
 compatibility: >
   Runs as the PostHog Signals scout in a Claude sandbox with PostHog MCP scopes: signal_scout:read + signal_scout_internal:write (for
   scratchpad-remember/forget) + signal_scout_report:write (for emit-report/edit-report,

--- a/products/signals/skills/signals-scout-health-checks/SKILL.md
+++ b/products/signals/skills/signals-scout-health-checks/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: signals-scout-health-checks
 description: >
-  Focused Signals scout for PostHog setup health. Reads the project's active health
-  issues — the deterministic findings of PostHog's own health checks (no live events,
-  outdated SDKs, missing reverse proxy, absent web vitals, ingestion warnings, failing
-  data-warehouse models, and more) — and decides which are genuinely worth surfacing.
-  Unlike a one-signal-per-issue push, it bundles kind-clusters into a single finding,
-  weights by real blast radius (cross-referencing actual event volume and reach), and
-  prioritizes issues an agent can resolve via the MCP. Emits only above the confidence
-  bar; otherwise writes durable memory and closes out empty. Self-contained peer in the
-  signals-scout-* fleet — no dependencies on other skills.
+  Signals scout over PostHog's own health checks. Reads the project's active health issues,
+  bundles them by kind, weights by blast radius, and surfaces the ones genuinely worth acting
+  on.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-inbox-validation/SKILL.md
+++ b/products/signals/skills/signals-scout-inbox-validation/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: signals-scout-inbox-validation
 description: >
-  Follow-up scout for the Signals inbox itself. Watches reports that recently
-  transitioned to resolved (an implementation PR merged) and, after a deployment soak
-  window, re-measures the underlying problem to check the fix actually held — plus a
-  strictly-gated escalation check on recently dismissed reports. Emits findings only
-  when a shipped fix demonstrably didn't hold; confirmations and unverifiable verdicts
-  become durable memory and an empty close-out. Self-contained peer in the
-  signals-scout-* fleet — no dependencies on other skills.
+  Follow-up Signals scout for the inbox itself. After a deployment soak window, re-measures
+  the problems behind recently resolved reports to check the fix held, plus a gated escalation
+  check on dismissed reports.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-insight-alerts/SKILL.md
+++ b/products/signals/skills/signals-scout-insight-alerts/SKILL.md
@@ -1,15 +1,9 @@
 ---
 name: signals-scout-insight-alerts
 description: >
-  Digest + triage scout over a PostHog project's own configured insight alerts. The team
-  already declared what matters by creating alerts with thresholds or anomaly detectors, so
-  this scout doesn't detect anomalies — it reads each alert's recent firing history and
-  surfaces the handful of recent firings a human likely missed, weighting hardest toward
-  firings the standard notification path stayed silent on (no subscribers, suppressed by the
-  investigation agent, or an alert that's silently Errored and no longer evaluating). Skips
-  snoozed, disabled, flapping, and already-notified-and-resolved alerts. Emits a finding only
-  when a firing clears the confidence bar; otherwise writes durable memory and closes out
-  empty. Self-contained peer in the signals-scout-* fleet.
+  Signals scout over a project's own configured insight alerts. Reads each alert's recent
+  firing history and surfaces the firings a human likely missed — especially ones the standard
+  notification path stayed silent on.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes the

--- a/products/signals/skills/signals-scout-logs/SKILL.md
+++ b/products/signals/skills/signals-scout-logs/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: signals-scout-logs
 description: >
-  Focused Signals scout for PostHog projects using logs. Watches for volume bursts,
-  severity-distribution shifts, service silence, fresh message patterns, and
-  trace-correlated bursts via the logs ingestion pipeline. Emits findings only when
-  they clear the confidence bar; otherwise writes durable memory and closes out empty.
-  Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for PostHog logs. Watches for volume bursts, severity-distribution shifts,
+  service silence, fresh message patterns, and trace-correlated bursts.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-observability-gaps/SKILL.md
+++ b/products/signals/skills/signals-scout-observability-gaps/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: signals-scout-observability-gaps
 description: >
-  Focused Signals scout for finding observability gaps in PostHog itself — significant
-  event volumes the team isn't tracking, custom events with no insight or dashboard
-  coverage, insights pointing at events that have stopped firing, dashboards missing
-  related context, critical events with no alerts. Watches the event-stream-vs-saved-
-  inventory delta as the team's product evolves and emits findings recommending new
-  insights, dashboard additions, or alerts when gaps clear the confidence bar.
-  Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for observability gaps — significant event volumes with no insight, dashboard,
+  or alert coverage. Recommends new insights, dashboards, or alerts as the team's product
+  evolves.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-product-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-product-analytics/SKILL.md
@@ -1,18 +1,9 @@
 ---
 name: signals-scout-product-analytics
 description: >
-  Focused Signals scout for the core product-analytics surface — the behavioral primitives
-  the product-analytics product is built on: funnels, retention, lifecycle, stickiness, and
-  paths. It watches the team's saved funnel / retention / lifecycle insights (and, where the
-  team hasn't built one, a single inferred activation flow) for behavioral regression — a
-  step-to-step conversion rate dropping, a retention curve sliding, or a lifecycle/stickiness
-  composition shifting away from that flow's own trailing, seasonality-matched baseline —
-  while the flow's entrant volume holds. Its discriminator is a derived-rate regression with a
-  steady denominator, which is what separates a real product regression from a capture or
-  volume problem (those belong to other scouts). It curates a durable watchlist and balances
-  re-scoring known flows (exploit) against discovering new ones (explore) across runs. Emits
-  findings only when they clear the confidence bar; otherwise writes durable memory and closes
-  out empty. Self-contained peer in the signals-scout-* fleet — no dependencies on other skills.
+  Signals scout for core product-analytics flows — funnels, retention, lifecycle, stickiness,
+  and paths. Watches the team's saved flows for a derived-rate regression (conversion or
+  retention sliding) while entrants hold.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes the

--- a/products/signals/skills/signals-scout-replay-vision/SKILL.md
+++ b/products/signals/skills/signals-scout-replay-vision/SKILL.md
@@ -1,17 +1,9 @@
 ---
 name: signals-scout-replay-vision
 description: >
-  Focused Signals scout for PostHog projects running Replay Vision scanners — the standing
-  LLM probes that watch session recordings and write `$recording_observed` events. Watches
-  two promises: that enabled scanners are actually observing (throughput / success-rate
-  cliffs, exhausted quota — a silent watch gap), and that what the scanners see in aggregate
-  gets surfaced (a monitor's `yes`-rate or a scorer's score stepping away from its own
-  baseline, a classifier tag or a recurring summarizer theme concentrating across many
-  sessions). It is the agentic pull complement to the per-session push path: scanners with
-  `emits_signals` already emit one signal per session into this same inbox, so this scout
-  never repeats them — it adds the cross-session shape the per-session probe can't see.
-  Emits findings only when they clear the confidence bar; otherwise writes durable memory
-  and closes out empty. Self-contained peer in the signals-scout-* fleet.
+  Signals scout for PostHog Replay Vision scanners. Watches that enabled scanners keep
+  observing (throughput / quota cliffs) and that what they see in aggregate gets surfaced
+  (score shifts, recurring themes across sessions).
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (mostly read-only, plus signal_scout_internal:write). Assumes the signals-scout MCP

--- a/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-revenue-analytics/SKILL.md
@@ -1,13 +1,8 @@
 ---
 name: signals-scout-revenue-analytics
 description: >
-  Focused Signals scout for PostHog projects using revenue analytics. Watches the
-  derived revenue product for upstream failures (Stripe sync stalls, capture
-  regressions), config drift (missing subscription property, currency mix surprises,
-  broken Stripe↔person joins, deferred-revenue gaps), and goal-miss escalations.
-  Emits findings only when they clear the confidence bar; otherwise writes durable
-  memory and closes out empty. Self-contained peer in the signals-scout-* fleet —
-  no dependencies on other skills.
+  Signals scout for PostHog revenue analytics. Watches for upstream failures (Stripe sync
+  stalls, capture regressions), config drift, and goal-miss escalations.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-session-replay/SKILL.md
+++ b/products/signals/skills/signals-scout-session-replay/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: signals-scout-session-replay
 description: >
-  Focused Signals scout for PostHog projects using session replay. Watches two promises
-  the replay product makes: that sessions are actually being recorded (capture integrity —
-  recording volume vanishing while site traffic doesn't), and that the friction evidence
-  inside recordings gets seen (rage-click / dead-click clusters concentrating on a page
-  or element, error-after-interaction cohorts, recurring replay vision themes nobody
-  aggregates). Emits findings only when they clear the confidence bar; otherwise writes
-  durable memory and closes out empty. Self-contained peer in the signals-scout-* fleet.
+  Signals scout for PostHog session replay. Watches that sessions keep recording (capture
+  cliffs) and that friction inside recordings — rage/dead-click clusters,
+  error-after-interaction cohorts — gets surfaced.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (mostly read-only, plus signal_scout_internal:write). Assumes the signals-scout MCP

--- a/products/signals/skills/signals-scout-surveys/SKILL.md
+++ b/products/signals/skills/signals-scout-surveys/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: signals-scout-surveys
 description: >
-  Focused Signals scout for PostHog projects running surveys. Watches active surveys for
-  score regressions (NPS / CSAT / rating drops), response-volume drops, abandonment
-  spikes, and targeting drift, AND aggregates open-text responses into recurring themes
-  the team should know about (clusters of complaints, praise, feature requests). Emits
-  findings only when a theme or anomaly clears the confidence bar; otherwise writes
-  durable memory and closes out empty. Self-contained peer in the signals-scout-* fleet
-  — no dependencies on other skills.
+  Signals scout for PostHog surveys. Watches active surveys for score regressions,
+  response-volume drops, abandonment spikes, and targeting drift, and aggregates open-text
+  responses into recurring themes.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes

--- a/products/signals/skills/signals-scout-web-analytics/SKILL.md
+++ b/products/signals/skills/signals-scout-web-analytics/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: signals-scout-web-analytics
 description: >
-  Focused Signals scout for PostHog projects with web traffic. Watches the acquisition
-  and site-health layer the web analytics product reports on: per-channel session volume
-  diverging from the site's own rhythm (an acquisition source silently collapsing or
-  surging), attribution breakage (paid/campaign traffic reclassifying into Direct or
-  Unknown when tagging breaks), landing pages that break (bounce-rate steps, 404 spikes,
-  entry-path cliffs), and page-performance regressions (web vitals p75 steps). Emits
-  findings only when they clear the confidence bar; otherwise writes durable memory and
-  closes out empty. Self-contained peer in the signals-scout-* fleet.
+  Signals scout for PostHog web traffic. Watches per-channel session volume, attribution
+  breakage, landing-page health (bounce / 404 steps), and web vitals regressions against the
+  site's own baseline.
 compatibility: >
   Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
   (mostly read-only, plus signal_scout_internal:write). Assumes the signals-scout MCP


### PR DESCRIPTION
## Problem

Scout `description` frontmatter had grown into full paragraphs. Every scout's description loads together into a caller's AI plugin, so the bulk eats into token budget — and a recent Claude Code change now aggressively truncates descriptions, so the tail gets cut anyway. The descriptions also surface verbatim in the app (the config roster / inbox), where the wordiness reads as clutter. Most of the length was the same fleet-wide boilerplate repeated 21 times: "emits only above the confidence bar, otherwise writes durable memory and closes out empty, self-contained peer in the signals-scout-* fleet."

## Changes

- Trimmed all 21 canonical scout (`signals-scout-*`) descriptions down to one or two sentences that name the product surface and the shapes the scout watches. Dropped the repeated boilerplate — it's a fleet-wide assumption, not per-scout information. Net ~170 lines removed.
- Updated the `authoring-scouts` guidance so new scouts follow suit:
  - `references/scout-anatomy.md` — the frontmatter description guidance, the "double duty" note (it's also the config-roster text), and the skeleton template all now call for a tight 1–2 sentence description and explain the token-budget/truncation reason.
  - `SKILL.md` quality bar — added a bullet requiring a tight description and skipping the boilerplate.

`compatibility` and `metadata` frontmatter are untouched; only `description` changed. The generated `products/posthog_ai/dist/skills/` copies are gitignored and rebuild from this source; per-team `LLMSkill` rows re-sync on the next coordinator tick (diverged rows are left alone).

## How did you test this code?

I'm an agent (Claude Code, Opus 4.8), working under Andy's direction. No manual UI testing. Automated/local checks only:

- Validated all 21 scout frontmatters parse as YAML with `name` + `description` present, and that key order / `compatibility` / `metadata` are preserved — before and after lint-staged's markdown formatter ran on commit.
- Confirmed no other tracked source (excluding gitignored `dist/`) embeds the old descriptions; there are no snapshot tests or description-length validations to update.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy flagged (via a Slack thread with the Signals team) that scout skill descriptions are too wordy — they burn token budget in AI plugins, get truncated by a new Claude Code behavior, and look ugly where the app exposes them. The ask was to trim every canonical scout description to a sentence or two and update the authoring guidance to keep them that way.

The repeated per-scout boilerplate was the obvious target since it carried no information unique to each scout. Each trimmed description keeps the discriminating detail (the surface + the concrete shapes watched) so the config roster still reads usefully without opening a scout's body. The bulk edit was done via a throwaway script (regex replace of the folded YAML `description` block) to keep all 21 consistent, then verified by parsing every frontmatter.

I deliberately left the two scout meta-skills (`authoring-scouts`, `exploring-scouts`) descriptions as-is: their `Use when… / Trigger on…` form is the standard skill-discovery routing text, and the complaint was specifically the ~20 canonical scouts.

No skills were invoked for this change.
