### PR TITLE
fix(data-warehouse): degrade Shopify orders query to granted scopes

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/constants.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/constants.py
@@ -5,11 +5,12 @@ from .queries.catalogs import CATALOGS_QUERY
 from .queries.collections import COLLECTIONS_QUERY
 from .queries.customers import CUSTOMERS_QUERY
 from .queries.discount_nodes import DISCOUNT_NODES_QUERY
-from .queries.orders import ORDERS_QUERY
+from .queries.orders import ORDERS_QUERY, build_orders_query
 from .queries.products import PRODUCTS_QUERY
 from .utils import ShopifyGraphQLObject
 
 SHOPIFY_ACCESS_TOKEN_URL = "https://{}.myshopify.com/admin/oauth/access_token"
+SHOPIFY_ACCESS_SCOPES_URL = "https://{}.myshopify.com/admin/oauth/access_scopes.json"
 SHOPIFY_ACCESS_TOKEN_GRANT = "client_credentials"
 SHOPIFY_API_VERSION = "2025-10"
 SHOPIFY_API_URL = "https://{}.myshopify.com/admin/api/{}/graphql.json"
@@ -87,6 +88,7 @@ SHOPIFY_GRAPHQL_OBJECTS = {
         name=ORDERS,
         query=ORDERS_QUERY,
         permissions_query="{ orders(first: 1) { nodes { id } } }",
+        protected_query_builder=build_orders_query,
     ),
     PRODUCTS: ShopifyGraphQLObject(
         name=PRODUCTS,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/queries/orders.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/queries/orders.py
@@ -15,8 +15,40 @@ from .fragments import (
 
 ORDERS_SORTKEY = "UPDATED_AT"
 
-# NOTE: 250 is the max allowable query size for nested connections
-ORDERS_QUERY = f"""
+# Fields gated behind scopes beyond `read_orders` -> scopes that unlock them (any one suffices).
+# Lets a `read_orders`-only token still import the rest of the order instead of "Access denied".
+ORDERS_PROTECTED_FIELDS: dict[str, set[str]] = {
+    "fulfillmentOrders": {
+        "read_merchant_managed_fulfillment_orders",
+        "read_third_party_fulfillment_orders",
+        "read_assigned_fulfillment_orders",
+    },
+    "paymentTerms": {"read_payment_terms"},
+}
+
+_FULFILLMENT_ORDERS_BLOCK = f"fulfillmentOrders(first: 250) {NODE_CONNECTION_ID_FRAGMENT}"
+
+_PAYMENT_TERMS_BLOCK = f"""paymentTerms {{
+                due
+                dueInDays
+                id
+                order {ID_NAME_CREATED_UPDATED_FRAGMENT}
+                overdue
+                paymentTermsName
+                paymentTermsType
+                translatedName
+            }}"""
+
+
+def build_orders_query(granted_scopes: set[str]) -> str:
+    """Orders query with each protected-field selection included only when its scope is granted."""
+    fulfillment_orders = (
+        _FULFILLMENT_ORDERS_BLOCK if granted_scopes & ORDERS_PROTECTED_FIELDS["fulfillmentOrders"] else ""
+    )
+    payment_terms = _PAYMENT_TERMS_BLOCK if granted_scopes & ORDERS_PROTECTED_FIELDS["paymentTerms"] else ""
+
+    # NOTE: 250 is the max allowable query size for nested connections
+    return f"""
 query PaginatedOrders($pageSize: Int!, $cursor: String, $query: String) {{
     orders(
         first: $pageSize, after: $cursor, sortKey: {ORDERS_SORTKEY},
@@ -88,7 +120,7 @@ query PaginatedOrders($pageSize: Int!, $cursor: String, $query: String) {{
             estimatedTaxes
             events(first: 250) {NODE_CONNECTION_ID_FRAGMENT}
             fulfillable
-            fulfillmentOrders(first: 250) {NODE_CONNECTION_ID_FRAGMENT}
+            {fulfillment_orders}
             fulfillments(first: 250) {{
                 id
                 createdAt
@@ -129,16 +161,7 @@ query PaginatedOrders($pageSize: Int!, $cursor: String, $query: String) {{
             originalTotalDutiesSet {MONEY_BAG_FRAGMENT}
             originalTotalPriceSet {MONEY_BAG_FRAGMENT}
             paymentGatewayNames
-            paymentTerms {{
-                due
-                dueInDays
-                id
-                order {ID_NAME_CREATED_UPDATED_FRAGMENT}
-                overdue
-                paymentTermsName
-                paymentTermsType
-                translatedName
-            }}
+            {payment_terms}
             phone
             poNumber
             presentmentCurrencyCode
@@ -210,3 +233,7 @@ query PaginatedOrders($pageSize: Int!, $cursor: String, $query: String) {{
         }}
     }}
 }}"""
+
+
+# Full query (all scopes granted); the sync path rebuilds it from the token's real scopes.
+ORDERS_QUERY = build_orders_query({scope for scopes in ORDERS_PROTECTED_FIELDS.values() for scope in scopes})

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/shopify.py
@@ -21,6 +21,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.ut
 )
 
 from .constants import (
+    SHOPIFY_ACCESS_SCOPES_URL,
     SHOPIFY_ACCESS_TOKEN_CHECK,
     SHOPIFY_ACCESS_TOKEN_GRANT,
     SHOPIFY_ACCESS_TOKEN_URL,
@@ -335,6 +336,19 @@ def _get_shopify_access_token(shopify_store_id: str, shopify_client_id: str, sho
     return access_res.json()["access_token"]
 
 
+def _get_granted_scopes(store_id: str, sess: requests.Session) -> set[str] | None:
+    """The token's granted scope handles, or None on any failure — best-effort so a blip degrades
+    the query rather than failing the sync."""
+    try:
+        res = sess.get(SHOPIFY_ACCESS_SCOPES_URL.format(store_id))
+        res.raise_for_status()
+        data = res.json()
+    except (requests.RequestException, ValueError):
+        return None
+    scopes = data.get("access_scopes", []) if isinstance(data, dict) else []
+    return {scope["handle"] for scope in scopes if isinstance(scope, dict) and "handle" in scope}
+
+
 def shopify_source(
     shopify_store_id: str,
     shopify_client_id: str,
@@ -358,6 +372,24 @@ def shopify_source(
         graphql_object = SHOPIFY_GRAPHQL_OBJECTS.get(schema_name)
         if not graphql_object:
             raise Exception(f"Shopify object does not exist: {schema_name}")
+
+        # Drop fields the token lacks the scope to read, so a partially scoped token imports the
+        # rest instead of hard-failing on "Access denied for <field>". Falls back to the minimal
+        # query when scopes can't be detected.
+        if graphql_object.protected_query_builder is not None:
+            granted_scopes = _get_granted_scopes(store_id, sess)
+            if granted_scopes is None:
+                granted_scopes = set()
+                logger.warning(
+                    f"Shopify: could not detect granted scopes for {schema_name}; syncing without protected fields"
+                )
+            graphql_object = ShopifyGraphQLObject(
+                name=graphql_object.name,
+                query=graphql_object.protected_query_builder(granted_scopes),
+                display_name=graphql_object.display_name,
+                permissions_query=graphql_object.permissions_query,
+                protected_query_builder=graphql_object.protected_query_builder,
+            )
 
         logger.debug(f"Shopify: reading from resource {schema_name}")
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_orders_query.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/tests/test_orders_query.py
@@ -1,0 +1,81 @@
+from typing import Any
+
+from unittest import mock
+
+import graphql
+import requests
+from parameterized import parameterized
+
+from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.queries.orders import (
+    ORDERS_PROTECTED_FIELDS,
+    ORDERS_QUERY,
+    build_orders_query,
+)
+from products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify import shopify_source
+
+_TOKEN_PATH = (
+    "products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify._get_shopify_access_token"
+)
+_SESSION_PATH = "products.warehouse_sources.backend.temporal.data_imports.sources.shopify.shopify.make_tracked_session"
+
+_ALL_SCOPES = {scope for scopes in ORDERS_PROTECTED_FIELDS.values() for scope in scopes}
+
+
+def test_orders_query_omits_protected_fields_without_their_scopes():
+    # The original bug: a read_orders-only token gets the full query, which reaches for
+    # fulfillmentOrders/paymentTerms and hard-fails with "Access denied for <field>".
+    query = build_orders_query({"read_orders"})
+
+    assert "fulfillmentOrders" not in query
+    assert "paymentTerms" not in query
+    assert graphql.parse(query) is not None
+
+
+@parameterized.expand(sorted(ORDERS_PROTECTED_FIELDS["fulfillmentOrders"]))
+def test_any_fulfillment_scope_alone_includes_fulfillment_orders(scope: str):
+    # Shopify exposes fulfillmentOrders under any of three scopes; granting just one must unlock it.
+    query = build_orders_query({scope})
+
+    assert "fulfillmentOrders" in query
+    assert "paymentTerms" not in query
+
+
+def test_orders_query_includes_all_protected_fields_with_full_scopes():
+    assert "fulfillmentOrders" in ORDERS_QUERY
+    assert "paymentTerms" in ORDERS_QUERY
+    assert ORDERS_QUERY == build_orders_query(_ALL_SCOPES)
+
+
+def test_scope_detection_failure_falls_back_to_minimal_query():
+    # If the access-scopes lookup fails we must degrade to the minimal query, not attempt the full
+    # one — otherwise a transient blip reintroduces the "Access denied" hard-fail this fix removes.
+    captured: dict[str, str] = {}
+
+    def post(_url: str, json: dict[str, Any] | None = None, **_kwargs: Any) -> mock.MagicMock:
+        captured["query"] = (json or {}).get("query", "")
+        response = mock.MagicMock(status_code=200)
+        response.json.return_value = {"data": {"orders": {"nodes": [], "pageInfo": {"hasNextPage": False}}}}
+        return response
+
+    def get(_url: str, **_kwargs: Any) -> mock.MagicMock:
+        raise requests.ConnectionError("scopes endpoint unreachable")
+
+    sess = mock.MagicMock(post=mock.MagicMock(side_effect=post), get=mock.MagicMock(side_effect=get))
+    resumable = mock.MagicMock(can_resume=mock.MagicMock(return_value=False))
+
+    with mock.patch(_TOKEN_PATH, return_value="tok"), mock.patch(_SESSION_PATH, return_value=sess):
+        response = shopify_source(
+            shopify_store_id="my-store",
+            shopify_client_id="cid",
+            shopify_client_secret="secret",
+            graphql_object_name="orders",
+            db_incremental_field_last_value=None,
+            db_incremental_field_earliest_value=None,
+            logger=mock.MagicMock(),
+            resumable_source_manager=resumable,
+            should_use_incremental_field=False,
+        )
+        list(response.items())
+
+    assert "fulfillmentOrders" not in captured["query"]
+    assert "paymentTerms" not in captured["query"]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/utils.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/shopify/utils.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from typing import Any
 from uuid import uuid4
 
@@ -9,6 +10,7 @@ class ShopifyGraphQLObject:
         query: str,
         display_name: str | None = None,
         permissions_query: str | None = None,
+        protected_query_builder: Callable[[set[str]], str] | None = None,
     ):
         # shopify graphql responses typically look like this:
         # {
@@ -31,6 +33,9 @@ class ShopifyGraphQLObject:
         # optional display name for cases where the shopify name makes less sense to users
         self.display_name: str | None = display_name
         self.permissions_query: str | None = permissions_query
+        # optional: rebuilds `query` from the token's granted scopes so a partially scoped token
+        # degrades gracefully instead of hard-failing on a field it can't read (see queries/orders.py)
+        self.protected_query_builder: Callable[[set[str]], str] | None = protected_query_builder
 
 
 def unwrap(payload: Any, path: str):


### PR DESCRIPTION
## Problem

Follow-up to #66459. After that fix, a customer's Shopify `orders` schema still failed with a "missing permissions" error even though their token held `read_orders` (and `read_all_orders`).

It's not a false negative — it's a validation false positive followed by a real sync failure. We validate each schema with a lightweight probe query (`{ orders(first: 1) { nodes { id } } }`), which only needs `read_orders`, so validation passes. But the full sync query reaches for two fields gated behind separate protected-data scopes:

- `fulfillmentOrders` → needs a fulfillment scope (`read_merchant_managed_fulfillment_orders` / `read_third_party_fulfillment_orders` / `read_assigned_fulfillment_orders`)
- `paymentTerms` → needs `read_payment_terms`

`read_orders` covers core orders and `read_all_orders` only widens the 60-day window — neither covers those fields. So the sync hits `Access denied for <field>`, which is matched as non-retryable, and the whole orders import fails. A token scoped for core order data genuinely can't import orders.

## Changes

Graceful degradation on the sync side: import core orders with `read_orders`, and include the protected fields only when the token actually holds a scope that unlocks them. The customer no longer has to grant scopes for ancillary data they don't want.

- `queries/orders.py`: `ORDERS_QUERY` becomes `build_orders_query(granted_scopes)` — the `fulfillmentOrders`/`paymentTerms` selections are included only when a granting scope is present. `ORDERS_QUERY` is kept as the full-scope constant.
- `shopify.py`: `_get_granted_scopes()` reads Shopify's `access_scopes.json` once per sync; `get_rows()` rebuilds the query, dropping fields the token can't read. If scope detection fails, it degrades to the minimal query — a degraded-but-successful sync beats a hard fail.
- `utils.py`: `ShopifyGraphQLObject` gains an optional `protected_query_builder` so the mechanism dispatches generically (no per-schema `if`) and is reusable for other resources later.
- `constants.py`: adds `SHOPIFY_ACCESS_SCOPES_URL` and wires the builder onto the `orders` entry.

The probe/validation path is intentionally untouched — the `{ ... id }` probe is now correct, because orders always sync (degraded if needed).

## How did you test this code?

I'm an agent (PostHog Code). I did not perform manual testing against a live Shopify store. Automated tests only:

- New `tests/test_orders_query.py` (6 cases): the minimal-scope query omits both protected fields and still parses as valid GraphQL (catches the original bug — protected fields leaking into a `read_orders`-only query); each of the three fulfillment scopes alone unlocks `fulfillmentOrders` (guards the any-of mapping); the full-scope build equals `ORDERS_QUERY`; and scope-detection failure falls back to the minimal query (guards the degrade-don't-fail decision).
- Full Shopify source suite (92 tests) passes; ran `ruff check`/`ruff format` clean.

These regressions weren't covered before — existing tests only exercise the validation/probe path, not query construction or scope-conditional sync.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code (Claude Opus 4.8), directed by @estefaniarabadan off a customer report.

- Decision: chose graceful degradation over (a) aligning the probe to require the extra scopes upfront or (b) dropping the two fields entirely. Degradation unblocks the customer without forcing them to grant scopes for data they don't need, and without losing those fields for customers who do have the scopes.
- Used Shopify's `access_scopes.json` (a single authoritative call) rather than per-field GraphQL probing.
- Scope detection is best-effort: any failure degrades to the minimal query so a transient blip can't reintroduce the hard-fail.
- Skill invoked: `/writing-tests` (to gate the new tests).

Open follow-up: degradation is silent (logs a warning). If we want the schema picker to tell users which fields were dropped due to missing scopes, that's a small additive change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
