### PR TITLE
chore: open PRs in draft by default to save CI costs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,6 +72,7 @@ Pass the description straight to the `body` argument of the PR-creation tool (th
 ### Pushing to remote
 
 Don't open GitHub issues or pull requests without human instruction.
+Open pull requests in Draft by default (`gh pr create --draft`). Draft PRs run only a narrow subset of CI, which saves a large amount of runner credits. Fix CI failures and run affected tests locally before marking the PR ready for review.
 Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
 Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,7 @@ Pass the description straight to the `body` argument of the PR-creation tool (th
 ### Pushing to remote
 
 Don't open GitHub issues or pull requests without human instruction.
-Open pull requests in Draft by default (`gh pr create --draft`). Draft PRs run only a narrow subset of CI, which saves a large amount of runner credits. Fix CI failures and run affected tests locally before marking the PR ready for review.
+When you do open a PR (with human instruction), open it in Draft by default (`gh pr create --draft`). Draft PRs run only a narrow subset of CI, which saves a large amount of runner credits. Fix CI failures and run affected tests locally before marking the PR ready for review.
 Once a branch already has an open PR, push incremental changes and fixes to it without waiting for human guidance — keeping the PR current is part of the work.
 Pushes still trigger CI, which burns runner credits, so batch related commits and push once the increment is ready rather than after every change.
 


### PR DESCRIPTION
## Problem

Draft PRs only run a narrow subset of CI, which significantly cuts runner credit spend. Agents working in this repo weren't told to default to draft, so they were opening ready-for-review PRs and triggering the full CI suite before fixes had landed.

## Changes

Added a line to the "Pushing to remote" section of `AGENTS.md` (symlinked as `CLAUDE.md`) instructing agents to open PRs in Draft by default (`gh pr create --draft`), fix CI failures, and run affected tests locally before marking ready for review.

## How did you test this code?

I'm an agent. No code changed — this is a docs/instructions-only edit, so there are no automated tests to run.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested in a Slack thread: add an instruction to the repo's agent guide to open PRs in draft by default, motivated by the CI cost savings from running only a partial test suite on draft PRs. Single-line addition to the existing "Pushing to remote" guidance; no skills required.
