### PR TITLE
fix(engineering_analytics): stop OTLP crash dropping all CI job logs

### DIFF
--- a/products/engineering_analytics/backend/logic/job_logs/activity.py
+++ b/products/engineering_analytics/backend/logic/job_logs/activity.py
@@ -85,7 +85,10 @@ async def fetch_and_emit_job_log_activity(inputs: FetchJobLogInputs) -> dict[str
         # Failures-only today; pass a different ThinningConfig once all-jobs ingestion lands.
         thinned = thin_log(archive)
         with JobLogsEmitter(endpoint=settings.OTLP_LOGS_INGEST_ENDPOINT, token=log_ingest_token) as emitter:
-            return emitter.emit_log_archive(thinned, attributes=attributes)
+            # run_id→trace, job_id→span so the Logs UI can group a whole run and isolate one job.
+            return emitter.emit_log_archive(
+                thinned, attributes=attributes, trace_id=inputs.run_id, span_id=inputs.job_id
+            )
 
     lines = await asyncio.to_thread(_thin_and_emit)
     log.info("github_job_log_emitted", lines=lines)

--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -20,6 +20,7 @@ from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
 from opentelemetry.sdk._logs import LoggerProvider, LogRecord
 from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter
 from opentelemetry.sdk.resources import Resource
+from opentelemetry.trace import TraceFlags
 
 logger = structlog.get_logger(__name__)
 
@@ -52,6 +53,21 @@ def _severity(body: str) -> tuple[str, SeverityNumber]:
     return "INFO", SeverityNumber.INFO
 
 
+def _otel_id(value: str | int | None, n_bytes: int) -> int:
+    """A GitHub run/job id packed as an OTLP trace/span id — an int the encoder serializes into
+    ``n_bytes``. GitHub ids arrive as int or numeric string (warehouse columns are nullable strings),
+    so coerce; return 0 (OTLP "unset") when missing, non-numeric, or out of range. Never None — the
+    SDK default — and never a str: either would crash serialization of the whole batch.
+    """
+    if value is None:
+        return 0
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return parsed if 0 < parsed < (1 << (n_bytes * 8)) else 0
+
+
 class JobLogsEmitter:
     """One record per line into Logs. Use as a context manager so the batch flushes on exit. Pass
     ``endpoint`` + ``token`` for production, ``exporter`` in tests; with neither it's a safe no-op
@@ -71,11 +87,25 @@ class JobLogsEmitter:
             logger.warning("github_ci_logs_emit_disabled", detail="no endpoint/token configured; skipping export")
         self._logger = self._provider.get_logger(_SERVICE_NAME)
 
-    def emit_log_archive(self, archive_text: str, *, attributes: Mapping[str, object]) -> int:
-        """Emit one Logs record per non-empty line. Returns the number of records emitted."""
+    def emit_log_archive(
+        self,
+        archive_text: str,
+        *,
+        attributes: Mapping[str, object],
+        trace_id: str | int | None = 0,
+        span_id: str | int | None = 0,
+    ) -> int:
+        """Emit one Logs record per non-empty line. Returns the number of records emitted.
+
+        ``trace_id``/``span_id`` map the GitHub run/job onto OTLP trace/span so the Logs UI can group
+        a whole workflow run (trace) and isolate one job (span); unmappable ids fall back to 0
+        (unset). They MUST be set: the encoder treats 0 as unset and calls ``int(trace_flags)``, so
+        the SDK's None default would crash serialization of the whole batch and nothing would land.
+        """
         if not self._enabled:
             return 0
         attrs = {key: value for key, value in attributes.items() if isinstance(value, _SCALAR)}
+        trace, span = _otel_id(trace_id, 16), _otel_id(span_id, 8)
         emitted = 0
         for raw in archive_text.splitlines():
             match = _LINE.match(raw)
@@ -87,6 +117,9 @@ class JobLogsEmitter:
                 LogRecord(
                     timestamp=timestamp,
                     observed_timestamp=timestamp,
+                    trace_id=trace,
+                    span_id=span,
+                    trace_flags=TraceFlags(TraceFlags.DEFAULT),
                     severity_text=severity_text,
                     severity_number=severity_number,
                     body=body,

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
@@ -1,6 +1,8 @@
 from datetime import UTC, datetime
 
+from opentelemetry.exporter.otlp.proto.common._internal._log_encoder import encode_logs
 from opentelemetry.sdk._logs.export import InMemoryLogExporter
+from parameterized import parameterized
 
 from products.engineering_analytics.backend.logic.job_logs.emitter import JobLogsEmitter
 
@@ -12,6 +14,43 @@ def _emit(archive: str, attributes=_ATTRS):
     with JobLogsEmitter(exporter=exporter) as emitter:
         emitted = emitter.emit_log_archive(archive, attributes=attributes)
     return emitted, [d.log_record for d in exporter.get_finished_logs()]
+
+
+def _encode_one(*, trace_id, span_id):
+    exporter = InMemoryLogExporter()
+    with JobLogsEmitter(exporter=exporter) as emitter:
+        emitter.emit_log_archive(
+            "2026-06-25T09:14:02.000000Z ##[error]boom", attributes=_ATTRS, trace_id=trace_id, span_id=span_id
+        )
+    encoded = encode_logs(exporter.get_finished_logs())  # must not raise
+    return encoded.resource_logs[0].scope_logs[0].log_records[0]
+
+
+def test_run_and_job_ids_encode_as_trace_and_span():
+    # Production ships via the real OTLP HTTP exporter, which protobuf-encodes each batch — the step
+    # InMemoryLogExporter skips. The encoder treats trace/span == 0 as "unset" and calls
+    # int(trace_flags); leaving them None (the SDK default) or passing a str (run_id is a nullable
+    # warehouse column, often numeric string) raises in encode_logs and silently drops the whole
+    # batch. This asserts a string run/job id coerces and round-trips into the right-width bytes.
+    record = _encode_one(trace_id="7", span_id="42")
+    assert record.body.string_value == "##[error]boom"
+    assert record.trace_id == (7).to_bytes(16, "big")
+    assert record.span_id == (42).to_bytes(8, "big")
+
+
+@parameterized.expand(
+    [
+        ("missing", None, None),
+        ("non_numeric", "abc", "xyz"),
+        ("out_of_range", 1 << 128, 1 << 64),  # too wide for trace (16B) / span (8B)
+    ]
+)
+def test_unmappable_ids_fall_back_to_unset(_name, trace_id, span_id):
+    # Bad/oversized ids must encode as unset (empty bytes), never crash the batch — int.to_bytes on
+    # an over-width id raises OverflowError, and a non-numeric str has no to_bytes at all.
+    record = _encode_one(trace_id=trace_id, span_id=span_id)
+    assert record.trace_id == b""
+    assert record.span_id == b""
 
 
 def test_emits_per_line_with_parsed_timestamp_severity_and_attributes():


### PR DESCRIPTION
## Problem

The GitHub CI job-logs worker reported success but nothing ever reached the Logs product. The worker builds OTLP `LogRecord`s by hand and never set `trace_id` / `span_id` / `trace_flags`, so the SDK left them `None`. The OTLP protobuf encoder treats `0` as "unset" (`span_id == 0`) and calls `int(trace_flags)` — `None` fails both and raises mid-serialization, dropping the **entire batch**. Export is fire-and-forget, so the activity logged `github_job_log_emitted` and moved on while every record died before leaving the worker. Discovery and fetch were fine; the emit hand-off only looked successful.

## Changes

- Set the OTel "unset" sentinels (`0` / `TraceFlags.DEFAULT`) so records actually serialize.
- Map `run_id` → `trace_id` and `job_id` → `span_id` so the Logs UI can group a whole workflow run and isolate a single job — on top of the existing `job_id` / `run_id` / `branch` / `conclusion` attributes. `run_id` is a nullable warehouse column and can arrive as a numeric string, so it's coerced; missing, non-numeric, or over-width ids fall back to unset rather than crashing the batch a second way.

## How did you test this code?

I'm an agent (Claude). Automated only — no manual testing claimed.

- Full `products/engineering_analytics/backend/logic/job_logs` suite green (40 tests).
- New regression in `test_job_logs_emitter.py`: it runs the real `encode_logs()` over emitted records — the protobuf step `InMemoryLogExporter` skips, which is exactly why the original suite never caught the crash. It asserts a numeric-string id coerces and round-trips into the right-width bytes, plus a parameterized unset-fallback case for missing / non-numeric / over-width ids.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed live: the worker logged success but a Logs query returned nothing. Traced it to repeated `Exception while exporting logs` (`'NoneType' object has no attribute 'to_bytes'`) in the worker's stdout — the OTLP encoder choking on `span_id=None`. Confirmed the SDK `LogRecord` defaults the trace fields to `None` and the encoder's "unset" guard is `== 0`, not `is None`.

Weighed just zeroing the fields (minimal fix) against also mapping the GitHub run/job onto trace/span. Chose the mapping: the Logs table exposes `trace_id` / `span_id` as queryable columns and the ids fit OTLP's 16/8-byte widths, so it's near-free run-level grouping. Kept it defensive — coercion plus a range clamp so a string or oversized id can't reintroduce the crash.

Tools: Claude Code; Grafana/Loki MCP to read the prod worker logs; PostHog MCP to query the Logs product. No repo skills shaped the code change.
