### PR TITLE
fix(cli): strip sourcemap urls after upload

### DIFF
--- a/cli/.sampo/changesets/gallant-sage-goulven.md
+++ b/cli/.sampo/changesets/gallant-sage-goulven.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: patch
+---
+
+Strip sourceMappingURL comments when deleting uploaded source maps

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -267,6 +267,14 @@ impl MinifiedSourceFile {
         Ok(Some(urlencoding::decode(&found)?.into_owned()))
     }
 
+    pub fn remove_sourcemap_reference(&mut self) -> bool {
+        let Some(range) = trailing_sourcemap_reference_range(&self.inner.content) else {
+            return false;
+        };
+        self.inner.content.replace_range(range, "");
+        true
+    }
+
     fn get_comment_value(&self, patterns: &[&str]) -> Option<String> {
         for line in self.inner.content.lines().rev() {
             if let Some(val) = patterns
@@ -330,6 +338,31 @@ impl MinifiedSourceFile {
     }
 }
 
+fn trailing_sourcemap_reference_range(content: &str) -> Option<std::ops::Range<usize>> {
+    let mut line_start = 0;
+    let mut lines = Vec::new();
+    for line in content.split_inclusive('\n') {
+        let line_end = line_start + line.len();
+        lines.push((line_start, line_end, line));
+        line_start = line_end;
+    }
+
+    for (line_start, line_end, line) in lines.into_iter().rev() {
+        let trimmed_line = line.trim();
+        if trimmed_line.is_empty() || trimmed_line.starts_with("//# chunkId=") {
+            continue;
+        }
+        if trimmed_line.starts_with("//# sourceMappingURL=")
+            || trimmed_line.starts_with("//@ sourceMappingURL=")
+        {
+            return Some(line_start..line_end);
+        }
+        return None;
+    }
+
+    None
+}
+
 impl TryInto<SymbolSetUpload> for SourceMapFile {
     type Error = anyhow::Error;
 
@@ -364,6 +397,12 @@ mod tests {
 
     fn content_from(value: Value) -> SourceMapContent {
         serde_json::from_value(value).expect("Failed to build SourceMapContent")
+    }
+
+    fn minified_source(content: &str) -> MinifiedSourceFile {
+        MinifiedSourceFile {
+            inner: SourceFile::new(PathBuf::from("chunk.js"), content.to_string()),
+        }
     }
 
     #[test]
@@ -486,5 +525,38 @@ mod tests {
             ],
         }));
         assert!(!sm.is_empty());
+    }
+
+    #[test]
+    fn remove_sourcemap_reference_strips_trailing_comment() {
+        let mut source = minified_source("console.log(1);\n//# sourceMappingURL=chunk.js.map\n");
+
+        assert!(source.remove_sourcemap_reference());
+        assert_eq!(source.inner.content, "console.log(1);\n");
+
+        let mut legacy_source =
+            minified_source("console.log(1);\r\n//@ sourceMappingURL=chunk.js.map");
+
+        assert!(legacy_source.remove_sourcemap_reference());
+        assert_eq!(legacy_source.inner.content, "console.log(1);\r\n");
+
+        let mut injected_source = minified_source(
+            "console.log(1);\n//# sourceMappingURL=chunk.js.map\n\n//# chunkId=00000",
+        );
+
+        assert!(injected_source.remove_sourcemap_reference());
+        assert_eq!(
+            injected_source.inner.content,
+            "console.log(1);\n\n//# chunkId=00000"
+        );
+    }
+
+    #[test]
+    fn remove_sourcemap_reference_leaves_non_trailing_comment() {
+        let original = "console.log(1);\n//# sourceMappingURL=chunk.js.map\nconsole.log(2);\n";
+        let mut source = minified_source(original);
+
+        assert!(!source.remove_sourcemap_reference());
+        assert_eq!(source.inner.content, original);
     }
 }

--- a/cli/src/sourcemaps/content.rs
+++ b/cli/src/sourcemaps/content.rs
@@ -528,27 +528,29 @@ mod tests {
     }
 
     #[test]
-    fn remove_sourcemap_reference_strips_trailing_comment() {
+    fn remove_sourcemap_reference_strips_standard_comment() {
         let mut source = minified_source("console.log(1);\n//# sourceMappingURL=chunk.js.map\n");
 
         assert!(source.remove_sourcemap_reference());
         assert_eq!(source.inner.content, "console.log(1);\n");
+    }
 
-        let mut legacy_source =
-            minified_source("console.log(1);\r\n//@ sourceMappingURL=chunk.js.map");
+    #[test]
+    fn remove_sourcemap_reference_strips_legacy_comment() {
+        let mut source = minified_source("console.log(1);\r\n//@ sourceMappingURL=chunk.js.map");
 
-        assert!(legacy_source.remove_sourcemap_reference());
-        assert_eq!(legacy_source.inner.content, "console.log(1);\r\n");
+        assert!(source.remove_sourcemap_reference());
+        assert_eq!(source.inner.content, "console.log(1);\r\n");
+    }
 
-        let mut injected_source = minified_source(
+    #[test]
+    fn remove_sourcemap_reference_strips_comment_with_injected_chunk_id() {
+        let mut source = minified_source(
             "console.log(1);\n//# sourceMappingURL=chunk.js.map\n\n//# chunkId=00000",
         );
 
-        assert!(injected_source.remove_sourcemap_reference());
-        assert_eq!(
-            injected_source.inner.content,
-            "console.log(1);\n\n//# chunkId=00000"
-        );
+        assert!(source.remove_sourcemap_reference());
+        assert_eq!(source.inner.content, "console.log(1);\n\n//# chunkId=00000");
     }
 
     #[test]

--- a/cli/src/sourcemaps/plain/mod.rs
+++ b/cli/src/sourcemaps/plain/mod.rs
@@ -33,7 +33,8 @@ pub struct ProcessArgs {
     #[clap(flatten)]
     pub release: ReleaseArgs,
 
-    /// Whether to delete the source map files after uploading them [default: false]
+    /// Whether to delete the source map files and strip sourceMappingURL comments after uploading them
+    /// [default: false]
     #[arg(long, default_value = "false")]
     pub delete_after: bool,
 

--- a/cli/src/sourcemaps/plain/upload.rs
+++ b/cli/src/sourcemaps/plain/upload.rs
@@ -1,4 +1,4 @@
-use std::time::Instant;
+use std::{path::PathBuf, time::Instant};
 
 use anyhow::{Context, Result};
 use serde_json::json;
@@ -19,6 +19,7 @@ use crate::{
     invocation_context::context,
     sourcemaps::{
         args::{FileSelectionArgs, ReleaseArgs, UploadConflictArgs},
+        content::MinifiedSourceFile,
         inject::get_release_for_maps,
         plain::inject::is_javascript_file,
         source_pairs::read_pairs,
@@ -37,7 +38,8 @@ pub struct Args {
     #[arg(short, long)]
     pub public_path_prefix: Option<String>,
 
-    /// Whether to delete the source map files after uploading them [default: false]
+    /// Whether to delete the source map files and strip sourceMappingURL comments after uploading them
+    /// [default: false]
     #[arg(long, default_value = "false")]
     pub delete_after: bool,
 
@@ -73,6 +75,10 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     let sourcemap_paths = pairs
         .iter()
         .map(|pair| pair.sourcemap.inner.path.clone())
+        .collect::<Vec<_>>();
+    let source_paths = pairs
+        .iter()
+        .map(|pair| pair.source.inner.path.clone())
         .collect::<Vec<_>>();
     info!("Found {} chunks to upload", pairs.len());
 
@@ -165,8 +171,23 @@ pub fn upload(args: &Args, existing_release: Option<&Release>) -> Result<()> {
     upload_result?;
 
     if args.delete_after {
+        remove_sourcemap_references(source_paths)
+            .context("While stripping sourcemap references")?;
         delete_files(sourcemap_paths).context("While deleting sourcemaps")?;
     }
 
+    Ok(())
+}
+
+fn remove_sourcemap_references(paths: Vec<PathBuf>) -> Result<()> {
+    for path in paths {
+        let mut source = MinifiedSourceFile::load(&path)
+            .with_context(|| format!("Failed to read source file: {}", path.display()))?;
+        if source.remove_sourcemap_reference() {
+            source
+                .save()
+                .with_context(|| format!("Failed to save source file: {}", path.display()))?;
+        }
+    }
     Ok(())
 }


### PR DESCRIPTION
Fixes: https://github.com/PostHog/posthog/issues/66165
Supersedes: https://github.com/PostHog/posthog/pull/66231

## Problem

`posthog-cli sourcemap upload --delete-after` deletes local `.map` files after a successful upload, but the sibling JavaScript files can still end with `sourceMappingURL` comments that point at the deleted files.

## Changes

- Strip trailing `//# sourceMappingURL=` and legacy `//@ sourceMappingURL=` comments from JavaScript files when `--delete-after` is used.
- Preserve PostHog's injected `//# chunkId=` comment when it appears after the source map URL.
- Update the `--delete-after` help text and add a Sampo patch changeset for the CLI release.

## How did you test this code?

Automated tests run as an agent:

- `cd cli && cargo test --lib`
- `cd cli && cargo clippy --lib -- -D warnings`

Added unit coverage for the regression where uploaded JavaScript would still reference a deleted source map, including the injected chunk ID layout and a guard that non-trailing source map comments are not stripped.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update. The CLI help text and Sampo changeset were updated.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with the Pi coding agent. Skills invoked: `/error-tracking`, `/writing-tests`, and `/pr`.

A human requested the CLI behavior change and later requested a Sampo changeset. The implementation keeps the behavior scoped to plain sourcemap upload/process flows and only strips source map references after a successful upload, immediately before deleting the `.map` files.
