### PR TITLE
chore(migrate): schedule temporal workflows on production deploys

### DIFF
--- a/bin/migrate
+++ b/bin/migrate
@@ -216,13 +216,26 @@ fi
 if [ -n "$CLICKHOUSE_PID" ]; then
     wait $CLICKHOUSE_PID
     CLICKHOUSE_WAIT_STATUS=$?
-    
+
     CH_STATUS=$(cat $CLICKHOUSE_STATUS)
     rm -f $CLICKHOUSE_STATUS
-    
+
     if [ "$CH_STATUS" != "0" ] || [ $CLICKHOUSE_WAIT_STATUS -ne 0 ]; then
         echo "Error in ClickHouse migrations, exiting."
         exit 1
+    fi
+fi
+
+# Temporal worker schedules. Skipped on hobby deploys (no Temporal cluster) and
+# on local dev (DEBUG=1, matching the persons-migration gate above).
+if run_scope "temporal-schedules"; then
+    if [ "${DEPLOYMENT:-}" != "hobby" ] && [ "${DEBUG:-0}" != "1" ]; then
+        echo "Scheduling Temporal worker workflows..."
+        python manage.py schedule_temporal_workflows
+        if [ $? -ne 0 ]; then
+            echo "Error in schedule_temporal_workflows, exiting."
+            exit 1
+        fi
     fi
 fi
 

--- a/bin/migrate
+++ b/bin/migrate
@@ -233,7 +233,11 @@ fi
 if run_scope "temporal-schedules"; then
     if [ "${DEPLOYMENT:-}" != "hobby" ] && [ "${DEBUG:-0}" != "1" ]; then
         echo "Scheduling Temporal worker workflows..."
-        if ! python manage.py schedule_temporal_workflows; then
+        # timeout guards against an unreachable Temporal frontend: the client has
+        # no connect/RPC deadline of its own, so a network black-hole would hang
+        # the whole migrate job otherwise. 90s leaves room for Django startup on a
+        # cold container; reconciliation is idempotent so a killed run resumes next deploy.
+        if ! timeout 90 python manage.py schedule_temporal_workflows; then
             echo "Warning: schedule_temporal_workflows failed, continuing."
         fi
     fi

--- a/bin/migrate
+++ b/bin/migrate
@@ -228,13 +228,13 @@ fi
 
 # Temporal worker schedules. Skipped on hobby deploys (no Temporal cluster) and
 # on local dev (DEBUG=1, matching the persons-migration gate above).
+# Non-fatal: scheduling is reconciled idempotently on every deploy, so a
+# transient Temporal outage should not block the migrate job.
 if run_scope "temporal-schedules"; then
     if [ "${DEPLOYMENT:-}" != "hobby" ] && [ "${DEBUG:-0}" != "1" ]; then
         echo "Scheduling Temporal worker workflows..."
-        python manage.py schedule_temporal_workflows
-        if [ $? -ne 0 ]; then
-            echo "Error in schedule_temporal_workflows, exiting."
-            exit 1
+        if ! python manage.py schedule_temporal_workflows; then
+            echo "Warning: schedule_temporal_workflows failed, continuing."
         fi
     fi
 fi


### PR DESCRIPTION
## Problem

The migration runner (`bin/migrate`) handles Postgres, ClickHouse, product DBs, persons, and async migrations, but Temporal worker schedules were never wired in. We want the schedules registered as part of the same cluster migrate step, without leaking into local dev or hobby deploys (hobby has no Temporal cluster).

## Changes

Added a step at the end of `bin/migrate` that runs `python manage.py schedule_temporal_workflows`. It runs after all DB migrations have completed (the script is `set -e`, so any earlier failure aborts first), so schedules are created against an already-migrated database.

The step is gated two ways:

- **Environment** — only runs when `DEPLOYMENT != hobby` **and** `DEBUG != 1`. The `DEBUG != 1` check is the same local-dev signal the persons-migration block above it uses, so local dev is excluded even if `DEPLOYMENT` happens to be set.
- **Scope** — wired into the existing `--scope` system as `temporal-schedules`, so a full `bin/migrate` run includes it while scoped invocations (e.g. `--scope=postgres`) don't. Local dev's mprocs only ever calls `bin/migrate` with explicit scopes, so it's doubly excluded there.

The step is **non-fatal**: scheduling reconciles idempotently on every deploy, so a transient Temporal outage logs a warning and the migrate job continues rather than aborting the whole run.

| Environment | `DEPLOYMENT` | `DEBUG` | Runs? |
|---|---|---|---|
| Local dev | unset | `1` | No |
| Hobby | `hobby` | — | No |
| Production | `prod` / etc. | unset | Yes |

## How did you test this code?

I'm an agent. I did not run this against a live Temporal cluster. Verification done:

- `bash -n bin/migrate` passes (syntax check).
- Traced the env signals through `.env`, `.env.development`, `docker-compose.*.yml`, and `bin/mprocs.yaml` to confirm `DEBUG=1` is the local-dev contract and that local dev only invokes `bin/migrate` with explicit non-temporal scopes.

A reviewer should confirm the migrate job's pod can reach the Temporal frontend.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8). No repo skills were invoked — this is a shell-script change, not a Django migration.

Decisions along the way: started with a `DEPLOYMENT`-presence gate, but the human pointed out the sqlx/persons flow keys off `DEBUG` rather than `DEPLOYMENT`, and that `DEPLOYMENT` isn't a reliable local-dev signal. Settled on `DEPLOYMENT != hobby && DEBUG != 1` to match the file's existing idiom. The step was initially hard-fail; switched to non-fatal after review feedback, since schedule reconciliation is idempotent and shouldn't block a deploy on a transient Temporal outage.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
