### PR TITLE
fix(hogql): dedup repeated cohort left join in one scope

### DIFF
--- a/posthog/hogql/transforms/in_cohort.py
+++ b/posthog/hogql/transforms/in_cohort.py
@@ -378,13 +378,20 @@ class InCohortResolver(TraversingVisitor):
         must_add_join = True
         last_join = select.select_from
         while last_join:
-            if isinstance(last_join.table, ast.Field) and last_join.table.chain[0] == f"in_cohort__{cohort_id}":
+            # Dedup on the join alias: a second `IN COHORT <id>` in the same scope must reuse the
+            # existing join, not add a colliding one. (The join's `table` is the cohort subquery, so
+            # the alias is the only place the `in_cohort__<id>` name lives.)
+            if last_join.alias == f"in_cohort__{cohort_id}":
                 must_add_join = False
                 break
             if last_join.next_join:
                 last_join = last_join.next_join
             else:
                 break
+
+        current_scope = self.stack[-1].type
+        if current_scope is None:
+            raise QueryError("Could not resolve current select scope")
 
         if must_add_join:
             inline_ast = inline_cohort_query(cohort_id, is_static, version, self.context)
@@ -421,9 +428,6 @@ class InCohortResolver(TraversingVisitor):
                     constraint_type="ON",
                 ),
             )
-            current_scope = self.stack[-1].type
-            if current_scope is None:
-                raise QueryError("Could not resolve current select scope")
             new_join = cast(
                 ast.JoinExpr,
                 resolve_types(
@@ -453,9 +457,6 @@ class InCohortResolver(TraversingVisitor):
                 last_join.next_join = new_join
             else:
                 select.select_from = new_join
-
-        if current_scope is None:
-            raise ValueError("Expected current scope when resolving cohort comparison")
 
         compare.op = ast.CompareOperationOp.NotEq if negative else ast.CompareOperationOp.Eq
         compare.left = resolve_types(

--- a/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
+++ b/posthog/hogql/transforms/test/__snapshots__/test_in_cohort.ambr
@@ -113,6 +113,32 @@
   LIMIT 100
   '''
 # ---
+# name: TestInCohort.test_in_cohort_same_cohort_referenced_twice
+  '''
+  -- ClickHouse
+  SELECT events.event AS event 
+  FROM events LEFT JOIN (
+    SELECT cohortpeople.person_id AS person_id, 1 AS matched 
+    FROM cohortpeople 
+    WHERE and(equals(cohortpeople.team_id, 99999), equals(cohortpeople.cohort_id, XX)) 
+    GROUP BY cohortpeople.person_id, cohortpeople.cohort_id, cohortpeople.version 
+    HAVING greater(sum(cohortpeople.sign), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, events.person_id) 
+  WHERE and(equals(events.team_id, 99999), equals(in_cohort__XX.matched, 1), equals(events.event, %(hogql_val_0)s), equals(in_cohort__XX.matched, 1)) 
+  LIMIT 100 
+  SETTINGS readonly=2, max_execution_time=60, allow_experimental_object_type=1, max_ast_elements=4000000, max_expanded_ast_elements=4000000, max_bytes_before_external_group_by=0, transform_null_in=1, optimize_min_equality_disjunction_chain_length=4294967295, optimize_rewrite_aggregate_function_with_if=0, optimize_min_inequality_conjunction_chain_length=4294967295, allow_experimental_join_condition=1, use_hive_partitioning=0
+  
+  -- HogQL
+  SELECT event 
+  FROM events LEFT JOIN (
+    SELECT person_id, 1 AS matched 
+    FROM raw_cohort_people 
+    WHERE equals(cohort_id, XX) 
+    GROUP BY person_id, cohort_id, version 
+    HAVING greater(sum(sign), 0)) AS in_cohort__XX ON equals(in_cohort__XX.person_id, person_id) 
+  WHERE and(equals(in_cohort__XX.matched, 1), equals(event, 'RANDOM_TEST_ID::UUID'), equals(in_cohort__XX.matched, 1)) 
+  LIMIT 100
+  '''
+# ---
 # name: TestInCohort.test_in_cohort_static
   '''
   -- ClickHouse

--- a/posthog/hogql/transforms/test/test_in_cohort.py
+++ b/posthog/hogql/transforms/test/test_in_cohort.py
@@ -54,6 +54,25 @@ class TestInCohort(BaseTest):
         self.assertEqual(len(response.results or []), 1)
         self.assertEqual((response.results or [])[0][0], random_uuid)
 
+    @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=False)
+    def test_in_cohort_same_cohort_referenced_twice(self):
+        # Two references to the same cohort in one scope must compile to a single LEFT JOIN,
+        # not collide on the in_cohort__<id> alias.
+        random_uuid = self._create_random_events()
+        cohort = Cohort.objects.create(
+            team=self.team,
+            groups=[{"properties": [{"key": "$os", "value": "Chrome", "type": "person"}]}],
+        )
+        recalculate_cohortpeople(cohort, pending_version=0, initiating_user_id=None)
+        response = execute_hogql_query(
+            f"SELECT event FROM events WHERE person_id IN COHORT {cohort.pk} AND event = '{random_uuid}' AND person_id IN COHORT {cohort.pk}",
+            self.team,
+            modifiers=HogQLQueryModifiers(inCohortVia=InCohortVia.LEFTJOIN),
+            pretty=False,
+        )
+        self.assertEqual(len(response.results or []), 1)
+        self.assertEqual((response.results or [])[0][0], random_uuid)
+
     @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_in_cohort_static(self):

--- a/posthog/hogql/transforms/test/test_in_cohort.py
+++ b/posthog/hogql/transforms/test/test_in_cohort.py
@@ -54,10 +54,11 @@ class TestInCohort(BaseTest):
         self.assertEqual(len(response.results or []), 1)
         self.assertEqual((response.results or [])[0][0], random_uuid)
 
+    @pytest.mark.usefixtures("unittest_snapshot")
     @override_settings(PERSON_ON_EVENTS_OVERRIDE=True, PERSON_ON_EVENTS_V2_OVERRIDE=False)
     def test_in_cohort_same_cohort_referenced_twice(self):
         # Two references to the same cohort in one scope must compile to a single LEFT JOIN,
-        # not collide on the in_cohort__<id> alias.
+        # not collide on the in_cohort__<id> alias. The snapshot locks in that single join.
         random_uuid = self._create_random_events()
         cohort = Cohort.objects.create(
             team=self.team,
@@ -70,6 +71,7 @@ class TestInCohort(BaseTest):
             modifiers=HogQLQueryModifiers(inCohortVia=InCohortVia.LEFTJOIN),
             pretty=False,
         )
+        assert pretty_print_response_in_tests(response, self.team.pk) == self.snapshot  # type: ignore
         self.assertEqual(len(response.results or []), 1)
         self.assertEqual((response.results or [])[0][0], random_uuid)
 


### PR DESCRIPTION
## Problem

Under `inCohortVia=LEFTJOIN`, a query that references the **same cohort more than once in a single scope** crashes during type resolution with:

> Already have joined a table called "in_cohort__<id>". Can't join another one with the same name.

This hits real insights — e.g. the same cohort used as both a global filter and a series/breakdown filter, which collapse into one `WHERE` scope. The default `inCohortVia=SUBQUERY` inlines cohorts and never creates the join, so the crash is specific to the left-join cohort strategy.

## Changes

`InCohortResolver._add_join_for_cohort` runs once per `IN COHORT` comparison and walks the join chain to avoid re-joining a cohort it has already joined. The guard checked `last_join.table.chain[0]`, but a cohort join stores its name in `alias` — its `table` is the cohort subquery, never a field. So the guard never matched a join it had added, and a second reference appended a duplicate `in_cohort__<id>` join.

- Dedup on the join **alias** instead.
- Hoist `current_scope` out of the `if must_add_join:` block so it's defined on the path where the join already exists (the comparison rewrite below runs unconditionally). Without this, the dedup fix alone would raise `UnboundLocalError`.

Net result: N references to one cohort in a scope produce **one** `LEFT JOIN`, with each comparison rewritten to `in_cohort__<id>.matched = 1`.

Scope: only the `LEFTJOIN` path. The conjoined resolver (`MultipleInCohortResolver`) has the same shape of guard but isn't reachable as a bug — it adds its join once per scope rather than once per comparison — so I left it untouched rather than change untested code with no reproducing case.

## How did you test this code?

I'm an agent (PostHog Code). I did **not** run the app manually.

- Added `test_in_cohort_same_cohort_referenced_twice`: references one cohort twice in a single scope under `inCohortVia=LEFTJOIN`, asserting it compiles and returns the right row. Every existing `LEFTJOIN` test references a cohort exactly once, so this path was uncovered. I traced that it fails on `master` (duplicate-alias `QueryError`) and passes with the fix — but did not execute it, see below.
- Static checks I ran locally: `python -m py_compile` and `ruff check` / `ruff format --check` on both files — clean.
- I could **not** run the ClickHouse-backed test suite in my environment (no Postgres/ClickHouse). CI runs `test_in_cohort.py` and `test_cohort.py` — please confirm green there.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: PostHog Code (Claude). Skill invoked: `/writing-tests` (test gate).
- Root cause: the dedup guard compared `last_join.table.chain[0]` against `in_cohort__<id>`, but that name lives on the join's `alias`, not its `table` — so it never deduped, and a repeated cohort reference collided. Fix dedups on `alias` and hoists `current_scope` (previously only assigned inside the add-join branch, which was safe only because the broken guard never let dedup succeed).
- Scoped deliberately to the `LEFTJOIN` path; flagged the latent-but-unreachable twin in `MultipleInCohortResolver` as a possible follow-up rather than touching it without a failing case.
