### PR TITLE
fix(agentic-provisioning): backfill wizard session scope for wizard tokens

### DIFF
--- a/ee/api/agentic_provisioning/test/test_provisioning_auth.py
+++ b/ee/api/agentic_provisioning/test/test_provisioning_auth.py
@@ -156,6 +156,59 @@ class TestProvisioningAuthentication(APIBaseTest):
         assert res.json()["status"] == "complete"
         assert "api_key" in res.json()["complete"]["access_configuration"]
 
+    def test_pkce_wizard_exchange_backfills_and_grants_wizard_session_scope(self):
+        from posthog.models.oauth import OAuthAccessToken
+
+        legacy_wizard_scopes = [
+            "dashboard:write",
+            "insight:write",
+            "llm_gateway:write",
+            "query:read",
+            "user:read",
+        ]
+        self.wizard_app.scopes = legacy_wizard_scopes
+        self.wizard_app.save(update_fields=["scopes"])
+
+        verifier, challenge = _pkce_pair()
+        res = self.client.post(
+            "/api/agentic/provisioning/account_requests",
+            data={
+                "id": "req_wizard_scope_backfill",
+                "email": "wizard-scope-backfill@example.com",
+                "client_id": WIZARD_CLIENT_ID,
+                "code_challenge": challenge,
+                "code_challenge_method": "S256",
+                "scopes": legacy_wizard_scopes,
+            },
+            content_type="application/json",
+            headers={"api-version": "0.1d"},
+        )
+        assert res.status_code == 200
+        code = res.json()["oauth"]["code"]
+
+        res = self.client.post(
+            "/api/agentic/oauth/token",
+            data=urlencode(
+                {
+                    "grant_type": "authorization_code",
+                    "code": code,
+                    "code_verifier": verifier,
+                }
+            ),
+            content_type="application/x-www-form-urlencoded",
+            headers={"api-version": "0.1d"},
+        )
+        assert res.status_code == 200
+
+        token = OAuthAccessToken.objects.get(token=res.json()["access_token"])
+        token_scopes = set(token.scope.split())
+        for scope in legacy_wizard_scopes:
+            assert scope in token_scopes
+        assert "wizard_session:write" in token_scopes
+
+        self.wizard_app.refresh_from_db()
+        assert "wizard_session:write" in self.wizard_app.scopes
+
     def test_pkce_wrong_verifier_rejected(self):
         _, challenge = _pkce_pair()
 

--- a/ee/api/agentic_provisioning/views.py
+++ b/ee/api/agentic_provisioning/views.py
@@ -96,6 +96,8 @@ _SAFE_STATE_RE = re.compile(r"^[A-Za-z0-9_\-]{1,256}$")
 # app. Mirrors the de-facto set tokens already carry (`StripeIntegration.SCOPES`,
 # the default in `_exchange_authorization_code` when no per-code scopes are given).
 STRIPE_CONTRACTED_SCOPES: list[str] = StripeIntegration.SCOPES.split()
+# Required for wizard state-sync writes (`POST /api/projects/:id/wizard/sessions/`).
+WIZARD_REQUIRED_SCOPES: tuple[str, ...] = ("wizard_session:write",)
 # Mirrors PersonalAPIKey.label's CharField(max_length=40) - keep in sync if that ever changes.
 PROVISIONED_PAT_LABEL_MAX_LENGTH = 40
 # Cap partner-supplied prefix below the full label length so " - {team_name}" still
@@ -1133,6 +1135,7 @@ def _exchange_authorization_code(request: Request) -> Response:
         # Direct-mint bypasses /authorize's OAuthValidator, so the per-app scope
         # ceiling has to be enforced here before the token is created by hand.
         requested_scopes = scopes if scopes else StripeIntegration.SCOPES.split()
+        requested_scopes = _with_required_wizard_scopes(locked_app, requested_scopes)
         app_scopes = locked_app.ceiling_scopes if locked_app else []
         if not scopes_within_ceiling(requested_scopes, app_scopes):
             _capture_provisioning_event("token_exchange", "scope_ceiling_exceeded", grant_type="authorization_code")
@@ -1295,7 +1298,7 @@ def _exchange_refresh_token(request: Request) -> Response:
                 },
                 status=400,
             )
-        new_scope = " ".join(narrowed_scopes)
+        new_scope = " ".join(_with_required_wizard_scopes(oauth_app, narrowed_scopes))
 
         # provisioning_partner_type is a stable marker set at partner registration;
         # checking it instead of is_provisioning_partner prevents a bypass when an admin
@@ -2565,6 +2568,19 @@ class LegacyStripeOAuthAppMissingError(Exception):
     operational misconfiguration, not something to paper over with a freshly
     created application that carries no scope ceiling.
     """
+
+
+def _with_required_wizard_scopes(app: OAuthApplication | None, scopes: list[str]) -> list[str]:
+    deduped_scopes = list(dict.fromkeys(scopes))
+    if app is None or app.provisioning_partner_type != "wizard":
+        return deduped_scopes
+
+    missing_ceiling = [scope for scope in WIZARD_REQUIRED_SCOPES if scope not in app.ceiling_scopes]
+    if missing_ceiling:
+        app.scopes = list(dict.fromkeys([*app.scopes, *missing_ceiling]))
+        app.save(update_fields=["scopes"])
+
+    return list(dict.fromkeys([*deduped_scopes, *WIZARD_REQUIRED_SCOPES]))
 
 
 def _seed_stripe_app_scopes(app: OAuthApplication) -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Wizard cloud-run tokens can miss `wizard_session:write`, which causes `POST /api/projects/:id/wizard/sessions/` to 403 and prevents onboarding wizard state sync.

## Changes

- Added a wizard-specific scope guard in agentic token minting/refresh:
  - Ensures wizard partner tokens always include `wizard_session:write`.
  - Backfills the wizard OAuth app ceiling with `wizard_session:write` when missing so ceiling checks pass and future mints keep it.
- Added a regression test that simulates the legacy wizard ceiling (without `wizard_session:write`) and verifies both token scope and app ceiling are updated during PKCE exchange.

## How did you test this code?

Agent-authored change.

Automated checks run:
- `python3 -m compileall ee/api/agentic_provisioning/views.py ee/api/agentic_provisioning/test/test_provisioning_auth.py`

Attempted but unavailable in this Cloud environment:
- `hogli test ee/api/agentic_provisioning/test/test_provisioning_auth.py::TestProvisioningAuthentication::test_pkce_wizard_exchange_backfills_and_grants_wizard_session_scope` (`hogli: command not found`)
- `python -m pytest ...` (`python: command not found`)
- `python3 -m pytest ...` (`No module named pytest`)
- `uv run pytest ...` (`uv: command not found`)

Regression guarded by added test:
- If wizard app ceilings are missing `wizard_session:write`, token exchange must backfill the app ceiling and include the scope in the minted bearer token.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs changes needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Implemented with Cursor Cloud agent tooling in this session.

Skills invoked:
- `/writing-tests`

Key decisions:
- Applied the fix in token issuance/refresh (source of minted credentials), not in the wizard session endpoint, so older wizard clients self-heal without loosening endpoint permissions.
- Backfill is additive-only: it appends `wizard_session:write` and leaves existing wizard scopes unchanged.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [GROW-90](https://linear.app/posthog-team-growth/issue/GROW-90/cloud-wizard-run-posts-no-state-updates-wizard-token-lacks-wizard)

<div><a href="https://cursor.com/agents/bc-b2659a72-0ef7-4777-b6b0-4086b56a1dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b2659a72-0ef7-4777-b6b0-4086b56a1dac"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

