### PR TITLE
feat(quill): add chat primitives

### DIFF
--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -9,6 +9,9 @@ process.env.TZ = process.env.TZ || 'UTC'
 
 const esmModules = [
     'query-selector-shadow-dom',
+    // @shadcn/react ships ESM-only; @posthog/quill-primitives chat components re-export its
+    // message-scroller, pulling it into frontend test module graphs via the quill barrel.
+    '@shadcn/react',
     '@react-hook',
     '@medv',
     'monaco-editor',

--- a/packages/quill/packages/primitives/package.json
+++ b/packages/quill/packages/primitives/package.json
@@ -35,6 +35,7 @@
     "dependencies": {
         "@base-ui/react": "catalog:",
         "@posthog/quill-tokens": "workspace:^",
+        "@shadcn/react": "^0.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.577.0",

--- a/packages/quill/packages/primitives/src/chat/chat-bubble.css
+++ b/packages/quill/packages/primitives/src/chat/chat-bubble.css
@@ -24,8 +24,11 @@
         align-self: flex-end;
     }
 
-    /* Inside an end-aligned message, the bubble hugs the end edge too. */
-    [data-slot='message'][data-align='end'] .quill-chat-bubble {
+    /*
+     * Inside an end-aligned message, a bubble inherits the end edge — but only when it hasn't set
+     * its own `align`. An explicit `data-align` on the bubble always wins over the message context.
+     */
+    [data-slot='message'][data-align='end'] .quill-chat-bubble:not([data-align]) {
         align-self: flex-end;
     }
 

--- a/packages/quill/packages/primitives/src/chat/chat-bubble.css
+++ b/packages/quill/packages/primitives/src/chat/chat-bubble.css
@@ -1,0 +1,124 @@
+@layer components {
+    /*
+     * Generic bubble surface. Deliberately neutral — consumers restyle per product. Variants set
+     * the fill on the inner content node; the outer bubble only owns layout + alignment.
+     */
+    .quill-chat-bubble-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        min-width: 0;
+    }
+
+    .quill-chat-bubble {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        width: fit-content;
+        min-width: 0;
+        max-width: 80%;
+    }
+
+    .quill-chat-bubble[data-align='end'] {
+        align-self: flex-end;
+    }
+
+    /* Inside an end-aligned message, the bubble hugs the end edge too. */
+    [data-slot='message'][data-align='end'] .quill-chat-bubble {
+        align-self: flex-end;
+    }
+
+    .quill-chat-bubble__content {
+        width: fit-content;
+        min-width: 0;
+        max-width: 100%;
+        padding-block: 0.375rem;
+        padding-inline: 0.625rem;
+        overflow: hidden;
+        font-size: var(--text-xs, 0.75rem);
+        line-height: 1.625;
+        overflow-wrap: break-word;
+        border: 1px solid transparent;
+        border-radius: 0.5rem;
+    }
+
+    /* Variants — fill lives on the content node. */
+    .quill-chat-bubble--variant-default .quill-chat-bubble__content {
+        color: var(--foreground);
+        background-color: var(--fill-hover);
+    }
+
+    .quill-chat-bubble--variant-secondary .quill-chat-bubble__content {
+        color: var(--foreground);
+        background-color: var(--muted);
+    }
+
+    .quill-chat-bubble--variant-muted .quill-chat-bubble__content {
+        color: var(--muted-foreground);
+        background-color: var(--muted);
+    }
+
+    .quill-chat-bubble--variant-tinted .quill-chat-bubble__content {
+        color: var(--foreground);
+        background-color: color-mix(in oklab, var(--foreground) 8%, transparent);
+    }
+
+    .quill-chat-bubble--variant-outline .quill-chat-bubble__content {
+        color: var(--foreground);
+        background-color: transparent;
+        border-color: var(--border);
+    }
+
+    .quill-chat-bubble--variant-destructive .quill-chat-bubble__content {
+        color: var(--destructive-foreground);
+        background-color: color-mix(in oklab, var(--destructive) 12%, transparent);
+    }
+
+    /* Ghost = no chrome, full width. Used for assistant prose. */
+    .quill-chat-bubble--variant-ghost {
+        max-width: 100%;
+    }
+
+    .quill-chat-bubble--variant-ghost .quill-chat-bubble__content {
+        padding: 0;
+        background-color: transparent;
+        border-color: transparent;
+        border-radius: 0;
+    }
+
+    .quill-chat-bubble-reactions {
+        position: absolute;
+        z-index: 10;
+        display: flex;
+        flex-shrink: 0;
+        gap: 0.25rem;
+        align-items: center;
+        justify-content: center;
+        width: fit-content;
+        padding-block: 0.125rem;
+        padding-inline: 0.375rem;
+        font-size: var(--text-xs, 0.75rem);
+        background-color: var(--muted);
+        border-radius: 9999px;
+        box-shadow: 0 0 0 2px var(--background);
+    }
+
+    .quill-chat-bubble-reactions[data-side='top'] {
+        top: 0;
+        transform: translateY(-75%);
+    }
+
+    .quill-chat-bubble-reactions[data-side='bottom'] {
+        bottom: 0;
+        transform: translateY(75%);
+    }
+
+    .quill-chat-bubble-reactions[data-align='start'] {
+        left: 0.75rem;
+    }
+
+    .quill-chat-bubble-reactions[data-align='end'] {
+        right: 0.75rem;
+    }
+}

--- a/packages/quill/packages/primitives/src/chat/chat-bubble.stories.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-bubble.stories.tsx
@@ -1,0 +1,76 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { ChatBubble, ChatBubbleContent, ChatBubbleGroup, ChatBubbleReactions } from './chat-bubble'
+
+const meta = {
+    title: 'Primitives/Chat/ChatBubble',
+    component: ChatBubble,
+    tags: ['autodocs'],
+    argTypes: {
+        variant: {
+            control: 'select',
+            options: ['default', 'secondary', 'muted', 'tinted', 'outline', 'ghost', 'destructive'],
+        },
+        align: { control: 'inline-radio', options: ['start', 'end'] },
+    },
+} satisfies Meta<typeof ChatBubble>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+const VARIANTS = [
+    { variant: 'default', description: 'A strong primary bubble, usually for the current user.' },
+    { variant: 'secondary', description: 'The standard neutral bubble for conversation content.' },
+    { variant: 'muted', description: 'A lower-emphasis bubble for quiet supporting content.' },
+    { variant: 'tinted', description: 'A subtle primary-tinted bubble.' },
+    { variant: 'outline', description: 'A bordered bubble for secondary or rich content.' },
+    { variant: 'ghost', description: 'Unframed content for assistant text or rich content.' },
+    { variant: 'destructive', description: 'A destructive bubble for error or failed actions.' },
+] as const
+
+/** Every variant. Fills are generic/neutral — restyle per product in `chat-bubble.css`. */
+export const Variants = {
+    render: () => (
+        <div className="flex w-[420px] flex-col gap-3">
+            {VARIANTS.map(({ variant, description }) => (
+                <ChatBubble key={variant} variant={variant}>
+                    <ChatBubbleContent>{description}</ChatBubbleContent>
+                </ChatBubble>
+            ))}
+        </div>
+    ),
+} satisfies Story
+
+/** start vs end alignment, as used for assistant (start) vs user (end). */
+export const Alignment = {
+    render: () => (
+        <div className="flex w-[420px] flex-col gap-3">
+            <ChatBubble align="start" variant="muted">
+                <ChatBubbleContent>Assistant, start-aligned.</ChatBubbleContent>
+            </ChatBubble>
+            <ChatBubble align="end" variant="default">
+                <ChatBubbleContent>User, end-aligned.</ChatBubbleContent>
+            </ChatBubble>
+        </div>
+    ),
+} satisfies Story
+
+/** Consecutive bubbles in a group, with a reaction overlay. */
+export const GroupWithReactions = {
+    render: () => (
+        <div className="w-[420px]">
+            <ChatBubbleGroup>
+                <ChatBubble variant="muted">
+                    <ChatBubbleContent>First message in the group.</ChatBubbleContent>
+                </ChatBubble>
+                <ChatBubble variant="muted">
+                    <ChatBubbleContent>Second message — reactions sit on the surface.</ChatBubbleContent>
+                    <ChatBubbleReactions>
+                        <span>👍</span>
+                        <span>🎉</span>
+                    </ChatBubbleReactions>
+                </ChatBubble>
+            </ChatBubbleGroup>
+        </div>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/chat/chat-bubble.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-bubble.tsx
@@ -1,0 +1,90 @@
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import * as React from 'react'
+
+import './chat-bubble.css'
+import { cn } from '../lib/utils'
+
+/**
+ * Bubble surface primitives, vendored from the shadcn `base-mira` registry and renamed `ChatX`.
+ * Scoped to the bubble surface only — avatar/name/timestamps/actions live on {@link ./chat-message}.
+ *
+ * Styling lives in `chat-bubble.css` (quill convention). Variants are intentionally generic;
+ * restyle per product. Assistant turns use `variant="ghost"` (transparent, full-width); user turns
+ * use a filled variant.
+ */
+function ChatBubbleGroup({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-quill data-slot="bubble-group" className={cn('quill-chat-bubble-group', className)} {...props} />
+}
+
+const bubbleVariants = cva('quill-chat-bubble', {
+    variants: {
+        variant: {
+            default: 'quill-chat-bubble--variant-default',
+            secondary: 'quill-chat-bubble--variant-secondary',
+            muted: 'quill-chat-bubble--variant-muted',
+            tinted: 'quill-chat-bubble--variant-tinted',
+            outline: 'quill-chat-bubble--variant-outline',
+            ghost: 'quill-chat-bubble--variant-ghost',
+            destructive: 'quill-chat-bubble--variant-destructive',
+        },
+    },
+    defaultVariants: {
+        variant: 'default',
+    },
+})
+
+function ChatBubble({
+    variant = 'default',
+    align = 'start',
+    className,
+    ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof bubbleVariants> & { align?: 'start' | 'end' }): React.ReactElement {
+    return (
+        <div
+            data-quill
+            data-slot="bubble"
+            data-variant={variant}
+            data-align={align}
+            className={cn(bubbleVariants({ variant }), className)}
+            {...props}
+        />
+    )
+}
+
+function ChatBubbleContent({ className, render, ...props }: useRender.ComponentProps<'div'>): React.ReactElement {
+    return useRender({
+        defaultTagName: 'div',
+        props: mergeProps<'div'>(
+            {
+                'data-slot': 'bubble-content',
+                className: cn('quill-chat-bubble__content', className),
+            } as Omit<React.ComponentProps<'div'>, 'ref'>,
+            props
+        ),
+        render,
+        state: {
+            slot: 'bubble-content',
+        },
+    })
+}
+
+function ChatBubbleReactions({
+    side = 'bottom',
+    align = 'end',
+    className,
+    ...props
+}: React.ComponentProps<'div'> & { align?: 'start' | 'end'; side?: 'top' | 'bottom' }): React.ReactElement {
+    return (
+        <div
+            data-slot="bubble-reactions"
+            data-align={align}
+            data-side={side}
+            className={cn('quill-chat-bubble-reactions', className)}
+            {...props}
+        />
+    )
+}
+
+export { ChatBubbleGroup, ChatBubble, ChatBubbleContent, ChatBubbleReactions, bubbleVariants }

--- a/packages/quill/packages/primitives/src/chat/chat-marker.css
+++ b/packages/quill/packages/primitives/src/chat/chat-marker.css
@@ -1,0 +1,152 @@
+@layer components {
+    /*
+     * Inline status / system-note / separator row, plus the quill collapsible extension.
+     *
+     * `quill-chat-marker` is the block. A flat marker is that block, rendered as a horizontal row.
+     * A collapsible marker is the block + `--collapsible`, which flips it to a column wrapper that
+     * stacks `__trigger` (a row sharing the block's appearance) above `__panel` — mirroring how
+     * `quill-accordion` nests `__trigger` + `__panel` under its block.
+     */
+    .quill-chat-marker,
+    .quill-chat-marker__trigger {
+        position: relative;
+        display: flex;
+        gap: 0.5rem;
+        align-items: center;
+        width: 100%;
+        min-height: 1rem;
+        font-size: var(--text-xs, 0.75rem);
+        line-height: 1.625;
+        color: var(--muted-foreground);
+        text-align: left;
+    }
+
+    /* Collapsible form: the block becomes the column wrapper; the trigger is the row. */
+    .quill-chat-marker--collapsible {
+        flex-direction: column;
+        gap: 0;
+        align-items: stretch;
+    }
+
+    .quill-chat-marker svg:not([class*='size-']) {
+        width: 0.875rem;
+        height: 0.875rem;
+    }
+
+    .quill-chat-marker a {
+        text-decoration: underline;
+        text-underline-offset: 3px;
+    }
+
+    .quill-chat-marker a:hover {
+        color: var(--foreground);
+    }
+
+    /* variant: border */
+    .quill-chat-marker--border {
+        padding-bottom: 0.5rem;
+        border-bottom: 1px solid var(--border);
+    }
+
+    /* variant: separator — centered label between two rules */
+    .quill-chat-marker--separator::before,
+    .quill-chat-marker--separator::after {
+        flex: 1;
+        min-width: 0;
+        height: 1px;
+        content: '';
+        background-color: var(--border);
+    }
+
+    .quill-chat-marker--separator::before {
+        margin-right: 0.25rem;
+    }
+
+    .quill-chat-marker--separator::after {
+        margin-left: 0.25rem;
+    }
+
+    .quill-chat-marker__icon {
+        flex-shrink: 0;
+        width: 0.875rem;
+        height: 0.875rem;
+    }
+
+    .quill-chat-marker__content {
+        min-width: 0;
+        overflow-wrap: break-word;
+    }
+
+    .quill-chat-marker--separator .quill-chat-marker__content {
+        flex: none;
+        text-align: center;
+    }
+
+    /* Collapsible extension */
+    .quill-chat-marker__trigger {
+        padding-inline: 0.25rem;
+        margin-inline: -0.25rem;
+        cursor: pointer;
+        border-radius: 0.375rem;
+    }
+
+    .quill-chat-marker__trigger:hover {
+        background-color: var(--fill-hover);
+    }
+
+    /* Keyboard focus needs a real ring, not just the hover fill (WCAG 2.4.7). */
+    .quill-chat-marker__trigger:focus-visible {
+        background-color: var(--fill-hover);
+        outline: none;
+        box-shadow: 0 0 0 2px color-mix(in oklab, var(--ring) 50%, transparent);
+    }
+
+    .quill-chat-marker__chevron {
+        flex-shrink: 0;
+        width: 0.875rem;
+        height: 0.875rem;
+        margin-inline-start: auto;
+        color: var(--muted-foreground);
+        opacity: 0;
+        transition:
+            opacity 150ms ease,
+            rotate 150ms ease;
+    }
+
+    .quill-chat-marker__trigger:hover .quill-chat-marker__chevron,
+    .quill-chat-marker__trigger[data-panel-open] .quill-chat-marker__chevron {
+        opacity: 1;
+    }
+
+    .quill-chat-marker__trigger[data-panel-open] .quill-chat-marker__chevron {
+        rotate: 90deg;
+    }
+
+    /* Collapsible panel: indent children + animate height. */
+    .quill-chat-marker__panel {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding-inline-start: 0.875rem;
+        margin-inline-start: 0.375rem;
+        overflow: hidden;
+        border-inline-start: 1px solid var(--border);
+        transition: height 150ms ease;
+    }
+
+    .quill-chat-marker__panel[data-starting-style],
+    .quill-chat-marker__panel[data-ending-style] {
+        height: 0;
+    }
+
+    .quill-chat-marker__panel[data-open] {
+        height: var(--collapsible-panel-height);
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .quill-chat-marker__chevron,
+        .quill-chat-marker__panel {
+            transition: none;
+        }
+    }
+}

--- a/packages/quill/packages/primitives/src/chat/chat-marker.stories.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-marker.stories.tsx
@@ -1,0 +1,111 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { CheckIcon, FileIcon, PencilIcon, SearchIcon, TerminalIcon } from 'lucide-react'
+
+import { ChatMarker, ChatMarkerContent, ChatMarkerIcon } from './chat-marker'
+import { Spinner } from '../spinner'
+
+const meta = {
+    title: 'Primitives/Chat/ChatMarker',
+    component: ChatMarker,
+    tags: ['autodocs'],
+} satisfies Meta<typeof ChatMarker>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** The three flat variants — no body, no collapse (stock shadcn Marker). */
+export const Variants = {
+    render: () => (
+        <div className="flex w-[420px] flex-col gap-4">
+            <ChatMarker>
+                <ChatMarkerIcon>
+                    <CheckIcon />
+                </ChatMarkerIcon>
+                <ChatMarkerContent>Explored 4 files</ChatMarkerContent>
+            </ChatMarker>
+            <ChatMarker variant="border">
+                <ChatMarkerIcon>
+                    <SearchIcon />
+                </ChatMarkerIcon>
+                <ChatMarkerContent>Searched the workspace</ChatMarkerContent>
+            </ChatMarker>
+            <ChatMarker variant="separator">
+                <ChatMarkerContent>Context compacted</ChatMarkerContent>
+            </ChatMarker>
+        </div>
+    ),
+} satisfies Story
+
+/** Live state: Spinner + shimmer text while a tool runs. */
+export const Live = {
+    render: () => (
+        <div className="w-[420px]">
+            <ChatMarker>
+                <ChatMarkerIcon>
+                    <Spinner />
+                </ChatMarkerIcon>
+                <ChatMarkerContent className="shimmer">Editing components/thread.tsx…</ChatMarkerContent>
+            </ChatMarker>
+        </div>
+    ),
+} satisfies Story
+
+/**
+ * Collapsible: pass `body` and the row gains a hover chevron + `bg-fill-hover`; click toggles.
+ * This is the tool-group summary → per-tool children pattern. `defaultOpen` is the app's
+ * grouping-mode decision (compact → false).
+ */
+export const Collapsible = {
+    render: () => (
+        <div className="flex w-[420px] flex-col gap-4">
+            <ChatMarker
+                defaultOpen={false}
+                body={
+                    <>
+                        <ChatMarker>
+                            <ChatMarkerIcon>
+                                <FileIcon />
+                            </ChatMarkerIcon>
+                            <ChatMarkerContent>Read store.ts</ChatMarkerContent>
+                        </ChatMarker>
+                        <ChatMarker>
+                            <ChatMarkerIcon>
+                                <FileIcon />
+                            </ChatMarkerIcon>
+                            <ChatMarkerContent>Read view.tsx</ChatMarkerContent>
+                        </ChatMarker>
+                        <ChatMarker>
+                            <ChatMarkerIcon>
+                                <PencilIcon />
+                            </ChatMarkerIcon>
+                            <ChatMarkerContent>Edited view.tsx</ChatMarkerContent>
+                        </ChatMarker>
+                    </>
+                }
+            >
+                <ChatMarkerIcon>
+                    <CheckIcon />
+                </ChatMarkerIcon>
+                <ChatMarkerContent>Read 2 files · Edited 1 file</ChatMarkerContent>
+            </ChatMarker>
+
+            <ChatMarker
+                defaultOpen
+                body={
+                    <ChatMarker>
+                        <ChatMarkerIcon>
+                            <TerminalIcon />
+                        </ChatMarkerIcon>
+                        <ChatMarkerContent>pnpm build — exit 0</ChatMarkerContent>
+                    </ChatMarker>
+                }
+            >
+                <ChatMarkerIcon>
+                    <TerminalIcon />
+                </ChatMarkerIcon>
+                <ChatMarkerContent>Ran 1 command (expanded by default)</ChatMarkerContent>
+            </ChatMarker>
+        </div>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/chat/chat-marker.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-marker.tsx
@@ -1,0 +1,122 @@
+import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible'
+import { mergeProps } from '@base-ui/react/merge-props'
+import { useRender } from '@base-ui/react/use-render'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { ChevronRightIcon } from 'lucide-react'
+import * as React from 'react'
+
+import './chat-marker.css'
+import { cn } from '../lib/utils'
+
+/**
+ * Inline status / system-note / separator row — vendored from the shadcn `base-mira` registry
+ * and renamed `ChatX`. Styling lives in `chat-marker.css` (quill convention).
+ *
+ * Quill divergence from stock shadcn Marker: pass `body` to make it collapsible. With a body the
+ * row becomes a Base-UI Collapsible trigger (hover reveals a chevron + `bg-fill-hover`, click
+ * toggles, the body renders below). Without a body it's the flat shadcn marker. This is how a
+ * single tool, a tool-group summary, and a status note are all the same primitive at different
+ * fill levels. Collapse state is uncontrolled via `defaultOpen`; `open`/`onOpenChange` are there
+ * for the rare case the app drives it (e.g. auto-expand the running tool).
+ */
+const markerVariants = cva('quill-chat-marker', {
+    variants: {
+        variant: {
+            default: '',
+            separator: 'quill-chat-marker--separator',
+            border: 'quill-chat-marker--border',
+        },
+    },
+    defaultVariants: {
+        variant: 'default',
+    },
+})
+
+type ChatMarkerProps = useRender.ComponentProps<'div'> &
+    VariantProps<typeof markerVariants> & {
+        /** Renders the marker as a collapsible: this becomes the expandable panel below the row. */
+        body?: React.ReactNode
+        /** Uncontrolled initial open state (only meaningful with `body`). */
+        defaultOpen?: boolean
+        open?: boolean
+        onOpenChange?: (open: boolean) => void
+    }
+
+function ChatMarker({ body, ...props }: ChatMarkerProps): React.ReactElement {
+    return body == null ? <ChatMarkerFlat {...props} /> : <ChatMarkerCollapsible body={body} {...props} />
+}
+
+function ChatMarkerFlat({
+    className,
+    variant = 'default',
+    render,
+    // `body`/collapse props are accepted by ChatMarker but inert in the flat path.
+    defaultOpen: _defaultOpen,
+    open: _open,
+    onOpenChange: _onOpenChange,
+    ...props
+}: ChatMarkerProps): React.ReactElement {
+    return useRender({
+        defaultTagName: 'div',
+        props: mergeProps<'div'>(
+            {
+                'data-quill': '',
+                'data-slot': 'marker',
+                'data-variant': variant,
+                className: cn(markerVariants({ variant, className })),
+            } as Omit<React.ComponentProps<'div'>, 'ref'>,
+            props
+        ),
+        render,
+        state: {
+            slot: 'marker',
+            variant,
+        },
+    })
+}
+
+function ChatMarkerCollapsible({
+    className,
+    variant = 'default',
+    body,
+    defaultOpen,
+    open,
+    onOpenChange,
+    children,
+    render,
+    ...props
+}: ChatMarkerProps): React.ReactElement {
+    return (
+        <CollapsiblePrimitive.Root
+            data-quill
+            data-slot="marker"
+            data-variant={variant}
+            defaultOpen={defaultOpen}
+            open={open}
+            onOpenChange={onOpenChange}
+            className={cn(markerVariants({ variant }), 'quill-chat-marker--collapsible')}
+        >
+            <CollapsiblePrimitive.Trigger
+                className={cn('quill-chat-marker__trigger', className)}
+                render={render}
+                {...(props as React.ComponentProps<typeof CollapsiblePrimitive.Trigger>)}
+            >
+                {children}
+                <ChevronRightIcon aria-hidden="true" className="quill-chat-marker__chevron" />
+            </CollapsiblePrimitive.Trigger>
+            <CollapsiblePrimitive.Panel data-slot="marker-panel" className="quill-chat-marker__panel">
+                {body}
+            </CollapsiblePrimitive.Panel>
+        </CollapsiblePrimitive.Root>
+    )
+}
+
+function ChatMarkerIcon({ className, ...props }: React.ComponentProps<'span'>): React.ReactElement {
+    return <span data-slot="marker-icon" aria-hidden="true" className={cn('quill-chat-marker__icon', className)} {...props} />
+}
+
+function ChatMarkerContent({ className, ...props }: React.ComponentProps<'span'>): React.ReactElement {
+    return <span data-slot="marker-content" className={cn('quill-chat-marker__content', className)} {...props} />
+}
+
+export { ChatMarker, ChatMarkerIcon, ChatMarkerContent, markerVariants }

--- a/packages/quill/packages/primitives/src/chat/chat-message-scroller.css
+++ b/packages/quill/packages/primitives/src/chat/chat-message-scroller.css
@@ -1,0 +1,105 @@
+@layer components {
+    /*
+     * The scroll engine lives in @shadcn/react/message-scroller; this file owns the layout and the
+     * scroll-to-edge button styling. The engine sets data attributes (data-autoscrolling on the
+     * viewport, data-active on the button) — styling keys off those, no React state.
+     */
+    .quill-chat-message-scroller {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        width: 100%;
+        height: 100%;
+        min-height: 0;
+        overflow: hidden;
+    }
+
+    .quill-chat-message-scroller__viewport {
+        width: 100%;
+        min-width: 0;
+        height: 100%;
+        min-height: 0;
+        overflow-y: auto;
+        overscroll-behavior: contain;
+        scrollbar-gutter: stable;
+        contain: content;
+    }
+
+    /*
+     * NOTE: we intentionally do NOT hide the scrollbar on [data-autoscrolling]. The engine sets that
+     * flag on every stick-to-bottom scroll — including the re-scroll triggered by a content-height
+     * change while pinned (e.g. expanding a collapsible) — so hiding the scrollbar there makes it
+     * flicker away on every such interaction, and with `scrollbar-gutter: stable` it can also shift
+     * content horizontally. A pinned scrollbar doesn't visibly jitter, so keep it stable.
+     */
+
+    .quill-chat-message-scroller__content {
+        display: flex;
+        flex-direction: column;
+        gap: 1rem;
+        height: max-content;
+        min-height: 100%;
+    }
+
+    /* Row spacing via the `density` prop (data-density on the content slot). */
+    .quill-chat-message-scroller__content[data-density='dense'] {
+        gap: 0.5rem;
+    }
+
+    .quill-chat-message-scroller__content[data-density='loose'] {
+        gap: 1.5rem;
+    }
+
+    /*
+     * Non-virtualized: every row stays in the DOM. content-visibility skips layout/paint for
+     * off-screen rows; contain-intrinsic-size is the off-screen size estimate — tune per row type
+     * if scroll drift shows on long threads.
+     */
+    .quill-chat-message-scroller__item {
+        flex-shrink: 0;
+        min-width: 0;
+        content-visibility: auto;
+        contain-intrinsic-size: auto 10rem;
+    }
+
+    .quill-chat-message-scroller__button {
+        position: absolute;
+        bottom: 1rem;
+        left: 50%;
+        z-index: 10;
+        border-radius: 9999px;
+        box-shadow: var(--shadow-md, 0 4px 6px -1px rgb(0 0 0 / 10%));
+        transition:
+            translate 200ms ease,
+            scale 200ms ease,
+            opacity 200ms ease;
+        translate: -50% 0;
+    }
+
+    .quill-chat-message-scroller__button[data-direction='start'] {
+        top: 1rem;
+        bottom: auto;
+    }
+
+    .quill-chat-message-scroller__button[data-direction='start'] svg {
+        rotate: 180deg;
+    }
+
+    .quill-chat-message-scroller__button[data-active='false'] {
+        pointer-events: none;
+        opacity: 0;
+        scale: 0.95;
+    }
+
+    .quill-chat-message-scroller__button[data-active='true'] {
+        opacity: 1;
+        scale: 1;
+        translate: -50% 0;
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+        .quill-chat-message-scroller__button {
+            transition: none;
+        }
+    }
+}

--- a/packages/quill/packages/primitives/src/chat/chat-message-scroller.stories.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-message-scroller.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from '@storybook/react'
+
+import { CheckIcon, FileIcon, TerminalIcon } from 'lucide-react'
+import * as React from 'react'
+
+import { ChatBubble, ChatBubbleContent } from './chat-bubble'
+import { ChatMarker, ChatMarkerContent, ChatMarkerIcon } from './chat-marker'
+import { ChatMessage, ChatMessageContent } from './chat-message'
+import {
+    ChatMessageScroller,
+    ChatMessageScrollerButton,
+    ChatMessageScrollerContent,
+    ChatMessageScrollerItem,
+    ChatMessageScrollerProvider,
+    ChatMessageScrollerViewport,
+} from './chat-message-scroller'
+import { Spinner } from '../spinner'
+
+const meta = {
+    title: 'Primitives/Chat/ChatMessageScroller',
+    component: ChatMessageScroller,
+    tags: ['autodocs'],
+    parameters: { layout: 'fullscreen' },
+} satisfies Meta<typeof ChatMessageScroller>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+/** A single user→assistant exchange, anchored on the user message. */
+function Turn({ index, withTools = false }: { index: number; withTools?: boolean }): React.ReactElement {
+    return (
+        <>
+            <ChatMessageScrollerItem messageId={`u-${index}`} scrollAnchor>
+                <ChatMessage align="end">
+                    <ChatMessageContent>
+                        <ChatBubble variant="muted" align="end">
+                            <ChatBubbleContent>Turn {index}: can you check the file and run the build?</ChatBubbleContent>
+                        </ChatBubble>
+                    </ChatMessageContent>
+                </ChatMessage>
+            </ChatMessageScrollerItem>
+
+            <ChatMessageScrollerItem messageId={`a-${index}`}>
+                <ChatMessage align="start">
+                    <ChatMessageContent>
+                        <ChatBubble variant="ghost">
+                            <ChatBubbleContent>
+                                Sure — here's what I found. The config looked fine, so I ran the build and it passed.
+                            </ChatBubbleContent>
+                        </ChatBubble>
+                        {withTools && (
+                            <ChatMarker
+                                defaultOpen={false}
+                                body={
+                                    <>
+                                        <ChatMarker>
+                                            <ChatMarkerIcon>
+                                                <FileIcon />
+                                            </ChatMarkerIcon>
+                                            <ChatMarkerContent>Read vite.config.ts</ChatMarkerContent>
+                                        </ChatMarker>
+                                        <ChatMarker>
+                                            <ChatMarkerIcon>
+                                                <TerminalIcon />
+                                            </ChatMarkerIcon>
+                                            <ChatMarkerContent>Ran pnpm build</ChatMarkerContent>
+                                        </ChatMarker>
+                                    </>
+                                }
+                            >
+                                <ChatMarkerIcon>
+                                    <CheckIcon />
+                                </ChatMarkerIcon>
+                                <ChatMarkerContent>Read 1 file · Ran 1 command</ChatMarkerContent>
+                            </ChatMarker>
+                        )}
+                    </ChatMessageContent>
+                </ChatMessage>
+            </ChatMessageScrollerItem>
+        </>
+    )
+}
+
+function Frame({ children }: { children: React.ReactNode }): React.ReactElement {
+    return (
+        <div className="mx-auto h-[600px] w-full max-w-[680px] p-4">
+            <ChatMessageScrollerProvider autoScroll defaultScrollPosition="end" scrollPreviousItemPeek={64}>
+                <ChatMessageScroller>
+                    <ChatMessageScrollerViewport>
+                        <ChatMessageScrollerContent className="px-2 py-4">{children}</ChatMessageScrollerContent>
+                    </ChatMessageScrollerViewport>
+                    <ChatMessageScrollerButton />
+                </ChatMessageScroller>
+            </ChatMessageScrollerProvider>
+        </div>
+    )
+}
+
+/** The full thread composition: messages, ghost/filled bubbles, and a collapsible tool-group marker. */
+export const Default = {
+    render: () => (
+        <Frame>
+            {Array.from({ length: 8 }, (_, i) => (
+                <Turn key={i} index={i + 1} withTools={i % 2 === 0} />
+            ))}
+            <ChatMessageScrollerItem messageId="a-live">
+                <ChatMessage align="start">
+                    <ChatMessageContent>
+                        <ChatMarker>
+                            <ChatMarkerIcon>
+                                <Spinner />
+                            </ChatMarkerIcon>
+                            <ChatMarkerContent className="shimmer">Reading large-file.ts…</ChatMarkerContent>
+                        </ChatMarker>
+                    </ChatMessageContent>
+                </ChatMessage>
+            </ChatMessageScrollerItem>
+        </Frame>
+    ),
+} satisfies Story
+
+/**
+ * Stress: 1000 turns, non-virtualized. Proves the `content-visibility: auto` thesis — every row
+ * is in the DOM, but off-screen rows skip layout/paint. Scroll should stay smooth.
+ */
+export const Stress1000Turns = {
+    name: 'Stress · 1000 turns',
+    render: () => (
+        <Frame>
+            {Array.from({ length: 1000 }, (_, i) => (
+                <Turn key={i} index={i + 1} withTools={i % 3 === 0} />
+            ))}
+        </Frame>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/chat/chat-message-scroller.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-message-scroller.tsx
@@ -1,0 +1,134 @@
+import {
+    MessageScroller as MessageScrollerPrimitive,
+    useMessageScroller,
+    useMessageScrollerScrollable,
+    useMessageScrollerVisibility,
+} from '@shadcn/react/message-scroller'
+import { ArrowDownIcon } from 'lucide-react'
+import * as React from 'react'
+
+import './chat-message-scroller.css'
+import { Button } from '../button'
+import { cn } from '../lib/utils'
+
+/**
+ * Thin quill wrapper over the headless `@shadcn/react/message-scroller` engine.
+ *
+ * Non-virtualized by design: rows stay in the DOM, kept cheap via `content-visibility: auto` +
+ * `contain-intrinsic-size` (see {@link ChatMessageScrollerItem}). Stick-to-bottom, anchoring, and
+ * preserve-on-prepend are imperative inside the engine and surfaced through `data-*` attributes —
+ * no React state on scroll. Styling lives in `chat-message-scroller.css` (quill convention).
+ */
+function ChatMessageScrollerProvider(
+    props: React.ComponentProps<typeof MessageScrollerPrimitive.Provider>
+): React.ReactElement {
+    return <MessageScrollerPrimitive.Provider {...props} />
+}
+
+function ChatMessageScroller({
+    className,
+    ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Root>): React.ReactElement {
+    return (
+        <MessageScrollerPrimitive.Root
+            data-quill
+            data-slot="chat-message-scroller"
+            className={cn('quill-chat-message-scroller group/chat-message-scroller', className)}
+            {...props}
+        />
+    )
+}
+
+function ChatMessageScrollerViewport({
+    className,
+    ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Viewport>): React.ReactElement {
+    return (
+        <MessageScrollerPrimitive.Viewport
+            data-slot="chat-message-scroller-viewport"
+            className={cn('quill-chat-message-scroller__viewport', className)}
+            {...props}
+        />
+    )
+}
+
+type ChatMessageScrollerContentProps = React.ComponentProps<typeof MessageScrollerPrimitive.Content> & {
+    /** Row spacing: `dense` 0.5rem, `default` 1rem, `loose` 1.5rem. */
+    density?: 'dense' | 'default' | 'loose'
+}
+
+function ChatMessageScrollerContent({
+    className,
+    density = 'default',
+    ...props
+}: ChatMessageScrollerContentProps): React.ReactElement {
+    return (
+        <MessageScrollerPrimitive.Content
+            data-slot="chat-message-scroller-content"
+            data-density={density}
+            className={cn('quill-chat-message-scroller__content', className)}
+            {...props}
+        />
+    )
+}
+
+/**
+ * One transcript row. `scrollAnchor` marks turn boundaries (the engine pins anchored rows near the
+ * viewport top on new turns). Off-screen size estimate is tuned in `chat-message-scroller.css`.
+ */
+function ChatMessageScrollerItem({
+    className,
+    scrollAnchor = false,
+    ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Item>): React.ReactElement {
+    return (
+        <MessageScrollerPrimitive.Item
+            data-slot="chat-message-scroller-item"
+            scrollAnchor={scrollAnchor}
+            className={cn('quill-chat-message-scroller__item', className)}
+            {...props}
+        />
+    )
+}
+
+/**
+ * Scroll-to-edge control. The engine toggles `data-active` from imperative scroll tracking;
+ * visibility/animation is pure CSS off that attribute.
+ */
+function ChatMessageScrollerButton({
+    direction = 'end',
+    className,
+    children,
+    render,
+    ...props
+}: React.ComponentProps<typeof MessageScrollerPrimitive.Button>): React.ReactElement {
+    return (
+        <MessageScrollerPrimitive.Button
+            data-slot="chat-message-scroller-button"
+            data-direction={direction}
+            direction={direction}
+            className={cn('quill-chat-message-scroller__button', className)}
+            render={render ?? <Button variant="outline" size="icon" />}
+            {...props}
+        >
+            {children ?? (
+                <>
+                    <ArrowDownIcon className="size-4" />
+                    <span className="sr-only">{direction === 'end' ? 'Scroll to end' : 'Scroll to start'}</span>
+                </>
+            )}
+        </MessageScrollerPrimitive.Button>
+    )
+}
+
+export {
+    ChatMessageScrollerProvider,
+    ChatMessageScroller,
+    ChatMessageScrollerViewport,
+    ChatMessageScrollerContent,
+    ChatMessageScrollerItem,
+    ChatMessageScrollerButton,
+    useMessageScroller as useChatMessageScroller,
+    useMessageScrollerScrollable as useChatMessageScrollerScrollable,
+    useMessageScrollerVisibility as useChatMessageScrollerVisibility,
+}

--- a/packages/quill/packages/primitives/src/chat/chat-message.css
+++ b/packages/quill/packages/primitives/src/chat/chat-message.css
@@ -1,0 +1,76 @@
+@layer components {
+    /* Message row layout. Alignment is driven by the `data-align` attribute on the row. */
+    .quill-chat-message-group {
+        display: flex;
+        flex-direction: column;
+        gap: 0.375rem;
+        min-width: 0;
+    }
+
+    .quill-chat-message {
+        position: relative;
+        display: flex;
+        gap: 0.375rem;
+        width: 100%;
+        min-width: 0;
+        font-size: var(--text-xs, 0.75rem);
+        line-height: 1.625;
+    }
+
+    .quill-chat-message[data-align='end'] {
+        flex-direction: row-reverse;
+    }
+
+    .quill-chat-message__avatar {
+        display: flex;
+        flex-shrink: 0;
+        align-items: center;
+        align-self: flex-end;
+        justify-content: center;
+        width: fit-content;
+        min-width: 2rem;
+        overflow: hidden;
+        background-color: var(--muted);
+        border-radius: 9999px;
+    }
+
+    /* Lift the avatar to clear a footer row when present. */
+    .quill-chat-message:has([data-slot='message-footer']) .quill-chat-message__avatar {
+        transform: translateY(-2rem);
+    }
+
+    .quill-chat-message__content {
+        display: flex;
+        flex-direction: column;
+        gap: 0.5rem;
+        width: 100%;
+        min-width: 0;
+        overflow-wrap: break-word;
+    }
+
+    .quill-chat-message[data-align='end'] .quill-chat-message__content > [data-slot] {
+        align-self: flex-end;
+    }
+
+    .quill-chat-message__header,
+    .quill-chat-message__footer {
+        display: flex;
+        align-items: center;
+        min-width: 0;
+        max-width: 100%;
+        padding-inline: 0.625rem;
+        font-size: 0.625rem;
+        font-weight: 500;
+        color: var(--muted-foreground);
+    }
+
+    .quill-chat-message[data-align='end'] .quill-chat-message__footer {
+        justify-content: flex-end;
+    }
+
+    /* Ghost bubbles carry no horizontal chrome, so meta rows sit flush. */
+    .quill-chat-message:has([data-variant='ghost']) .quill-chat-message__header,
+    .quill-chat-message:has([data-variant='ghost']) .quill-chat-message__footer {
+        padding-inline: 0;
+    }
+}

--- a/packages/quill/packages/primitives/src/chat/chat-message.stories.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-message.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import * as React from 'react'
+
+import { ChatBubble, ChatBubbleContent } from './chat-bubble'
+import {
+    ChatMessage,
+    ChatMessageAvatar,
+    ChatMessageContent,
+    ChatMessageFooter,
+    ChatMessageGroup,
+    ChatMessageHeader,
+} from './chat-message'
+
+const meta = {
+    title: 'Primitives/Chat/ChatMessage',
+    component: ChatMessage,
+    tags: ['autodocs'],
+    argTypes: {
+        align: { control: 'inline-radio', options: ['start', 'end'] },
+    },
+} satisfies Meta<typeof ChatMessage>
+
+export default meta
+type Story = StoryObj<typeof meta>
+
+function Avatar({ children }: { children: string }): React.ReactElement {
+    return <div className="grid size-7 place-items-center text-[0.625rem] font-medium">{children}</div>
+}
+
+/** Assistant (start, ghost bubble, no avatar) vs user (end, filled bubble). */
+export const Conversation = {
+    render: () => (
+        <div className="flex w-[480px] flex-col gap-6">
+            <ChatMessage align="start">
+                <ChatMessageContent>
+                    <ChatBubble variant="ghost">
+                        <ChatBubbleContent>
+                            Sure — I checked the config and ran the build. Everything passed.
+                        </ChatBubbleContent>
+                    </ChatBubble>
+                </ChatMessageContent>
+            </ChatMessage>
+
+            <ChatMessage align="end">
+                <ChatMessageContent>
+                    <ChatBubble align="end" variant="default">
+                        <ChatBubbleContent>Thanks! Can you also run the tests?</ChatBubbleContent>
+                    </ChatBubble>
+                </ChatMessageContent>
+            </ChatMessage>
+        </div>
+    ),
+} satisfies Story
+
+/** With optional avatar, header (name), and footer (timestamp/actions). */
+export const WithAvatarHeaderFooter = {
+    render: () => (
+        <div className="w-[480px]">
+            <ChatMessage align="start">
+                <ChatMessageAvatar>
+                    <Avatar>AI</Avatar>
+                </ChatMessageAvatar>
+                <ChatMessageContent>
+                    <ChatMessageHeader>Assistant</ChatMessageHeader>
+                    <ChatBubble variant="muted">
+                        <ChatBubbleContent>Avatar anchors to the bottom of the message.</ChatBubbleContent>
+                    </ChatBubble>
+                    <ChatMessageFooter>just now</ChatMessageFooter>
+                </ChatMessageContent>
+            </ChatMessage>
+        </div>
+    ),
+} satisfies Story
+
+/** Consecutive messages from the same author collapse spacing via MessageGroup. */
+export const Group = {
+    render: () => (
+        <div className="w-[480px]">
+            <ChatMessageGroup>
+                <ChatMessage align="end">
+                    <ChatMessageContent>
+                        <ChatBubble align="end">
+                            <ChatBubbleContent>One.</ChatBubbleContent>
+                        </ChatBubble>
+                    </ChatMessageContent>
+                </ChatMessage>
+                <ChatMessage align="end">
+                    <ChatMessageContent>
+                        <ChatBubble align="end">
+                            <ChatBubbleContent>Two, tighter spacing.</ChatBubbleContent>
+                        </ChatBubble>
+                    </ChatMessageContent>
+                </ChatMessage>
+            </ChatMessageGroup>
+        </div>
+    ),
+} satisfies Story

--- a/packages/quill/packages/primitives/src/chat/chat-message.tsx
+++ b/packages/quill/packages/primitives/src/chat/chat-message.tsx
@@ -1,0 +1,56 @@
+import * as React from 'react'
+
+import './chat-message.css'
+import { cn } from '../lib/utils'
+
+/**
+ * Message row primitives, vendored from the shadcn `base-mira` registry and renamed `ChatX`.
+ * Styling lives in `chat-message.css` (quill convention); `data-slot`/`data-align` attributes drive
+ * the selectors. Avatar is optional.
+ *
+ * Anatomy:  ChatMessage > [ChatMessageAvatar] + ChatMessageContent > [Header] + Bubble + [Footer]
+ */
+function ChatMessageGroup({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-quill data-slot="message-group" className={cn('quill-chat-message-group', className)} {...props} />
+}
+
+function ChatMessage({
+    className,
+    align = 'start',
+    ...props
+}: React.ComponentProps<'div'> & { align?: 'start' | 'end' }): React.ReactElement {
+    return (
+        <div
+            data-quill
+            data-slot="message"
+            data-align={align}
+            className={cn('quill-chat-message', className)}
+            {...props}
+        />
+    )
+}
+
+function ChatMessageAvatar({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-slot="message-avatar" className={cn('quill-chat-message__avatar', className)} {...props} />
+}
+
+function ChatMessageContent({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-slot="message-content" className={cn('quill-chat-message__content', className)} {...props} />
+}
+
+function ChatMessageHeader({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-slot="message-header" className={cn('quill-chat-message__header', className)} {...props} />
+}
+
+function ChatMessageFooter({ className, ...props }: React.ComponentProps<'div'>): React.ReactElement {
+    return <div data-slot="message-footer" className={cn('quill-chat-message__footer', className)} {...props} />
+}
+
+export {
+    ChatMessageGroup,
+    ChatMessage,
+    ChatMessageAvatar,
+    ChatMessageContent,
+    ChatMessageFooter,
+    ChatMessageHeader,
+}

--- a/packages/quill/packages/primitives/src/index.ts
+++ b/packages/quill/packages/primitives/src/index.ts
@@ -33,6 +33,27 @@ export {
 export { Avatar, AvatarImage, AvatarFallback, AvatarGroup } from './avatar'
 export { Badge, badgeVariants } from './badge'
 export { Button, buttonVariants, type ButtonProps } from './button'
+export { ChatBubbleGroup, ChatBubble, ChatBubbleContent, ChatBubbleReactions, bubbleVariants } from './chat/chat-bubble'
+export { ChatMarker, ChatMarkerIcon, ChatMarkerContent, markerVariants } from './chat/chat-marker'
+export {
+    ChatMessageGroup,
+    ChatMessage,
+    ChatMessageAvatar,
+    ChatMessageContent,
+    ChatMessageFooter,
+    ChatMessageHeader,
+} from './chat/chat-message'
+export {
+    ChatMessageScrollerProvider,
+    ChatMessageScroller,
+    ChatMessageScrollerViewport,
+    ChatMessageScrollerContent,
+    ChatMessageScrollerItem,
+    ChatMessageScrollerButton,
+    useChatMessageScroller,
+    useChatMessageScrollerScrollable,
+    useChatMessageScrollerVisibility,
+} from './chat/chat-message-scroller'
 export { ButtonGroup, ButtonGroupSeparator, ButtonGroupText, buttonGroupVariants } from './button-group'
 export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent } from './card'
 export { CardGroup } from './card-group'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -360,7 +360,7 @@ importers:
         version: 0.25.12
       jest:
         specifier: ^29.7.0
-        version: 29.7.0(@types/node@22.18.8)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+        version: 29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       puppeteer:
         specifier: 19.0.0
         version: 19.0.0(encoding@0.1.13)
@@ -481,7 +481,7 @@ importers:
         version: 5.5.3(webpack@5.105.4)
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       less-loader:
         specifier: ^7.0.2
         version: 7.3.0(less@4.2.2)(webpack@5.105.4)
@@ -1860,7 +1860,7 @@ importers:
         version: 3.6.0
       jest-image-snapshot:
         specifier: ^6.4.0
-        version: 6.4.0(jest@29.7.0(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
+        version: 6.4.0(jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)))
       storybook:
         specifier: 'catalog:'
         version: 10.4.6(@testing-library/dom@10.4.0)(@types/react@18.3.27)(prettier@3.8.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2044,6 +2044,9 @@ importers:
       '@posthog/quill-tokens':
         specifier: workspace:^
         version: link:../tokens
+      '@shadcn/react':
+        specifier: ^0.1.0
+        version: 0.1.0(@types/react@18.3.27)(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -2598,7 +2601,7 @@ importers:
         version: 8.57.0
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -3343,7 +3346,7 @@ importers:
         version: 2.1.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -4172,7 +4175,7 @@ importers:
         version: 1.2.1
       jest:
         specifier: '*'
-        version: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+        version: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       kea:
         specifier: 'catalog:'
         version: 4.0.0-pre.5(react@18.3.1)
@@ -10798,6 +10801,17 @@ packages:
   '@sentry/core@8.55.2':
     resolution: {integrity: sha512-YlEBwybUcOQ/KjMHDmof1vwweVnBtBxYlQp7DE3fOdtW4pqqdHWTnTntQs4VgYfxzjJYgtkd9LHlGtg8qy+JVQ==}
     engines: {node: '>=14.18'}
+
+  '@shadcn/react@0.1.0':
+    resolution: {integrity: sha512-6i67TEnqValsZY7e4exJ4rkHo2OdHXmDH152YulwSpuEUnTQYumHkXzFsaje7HB7GbMTWuI9x1Jn6sSduCYdeA==}
+    peerDependencies:
+      '@types/react': 18.3.27
+      react: 18.3.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   '@shikijs/engine-oniguruma@3.23.0':
     resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
@@ -22549,8 +22563,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  unlayer-types@1.436.0:
-    resolution: {integrity: sha512-c/Mo8MHhHrRC3r7QS6bh1uoCwDoG1vT0267ov66RGYpVPFGG1JXNcUKzsK3k1kt7PfJ5eXWqLyEn3Gs0w3IDfw==}
+  unlayer-types@1.437.0:
+    resolution: {integrity: sha512-CUYl/aS63Mtj31bCpyCzQdfhl3JxEm0TivaHHOjX4CBHCwHU8XC4F4Gi9/DibkJh8BjHX2ssk9tc/W1Rv8VsYg==}
 
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
@@ -27451,7 +27465,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27466,7 +27480,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -27487,7 +27501,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))':
+  '@jest/core@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))':
     dependencies:
       '@jest/console': 30.0.5
       '@jest/pattern': 30.0.1
@@ -27502,7 +27516,7 @@ snapshots:
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.0.5
-      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-haste-map: 30.0.5
       jest-message-util: 30.0.5
       jest-regex-util: 30.0.1
@@ -31260,6 +31274,11 @@ snapshots:
       '@sentry/core': 8.55.2
 
   '@sentry/core@8.55.2': {}
+
+  '@shadcn/react@0.1.0(@types/react@18.3.27)(react@18.3.1)':
+    optionalDependencies:
+      '@types/react': 18.3.27
+      react: 18.3.1
 
   '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
@@ -39072,15 +39091,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest-cli@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-config: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -39091,15 +39110,15 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-cli@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-cli@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/test-result': 30.0.5
       '@jest/types': 30.0.5
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       jest-util: 30.0.5
       jest-validate: 30.0.5
       yargs: 17.7.2
@@ -39268,39 +39287,6 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.0.1
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.0.5
-      '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.0.5
-      jest-docblock: 30.0.1
-      jest-environment-node: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-runner: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.0.5
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      '@types/node': 22.18.8
-      esbuild-register: 3.6.0(esbuild@0.28.0)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
   jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -39331,6 +39317,40 @@ snapshots:
       '@types/node': 22.18.8
       esbuild-register: 3.6.0(esbuild@0.28.0)
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@22.18.8)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
+  jest-config@30.0.5(@types/node@22.18.8)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 22.18.8
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -39368,6 +39388,40 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
+  jest-config@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+    dependencies:
+      '@babel/core': 7.29.0
+      '@jest/get-type': 30.0.1
+      '@jest/pattern': 30.0.1
+      '@jest/test-sequencer': 30.0.5
+      '@jest/types': 30.0.5
+      babel-jest: 30.0.5(@babel/core@7.29.0)
+      chalk: 4.1.2
+      ci-info: 4.3.0
+      deepmerge: 4.3.1
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      jest-circus: 30.0.5
+      jest-docblock: 30.0.1
+      jest-environment-node: 30.0.5
+      jest-regex-util: 30.0.1
+      jest-resolve: 30.0.5
+      jest-runner: 30.0.5
+      jest-util: 30.0.5
+      jest-validate: 30.0.5
+      micromatch: 4.0.8
+      parse-json: 5.2.0
+      pretty-format: 30.0.5
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    optionalDependencies:
+      '@types/node': 25.8.0
+      esbuild-register: 3.6.0(esbuild@0.28.0)
+      ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
+    transitivePeerDependencies:
+      - babel-plugin-macros
+      - supports-color
+
   jest-config@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
       '@babel/core': 7.29.0
@@ -39397,38 +39451,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.8.0
       ts-node: 10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)
-    transitivePeerDependencies:
-      - babel-plugin-macros
-      - supports-color
-
-  jest-config@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@jest/get-type': 30.0.1
-      '@jest/pattern': 30.0.1
-      '@jest/test-sequencer': 30.0.5
-      '@jest/types': 30.0.5
-      babel-jest: 30.0.5(@babel/core@7.29.0)
-      chalk: 4.1.2
-      ci-info: 4.3.0
-      deepmerge: 4.3.1
-      glob: 10.5.0
-      graceful-fs: 4.2.11
-      jest-circus: 30.0.5
-      jest-docblock: 30.0.1
-      jest-environment-node: 30.0.5
-      jest-regex-util: 30.0.1
-      jest-resolve: 30.0.5
-      jest-runner: 30.0.5
-      jest-util: 30.0.5
-      jest-validate: 30.0.5
-      micromatch: 4.0.8
-      parse-json: 5.2.0
-      pretty-format: 30.0.5
-      slash: 3.0.0
-      strip-json-comments: 3.1.1
-    optionalDependencies:
-      esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
       - supports-color
@@ -40335,12 +40357,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
+  jest@30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
+      jest-cli: 30.0.5(@types/node@25.8.0)(esbuild-register@3.6.0(esbuild@0.28.0))(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -40348,12 +40370,12 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest@30.0.5(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest@30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3)):
     dependencies:
-      '@jest/core': 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      '@jest/core': 30.0.5(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
       '@jest/types': 30.0.5
       import-local: 3.2.0
-      jest-cli: 30.0.5(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-cli: 30.0.5(@types/node@25.8.0)(ts-node@10.9.1(@swc/core@1.15.18)(@types/node@25.8.0)(typescript@6.0.3))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -44150,7 +44172,7 @@ snapshots:
   react-email-editor@1.7.11(react@18.3.1):
     dependencies:
       react: 18.3.1
-      unlayer-types: 1.436.0
+      unlayer-types: 1.437.0
 
   react-grid-layout@2.2.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
@@ -46524,7 +46546,7 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  unlayer-types@1.436.0: {}
+  unlayer-types@1.437.0: {}
 
   unpipe@1.0.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -85,6 +85,7 @@ minimumReleaseAgeExclude:
     - oxfmt@0.35.0
     - '@oxfmt/*'
     - bloommx@1.0.3
+    - '@shadcn/react'
     - mermaid@11.15.0
     - '@mermaid-js/*'
     - kea-typegen


### PR DESCRIPTION
## Summary

<img width="526" height="107" alt="image" src="https://github.com/user-attachments/assets/929022bb-8c5f-4f06-b9ec-6505418a3cce" />

<img width="472" height="125" alt="image" src="https://github.com/user-attachments/assets/c91798bf-0a3c-42b7-b8df-b8d551b68594" />

<img width="480" height="106" alt="image" src="https://github.com/user-attachments/assets/e4b3c601-624f-479a-971c-138bf9abe846" />


Adds headless chat primitives to `@posthog/quill-primitives` for building agent/chat threads. These back the upcoming thread rebuild in the desktop app.

New primitives (each with CSS + Storybook stories):

- **ChatBubble** — `ChatBubbleGroup`, `ChatBubble`, `ChatBubbleContent`, `ChatBubbleReactions`, `bubbleVariants`
- **ChatMarker** — inline status / system-note / separator row, with an optional **collapsible** form that mirrors the accordion block + `__trigger` + `__panel` structure. Exposes `ChatMarker`, `ChatMarkerIcon`, `ChatMarkerContent`, `markerVariants`
- **ChatMessage** — `ChatMessageGroup`, `ChatMessage`, `ChatMessageAvatar`, `ChatMessageContent`, `ChatMessageHeader`, `ChatMessageFooter`
- **ChatMessageScroller** — stick-to-bottom viewport with a scroll-to-latest button and `useChatMessageScroller` / `…Scrollable` / `…Visibility` hooks

### Notes
- Scroller intentionally keeps the scrollbar visible during programmatic stick-to-bottom scrolls — hiding it on `[data-autoscrolling]` made it flicker on every content-height change while pinned (e.g. expanding a collapsible) and could shift content with `scrollbar-gutter: stable`.
- Collapsible marker trigger gets a real focus ring (WCAG 2.4.7), not just the hover fill.

## Test plan
- [ ] Review the Storybook stories for each primitive
- [ ] Typecheck `@posthog/quill-primitives`

🤖 Generated with [Claude Code](https://claude.com/claude-code)