### PR TITLE
fix(logs): drop-rule rate limit not enforcing the configured rate

### DIFF
--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -278,6 +278,52 @@ describe('KeyedRateLimiterService', () => {
         })
     })
 
+    describe('rateLimitMany (scriptVersion v3 — floor-drain on overdraft)', () => {
+        const buildV3Limiter = (name: string, overrides: Partial<{ bucketSize: number; refillRate: number }> = {}) =>
+            new KeyedRateLimiterService(
+                {
+                    name,
+                    bucketSize: overrides.bucketSize ?? 100,
+                    refillRate: overrides.refillRate ?? 10,
+                    ttlSeconds: 60 * 60 * 24,
+                    scriptVersion: 'v3',
+                },
+                redis
+            )
+
+        it('floor-drains the available tokens on overdraft instead of preserving the balance', async () => {
+            const limiter = buildV3Limiter('test-v3-drain')
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            await limiter.rateLimitMany([{ id: 'team-1', cost: 100 }])
+            advanceTime(1000)
+            const res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1000 }])
+
+            expect(res[0][1].isRateLimited).toBe(true)
+            expect(res[0][1].tokensBefore).toBe(10)
+            const bucket = await readBucket(`${limiter.getKeyPrefix()}/team-1`)
+            expect(Number(bucket.pool)).toBe(0)
+        })
+
+        it('caps sustained-overload admission at refillRate per batch (drop-rule regression)', async () => {
+            const limiter = buildV3Limiter('test-v3-overload')
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            await limiter.rateLimitMany([{ id: 'team-1', cost: 100 }])
+
+            const budgets: number[] = []
+            for (let i = 0; i < 10; i++) {
+                advanceTime(1000)
+                const res = await limiter.rateLimitMany([{ id: 'team-1', cost: 1000 }])
+                budgets.push(res[0][1].tokensBefore)
+            }
+
+            for (const budget of budgets) {
+                expect(budget).toBeLessThanOrEqual(10)
+            }
+        })
+    })
+
     describe('rateLimitGrouped (V3 + coalesced + per-input fan-out)', () => {
         it('returns one decision per input request (parallel to input order)', async () => {
             const limiter = buildLimiter('grouped-shape')

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -26,6 +26,7 @@ export interface KeyedRateLimiterConfig {
     ttlSeconds?: number
     /** When false, throw if the Redis pipeline returns null instead of fail-open allowing all. Default: true (fail open). */
     failOpen?: boolean
+    scriptVersion?: 'v2' | 'v3'
 }
 
 export interface KeyedRateLimitRequest {
@@ -105,11 +106,17 @@ export class KeyedRateLimiterService implements KeyedRateLimiter {
             return bucketSize
         })
 
+        const useV3 = this.config.scriptVersion === 'v3'
         const res = await this.redis.usePipeline(
             { name: `keyed-rate-limiter:${this.config.name}`, failOpen: true },
             (pipeline) => {
                 requests.forEach((req) => {
-                    pipeline.checkRateLimitV2(...this.rateLimitArgs(req))
+                    const args = this.rateLimitArgs(req)
+                    if (useV3) {
+                        pipeline.checkRateLimitV3(...args)
+                    } else {
+                        pipeline.checkRateLimitV2(...args)
+                    }
                 })
             }
         )

--- a/nodejs/src/logs/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.test.ts
@@ -72,7 +72,7 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV2: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
                 const pipelineResult: [Error | null, any][] = [[null, [2, 0] as const]]
                 return Promise.resolve(pipelineResult)
@@ -115,7 +115,7 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV2: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
                 const pipelineResult: [Error | null, any][] = [[null, [1, 0] as const]]
                 return Promise.resolve(pipelineResult)
@@ -154,7 +154,7 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV2: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
                 const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
                 return Promise.resolve(pipelineResult)
@@ -200,7 +200,7 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV2: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
                 const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
                 return Promise.resolve(pipelineResult)

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -98,7 +98,10 @@ export class LogsSamplingService {
     private rateLimiter: KeyedRateLimiterService
 
     constructor(redis: RedisV2, ttlSeconds: number) {
-        this.rateLimiter = new KeyedRateLimiterService({ name: 'logs-sampling-rate', ttlSeconds }, redis)
+        this.rateLimiter = new KeyedRateLimiterService(
+            { name: 'logs-sampling-rate', ttlSeconds, scriptVersion: 'v3' },
+            redis
+        )
     }
 
     @instrumented({


### PR DESCRIPTION
## Problem

Logs drop rules with a "Rate limit" action weren't holding ingestion to the configured rate (e.g. a 10 MB/s rule let far more than 10 MB/s through).

Root cause is in the backend token bucket, not the UI. The logs sampling limiter sends one aggregated-cost call per batch and admits records up to the returned `tokensBefore`. But it runs on the **V2** token-bucket Lua, which on overdraft *preserves* the full bucket balance instead of draining it. So under sustained overload the bucket refills back up to the burst pool and re-admits a full pool on every batch — effective throughput becomes roughly `poolMax × batches/sec` instead of the configured `refillRate/sec`. It works at low volume (where a batch fits in the bucket) and fails exactly when the limit should bite.

The volume-preview chart is correct — bars above the reference line are expected for a preview of historical (pre-drop) volume.

## Changes

- Switch the logs sampling rate limiter to the **V3** token-bucket Lua, which floor-drains the available tokens on overdraft — exactly matching the aggregated-cost partial-admission pattern the caller uses. The bucket can no longer sit at the full burst pool and re-admit it every batch.
- V3 is opt-in via a new `scriptVersion` flag on `KeyedRateLimiterService` (default stays V2). The shared limiter's existing V2 contract — including the deliberate repeated-same-id "wedge fix" that `rateLimitGrouped` and other callers rely on — is left untouched.

Scoped to the reported drop-rule path. The team-level logs limiter (`logs-rate-limiter.service.ts`) and the metrics limiter (`metrics-rate-limiter.service.ts`) use the same aggregated-cost partial-admission pattern and carry the same latent bug; they're intentionally left on V2 here and can be flipped in a follow-up.

## How did you test this code?

I'm an agent (PostHog Code); listing only automated tests I actually ran.

- Added two real-Redis regression tests in `keyed-rate-limiter.service.test.ts`:
  - `floor-drains the available tokens on overdraft instead of preserving the balance` — asserts the stored pool is drained to empty after an over-budget call.
  - `caps sustained-overload admission at refillRate per batch (drop-rule regression)` — reproduces the original bug: repeated over-budget batches stay pinned at ~`refillRate` per batch. Under the old V2 path the per-batch budget climbs toward `poolMax`, so this test fails pre-fix — the regression no existing test caught.
- Updated the stubbed pipeline mocks in `logs-sampling.service.test.ts` to the V3 command name (they feed a fixed return, so they still exercise the admission walk).
- Ran `keyed-rate-limiter.service.test.ts`, `logs-sampling.service.test.ts`, and `logs-rate-limiter.service.test.ts` — 89 passed. `eslint` clean on the changed files; `tsc` clean (remaining tsc errors are pre-existing, unrelated `@posthog/hogvm`/`@posthog/cyclotron` native-dep resolution failures in `src/cdp/*`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a reported "rate limit not limiting" bug starting from a screenshot of the drop-rule UI. Traced end to end: confirmed the volume-preview chart math (contiguous zero-filled buckets, correct per-second→per-bucket projection) was sound and ruled out the visualization, then found the real defect in the token-bucket Lua's overdraft branch.

Key decision: rather than flip the shared `rateLimitMany` to V3 wholesale (which would discard V2's intentional preserve-on-denial behavior and churn the generic suite), made V3 opt-in via config and switched only the logs sampling path. No repo skills were applicable to this Node.js ingestion change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
