### PR TITLE
fix(funnels): load reused step-legend styles in quill funnel charts

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -165,9 +165,9 @@ snapshots:
     components-cards-insight-card--access-control-manager-access--light:
         hash: v1.k794b7964.ffebe7d4c951093bb76b7251ac7ed5a2a6ba51ca9b7bbb734eb0978dc010afbc.jP26OBXRfQ_ycnMc2p9HAop2_7RS_Fu7F28IQkYZp88
     components-cards-insight-card--access-control-mixed-permissions--dark:
-        hash: v1.k794b7964.8b4d66273b1eca0fe2e943a2759e3d900f4539ce13c732e703370fb78d1be97d.8sixKvtz6yjtwn6EVptz3kI3p45ugJWOFWWJakCISVA
+        hash: v1.k794b7964.829986b8f4b184140aaa116abc59753b60dccbfdd9bb5790e21c7f70120e86b5.9fCLoidkkBKEjCJh8o7eWfe382lzYYCM3UgtMMDqYiM
     components-cards-insight-card--access-control-mixed-permissions--light:
-        hash: v1.k794b7964.4511d4d38b60d4ec4e87885cbcfae6ebdef8b6295ff9c71a78f8c3c9014c2a96.rW15TKs41AHUllPADWbJJG8CbNnBqpfaxH3fq7B9gqI
+        hash: v1.k794b7964.98379001d0522f3f161b29af5841eccb77b74f368972f73415ccbc5b59f35999.8i9UIMC9gO9DjaBS25yq3nLFYD1fwHaG3zOBPvrytow
     components-cards-insight-card--access-control-no-access--dark:
         hash: v1.k794b7964.2aa7dada4afabba5efa5e1b0e9b36a8be9add036ff4b67cd3f7c154a2f24e71c.IVeTit32HuunN9lnT91h39Cc_54OBU1QgFmmllCaUIU
     components-cards-insight-card--access-control-no-access--light:
@@ -177,9 +177,9 @@ snapshots:
     components-cards-insight-card--access-control-viewer-access--light:
         hash: v1.k794b7964.385f2553db1ac44aca115ac9ff046815a68450e80d321459839b0d4f4ffcee6b.EArgipiRGDp0FnfrLv2pR5cvjnk0Wyz3kfevjOZ7WTY
     components-cards-insight-card--insight-card--dark:
-        hash: v1.k794b7964.559ba17eb3af5356dff4c4dce3874b0b1ea432696d8a9e2515bc1449cf79268f.hPOjU-OM0rUypdy6gw-fMH-557l9gGdxVt_djVxKtM4
+        hash: v1.k794b7964.ee3a3a73efcc7d9f48ab9dfd1e46811861852bac25a273ab5adc8246f4681900.gB9BNOiS4EaM-G_tM9nfWurHv70VDoAxcAyi-FX9Oao
     components-cards-insight-card--insight-card--light:
-        hash: v1.k794b7964.9c4c811437c65c6dbcb5e6c57c51eb6e2adfa0a8779d4b73b5fb05e67caa73e3.YqxeouU2vQLML7U7fNQbCWhJ432Qtvvc5TiJkWIx2jg
+        hash: v1.k794b7964.cdd71e7653f9a8b86ab12b25a3b1eb809811a502983b794ad828b5ea442d43e0.3sEUw3mwl_VUVCPhRsj87AM_c0QU6yU6cQTdIwsQIF4
     components-cards-insight-details--data-table-events-query--dark:
         hash: v1.k794b7964.6956ffc51d0a9527e5d9a47c8ed61d34c47c7b15cfa171c634057d0eabda0dd2.pxLvJTrPbgP0Y-yg7R_SZHFQbAIrPtI5-fGMsReGRAs
     components-cards-insight-details--data-table-events-query--light:
@@ -473,17 +473,17 @@ snapshots:
     components-errors-error-display--with-cymbal-errors--light:
         hash: v1.k794b7964.33d6457d0ce96480ffe75e0d1889a14c66404e0c7c02a54dce29c76bcbdb1ee7.c4GXiWMq_NCrT4lXQRtJq8OiQDEvF2bhYqF1MP33SbA
     components-funneltooltip--default--dark:
-        hash: v1.k794b7964.bab695922c9d31c701004295faa30132f46f2ab604a637f32a838edf70853720.JXPgEOYFNBge00rd18LqAMiS8r2wHcaZBMeiFmmk60I
+        hash: v1.k794b7964.47d1dfc647e4d28502288450dcb922b5e61bc16e471d9728d6410f12a580737f.MSAC_E--WQpeF_46dZIi1V3VpCe84zLlT-UvH0UY4Gs
     components-funneltooltip--default--light:
-        hash: v1.k794b7964.c26616a68f479a26b44537cdd13974f2c46dc6a540d2f3249a69cdbfb479120a.ynNwEh7lw1ywF1jGOBSfm7QP3LiZkwV7bPzLVyuL5SY
+        hash: v1.k794b7964.eb2bd31d68473d0bbdb88dd48525c91697da988e4bd375217509b4573fd4ba3c.lqWFwrjWtP21hD_VFcVdcpftOIGTxiIUE05HK_OpGqE
     components-funneltooltip--with-long-name--dark:
-        hash: v1.k794b7964.6908c14fcbb1dd1889bef7bec2d32c98e65f94112094456efabf14fc936db891.4WbbTP66kzbS4E5_PpIiU25_aVwhS3vcT-ORN8hXrnA
+        hash: v1.k794b7964.c273968ff8d74db2d8b4a1bc0688c4d1779ff4eb9d4909dc810626196f39cb84.ff6jSCK3ZetuE0l0PhpOKNUjO5-ephvkGLFVr3ca314
     components-funneltooltip--with-long-name--light:
-        hash: v1.k794b7964.7e82debb1d5ece284b60d6b1d3a3bae78b702caf1774c1cb7594ed94ba830212.IDOPYXXq4ZjI1WOUbw9MBPGrSrrh00lqozPixmgij2U
+        hash: v1.k794b7964.de8dbc34acaf585d30c4490f282132cfea974ad4040a7110c217f4f0b88ce118.t-7U7k_59bMrZKwG8a9ZtQrYP2_XnUMNZEAbPlvceig
     components-funneltooltip--with-long-unbroken-name--dark:
-        hash: v1.k794b7964.633aa1a51a21fc04a50b35f312429078b3ea5f3c84d4e82a67d1ab2c02788840.VGWrj0ULaO_Ts7lUwvrQupH931Bk1e0x52JHPYJLUI0
+        hash: v1.k794b7964.499edb71cce774e46501e7780e08bf76fb07fafdc08550429ee00faff3dd9648.skvJ87LKId6kEezvpIjuPJuL-ch9ztzWQhmQ1bKSMYA
     components-funneltooltip--with-long-unbroken-name--light:
-        hash: v1.k794b7964.f83258788b1281380a1b78d0584c4034b78abd78941b650048e8ef3f3a237096.nyeJwxyLnxbUk0-jc1dgWqasWaODcGUq8B71urHyIsM
+        hash: v1.k794b7964.9f017f19151042387f0c5b4f54aca5a99b8c907c4f3bd39b84eaf93aa8bfc82b.lQmW0GPhFEksdR2uewLWwu6y7aSSJS4ehIxJwAWTD0I
     components-hedgehogmode--profile-picture-hog--dark:
         hash: v1.k794b7964.969bdab0c4f15b4457bc162b9ad87ec0341d5e98ed3a9279494cc2f019c12250.5eEGiofVhJFttdE4ETVy01n1PTA-WrkIsgHZEB9rG5I
     components-hedgehogmode--profile-picture-hog--light:
@@ -2049,13 +2049,13 @@ snapshots:
     errortracking-volumesparkline--events-before-data-range--light:
         hash: v1.k794b7964.683c24f2509215d174cda4a69fd2aa0f021af91d45f7ccdab742f78755c2e4ca.l0oCDgytHq-3gkB5Nza3SN1Tpmvc_LP_dsSdGCfoXxo
     exporter-funnels--funnel-left-to-right-breakdown-insight--dark:
-        hash: v1.k794b7964.6a75f41f6923b14c3b49812561ea0d908c6c7e466d5288541ebde23517c15102.RJuMe_-ZWf6JEiStu-Z_HeuKx0GOPhaSLY-Cmdzg_4g
+        hash: v1.k794b7964.0ef0ab53aa4f4a44d22b2cd8bc9e78fdb2c268af95eb1a7e4008807235d79933.Y2wPvWEHhbmZWvV4biF2OD0fT0sPymSrSv4Ef1jHpy4
     exporter-funnels--funnel-left-to-right-breakdown-insight--light:
-        hash: v1.k794b7964.cf8d6138be64eb309767988932d87de419af25958b00b2abe8ecf11c28ee330e.iDBtXGRimL8eVfT7kFT3fM93v_CBxaOGcA7czx91z7c
+        hash: v1.k794b7964.ea4b967576c0d6c6c10ac0547965c7426a782333ff6d4416b7ccdcf5383b3482.ph39K4p3DOQ4i_ycS51oIGYmjIVgTSeGJTQH8W11wX4
     exporter-funnels--funnel-left-to-right-insight--dark:
-        hash: v1.k794b7964.0dc99817200305823a16189e604bf5c1f8b2c13465b3eb630d070843d5f99dc2.VIJVI-ufTYIFSNgRvu4diwvodFXRuRFxw6A9_LQnFWg
+        hash: v1.k794b7964.1aba7ba5a823af06234a31049b24f52fff278e7ffef6e10d8529f26d0878e3c7.sPqHc5vbj1RdulBvauVcX8PQJM-YCagoltmcnRiCNFY
     exporter-funnels--funnel-left-to-right-insight--light:
-        hash: v1.k794b7964.c58c741b830919a1b771d8c5ec1eca4eeccbbc138e8014ad6dc4d5c67dc64f0a.wsrA8V4-sr15vB9N7c57AfGR2E61K-HRkxVM-51XjSk
+        hash: v1.k794b7964.f6b92ea07135b56e096b818179e9713e180a937c6d3ea366114d77ad04783eaa.S9NtpCk5GJMVCA-5Og64PqTDRaFLcM3Iruabmx-Yvw8
     exporter-funnels--funnel-left-to-right-insight-no-results--dark:
         hash: v1.k794b7964.5d0d328d83dd60bee58184c0c33ec821333a741e828d9912c45804c2f608a7d4.5uOR8sk7Lnfb2QWLi0nLjsSLgxj5tmHI3nGJNb8K-F8
     exporter-funnels--funnel-left-to-right-insight-no-results--light:
@@ -2497,21 +2497,21 @@ snapshots:
     insights-funnelpropertycorrelationtable--default--light:
         hash: v1.k794b7964.93b684089bf1841a469d9729f6def9de52d3c4e78c26ccd34e7b8647ae987c8a.P883wk4hR7v-ZFklyJK1eNxBfhwFq31G6RFxI3knt3s
     insights-funnelstepsbarchart--breakdown--dark:
-        hash: v1.k794b7964.24231a6c0aa897026ddab3516709f6b5b63f78ba31cde438f8d05d48eed3f580.AhJlZ_9B4fS1-k9KjUe5Rpm5EhXFg-tDGcebGbLSaZ0
+        hash: v1.k794b7964.08c62f2d1f147e05e754f1b13e95f0c2af9856209c0c197e942b26aad380d8b7.mykkKmdnCwBsZmTRTw_5qRP_ImQp3IU1cL6pXQNzEHM
     insights-funnelstepsbarchart--breakdown--light:
-        hash: v1.k794b7964.d251129665fb4a0cd45c06d2ab7186b4c5e2f70cadc2a24351f400c8b6e2d122.M4Ps9X0HSaPRWazFcYZAU9fHv56ShPenJcRtk7Bakd4
+        hash: v1.k794b7964.ef5b8d25d48688261cfaa80a3fc0eb72591947c058b608785e0b82ff0f9a789f.Ew5iFWL3G7CoqIph640J4EcyQkv7EMC__wX_42-3yME
     insights-funnelstepsbarchart--breakdown-and-compare--dark:
-        hash: v1.k794b7964.b61959316021ea8cbf21ff7c425a3b58c8c502bfff8c862cc0bb2947f6f28473.CIijpnagLBbNi_-hphYo03M_c6lxDQmfBjW-1uBjS10
+        hash: v1.k794b7964.88ae974582c9dcba3100f28eb688af198cfd7480a56375eee40d42e4839c233a.CEFZgymiNhpGlXdyaHivgzWQ8u0Anj0u72yq4ulch9A
     insights-funnelstepsbarchart--breakdown-and-compare--light:
-        hash: v1.k794b7964.8761cb5f23b7368c5765b2a570c05f1fb32ee8185987b47404b0df383f54bde8.DYW47or6IzDPEt1o5wofB3lX-jbZ0F1-3n0-1SuIGhs
+        hash: v1.k794b7964.9f202e1484c79485c02ddf726b822bccaa4f208f6663ff287dae0245bb3b4a5e.FbEco_G_czhBhk9FIXa5xVQ1aP6_Hi8ndmheuCgvPaI
     insights-funnelstepsbarchart--compare--dark:
-        hash: v1.k794b7964.1345d85fb01c520cb48b23af3c601d0f9eb6bed0ac6cf16d6241c02e2bed7172.KwYwgZ7U_QH7KYIUG0zl7uUmP2Jw9KYcHZqjQD_PYJk
+        hash: v1.k794b7964.4b63e733bb826606ac813e27b2c259007c1c37f790fed33baf77d5069048bbf3.0_oTFagU6uG6SHNAfgui8JXZxijxgS2PtPF_lPCo4JY
     insights-funnelstepsbarchart--compare--light:
-        hash: v1.k794b7964.a63240be8440e7a836ef058d0357b68ad56f87c260ccf147865c2fb2c495656e.ugIoHV6W-pMCpJys198JQiEWjpyF-xBz5ASqcsCbbqc
+        hash: v1.k794b7964.e7b47f099f0ae984c8bcc5f251e1eee8edbb20b3c4b10b504c3ee58d0a3d479d.5giqurdSr41CHswwkeVaNjraBs1OS2m5z_M0mt97QOI
     insights-funnelstepsbarchart--default--dark:
-        hash: v1.k794b7964.7d34454430cfb4586695de29f16bfa7c93e39f3f0b3694d0b341de711b829f5f.Me8dOXwJ_ZztmRu1eL3TOOjdr_rG1UN8oU6Kd-3IPZU
+        hash: v1.k794b7964.5317f73d42180be586139ca1ee35001cb08f764246dc98d9a1421949c796f235.6kheIKEWojErjDJhqIIyLd6JPoj9uopMYZ2q1qxKlRg
     insights-funnelstepsbarchart--default--light:
-        hash: v1.k794b7964.fe6293e80ff3014aac37a652107195613baf23e61d8612e7a2156478bce8a138.FLFOJroOGoBFApFzYil15PPT2jNF01yQtezK_StFjHU
+        hash: v1.k794b7964.7931cb026a0f8270bf9c7c2d683851e2c195c4d6a56b3b867d2489294456101a.fy4NiaUff203nBnzLjP_WZocBSdSNgmBRrpsXGpZA5w
     insights-funneltimetoconverttable--default--dark:
         hash: v1.k794b7964.705be97725fbf4864c1ee89bfe71f783b8258340a17c845c6c4c7a2ca2649a86.EErdKEVTegibMohKXzFfjUSUW495svDW88KdGAc9eDg
     insights-funneltimetoconverttable--default--light:
@@ -5021,9 +5021,9 @@ snapshots:
     scenes-app-dashboards--access-control-dashboard--light:
         hash: v1.k794b7964.2cb1dc53e388e2ba2f1ba027db19970b5c836420c212719646cc6e01df3eb532.3JJd9GmozBQFNT4B9WyN_CM7iuWaWKL1u3Fq6SXTnhI
     scenes-app-dashboards--edit--dark:
-        hash: v1.k794b7964.083587fcf5cb279b32adeda05783970f3e222dc33a17ad5686f5196be865a8ab.A-1zzLAHX5TOyD8dvQYlCNH2xD4FZiiDW7CXMovArYM
+        hash: v1.k794b7964.6aa70ce359a5c4a0c09a57a8629d73f8a152d204d9d22d44d0d4777f6eeb0c06.BZXugeWh6SNKv6iKcjcRl4pEjlyPgbD9HQHJCVuHcZ8
     scenes-app-dashboards--edit--light:
-        hash: v1.k794b7964.a2f42d94fac861654f447f332cd513eaa9bd81f3c108967e6745f695f12c2546.mV7i91ApKabQ_d_YjjU0K5OMYpM7el5LmffL9XWr8M8
+        hash: v1.k794b7964.b42a16df47349f0098289f0917478e2bfa25c4c0372db6293dd5c7973aab779f.W5J45Zee4_WYg_lH-7LwmFxAflRM8l-nXybTFHT10T8
     scenes-app-dashboards--erroring--dark:
         hash: v1.k794b7964.a356bf2ce40e53018919ebc890579c0ad6e493385f546d26b1f70471bf99f726.UER3Vv5UUZ1POzJv4_TuxrLBcLfLa8WTZ_hyUX9t72s
     scenes-app-dashboards--erroring--light:
@@ -5685,29 +5685,29 @@ snapshots:
     scenes-app-insights-funnels--funnel-historical-trends-edit--light:
         hash: v1.k794b7964.296746d8a2788ab88883975bd97d8ab5cd502727c68cea48f5565501f722bd66.KurWhGCdkOzxxPW1LFjCoq3T9HxUNEXzOUEkrud6Smo
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--dark:
-        hash: v1.k794b7964.2e764e6f3647ff86ca5c088a4b463b239254a854d85ae678755173e90c9714ab.uhusaADhMsDZRFVdbU0F9ViTpdzJKHD7Vo2QctRpMWU
+        hash: v1.k794b7964.5bdb0ffd2317315384836d2ba8e7600c68c27adcdfcca585e99a5df9b6dced2b.izDC64qux-_Jdb-uExXHcCcGGkU7nGo4z3DF0S28RFE
     scenes-app-insights-funnels--funnel-left-to-right-breakdown-edit--light:
-        hash: v1.k794b7964.500e1fdfe93be682e9c64acfcf557b2bd12e8136c87481a772db2795db4fc170.t6FdCh7gk4-BNTRB_wzTVu8VcyyzJjHJbbZb_QyLjCU
+        hash: v1.k794b7964.7ea36b6183af10b29a7294f85bfcff4a09590b90558904c7065018b77cfc35ef.jcwzdxAwnJjku6Nfe2HPb2IRClfbpiG3SFnh2EpSqXI
     scenes-app-insights-funnels--funnel-left-to-right-compare--dark:
-        hash: v1.k794b7964.c06558a5d730d4d4787f1c99172c390030bf55f05ed7596bd4d1f6bd0bbe0a1a.kxR9FFETw4hbO_cV17X3fMfFOrrxD2w-I8gACLI3WG4
+        hash: v1.k794b7964.e2b87a572d6503c8ebfbe7adf54031db98fda2b30d97b933c63fd094ef330ab4.GeSi46whIPeDDDWAO_Ow8pWiaDWnTg7VgQ5GJMdVBNE
     scenes-app-insights-funnels--funnel-left-to-right-compare--light:
-        hash: v1.k794b7964.efd117b25bc08be5aafeea0d2eebbb2d4b07a542e762584e99b8b68172520877.emnTmFYizx7ABBBfqC7j-WmDRIqgqkQHt7Wv5kj0H4s
+        hash: v1.k794b7964.0a836d6b292fbfcccb587e3de3996e87a3b9933657642b4aee882a592da20008.3SxlWfNeYtsnARocwkgnRA43UgJECOkgM7e6rVSxnjE
     scenes-app-insights-funnels--funnel-left-to-right-edit--dark:
-        hash: v1.k794b7964.20964c5fc0c9092c4d49421d8b86859cd8e34f7cbe5772c30b5cf615ac3195ba.dzFx3sC7oIadc1AGNEzOEKE8G_ckf3LBdf2EpE4AvOk
+        hash: v1.k794b7964.19e87533e1bdb4761c1a9f973894c8732e54fc65c230a4f675c0d71be67a01a0.WZPWNrUf1ZmNmJCLpgck7R_7RTWMaiuufEIDvKP08nk
     scenes-app-insights-funnels--funnel-left-to-right-edit--light:
-        hash: v1.k794b7964.ef6ff8fcfe19c020b07a66ccce3e93aa11056c535ab152b848e89e6b7406dba2.s1QJ4bkZUJlA9qwl3ss9ZHHfPY-OfGZSY6yECXKzoLg
+        hash: v1.k794b7964.a6545e07243ed209cc192018c823885f18258634f9da9c5ef7ed0aefc2bf88f1.s9Gtj1xaDfpxjtlmNuAunLTN1sA-FRkPy53Utc8sWBc
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--dark:
         hash: v1.k794b7964.89fdfcc51f8471de4c13f9858bb60874909cf33539b456755dc5e61af26b374f.e66Yjt-7kjXzCYcHEH3nTiv-uFgg-wi4eRrokFsPjQg
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--medium--light:
         hash: v1.k794b7964.91904e00072f6ee9a2f12f4bf2892a0e9a7782f46c04734c0b1f0e14baa66396.wqlNoRGwk3Wi8pOi_7jmX-sAfJgrQdR2ZO9KHW23K0E
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--dark:
-        hash: v1.k794b7964.a9771cd7dc958b4b77baee5c409c2abf6ea85f3bba61aead37ae749339c0727f.XNZOfKq7d7uxBPQCnxVyVxSXp9jUPh8fIC0AlmHwK3s
+        hash: v1.k794b7964.beb19fb8129e1684835ca88100bfcd2950de5b85b4a66560c39d7d6f56b5876c.9sAV-xhD1GucVIrNx-ECaA_peHt5yWUmAa4vyF1i0Bs
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--superwide--light:
-        hash: v1.k794b7964.a4910e3b150c07651b9ea86c326cc7b9dd1d43f6c56127826b323d3b75c5b814.6xgvV6z4bESi2u9Jp5lxC2wGcSm2wK2OvLLTlkzRsRk
+        hash: v1.k794b7964.b5119c9c72481062addcf1e10ac01f99b8736a2197b9c7cf89d23c70568cde46.yGaGiuys9tnfP_hSDUACtttY7e4FuxBQ2KJNB8NtYBM
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--dark:
-        hash: v1.k794b7964.20964c5fc0c9092c4d49421d8b86859cd8e34f7cbe5772c30b5cf615ac3195ba.pQpibJAZDRxXbfR52PXwzHBdvV46T-iCLgduKiJ54yc
+        hash: v1.k794b7964.19e87533e1bdb4761c1a9f973894c8732e54fc65c230a4f675c0d71be67a01a0.pAxdGVeVgcOPIbVQXj9ax-kc_mhhIl9l1MWjowHgU4A
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
-        hash: v1.k794b7964.ef6ff8fcfe19c020b07a66ccce3e93aa11056c535ab152b848e89e6b7406dba2.-whJ_jGwxTf_nzSec874Pk6ox4Tz6spex4gRsJUg3OI
+        hash: v1.k794b7964.a6545e07243ed209cc192018c823885f18258634f9da9c5ef7ed0aefc2bf88f1.3QGxHpuDQiT3BnolocywC5Fdo34arGKBD4qwH4nPJLk
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
         hash: v1.k794b7964.c744f53550b964a531653504150021418f1e4f3a97b49a5bdc630702c4f1e647.lWgC3HqBecT9i-QNSnIiRtqRCiPyxwGXhJgSphsG2ow
     scenes-app-insights-funnels--funnel-time-to-convert--light:
@@ -5733,9 +5733,9 @@ snapshots:
     scenes-app-insights-funnels--funnel-top-to-bottom-edit--light:
         hash: v1.k794b7964.f78e24e51ece8c96efb92693d8732a68b268a83803682b8b4fedbd1d451c4ed1.xfg-TjZJTYOCnTs0aiPqTmE4j4ESXGz6SKyXLPVxrSE
     scenes-app-insights-funnels--funnel-with-inline-events-edit--dark:
-        hash: v1.k794b7964.65778076636ff8753cd578d406c10820394eab62b5a3e03b423da9846d8f7e9d.iOGZxePDMGolQrRwl3nXNaw3OWDORHG4zJMDIk35EA4
+        hash: v1.k794b7964.36eb74ebe608fe5d7ba7c81bcd11100a3ee94b16b45c55295c2f7d09d9866cac.w5Ypu9PCYNSWTi90RRmzQmspDsKtLiGH3e82f-MXblY
     scenes-app-insights-funnels--funnel-with-inline-events-edit--light:
-        hash: v1.k794b7964.03fa59b4d62c55775880f09d3fafcc589596e845d4df2bb9f621e81282df1e96.Ac8qcwrvDKOltwsaIuWm0ykMda6ZlpnF7NLnfUYRWSM
+        hash: v1.k794b7964.2febd6f1b193b708e3389907fb86691d7f3c744798bb497c0a4771e80563fd44.wSBkWAX8cF5FEk52xte_1YcvstrbJay0T1by1HQLO8E
     scenes-app-insights-insight-quick-start--default--dark:
         hash: v1.k794b7964.505184dee13f2d14931ad37a214599ef534ec76d53c45fc38277b3d872fc23c1.Oxp2sMs9fSJsbiIjUKJSjknQYgvY9O9VrcEJX5aRPEo
     scenes-app-insights-insight-quick-start--default--light:

--- a/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
+++ b/frontend/src/scenes/funnels/FunnelBarVertical/StepLegend.tsx
@@ -1,3 +1,7 @@
+// .StepLegend styles live in FunnelBarVertical.scss; import here so they load on the quill funnel
+// charts that reuse this component (the old FunnelBarVertical that used to pull them in is gone).
+import './FunnelBarVertical.scss'
+
 import { useActions, useValues } from 'kea'
 
 import { IconClock } from '@posthog/icons'

--- a/frontend/src/scenes/funnels/FunnelTooltip.tsx
+++ b/frontend/src/scenes/funnels/FunnelTooltip.tsx
@@ -1,3 +1,7 @@
+// .FunnelTooltip styles live in FunnelBarVertical.scss; import here so they load on the quill funnel
+// charts that reuse this tooltip (the old FunnelBarVertical that used to pull them in is gone).
+import './FunnelBarVertical/FunnelBarVertical.scss'
+
 import clsx from 'clsx'
 import { useValues } from 'kea'
 import { useEffect, useRef } from 'react'


### PR DESCRIPTION
## Problem

The funnel step legend (and the funnel tooltip) render unstyled in local dev while looking correct in production: the "⋯" step menu is pushed to the far right instead of hugging the step title, rows are too loosely spaced, and the step name/counts render at regular weight instead of medium/semibold. `hogli nuke` and an incognito window don't help, because nothing is cached wrong.

## Changes

When vertical funnels migrated to the quill-based `FunnelStepsBarChart` (and horizontal to `FunnelBarHorizontalChart`), those components reused the existing `StepLegend` and `FunnelTooltip` components — but the styles for those components live in `FunnelBarVertical.scss`, which neither one imports. The only remaining importer of that stylesheet is the experiments `FunnelBarVertical`, which isn't on the funnel insights page.

esbuild's production bundle hoists those rules into shared CSS that's present on essentially every page, so prod looks fine. Vite's dev server loads a component's CSS only when that component imports it, so in local dev the `.StepLegend` / `.FunnelTooltip` rules never load and both components fall back to bare `LemonRow` styling.

The fix imports the stylesheet from the two components that depend on it, so the styles load wherever the components are used — independent of bundler-specific global-CSS behavior. This covers both the vertical and horizontal funnel layouts (both reuse the shared `FunnelTooltip`).

## How did you test this code?

I'm an agent (PostHog Code) — no manual browser testing claimed. Automated checks actually run:

- oxlint + oxfmt on the changed files — clean.
- Frontend `typescript:check` — the changed files have no errors (the run only surfaced pre-existing, unrelated errors under `products/workflows/`).
- Against the running Vite dev server, confirmed the transformed `StepLegend` module now imports `FunnelBarVertical.scss`, and that module serves the `.StepLegend` rules (`width: fit-content`, `font-weight: 600`) that were previously absent on the funnel page.

Suggested manual check: open a Steps funnel insight in local dev and confirm the legend matches production (⋯ next to the title, tight rows, semibold weight).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with PostHog Code. The starting report was "local CSS differs from prod" on the funnel steps. The first hypothesis — the `MatterSQ` title font being CORS-blocked at the `localhost:8010` dev origin — was rejected, because a font swap can't move the "⋯" or change row spacing. Tracing the real render path showed the quill funnel charts reuse `StepLegend`/`FunnelTooltip` without importing their stylesheet, and that the prod/dev difference is esbuild's global CSS bundle vs Vite's per-module CSS loading. No repo skills were needed for this change.

Separately noted (out of scope): `MatterSQ` only loads from a CDN whose CORS allowlist includes `localhost:8000` but not the current `localhost:8010` dev origin, so title-font text falls back to the system font app-wide in local dev. That's a minor, unrelated latent issue.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
