### PR TITLE
fix(workflows): use real moments when comparing recurrence occurrences to now

### DIFF
--- a/products/workflows/frontend/Workflows/hogflows/steps/components/rrule-helpers.test.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/rrule-helpers.test.ts
@@ -244,6 +244,31 @@ describe('rrule-helpers', () => {
                 expect(d.getTime()).toBeGreaterThan(Date.now())
             }
         })
+
+        describe("keeps today's still-pending occurrence across a timezone offset", () => {
+            afterEach(() => {
+                jest.useRealTimers()
+            })
+
+            // now=12:26 UTC; today's 9 AM Toronto occurrence is 13:00 UTC (~34 min away).
+            // The occurrence's fake-UTC value (09:00) is "before" now in raw UTC terms, so a
+            // naive comparison drops it — the real moment must be used instead.
+            it('includes the occurrence later today rather than skipping to tomorrow', () => {
+                jest.useFakeTimers().setSystemTime(new Date('2026-06-30T12:26:00Z'))
+                const state: ScheduleState = {
+                    ...DEFAULT_STATE,
+                    frequency: 'weekly',
+                    weekdays: [0, 1, 2, 3, 4], // Mon–Fri
+                    endType: 'never',
+                }
+                // 9 AM America/Toronto (EDT, UTC-4) on Mon June 22 2026 == 13:00 UTC
+                const result = computePreviewOccurrences(state, '2026-06-22T13:00:00Z', 'America/Toronto')
+
+                // First occurrence must be Tue June 30 (still pending today), not Wed July 1
+                const first = fakeUtcToReal(result[0], 'America/Toronto')
+                expect(first.tz('America/Toronto').format('YYYY-MM-DD HH:mm')).toBe('2026-06-30 09:00')
+            })
+        })
     })
 
     describe('fakeUtcToReal', () => {

--- a/products/workflows/frontend/Workflows/hogflows/steps/components/rrule-helpers.ts
+++ b/products/workflows/frontend/Workflows/hogflows/steps/components/rrule-helpers.ts
@@ -212,10 +212,13 @@ export function computePreviewOccurrences(
         const rule = new RRule(options as ConstructorParameters<typeof RRule>[0])
         const isFinite = state.endType !== 'never'
 
-        if (dayjs(dtstart).isBefore(dayjs())) {
+        // Occurrences are "fake UTC" (their UTC fields encode local time in the schedule
+        // timezone), so convert each to a real moment before comparing against now —
+        // otherwise an occurrence still pending today is wrongly treated as already past.
+        const now = dayjs()
+        if (fakeUtcToReal(dtstart, timezone).isBefore(now)) {
             const all = rule.all((_, i) => i < (isFinite ? MAX_PREVIEW_COUNT : limit * 50))
-            const now = new Date()
-            const future = all.filter((d) => d.getTime() > now.getTime())
+            const future = all.filter((d) => fakeUtcToReal(d, timezone).isAfter(now))
             return isFinite ? future : future.slice(0, limit)
         }
         return rule.all((_, i) => i < (isFinite ? MAX_PREVIEW_COUNT : limit))


### PR DESCRIPTION
## Problem

When computing preview occurrences for workflow schedules with timezone offsets, occurrences that are still pending today were incorrectly skipped. This happened because the code compared "fake UTC" values (where UTC fields encode local time in the schedule timezone) directly against the current moment, causing occurrences that appear earlier in raw UTC terms but are actually still pending in the local timezone to be treated as already past.

For example, a 9 AM Toronto occurrence (EDT, UTC-4) on a day when it's 12:26 UTC is actually ~34 minutes away, but the raw UTC comparison (09:00 vs 12:26) would incorrectly skip it.

## Changes

Updated `computePreviewOccurrences` to convert fake UTC occurrence values to real moments before comparing against the current time:

- Added a comment explaining the fake UTC encoding scheme
- Changed the initial check from comparing raw `dtstart` to comparing `fakeUtcToReal(dtstart, timezone)` against now
- Updated the filter for past occurrences to use `fakeUtcToReal(d, timezone).isAfter(now)` instead of raw timestamp comparison

Added a test case that verifies an occurrence still pending today in the local timezone is included rather than skipped in favor of tomorrow's occurrence.

## How did you test this code?

**Unit test:** Added `keeps today's still-pending occurrence across a timezone offset`, which reproduces the bug scenario - a 9 AM Toronto occurrence on a day when it's 12:26 UTC should be the first preview occurrence, not skipped. It asserts the first returned occurrence is today at 9 AM Toronto time, not tomorrow. The full `rrule-helpers` suite passes locally (65/65).

**Manual test in the live editor (localhost):** Built a Batch-trigger workflow with a daily recurring schedule at 12:00 PM `America/Los_Angeles`, at a moment when noon LA was still pending today but its fake-UTC value was already behind the current UTC time (the exact bug condition).

- Before the fix, the "Next occurrences" preview skipped today and listed tomorrow as the first occurrence.
- With the fix applied, the preview correctly listed today's noon occurrence first.

Same schedule and same wall-clock moment in both cases; only the comparison logic differed.

https://claude.ai/code/session_01J655v3muxRC3wYtEeu11Ey
