### PR TITLE
fix(ci): bound master-red alert duration + fire on CI events

### DIFF
--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -37,13 +37,8 @@ const HISTORY_LIMIT = 100
 // Attachment side-bar colors (Slack's red / green).
 const ACTIVE_COLOR = '#E01E5A'
 const RESOLVED_COLOR = '#2EB67D'
-// Caps the *reported* red duration, not detection. Cancelled/skipped runs are dropped before the
-// failure streak is counted, so two kept failures can sit far apart in wall-clock when everything
-// between them was cancelled (a quiet weekend, a path-filtered workflow, or a stale/incomplete API
-// page). The streak — and the byCount/byDuration arms — still span the full run of failures, but the
-// duration we *show* must not silently claim master stayed red across a gap we have no evidence for.
-// So the display anchor stops at the first gap wider than this; without it the headline anchors to a
-// days-old failure and reads as wildly inflated (the "red 61h" bug). Detection is unaffected.
+// Caps the *displayed* red duration only (not detection): the shown span won't bridge a gap this
+// wide between kept failures, so it can't anchor to a days-old run (the "red 61h" bug).
 const STREAK_MAX_GAP_MINUTES = 180
 
 // ---------------------------------------------------------------------------
@@ -70,9 +65,7 @@ async function fetchWorkflowRuns(github, owner, repo, workflowFile, perPage) {
             sha: run.head_sha,
             run_url: run.html_url,
             updated_at: run.updated_at,
-            // Immutable and the API's sort key — unlike updated_at it isn't bumped by re-runs, so
-            // gaps measured from it stay correct (and non-negative) when an old run is re-run.
-            created_at: run.created_at,
+            created_at: run.created_at, // immutable; updated_at is bumped by re-runs
             workflow_file: workflowFile,
         }))
 }
@@ -89,20 +82,14 @@ function countConsecutiveFailures(runs) {
     return count
 }
 
-// Display-only "red since": the oldest failure reachable from the newest without crossing a gap
-// wider than STREAK_MAX_GAP_MINUTES. Detection uses the full streak (`since`); this only bounds the
-// duration we report so it can't claim red across an evidence-free gap. Gaps are measured from
-// created_at (immutable, the API sort key); an unparseable timestamp stops the walk (fail short,
-// never fail open into an inflated duration).
+// Display-only "red since": oldest failure reachable from the newest without crossing a gap wider
+// than STREAK_MAX_GAP_MINUTES. Uses immutable created_at so re-runs can't collapse the span.
 function contiguousFailureSince(runs, count) {
-    // created_at (dispatch time, the API sort key) is immutable; updated_at is bumped by re-runs.
-    // Use it for both the gap and the returned anchor so re-running a run in the streak can't
-    // collapse the shown duration, and a just-completed failure reads as its run age, not "0m".
     const dispatchedAt = (run) => run.created_at || run.updated_at
     let oldest = runs[0]
     for (let i = 1; i < count; i++) {
         const gapMins = (new Date(dispatchedAt(runs[i - 1])).getTime() - new Date(dispatchedAt(runs[i])).getTime()) / 60000
-        if (!(gapMins <= STREAK_MAX_GAP_MINUTES)) break // NaN-safe: unknown/oversized gap stops here
+        if (!(gapMins <= STREAK_MAX_GAP_MINUTES)) break // NaN-safe
         oldest = runs[i]
     }
     return dispatchedAt(oldest)
@@ -119,8 +106,8 @@ function buildFailingMap(allWorkflowRuns) {
             const oldest = runs[count - 1]
             failing[latest.name] = {
                 name: latest.name,
-                since: oldest.updated_at, // full streak — drives byCount/byDuration/blocking (detection)
-                displaySince: contiguousFailureSince(runs, count), // gap-bounded — drives the shown duration only
+                since: oldest.updated_at, // detection (full streak)
+                displaySince: contiguousFailureSince(runs, count), // display only (gap-bounded)
                 run_url: latest.run_url,
                 workflow_file: latest.workflow_file,
                 consecutive_failures: count,
@@ -405,8 +392,7 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
 
     const allFailingRunsUrl = `https://github.com/${owner}/${repo}/actions?query=branch%3Amaster+is%3Afailure`
 
-    // Earliest start across both active signals, for the shown duration (preserve original on
-    // update). Uses each blocker's gap-bounded displaySince, so the headline can't inflate either.
+    // Earliest start across both active signals (preserve original on update); gap-bounded displaySince.
     const computeSince = () => {
         const times = blocking.map((b) => new Date(b.displaySince).getTime())
         if (commitActive && commitStreakSince) times.push(new Date(commitStreakSince).getTime())

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -37,6 +37,13 @@ const HISTORY_LIMIT = 100
 // Attachment side-bar colors (Slack's red / green).
 const ACTIVE_COLOR = '#E01E5A'
 const RESOLVED_COLOR = '#2EB67D'
+// A failure streak must be contiguous in *real* (non-cancelled) runs. Cancelled/skipped runs
+// are dropped before counting, so two failures can sit far apart in wall-clock when everything
+// between them was cancelled (e.g. a quiet weekend whose only non-cancelled runs were old
+// failures). A gap wider than this between adjacent kept failures means we have no evidence
+// master stayed red across it, so the streak stops there — otherwise the incident `since` anchors
+// to a stale, days-old failure and the duration reads as wildly inflated (e.g. "red 61h").
+const STREAK_MAX_GAP_MINUTES = 180
 
 // ---------------------------------------------------------------------------
 // GitHub data
@@ -66,14 +73,19 @@ async function fetchWorkflowRuns(github, owner, repo, workflowFile, perPage) {
         }))
 }
 
-function countConsecutiveFailures(runs) {
+// Length of the leading run-after-run failure streak (runs are newest-first). A wall-clock gap
+// wider than STREAK_MAX_GAP_MINUTES between two adjacent kept failures breaks the streak — see the
+// constant's note. This keeps `since` anchored to the current contiguous breakage, not a stale run.
+function leadingFailureStreak(runs) {
     let count = 0
-    for (const run of runs) {
-        if (run.conclusion === 'failure' || run.conclusion === 'timed_out') {
-            count++
-        } else {
-            break
+    for (let i = 0; i < runs.length; i++) {
+        const run = runs[i]
+        if (run.conclusion !== 'failure' && run.conclusion !== 'timed_out') break
+        if (i > 0) {
+            const gapMins = (new Date(runs[i - 1].updated_at).getTime() - new Date(run.updated_at).getTime()) / 60000
+            if (gapMins > STREAK_MAX_GAP_MINUTES) break
         }
+        count++
     }
     return count
 }
@@ -83,7 +95,7 @@ function buildFailingMap(allWorkflowRuns) {
     const failing = {}
     for (const runs of allWorkflowRuns) {
         if (runs.length === 0) continue
-        const count = countConsecutiveFailures(runs)
+        const count = leadingFailureStreak(runs)
         if (count > 0) {
             const latest = runs[0]
             const oldest = runs[count - 1]

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -38,7 +38,7 @@ const HISTORY_LIMIT = 100
 const ACTIVE_COLOR = '#E01E5A'
 const RESOLVED_COLOR = '#2EB67D'
 // Caps the *displayed* red duration only (not detection): the shown span won't bridge a gap this
-// wide between kept failures, so it can't anchor to a days-old run (the "red 61h" bug).
+// wide between kept failures, so it can't anchor to a stale run.
 const STREAK_MAX_GAP_MINUTES = 180
 
 // ---------------------------------------------------------------------------

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -95,14 +95,17 @@ function countConsecutiveFailures(runs) {
 // created_at (immutable, the API sort key); an unparseable timestamp stops the walk (fail short,
 // never fail open into an inflated duration).
 function contiguousFailureSince(runs, count) {
-    const dispatchedAt = (run) => new Date(run.created_at || run.updated_at).getTime()
+    // created_at (dispatch time, the API sort key) is immutable; updated_at is bumped by re-runs.
+    // Use it for both the gap and the returned anchor so re-running a run in the streak can't
+    // collapse the shown duration, and a just-completed failure reads as its run age, not "0m".
+    const dispatchedAt = (run) => run.created_at || run.updated_at
     let oldest = runs[0]
     for (let i = 1; i < count; i++) {
-        const gapMins = (dispatchedAt(runs[i - 1]) - dispatchedAt(runs[i])) / 60000
+        const gapMins = (new Date(dispatchedAt(runs[i - 1])).getTime() - new Date(dispatchedAt(runs[i])).getTime()) / 60000
         if (!(gapMins <= STREAK_MAX_GAP_MINUTES)) break // NaN-safe: unknown/oversized gap stops here
         oldest = runs[i]
     }
-    return oldest.updated_at
+    return dispatchedAt(oldest)
 }
 
 // Workflows whose newest run starts a failure streak, keyed by display name.
@@ -383,7 +386,7 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
             }
         })
         .filter((f) => f.byCount || f.byDuration)
-        .sort((a, b) => b.displayRedForMins - a.displayRedForMins) // longest shown-red first
+        .sort((a, b) => b.redForMins - a.redForMins) // most-severe (longest true red) first
 
     const latestCommit = commits[0] || null
     // Fail closed: no dated commit → not recent → the wall-clock arm won't open.

--- a/.github/scripts/ci-alerts-devex.js
+++ b/.github/scripts/ci-alerts-devex.js
@@ -37,12 +37,13 @@ const HISTORY_LIMIT = 100
 // Attachment side-bar colors (Slack's red / green).
 const ACTIVE_COLOR = '#E01E5A'
 const RESOLVED_COLOR = '#2EB67D'
-// A failure streak must be contiguous in *real* (non-cancelled) runs. Cancelled/skipped runs
-// are dropped before counting, so two failures can sit far apart in wall-clock when everything
-// between them was cancelled (e.g. a quiet weekend whose only non-cancelled runs were old
-// failures). A gap wider than this between adjacent kept failures means we have no evidence
-// master stayed red across it, so the streak stops there — otherwise the incident `since` anchors
-// to a stale, days-old failure and the duration reads as wildly inflated (e.g. "red 61h").
+// Caps the *reported* red duration, not detection. Cancelled/skipped runs are dropped before the
+// failure streak is counted, so two kept failures can sit far apart in wall-clock when everything
+// between them was cancelled (a quiet weekend, a path-filtered workflow, or a stale/incomplete API
+// page). The streak — and the byCount/byDuration arms — still span the full run of failures, but the
+// duration we *show* must not silently claim master stayed red across a gap we have no evidence for.
+// So the display anchor stops at the first gap wider than this; without it the headline anchors to a
+// days-old failure and reads as wildly inflated (the "red 61h" bug). Detection is unaffected.
 const STREAK_MAX_GAP_MINUTES = 180
 
 // ---------------------------------------------------------------------------
@@ -69,25 +70,39 @@ async function fetchWorkflowRuns(github, owner, repo, workflowFile, perPage) {
             sha: run.head_sha,
             run_url: run.html_url,
             updated_at: run.updated_at,
+            // Immutable and the API's sort key — unlike updated_at it isn't bumped by re-runs, so
+            // gaps measured from it stay correct (and non-negative) when an old run is re-run.
+            created_at: run.created_at,
             workflow_file: workflowFile,
         }))
 }
 
-// Length of the leading run-after-run failure streak (runs are newest-first). A wall-clock gap
-// wider than STREAK_MAX_GAP_MINUTES between two adjacent kept failures breaks the streak — see the
-// constant's note. This keeps `since` anchored to the current contiguous breakage, not a stale run.
-function leadingFailureStreak(runs) {
+function countConsecutiveFailures(runs) {
     let count = 0
-    for (let i = 0; i < runs.length; i++) {
-        const run = runs[i]
-        if (run.conclusion !== 'failure' && run.conclusion !== 'timed_out') break
-        if (i > 0) {
-            const gapMins = (new Date(runs[i - 1].updated_at).getTime() - new Date(run.updated_at).getTime()) / 60000
-            if (gapMins > STREAK_MAX_GAP_MINUTES) break
+    for (const run of runs) {
+        if (run.conclusion === 'failure' || run.conclusion === 'timed_out') {
+            count++
+        } else {
+            break
         }
-        count++
     }
     return count
+}
+
+// Display-only "red since": the oldest failure reachable from the newest without crossing a gap
+// wider than STREAK_MAX_GAP_MINUTES. Detection uses the full streak (`since`); this only bounds the
+// duration we report so it can't claim red across an evidence-free gap. Gaps are measured from
+// created_at (immutable, the API sort key); an unparseable timestamp stops the walk (fail short,
+// never fail open into an inflated duration).
+function contiguousFailureSince(runs, count) {
+    const dispatchedAt = (run) => new Date(run.created_at || run.updated_at).getTime()
+    let oldest = runs[0]
+    for (let i = 1; i < count; i++) {
+        const gapMins = (dispatchedAt(runs[i - 1]) - dispatchedAt(runs[i])) / 60000
+        if (!(gapMins <= STREAK_MAX_GAP_MINUTES)) break // NaN-safe: unknown/oversized gap stops here
+        oldest = runs[i]
+    }
+    return oldest.updated_at
 }
 
 // Workflows whose newest run starts a failure streak, keyed by display name.
@@ -95,13 +110,14 @@ function buildFailingMap(allWorkflowRuns) {
     const failing = {}
     for (const runs of allWorkflowRuns) {
         if (runs.length === 0) continue
-        const count = leadingFailureStreak(runs)
+        const count = countConsecutiveFailures(runs)
         if (count > 0) {
             const latest = runs[0]
             const oldest = runs[count - 1]
             failing[latest.name] = {
                 name: latest.name,
-                since: oldest.updated_at,
+                since: oldest.updated_at, // full streak — drives byCount/byDuration/blocking (detection)
+                displaySince: contiguousFailureSince(runs, count), // gap-bounded — drives the shown duration only
                 run_url: latest.run_url,
                 workflow_file: latest.workflow_file,
                 consecutive_failures: count,
@@ -249,8 +265,8 @@ function buildAnchorMessage({
     // Duration-only blockers show just the red time — no sub-threshold "N failed runs" count.
     const lines = blocking.map((wf) =>
         wf.byCount
-            ? `• ${workflowLink(wf)} — ${plural(wf.consecutive_failures, 'failed run')} in a row · red for ${formatDuration(wf.redForMins)}`
-            : `• ${workflowLink(wf)} — red for ${formatDuration(wf.redForMins)}`
+            ? `• ${workflowLink(wf)} — ${plural(wf.consecutive_failures, 'failed run')} in a row · red for ${formatDuration(wf.displayRedForMins)}`
+            : `• ${workflowLink(wf)} — red for ${formatDuration(wf.displayRedForMins)}`
     )
     if (commitActive) {
         lines.push(`• _${plural(commitStreakCount, 'commit')} in a row failed a required check_`)
@@ -360,13 +376,14 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
             return {
                 ...f,
                 runsUrl: runsUrlFor(owner, repo, f.workflow_file),
-                redForMins,
+                redForMins, // detection: byDuration + open/resolve thresholds
+                displayRedForMins: Math.round((now.getTime() - new Date(f.displaySince).getTime()) / 60000),
                 byCount: f.consecutive_failures >= workflowThreshold,
                 byDuration: redForMins >= minutesThreshold,
             }
         })
         .filter((f) => f.byCount || f.byDuration)
-        .sort((a, b) => b.redForMins - a.redForMins) // longest red first
+        .sort((a, b) => b.displayRedForMins - a.displayRedForMins) // longest shown-red first
 
     const latestCommit = commits[0] || null
     // Fail closed: no dated commit → not recent → the wall-clock arm won't open.
@@ -385,9 +402,10 @@ module.exports = async ({ context, github, core }, { now: _now, slack: _slack, f
 
     const allFailingRunsUrl = `https://github.com/${owner}/${repo}/actions?query=branch%3Amaster+is%3Afailure`
 
-    // Earliest start across both active signals (preserve original on update).
+    // Earliest start across both active signals, for the shown duration (preserve original on
+    // update). Uses each blocker's gap-bounded displaySince, so the headline can't inflate either.
     const computeSince = () => {
-        const times = blocking.map((b) => new Date(b.since).getTime())
+        const times = blocking.map((b) => new Date(b.displaySince).getTime())
         if (commitActive && commitStreakSince) times.push(new Date(commitStreakSince).getTime())
         return times.length ? new Date(Math.min(...times)).toISOString() : now.toISOString()
     }

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -307,24 +307,92 @@ describe('ci-alerts-devex', () => {
         assert.doesNotMatch(body, /failed runs? in a row/) // duration-only bullet omits the count
     })
 
-    it('does not bridge a stale failure across a long gap when counting the streak (regression)', async () => {
-        // A recent failure (red 30m) and a days-old failure with only cancelled/no real runs
-        // between them — the gap a quiet weekend leaves. The streak must stop at the recent
-        // cluster, so `since` stays recent ("red for 30m") instead of anchoring to the stale
-        // run ("red for 50h") and reporting a wildly inflated duration.
-        const staleGapRuns = [
-            { name: 'Backend CI', conclusion: 'failure', head_sha: 'recent', html_url: 'https://github.com/runs/backend/recent', updated_at: minutes(-30).toISOString() },
-            { name: 'Backend CI', conclusion: 'failure', head_sha: 'stale', html_url: 'https://github.com/runs/backend/stale', updated_at: minutes(-3000).toISOString() },
-        ]
+    // --- Stale-bridge duration (the 2026-06-30 "red 61h 41m" incident) -----------------------
+    // Detection must stay unchanged (the incident still opens / stays open); only the *reported*
+    // duration must stop bridging a cancelled-only gap to a days-old failure. A failure object whose
+    // adjacent kept neighbour is far older — the shape left when everything between was cancelled.
+    const failureRun = (name, key, createdAt, updatedAt) => ({
+        name,
+        conclusion: 'failure',
+        head_sha: `${name}_${key}`,
+        html_url: `https://github.com/runs/${name}/${key}`,
+        created_at: createdAt,
+        updated_at: updatedAt,
+    })
+    const pushAt = (iso) => [
+        { sha: 'push', html_url: 'https://github.com/commit/push', author: { login: 'dev' }, commit: { message: 'p', author: { name: 'dev', date: iso } } },
+    ]
+
+    it('the incident that triggered this: a bridged stale failure no longer inflates the duration (regression)', async () => {
+        // Real shape of the 2026-06-30 incident. Rust CI and Backend CI each had a recent master
+        // failure, but every run back to a days-old failure (Rust 0ee6d13f4 @ 2026-06-27T23:20:46Z)
+        // was cancelled — dropped here — so the leading failure streak bridged ~60h and the bot
+        // reported "red 61h 41m". The fix: still open (byDuration on the full span), but show the
+        // recent contiguous red, not the stale anchor.
+        const now = new Date('2026-06-30T12:12:54Z')
         const github = createGithubMock(
-            { 'ci-backend.yml': staleGapRuns, 'ci-frontend.yml': runs('Frontend CI', ['success']) },
-            { commits: commitsAt(3) }
+            {
+                'ci-rust.yml': [
+                    failureRun('Rust CI', 'recent', '2026-06-30T11:50:48Z', '2026-06-30T12:05:00Z'),
+                    failureRun('Rust CI', 'stale', '2026-06-27T23:06:46Z', '2026-06-27T23:20:46Z'),
+                ],
+                'ci-backend.yml': [
+                    failureRun('Backend CI', 'recent', '2026-06-30T11:39:11Z', '2026-06-30T12:06:00Z'),
+                    failureRun('Backend CI', 'stale', '2026-06-27T23:15:06Z', '2026-06-27T23:29:17Z'),
+                ],
+            },
+            { commits: pushAt('2026-06-30T12:08:00Z') }
         )
-        const { slack, outputs } = await run(github)
-        assert.equal(outputs.action, 'create')
+        const { slack, outputs } = await run(github, { now, env: { GATING_WORKFLOWS: 'ci-rust.yml,ci-backend.yml' } })
+
+        assert.equal(outputs.action, 'create') // detection unchanged: full-span byDuration still opens
+        const anchor = slack.postMessage.calls[0][0]
+        const body = JSON.stringify(anchor.attachments)
+        assert.match(body, /Rust CI/)
+        assert.match(body, /Backend CI/)
+        assert.doesNotMatch(body, /\d{2,}h/) // the bug read "61h"; no multi-hour duration survives
+        assert.match(anchor.text, /\(\d+m\)/) // summary duration is minutes of recent contiguous red
+        // anchored to the recent failure (2026-06-30), not the 2026-06-27 stale run
+        assert.match(anchor.metadata.event_payload.since, /^2026-06-30/)
+    })
+
+    it('does not falsely resolve an open incident while the newest run is still failing (regression)', async () => {
+        // Newest run still a failure, prior failure >180m back (cancelled-only gap). The display
+        // anchor is recent, but detection uses the full span — the incident must stay open, never
+        // post a false "master recovered".
+        const now = new Date('2026-06-30T12:12:54Z')
+        const github = createGithubMock({
+            'ci-backend.yml': [
+                failureRun('Backend CI', 'recent', '2026-06-30T11:50:00Z', '2026-06-30T12:05:00Z'),
+                failureRun('Backend CI', 'stale', '2026-06-27T23:06:00Z', '2026-06-27T23:20:00Z'),
+            ],
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+        const { slack, outputs } = await run(github, { now, history: [activeAnchor()] })
+        assert.equal(outputs.action, 'update') // stays open — not 'resolve'
+        assert.equal(slack.update.calls[0][0].attachments[0].color, '#E01E5A')
+        assert.equal(slack.update.calls[0][0].metadata.event_payload.status, 'active')
+    })
+
+    it('still pages for a sparse workflow whose genuine failures are far apart (regression)', async () => {
+        // A path-filtered workflow (Rust) runs only on matching pushes, so two genuine failures can
+        // be >180m apart with no green between. The wall-clock arm must still open on the full span.
+        const now = new Date('2026-06-30T12:12:54Z')
+        const github = createGithubMock(
+            {
+                'ci-rust.yml': [
+                    failureRun('Rust CI', 'recent', '2026-06-30T11:55:00Z', '2026-06-30T12:02:00Z'),
+                    failureRun('Rust CI', 'older', '2026-06-30T07:30:00Z', '2026-06-30T07:45:00Z'),
+                ],
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
+            },
+            { commits: pushAt('2026-06-30T12:08:00Z') }
+        )
+        const { slack, outputs } = await run(github, { now, env: { GATING_WORKFLOWS: 'ci-rust.yml,ci-frontend.yml' } })
+        assert.equal(outputs.action, 'create') // old gap-break would have missed this entirely
         const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
-        assert.match(body, /red for 30m/) // anchored to the recent failure, not the 50h-old one
-        assert.doesNotMatch(body, /50h/)
+        assert.match(body, /red for \d+m/) // shows the recent contiguous red, not the ~4.5h span
+        assert.doesNotMatch(body, /red for \d+h/)
     })
 
     it('stays silent when red past the threshold but no recent push (quiet weekend)', async () => {

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -307,10 +307,7 @@ describe('ci-alerts-devex', () => {
         assert.doesNotMatch(body, /failed runs? in a row/) // duration-only bullet omits the count
     })
 
-    // --- Stale-bridge duration (the 2026-06-30 "red 61h 41m" incident) -----------------------
-    // Detection must stay unchanged (the incident still opens / stays open); only the *reported*
-    // duration must stop bridging a cancelled-only gap to a days-old failure. A failure object whose
-    // adjacent kept neighbour is far older — the shape left when everything between was cancelled.
+    // --- Stale-bridge duration (the 2026-06-30 "red 61h 41m" incident) ---
     const failureRun = (name, key, createdAt, updatedAt) => ({
         name,
         conclusion: 'failure',
@@ -324,11 +321,8 @@ describe('ci-alerts-devex', () => {
     ]
 
     it('the incident that triggered this: a bridged stale failure no longer inflates the duration (regression)', async () => {
-        // Real shape of the 2026-06-30 incident. Rust CI and Backend CI each had a recent master
-        // failure, but every run back to a days-old failure (Rust 0ee6d13f4 @ 2026-06-27T23:20:46Z)
-        // was cancelled — dropped here — so the leading failure streak bridged ~60h and the bot
-        // reported "red 61h 41m". The fix: still open (byDuration on the full span), but show the
-        // recent contiguous red, not the stale anchor.
+        // Recent failure + a days-old failure (the cancelled runs between are dropped) → the streak
+        // bridged ~60h. Must still open, but report the recent contiguous red, not 61h.
         const now = new Date('2026-06-30T12:12:54Z')
         const github = createGithubMock(
             {
@@ -357,9 +351,8 @@ describe('ci-alerts-devex', () => {
     })
 
     it('does not falsely resolve an open incident while the newest run is still failing (regression)', async () => {
-        // Newest run still a failure, prior failure >180m back (cancelled-only gap). The display
-        // anchor is recent, but detection uses the full span — the incident must stay open, never
-        // post a false "master recovered".
+        // Newest run still failing, prior failure >180m back — detection uses the full span, so the
+        // incident must stay open (never a false "master recovered").
         const now = new Date('2026-06-30T12:12:54Z')
         const github = createGithubMock({
             'ci-backend.yml': [
@@ -375,8 +368,7 @@ describe('ci-alerts-devex', () => {
     })
 
     it('still pages for a sparse workflow whose genuine failures are far apart (regression)', async () => {
-        // A path-filtered workflow (Rust) runs only on matching pushes, so two genuine failures can
-        // be >180m apart with no green between. The wall-clock arm must still open on the full span.
+        // Sparse workflow: two genuine failures >180m apart, no green between. Must still open.
         const now = new Date('2026-06-30T12:12:54Z')
         const github = createGithubMock(
             {
@@ -396,9 +388,7 @@ describe('ci-alerts-devex', () => {
     })
 
     it('re-running a run inside the streak does not collapse the shown duration to ~0', async () => {
-        // The display anchor is created_at (immutable), not updated_at (bumped by re-runs). Five
-        // contiguous failures dispatched 5m apart; the oldest was re-run so its updated_at is now —
-        // the bullet must still read the full ~33m from dispatch, not ~2m.
+        // Oldest failure re-run (updated_at bumped to ~now) — created_at anchor keeps the full span.
         const now = new Date('2026-06-30T12:12:54Z')
         const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
         const github = createGithubMock({
@@ -419,8 +409,7 @@ describe('ci-alerts-devex', () => {
     })
 
     it('reports the honest full duration for a genuinely-continuous outage', async () => {
-        // Dense failures with no gap > 180m — the cap must NOT fire here, so a real ~1h13m outage
-        // is reported in full (the fix only de-inflates evidence-free gaps).
+        // Dense failures, no gap > 180m — the cap must NOT fire, so the full ~1h13m is reported.
         const now = new Date('2026-06-30T12:12:54Z')
         const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
         const github = createGithubMock(

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -395,6 +395,51 @@ describe('ci-alerts-devex', () => {
         assert.doesNotMatch(body, /red for \d+h/)
     })
 
+    it('re-running a run inside the streak does not collapse the shown duration to ~0', async () => {
+        // The display anchor is created_at (immutable), not updated_at (bumped by re-runs). Five
+        // contiguous failures dispatched 5m apart; the oldest was re-run so its updated_at is now —
+        // the bullet must still read the full ~33m from dispatch, not ~2m.
+        const now = new Date('2026-06-30T12:12:54Z')
+        const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
+        const github = createGithubMock({
+            'ci-backend.yml': [
+                f('f5', '2026-06-30T12:00:00Z', '2026-06-30T12:07:00Z'),
+                f('f4', '2026-06-30T11:55:00Z', '2026-06-30T12:02:00Z'),
+                f('f3', '2026-06-30T11:50:00Z', '2026-06-30T11:57:00Z'),
+                f('f2', '2026-06-30T11:45:00Z', '2026-06-30T11:52:00Z'),
+                f('f1', '2026-06-30T11:40:00Z', '2026-06-30T12:11:00Z'), // oldest, re-run → updated bumped
+            ],
+            'ci-frontend.yml': runs('Frontend CI', ['success']),
+        })
+        const { slack, outputs } = await run(github, { now })
+        assert.equal(outputs.action, 'create')
+        const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
+        assert.match(body, /5 failed runs in a row/)
+        assert.match(body, /red for 33m/) // from f1's created_at (11:40), not its re-run updated_at (12:11)
+    })
+
+    it('reports the honest full duration for a genuinely-continuous outage', async () => {
+        // Dense failures with no gap > 180m — the cap must NOT fire here, so a real ~1h13m outage
+        // is reported in full (the fix only de-inflates evidence-free gaps).
+        const now = new Date('2026-06-30T12:12:54Z')
+        const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
+        const github = createGithubMock(
+            {
+                'ci-backend.yml': [
+                    f('c3', '2026-06-30T11:55:00Z', '2026-06-30T12:05:00Z'),
+                    f('c2', '2026-06-30T11:30:00Z', '2026-06-30T11:40:00Z'),
+                    f('c1', '2026-06-30T11:00:00Z', '2026-06-30T11:10:00Z'),
+                ],
+                'ci-frontend.yml': runs('Frontend CI', ['success']),
+            },
+            { commits: pushAt('2026-06-30T12:08:00Z') }
+        )
+        const { slack, outputs } = await run(github, { now })
+        assert.equal(outputs.action, 'create')
+        const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
+        assert.match(body, /red for 1h 13m/) // 12:12:54 − 11:00 dispatch ≈ 72.9m → 73m, not truncated
+    })
+
     it('stays silent when red past the threshold but no recent push (quiet weekend)', async () => {
         const github = createGithubMock(
             { 'ci-backend.yml': failingFor(2400), 'ci-frontend.yml': runs('Frontend CI', ['success']) },

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -307,7 +307,7 @@ describe('ci-alerts-devex', () => {
         assert.doesNotMatch(body, /failed runs? in a row/) // duration-only bullet omits the count
     })
 
-    // --- Stale-bridge duration (the 2026-06-30 "red 61h 41m" incident) ---
+    // --- Stale-bridge duration ---
     const failureRun = (name, key, createdAt, updatedAt) => ({
         name,
         conclusion: 'failure',
@@ -320,22 +320,22 @@ describe('ci-alerts-devex', () => {
         { sha: 'push', html_url: 'https://github.com/commit/push', author: { login: 'dev' }, commit: { message: 'p', author: { name: 'dev', date: iso } } },
     ]
 
-    it('the incident that triggered this: a bridged stale failure no longer inflates the duration (regression)', async () => {
-        // Recent failure + a days-old failure (the cancelled runs between are dropped) → the streak
-        // bridged ~60h. Must still open, but report the recent contiguous red, not 61h.
-        const now = new Date('2026-06-30T12:12:54Z')
+    it('bridged stale failures do not inflate the displayed duration (regression)', async () => {
+        // Recent failure + stale failure (the cancelled runs between are dropped) → the detection
+        // streak spans multiple days. Must still open, but report the recent contiguous red.
+        const now = minutes(13)
         const github = createGithubMock(
             {
                 'ci-rust.yml': [
-                    failureRun('Rust CI', 'recent', '2026-06-30T11:50:48Z', '2026-06-30T12:05:00Z'),
-                    failureRun('Rust CI', 'stale', '2026-06-27T23:06:46Z', '2026-06-27T23:20:46Z'),
+                    failureRun('Rust CI', 'recent', minutes(-9).toISOString(), minutes(5).toISOString()),
+                    failureRun('Rust CI', 'stale', minutes(-3600).toISOString(), minutes(-3586).toISOString()),
                 ],
                 'ci-backend.yml': [
-                    failureRun('Backend CI', 'recent', '2026-06-30T11:39:11Z', '2026-06-30T12:06:00Z'),
-                    failureRun('Backend CI', 'stale', '2026-06-27T23:15:06Z', '2026-06-27T23:29:17Z'),
+                    failureRun('Backend CI', 'recent', minutes(-21).toISOString(), minutes(6).toISOString()),
+                    failureRun('Backend CI', 'stale', minutes(-3590).toISOString(), minutes(-3576).toISOString()),
                 ],
             },
-            { commits: pushAt('2026-06-30T12:08:00Z') }
+            { commits: pushAt(minutes(8).toISOString()) }
         )
         const { slack, outputs } = await run(github, { now, env: { GATING_WORKFLOWS: 'ci-rust.yml,ci-backend.yml' } })
 
@@ -344,20 +344,20 @@ describe('ci-alerts-devex', () => {
         const body = JSON.stringify(anchor.attachments)
         assert.match(body, /Rust CI/)
         assert.match(body, /Backend CI/)
-        assert.doesNotMatch(body, /\d{2,}h/) // the bug read "61h"; no multi-hour duration survives
+        assert.doesNotMatch(body, /\d{2,}h/) // no stale multi-day duration survives
         assert.match(anchor.text, /\(\d+m\)/) // summary duration is minutes of recent contiguous red
-        // anchored to the recent failure (2026-06-30), not the 2026-06-27 stale run
-        assert.match(anchor.metadata.event_payload.since, /^2026-06-30/)
+        // anchored to the recent failure, not the stale run
+        assert.equal(anchor.metadata.event_payload.since, minutes(-21).toISOString())
     })
 
     it('does not falsely resolve an open incident while the newest run is still failing (regression)', async () => {
         // Newest run still failing, prior failure >180m back — detection uses the full span, so the
         // incident must stay open (never a false "master recovered").
-        const now = new Date('2026-06-30T12:12:54Z')
+        const now = minutes(13)
         const github = createGithubMock({
             'ci-backend.yml': [
-                failureRun('Backend CI', 'recent', '2026-06-30T11:50:00Z', '2026-06-30T12:05:00Z'),
-                failureRun('Backend CI', 'stale', '2026-06-27T23:06:00Z', '2026-06-27T23:20:00Z'),
+                failureRun('Backend CI', 'recent', minutes(-10).toISOString(), minutes(5).toISOString()),
+                failureRun('Backend CI', 'stale', minutes(-3600).toISOString(), minutes(-3586).toISOString()),
             ],
             'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
@@ -369,16 +369,16 @@ describe('ci-alerts-devex', () => {
 
     it('still pages for a sparse workflow whose genuine failures are far apart (regression)', async () => {
         // Sparse workflow: two genuine failures >180m apart, no green between. Must still open.
-        const now = new Date('2026-06-30T12:12:54Z')
+        const now = minutes(13)
         const github = createGithubMock(
             {
                 'ci-rust.yml': [
-                    failureRun('Rust CI', 'recent', '2026-06-30T11:55:00Z', '2026-06-30T12:02:00Z'),
-                    failureRun('Rust CI', 'older', '2026-06-30T07:30:00Z', '2026-06-30T07:45:00Z'),
+                    failureRun('Rust CI', 'recent', minutes(-5).toISOString(), minutes(2).toISOString()),
+                    failureRun('Rust CI', 'older', minutes(-270).toISOString(), minutes(-255).toISOString()),
                 ],
                 'ci-frontend.yml': runs('Frontend CI', ['success']),
             },
-            { commits: pushAt('2026-06-30T12:08:00Z') }
+            { commits: pushAt(minutes(8).toISOString()) }
         )
         const { slack, outputs } = await run(github, { now, env: { GATING_WORKFLOWS: 'ci-rust.yml,ci-frontend.yml' } })
         assert.equal(outputs.action, 'create') // old gap-break would have missed this entirely
@@ -389,15 +389,15 @@ describe('ci-alerts-devex', () => {
 
     it('re-running a run inside the streak does not collapse the shown duration to ~0', async () => {
         // Oldest failure re-run (updated_at bumped to ~now) — created_at anchor keeps the full span.
-        const now = new Date('2026-06-30T12:12:54Z')
+        const now = minutes(13)
         const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
         const github = createGithubMock({
             'ci-backend.yml': [
-                f('f5', '2026-06-30T12:00:00Z', '2026-06-30T12:07:00Z'),
-                f('f4', '2026-06-30T11:55:00Z', '2026-06-30T12:02:00Z'),
-                f('f3', '2026-06-30T11:50:00Z', '2026-06-30T11:57:00Z'),
-                f('f2', '2026-06-30T11:45:00Z', '2026-06-30T11:52:00Z'),
-                f('f1', '2026-06-30T11:40:00Z', '2026-06-30T12:11:00Z'), // oldest, re-run → updated bumped
+                f('f5', minutes(0).toISOString(), minutes(7).toISOString()),
+                f('f4', minutes(-5).toISOString(), minutes(2).toISOString()),
+                f('f3', minutes(-10).toISOString(), minutes(-3).toISOString()),
+                f('f2', minutes(-15).toISOString(), minutes(-8).toISOString()),
+                f('f1', minutes(-20).toISOString(), minutes(11).toISOString()), // oldest, re-run → updated bumped
             ],
             'ci-frontend.yml': runs('Frontend CI', ['success']),
         })
@@ -405,28 +405,28 @@ describe('ci-alerts-devex', () => {
         assert.equal(outputs.action, 'create')
         const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
         assert.match(body, /5 failed runs in a row/)
-        assert.match(body, /red for 33m/) // from f1's created_at (11:40), not its re-run updated_at (12:11)
+        assert.match(body, /red for 33m/) // from f1's created_at, not its re-run updated_at
     })
 
     it('reports the honest full duration for a genuinely-continuous outage', async () => {
         // Dense failures, no gap > 180m — the cap must NOT fire, so the full ~1h13m is reported.
-        const now = new Date('2026-06-30T12:12:54Z')
+        const now = minutes(13)
         const f = (key, created, updated) => failureRun('Backend CI', key, created, updated)
         const github = createGithubMock(
             {
                 'ci-backend.yml': [
-                    f('c3', '2026-06-30T11:55:00Z', '2026-06-30T12:05:00Z'),
-                    f('c2', '2026-06-30T11:30:00Z', '2026-06-30T11:40:00Z'),
-                    f('c1', '2026-06-30T11:00:00Z', '2026-06-30T11:10:00Z'),
+                    f('c3', minutes(-5).toISOString(), minutes(5).toISOString()),
+                    f('c2', minutes(-30).toISOString(), minutes(-20).toISOString()),
+                    f('c1', minutes(-60).toISOString(), minutes(-50).toISOString()),
                 ],
                 'ci-frontend.yml': runs('Frontend CI', ['success']),
             },
-            { commits: pushAt('2026-06-30T12:08:00Z') }
+            { commits: pushAt(minutes(8).toISOString()) }
         )
         const { slack, outputs } = await run(github, { now })
         assert.equal(outputs.action, 'create')
         const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
-        assert.match(body, /red for 1h 13m/) // 12:12:54 − 11:00 dispatch ≈ 72.9m → 73m, not truncated
+        assert.match(body, /red for 1h 13m/)
     })
 
     it('stays silent when red past the threshold but no recent push (quiet weekend)', async () => {

--- a/.github/scripts/ci-alerts-devex.test.js
+++ b/.github/scripts/ci-alerts-devex.test.js
@@ -307,6 +307,26 @@ describe('ci-alerts-devex', () => {
         assert.doesNotMatch(body, /failed runs? in a row/) // duration-only bullet omits the count
     })
 
+    it('does not bridge a stale failure across a long gap when counting the streak (regression)', async () => {
+        // A recent failure (red 30m) and a days-old failure with only cancelled/no real runs
+        // between them — the gap a quiet weekend leaves. The streak must stop at the recent
+        // cluster, so `since` stays recent ("red for 30m") instead of anchoring to the stale
+        // run ("red for 50h") and reporting a wildly inflated duration.
+        const staleGapRuns = [
+            { name: 'Backend CI', conclusion: 'failure', head_sha: 'recent', html_url: 'https://github.com/runs/backend/recent', updated_at: minutes(-30).toISOString() },
+            { name: 'Backend CI', conclusion: 'failure', head_sha: 'stale', html_url: 'https://github.com/runs/backend/stale', updated_at: minutes(-3000).toISOString() },
+        ]
+        const github = createGithubMock(
+            { 'ci-backend.yml': staleGapRuns, 'ci-frontend.yml': runs('Frontend CI', ['success']) },
+            { commits: commitsAt(3) }
+        )
+        const { slack, outputs } = await run(github)
+        assert.equal(outputs.action, 'create')
+        const body = JSON.stringify(slack.postMessage.calls[0][0].attachments)
+        assert.match(body, /red for 30m/) // anchored to the recent failure, not the 50h-old one
+        assert.doesNotMatch(body, /50h/)
+    })
+
     it('stays silent when red past the threshold but no recent push (quiet weekend)', async () => {
         const github = createGithubMock(
             { 'ci-backend.yml': failingFor(2400), 'ci-frontend.yml': runs('Frontend CI', ['success']) },

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -13,24 +13,17 @@ name: Master CI Alerts
 # state to race or lose). See .github/scripts/ci-alerts-devex.js.
 
 on:
-    # Reconcile within ~a minute of a gating workflow finishing on master, instead of waiting on
-    # the schedule below — GitHub heavily throttles cron under repo load (observed ~hourly, not
-    # every 5m), so the cron alone leaves master breakage undetected for far too long. Keep the
-    # cron as a backstop for resolves and quiet periods. The job is gated to master-push runs.
+    # Reconcile within ~a minute of master CI finishing, instead of waiting on the schedule below —
+    # GitHub heavily throttles cron under repo load (observed ~hourly, not every 5m), so the cron
+    # alone leaves master breakage undetected for far too long. Each reconcile reads ALL gating
+    # workflows regardless of which one triggered it, so we hook only Backend CI — the long-pole
+    # that runs on ~every master push — to get the freshness without ~11 redundant runs per push.
+    # `branches: [master]` keeps PR completions from firing at all. Cron stays a backstop for
+    # resolves, quiet periods, and any push that didn't run Backend CI.
     workflow_run:
-        workflows:
-            - 'Python CI'
-            - 'Backend CI'
-            - 'Node.js CI'
-            - 'Frontend CI'
-            - 'Storybook'
-            - 'Security'
-            - 'Dagster CI'
-            - 'E2E CI Playwright'
-            - 'Rust CI'
-            - 'MCP CI'
-            - 'LLM Services CI'
+        workflows: ['Backend CI']
         types: [completed]
+        branches: [master]
     schedule:
         - cron: '*/5 * * * *'
     workflow_dispatch: # manual trigger for testing
@@ -62,11 +55,10 @@ env:
 
 jobs:
     check-master:
-        # workflow_run fires for every branch/event of the listed workflows; only reconcile for
-        # master-push completions so PR CI doesn't spin up a runner. schedule/dispatch always run.
+        # branches: master already filters to master at the trigger; this drops the rare master
+        # Backend CI run not from a push (e.g. manual re-run) so we only reconcile real pushes.
         if: >-
-            github.event_name != 'workflow_run' ||
-            (github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.event == 'push')
+            github.event_name != 'workflow_run' || github.event.workflow_run.event == 'push'
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -13,13 +13,9 @@ name: Master CI Alerts
 # state to race or lose). See .github/scripts/ci-alerts-devex.js.
 
 on:
-    # Reconcile within ~a minute of master CI finishing, instead of waiting on the schedule below —
-    # GitHub heavily throttles cron under repo load (observed ~hourly, not every 5m), so the cron
-    # alone leaves master breakage undetected for far too long. Each reconcile reads ALL gating
-    # workflows regardless of which one triggered it, so we hook only Backend CI — the long-pole
-    # that runs on ~every master push — to get the freshness without ~11 redundant runs per push.
-    # `branches: [master]` keeps PR completions from firing at all. Cron stays a backstop for
-    # resolves, quiet periods, and any push that didn't run Backend CI.
+    # Reconcile ~a minute after master CI finishes; GitHub throttles the cron below to ~hourly under
+    # load. A reconcile reads all gating workflows anyway, so one hook on Backend CI (the long-pole on
+    # ~every push) suffices. branches:[master] skips PR completions; cron stays a backstop.
     workflow_run:
         workflows: ['Backend CI']
         types: [completed]
@@ -55,8 +51,7 @@ env:
 
 jobs:
     check-master:
-        # branches: master already filters to master at the trigger; this drops the rare master
-        # Backend CI run not from a push (e.g. manual re-run) so we only reconcile real pushes.
+        # only reconcile on push completions (branches:[master] already scopes the trigger to master)
         if: >-
             github.event_name != 'workflow_run' || github.event.workflow_run.event == 'push'
         runs-on: ubuntu-latest

--- a/.github/workflows/ci-alerts-devex.yml
+++ b/.github/workflows/ci-alerts-devex.yml
@@ -13,6 +13,24 @@ name: Master CI Alerts
 # state to race or lose). See .github/scripts/ci-alerts-devex.js.
 
 on:
+    # Reconcile within ~a minute of a gating workflow finishing on master, instead of waiting on
+    # the schedule below — GitHub heavily throttles cron under repo load (observed ~hourly, not
+    # every 5m), so the cron alone leaves master breakage undetected for far too long. Keep the
+    # cron as a backstop for resolves and quiet periods. The job is gated to master-push runs.
+    workflow_run:
+        workflows:
+            - 'Python CI'
+            - 'Backend CI'
+            - 'Node.js CI'
+            - 'Frontend CI'
+            - 'Storybook'
+            - 'Security'
+            - 'Dagster CI'
+            - 'E2E CI Playwright'
+            - 'Rust CI'
+            - 'MCP CI'
+            - 'LLM Services CI'
+        types: [completed]
     schedule:
         - cron: '*/5 * * * *'
     workflow_dispatch: # manual trigger for testing
@@ -44,6 +62,11 @@ env:
 
 jobs:
     check-master:
+        # workflow_run fires for every branch/event of the listed workflows; only reconcile for
+        # master-push completions so PR CI doesn't spin up a runner. schedule/dispatch always run.
+        if: >-
+            github.event_name != 'workflow_run' ||
+            (github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.event == 'push')
         runs-on: ubuntu-latest
         timeout-minutes: 5
         steps:


### PR DESCRIPTION
## Problem

The #alerts-devex bot fired `Master recovered — was red 61h 41m` when master had not been red for anything close to that. Two independent bugs:

- **Inflated duration.** An incident's `since` is the oldest run in a workflow's leading failure streak. Cancelled runs are dropped *before* the streak is counted, so the streak silently bridges long quiet gaps (a weekend, a path-filtered workflow, or a stale/incomplete API page). On open it anchored to a stale Rust CI failure ~60h earlier (run `0ee6d13f4`, `2026-06-27T23:20:46Z`), so a freshly-opened incident reported 61h. Same root cause produced earlier bogus durations (14h58m, 9h8m) in the same window.
- **Detection latency.** The bot ran only on `schedule: '*/5'`, but GitHub throttles cron under repo load — it actually fired ~hourly (80 ticks across a 67h window), so breakage went unnoticed for up to ~90 min and the "now failing" lines were stale by the time anyone read them.

## Changes

**Duration — fix the *reported* number without touching detection.** The streak count, `byCount`/`byDuration`, `blocking`, and resolve all still use the full failure streak, so detection sensitivity is identical. Only the *displayed* duration uses a separate `displaySince` anchor that stops at the first gap > 180 min between failures, measured and anchored from the immutable `created_at` (so re-runs can't mutate it and a just-completed failure never reads "0m"). The headline can't claim red across an evidence-free gap, while a genuinely-continuous outage still shows its full span.

**Latency — fire on CI completion.** Add a `workflow_run` trigger scoped to `Backend CI` only (the long-pole that runs on ~every master push) with `branches: [master]`. Each reconcile reads *all* gating workflows regardless of trigger, so one hook gives ~1-min freshness without ~11 redundant runs per push, and `branches: [master]` keeps PR completions from firing at all. Cron stays as a backstop.

## How did you test this code?

I'm an agent. `node --test .github/scripts/ci-alerts-devex.test.js` — 28/28 pass. Five scenario tests, each catching a bug no existing test did:
- **the exact 2026-06-30 incident** — a bridged stale failure now reports minutes of recent contiguous red, not 61h, and still opens.
- **false-resolve guard** — an open incident whose newest run is still failing across a >180m gap stays open (never posts "master recovered").
- **sparse-workflow guard** — a path-filtered workflow with genuine failures >180m apart still pages.
- **re-run guard** — re-running the oldest failure in the streak (bumping its `updated_at`) does not collapse the shown duration; it stays anchored to `created_at`.
- **honest-duration guard** — a genuinely-continuous dense outage reports its full span (the cap only fires on evidence-free gaps).

Also ran a standalone end-to-end simulation reproducing the incident. Did not run the workflow live.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated the alert with Claude Code (Slack thread + GitHub Actions API + the bot's own per-tick logs), confirming the stale `since` anchor and the ~hourly cron cadence. Two `/code-review` passes shaped the fix: the first showed that capping the failure *streak* shrank detection (false "recovered" during a live outage, missed pages for sparse workflows), so detection now keeps the full streak and only the displayed duration is gap-bounded. The second confirmed detection was safe but flagged display edge-cases — fixed by anchoring the display span to the immutable `created_at` (no re-run collapse, no "0m") and sorting blockers by true redness. The `workflow_run` trigger is scoped to one workflow on master to avoid PR-completion floods, concurrency-cancel races, and multi-list drift.
