### PR TITLE
fix(data-warehouse): add search aliases for self-managed storage sources

### DIFF
--- a/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
+++ b/products/data_warehouse/frontend/scenes/NewSourceScene/sourceCatalogLogic.ts
@@ -34,6 +34,16 @@ export const ALL_SOURCES_CATEGORY = 'all'
 // them in a sensible catalog bucket explicitly.
 const MANUAL_SOURCE_CATEGORY: DataWarehouseSourceCategory = 'File storage'
 
+// Self-managed connectors carry no SourceConfig keywords, and their labels alone ("S3",
+// "Google Cloud Storage") miss the terms users actually search ("amazon", "aws", "gcs").
+// Keys match ManualLinkSourceType.
+const MANUAL_SOURCE_KEYWORDS: Record<string, string[]> = {
+    aws: ['amazon', 'aws', 's3', 'amazon web services', 'amazon s3'],
+    'google-cloud': ['gcs', 'gcp', 'google cloud', 'google cloud storage'],
+    'cloudflare-r2': ['cloudflare', 'r2', 'object storage'],
+    azure: ['azure', 'microsoft azure', 'azure blob', 'blob storage'],
+}
+
 // "Request a data warehouse source" survey. We render our own modal and submit the answer
 // directly as a `survey sent` event rather than using the posthog-js survey popover.
 export const SOURCE_REQUEST_SURVEY_ID = '0190ff15-5032-0000-722a-e13933c140ac'
@@ -163,7 +173,7 @@ export const sourceCatalogLogic = kea<sourceCatalogLogicType>([
                         label: source.name,
                         iconType: source.type,
                         category: MANUAL_SOURCE_CATEGORY,
-                        keywords: [],
+                        keywords: MANUAL_SOURCE_KEYWORDS[source.type] ?? [],
                         status: 'stable',
                         url: urls.dataWarehouseSourceNew(source.type),
                     })


### PR DESCRIPTION
## Problem

In the "New source" catalog, search is fuzzy-matched over each connector's `label`, `name`, `keywords`, and `category`. The self-managed storage connectors — S3, Google Cloud Storage, Cloudflare R2, Azure — are built in the frontend with an empty `keywords` array, so they only match on their short labels. A user searching "amazon", "aws", "gcs", or "blob storage" gets no result, even though the connector exists and is fully connectable. (There's also an *unreleased* "Amazon S3" managed entry that shows as "Coming soon", which can make it look like S3 isn't available at all.)

## Changes

Added the common alternate names as search keywords for the four self-managed storage sources, mirroring how managed connectors already declare `keywords` in their `SourceConfig` (e.g. `gcs`, `magento`, `sql server`). Purely additive — no change to the connectors or the wizard flow.

| Source | Added keywords |
| --- | --- |
| S3 (`aws`) | amazon, aws, s3, amazon web services, amazon s3 |
| Google Cloud Storage | gcs, gcp, google cloud, google cloud storage |
| Cloudflare R2 | cloudflare, r2, object storage |
| Azure | azure, microsoft azure, azure blob, blob storage |

## How did you test this code?

I'm an agent. This is a data-only addition to the catalog item keyword list consumed by the existing Fuse.js index; no logic changed. I could not run the frontend lint/test suite in this environment (`node_modules` not installed); CI will run it.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Authored by Claude Code (Opus 4.8) from a synthesis of data-warehouse onboarding session observations, where users browsing the catalog searched storage providers by full/alternate names and came up empty. Chose to extend keywords (the established idiom — ~50 connectors already set them) rather than touch the search logic.
