### PR TITLE
fix(postgres): recover transient proxy auth-timeout connects in-process

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -190,6 +190,15 @@ _CONNECTION_DROPPED_ERROR_SUBSTRINGS = (
     # "{:error, :etimedout}". Same transient class as the libpq drops above — recover by
     # reconnecting. The Erlang-tuple wording is the stable, low-false-positive signal.
     "{:error, :etimedout}",
+    # Neon's proxy reports a compute that didn't finish waking from scale-to-zero before the
+    # auth handshake deadline as a ConnectionFailure (SQLSTATE 08006, an OperationalError):
+    # "Failed to connect to database: authentication did not complete within <n>ms". The wake is
+    # transient (a suspended compute reactivates in seconds), so a fresh connect after a short
+    # backoff succeeds — recover by reconnecting rather than failing the whole activity. Match the
+    # timeout phrasing, which is distinct from the permanent credential-rejection wordings
+    # ("password authentication failed", "SASL authentication failed"), and exclude the volatile
+    # millisecond value.
+    "authentication did not complete within",
 )
 
 # Supavisor (Supabase's connection pooler) doesn't surface a dropped upstream connection with a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1062,6 +1062,11 @@ class TestIsConnectionDroppedError:
             # ConnectionFailure (08006, an OperationalError) carrying the Erlang-tuple reason
             # "{:error, :etimedout}" — a transient drop the in-process recovery must catch.
             psycopg.errors.ConnectionFailure("Failed to connect to database: {:error, :etimedout}"),
+            # Neon's proxy reports a compute that didn't wake from scale-to-zero before the auth
+            # deadline as a ConnectionFailure — a transient drop the in-process recovery must catch.
+            psycopg.errors.ConnectionFailure(
+                "Failed to connect to database: authentication did not complete within 15000ms"
+            ),
         ],
     )
     def test_connection_dropped_errors_are_detected(self, error):


### PR DESCRIPTION
## Problem

PostHog error tracking surfaced a `ConnectionFailure` from the Postgres data-warehouse import source:

> Failed to connect to database: authentication did not complete within 15000ms

The stack originates in `_get_table` (`products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py`) during metadata discovery in `postgres_source`.

This is a serverless-Postgres proxy message: a compute that scaled to zero didn't finish waking before the proxy's auth-handshake deadline. It's transient — a suspended compute reactivates in seconds, so a fresh connect after a short backoff succeeds. ([Neon: connection errors](https://neon.com/docs/connect/connection-errors) documents this scale-to-zero wake timeout.) Observed as a single one-off occurrence, the textbook signature of a transient blip.

The source already has an in-process bounded reconnect for transient connect/setup drops (`_connect_with_dropped_retry` and the setup loop's `_CONNECTION_DROPPED_ERROR_TYPES` handler), gated on `_CONNECTION_DROPPED_ERROR_SUBSTRINGS`. This proxy message wasn't in that list, so the reconnect didn't recognise it and the error escaped to fail the activity (relying on a full Temporal-level activity retry and generating error-tracking noise).

## Changes

Added `"authentication did not complete within"` to `_CONNECTION_DROPPED_ERROR_SUBSTRINGS` so `_is_connection_dropped_error` recognises it as a transient drop and the existing in-process reconnect recovers it.

This mirrors the existing Supavisor `{:error, :etimedout}` case — also a `ConnectionFailure` (08006) with the identical `"Failed to connect to database: ..."` shape — that's already handled the same way.

It stays **retryable** and is deliberately *not* added to `get_non_retryable_errors`: a wake timeout is not a permanent credential/config failure, and marking it non-retryable would permanently disable syncs on a transient blip. The substring matches the timeout phrasing only, which is distinct from the permanent credential-rejection wordings (`password authentication failed`, `SASL authentication failed`, `PAM authentication failed`), so it won't swallow real auth failures — those keep their own non-retryable handling.

## How did you test this code?

I'm an agent. pytest wasn't runnable in my environment, so I did not run the suite — please let CI run it.

- Extended `TestIsConnectionDroppedError::test_connection_dropped_errors_are_detected` with the Neon-style `ConnectionFailure` message, asserting it is now classified as a transient drop. The regression it catches: this proxy wake-timeout escaping the in-process reconnect and failing the activity instead of recovering. The existing `test_unrelated_errors_are_not_detected` (with `password authentication failed for user`) already guards against false-positives.
- Verified the substring logic standalone: the new substring matches the wake-timeout message at any millisecond value but not `password authentication failed` / `SASL authentication failed` / `PAM authentication failed`.
- `ruff check` and `ruff format --check` pass on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a Postgres data-warehouse import error from PostHog error tracking. Pulled the issue's stack trace and a representative event via the PostHog error-tracking tools, traced the failure into `_get_table` / `postgres_source`, and read the source's existing connection-drop and non-retryable-error classification.

Decision: the message is a serverless-Postgres proxy scale-to-zero wake timeout — transient infrastructure, not a user/upstream permanent error and not a code bug — so it must stay retryable. Rather than touch `NonRetryableErrors` (which would wrongly disable syncs on a blip), the fix teaches the existing in-process reconnect to recognise it, following the established `{:error, :etimedout}` precedent. Confirmed the transient/Neon attribution via the Neon connection-errors docs, and checked open PRs (including the maintainer's) for duplicates — none address this.
