### PR TITLE
fix(data-warehouse): scope convex resume cursors per endpoint

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/resumable.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/resumable.py
@@ -20,11 +20,23 @@ class ResumableSourceManager(Generic[ResumableData]):
     _inputs: SourceInputs
     _data_class: type[ResumableData]
     _logger: FilteringBoundLogger
+    _namespace: str | None
 
-    def __init__(self, inputs: SourceInputs, data_class: type[ResumableData]):
+    def __init__(self, inputs: SourceInputs, data_class: type[ResumableData], namespace: str | None = None):
         self._inputs = inputs
         self._data_class = data_class
         self._logger = inputs.logger
+        self._namespace = namespace
+
+    def with_namespace(self, namespace: str) -> "ResumableSourceManager[ResumableData]":
+        """Return a sibling manager whose Redis state is isolated under `namespace`.
+
+        A source that reaches more than one endpoint within a single job — where each
+        endpoint stores an incompatible cursor format — uses this to keep their resume
+        state in separate slots. Without it a retry that switches endpoints could load a
+        cursor the other endpoint wrote and replay it against an API that can't parse it.
+        """
+        return ResumableSourceManager(self._inputs, self._data_class, namespace=namespace)
 
     @contextmanager
     def _get_redis(self):
@@ -40,7 +52,8 @@ class ResumableSourceManager(Generic[ResumableData]):
 
     @property
     def _key(self) -> str:
-        return f"posthog:data_warehouse:resumable_source:{self._inputs.team_id}:{self._inputs.job_id}"
+        base = f"posthog:data_warehouse:resumable_source:{self._inputs.team_id}:{self._inputs.job_id}"
+        return f"{base}:{self._namespace}" if self._namespace else base
 
     def _dump_json(self, data: ResumableData) -> str:
         data_dict = dataclasses.asdict(data)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -32,9 +32,17 @@ _CONVEX_RETRY = DEFAULT_RETRY.new(
 )
 
 
+# list_snapshot cursors are opaque {tablet, id} strings; document_deltas cursors are integer
+# `_ts` timestamps. The two are not interchangeable, so each endpoint's resume state is kept
+# under its own Redis namespace (see convex_source) to stop a retry that flips between them
+# from replaying one endpoint's cursor against the other.
+_SNAPSHOT_RESUME_NAMESPACE = "list_snapshot"
+_DELTAS_RESUME_NAMESPACE = "document_deltas"
+
+
 @dataclasses.dataclass
 class ConvexResumeConfig:
-    cursor: int
+    cursor: int | str
     snapshot: int | None = None
 
 
@@ -110,7 +118,8 @@ def list_snapshot(
     which can be used as the starting cursor for document_deltas.
     """
     base_url = f"{deploy_url.rstrip('/')}/api/list_snapshot"
-    cursor: int | None = None
+    # Convex returns the snapshot cursor as an opaque {tablet, id} string, not an integer.
+    cursor: int | str | None = None
     snapshot: int | None = None
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
@@ -170,7 +179,10 @@ def document_deltas(
     current_cursor = cursor
 
     resume_config = resumable_source_manager.load_state() if resumable_source_manager.can_resume() else None
-    if resume_config is not None:
+    # Only trust an integer resume cursor — document_deltas requires an integer `_ts`. A
+    # non-integer here means stale or cross-endpoint state; ignore it and restart from the
+    # DB watermark rather than replaying a cursor Convex would reject with a 400.
+    if resume_config is not None and isinstance(resume_config.cursor, int):
         current_cursor = resume_config.cursor
 
     while True:
@@ -254,10 +266,12 @@ def convex_source(
     def items_generator():
         if should_use_incremental_field and db_incremental_field_last_value is not None:
             cursor = int(db_incremental_field_last_value)
-            for batch in document_deltas(clean_url, deploy_key, table_name, cursor, resumable_source_manager):
+            deltas_manager = resumable_source_manager.with_namespace(_DELTAS_RESUME_NAMESPACE)
+            for batch in document_deltas(clean_url, deploy_key, table_name, cursor, deltas_manager):
                 yield _normalize_timestamps(batch)
         else:
-            for batch in list_snapshot(clean_url, deploy_key, table_name, resumable_source_manager):
+            snapshot_manager = resumable_source_manager.with_namespace(_SNAPSHOT_RESUME_NAMESPACE)
+            for batch in list_snapshot(clean_url, deploy_key, table_name, snapshot_manager):
                 yield _normalize_timestamps(batch)
 
     return SourceResponse(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -182,8 +182,16 @@ def document_deltas(
     # Only trust an integer resume cursor — document_deltas requires an integer `_ts`. A
     # non-integer here means stale or cross-endpoint state; ignore it and restart from the
     # DB watermark rather than replaying a cursor Convex would reject with a 400.
-    if resume_config is not None and isinstance(resume_config.cursor, int):
-        current_cursor = resume_config.cursor
+    if resume_config is not None:
+        if isinstance(resume_config.cursor, int):
+            current_cursor = resume_config.cursor
+        else:
+            # Namespacing should keep this from happening; if it does, surface it rather than
+            # silently dropping the saved cursor.
+            logger.warning(
+                "Discarding non-integer document_deltas resume cursor for table '%s'; restarting from the DB watermark",
+                table_name,
+            )
 
     while True:
         params: dict[str, Any] = {"tableName": table_name, "cursor": current_cursor, "format": "json"}

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -236,6 +236,8 @@ class TestDocumentDeltasResumable:
         assert batches == [[{"_id": "b"}]]
         first_params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
         assert first_params["cursor"] == 10
+        # Discarding a poisoned cursor must not persist new state off the back of it.
+        manager.save_state.assert_not_called()
 
 
 class TestConvexRetryPolicy:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -34,6 +34,9 @@ def _make_manager(can_resume: bool = False, state: ConvexResumeConfig | None = N
     manager = MagicMock(spec=ResumableSourceManager)
     manager.can_resume.return_value = can_resume
     manager.load_state.return_value = state
+    # Endpoint scoping returns a sibling manager; resolve it back to this mock so call
+    # assertions still observe the same object.
+    manager.with_namespace.return_value = manager
     return manager
 
 
@@ -216,6 +219,23 @@ class TestDocumentDeltasResumable:
         first_params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
         assert first_params["cursor"] == 25
         manager.save_state.assert_not_called()
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_non_integer_resume_cursor_is_ignored(self, mock_get: Mock) -> None:
+        # A list_snapshot resume cursor ({tablet, id}) leaking into document_deltas must not be
+        # replayed — document_deltas requires an integer _ts and Convex 400s on the malformed
+        # cursor. Fall back to the db watermark instead.
+        saved = ConvexResumeConfig(cursor='{"tablet":"-cxKinhlnLuQp","id":"v9769ybsnjbhc9"}')
+        manager = _make_manager(can_resume=True, state=saved)
+        mock_get.return_value.get.return_value = _make_response(
+            {"values": [{"_id": "b"}], "cursor": 30, "hasMore": False}
+        )
+
+        batches = list(document_deltas("https://x.convex.cloud", "key", "t", 10, manager))
+
+        assert batches == [[{"_id": "b"}]]
+        first_params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
+        assert first_params["cursor"] == 10
 
 
 class TestConvexRetryPolicy:


### PR DESCRIPTION
## Problem

A Convex sync can fail with a bare `HTTPError: 400 Client Error: Bad Request` from the `document_deltas` streaming-export endpoint. The request carries a cursor shaped like `{"tablet": "...", "id": "..."}` — which is a `list_snapshot` (full-refresh) pagination cursor, not the integer `_ts` timestamp `document_deltas` expects. Convex rejects the malformed cursor, and because it isn't the known `InvalidWindowToReadDocuments` case, it surfaces as an unhandled 400 that fails the sync with no actionable message.

Root cause: the resumable-source cursor is stored in a single Redis slot keyed only by `team_id` + `job_id`. The two Convex endpoints store **incompatible cursor formats** in that one slot. The collision is reachable on a manually-triggered resync:

1. A resync starts on `list_snapshot`. It pages partway, persisting a `{tablet, id}` resume cursor to Redis — the presence of that cursor means the snapshot was interrupted before completing.
2. The interrupted attempt advances the per-batch incremental watermark and clears the early `reset_pipeline` flag.
3. The retry (same `job_id`) recomputes full-vs-incremental, now sees a non-null watermark, and flips to `document_deltas`.
4. `document_deltas` loads the shared Redis slot, finds the leftover snapshot cursor, and replays it — 400.

## Changes

- `ResumableSourceManager` gains an optional `namespace` (and a `with_namespace()` helper) that suffixes the Redis key. The key is unchanged when no namespace is set, so other resumable sources are unaffected.
- The Convex source now scopes `list_snapshot` and `document_deltas` into separate Redis namespaces, so a retry that switches endpoints can no longer read the other endpoint's cursor.
- `document_deltas` ignores any non-integer resume cursor as a backstop — if stale or already-poisoned state reaches it, it restarts from the DB watermark instead of replaying a cursor Convex can't parse.
- Widened `ConvexResumeConfig.cursor` to `int | str` and the `list_snapshot` local cursor type to match what Convex actually returns (the previous `int` annotation was incorrect).

This does not migrate Convex to the V3 watermark-staging pipeline (which stages the watermark per-attempt and would remove the endpoint-flip trigger at its source). That's a larger follow-up; the namespacing + guard fixes the cursor collision regardless of pipeline version.

## How did you test this code?

I'm an agent (PostHog Code), so no manual testing. Automated only:

- Added `test_non_integer_resume_cursor_is_ignored` to `TestDocumentDeltasResumable` — feeds a `{tablet, id}` string as resume state and asserts the request falls back to the integer DB watermark rather than sending the bad cursor. This is the exact regression behind the customer 400; no existing test exercised a cross-endpoint cursor.
- Updated the shared `_make_manager` mock so `with_namespace` resolves back to the same mock, keeping existing call-count assertions valid.
- Ran `hogli test products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py` → 53 passed. `ruff` + `ty check` clean (via pre-commit).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a single failing-sync error string plus the Temporal `WorkflowExecutionStarted` event, which revealed the run was an admin-triggered resync. Traced the cursor-format mismatch through the Convex source, the shared `ResumableSourceManager` Redis key, and the activity-level full-vs-incremental decision (including how `reset_pipeline` is popped early and how the V2 pipeline advances the watermark per batch on retry).

Skills invoked: `/writing-tests` (to gate the single added regression test).

Decisions: chose endpoint-scoped Redis namespacing as the root-cause fix over adding the table to the key (the key is already per-table since each job covers one schema, so a table suffix buys nothing). Added the non-integer-cursor guard as defense-in-depth so the specific 400 can't recur even from stale state. Left the V3 pipeline migration as a follow-up rather than scope-creep.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
