### PR TITLE
refactor(logs): extract shared DateRangePickerWithZoom composite

### DIFF
--- a/frontend/src/lib/components/DateFilter/DateRangePicker/DateRangePickerWithZoom.tsx
+++ b/frontend/src/lib/components/DateFilter/DateRangePicker/DateRangePickerWithZoom.tsx
@@ -1,0 +1,51 @@
+import { IconMinusSquare, IconPlusSquare } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { DateRangePicker, DateRangePickerProps } from './DateRangePicker'
+import { zoomDateRange } from './zoom-utils'
+
+export interface DateRangePickerWithZoomProps extends DateRangePickerProps {
+    /**
+     * Override how zoom is applied. When omitted, zoom multiplies the current range via `zoomDateRange`
+     * and calls `setDateRange`. Provide this to route zoom through a logic action that also fires
+     * analytics or triggers side effects (e.g. reloading a histogram).
+     */
+    onZoom?: (multiplier: number) => void
+}
+
+/**
+ * Date range picker flanked by zoom-out / zoom-in buttons, fused into a single control via the
+ * `DateRangePickerButtonGroup` wrapper (squared inner corners, rounded outer corners). The picker's
+ * trigger button is a direct DOM child of the group — `Popover` clones rather than wraps it — so the
+ * group's `> .LemonButton` styling treats all three buttons as one seamless unit.
+ */
+export const DateRangePickerWithZoom = ({ onZoom, ...pickerProps }: DateRangePickerWithZoomProps): JSX.Element => {
+    const handleZoom = (multiplier: number): void => {
+        if (onZoom) {
+            onZoom(multiplier)
+            return
+        }
+        const zoomed = zoomDateRange(pickerProps.dateRange, multiplier)
+        pickerProps.setDateRange({ date_from: zoomed.date_from ?? null, date_to: zoomed.date_to ?? null })
+    }
+
+    return (
+        <div className="DateRangePickerButtonGroup">
+            <LemonButton
+                size="small"
+                icon={<IconMinusSquare />}
+                type="secondary"
+                tooltip="Zoom out"
+                onClick={() => handleZoom(2)}
+            />
+            <DateRangePicker {...pickerProps} />
+            <LemonButton
+                size="small"
+                icon={<IconPlusSquare />}
+                type="secondary"
+                tooltip="Zoom in"
+                onClick={() => handleZoom(0.5)}
+            />
+        </div>
+    )
+}

--- a/frontend/src/lib/components/DateFilter/DateRangePicker/index.ts
+++ b/frontend/src/lib/components/DateFilter/DateRangePicker/index.ts
@@ -1,4 +1,6 @@
 export { DateRangePicker } from './DateRangePicker'
 export type { DateRangePickerProps } from './DateRangePicker'
+export { DateRangePickerWithZoom } from './DateRangePickerWithZoom'
+export type { DateRangePickerWithZoomProps } from './DateRangePickerWithZoom'
 export { DEFAULT_DATE_RANGE_PICKER_OPTIONS } from './constants'
 export { zoomDateRange } from './zoom-utils'

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/LogsDateRangePicker.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsDateRangePicker/LogsDateRangePicker.tsx
@@ -1,9 +1,10 @@
 import { useActions, useValues } from 'kea'
 
-import { DateRangePicker } from 'lib/components/DateFilter/DateRangePicker'
+import { DateRangePickerWithZoom } from 'lib/components/DateFilter/DateRangePicker'
 
 import { DateRange } from '~/queries/schema/schema-general'
 
+import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
 import { logsViewerSettingsLogic } from 'products/logs/frontend/components/LogsViewer/logsViewerSettingsLogic'
 
 export interface LogsDateRangePickerProps {
@@ -14,14 +15,17 @@ export interface LogsDateRangePickerProps {
 export const LogsDateRangePicker = ({ dateRange, setDateRange }: LogsDateRangePickerProps): JSX.Element => {
     const { timezone } = useValues(logsViewerSettingsLogic)
     const { setTimezone } = useActions(logsViewerSettingsLogic)
+    // Route zoom through the logic action so it captures analytics and reloads dependent views (histogram, patterns).
+    const { zoomDateRange } = useActions(logsViewerFiltersLogic)
 
     return (
-        <DateRangePicker
+        <DateRangePickerWithZoom
             logicKey="logs"
             dateRange={dateRange}
             setDateRange={setDateRange}
             timezone={timezone}
             onTimezoneChange={setTimezone}
+            onZoom={zoomDateRange}
         />
     )
 }

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -91,26 +91,27 @@ export const LogsQueryControls = (): JSX.Element => {
 
     return (
         <div className="flex shrink-0 gap-1.5">
-            <div className="flex">
-                <LemonButton
-                    size="small"
-                    icon={<IconMinusSquare />}
-                    type="secondary"
-                    tooltip="Zoom out"
-                    onClick={() => zoomDateRange(2)}
-                />
-
-                {!newLogsDateRangePicker && <DateRangeFilter />}
-                {newLogsDateRangePicker && <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />}
-
-                <LemonButton
-                    size="small"
-                    icon={<IconPlusSquare />}
-                    type="secondary"
-                    tooltip="Zoom in"
-                    onClick={() => zoomDateRange(0.5)}
-                />
-            </div>
+            {newLogsDateRangePicker ? (
+                <LogsDateRangePicker dateRange={dateRange} setDateRange={setDateRange} />
+            ) : (
+                <div className="flex">
+                    <LemonButton
+                        size="small"
+                        icon={<IconMinusSquare />}
+                        type="secondary"
+                        tooltip="Zoom out"
+                        onClick={() => zoomDateRange(2)}
+                    />
+                    <DateRangeFilter />
+                    <LemonButton
+                        size="small"
+                        icon={<IconPlusSquare />}
+                        type="secondary"
+                        tooltip="Zoom in"
+                        onClick={() => zoomDateRange(0.5)}
+                    />
+                </div>
+            )}
 
             <LemonButton
                 size="small"

--- a/products/tracing/frontend/TracingFilterBar.tsx
+++ b/products/tracing/frontend/TracingFilterBar.tsx
@@ -1,7 +1,7 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useRef, useState } from 'react'
 
-import { IconChevronDown, IconList, IconListTree, IconMinusSquare, IconPlusSquare, IconRefresh } from '@posthog/icons'
+import { IconChevronDown, IconList, IconListTree, IconRefresh } from '@posthog/icons'
 import {
     LemonButton,
     LemonCheckbox,
@@ -12,7 +12,7 @@ import {
     LemonTag,
 } from '@posthog/lemon-ui'
 
-import { DateRangePicker, zoomDateRange } from 'lib/components/DateFilter/DateRangePicker'
+import { DateRangePickerWithZoom } from 'lib/components/DateFilter/DateRangePicker'
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
@@ -67,41 +67,13 @@ export function TracingFilterBar(): JSX.Element {
                         </div>
                     </div>
                     <div className="flex shrink-0 gap-1.5">
-                        <div className="DateRangePickerButtonGroup">
-                            <LemonButton
-                                size="small"
-                                icon={<IconMinusSquare />}
-                                type="secondary"
-                                tooltip="Zoom out"
-                                onClick={() => {
-                                    const zoomed = zoomDateRange(dateRange, 2)
-                                    setDateRange({
-                                        date_from: zoomed.date_from ?? null,
-                                        date_to: zoomed.date_to ?? null,
-                                    })
-                                }}
-                            />
-                            <DateRangePicker
-                                logicKey="tracing"
-                                dateRange={dateRange}
-                                setDateRange={setDateRange}
-                                timezone={timezone}
-                                onTimezoneChange={setTimezone}
-                            />
-                            <LemonButton
-                                size="small"
-                                icon={<IconPlusSquare />}
-                                type="secondary"
-                                tooltip="Zoom in"
-                                onClick={() => {
-                                    const zoomed = zoomDateRange(dateRange, 0.5)
-                                    setDateRange({
-                                        date_from: zoomed.date_from ?? null,
-                                        date_to: zoomed.date_to ?? null,
-                                    })
-                                }}
-                            />
-                        </div>
+                        <DateRangePickerWithZoom
+                            logicKey="tracing"
+                            dateRange={dateRange}
+                            setDateRange={setDateRange}
+                            timezone={timezone}
+                            onTimezoneChange={setTimezone}
+                        />
                         {!compareMode && (
                             <LemonSegmentedButton<TracingViewMode>
                                 size="small"


### PR DESCRIPTION
## Problem

The zoom-out · date picker · zoom-in control was duplicated across the logs and tracing filter bars. The picker primitive (`DateRangePicker`) was already shared, but the button-group composition around it was not: tracing wrapped it in the `DateRangePickerButtonGroup` styling, while logs hand-rolled a bare `flex` div and never picked up the attached-buttons look. The zoom math was also wired twice, in two different styles.

## Changes

Extracted a single shared composite — `DateRangePickerWithZoom` (`lib/components/DateFilter/DateRangePicker/`) — that owns the zoom buttons, the picker, and the `DateRangePickerButtonGroup` wrapper. Both filter bars now render it instead of re-deriving the layout.

- **Tracing** drops its inline button group and its two hand-wired zoom handlers.
- **Logs** renders the composite via `LogsDateRangePicker`. Its zoom routes through the existing `zoomDateRange` kea action (passed as the `onZoom` override) so the analytics event and the dependent histogram/patterns reload are preserved. The legacy `DateRangeFilter` branch (behind `NEW_LOGS_DATE_RANGE_PICKER`) is untouched.

The attached look — rounded outer corners, squared inner corners, collapsed shared borders — is the existing `DateRangePickerButtonGroup` SCSS. It relies on the picker's trigger button being a *direct* DOM child of the group, which holds because `Popover` clones its child rather than wrapping it. Encapsulating this in the composite means that contract lives in one place.

## How did you test this code?

I'm an agent (PostHog Code). Automated checks only — I did not manually exercise the UI:

- oxlint + oxfmt: clean on all changed files.
- TypeScript: the new component and its wiring (including `onZoom={zoomDateRange}` against the generated action type) produce zero diagnostics. Remaining whole-app `tsgo` errors are pre-existing kea-typegen-absence noise unrelated to this change.

Screenshots of both filter bars would be worth a glance before merge.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Jon directed this: he asked for the zoom buttons to be visually attached to the picker (rounded outer corners, squared inner corners) and for the composition to be owned by one shared component rather than copy-pasted between logs and tracing.

Key decision: logs couldn't simply adopt the composite's default util-based zoom, because its `zoomDateRange` kea action also fires an analytics event and triggers a histogram/patterns reload that other code depends on. Rather than duplicate those side effects, the composite exposes an optional `onZoom` override — logs passes its action, tracing uses the default. The "attached" styling turned out to already exist in SCSS; the logs bug was that it never opted into the class, so the fix is structural (the composite is now the only way to render the control).

No repo skills were required for this change (pure `.tsx`/`.ts` frontend refactor, no serializer/migration/API surface).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
