### PR TITLE
feat(signals): opt the ai-observability scout into the report channel

### DIFF
--- a/products/signals/skills/AGENTS.md
+++ b/products/signals/skills/AGENTS.md
@@ -270,9 +270,13 @@ directly and does not `emit_signal`, so it carries two references:
   reads only its own files at runtime, so any future report-channel adopter bundles its
   own copy rather than pointing here.
 
-The rest of the fleet still emits weak `emit_signal` findings for the pipeline to
-cluster; those specialists carry their own emit/dedupe contract where they need it,
-and its canonical write-up now lives in
+The rest of the fleet is being ported onto the **report channel** one scout per PR,
+biggest reach first (see the `scouts-emit-reports` spec). A ported scout is report-only —
+its frontmatter `allowed_tools` lists `emit_report` / `edit_report` and it bundles its own
+`references/report.md`, the same shape as the generalist (`signals-scout-ai-observability`
+is on the channel; others follow). A scout not yet ported still emits weak `emit_signal`
+findings for the pipeline to cluster; those specialists carry their own emit/dedupe contract
+where they need it, and its canonical write-up now lives in
 `authoring-scouts/references/emit-contract.md`.
 
 The specialists each carry their own domain discriminator + investigation patterns.

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -174,8 +174,10 @@ candidate:
   `suppressed` / `failed` report (one that won't surface) buries a real relapse under a closed
   item. When the prior report is no longer live, **author a fresh report** for the relapse and
   repoint `report:llm_analytics:<entity>` at the new id.
-- **Author** a fresh report via `signals-scout-emit-report` when nothing in the inbox covers
-  it (or a known regression has new evidence that changes the verdict). A **strong finding**
+- **Author** a fresh report via `signals-scout-emit-report` only when nothing live in the inbox
+  covers it. New evidence on a regression an existing report already tracks is an **edit**, not a
+  new report — `emit-report` is for a genuinely uncovered slice (or a relapse whose prior report is
+  no longer live, per the Edit bullet). A **strong finding**
   here: confidence ≥ 0.85, the move localized to a specific slice (not an aggregate artifact),
   with concrete trace / generation / evaluation / cluster IDs and query results in the
   `evidence`. A cost / latency / eval regression is an investigation, not a one-line code fix,
@@ -183,9 +185,10 @@ candidate:
   they're PR-autostart fields, and supplying `priority` + `suggested_reviewers` with no
   `repository` signals PR intent that spins up a repo-selection sandbox only to no-op
   (autostart needs `immediately_actionable`). **Always set `suggested_reviewers`** regardless —
-  resolve the owning person's GitHub login with `org-member-get-github-login` (cache it under a
-  `reviewer:llm_analytics:<area>` key). It's how the report reaches a human; left empty, the
-  report is assigned to nobody and is likely missed. After authoring, write a
+  resolve the owning person via `org-member-get-github-login` and pass it as a `{github_login}` (or
+  `{user_uuid}`) object, since `suggested_reviewers` is a **list of objects, not bare strings** (cache
+  the login under a `reviewer:llm_analytics:<area>` key). It's how the report reaches a human; left
+  empty, the report is assigned to nobody and is likely missed. After authoring, write a
   `report:llm_analytics:<entity>` scratchpad entry with the `report_id` so the next run edits
   it instead of duplicating.
 - **Remember** if it's below the bar but worth carrying forward, or to record what you
@@ -261,8 +264,8 @@ Inbox & reviewer routing:
 - `inbox-report-artefacts-list` — a comparable report's artefact log, where the routed
   `suggested_reviewers` live (the report record doesn't expose them) — reviewer precedent.
 - `org-members-list` / `org-member-get-github-login` — resolve a product / model / eval owner
-  to a bare GitHub login for `suggested_reviewers` (returns null when unlinked → try the next
-  owner).
+  to a GitHub login, wrapped as a `{github_login}` object for `suggested_reviewers` (returns null
+  when unlinked → try the next owner, or pass the member's `{user_uuid}` and let the server resolve).
 
 Harness-level:
 

--- a/products/signals/skills/signals-scout-ai-observability/SKILL.md
+++ b/products/signals/skills/signals-scout-ai-observability/SKILL.md
@@ -2,12 +2,18 @@
 name: signals-scout-ai-observability
 description: >
   Signals scout for PostHog AI observability. Watches LLM traces for cost, latency, error,
-  volume, and eval-performance regressions, sliced by the dimensions it discovers over time.
+  volume, and eval-performance regressions, sliced by the dimensions it discovers over time,
+  and files each validated regression as a report in the inbox.
 compatibility: >
-  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes
-  (read-only analytics plus signal_scout_internal:write for scratchpad and emit). Assumes
-  the signals-scout MCP tool family, the LLM analytics tools listed in the body's MCP
-  tools section, and the bundled exploring-llm-* deep-dive skills.
+  Designed for the PostHog Signals agent in a Claude sandbox with PostHog MCP scopes:
+  read-only analytics plus signal_scout_internal:write (for scratchpad) +
+  signal_scout_report:write (for emit-report/edit-report, granted because this scout authors
+  reports directly via the report channel). Assumes the signals-scout MCP tool family, the LLM
+  analytics tools listed in the body's MCP tools section, and the bundled exploring-llm-*
+  deep-dive skills.
+allowed_tools:
+  - emit_report
+  - edit_report
 metadata:
   owner_team: signals
   scope: llm_analytics
@@ -17,8 +23,17 @@ metadata:
 
 You are a focused AI observability scout. Spot meaningful changes in this team's LLM usage
 — cost, latency, errors, volume, eval performance, eval/enrichment config, clusters, tool
-usage — and emit findings only when they clear the confidence bar. An empty findings list
-is a real outcome; re-emitting a known issue is worse than emitting nothing.
+usage — and file a report only when a change clears the confidence bar. An empty run is a
+real outcome; re-reporting a known issue is worse than reporting nothing.
+
+You author reports directly via the report channel (`signals-scout-emit-report` /
+`signals-scout-edit-report`): you've done the research, so you own each report 1:1
+end-to-end rather than firing weak signals for a pipeline to cluster. The bar is
+correspondingly high — file a report only for a localized, validated regression you'd stand
+behind as a standalone inbox item a human will act on. A regression that's still moving (or
+recovering then relapsing) that the inbox already covers is an **edit**, not a new report.
+The full report channel — fields, status mapping, reviewer routing, dedupe, and the edit
+rules — lives in [`references/report.md`](references/report.md).
 
 ## Quick close-out: is AI observability even in use?
 
@@ -44,14 +59,22 @@ Three cheap reads cold-start a run:
 
 - `signals-scout-scratchpad-search` (`text=llm` or `text=ai_`) — durable team
   steering inherited from past LLM-focused runs. **Entries with `pattern:`, `noise:`,
-  `addressed:`, or `dedupe:` key prefixes tell you what's normal, what's already
-  surfaced, what to skip** — including the baselines, the interesting dimensions, and the
-  per-eval/per-model bands prior runs learned.
+  `addressed:`, `dedupe:`, `report:`, or `reviewer:` key prefixes tell you what's normal,
+  what's already surfaced, what to skip, which report covers a regression, and who owns it**
+  — including the baselines, the interesting dimensions, and the per-eval/per-model bands
+  prior runs learned.
 - `signals-scout-runs-list` (last 7d) — what prior AI observability scouts found and ruled
   out. Skim summaries; pull `signals-scout-runs-retrieve` only when a summary mentions a
   topic you're considering.
 - `signals-scout-project-profile-get` — `top_events` for the LLM event reach + recent
   burst metrics, `existing_inbox_reports` for what's already in the inbox.
+- `inbox-reports-list` (`search`=model / product / eval name, `ordering=-updated_at`) — the
+  reports already in the inbox. Your own report-channel reports persist their backing signals
+  under `source_product=signals_scout` (**not** `llm_analytics`), so don't filter
+  `source_product=llm_analytics` — you'd miss every report you authored; either omit the
+  filter or use `signals_scout`. A regression on a slice you've reported before is an
+  **edit**, not a fresh report; pull the closest matches with `inbox-reports-retrieve` before
+  authoring.
 
 ### Explore: the lenses
 
@@ -89,11 +112,11 @@ than reinventing its SQL.**
 
 ### Dig in
 
-When a lens flags something, don't emit the top-line number — localize and sample:
+When a lens flags something, don't report the top-line number — localize and sample:
 
 - **Localize.** Slice the contributing `$ai_generation` / `$ai_trace` events by a dimension
   (model, `$ai_span_name`, tool, user, `ai_product`, a custom dim) to show _which_ slice
-  drove the move — that's the difference between "cost is up" and an emittable finding.
+  drove the move — that's the difference between "cost is up" and a reportable finding.
 - **Sample.** Pull one or two representative traces via `query-llm-trace` (or a failing
   generation sampled from the raw `$ai_evaluation` rows) and cite concrete trace /
   generation / evaluation IDs in the evidence. `llma-evaluation-summary-create` groups
@@ -119,31 +142,66 @@ runs can find it with a single `text=` search:
   re-investigate only if > 100/hr for 2h or daily rate clears 0.05%."_
 - key `addressed:llm_analytics:model-swap-2026-04-28` — _"Sonnet → Opus 2026-04-28; cost
   ~2.1x baseline expected."_
+- key `report:llm_analytics:<entity>` — the `report_id` of a report you authored for a
+  regression on this slice (a model, `ai_product`, eval, or cluster), so the next run edits
+  it (append_note with the fresh window) instead of duplicating.
+- key `reviewer:llm_analytics:<area>` — a resolved owner (bare lowercase GitHub login) for a
+  product / model / eval area, so reports route to a human faster.
 
 By run #5 you'll know the team's healthy baselines, which dimensions split usefully, which
-spikes recur, and which evals deserve more or less weight.
+spikes recur, which evals deserve more or less weight, and who owns each surface.
 
 ### Decide
 
-For each candidate finding:
+Before you author, check whether this slice already has a report — the
+`report:llm_analytics:<entity>` scratchpad pointer is the reliable path: it holds the
+`report_id`, so `inbox-reports-retrieve` it directly. Only with no pointer fall back to an
+`inbox-reports-list` search (`ordering=-updated_at`), and search the slice's _specific_ terms
+(the model, the `ai_product`, the eval name, the cluster id) — a broad word like `latency`
+returns hundreds of unrelated reports on a busy project and buries yours. Then, for each
+candidate:
 
-- **Emit** via `signals-scout-emit-signal` if it clears the confidence bar.
-  Findings carry a hypothesis, evidence, severity, and confidence ∈ [0, 1].
-  Strong scout findings: confidence ≥ 0.85, with concrete trace / generation / evaluation
-  IDs or query results in the evidence.
+- **Edit** the existing report via `signals-scout-edit-report` when the inbox already covers
+  the slice. A regression is rarely brand-new — a cost step that's still elevated, a latency
+  band that hasn't recovered, an eval still failing more: `append_note` with the fresh
+  window's numbers (or rewrite the title/summary on a report you authored). This is the
+  default when a match exists **and it's still live in the inbox**; don't mint a
+  near-duplicate. **A persistent regression is one report across runs:** when a new complete
+  window confirms the issue is ongoing, that's a _re-escalation_ — `append_note` the fresh
+  window onto the report your `report:llm_analytics:<entity>` pointer names and advance the
+  `dedupe:` gate; do **not** author a fresh report per tick. **But check the matched report's
+  status first:** `edit-report` can't change status, so appending to a `resolved` /
+  `suppressed` / `failed` report (one that won't surface) buries a real relapse under a closed
+  item. When the prior report is no longer live, **author a fresh report** for the relapse and
+  repoint `report:llm_analytics:<entity>` at the new id.
+- **Author** a fresh report via `signals-scout-emit-report` when nothing in the inbox covers
+  it (or a known regression has new evidence that changes the verdict). A **strong finding**
+  here: confidence ≥ 0.85, the move localized to a specific slice (not an aggregate artifact),
+  with concrete trace / generation / evaluation / cluster IDs and query results in the
+  `evidence`. A cost / latency / eval regression is an investigation, not a one-line code fix,
+  so set `actionability=requires_human_input` and **leave `priority` and `repository` unset** —
+  they're PR-autostart fields, and supplying `priority` + `suggested_reviewers` with no
+  `repository` signals PR intent that spins up a repo-selection sandbox only to no-op
+  (autostart needs `immediately_actionable`). **Always set `suggested_reviewers`** regardless —
+  resolve the owning person's GitHub login with `org-member-get-github-login` (cache it under a
+  `reviewer:llm_analytics:<area>` key). It's how the report reaches a human; left empty, the
+  report is assigned to nobody and is likely missed. After authoring, write a
+  `report:llm_analytics:<entity>` scratchpad entry with the `report_id` so the next run edits
+  it instead of duplicating.
 - **Remember** if it's below the bar but worth carrying forward, or to record what you
   ruled out and why.
 - **Skip** with a one-line note in your final summary if a scratchpad entry with a
-  `noise:` or `addressed:` key prefix already covers it.
+  `noise:` / `addressed:` / `dedupe:` key prefix, or an existing inbox report, already
+  covers it.
 
-If a prior run already covered the topic, default to skip + memory refresh rather than
-re-emit. Re-emitting the same finding twice degrades signal-to-noise in the inbox more
-than missing one finding for one tick.
+If a prior run already covered the topic, default to edit-or-skip + memory refresh rather
+than authoring a near-duplicate. The same fact twice in the inbox degrades signal-to-noise
+more than missing one finding for one tick.
 
 ### Close out
 
-**Summarize the run** — one paragraph: which lens(es) you looked at, what you emitted, what
-you remembered, what you ruled out and why. The harness writes that summary to the run row
+**Summarize the run** — one paragraph: which lens(es) you looked at, which reports you
+authored or edited, what you remembered, what you ruled out and why. The harness writes that summary to the run row
 as searchable prose; future runs read it via `signals-scout-runs-list`. Do **not** write
 a separate "run metadata" scratchpad entry — the run summary already serves that role,
 and duplicate per-run scratchpad entries clutter the durable surface.
@@ -161,12 +219,12 @@ and duplicate per-run scratchpad entries clutter the durable surface.
 - **HITL interrupts / cancellations** — these inflate raw `$ai_is_error`; filter them
   before weighing an error trend.
 - **Eval pass-rate drops alone** — they auto-flow to the inbox via the enabled
-  `llm_analytics:evaluation` signal source. Only emit when you've localized a cause the
+  `llm_analytics:evaluation` signal source. Only author when you've localized a cause the
   auto-flow won't.
 - **Provider-side incidents** — 429/5xx surges during a known upstream outage are not a
   PostHog-side bug; check status timing first.
 
-When in doubt, write a memory entry instead of emitting. Cost / eval signals have a
+When in doubt, write a memory entry instead of filing a report. Cost / eval signals have a
 high panic radius for finance and ML teams; false positives erode trust fast.
 
 ## MCP tools
@@ -196,12 +254,23 @@ Schema:
 - `read-data-schema` — discover events, properties, and the team's custom dimensions
   before filtering or grouping on them.
 
+Inbox & reviewer routing:
+
+- `inbox-reports-list` / `inbox-reports-retrieve` — the reports already in the inbox; check
+  before authoring so you edit instead of duplicating (`ordering=-updated_at`).
+- `inbox-report-artefacts-list` — a comparable report's artefact log, where the routed
+  `suggested_reviewers` live (the report record doesn't expose them) — reviewer precedent.
+- `org-members-list` / `org-member-get-github-login` — resolve a product / model / eval owner
+  to a bare GitHub login for `suggested_reviewers` (returns null when unlinked → try the next
+  owner).
+
 Harness-level:
 
 - `signals-scout-project-profile-get` — cold orientation snapshot.
 - `signals-scout-scratchpad-search` / `signals-scout-scratchpad-remember` — durable steering across runs.
 - `signals-scout-runs-list` / `signals-scout-runs-retrieve` — what prior runs found.
-- `signals-scout-emit-signal` — emit a finding.
+- `signals-scout-emit-report` / `signals-scout-edit-report` — author a report / edit an
+  existing one (see [`references/report.md`](references/report.md)).
 
 Deep-dive skills (baked into the sandbox — read the matching one when you go deep, don't
 reinvent its queries): `posthog:exploring-llm-costs`, `posthog:exploring-llm-traces`,
@@ -213,8 +282,8 @@ lens.
 
 - Scratchpad + recent runs + profile are quiet → close out empty.
 - A candidate matches a scratchpad entry with `noise:` / `addressed:` / `dedupe:` key
-  prefix → skip with a one-line note.
-- You've validated some hypotheses and emitted what's solid → close out, even if
-  there's more you could look at. Fewer, better signals.
+  prefix, or an existing inbox report → edit-or-skip with a one-line note.
+- You've validated some hypotheses and filed reports for what's solid → close out, even if
+  there's more you could look at. Fewer, better reports.
 
 "Looked but found nothing meaningful" is a real outcome, not a failure.

--- a/products/signals/skills/signals-scout-ai-observability/references/lenses.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/lenses.md
@@ -106,7 +106,7 @@ lens**, not on every run:
   treat it as a bonus, not a dependency, and fall back to sampling the raw failing rows via
   `query-llm-trace` when it's unavailable.
 - **Discipline.** Pass-rate regressions **also auto-flow to the inbox** via the enabled
-  `llm_analytics:evaluation` signal source — so only emit when you've localized something
+  `llm_analytics:evaluation` signal source — so only report when you've localized something
   the auto-flow won't (a specific eval + a specific failure pattern + a cause); otherwise
   hold + remember. A known-flaky eval (steady % noise) is `noise:` with a floor.
 
@@ -125,7 +125,7 @@ LLM/Hog jobs that can silently break.
   lens has already surfaced (ProviderMismatchError, disabled-key) — those are this surface
   failing _reactively_; this lens is how you'd catch it _proactively_.
 - **Discipline.** These are config objects — a deliberately-disabled tagger is not a
-  defect. Emit only when something meant to be running is silently failing or scoring
+  defect. Report only when something meant to be running is silently failing or scoring
   nothing.
 
 ## Clusters — read `posthog:exploring-llm-clusters`

--- a/products/signals/skills/signals-scout-ai-observability/references/report.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/report.md
@@ -41,7 +41,7 @@ Judges the report for safety, then persists it at the judged status.
 | `actionability_explanation` | string                  | One sentence justifying the actionability call below.                                                                                                                                                                                              |
 | `actionability`             | enum                    | `immediately_actionable` / `requires_human_input` / `not_actionable`. You make this call — the channel does not re-research it.                                                                                                                    |
 | `already_addressed`         | bool, default `false`   | Set when the underlying issue is already handled and you're filing for the record.                                                                                                                                                                 |
-| `suggested_reviewers`       | list of strings         | Bare, lowercase GitHub logins. The **single most important routing field** — set on every report (PR or not). See the _`suggested_reviewers`_ section below for resolution steps.                                                                  |
+| `suggested_reviewers`       | list of objects         | Each `{github_login}` and/or `{user_uuid}` (**not** a bare string). The **single most important routing field** — set on every report (PR or not). See the _`suggested_reviewers`_ section below for the object shape + resolution steps.          |
 
 **Status is decided for you, from safety × actionability:**
 
@@ -117,10 +117,18 @@ is assigned to nobody — it lands in the shared inbox and is very likely to be 
 set at least one reviewer on every report you author, including informational `requires_human_input`
 ones.
 
-Each entry must be a **bare, lowercase GitHub login** — no `@`, no display name (e.g. `octocat`, not
-`@OctoCat`). Assignment matches the login against each user's linked GitHub login by exact, lowercased
-comparison, so a mis-cased handle, an `@`-prefix, a display name, a team slug, or an email won't
-assign to anyone. You rarely know the login outright, so resolve it — cheapest first:
+Each entry is an **object**, not a bare string — `{"github_login": "..."}` and/or
+`{"user_uuid": "..."}` (at least one of the two per entry; a list of plain strings like `["octocat"]`
+**fails validation**). Pick whichever you resolved:
+
+- **`github_login`** — the GitHub login, case-insensitive (stored lowercased), no `@`, no display name
+  (e.g. `{"github_login": "octocat"}`).
+- **`user_uuid`** — the PostHog user UUID (e.g. from `org-members-list`); the server resolves it to the
+  member's linked GitHub login. Use this when you know the PostHog user but not their handle. A
+  `user_uuid` that isn't an org member with a linked GitHub identity is **rejected** (never silently
+  dropped), so the reviewer always routes or the call tells you it didn't.
+
+You rarely know either outright, so resolve it — cheapest first:
 
 1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a prior run) recorded — reuse it.
    For AI observability, key by the owning product / model area (`reviewer:llm_analytics:<area>`).
@@ -130,19 +138,20 @@ assign to anyone. You rarely know the login outright, so resolve it — cheapest
    expose it). Reuse that reviewer for the same area.
 3. **`org-member-get-github-login`** — the **canonical resolver, available on every run**. Identify the
    owning **person** (by name/email via `org-members-list`, or `@me`), then pass their PostHog user
-   UUID to `org-member-get-github-login` to get their linked GitHub login. It returns null when the
+   UUID to `org-member-get-github-login` to get their linked GitHub login (or just pass the UUID
+   straight through as `{"user_uuid": "..."}` and let the server resolve it). It returns null when the
    person hasn't linked a GitHub account — then try the next plausible owner.
 
 **Never guess a handle** — a wrong login mis-assigns the report, which is worse than leaving it open.
 If you genuinely can't resolve any confident owner, author the report anyway (it still surfaces) but
 treat that as the exception, not the norm. Once you've tied a product/model area to an owner, write a
-`reviewer:llm_analytics:<area>` scratchpad entry with the bare lowercase login so the next run routes
+`reviewer:llm_analytics:<area>` scratchpad entry with the resolved login so the next run routes
 instantly.
 
-**On `edit-report`:** reviewers are set at author time and `edit-report` can't change them — so the
-one chance to route a report is when you `emit-report` it. If you're editing a report that landed with
-no reviewer, `append_note` naming the owner you'd route it to so a human can pick it up; the durable
-fix is to get `suggested_reviewers` right at emit.
+**On `edit-report`:** `edit-report` **also accepts `suggested_reviewers`** — it replaces the report's
+reviewer list (an empty list is a no-op; existing reviewers are never cleared) and re-runs autostart,
+so it's the right tool to **route a report that surfaced with no owner**. When a later run resolves an
+owner for an orphaned report, `edit-report` it with the reviewer rather than only appending a note.
 
 ## `edit-report` — update an existing report
 

--- a/products/signals/skills/signals-scout-ai-observability/references/report.md
+++ b/products/signals/skills/signals-scout-ai-observability/references/report.md
@@ -1,0 +1,198 @@
+# The report channel: `emit-report` / `edit-report`
+
+The report channel is your output: you've already done the research, so you file a full
+`SignalReport` into the inbox directly — no weak signals, no pipeline clustering. This reference
+is the contract: the two tools, their fields, how to choose between authoring and editing, and the
+two behaviors that make this channel different (it isn't idempotent, and the pipeline may later
+rewrite what you authored).
+
+> Like every `signals-scout-*` tool, **both report tools require the current `run_id`** (the
+> run you're executing in) on every call — omitting it fails validation.
+
+## Author or edit
+
+| You have…                                                                                                       | Use           |
+| --------------------------------------------------------------------------------------------------------------- | ------------- |
+| A finished, well-formed finding nothing in the inbox covers — filed **1:1** with full control of title/summary. | `emit-report` |
+| New information about a report that already exists (one you authored last run, or a pipeline report).           | `edit-report` |
+
+**Always search the inbox first** (`inbox-reports-list` → `inbox-reports-retrieve`): edit an
+existing report rather than mint a near-duplicate. An AI observability shift is report-shaped when
+it's a single, localized, validated change — one model/product's cost step, one latency band
+shifting, one eval silently broken or regressing, one error class firing at scale, one runaway
+cluster — that you've corroborated and would stand behind as a standalone inbox item. A scatter of
+small, weakly-correlated wobbles across many models or dimensions is not a report — it's a sign you
+haven't found the finding yet; keep investigating or record it in the scratchpad and move on.
+
+Filing a report is a **high bar**. Author one only for a finding you'd own end-to-end as an inbox
+item a human will act on. When you can't get there, a scratchpad note is the right home — never
+file a half-formed report to fill space.
+
+## `emit-report` — author a full report
+
+Judges the report for safety, then persists it at the judged status.
+
+| Field                       | Type                    | Notes                                                                                                                                                                                                                                              |
+| --------------------------- | ----------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `run_id`                    | string, required        | The current run's id — same as every `signals-scout-*` tool.                                                                                                                                                                                       |
+| `title`                     | string, ≤300, non-empty | The inbox headline. One specific, quantified line.                                                                                                                                                                                                 |
+| `summary`                   | string                  | The report body prose — hook → pattern → hypothesis → recommendation. See _Writing the summary_ below.                                                                                                                                             |
+| `evidence`                  | list, 1–50              | Each `{description, source_id}`. Becomes a bound signal row backing the report. `source_id` is the citable entity id. Hard cap of **50** — summarize/trim before calling; a longer list fails validation before the report is judged or persisted. |
+| `actionability_explanation` | string                  | One sentence justifying the actionability call below.                                                                                                                                                                                              |
+| `actionability`             | enum                    | `immediately_actionable` / `requires_human_input` / `not_actionable`. You make this call — the channel does not re-research it.                                                                                                                    |
+| `already_addressed`         | bool, default `false`   | Set when the underlying issue is already handled and you're filing for the record.                                                                                                                                                                 |
+| `suggested_reviewers`       | list of strings         | Bare, lowercase GitHub logins. The **single most important routing field** — set on every report (PR or not). See the _`suggested_reviewers`_ section below for resolution steps.                                                                  |
+
+**Status is decided for you, from safety × actionability:**
+
+| Safety judge | `actionability`          | Resulting status | Surfaces in inbox? |
+| ------------ | ------------------------ | ---------------- | ------------------ |
+| safe         | `immediately_actionable` | `READY`          | yes                |
+| safe         | `requires_human_input`   | `PENDING_INPUT`  | yes                |
+| safe         | `not_actionable`         | `SUPPRESSED`     | no                 |
+| unsafe       | (any)                    | `SUPPRESSED`     | no                 |
+
+Note the trap: `not_actionable` is **suppressed** (never surfaces). Reserve it for filing-for-the-record;
+if you want a human to see it, it must be `immediately_actionable` or `requires_human_input`.
+
+The result tells you what happened: `report_id` (always set when a report was persisted —
+**even when suppressed**, so you can edit or dedup against it), `report_status` (the birth status —
+`ready` / `pending_input` / `suppressed`), `emitted` (true only when it actually surfaced),
+`safety_explanation`, and `skipped_reason` (set only when a preflight gate — the team's
+AI-data-processing approval or the signals-scout source being enabled — stopped the call before any
+report was created).
+
+### Writing the `title` and `summary`
+
+The `title` is the inbox headline and the `summary` is the body a human reads to decide whether to
+act — write both for a busy reader scanning a feed of other reports.
+
+- **`title`** — one specific, quantified line. Lead with what's wrong, which slice, and the blast
+  radius, not a vague category. _"`sonnet` p90 latency jumped from ~19s to ~48s after 14:00 UTC,
+  confined to the `posthog_ai` product"_, not _"LLM latency up"_.
+- **`summary`** — a tight few paragraphs following hook → pattern → hypothesis → recommendation:
+  1. **Hook** — what's happening, quantified ("`$ai_total_cost_usd` for the `code` product rose from
+     ~$40/day to ~$210/day between Apr 26–28, while generation count held flat").
+  2. **Pattern** — the shape that makes this signal, not noise ("the rise is confined to one
+     `ai_product` and one model after a prompt-version bump in the same window; other products' spend
+     is flat — a per-product cost regression, not a fleet-wide price change").
+  3. **Hypothesis** — your best read of the cause.
+  4. **Recommendation** — the concrete action that would resolve it.
+
+Quantify ("~$210/day", "p90 ~48s") over qualitative ("a lot"), and cite entity ids (trace ids,
+generation ids, evaluation ids, model/provider names, eval names, cluster ids, prompt versions, time
+ranges) inline so a reviewer can pivot straight from prose to source. Put the same citations in
+`evidence` so they back the report as bound signals.
+
+### Opening a draft PR (autostart)
+
+First, `suggested_reviewers` is **not** a PR field — set it whenever you can name a plausible owner,
+PR or not. It's the routing lever and is covered in its own section below; the three fields in this
+section are the **PR-only** ones.
+
+A surfaced, immediately-actionable report can open a draft PR automatically. It's opt-in per report
+via these fields; supply them only when the report is a concrete, fixable issue you'd want a PR for.
+
+| Field                  | Type      | Notes                                                                                                                                                                                                                                                    |
+| ---------------------- | --------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `repository`           | string    | `"owner/repo"` targets that repo; the `NO_REPO` sentinel opts out; **omitting it** falls back to free-form selection across the team's repos — the slow path on a many-repo team (it spawns a selection sandbox), so pass `owner/repo` when you know it. |
+| `priority`             | `P0`-`P4` | Required for a PR. Pair with `priority_explanation`.                                                                                                                                                                                                     |
+| `priority_explanation` | string    | Required when `priority` is set.                                                                                                                                                                                                                         |
+
+Repo selection only runs when you signal PR intent — an explicit `repository`, or both `priority`
+and `suggested_reviewers`. A report that supplies none of these just surfaces in the inbox (no repo
+sandbox, no PR). Autostart no-ops unless the report is `immediately_actionable`, has a repo +
+priority, and a reviewer qualifies — so these three PR fields are safe to omit for an informational
+report. `suggested_reviewers` is not: set it whenever you can name a plausible owner (see the next
+section), PR or not. An AI observability regression (cost / latency / eval / runaway loop) is almost
+always a thing to investigate, not a one-line code fix, so most of these reports want
+`requires_human_input` and a reviewer, not a PR.
+
+## `suggested_reviewers` — set it on every report (this is how it reaches a human)
+
+`suggested_reviewers` is the **single most important routing field**. It is how a report reaches the
+right person: the inbox orders by `is_suggested_reviewer`, so a reviewer's own reports float to the
+top of _their_ inbox even when **no PR** is involved. **A report with an empty `suggested_reviewers`
+is assigned to nobody — it lands in the shared inbox and is very likely to be missed.** So resolve and
+set at least one reviewer on every report you author, including informational `requires_human_input`
+ones.
+
+Each entry must be a **bare, lowercase GitHub login** — no `@`, no display name (e.g. `octocat`, not
+`@OctoCat`). Assignment matches the login against each user's linked GitHub login by exact, lowercased
+comparison, so a mis-cased handle, an `@`-prefix, a display name, a team slug, or an email won't
+assign to anyone. You rarely know the login outright, so resolve it — cheapest first:
+
+1. **Scratchpad cache.** A `reviewer:<domain>:<area>` entry you (or a prior run) recorded — reuse it.
+   For AI observability, key by the owning product / model area (`reviewer:llm_analytics:<area>`).
+2. **Inbox precedent.** `inbox-reports-list` (filter by `source_product` + a free-text `search`) for a
+   comparable report on the same product/model/eval, then `inbox-report-artefacts-list` on it — the
+   `suggested_reviewers` artefact is where the routed reviewer lives (the report record itself doesn't
+   expose it). Reuse that reviewer for the same area.
+3. **`org-member-get-github-login`** — the **canonical resolver, available on every run**. Identify the
+   owning **person** (by name/email via `org-members-list`, or `@me`), then pass their PostHog user
+   UUID to `org-member-get-github-login` to get their linked GitHub login. It returns null when the
+   person hasn't linked a GitHub account — then try the next plausible owner.
+
+**Never guess a handle** — a wrong login mis-assigns the report, which is worse than leaving it open.
+If you genuinely can't resolve any confident owner, author the report anyway (it still surfaces) but
+treat that as the exception, not the norm. Once you've tied a product/model area to an owner, write a
+`reviewer:llm_analytics:<area>` scratchpad entry with the bare lowercase login so the next run routes
+instantly.
+
+**On `edit-report`:** reviewers are set at author time and `edit-report` can't change them — so the
+one chance to route a report is when you `emit-report` it. If you're editing a report that landed with
+no reviewer, `append_note` naming the owner you'd route it to so a human can pick it up; the durable
+fix is to get `suggested_reviewers` right at emit.
+
+## `edit-report` — update an existing report
+
+Rewrite `title`/`summary` and/or append a note to a report that already exists. Pass `run_id` and
+`report_id`, plus at least one of `title`, `summary`, `append_note`.
+
+`edit-report` can target **any** of the team's inbox reports — not just ones a scout authored. That
+makes it the right tool when a later run learns something about a report the pipeline (or another
+scout) created. Two rules of good behavior:
+
+- **Prefer `append_note` over rewriting** `title`/`summary` on a report you didn't author. A note is
+  additive and audit-friendly (it carries your scout as author); a rewrite silently overwrites a
+  human- or pipeline-authored headline.
+- **Don't fight an in-flight pipeline.** A report the summary/research workflow is mid-run on can have
+  its fields overwritten under you. If a report is actively being worked, append a note rather than
+  rewriting.
+
+**A persistent regression is one report, not one per tick.** A cost step that's still elevated, a
+latency band that hasn't recovered, an eval still failing more: when a new complete window confirms
+the same issue is ongoing, `append_note` the fresh window onto the report your
+`report:llm_analytics:<entity>` pointer names — don't author a fresh report each run. But
+`edit-report` **can't change status**, so appending to a `resolved` / `suppressed` / `failed` report
+(one that won't surface in the inbox) buries a real relapse under a closed item. Check the matched
+report's status first: when it's no longer live, **author a fresh report** for the relapse and
+repoint the `report:llm_analytics:<entity>` scratchpad key at the new id.
+
+## Dedup: the channel is NOT idempotent
+
+`emit-report` is **not idempotent** — a retried call authors a _second_ report. There is no
+server-side dedup key. The dedup story is two-sided and you own it:
+
+1. **Before authoring**, `inbox-reports-list` for a prior report on the same topic (filter by
+   `search` / `status`). Pass `ordering=-updated_at` — the default ordering buckets by your own
+   reviewer-match and status first, so without it the most recent duplicate can sort below older rows
+   and you'd miss it. **Don't filter `source_product=llm_analytics`:** your own report-channel reports
+   persist their backing signals under `source_product=signals_scout`, so a `llm_analytics` filter
+   matches none of them — omit it, or use `signals_scout`. Found a match? `edit-report` it instead of
+   authoring a new one.
+2. **After authoring**, write a `report:llm_analytics:<entity>` scratchpad entry recording the
+   `report_id` so the next run finds it (via `inbox-reports-retrieve`) without a title-search guess.
+
+**Never retry an `emit-report` / `edit-report` call that may have succeeded** — a transport error
+after the write commits, retried, double-files. If unsure whether a call landed, `inbox-reports-list`
+to check before retrying.
+
+## The pipeline may rewrite what you authored (accepted)
+
+An authored report is a first-class report that coexists with pipeline reports. When future signals
+consolidate around the same topic, the pipeline may **re-promote and re-research the report,
+overwriting your authored `title`/`summary`**. This is accepted behavior, not a bug — there is no
+pin. Author the finding, and let the inbox stay the source of truth for how it's currently framed.
+Your durable record of "I filed this" is the `report:` scratchpad entry and the `report_id`, not the
+title text.


### PR DESCRIPTION
## Problem

Part of the canonical Signals scout fleet's migration onto the **report channel** — opted-in scouts author a full `SignalReport` directly (via `emit-report` / `edit-report`) instead of firing weak `emit_signal` findings for the grouping pipeline to cluster. The fleet is being ported one scout per PR, biggest reach first. `general` (#1, 131 teams), `logs`, and `product-analytics` (#2, 77 teams) are already done; this ports the next by reach: **`ai-observability` (#3, 49 teams)**.

The AI observability scout already does the full research for a cost / latency / error / volume / eval regression before it surfaces anything. Routing that through the pipeline loses fidelity and the 1:1 control the scout has already earned. The report channel lets it own each finding end-to-end and land it in the inbox where a human acts on it.

## Changes

Makes `signals-scout-ai-observability` **report-only**, mirroring the `logs` and `product-analytics` ports:

- **Frontmatter:** `allowed_tools: [emit_report, edit_report]`; `signal_scout_report:write` added to the compatibility scope line; description reframed to "files each validated regression as a report".
- **Decide step** rewritten from emit/remember/skip to **edit / author / remember / skip**: search the inbox first (via the `report:` scratchpad pointer, then a specific-terms `inbox-reports-list` search), edit an existing report rather than mint a near-duplicate, and **always set `suggested_reviewers`** (resolved via `org-member-get-github-login`, cached under a `reviewer:` key) so the report reaches a human.
- **Bundled `references/report.md`** — the channel contract (fields, safety × actionability status mapping, reviewer routing, non-idempotent dedup, the pipeline-rewrite caveat), adapted with AI-observability examples. A scout reads only its own files at runtime, so each adopter bundles its own copy.
- **Memory:** `report:llm_analytics:<entity>` and `reviewer:llm_analytics:<area>` scratchpad keys added for cross-run report dedup and reviewer continuity.
- Reframed the residual emit-signal language across the body and `lenses.md` to the report channel.

Pre-empts the recurring bot-review catches from earlier ports:
- dedup search must **not** filter `source_product=llm_analytics` — report-channel signals persist under `signals_scout`, so that filter would miss the scout's own reports;
- `priority` / `repository` stay unset on `requires_human_input` reports (they signal PR intent and spin up a no-op repo-selection sandbox);
- a relapse on a `resolved` / `suppressed` / `failed` report is a **fresh report**, not an `append_note` — `edit_report` can't change status.

## How did you test this code?

I'm an agent (Claude Opus 4.8). No manual scout runs. Validation done:

- `products/posthog_ai/scripts/build_skills.py --lint` — passes (99 skills); the one advisory warning is pre-existing in `authoring-scouts/SKILL.md`, unrelated to this change.
- `oxfmt` + lint-staged markdown formatting applied to the changed files.

The change is skill-content only (no backend code); the report-channel machinery it targets is already merged. Behavioral validation happens via the emit-and-inspect loop once the scout runs on an enrolled team.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Andy directed this via the `scouts-emit-reports` tracking skill; assigned as DRI.

- Tool: Claude Code (Opus 4.8). Skill invoked: `/phs scouts-emit-reports` (the feature's living tracking doc) for the locked port recipe and `references/canonical-port-order.md` for the next-by-reach target.
- Followed the per-scout port recipe verbatim from `plan.md` §Per-scout canonical port, using the merged `logs` port as the on-disk template (`product-analytics`'s bundled `report.md` isn't on master yet). The `report.md` was adapted from the logs scout's with AI-observability-specific examples (cost/latency/eval slices, `ai_product`/model/eval reviewer keying).
- Report-only **drops `emit_signal`** for this scout, per the fleet direction to retire `emit_signal`. The build prompt fork is binary on `allowed_tools`, so a hybrid body would contradict the report persona.
