### PR TITLE
chore(ci): warn instead of failing CI on eager graph budget breaches

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -423,7 +423,7 @@ jobs:
             # The eager graph check runs in --report-only mode inside build:with-report
             # (compressed-size-action runs that for the PR AND base builds — a failing
             # base build must not abort the action for every open PR). These steps post
-            # the sticky PR comment and enforce the budgets from the PR build's report,
+            # the sticky PR comment and warn on budget breaches from the PR build's report,
             # which carries the checkout sha in its filename because the base build
             # overwrites the plain one. After compressed-size-action the tree is on the
             # BASE branch, so guard for the scripts' absence (also covers branches
@@ -439,11 +439,11 @@ jobs:
                       echo "Skipping eager graph comment — script not present on this checkout"
                   fi
 
-            - name: Enforce eager graph budgets
+            - name: Check eager graph budgets (warn only)
               if: always() && github.event_name == 'pull_request'
               run: |
                   if [ ! -f frontend/bin/check-eager-graph.mjs ]; then
-                      echo "Skipping eager graph enforcement — script not present on this checkout"
+                      echo "Skipping eager graph check — script not present on this checkout"
                       exit 0
                   fi
                   REPORT="frontend/eager-graph-report-${GITHUB_SHA}.json"
@@ -451,7 +451,7 @@ jobs:
                       REPORT="frontend/eager-graph-report.json"
                   fi
                   if [ ! -f "$REPORT" ]; then
-                      echo "Skipping eager graph enforcement — no report found (branch may predate the check)"
+                      echo "Skipping eager graph check — no report found (branch may predate the check)"
                       exit 0
                   fi
                   node frontend/bin/check-eager-graph.mjs --assert-report "$REPORT"

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -11,11 +11,12 @@ const metaPath = path.join(frontendDir, 'posthog-app-esbuild-meta.json')
 // --report-only: record results without failing the build. Used by build:with-report
 // because compressed-size-action runs that script for BOTH the PR build and the base
 // build — a base-branch budget breach must not abort the action for every open PR.
-// Enforcement happens in the dedicated workflow step via --assert-report.
+// Budget breaches are surfaced as warnings in the dedicated workflow step via --assert-report.
 const reportOnly = process.argv.includes('--report-only')
 
-// --assert-report <path>: skip measuring; read a previously written report and exit
-// non-zero if it records violations.
+// --assert-report <path>: skip measuring; read a previously written report and surface any
+// recorded violations as warnings (GitHub Actions annotations) without failing CI — the
+// bundle-size Signals scout tracks regressions from the PR comment, so the check informs.
 const assertReportIndex = process.argv.indexOf('--assert-report')
 
 // The eager graph is everything reachable from a root through STATIC imports only —
@@ -53,45 +54,60 @@ function fail(message) {
     process.exitCode = 1
 }
 
+function warnViolation(message) {
+    console.warn(`\n⚠️ ${message}`)
+    const encoded = message.replace(/%/g, '%25').replace(/\r/g, '%0D').replace(/\n/g, '%0A')
+    // console.info (not console.log, which oxlint strips) writes to stdout, where GitHub Actions parses workflow commands.
+    console.info(`::warning title=Eager graph budget::${encoded}`)
+}
+
 function assertReport(reportFilePath) {
     if (!fs.existsSync(reportFilePath)) {
-        fail(`Report not found at ${reportFilePath} — did the build run the check?`)
-        return
+        warnViolation(`Report not found at ${reportFilePath} — did the build run the check?`)
+        return 0
     }
     const reportToAssert = JSON.parse(fs.readFileSync(reportFilePath, 'utf-8'))
+    let violations = 0
     for (const message of reportToAssert.errors ?? []) {
-        fail(message)
+        warnViolation(message)
+        violations++
     }
     for (const r of reportToAssert.roots) {
         if (r.overBudget) {
-            fail(
+            warnViolation(
                 `Eager graph for '${r.root}' is ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
                     `Largest files in the closure:\n` +
                     r.largest.map(({ file, bytes }) => `   ${formatMiB(bytes).padStart(9)}  ${file}`).join('\n') +
                     `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
                     `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
             )
+            violations++
         }
         for (const hit of r.forbiddenHits) {
-            fail(
+            warnViolation(
                 `'${hit.module}' is statically reachable from '${r.root}' — it must stay behind a dynamic import.\n` +
                     `Import chain:\n   ${hit.chain.join('\n   -> ')}`
             )
+            violations++
         }
-        if (!process.exitCode) {
+        if (!r.overBudget && r.forbiddenHits.length === 0) {
             console.info(`✅ ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
+    return violations
 }
 
 if (assertReportIndex !== -1) {
-    assertReport(process.argv[assertReportIndex + 1])
-    if (process.exitCode) {
-        console.error('\nEager graph check failed — see above.')
+    const violations = assertReport(process.argv[assertReportIndex + 1])
+    if (violations) {
+        console.warn(
+            `\n⚠️ Eager graph over budget — ${violations} issue(s) above. Not failing CI: the bundle-size ` +
+                `Signals scout tracks this from the eager graph PR comment. Trim the eager closure when you can.`
+        )
     } else {
         console.info('\nAll eager graph budgets respected.')
     }
-    process.exit(process.exitCode ?? 0)
+    process.exit(0)
 }
 
 function formatMiB(bytes) {

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -64,11 +64,12 @@ function warnViolation(message) {
 function assertReport(reportFilePath) {
     if (!fs.existsSync(reportFilePath)) {
         warnViolation(`Report not found at ${reportFilePath} — did the build run the check?`)
-        return 0
+        return 1
     }
     const reportToAssert = JSON.parse(fs.readFileSync(reportFilePath, 'utf-8'))
     let violations = 0
-    for (const message of reportToAssert.errors ?? []) {
+    const topLevelErrors = reportToAssert.errors ?? []
+    for (const message of topLevelErrors) {
         warnViolation(message)
         violations++
     }
@@ -90,7 +91,7 @@ function assertReport(reportFilePath) {
             )
             violations++
         }
-        if (!r.overBudget && r.forbiddenHits.length === 0) {
+        if (topLevelErrors.length === 0 && !r.overBudget && r.forbiddenHits.length === 0) {
             console.info(`✅ ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
@@ -101,8 +102,8 @@ if (assertReportIndex !== -1) {
     const violations = assertReport(process.argv[assertReportIndex + 1])
     if (violations) {
         console.warn(
-            `\n⚠️ Eager graph over budget — ${violations} issue(s) above. Not failing CI: the bundle-size ` +
-                `Signals scout tracks this from the eager graph PR comment. Trim the eager closure when you can.`
+            `\n⚠️ Eager graph check — ${violations} issue(s) above. Not failing CI: the bundle-size ` +
+                `Signals scout tracks eager-graph regressions from the PR comment. Trim the eager closure when you can.`
         )
     } else {
         console.info('\nAll eager graph budgets respected.')


### PR DESCRIPTION
## Problem

The eager graph check (`frontend/bin/check-eager-graph.mjs --assert-report`) hard-fails CI when a PR pushes a root's static-import closure over budget or pulls a forbidden module into it. We now have a bundle-size Signals scout that watches the eager graph PR comment, diagnoses the offending import, and files a remediation report — so the gate can inform rather than block.

## Changes

In `--assert-report` mode the check now emits a GitHub Actions **warning annotation** for each breach and exits 0, instead of exiting non-zero and failing the job.

- The sticky PR comment (`post-eager-graph-comment.mjs`) is unchanged — full detail still shows there.
- The `--report-only` build path (already exit 0) and the no-flag local-dev invocation (still a hard failure for fast local feedback) are unchanged.
- Workflow step renamed `Enforce eager graph budgets` -> `Check eager graph budgets (warn only)`; the only workflow change is cosmetic (name + comment wording), so in-flight PRs that haven't rebased keep their current behavior until they pick up the new script.

The annotation is emitted via `console.info` (stdout) rather than `console.log` — oxlint's `no-console` autofix strips `console.log`, and GitHub parses workflow commands from stdout. There's a one-line comment guarding that, because it's an easy thing to "tidy" back into a silent regression.

## How did you test this code?

I'm an agent (PostHog Code). No manual browser testing. Automated checks I actually ran locally:

- `node --check frontend/bin/check-eager-graph.mjs` — passes.
- Ran the script with `--assert-report` against a synthetic over-budget report: exits **0**, prints a `::warning title=Eager graph budget::…` line on **stdout** for both an over-budget root and a forbidden-import hit.
- Ran it against a within-budget report: prints ✅ and "All eager graph budgets respected", exits 0.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed this; assigned as DRI.

Paul asked to stop the eager graph check from failing CI now that a Signals scout covers bundle-size regressions, and to have it warn where it previously failed. The change is deliberately contained to the `--assert-report` path so local-dev and the base-build `--report-only` path keep their current behavior, and so the workflow edit stays backwards-compatible with unrebased open PRs (only the companion script changes behavior, and it lands on rebase).

Tooling: authored in PostHog Code. The lint-staged `hogli format:js` hook (oxlint) silently deleted the original `console.log` annotation line on first commit; caught it in the committed diff and switched to `console.info` + a guard comment. No repo skills were invoked for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
