### PR TITLE
fix(tasks): suppress post_completion Slack card when PR was already announced

### DIFF
--- a/products/slack_app/backend/slack_thread.py
+++ b/products/slack_app/backend/slack_thread.py
@@ -179,9 +179,25 @@ class SlackThreadHandler:
         except Exception as e:
             logger.exception("slack_progress_update_failed", error=str(e))
 
-    def post_pr_opened_sandbox_cleaned(self, pr_url: str, task_url: str | None) -> None:
-        """Post final PR message after sandbox cleanup."""
-        header = "*Pull request opened* :rocket:"
+    def post_pr_opened(
+        self,
+        pr_url: str,
+        task_url: str | None,
+        reply_target_slack_user_id: str | None = None,
+    ) -> None:
+        """Post the single per-run "PR opened" card.
+
+        Used at every lifecycle moment a run surfaces a PR for the first
+        time — mid-run announcement, post-sandbox cleanup, terminal
+        completion. The activity-level dedupe in
+        ``_post_pr_opened_notification_once`` ensures this fires once per
+        ``pr_url`` per run regardless of which moment got there first.
+
+        ``reply_target_slack_user_id`` is the resolved actor — typically the
+        most recent thread participant. ``None`` produces an untagged message.
+        """
+        mention_prefix = f"<@{reply_target_slack_user_id}> " if reply_target_slack_user_id else ""
+        header = f"{mention_prefix}*Pull request opened* :rocket:"
 
         buttons: list[dict[str, Any]] = [
             {
@@ -214,59 +230,6 @@ class SlackThreadHandler:
 
         self._delete_progress_and_post(header, blocks)
 
-    def post_pr_opened(
-        self,
-        pr_url: str,
-        task_url: str | None,
-        reply_target_slack_user_id: str | None = None,
-    ) -> None:
-        """Post PR opened message with action buttons.
-
-        ``reply_target_slack_user_id`` is the resolved actor — typically the
-        most recent thread participant. ``None`` produces an untagged message.
-        """
-        mention_prefix = f"<@{reply_target_slack_user_id}> " if reply_target_slack_user_id else ""
-        header = f"{mention_prefix}Pull request opened."
-
-        buttons: list[dict[str, Any]] = [
-            {
-                "type": "button",
-                "text": {
-                    "type": "plain_text",
-                    "text": "View PR",
-                    "emoji": True,
-                },
-                "url": pr_url,
-            },
-        ]
-        if task_url:
-            buttons.append(
-                {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Open in PostHog",
-                        "emoji": True,
-                    },
-                    "url": task_url,
-                }
-            )
-
-        blocks: list[dict[str, Any]] = [
-            {"type": "section", "text": {"type": "mrkdwn", "text": header}},
-            {"type": "actions", "elements": buttons},
-        ]
-
-        try:
-            self._get_client().chat_postMessage(
-                channel=self.context.channel,
-                thread_ts=self.context.thread_ts,
-                text=header,
-                blocks=blocks,
-            )
-        except Exception as e:
-            logger.warning("slack_post_pr_opened_failed", error=str(e))
-
     def post_thread_message(self, text: str) -> None:
         """Post a plain message in the existing thread."""
         try:
@@ -278,41 +241,36 @@ class SlackThreadHandler:
         except Exception as e:
             logger.warning("slack_post_thread_message_failed", error=str(e))
 
-    def post_completion(self, pr_url: str | None, task_url: str | None) -> None:
-        """Post completion message with PR link."""
-        if pr_url:
-            header = "*Pull Request Created* :rocket:"
-        else:
-            header = "*Task Completed* :hedgehog:"
+    def post_completion(self, task_url: str | None) -> None:
+        """Post the no-PR completion message.
+
+        Runs that produce a PR surface it via ``post_pr_opened`` (routed
+        through ``_post_pr_opened_notification_once`` for once-per-URL
+        semantics). This card is the "task finished without opening a PR"
+        terminal state.
+        """
+        header = "*Task Completed* :hedgehog:"
 
         blocks: list[dict[str, Any]] = [
             {"type": "section", "text": {"type": "mrkdwn", "text": header}},
         ]
-
-        buttons: list[dict[str, Any]] = []
-        if pr_url:
-            buttons.append(
-                {
-                    "type": "button",
-                    "text": {"type": "plain_text", "text": "View PR", "emoji": True},
-                    "url": pr_url,
-                }
-            )
         if task_url:
-            buttons.append(
+            blocks.append(
                 {
-                    "type": "button",
-                    "text": {
-                        "type": "plain_text",
-                        "text": "Open in PostHog",
-                        "emoji": True,
-                    },
-                    "url": task_url,
+                    "type": "actions",
+                    "elements": [
+                        {
+                            "type": "button",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Open in PostHog",
+                                "emoji": True,
+                            },
+                            "url": task_url,
+                        }
+                    ],
                 }
             )
-
-        if buttons:
-            blocks.append({"type": "actions", "elements": buttons})
 
         self._delete_progress_and_post(header, blocks)
 

--- a/products/slack_app/backend/tests/test_slack_thread.py
+++ b/products/slack_app/backend/tests/test_slack_thread.py
@@ -192,22 +192,7 @@ class TestSlackThreadHandlerWithoutTaskUrl(TestCase):
 
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_post_pr_opened_sandbox_cleaned_without_task_url_keeps_pr_button(
-        self, mock_get_client, _mock_delete_progress
-    ):
-        mock_client = MagicMock()
-        mock_get_client.return_value = mock_client
-        handler = SlackThreadHandler(self._make_context())
-
-        handler.post_pr_opened_sandbox_cleaned("https://github.com/org/repo/pull/1", task_url=None)
-
-        mock_client.chat_postMessage.assert_called_once()
-        actions = _action_blocks(mock_client.chat_postMessage.call_args.kwargs)
-        assert len(actions) == 1
-        assert _button_texts(actions[0]) == ["View PR"]
-
-    @patch.object(SlackThreadHandler, "_get_client")
-    def test_post_pr_opened_without_task_url_keeps_pr_button(self, mock_get_client):
+    def test_post_pr_opened_without_task_url_keeps_pr_button(self, mock_get_client, _mock_delete_progress):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
         handler = SlackThreadHandler(self._make_context())
@@ -221,26 +206,15 @@ class TestSlackThreadHandlerWithoutTaskUrl(TestCase):
 
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "_get_client")
-    def test_post_completion_without_task_url_keeps_pr_button(self, mock_get_client, _mock_delete_progress):
+    def test_post_completion_without_task_url_drops_actions(self, mock_get_client, _mock_delete_progress):
+        # The PR-bearing completion case routes through ``post_pr_opened`` via
+        # the activity-level dedupe helper, so ``post_completion`` only handles
+        # the no-PR terminal state and never carries a View PR button.
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client
         handler = SlackThreadHandler(self._make_context())
 
-        handler.post_completion("https://github.com/org/repo/pull/1", task_url=None)
-
-        mock_client.chat_postMessage.assert_called_once()
-        actions = _action_blocks(mock_client.chat_postMessage.call_args.kwargs)
-        assert len(actions) == 1
-        assert _button_texts(actions[0]) == ["View PR"]
-
-    @patch.object(SlackThreadHandler, "delete_progress")
-    @patch.object(SlackThreadHandler, "_get_client")
-    def test_post_completion_without_pr_or_task_url_drops_actions(self, mock_get_client, _mock_delete_progress):
-        mock_client = MagicMock()
-        mock_get_client.return_value = mock_client
-        handler = SlackThreadHandler(self._make_context())
-
-        handler.post_completion(pr_url=None, task_url=None)
+        handler.post_completion(task_url=None)
 
         mock_client.chat_postMessage.assert_called_once()
         assert _action_blocks(mock_client.chat_postMessage.call_args.kwargs) == []
@@ -284,10 +258,11 @@ class TestPostPrOpenedReplyTarget(TestCase):
 
     @parameterized.expand(
         [
-            ("explicit_actor_tags_them", "ULATEST", "<@ULATEST> Pull request opened."),
-            ("none_means_no_tag", None, "Pull request opened."),
+            ("explicit_actor_tags_them", "ULATEST", "<@ULATEST> *Pull request opened* :rocket:"),
+            ("none_means_no_tag", None, "*Pull request opened* :rocket:"),
         ]
     )
+    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "_get_client")
     def test_post_pr_opened_uses_caller_supplied_target(
         self,
@@ -295,6 +270,7 @@ class TestPostPrOpenedReplyTarget(TestCase):
         reply_target: str | None,
         expected_text_start: str,
         mock_get_client,
+        _mock_delete_progress,
     ):
         mock_client = MagicMock()
         mock_get_client.return_value = mock_client

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -128,6 +128,13 @@ def _post_pr_opened_notification_once(
     from products.slack_app.backend.models import SlackThreadTaskMapping
 
     if _is_pr_opened_notified(task_run, pr_url):
+        # Don't repost the PR card, but still clear any progress marker that
+        # may have lingered in the thread — every PR-bearing branch in
+        # ``post_slack_update`` used to do this explicitly on the dedupe path
+        # before collapsing into this helper. Same Slack-side effect as the
+        # ``post_pr_opened`` call below, which goes through
+        # ``_delete_progress_and_post``.
+        handler.delete_progress()
         return
 
     # Resolve the reply target from the live mapping so the PR notification

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -65,12 +65,7 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
         if input.sandbox_cleaned:
             if pr_url:
                 handler.update_reaction("hedgehog")
-                if _is_pr_opened_notified(task_run, pr_url):
-                    handler.delete_progress()
-                    return
-
-                handler.post_pr_opened_sandbox_cleaned(pr_url, task_url)
-                _mark_pr_opened_notified(task_run, pr_url)
+                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
             elif task_run.status == TaskRun.Status.CANCELLED:
                 handler.update_reaction("hedgehog")
                 handler.post_cancelled(task_url)
@@ -85,18 +80,10 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             if task_run.error_message and "timed out" in task_run.error_message:
                 handler.delete_progress()
                 return
-            # Skip the completion card when the PR was already announced for this
-            # run. The CI follow-up loop can keep the workflow alive long after
-            # the user's conversation ended; firing a "Pull Request Created"
-            # card hours later then reads as a duplicate rather than a useful
-            # confirmation. The same dedupe shape the ``sandbox_cleaned``
-            # branch already uses for ``post_pr_opened_sandbox_cleaned``.
-            if pr_url and _is_pr_opened_notified(task_run, pr_url):
-                handler.delete_progress()
-                return
-            handler.post_completion(pr_url, task_url)
             if pr_url:
-                _mark_pr_opened_notified(task_run, pr_url)
+                _post_pr_opened_notification_once(task_run, handler, pr_url, task_url)
+            else:
+                handler.post_completion(task_url)
         elif task_run.status == TaskRun.Status.CANCELLED:
             handler.update_reaction("hedgehog")
             handler.post_cancelled(task_url)
@@ -110,7 +97,6 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
                 # Task is still running (PR opened mid-run) — keep the :eyes: reaction
                 # so the thread reads as in-progress until it genuinely completes.
                 handler.update_reaction("eyes")
-                handler.delete_progress()
                 return
             stage = _get_stage_from_status(task_run.status, task_run.stage)
             handler.post_or_update_progress(stage, task_url)

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -85,7 +85,18 @@ def post_slack_update(input: PostSlackUpdateInput) -> None:
             if task_run.error_message and "timed out" in task_run.error_message:
                 handler.delete_progress()
                 return
+            # Skip the completion card when the PR was already announced for this
+            # run. The CI follow-up loop can keep the workflow alive long after
+            # the user's conversation ended; firing a "Pull Request Created"
+            # card hours later then reads as a duplicate rather than a useful
+            # confirmation. The same dedupe shape the ``sandbox_cleaned``
+            # branch already uses for ``post_pr_opened_sandbox_cleaned``.
+            if pr_url and _is_pr_opened_notified(task_run, pr_url):
+                handler.delete_progress()
+                return
             handler.post_completion(pr_url, task_url)
+            if pr_url:
+                _mark_pr_opened_notified(task_run, pr_url)
         elif task_run.status == TaskRun.Status.CANCELLED:
             handler.update_reaction("hedgehog")
             handler.post_cancelled(task_url)

--- a/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
+++ b/products/tasks/backend/temporal/process_task/activities/post_slack_update.py
@@ -128,12 +128,7 @@ def _post_pr_opened_notification_once(
     from products.slack_app.backend.models import SlackThreadTaskMapping
 
     if _is_pr_opened_notified(task_run, pr_url):
-        # Don't repost the PR card, but still clear any progress marker that
-        # may have lingered in the thread — every PR-bearing branch in
-        # ``post_slack_update`` used to do this explicitly on the dedupe path
-        # before collapsing into this helper. Same Slack-side effect as the
-        # ``post_pr_opened`` call below, which goes through
-        # ``_delete_progress_and_post``.
+        # Skip the repost but still clear any lingering progress marker.
         handler.delete_progress()
         return
 

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -282,6 +282,7 @@ class TestPostSlackUpdate(TestCase):
             reply_target_slack_user_id=None,
         )
 
+    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
@@ -292,12 +293,15 @@ class TestPostSlackUpdate(TestCase):
         mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
+        mock_delete_progress,
     ):
         # Regression: when the same ``pr_url`` was already announced mid-run,
         # the COMPLETED-state Slack update must not fire a second card. The
         # follow-up loop can keep the workflow alive long after the user's
         # conversation ended, and a fresh card hours later reads as a
-        # duplicate of the original.
+        # duplicate of the original. The dedupe-skip path must still clear
+        # any lingering progress marker so the thread doesn't keep a stale
+        # "Working on task..." card next to the already-posted PR card.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
             output={"pr_url": "https://github.com/org/repo/pull/1"},
@@ -312,6 +316,7 @@ class TestPostSlackUpdate(TestCase):
 
         mock_update_reaction.assert_called_once_with("hedgehog")
         mock_post_pr_opened.assert_not_called()
+        mock_delete_progress.assert_called_once()
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
@@ -351,6 +356,7 @@ class TestPostSlackUpdate(TestCase):
             },
         )
 
+    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
@@ -361,6 +367,7 @@ class TestPostSlackUpdate(TestCase):
         mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
+        mock_delete_progress,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
@@ -379,7 +386,9 @@ class TestPostSlackUpdate(TestCase):
 
         mock_update_reaction.assert_called_once_with("hedgehog")
         mock_post_pr_opened.assert_not_called()
+        mock_delete_progress.assert_called_once()
 
+    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
@@ -390,6 +399,7 @@ class TestPostSlackUpdate(TestCase):
         mock_handler_init,
         mock_update_reaction,
         mock_post_pr_opened,
+        mock_delete_progress,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
@@ -411,6 +421,7 @@ class TestPostSlackUpdate(TestCase):
 
         mock_update_reaction.assert_called_once_with("hedgehog")
         mock_post_pr_opened.assert_not_called()
+        mock_delete_progress.assert_called_once()
 
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
@@ -510,12 +521,15 @@ class TestPostSlackUpdate(TestCase):
             mock_task_run_class.objects.select_related.return_value.get.return_value = run
             post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
             handler_mock.assert_called_once()
-            # ``task_url`` is always the trailing positional argument on every
-            # handler signature; passing ``None`` is the contract for "no access".
-            assert (
-                handler_mock.call_args.args[-1] is None
-                or handler_mock.call_args.kwargs.get("reply_target_slack_user_id") is None
+            # ``task_url`` is the second positional argument on ``post_pr_opened``
+            # and the trailing positional argument on every other handler — the
+            # contract is "no access ⇒ this argument is ``None``".
+            task_url_arg = (
+                handler_mock.call_args.args[1]
+                if handler_mock is mock_post_pr_opened
+                else handler_mock.call_args.args[-1]
             )
+            assert task_url_arg is None
 
         mock_post_pr_opened.reset_mock()
         cleaned_with_pr = self._make_mock_run(

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -51,13 +51,16 @@ class TestPostSlackUpdate(TestCase):
             setattr(mock_run, k, v)
         return mock_run
 
-    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_completed_run_updates_reaction_to_hedgehog(
-        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_completion
+    def test_completed_run_with_pr_routes_through_post_pr_opened(
+        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_pr_opened
     ):
+        # Completed runs with a PR funnel through the single ``post_pr_opened``
+        # template via the dedupe helper. ``post_completion`` is reserved for
+        # the no-PR terminal state only.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
             output={"pr_url": "https://github.com/org/repo/pull/1"},
@@ -67,7 +70,30 @@ class TestPostSlackUpdate(TestCase):
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_completion.assert_called_once()
+        mock_post_pr_opened.assert_called_once()
+        mock_task_run_class.update_state_atomic.assert_called_once_with(
+            "run-1",
+            updates={
+                "slack_pr_opened_notified": True,
+                "slack_notified_pr_url": "https://github.com/org/repo/pull/1",
+            },
+        )
+
+    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "update_reaction")
+    @patch.object(SlackThreadHandler, "__init__", return_value=None)
+    @patch("products.tasks.backend.models.TaskRun")
+    def test_completed_run_without_pr_posts_task_completed(
+        self, mock_task_run_class, mock_handler_init, mock_update_reaction, mock_post_completion
+    ):
+        # ``post_completion`` is the no-PR terminal-state card.
+        mock_run = self._make_mock_run(mock_task_run_class.Status.COMPLETED, output={})
+        mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
+
+        post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
+
+        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_post_completion.assert_called_once_with("http://localhost:8000/project/1/tasks/10?runId=run-1")
 
     @patch.object(SlackThreadHandler, "post_error")
     @patch.object(SlackThreadHandler, "update_reaction")
@@ -120,20 +146,18 @@ class TestPostSlackUpdate(TestCase):
         # mobile) rather than a desktop-only ``posthog-code://`` deep link.
         assert mock_post_progress.call_args[0][1] == "http://localhost:8000/project/1/tasks/10?runId=run-1"
 
-    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_in_progress_with_pr_keeps_eyes_reaction_and_deletes_progress(
+    def test_in_progress_with_pr_keeps_eyes_reaction(
         self,
         mock_task_run_class,
         mock_handler_init,
         _mock_post_pr_opened,
         mock_post_progress,
         mock_update_reaction,
-        mock_delete_progress,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.IN_PROGRESS,
@@ -147,10 +171,8 @@ class TestPostSlackUpdate(TestCase):
         mock_post_progress.assert_not_called()
         # Task is still running (PR opened mid-run) — reaction stays :eyes:, not :hedgehog:.
         mock_update_reaction.assert_called_once_with("eyes")
-        mock_delete_progress.assert_called_once()
 
     @patch("products.slack_app.backend.models.SlackThreadTaskMapping")
-    @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_pr_opened")
@@ -163,7 +185,6 @@ class TestPostSlackUpdate(TestCase):
         mock_post_pr_opened,
         mock_post_progress,
         mock_update_reaction,
-        mock_delete_progress,
         mock_mapping_class,
     ):
         mock_run = self._make_mock_run(
@@ -195,7 +216,6 @@ class TestPostSlackUpdate(TestCase):
             reply_target_slack_user_id="U123",
         )
         mock_update_reaction.assert_called_once_with("eyes")
-        mock_delete_progress.assert_called_once()
         mock_post_progress.assert_not_called()
         mock_task_run_class.update_state_atomic.assert_called_once_with(
             "run-1",
@@ -227,19 +247,19 @@ class TestPostSlackUpdate(TestCase):
         mock_delete_progress.assert_called_once()
         mock_post_completion.assert_not_called()
 
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
-    @patch.object(SlackThreadHandler, "delete_progress")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_completed_pr_run_after_cleanup_posts_cleaned_message(
+    def test_completed_pr_run_after_cleanup_posts_pr_opened_card(
         self,
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_delete_progress,
-        mock_post_pr_opened_sandbox_cleaned,
+        mock_post_pr_opened,
     ):
+        # The sandbox-cleaned branch funnels through ``post_pr_opened`` — same
+        # single template every PR lifecycle moment uses.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
             output={"pr_url": "https://github.com/org/repo/pull/1"},
@@ -256,32 +276,28 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_delete_progress.assert_not_called()
-        mock_post_pr_opened_sandbox_cleaned.assert_called_once_with(
+        mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/1",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id=None,
         )
 
-    @patch.object(SlackThreadHandler, "post_completion")
-    @patch.object(SlackThreadHandler, "delete_progress")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_completed_run_skips_post_completion_when_pr_already_announced(
+    def test_completed_run_does_not_repost_pr_when_already_announced(
         self,
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_delete_progress,
-        mock_post_completion,
+        mock_post_pr_opened,
     ):
-        # Regression: when the agent announced the PR mid-run (e.g. via the
-        # API-PATCH-driven `_post_pr_opened_notification_once` path), the
-        # subsequent COMPLETED-state Slack update must not fire a second card
-        # for the same PR. Without this guard, a CI-follow-up loop that keeps
-        # the orchestrator alive for hours surfaces a "Pull Request Created"
-        # card long after the user's conversation ended, reading as a stale
-        # duplicate of the original "Pull request opened" card.
+        # Regression: when the same ``pr_url`` was already announced mid-run,
+        # the COMPLETED-state Slack update must not fire a second card. The
+        # follow-up loop can keep the workflow alive long after the user's
+        # conversation ended, and a fresh card hours later reads as a
+        # duplicate of the original.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
             output={"pr_url": "https://github.com/org/repo/pull/1"},
@@ -295,25 +311,21 @@ class TestPostSlackUpdate(TestCase):
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_delete_progress.assert_called_once()
-        mock_post_completion.assert_not_called()
+        mock_post_pr_opened.assert_not_called()
 
-    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_completed_run_with_new_pr_url_posts_completion_even_if_old_url_notified(
+    def test_completed_run_with_new_pr_url_posts_card_even_if_old_url_notified(
         self,
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_post_completion,
+        mock_post_pr_opened,
     ):
-        # An older URL having been announced doesn't suppress the completion
-        # card for a different URL — mirrors the per-URL dedupe the
-        # ``sandbox_cleaned`` branch already does. Also marks the new URL so
-        # the post-cleanup ``post_pr_opened_sandbox_cleaned`` call that
-        # follows in the workflow's ``finally`` block is suppressed for it.
+        # An older URL having been announced doesn't suppress the card for a
+        # different URL. The dedupe is per-URL, not per-run.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
             output={"pr_url": "https://github.com/org/repo/pull/2"},
@@ -326,9 +338,10 @@ class TestPostSlackUpdate(TestCase):
 
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
-        mock_post_completion.assert_called_once_with(
+        mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/2",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id=None,
         )
         mock_task_run_class.update_state_atomic.assert_called_once_with(
             "run-1",
@@ -338,8 +351,7 @@ class TestPostSlackUpdate(TestCase):
             },
         )
 
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
-    @patch.object(SlackThreadHandler, "delete_progress")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
@@ -348,8 +360,7 @@ class TestPostSlackUpdate(TestCase):
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_delete_progress,
-        mock_post_pr_opened_sandbox_cleaned,
+        mock_post_pr_opened,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
@@ -367,11 +378,9 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_delete_progress.assert_called_once()
-        mock_post_pr_opened_sandbox_cleaned.assert_not_called()
+        mock_post_pr_opened.assert_not_called()
 
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
-    @patch.object(SlackThreadHandler, "delete_progress")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
@@ -380,8 +389,7 @@ class TestPostSlackUpdate(TestCase):
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_delete_progress,
-        mock_post_pr_opened_sandbox_cleaned,
+        mock_post_pr_opened,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
@@ -402,10 +410,9 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_delete_progress.assert_called_once()
-        mock_post_pr_opened_sandbox_cleaned.assert_not_called()
+        mock_post_pr_opened.assert_not_called()
 
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
@@ -414,7 +421,7 @@ class TestPostSlackUpdate(TestCase):
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_post_pr_opened_sandbox_cleaned,
+        mock_post_pr_opened,
     ):
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.COMPLETED,
@@ -435,16 +442,16 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_pr_opened_sandbox_cleaned.assert_called_once_with(
+        mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/2",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id=None,
         )
 
     @patch.object(SlackThreadHandler, "post_completion")
     @patch.object(SlackThreadHandler, "post_or_update_progress")
     @patch.object(SlackThreadHandler, "post_error")
     @patch.object(SlackThreadHandler, "post_cancelled")
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
     @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
@@ -455,7 +462,6 @@ class TestPostSlackUpdate(TestCase):
         _mock_handler_init,
         _mock_update_reaction,
         mock_post_pr_opened,
-        mock_post_pr_opened_sandbox_cleaned,
         mock_post_cancelled,
         mock_post_error,
         mock_post_progress,
@@ -474,10 +480,13 @@ class TestPostSlackUpdate(TestCase):
 
         scenarios: list[tuple[MagicMock, MagicMock]] = []
 
-        completed = self._make_mock_run(
-            mock_task_run_class.Status.COMPLETED, output={"pr_url": "https://github.com/org/repo/pull/1"}
+        completed_no_pr = self._make_mock_run(mock_task_run_class.Status.COMPLETED, output={})
+        scenarios.append((completed_no_pr, mock_post_completion))
+
+        completed_with_pr = self._make_mock_run(
+            mock_task_run_class.Status.COMPLETED, output={"pr_url": "https://github.com/org/repo/pull/1"}, state={}
         )
-        scenarios.append((completed, mock_post_completion))
+        scenarios.append((completed_with_pr, mock_post_pr_opened))
 
         failed = self._make_mock_run(mock_task_run_class.Status.FAILED, error_message="boom")
         scenarios.append((failed, mock_post_error))
@@ -496,12 +505,6 @@ class TestPostSlackUpdate(TestCase):
         )
         scenarios.append((in_progress_with_pr, mock_post_pr_opened))
 
-        cleaned_with_pr = self._make_mock_run(
-            mock_task_run_class.Status.COMPLETED,
-            output={"pr_url": "https://github.com/org/repo/pull/3"},
-            state={},
-        )
-
         for run, handler_mock in scenarios:
             handler_mock.reset_mock()
             mock_task_run_class.objects.select_related.return_value.get.return_value = run
@@ -509,9 +512,17 @@ class TestPostSlackUpdate(TestCase):
             handler_mock.assert_called_once()
             # ``task_url`` is always the trailing positional argument on every
             # handler signature; passing ``None`` is the contract for "no access".
-            assert handler_mock.call_args.args[-1] is None
+            assert (
+                handler_mock.call_args.args[-1] is None
+                or handler_mock.call_args.kwargs.get("reply_target_slack_user_id") is None
+            )
 
-        mock_post_pr_opened_sandbox_cleaned.reset_mock()
+        mock_post_pr_opened.reset_mock()
+        cleaned_with_pr = self._make_mock_run(
+            mock_task_run_class.Status.COMPLETED,
+            output={"pr_url": "https://github.com/org/repo/pull/3"},
+            state={},
+        )
         mock_task_run_class.objects.select_related.return_value.get.return_value = cleaned_with_pr
         post_slack_update(
             PostSlackUpdateInput(
@@ -520,10 +531,11 @@ class TestPostSlackUpdate(TestCase):
                 sandbox_cleaned=True,
             )
         )
-        mock_post_pr_opened_sandbox_cleaned.assert_called_once()
-        assert mock_post_pr_opened_sandbox_cleaned.call_args.args[-1] is None
+        mock_post_pr_opened.assert_called_once()
+        # task_url is the second positional argument on post_pr_opened.
+        assert mock_post_pr_opened.call_args.args[1] is None
 
-    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
@@ -532,7 +544,7 @@ class TestPostSlackUpdate(TestCase):
         mock_task_run_class,
         _mock_handler_init,
         _mock_update_reaction,
-        mock_post_completion,
+        mock_post_pr_opened,
     ):
         # ``has_tasks_access`` is never reached when the run has no creator —
         # a None viewer short-circuits to "no access" without consulting the
@@ -556,9 +568,11 @@ class TestPostSlackUpdate(TestCase):
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
         sentinel.assert_not_called()
-        mock_post_completion.assert_called_once_with("https://github.com/org/repo/pull/1", None)
+        mock_post_pr_opened.assert_called_once_with(
+            "https://github.com/org/repo/pull/1", None, reply_target_slack_user_id=None
+        )
 
-    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
@@ -567,7 +581,7 @@ class TestPostSlackUpdate(TestCase):
         mock_task_run_class,
         _mock_handler_init,
         _mock_update_reaction,
-        mock_post_completion,
+        mock_post_pr_opened,
     ):
         # A flag-service blip must not surface the link to a user we can't
         # confirm has access — and must not break the surrounding update.
@@ -586,19 +600,24 @@ class TestPostSlackUpdate(TestCase):
 
         post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
 
-        mock_post_completion.assert_called_once_with("https://github.com/org/repo/pull/1", None)
+        mock_post_pr_opened.assert_called_once_with(
+            "https://github.com/org/repo/pull/1", None, reply_target_slack_user_id=None
+        )
 
-    @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
+    @patch.object(SlackThreadHandler, "post_pr_opened")
     @patch.object(SlackThreadHandler, "update_reaction")
     @patch.object(SlackThreadHandler, "__init__", return_value=None)
     @patch("products.tasks.backend.models.TaskRun")
-    def test_cancelled_pr_run_after_cleanup_posts_cleaned_message(
+    def test_cancelled_pr_run_after_cleanup_posts_pr_opened_card(
         self,
         mock_task_run_class,
         mock_handler_init,
         mock_update_reaction,
-        mock_post_pr_opened_sandbox_cleaned,
+        mock_post_pr_opened,
     ):
+        # A cancelled run that still produced a PR funnels through the same
+        # single template — the cancellation card only fires when no PR was
+        # opened.
         mock_run = self._make_mock_run(
             mock_task_run_class.Status.CANCELLED,
             output={"pr_url": "https://github.com/org/repo/pull/2"},
@@ -614,7 +633,8 @@ class TestPostSlackUpdate(TestCase):
         )
 
         mock_update_reaction.assert_called_once_with("hedgehog")
-        mock_post_pr_opened_sandbox_cleaned.assert_called_once_with(
+        mock_post_pr_opened.assert_called_once_with(
             "https://github.com/org/repo/pull/2",
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
+            reply_target_slack_user_id=None,
         )

--- a/products/tasks/backend/tests/test_post_slack_update.py
+++ b/products/tasks/backend/tests/test_post_slack_update.py
@@ -262,6 +262,82 @@ class TestPostSlackUpdate(TestCase):
             "http://localhost:8000/project/1/tasks/10?runId=run-1",
         )
 
+    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "delete_progress")
+    @patch.object(SlackThreadHandler, "update_reaction")
+    @patch.object(SlackThreadHandler, "__init__", return_value=None)
+    @patch("products.tasks.backend.models.TaskRun")
+    def test_completed_run_skips_post_completion_when_pr_already_announced(
+        self,
+        mock_task_run_class,
+        mock_handler_init,
+        mock_update_reaction,
+        mock_delete_progress,
+        mock_post_completion,
+    ):
+        # Regression: when the agent announced the PR mid-run (e.g. via the
+        # API-PATCH-driven `_post_pr_opened_notification_once` path), the
+        # subsequent COMPLETED-state Slack update must not fire a second card
+        # for the same PR. Without this guard, a CI-follow-up loop that keeps
+        # the orchestrator alive for hours surfaces a "Pull Request Created"
+        # card long after the user's conversation ended, reading as a stale
+        # duplicate of the original "Pull request opened" card.
+        mock_run = self._make_mock_run(
+            mock_task_run_class.Status.COMPLETED,
+            output={"pr_url": "https://github.com/org/repo/pull/1"},
+            state={
+                "slack_pr_opened_notified": True,
+                "slack_notified_pr_url": "https://github.com/org/repo/pull/1",
+            },
+        )
+        mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
+
+        post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
+
+        mock_update_reaction.assert_called_once_with("hedgehog")
+        mock_delete_progress.assert_called_once()
+        mock_post_completion.assert_not_called()
+
+    @patch.object(SlackThreadHandler, "post_completion")
+    @patch.object(SlackThreadHandler, "update_reaction")
+    @patch.object(SlackThreadHandler, "__init__", return_value=None)
+    @patch("products.tasks.backend.models.TaskRun")
+    def test_completed_run_with_new_pr_url_posts_completion_even_if_old_url_notified(
+        self,
+        mock_task_run_class,
+        mock_handler_init,
+        mock_update_reaction,
+        mock_post_completion,
+    ):
+        # An older URL having been announced doesn't suppress the completion
+        # card for a different URL — mirrors the per-URL dedupe the
+        # ``sandbox_cleaned`` branch already does. Also marks the new URL so
+        # the post-cleanup ``post_pr_opened_sandbox_cleaned`` call that
+        # follows in the workflow's ``finally`` block is suppressed for it.
+        mock_run = self._make_mock_run(
+            mock_task_run_class.Status.COMPLETED,
+            output={"pr_url": "https://github.com/org/repo/pull/2"},
+            state={
+                "slack_pr_opened_notified": True,
+                "slack_notified_pr_url": "https://github.com/org/repo/pull/1",
+            },
+        )
+        mock_task_run_class.objects.select_related.return_value.get.return_value = mock_run
+
+        post_slack_update(PostSlackUpdateInput(run_id="run-1", slack_thread_context=self.slack_thread_context))
+
+        mock_post_completion.assert_called_once_with(
+            "https://github.com/org/repo/pull/2",
+            "http://localhost:8000/project/1/tasks/10?runId=run-1",
+        )
+        mock_task_run_class.update_state_atomic.assert_called_once_with(
+            "run-1",
+            updates={
+                "slack_pr_opened_notified": True,
+                "slack_notified_pr_url": "https://github.com/org/repo/pull/2",
+            },
+        )
+
     @patch.object(SlackThreadHandler, "post_pr_opened_sandbox_cleaned")
     @patch.object(SlackThreadHandler, "delete_progress")
     @patch.object(SlackThreadHandler, "update_reaction")


### PR DESCRIPTION
## Problem

The `COMPLETED` branch of `post_slack_update` had no `_is_pr_opened_notified` gate. When the babysitting loop kept a run alive for hours after the user's conversation ended, the workflow's terminal `post_completion` fired a stale "Pull Request Created :rocket:" card in a thread the user had long left.

Three near-identical "PR opened" templates (`post_pr_opened`, `post_pr_opened_sandbox_cleaned`, `post_completion`) made the inconsistency easy to miss.

## Solution

Collapse the three templates into a single `post_pr_opened` (rocket + optional `@mention`), and route every PR-bearing branch through the existing `_post_pr_opened_notification_once` helper — so the per-`pr_url` dedupe holds uniformly across in-progress, sandbox-cleaned, and terminal-completion moments.

`post_completion` shrinks to the no-PR terminal case only. `post_pr_opened_sandbox_cleaned` is removed.

## When the PR card is posted — before vs after

| Lifecycle moment | After: dedupe check at this stage | Before | After |
|---|---|---|---|
| Agent opens PR mid-run (first time) | not yet notified → **post + mark** | `post_pr_opened` "Pull request opened." | `post_pr_opened` "**Pull request opened** :rocket:" |
| CI follow-up, run still in-progress, same `pr_url` | already notified → **skip** | no card | no card |
| `COMPLETED`, PR already announced mid-run | already notified → **skip** | `post_completion` "**Pull Request Created** :rocket:" — **bug, no check** | no card |
| `COMPLETED`, PR set via webhook backstop only | not yet notified → **post + mark** | `post_completion` "**Pull Request Created** :rocket:" | `post_pr_opened` "**Pull request opened** :rocket:" |
| Sandbox cleanup, PR already announced | already notified → **skip** | no card | no card |
| Sandbox cleanup, PR set via webhook only | not yet notified → **post + mark** | `post_pr_opened_sandbox_cleaned` "**Pull request opened** :rocket:" | `post_pr_opened` "**Pull request opened** :rocket:" |
| Cancelled run that produced a PR | not yet notified → **post + mark** | `post_pr_opened_sandbox_cleaned` "**Pull request opened** :rocket:" | `post_pr_opened` "**Pull request opened** :rocket:" |
| Run completes with no PR | n/a — no PR check needed | `post_completion` "**Task Completed** :hedgehog:" | unchanged |

## How did you test this code?

- Unit tests: 38/38 pass in `test_post_slack_update.py` + `test_slack_thread.py`.
- Manual: opened a PR end-to-end via Slack against a local dev stack, then signalled the orchestrator to complete — single PR card in the thread, no duplicate on workflow termination.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

skip-inkeep-docs

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)