### PR TITLE
fix(logs): fix daterange picker wrapping

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -91,7 +91,7 @@ export const LogsQueryControls = (): JSX.Element => {
 
     return (
         <div className="flex shrink-0 gap-1.5">
-            <div className="LogsDateButtonGroup">
+            <div className="flex">
                 <LemonButton
                     size="small"
                     icon={<IconMinusSquare />}


### PR DESCRIPTION
Problem

The `LogsDateButtonGroup` CSS class was being used purely for layout on a wrapper `div` in the logs filter bar, but a simple `flex` Tailwind utility is sufficient and more consistent with the rest of the codebase.

## Changes

Replaced the `LogsDateButtonGroup` class on the date button group wrapper with the `flex` Tailwind utility class.

## How did you test this code?

Visually verified the logs filter bar renders correctly with the updated class.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?