### PR TITLE
fix(data-warehouse): keep SQL editor sync warning banner fixed above results

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -989,7 +989,7 @@ const SyncWarningsBanner = ({ warnings }: { warnings?: HogQLQueryResponse['warni
         return null
     }
     return (
-        <LemonBanner type="warning" className="m-2" data-attr="sql-editor-output-pane-sync-warnings">
+        <LemonBanner type="warning" className="m-2 flex-shrink-0" data-attr="sql-editor-output-pane-sync-warnings">
             <div className="font-semibold mb-1">
                 Some warehouse sources used by this query are out of date — results may not reflect current data
             </div>
@@ -1126,7 +1126,7 @@ const Content = ({
         }
 
         return (
-            <div className="absolute inset-0 flex flex-col border-t">
+            <div className="absolute inset-0 flex flex-col border-t overflow-hidden">
                 <SyncWarningsBanner warnings={response?.warnings} />
                 <div className="flex flex-col flex-1 min-h-0 hide-scrollbar overflow-auto">
                     <InternalDataTableVisualization
@@ -1188,7 +1188,7 @@ const Content = ({
 
     if (activeTab === OutputTab.Results) {
         return (
-            <div className="flex flex-col flex-1 min-h-0 w-full">
+            <div className="flex flex-col flex-1 min-h-0 w-full overflow-hidden">
                 <SyncWarningsBanner warnings={response?.warnings} />
                 <TabScroller data-attr="sql-editor-output-pane-results">
                     <DataGrid

--- a/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/OutputPane.tsx
@@ -1126,19 +1126,21 @@ const Content = ({
         }
 
         return (
-            <div className="absolute inset-0 flex flex-col hide-scrollbar border-t overflow-auto">
+            <div className="absolute inset-0 flex flex-col border-t">
                 <SyncWarningsBanner warnings={response?.warnings} />
-                <InternalDataTableVisualization
-                    uniqueKey={vizKey}
-                    query={sourceQuery}
-                    setQuery={setSourceQuery}
-                    context={{}}
-                    cachedResults={undefined}
-                    exportContext={exportContext}
-                    editMode
-                    embedded={isEmbeddedMode}
-                    showSettingsPanel={showVisualizationSettings}
-                />
+                <div className="flex flex-col flex-1 min-h-0 hide-scrollbar overflow-auto">
+                    <InternalDataTableVisualization
+                        uniqueKey={vizKey}
+                        query={sourceQuery}
+                        setQuery={setSourceQuery}
+                        context={{}}
+                        cachedResults={undefined}
+                        exportContext={exportContext}
+                        editMode
+                        embedded={isEmbeddedMode}
+                        showSettingsPanel={showVisualizationSettings}
+                    />
+                </div>
             </div>
         )
     }
@@ -1186,16 +1188,18 @@ const Content = ({
 
     if (activeTab === OutputTab.Results) {
         return (
-            <TabScroller data-attr="sql-editor-output-pane-results">
+            <div className="flex flex-col flex-1 min-h-0 w-full">
                 <SyncWarningsBanner warnings={response?.warnings} />
-                <DataGrid
-                    className={clsx(isDarkModeOn ? 'rdg-dark h-full' : 'rdg-light h-full', 'ph-no-capture')}
-                    columns={columns}
-                    rows={sortedRows}
-                    sortColumns={sortColumns}
-                    onSortColumnsChange={setSortColumns}
-                />
-            </TabScroller>
+                <TabScroller data-attr="sql-editor-output-pane-results">
+                    <DataGrid
+                        className={clsx(isDarkModeOn ? 'rdg-dark h-full' : 'rdg-light h-full', 'ph-no-capture')}
+                        columns={columns}
+                        rows={sortedRows}
+                        sortColumns={sortColumns}
+                        onSortColumnsChange={setSortColumns}
+                    />
+                </TabScroller>
+            </div>
         )
     }
     return null


### PR DESCRIPTION
## Problem

In the SQL editor, the warning banner shown when a queried warehouse source is stale / not synced (`SyncWarningsBanner`) doesn't resize properly — reported in [Slack](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782814375720139) (ticket #2314).

The banner was rendered *inside* the scrolling results region, as a sibling of the data grid / visualization:

- **Results tab:** banner lived inside `TabScroller`, whose content wrapper is `absolute inset-0`. The `DataGrid` is `h-full` (100% of that absolute box), so the grid claimed the full pane height *and* the banner stacked on top of it — combined height overflowed the container, and the banner's width was pinned to the initial client box instead of tracking the grid's scroll width.
- **Visualization tab:** banner was a flex child inside the `absolute inset-0 … overflow-auto` scroll container, so it scrolled with (and was sized against) the visualization rather than staying put.

Net effect: the banner didn't track the pane as it resized / scrolled.

## Changes

Hoist `SyncWarningsBanner` out of the scrolling region in both output tabs so it's a fixed-height row above a `flex-1 min-h-0` scroll area:

- **Results:** wrap in `flex flex-col flex-1 min-h-0`, banner on top, `TabScroller` (containing only the grid) below.
- **Visualization:** keep the outer `absolute inset-0 flex flex-col`, banner on top, move `overflow-auto` to an inner `flex-1 min-h-0` wrapper around the visualization.

`SyncWarningsBanner` already returns `null` when there are no warnings, so the wrappers are inert in the common case.

## How did you test this code?

I'm an agent (Claude Code). No automated tests cover this banner; the change is structural CSS/layout only. I ran `tsc --noEmit` over the frontend — no errors in `OutputPane.tsx`. I did **not** manually verify in a running app — the original report includes a screen recording, and a human should confirm the banner now resizes correctly in both the Results and Visualization tabs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a forwarded Slack report. Used Claude Code (Explore subagent to locate the component, then direct edits). No repo skills were required for this layout-only change. Root cause was the banner being a sibling of `h-full`/absolutely-positioned scroll content rather than a fixed row above it; fix mirrors the standard fixed-header + scroll-body flex column. Did not change the banner's copy or the `warnings` data flow.
