### PR TITLE
feat(data-warehouse): open SQL editor in view mode from models scene

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/SQLEditor.tsx
@@ -408,6 +408,11 @@ function SQLEditorSceneTitle(): JSX.Element | null {
             return
         }
 
+        if (saveAsMenuItems.primary.action === 'view') {
+            saveAsView()
+            return
+        }
+
         saveAsInsight()
     }
 
@@ -649,7 +654,9 @@ function SQLEditorSceneTitle(): JSX.Element | null {
                                     saveAsDisabledReason ??
                                     (saveAsMenuItems.primary.action === 'endpoint'
                                         ? saveAsEndpointAccessDisabledReason
-                                        : undefined)
+                                        : saveAsMenuItems.primary.action === 'view'
+                                          ? saveAsViewAccessDisabledReason
+                                          : undefined)
                                 }
                                 sideAction={{
                                     icon: <IconChevronDown />,

--- a/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/editorSceneLogic.tsx
@@ -224,6 +224,21 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                     }
                 }
 
+                if (editorSource === 'view') {
+                    const forceBackTo: Breadcrumb = {
+                        key: 'models',
+                        name: 'Models',
+                        path: urls.models(),
+                        iconType: 'sql_editor',
+                    }
+
+                    return {
+                        forceBackTo,
+                        name: 'New view',
+                        resourceType: { type: 'sql_editor' },
+                    }
+                }
+
                 if (dashboardId) {
                     const forceBackTo: Breadcrumb = {
                         key: 'dashboard',
@@ -267,6 +282,13 @@ export const editorSceneLogic = kea<editorSceneLogicType>([
                     return {
                         primary: saveAsEndpointItem,
                         secondary: [saveAsInsightItem, saveAsViewItem],
+                    }
+                }
+
+                if (editorSource === 'view') {
+                    return {
+                        primary: saveAsViewItem,
+                        secondary: endpointsEnabled ? [saveAsInsightItem, saveAsEndpointItem] : [saveAsInsightItem],
                     }
                 }
 

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.test.ts
@@ -1099,6 +1099,48 @@ describe('sqlEditorLogic', () => {
             })
         })
 
+        it('remembers view source when URL sync removes search params', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+
+            router.actions.push(urls.sqlEditor(), { source: 'view' }, { q: 'SELECT 1' })
+
+            await expectLogic(logic).toDispatchActions(['setEditorSource', 'createTab', 'updateTab'])
+
+            logic.actions.setQueryInput('SELECT 2')
+            await new Promise((resolve) => setTimeout(resolve, 600))
+
+            expect(router.values.searchParams.source).toBeUndefined()
+            expect(router.values.hashParams.q).toEqual('SELECT 2')
+            expect(logic.values.editorSource).toEqual('view')
+        })
+
+        it('shows back button to models when view source is active', async () => {
+            logic = sqlEditorLogic({
+                tabId: TAB_ID,
+                monaco: createMockMonaco(),
+                editor: createMockEditor(),
+            })
+            logic.mount()
+            editorRootLogic = editorSceneLogic({ tabId: TAB_ID })
+            editorRootLogic.mount()
+
+            router.actions.push(urls.sqlEditor(), { source: 'view' })
+
+            await expectLogic(logic).toDispatchActions(['setEditorSource', 'createTab', 'updateTab'])
+
+            expect(editorRootLogic.values.titleSectionProps.forceBackTo).toEqual({
+                key: 'models',
+                name: 'Models',
+                path: urls.models(),
+                iconType: 'sql_editor',
+            })
+        })
+
         it('ignores the legacy top-level connectionId when selecting the active connection', () => {
             logic = sqlEditorLogic({
                 tabId: TAB_ID,

--- a/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sqlEditorLogic.tsx
@@ -202,7 +202,7 @@ export interface QueryTab {
     draft?: DataWarehouseSavedQueryDraft
 }
 
-export type SqlEditorSource = 'insight' | 'endpoint'
+export type SqlEditorSource = 'insight' | 'endpoint' | 'view'
 
 export interface DataWarehouseAccessControlModalProps {
     resource: AccessControlResourceType.WarehouseTable | AccessControlResourceType.WarehouseView
@@ -2212,7 +2212,11 @@ export const sqlEditorLogic = kea<sqlEditorLogicType>([
                 return
             }
 
-            if (searchParams.source === 'endpoint' || searchParams.source === 'insight') {
+            if (
+                searchParams.source === 'endpoint' ||
+                searchParams.source === 'insight' ||
+                searchParams.source === 'view'
+            ) {
                 actions.setEditorSource(searchParams.source)
             }
             if (searchParams.dashboard) {

--- a/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
+++ b/frontend/src/scenes/data-warehouse/scene/ViewsTab.tsx
@@ -456,7 +456,7 @@ export function ViewsTab({ getViewUrl }: ViewsTabProps = {}): JSX.Element {
                         resourceType={AccessControlResourceType.WarehouseObjects}
                         minAccessLevel={AccessControlLevel.Editor}
                     >
-                        <LemonButton type="primary" to={urls.sqlEditor()} className="inline-block">
+                        <LemonButton type="primary" to={urls.sqlEditor({ source: 'view' })} className="inline-block">
                             Create view
                         </LemonButton>
                     </AccessControlAction>

--- a/frontend/src/scenes/models/ModelsScene.tsx
+++ b/frontend/src/scenes/models/ModelsScene.tsx
@@ -82,7 +82,7 @@ export function ModelsScene(): JSX.Element {
                                 >
                                     <LemonButton
                                         type="primary"
-                                        to={urls.sqlEditor()}
+                                        to={urls.sqlEditor({ source: 'view' })}
                                         size="small"
                                         tooltip="Create view"
                                         data-attr="new-view-button"


### PR DESCRIPTION
## Problem

Clicking **Create view** on the `/models` scene drops you into the SQL editor, but the editor doesn't know you came there to build a view — the primary save button still reads **Save as insight**, and there's no breadcrumb back to Models. Endpoints already solved this: it links to the editor with `?source=endpoint`, which flips the primary button to **Save as endpoint** and adds an Endpoints back-breadcrumb. Views should get the same treatment.

## Changes

Adds a `view` value to the existing `?source=` mechanism, reusing the same plumbing as `endpoint`/`insight`:

- **`sqlEditorLogic`** — `'view'` added to the `SqlEditorSource` type and to the `?source=` whitelist parsed in `urlToAction`, so navigating from Models dispatches `setEditorSource('view')`.
- **`editorSceneLogic`** — when `editorSource === 'view'`, `saveAsMenuItems` makes **Save as view** the primary action (insight/endpoint move to the secondary menu), and `titleSectionProps` shows a **Models** back-breadcrumb titled "New view".
- **`SQLEditor`** — `onPrimarySaveClick` routes the `view` primary action to `saveAsView()`, and the primary button's `disabledReason` respects the view access-control reason.
- **`ModelsScene` / `ViewsTab`** — both "Create view" buttons (header + empty state) now link to `urls.sqlEditor({ source: 'view' })`.

The "Save as view" menu item already existed as a secondary option; this just promotes it to primary when you arrive with `source=view`.

## How did you test this code?

I'm an agent (Claude Code). I ran the automated Jest suite — no manual browser testing.

Added two cases to the existing "source URL parameter" block in `sqlEditorLogic.test.ts`, mirroring the endpoint cases:
- **persistence** — `source=view` sets `editorSource='view'` and survives URL sync dropping the search param. Catches removal of the `'view'` whitelist branch in `urlToAction` (the existing endpoint test wouldn't, since it's a separate OR branch).
- **back-breadcrumb** — `editorSource='view'` produces the Models `forceBackTo`. Catches breakage of the new `editorSource === 'view'` branch in `titleSectionProps`.

All 15 tests in the block pass (`pnpm jest sqlEditorLogic.test.ts -t "source URL parameter"`). Lint clean on the touched files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code at Jovan's direction. The ask: make the Models "Create view" button open the SQL editor in a dedicated "view" mode, exactly the way Endpoints already drives the editor via `?source=endpoint`.

Approach was to follow the existing `endpoint`/`insight` source pattern rather than invent a new mechanism — extend the `SqlEditorSource` union, the `?source=` whitelist, and the two source-aware selectors (`saveAsMenuItems`, `titleSectionProps`). Invoked the `/writing-tests` skill before adding tests; the two new cases mirror the existing endpoint tests and each guards a distinct regression in the new code paths.
