### PR TITLE
fix(tasks): reap orphaned prewarmed runs stuck in QUEUED

### DIFF
--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -148,30 +148,46 @@ def kill_stale_queued_task_runs() -> None:
     BATCH_SIZE = 500
     STALE_AFTER = datetime.timedelta(hours=24)
     CREATED_HARD_CAP = datetime.timedelta(hours=48)
+    # A live warm run self-terminates via the in-workflow WARM_IDLE_TIMEOUT (10m); one still QUEUED
+    # past this window has no workflow behind it (dispatch lost) so there is nothing else to finalize
+    # it. Kept comfortably above WARM_IDLE_TIMEOUT so a still-idling warm run is never killed early.
+    PREWARMED_STALE_AFTER = datetime.timedelta(minutes=30)
     REASON = "Run was stuck in QUEUED state for over 24h and was killed by the cleanup job."
+    PREWARMED_REASON = "Prewarmed run never started its workflow and was orphaned in QUEUED; reaped by the cleanup job."
+
+    def _fail_each(run_ids: list, reason: str) -> tuple[int, int]:
+        swept = errors = 0
+        for run_id in run_ids:
+            try:
+                # fail_task_run refetches with status=QUEUED, handling the race where a worker
+                # picked up the run between selection and update (returns False -> skip).
+                if tasks_facade.fail_task_run(run_id, reason):
+                    swept += 1
+                    STALE_QUEUED_TASK_RUN_SWEPT_COUNTER.inc()
+            except Exception as exc:  # noqa: BLE001 - one run must not block the sweep
+                errors += 1
+                STALE_QUEUED_TASK_RUN_ERRORS_COUNTER.inc()
+                capture_exception(exc)
+        return swept, errors
 
     # Janitor sweep is intentionally cross-team — it runs without a team context.
     stale_ids = tasks_facade.get_stale_queued_task_run_ids(STALE_AFTER, BATCH_SIZE, created_hard_cap=CREATED_HARD_CAP)
-    swept = 0
-    errors = 0
-    for run_id in stale_ids:
-        try:
-            # fail_task_run refetches with status=QUEUED, handling the race where a worker
-            # picked up the run between selection and update (returns False -> skip).
-            if tasks_facade.fail_task_run(run_id, REASON):
-                swept += 1
-                STALE_QUEUED_TASK_RUN_SWEPT_COUNTER.inc()
-        except Exception as exc:  # noqa: BLE001 - one run must not block the sweep
-            errors += 1
-            STALE_QUEUED_TASK_RUN_ERRORS_COUNTER.inc()
-            capture_exception(exc)
-    saturated = len(stale_ids) >= BATCH_SIZE
+    swept, errors = _fail_each(stale_ids, REASON)
+
+    # Fast-reap orphaned prewarmed runs so they don't ride QUEUED to the 24h sweep above.
+    prewarmed_ids = tasks_facade.get_stale_prewarmed_queued_task_run_ids(PREWARMED_STALE_AFTER, BATCH_SIZE)
+    prewarmed_swept, prewarmed_errors = _fail_each(prewarmed_ids, PREWARMED_REASON)
+
+    saturated = len(stale_ids) >= BATCH_SIZE or len(prewarmed_ids) >= BATCH_SIZE
     log = logger.warning if saturated else logger.info
     log(
         "kill_stale_queued_task_runs.sweep_done",
         candidates=len(stale_ids),
         swept=swept,
         errors=errors,
+        prewarmed_candidates=len(prewarmed_ids),
+        prewarmed_swept=prewarmed_swept,
+        prewarmed_errors=prewarmed_errors,
         batch_size=BATCH_SIZE,
         saturated=saturated,
     )

--- a/posthog/tasks/tasks.py
+++ b/posthog/tasks/tasks.py
@@ -64,6 +64,19 @@ STALE_QUEUED_TASK_RUN_ERRORS_COUNTER = Counter(
     "Errors raised while marking a TaskRun FAILED in the stale-queued cleanup sweep",
 )
 
+# Separate from the stale-queued counters above so the 24h sweep and the prewarmed fast-reap
+# stay distinguishable in Prometheus (dashboards/alerts on the 24h sweep shouldn't absorb the
+# prewarmed reap rate).
+PREWARMED_QUEUED_TASK_RUN_SWEPT_COUNTER = Counter(
+    "posthog_task_run_prewarmed_queued_swept_total",
+    "Orphaned prewarmed TaskRuns marked FAILED by the prewarmed-queued cleanup sweep",
+)
+
+PREWARMED_QUEUED_TASK_RUN_ERRORS_COUNTER = Counter(
+    "posthog_task_run_prewarmed_queued_errors_total",
+    "Errors raised while marking an orphaned prewarmed TaskRun FAILED in the prewarmed-queued cleanup sweep",
+)
+
 
 @shared_task(ignore_result=True)
 def delete_expired_exported_assets() -> None:
@@ -155,7 +168,7 @@ def kill_stale_queued_task_runs() -> None:
     REASON = "Run was stuck in QUEUED state for over 24h and was killed by the cleanup job."
     PREWARMED_REASON = "Prewarmed run never started its workflow and was orphaned in QUEUED; reaped by the cleanup job."
 
-    def _fail_each(run_ids: list, reason: str) -> tuple[int, int]:
+    def _fail_each(run_ids: list, reason: str, swept_counter: Counter, errors_counter: Counter) -> tuple[int, int]:
         swept = errors = 0
         for run_id in run_ids:
             try:
@@ -163,20 +176,27 @@ def kill_stale_queued_task_runs() -> None:
                 # picked up the run between selection and update (returns False -> skip).
                 if tasks_facade.fail_task_run(run_id, reason):
                     swept += 1
-                    STALE_QUEUED_TASK_RUN_SWEPT_COUNTER.inc()
+                    swept_counter.inc()
             except Exception as exc:  # noqa: BLE001 - one run must not block the sweep
                 errors += 1
-                STALE_QUEUED_TASK_RUN_ERRORS_COUNTER.inc()
+                errors_counter.inc()
                 capture_exception(exc)
         return swept, errors
 
     # Janitor sweep is intentionally cross-team — it runs without a team context.
     stale_ids = tasks_facade.get_stale_queued_task_run_ids(STALE_AFTER, BATCH_SIZE, created_hard_cap=CREATED_HARD_CAP)
-    swept, errors = _fail_each(stale_ids, REASON)
+    swept, errors = _fail_each(
+        stale_ids, REASON, STALE_QUEUED_TASK_RUN_SWEPT_COUNTER, STALE_QUEUED_TASK_RUN_ERRORS_COUNTER
+    )
 
     # Fast-reap orphaned prewarmed runs so they don't ride QUEUED to the 24h sweep above.
     prewarmed_ids = tasks_facade.get_stale_prewarmed_queued_task_run_ids(PREWARMED_STALE_AFTER, BATCH_SIZE)
-    prewarmed_swept, prewarmed_errors = _fail_each(prewarmed_ids, PREWARMED_REASON)
+    prewarmed_swept, prewarmed_errors = _fail_each(
+        prewarmed_ids,
+        PREWARMED_REASON,
+        PREWARMED_QUEUED_TASK_RUN_SWEPT_COUNTER,
+        PREWARMED_QUEUED_TASK_RUN_ERRORS_COUNTER,
+    )
 
     saturated = len(stale_ids) >= BATCH_SIZE or len(prewarmed_ids) >= BATCH_SIZE
     log = logger.warning if saturated else logger.info

--- a/posthog/tasks/test/test_kill_stale_queued_task_runs.py
+++ b/posthog/tasks/test/test_kill_stale_queued_task_runs.py
@@ -38,9 +38,12 @@ class TestKillStaleQueuedTaskRuns(TestCase):
         status: str,
         age: datetime.timedelta,
         updated_age: datetime.timedelta | None = None,
+        *,
+        prewarmed: bool = False,
     ) -> "TaskRun":
         TaskRun = apps.get_model("tasks", "TaskRun")
-        run = TaskRun.objects.create(task=self.task, team=self.team, status=status)
+        state = {"prewarmed": True, "await_user_message": True} if prewarmed else {}
+        run = TaskRun.objects.create(task=self.task, team=self.team, status=status, state=state)
         now = timezone.now()
         TaskRun.objects.filter(pk=run.pk).update(
             created_at=now - age, updated_at=now - (updated_age if updated_age is not None else age)
@@ -83,6 +86,31 @@ class TestKillStaleQueuedTaskRuns(TestCase):
         run.refresh_from_db()
         self.assertEqual(run.status, TaskRun.Status.QUEUED)
         self.assertIsNone(run.completed_at)
+        self.assertIsNone(run.error_message)
+
+    def test_reaps_orphaned_prewarmed_run_well_before_24h(self) -> None:
+        # A prewarmed run whose workflow never started has no in-workflow timer to finalize it,
+        # so it must be reaped on the short prewarmed window rather than riding QUEUED to 24h.
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        run = self._make_run(TaskRun.Status.QUEUED, datetime.timedelta(minutes=31), prewarmed=True)
+
+        kill_stale_queued_task_runs()
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, TaskRun.Status.FAILED)
+        self.assertIn("orphaned in QUEUED", run.error_message or "")
+        self.assertIsNotNone(run.completed_at)
+
+    def test_spares_prewarmed_run_still_inside_idle_window(self) -> None:
+        # A live warm run idles in QUEUED awaiting its first message; it must not be killed before
+        # the in-workflow WARM_IDLE_TIMEOUT (10m) has had a chance to finalize an abandoned one.
+        TaskRun = apps.get_model("tasks", "TaskRun")
+        run = self._make_run(TaskRun.Status.QUEUED, datetime.timedelta(minutes=10), prewarmed=True)
+
+        kill_stale_queued_task_runs()
+
+        run.refresh_from_db()
+        self.assertEqual(run.status, TaskRun.Status.QUEUED)
         self.assertIsNone(run.error_message)
 
     def test_hard_cap_reaps_ancient_run_with_bumped_updated_at(self) -> None:

--- a/products/tasks/backend/facade/api.py
+++ b/products/tasks/backend/facade/api.py
@@ -123,6 +123,7 @@ __all__ = [
     "get_latest_run_by_task",
     "get_sandbox_environment",
     "get_sandbox_snapshot",
+    "get_stale_prewarmed_queued_task_run_ids",
     "get_stale_queued_task_run_ids",
     "get_task_automation",
     "get_task_detail",
@@ -544,6 +545,30 @@ def get_stale_queued_task_run_ids(
     return list(
         TaskRun.objects.filter(status=TaskRun.Status.QUEUED)  # nosemgrep: celery-task-team-scope-audit
         .filter(stale)
+        .order_by("updated_at")
+        .values_list("id", flat=True)[:limit]
+    )
+
+
+def get_stale_prewarmed_queued_task_run_ids(older_than: timedelta, limit: int) -> list[UUID]:
+    """Ids of prewarmed runs orphaned in QUEUED — their processing workflow never started, so the
+    in-workflow ``WARM_IDLE_TIMEOUT`` (10m) never armed to finalize them.
+
+    A live warm run idles in QUEUED awaiting its first message and self-terminates at
+    ``WARM_IDLE_TIMEOUT``, so a prewarmed run still QUEUED well past that window has no workflow
+    behind it (dispatch lost — e.g. an ``on_commit`` callback that never ran) and can be reaped
+    immediately rather than lingering until the 24h stale sweep. ``older_than`` should sit safely
+    above ``WARM_IDLE_TIMEOUT`` so a still-idling warm run is never killed early.
+
+    Intentionally cross-team — the janitor sweep runs without a team context.
+    """
+    now = django_timezone.now()
+    return list(
+        TaskRun.objects.filter(  # nosemgrep: celery-task-team-scope-audit
+            status=TaskRun.Status.QUEUED,
+            state__prewarmed=True,
+            updated_at__lt=now - older_than,
+        )
         .order_by("updated_at")
         .values_list("id", flat=True)[:limit]
     )

--- a/products/tasks/backend/temporal/client.py
+++ b/products/tasks/backend/temporal/client.py
@@ -155,9 +155,14 @@ async def execute_task_processing_workflow_async(
         "execute_task_processing_workflow_async_called",
         extra={"task_id": task_id, "run_id": run_id},
     )
-    task_run_for_metrics = await _aget_task_run_for_metrics(run_id)
-    observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
+    # Keep the metrics lookups inside the try: if either raises, the except clauses must still
+    # terminalize the run. When they ran before the try, an exception here aborted the dispatch
+    # without marking the run FAILED, orphaning it in QUEUED until the 24h janitor swept it.
+    # observe_task_run_workflow_start tolerates a None task_run.
+    task_run_for_metrics: TaskRun | None = None
     try:
+        task_run_for_metrics = await _aget_task_run_for_metrics(run_id)
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
         await Team.objects.select_related("organization").aget(id=team_id)
         await sync_to_async(_capture_sandbox_event_ingest_flag)(run_id)
 
@@ -227,9 +232,12 @@ def execute_task_processing_workflow(
     Start the task processing workflow synchronously. Fire-and-forget.
     Use this from sync contexts (e.g., API endpoints).
     """
-    task_run_for_metrics = _get_task_run_for_metrics(run_id)
-    observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
+    # Metrics lookups stay inside the try so a failure here can't bypass terminalization and
+    # leave the run orphaned in QUEUED (see the async variant above).
+    task_run_for_metrics: TaskRun | None = None
     try:
+        task_run_for_metrics = _get_task_run_for_metrics(run_id)
+        observe_task_run_workflow_start(task_run_for_metrics, outcome="attempted", reason="requested")
         logger.info(
             "execute_task_processing_workflow_called",
             extra={"task_id": task_id, "run_id": run_id, "team_id": team_id, "user_id": user_id},


### PR DESCRIPTION
## Problem

Cloud task runs were showing up as "not responding" and `task_run_failed` spiked from <1% to ~5–8% of runs starting around the rollout of warm-sandbox-on-compose. Almost all of the new failures carried the error `Run was stuck in QUEUED state for over 24h and was killed by the cleanup job.`

Root cause: a prewarmed run is created in `QUEUED` while it idles awaiting its first message, and an abandoned one is meant to be finalized by the **in-workflow** `WARM_IDLE_TIMEOUT` (10m). That timer only exists if the processing workflow actually started. When dispatch is lost — the `transaction.on_commit` callback never runs, or a metrics lookup ahead of the dispatch `try/except` raises and skips terminalization — the run is orphaned in `QUEUED` with nothing to finalize it, so only the 24h janitor eventually catches it. On submit, the reuse path can also hand a user's message to one of these dead warm runs, which reads as the run hanging.

## Changes

- `products/tasks/backend/temporal/client.py`: move the metrics lookups (`_get/_aget_task_run_for_metrics`, `observe_task_run_workflow_start`) **inside** the dispatch `try` in both the sync and async paths, so an exception there can no longer bypass `_terminalize_unstarted_task_run` and orphan the run.
- `products/tasks/backend/facade/api.py`: add `get_stale_prewarmed_queued_task_run_ids`, selecting prewarmed runs still `QUEUED` past a short window.
- `posthog/tasks/tasks.py`: the janitor now fast-reaps those orphaned prewarmed runs (window 30m, comfortably above the 10m idle timeout so a still-idling warm run is never killed early) with a distinct error reason, instead of letting them ride to the 24h sweep. The 24h sweep is unchanged.

This shortens the orphan window from 24h to ~30m and closes the silent-bypass path that created orphans in the first place. It does not change behavior for runs whose workflow started normally — those still self-terminate via the in-workflow idle timeout and exit as `completed`.

## How did you test this code?

I'm an agent (PostHog Slack app). I did not manually run the app. Automated tests added (not executed in my environment — CI will run them):

- `test_reaps_orphaned_prewarmed_run_well_before_24h` — catches the regression where an orphaned prewarmed run is left to ride QUEUED to the 24h sweep instead of being reaped on the short window. No existing test exercised the sub-24h prewarmed path.
- `test_spares_prewarmed_run_still_inside_idle_window` — guards against the reaper killing a live warm run that is legitimately idling inside the 10m idle window.

`ruff check` and `ruff format` pass on all changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread: queried Tasks lifecycle events in PostHog, isolated the `task_run_failed` regression to the `Run was stuck in QUEUED…` reason, confirmed it was silent (no workflow-start error) and not a sandbox/setup-pipeline failure, then traced it through the warm-sandbox dispatch path in the repo to the two orphan vectors fixed here.

Considered but rejected: relying solely on moving the metrics calls inside `try` — it closes only one vector (the `on_commit`-never-ran case still orphans), so the short prewarmed reaper is the catch-all. Reaping window set to 30m to stay well clear of the 10m in-workflow idle timeout. No repo skills were applicable to these files; the `/writing-tests` value gate was applied manually when adding the two tests.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0AH01HDNMP/p1782828463602999)*
