### PR TITLE
feat(experiments): add outcome column to slowest queries

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -92,8 +92,8 @@ function outcome(item: SlowestQuery): { label: string; type: LemonTagType } {
     if (!parentFailed && !buildFailed) {
         return { label: 'OK', type: 'success' }
     }
-    if (parentFailed && buildFailed && item.exception_code === 307) {
-        return { label: `Build + read ${codeLabel(307)}`, type: 'danger' }
+    if (parentFailed && buildFailed) {
+        return { label: `Build + read ${codeLabel(item.exception_code)}`, type: 'danger' }
     }
     if (parentFailed) {
         return { label: `Read ${codeLabel(item.exception_code)}`, type: 'danger' }

--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -10,7 +10,7 @@ import { LemonInput } from 'lib/lemon-ui/LemonInput'
 import { LemonSelect } from 'lib/lemon-ui/LemonSelect'
 import { LemonSwitch } from 'lib/lemon-ui/LemonSwitch'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
-import { LemonTag } from 'lib/lemon-ui/LemonTag'
+import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Tooltip } from 'lib/lemon-ui/Tooltip'
 import { humanizeBytes } from 'lib/utils/numbers'
@@ -74,6 +74,31 @@ function reasonForDirect(item: SlowestQuery, table: 'exposures' | 'metric_events
         return 'build incomplete / not ready'
     }
     return 'not ready'
+}
+
+const EXCEPTION_CODE_LABELS: Record<number, string> = {
+    307: 'exceeded byte limit',
+    159: 'timeout',
+    241: 'out of memory',
+    202: 'cluster busy',
+}
+
+const codeLabel = (code: number): string => EXCEPTION_CODE_LABELS[code] ?? `error ${code}`
+
+// One-glance terminal result for the group: the read plus its precompute builds. exception_code 0 = ok.
+function outcome(item: SlowestQuery): { label: string; type: LemonTagType } {
+    const parentFailed = item.exception_code !== 0
+    const buildFailed = item.sub_queries.some((q) => q.exception_code !== 0)
+    if (!parentFailed && !buildFailed) {
+        return { label: 'OK', type: 'success' }
+    }
+    if (parentFailed && buildFailed && item.exception_code === 307) {
+        return { label: `Build + read ${codeLabel(307)}`, type: 'danger' }
+    }
+    if (parentFailed) {
+        return { label: `Read ${codeLabel(item.exception_code)}`, type: 'danger' }
+    }
+    return { label: 'Build failed', type: 'warning' }
 }
 
 function QueryStats({
@@ -356,6 +381,14 @@ export function QueryPerformance(): JSX.Element {
                         </div>
                     </Tooltip>
                 )
+            },
+        },
+        {
+            title: 'Outcome',
+            width: 160,
+            render: function Outcome(_, item): JSX.Element {
+                const { label, type } = outcome(item)
+                return <LemonTag type={type}>{label}</LemonTag>
             },
         },
     ]


### PR DESCRIPTION
Adds a derived "Outcome" column to the staff-only query-performance table that classifies each group's terminal result at a glance — OK, read/build failures, and the combined "Build + read exceeded byte limit" case — so the failure pattern is scannable without reading each error.

## 🤖 Agent context

Internal staff-only tooling. Pure render column derived from `exception_code` on the parent row and its sub-queries (already in master). No new tests — branch-dispatch render logic covered by typecheck.
