### PR TITLE
chore(skills): add checking-deployment-status skill

### DIFF
--- a/.agents/skills/checking-deployment-status/SKILL.md
+++ b/.agents/skills/checking-deployment-status/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: checking-deployment-status
+description: >
+  Determines whether a PostHog branch, commit, or pull request has deployed to
+  PostHog Cloud (the `dev`, `prod-us`, and `prod-eu` environments). Use when the
+  user asks "has my PR deployed yet?", "is my branch live?", "did my change ship
+  to prod?", "is <PR/commit> in prod-us/prod-eu?", "what's currently deployed?",
+  or mentions deploy status, rollout, shipping to production, or following a
+  merged change to Cloud. Resolves a PR or branch to its merge commit, then uses
+  the GitHub Deployments API plus an ancestor check (not a naive SHA match,
+  because deploys are batched) to report which environments already contain the
+  change. Read-only — never triggers, reruns, or blocks a deploy.
+---
+
+# Checking PostHog deployment status
+
+Answer "has X deployed yet?" for a PostHog branch, commit, or PR. Resolve the
+input to a commit SHA, then check — per environment — whether the currently
+deployed code already contains that commit. This is read-only inspection.
+
+## How PostHog deploys (the mental model)
+
+- When a PR merges to `master`, CI builds a container image and dispatches a
+  `commit_state_update` to the **[PostHog/charts](https://github.com/PostHog/charts)**
+  repo, which orchestrates the actual rollout. `posthog/posthog` never deploys
+  directly — charts does.
+- Each rollout is recorded as a **GitHub Deployment** on `PostHog/posthog`,
+  keyed by the built commit SHA and an `environment`: `dev`, `prod-us`,
+  `prod-eu`. (You may also see `Release SDK` — that's SDK releases, ignore it.)
+- Deploys are **batched and gradual**: a single build bundles several merged
+  commits, and it reaches `dev` first, then `prod-us` / `prod-eu`. US and EU
+  roll out independently.
+
+The batching is the key gotcha: **your merge commit usually never gets its own
+deployment record.** It gets folded into a later build cut at a different SHA.
+So checking `deployments?sha=<your-merge-commit>` gives false negatives. The
+correct question is _"is my commit an ancestor of the SHA currently deployed to
+this environment?"_ — answer it with the compare API.
+
+## Workflow
+
+### 1. Resolve the input to a commit SHA
+
+- **PR number** → get the merge commit. If it isn't merged yet, stop: there is
+  nothing to deploy.
+
+  ```bash
+  gh pr view <pr> --repo PostHog/posthog \
+    --json state,mergedAt,mergeCommit \
+    --jq '{state, mergedAt, mergeCommit: .mergeCommit.oid}'
+  ```
+
+- **Branch** → resolve to the commit that actually landed on `master`. If the
+  branch is unmerged, the work cannot be deployed; say so and stop.
+- **Commit SHA** → use it directly (full 40-char SHA preferred for the compare
+  API).
+
+### 2. Check each environment
+
+For each of `dev`, `prod-us`, `prod-eu`, find the SHA currently deployed there
+and compare it against the target commit:
+
+```bash
+gh api "repos/PostHog/posthog/deployments?environment=<env>&per_page=1" \
+  --jq '.[0].sha'                       # SHA currently deployed to <env>
+
+gh api "repos/PostHog/posthog/compare/<target_sha>...<deployed_sha>" \
+  --jq '.status'                        # ahead | identical | behind | diverged
+```
+
+Interpret the compare `status` (base = your commit, head = deployed SHA):
+
+| status      | meaning                                            | verdict             |
+| ----------- | -------------------------------------------------- | ------------------- |
+| `identical` | deployed SHA _is_ your commit                      | ✅ deployed         |
+| `ahead`     | deployed SHA is ahead of your commit (contains it) | ✅ deployed         |
+| `behind`    | deployed SHA is behind your commit                 | ⏳ not yet          |
+| `diverged`  | deployed line doesn't contain your commit          | ⏳ not on this line |
+
+### 3. Or just run the helper
+
+[`scripts/check-deploy.sh`](scripts/check-deploy.sh) does all of the above for a
+PR number or a commit SHA:
+
+```bash
+.agents/skills/checking-deployment-status/scripts/check-deploy.sh 66924
+.agents/skills/checking-deployment-status/scripts/check-deploy.sh 3428ae2ba593...
+```
+
+## Reporting
+
+Give a per-environment verdict, and when something isn't deployed, say _why_ in
+terms the user can act on — e.g. "merged 13:27, but the latest `dev` build was
+cut 8 commits before yours, so it'll land in the next rollout." Useful extras:
+
+- The merge time vs. the latest deploy time per env (a deploy that fired _before_
+  the merge obviously can't contain it).
+- That rollout is gradual, so `dev` leads `prod-us`/`prod-eu` by a cycle.
+
+Web equivalents the user can bookmark:
+
+- All deployments: <https://github.com/PostHog/posthog/deployments>
+- Rollout progress: <https://github.com/PostHog/charts/actions>
+
+To watch until it lands, re-run the helper (or the env loop) periodically — the
+`/loop` skill can poll it and notify when prod flips to ✅.
+
+## Boundaries
+
+Read-only. Do **not** trigger, rerun, cancel, roll back, or block a deploy, and
+do not push to charts — those are human-initiated actions. This skill only
+reports state.

--- a/.agents/skills/checking-deployment-status/scripts/check-deploy.sh
+++ b/.agents/skills/checking-deployment-status/scripts/check-deploy.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Check whether a PostHog PR or commit has deployed to dev / prod-us / prod-eu.
+#
+# Usage:
+#   check-deploy.sh <pr-number>
+#   check-deploy.sh <commit-sha>
+#
+# Read-only: queries the GitHub Deployments + compare APIs via `gh`. Deploys are
+# batched, so it asks "is my commit an ancestor of what's deployed?" rather than
+# matching the merge SHA exactly.
+set -euo pipefail
+
+REPO="PostHog/posthog"
+ENVS=("dev" "prod-us" "prod-eu")
+
+arg="${1:-}"
+if [[ -z "$arg" ]]; then
+  echo "Usage: check-deploy.sh <pr-number|commit-sha>" >&2
+  exit 2
+fi
+
+# Resolve the input to a full commit SHA.
+if [[ "$arg" =~ ^[0-9]+$ ]]; then
+  info=$(gh pr view "$arg" --repo "$REPO" \
+    --json state,mergedAt,mergeCommit \
+    --jq '[.state, (.mergedAt // "null"), (.mergeCommit.oid // "null")] | @tsv')
+  pr_state=$(cut -f1 <<<"$info")
+  pr_merged=$(cut -f2 <<<"$info")
+  sha=$(cut -f3 <<<"$info")
+  if [[ "$pr_state" != "MERGED" || "$sha" == "null" ]]; then
+    echo "PR #$arg is $pr_state — not merged, so nothing to deploy yet."
+    exit 0
+  fi
+  echo "PR #$arg merged at $pr_merged"
+  echo "Merge commit: $sha"
+else
+  sha="$arg"
+fi
+
+echo
+echo "Deployment status for ${sha:0:12}:"
+for env in "${ENVS[@]}"; do
+  deployed=$(gh api "repos/$REPO/deployments?environment=$env&per_page=1" \
+    --jq '.[0].sha // empty' 2>/dev/null || true)
+  if [[ -z "$deployed" ]]; then
+    echo "  $env: no deployments found"
+    continue
+  fi
+  cmp=$(gh api "repos/$REPO/compare/$sha...$deployed" --jq '.status' 2>/dev/null || echo "error")
+  case "$cmp" in
+    identical|ahead) verdict="✅ DEPLOYED" ;;
+    behind|diverged) verdict="⏳ not yet" ;;
+    *)               verdict="? unknown ($cmp)" ;;
+  esac
+  echo "  $env: $verdict (env at ${deployed:0:12})"
+done


### PR DESCRIPTION
## Problem

Devs frequently ask "has my branch/PR deployed yet?" and there's no quick, reliable way to answer it. The obvious approach — looking up a deployment record by the merge commit SHA — is misleading: PostHog deploys are batched, so a merge commit usually never gets its own deployment record (it's folded into a later build cut at a different SHA). That makes a naive SHA lookup return false negatives.

## Changes

Adds a repo-local dev-tooling skill `checking-deployment-status` under `.agents/skills/` (same tier as `debugging-ci-failures` and `hogli`), so it's available to every agent working in the monorepo via the `.claude/skills` symlink. It is **not** a product skill, so it is intentionally not packaged into `skills.zip` / published to `PostHog/skills`.

The skill:

- Explains the deploy model (merge to `master` → CI dispatches `commit_state_update` to `PostHog/charts` → rollout recorded as GitHub Deployments keyed by SHA + environment `dev` / `prod-us` / `prod-eu`).
- Resolves a PR number or branch to its merge commit, then for each environment uses the GitHub **compare** API to check whether the currently deployed SHA already *contains* that commit (ancestor check), instead of matching the SHA exactly.
- Ships `scripts/check-deploy.sh`, a runnable helper that takes a PR number or commit SHA and prints a per-environment ✅ / ⏳ verdict.

Read-only by design: it never triggers, reruns, rolls back, or blocks a deploy.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran locally:

- `hogli lint:skills` — passes (the one advisory warning is in an unrelated skill).
- `hogli build:skills` — green.
- Ran `scripts/check-deploy.sh` against both a negative case (a freshly merged PR not yet deployed → ⏳ on all envs) and a positive case (a SHA currently live in prod → ✅ on all envs); both reported correctly.

No manual UI testing — this is tooling/docs only.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the request of @sinan-ku, who hit exactly this question while tracking a merged PR. Invoked the `/writing-skills` skill for conventions and placement.

Key decision: scoped this as a repo-local skill in `.agents/skills/` rather than a product skill in `products/*/skills/`. Verified in `products/posthog_ai/scripts/build_skills.py` that the dist zip (which publishes to `PostHog/skills` for external/product-facing agents) only collects from `products/*/skills/`; `.agents/skills/` is read only for cross-reference linting. An internal "is my change deployed" helper belongs with the other monorepo dev-tooling skills, not in the product-facing distribution.

The ancestor-based check (compare API) over a naive SHA match is the core correctness point — batched deploys mean the merge SHA rarely appears as its own deployment, so matching exactly would tell devs their change hadn't shipped when it had.
