### PR TITLE
feat(logs): extract full screen button to separate component

### DIFF
--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsFilterBar.tsx
@@ -4,8 +4,6 @@ import { useRef, useState } from 'react'
 import { IconMinusSquare, IconPlusSquare, IconRefresh } from '@posthog/icons'
 import { LemonButton, LemonDropdown } from '@posthog/lemon-ui'
 
-import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
-import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { InfiniteSelectResults } from 'lib/components/TaxonomicFilter/InfiniteSelectResults'
 import { TaxonomicFilterSearchInput } from 'lib/components/TaxonomicFilter/TaxonomicFilter'
 import { taxonomicFilterLogic } from 'lib/components/TaxonomicFilter/taxonomicFilterLogic'
@@ -16,8 +14,6 @@ import { isUniversalGroupFilterLike } from 'lib/components/UniversalFilters/util
 import { dayjs } from 'lib/dayjs'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useOnMountEffect } from 'lib/hooks/useOnMountEffect'
-import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
-import { Scene } from 'scenes/sceneTypes'
 
 import {
     AnyPropertyFilter,
@@ -29,6 +25,7 @@ import {
 
 import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { LogsFullScreenButton } from 'products/logs/frontend/components/LogsViewer/LogsFullScreenButton'
 import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 
 import { DateRangeFilter } from '../DateRangeFilter'
@@ -44,7 +41,13 @@ const taxonomicGroupTypes = [
     TaxonomicFilterGroupType.LogAttributes,
 ]
 
-export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
+export const LogsFilterBar = ({
+    showSavedViewsButton = false,
+    showFullScreenButton = false,
+}: {
+    showSavedViewsButton?: boolean
+    showFullScreenButton?: boolean
+}): JSX.Element => {
     // When the facet rail is on, Level + Service live in the rail instead of this bar.
     const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const { setSeverityLevels, setServiceNames } = useActions(logsViewerFiltersLogic)
@@ -72,7 +75,10 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
                         <FilterHistoryDropdown />
                         {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
                     </div>
-                    <LogsQueryControls />
+                    <div className="flex shrink-0 gap-1.5">
+                        <LogsQueryControls />
+                        {showFullScreenButton && <LogsFullScreenButton id={id} />}
+                    </div>
                 </div>
                 <LogsAppliedFilters />
             </div>
@@ -80,11 +86,16 @@ export const LogsFilterBar = ({ showSavedViewsButton = false }: { showSavedViews
     )
 }
 
-/** Time range, zoom, refresh and live tail — the "execute the query" controls shared by both bars. */
+/**
+ * Time range, zoom and refresh — the always-relevant "execute the query" controls shared by both bars.
+ * Live tail lives in the results bar instead (LogsViewerToolbar): it's the one streaming control we
+ * deliberately place with the Logs-only tools so it hides cleanly with that cluster in Patterns mode,
+ * rather than collapsing in this top bar and shifting its layout.
+ */
 export const LogsQueryControls = (): JSX.Element => {
     const newLogsDateRangePicker = useFeatureFlag('NEW_LOGS_DATE_RANGE_PICKER')
-    const { logsLoading, liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
-    const { runQuery, setLiveTailRunning } = useActions(logsViewerDataLogic)
+    const { logsLoading, liveTailRunning } = useValues(logsViewerDataLogic)
+    const { runQuery } = useActions(logsViewerDataLogic)
     const { zoomDateRange, setDateRange } = useActions(logsViewerFiltersLogic)
     const { filters } = useValues(logsViewerFiltersLogic)
     const { dateRange } = filters
@@ -121,23 +132,6 @@ export const LogsQueryControls = (): JSX.Element => {
                 loading={logsLoading || liveTailRunning}
                 disabledReason={liveTailRunning ? 'Disable live tail to manually refresh' : undefined}
             />
-            <Shortcut
-                name="LogsLiveTail"
-                keybind={[keyBinds.edit]}
-                intent={liveTailRunning ? 'Stop live tail' : 'Start live tail'}
-                interaction="click"
-                scope={Scene.Logs}
-            >
-                <LemonButton
-                    size="small"
-                    type={liveTailRunning ? 'primary' : 'secondary'}
-                    icon={liveTailRunning ? <IconPauseCircle /> : <IconPlayCircle />}
-                    onClick={() => setLiveTailRunning(!liveTailRunning)}
-                    disabledReason={liveTailRunning ? undefined : liveTailDisabledReason}
-                >
-                    Live tail
-                </LemonButton>
-            </Shortcut>
         </div>
     )
 }

--- a/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/Filters/LogsFilterBar/LogsQueryBar.tsx
@@ -1,6 +1,7 @@
 import { useValues } from 'kea'
 
 import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsViewer/Filters/logsViewerFiltersLogic'
+import { LogsFullScreenButton } from 'products/logs/frontend/components/LogsViewer/LogsFullScreenButton'
 import { SavedViewsButton } from 'products/logs/frontend/components/LogsViews/SavedViewsButton'
 
 import { FilterHistoryDropdown } from '../FilterHistoryDropdown'
@@ -13,7 +14,13 @@ import { LogsAppliedFilters, LogsFilterGroup, LogsFilterSearch, LogsQueryControl
  *
  * Level + Service aren't here — they're facets in the rail. The active-filter chips render under the bar.
  */
-export const LogsQueryBar = ({ showSavedViewsButton = false }: { showSavedViewsButton?: boolean }): JSX.Element => {
+export const LogsQueryBar = ({
+    showSavedViewsButton = false,
+    showFullScreenButton = false,
+}: {
+    showSavedViewsButton?: boolean
+    showFullScreenButton?: boolean
+}): JSX.Element => {
     const { id } = useValues(logsViewerFiltersLogic)
 
     return (
@@ -27,7 +34,10 @@ export const LogsQueryBar = ({ showSavedViewsButton = false }: { showSavedViewsB
                         <FilterHistoryDropdown />
                         {showSavedViewsButton && <SavedViewsButton id={id} iconOnly />}
                     </div>
-                    <LogsQueryControls />
+                    <div className="flex shrink-0 gap-1.5">
+                        <LogsQueryControls />
+                        {showFullScreenButton && <LogsFullScreenButton id={id} />}
+                    </div>
                 </div>
                 <LogsAppliedFilters />
             </div>

--- a/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsDisplayBar.tsx
@@ -1,33 +1,103 @@
 import { useActions, useValues } from 'kea'
 
 import { IconChevronLeft, IconChevronRight } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
+import { LemonButton, LemonSegmentedButton } from '@posthog/lemon-ui'
+
+import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
+import { humanFriendlyNumber } from 'lib/utils/numbers'
+
+import { logsPatternsLogic } from 'products/logs/frontend/components/LogsPatterns/logsPatternsLogic'
+import { LogsOrderBy } from 'products/logs/frontend/types'
 
 import { logsViewerConfigLogic } from './config/logsViewerConfigLogic'
-import { LogsViewerToolbar, LogsViewerToolbarProps } from './LogsViewerToolbar'
+import { LogsViewerToolbar } from './LogsViewerToolbar'
+
+export interface LogsDisplayBarProps {
+    id: string
+    // Whether to render the facet-rail collapse toggle in the frame (facet-rail layout only).
+    showFacetRailToggle?: boolean
+    totalLogsCount?: number
+    orderBy: LogsOrderBy
+    onChangeOrderBy: (orderBy: LogsOrderBy) => void
+}
 
 /**
- * Bottom toolbar for the facet-rail layout — the "operate on the data" controls: the rail toggle plus
- * the result-view controls (sort, wrap, timezone, export, fullscreen, count). Sits below the sparkline,
- * next to the table it affects. None of these re-run the query; they only change how results render.
+ * The bar above the results, grouped by scope rather than by widget kind:
+ *
+ *  - persistent-left "frame": controls that belong to the results region in *both* lenses —
+ *    the filters toggle, the Logs⇄Patterns switch, and a lens-aware count indicator.
+ *  - contextual-right: the Logs-only presentation tools (sort, wrap, timezone, export, shortcuts),
+ *    hidden entirely in Patterns mode where none of them apply.
+ *
+ * Sits below the sparkline, next to the table it affects. None of these re-run the query.
  */
-export const LogsDisplayBar = (props: LogsViewerToolbarProps): JSX.Element => {
-    const { facetRailCollapsed } = useValues(logsViewerConfigLogic)
-    const { setFacetRailCollapsed } = useActions(logsViewerConfigLogic)
+export const LogsDisplayBar = ({
+    id,
+    showFacetRailToggle = false,
+    totalLogsCount,
+    orderBy,
+    onChangeOrderBy,
+}: LogsDisplayBarProps): JSX.Element => {
+    const { facetRailCollapsed, viewMode } = useValues(logsViewerConfigLogic)
+    const { setFacetRailCollapsed, setViewMode } = useActions(logsViewerConfigLogic)
+    const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
+
+    const inPatternsMode = showPatternsView && viewMode === 'patterns'
 
     return (
-        <div className="flex items-start gap-2">
-            <LemonButton
-                size="small"
-                icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
-                onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
-                aria-label={facetRailCollapsed ? 'Show filters' : 'Hide filters'}
-            >
-                {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
-            </LemonButton>
-            <div className="flex-1 min-w-0">
-                <LogsViewerToolbar {...props} />
+        <div className="flex items-center justify-between gap-2 flex-wrap">
+            <div className="flex items-center gap-2 flex-wrap">
+                {showFacetRailToggle && (
+                    <LemonButton
+                        size="small"
+                        icon={facetRailCollapsed ? <IconChevronRight /> : <IconChevronLeft />}
+                        onClick={() => setFacetRailCollapsed(!facetRailCollapsed)}
+                        aria-label={facetRailCollapsed ? 'Show filters' : 'Hide filters'}
+                    >
+                        {facetRailCollapsed ? 'Show filters' : 'Hide filters'}
+                    </LemonButton>
+                )}
+                {showPatternsView && (
+                    <LemonSegmentedButton
+                        size="small"
+                        value={viewMode}
+                        onChange={setViewMode}
+                        options={[
+                            { value: 'logs', label: 'Logs' },
+                            { value: 'patterns', label: 'Patterns' },
+                        ]}
+                    />
+                )}
+                {inPatternsMode ? (
+                    <PatternsCountIndicator id={id} />
+                ) : (
+                    totalLogsCount !== undefined &&
+                    totalLogsCount > 0 && (
+                        <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
+                    )
+                )}
             </div>
+            {!inPatternsMode && (
+                <LogsViewerToolbar
+                    totalLogsCount={totalLogsCount}
+                    orderBy={orderBy}
+                    onChangeOrderBy={onChangeOrderBy}
+                />
+            )}
         </div>
     )
+}
+
+/**
+ * Lens-aware count for Patterns mode. Split into its own component so `logsPatternsLogic` is only
+ * mounted while Patterns is active — mounting it in Logs mode would kick off the heavier patterns query.
+ */
+const PatternsCountIndicator = ({ id }: { id: string }): JSX.Element | null => {
+    const { patterns } = useValues(logsPatternsLogic({ id }))
+
+    if (patterns.length === 0) {
+        return null
+    }
+
+    return <span className="text-muted text-xs">{humanFriendlyNumber(patterns.length)} patterns</span>
 }

--- a/products/logs/frontend/components/LogsViewer/LogsFullScreenButton.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsFullScreenButton.tsx
@@ -1,0 +1,24 @@
+import { useActions } from 'kea'
+
+import { IconExpand45 } from '@posthog/icons'
+import { LemonButton } from '@posthog/lemon-ui'
+
+import { logsViewerModalLogic } from './LogsViewerModal/logsViewerModalLogic'
+
+/**
+ * Maximises the whole viewer surface. Viewer-scoped (not scene-scoped: it only applies to the
+ * Logs Viewer tab), so it lives at the top-right of the query bar rather than in the results bar.
+ */
+export const LogsFullScreenButton = ({ id }: { id: string }): JSX.Element => {
+    const { openLogsViewerModal } = useActions(logsViewerModalLogic)
+
+    return (
+        <LemonButton
+            size="small"
+            type="secondary"
+            icon={<IconExpand45 />}
+            onClick={() => openLogsViewerModal({ id })}
+            tooltip="Full screen"
+        />
+    )
+}

--- a/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewer.tsx
@@ -1,8 +1,6 @@
 import { BindLogic, useActions, useValues } from 'kea'
 import { useCallback, useEffect, useRef } from 'react'
 
-import { LemonSegmentedButton } from '@posthog/lemon-ui'
-
 import { TZLabelProps } from 'lib/components/TZLabel'
 import { useFeatureFlag } from 'lib/hooks/useFeatureFlag'
 import { useKeyboardHotkeys } from 'lib/hooks/useKeyboardHotkeys'
@@ -22,14 +20,13 @@ import { logsViewerFiltersLogic } from 'products/logs/frontend/components/LogsVi
 import { logsExportLogic } from 'products/logs/frontend/components/LogsViewer/logsExportLogic'
 import { VirtualizedLogsList } from 'products/logs/frontend/components/VirtualizedLogsList/VirtualizedLogsList'
 import { virtualizedLogsListLogic } from 'products/logs/frontend/components/VirtualizedLogsList/virtualizedLogsListLogic'
+import { LogsOrderBy } from 'products/logs/frontend/types'
 
 import { LogDetailsModal } from './LogDetailsModal'
 import { logDetailsModalLogic } from './LogDetailsModal/logDetailsModalLogic'
 import { LogsDisplayBar } from './LogsDisplayBar'
 import { logsViewerLogic } from './logsViewerLogic'
-import { logsViewerModalLogic } from './LogsViewerModal/logsViewerModalLogic'
 import { LogsSparkline } from './LogsViewerSparkline'
-import { LogsViewerToolbar, LogsViewerToolbarProps } from './LogsViewerToolbar'
 
 const SCROLL_INTERVAL_MS = 16 // ~60fps
 const SCROLL_AMOUNT_PX = 8
@@ -112,13 +109,11 @@ function LogsViewerContent({
     } = useActions(logsViewerLogic)
     const { orderBy, sparklineBreakdownBy, sparklineCollapsed, facetRailCollapsed, viewMode } =
         useValues(logsViewerConfigLogic)
-    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed, setViewMode } =
-        useActions(logsViewerConfigLogic)
+    const { setOrderBy, setSparklineBreakdownBy, toggleSparklineCollapsed } = useActions(logsViewerConfigLogic)
     const { logsLoading, parsedLogs, sparklineData, sparklineLoading, hasMoreLogsToLoad, totalLogsMatchingFilters } =
         useValues(logsViewerDataLogic)
     const { runQuery, fetchNextLogsPage } = useActions(logsViewerDataLogic)
     const { setDateRange, zoomDateRange } = useActions(logsViewerFiltersLogic)
-    const { openLogsViewerModal } = useActions(logsViewerModalLogic)
     const showFacetRail = useFeatureFlag('LOGS_FACET_RAIL')
     const showPatternsView = useFeatureFlag('LOGS_PATTERNS_VIEW')
     const { cellScrollLefts } = useValues(virtualizedLogsListLogic({ id }))
@@ -304,13 +299,15 @@ function LogsViewerContent({
         </>
     )
 
-    const filterBar = showFilterBar ? <LogsFilterBar showSavedViewsButton={showSavedViewsButton} /> : null
+    const filterBar = showFilterBar ? (
+        <LogsFilterBar showSavedViewsButton={showSavedViewsButton} showFullScreenButton={showFullScreenButton} />
+    ) : null
 
-    const toolbarProps: LogsViewerToolbarProps = {
+    const displayBarProps = {
+        id,
         totalLogsCount: sparklineLoading ? undefined : totalLogsMatchingFilters,
         orderBy,
-        onChangeOrderBy: (newOrderBy) => setOrderBy(newOrderBy, 'toolbar'),
-        onOpenFullScreen: showFullScreenButton ? () => openLogsViewerModal({ id }) : undefined,
+        onChangeOrderBy: (newOrderBy: LogsOrderBy) => setOrderBy(newOrderBy, 'toolbar'),
     }
 
     const logList = (
@@ -353,24 +350,12 @@ function LogsViewerContent({
     const inPatternsMode = showPatternsView && viewMode === 'patterns'
     const resultsRegion = inPatternsMode ? <LogsPatterns id={id} /> : logList
 
-    const modeToggle = showPatternsView ? (
-        <LemonSegmentedButton
-            size="small"
-            value={viewMode}
-            onChange={setViewMode}
-            options={[
-                { value: 'logs', label: 'Logs' },
-                { value: 'patterns', label: 'Patterns' },
-            ]}
-        />
-    ) : null
-
-    // Both layouts share the same results column; only the bar above it differs. Keeping the
-    // mode toggle + "patterns hides the bar" rule in one place avoids drift between the branches.
+    // Both layouts share the same results column; only the results bar above it differs (the facet-rail
+    // layout adds the rail toggle). The bar owns the Logs⇄Patterns switch and hides its Logs-only tools
+    // in Patterns mode, so it renders in both modes — keeping the frame (toggle, count) persistent.
     const resultsColumn = (bar: JSX.Element): JSX.Element => (
         <>
-            {modeToggle}
-            {!inPatternsMode && bar}
+            {bar}
             {resultsRegion}
         </>
     )
@@ -380,12 +365,12 @@ function LogsViewerContent({
         // row of [facet rail | display bar (operate on the data) + the log lists].
         return (
             <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
-                <LogsQueryBar showSavedViewsButton={showSavedViewsButton} />
+                <LogsQueryBar showSavedViewsButton={showSavedViewsButton} showFullScreenButton={showFullScreenButton} />
                 {sparklineSection}
                 <div className="flex flex-row gap-2 flex-1 min-h-0">
                     {!facetRailCollapsed && <FacetRail id={id} />}
                     <div className="flex flex-col gap-2 flex-1 min-w-0">
-                        {resultsColumn(<LogsDisplayBar {...toolbarProps} />)}
+                        {resultsColumn(<LogsDisplayBar {...displayBarProps} showFacetRailToggle />)}
                     </div>
                 </div>
                 <LogDetailsModal timezone={timezone} />
@@ -397,7 +382,7 @@ function LogsViewerContent({
         <div className="flex flex-col gap-2 h-full" data-attr="logs-viewer">
             {sparklineSection}
             {filterBar}
-            {resultsColumn(<LogsViewerToolbar {...toolbarProps} />)}
+            {resultsColumn(<LogsDisplayBar {...displayBarProps} />)}
             <LogDetailsModal timezone={timezone} />
         </div>
     )

--- a/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
+++ b/products/logs/frontend/components/LogsViewer/LogsViewerToolbar.tsx
@@ -1,106 +1,121 @@
 import { useActions, useValues } from 'kea'
 
-import { IconExpand45, IconKeyboard } from '@posthog/icons'
+import { IconKeyboard } from '@posthog/icons'
 import { LemonButton, LemonCheckbox, LemonSegmentedButton, Tooltip } from '@posthog/lemon-ui'
 
+import { Shortcut } from 'lib/components/Shortcuts/Shortcut'
+import { keyBinds } from 'lib/components/Shortcuts/shortcuts'
 import { TimezoneSelect } from 'lib/components/TimezoneSelect'
-import { humanFriendlyNumber } from 'lib/utils/numbers'
+import { IconPauseCircle, IconPlayCircle } from 'lib/lemon-ui/icons'
+import { Scene } from 'scenes/sceneTypes'
 
 import { KeyboardShortcut } from '~/layout/navigation-3000/components/KeyboardShortcut'
 
+import { logsViewerDataLogic } from 'products/logs/frontend/components/LogsViewer/data/logsViewerDataLogic'
 import { LogsOrderBy } from 'products/logs/frontend/types'
 
 import { LogsExportMenu } from './LogsExportMenu'
 import { logsViewerLogic } from './logsViewerLogic'
 
 export interface LogsViewerToolbarProps {
+    // Used by the export menu for its "all matching logs" label + size limit, not shown as a count here
+    // (the lens-aware count indicator lives in the results bar's persistent-left frame).
     totalLogsCount?: number
     orderBy: LogsOrderBy
     onChangeOrderBy: (orderBy: LogsOrderBy) => void
-    onOpenFullScreen?: () => void
 }
 
+/**
+ * Contextual-right cluster of the results bar — live tail plus how the Logs list renders (sort, wrap,
+ * timezone, export) and the keyboard-shortcut help. Logs-only: the bar hides this whole cluster in
+ * Patterns mode, where none of it applies. Live tail streams the query (the others don't re-run it) —
+ * it lives here, technically the "wrong" scope, so it hides with this cluster instead of shifting the
+ * top bar's layout when the lens changes.
+ */
 export const LogsViewerToolbar = ({
     totalLogsCount,
     orderBy,
     onChangeOrderBy,
-    onOpenFullScreen,
 }: LogsViewerToolbarProps): JSX.Element => {
     const { wrapBody, timezone } = useValues(logsViewerLogic)
     const { setWrapBody, setTimezone } = useActions(logsViewerLogic)
+    const { liveTailRunning, liveTailDisabledReason } = useValues(logsViewerDataLogic)
+    const { setLiveTailRunning } = useActions(logsViewerDataLogic)
 
     return (
-        <div className="flex justify-between flex-wrap gap-2">
-            <div className="flex gap-2 flex-wrap">
-                <LemonSegmentedButton
-                    value={orderBy}
-                    onChange={onChangeOrderBy}
-                    options={[
-                        {
-                            value: 'earliest',
-                            label: 'Earliest',
-                        },
-                        {
-                            value: 'latest',
-                            label: 'Latest',
-                        },
-                    ]}
+        <div className="flex items-center gap-2 flex-wrap">
+            <Shortcut
+                name="LogsLiveTail"
+                keybind={[keyBinds.edit]}
+                intent={liveTailRunning ? 'Stop live tail' : 'Start live tail'}
+                interaction="click"
+                scope={Scene.Logs}
+            >
+                <LemonButton
                     size="small"
-                />
-                <LemonCheckbox checked={wrapBody} bordered onChange={setWrapBody} label="Wrap message" size="small" />
-                <TimezoneSelect value={timezone} onChange={setTimezone} size="small" />
-                <LogsExportMenu totalLogsCount={totalLogsCount} />
-                {onOpenFullScreen && (
-                    <LemonButton
-                        size="small"
-                        icon={<IconExpand45 />}
-                        onClick={onOpenFullScreen}
-                        tooltip="Full screen"
-                    />
-                )}
-            </div>
-            <div className="flex items-center gap-4 flex-wrap">
-                {totalLogsCount !== undefined && totalLogsCount > 0 && (
-                    <span className="text-muted text-xs">{humanFriendlyNumber(totalLogsCount)} logs</span>
-                )}
-                <Tooltip
-                    title={
-                        <div className="flex flex-col gap-1.5 p-1">
-                            <div className="flex items-center justify-between gap-4">
-                                <span>Navigate</span>
-                                <span className="flex items-center gap-1">
-                                    <KeyboardShortcut arrowup />
-                                    <KeyboardShortcut arrowdown />
-                                    or
-                                    <KeyboardShortcut j />
-                                    <KeyboardShortcut k />
-                                </span>
-                            </div>
-                            <div className="flex items-center justify-between gap-4">
-                                <span>Expand</span>
-                                <KeyboardShortcut enter />
-                            </div>
-                            <div className="flex items-center justify-between gap-4">
-                                <span>Prettify</span>
-                                <KeyboardShortcut p />
-                            </div>
-                            <div className="flex items-center justify-between gap-4">
-                                <span>Refresh</span>
-                                <KeyboardShortcut r />
-                            </div>
-                        </div>
-                    }
+                    type={liveTailRunning ? 'primary' : 'secondary'}
+                    icon={liveTailRunning ? <IconPauseCircle /> : <IconPlayCircle />}
+                    onClick={() => setLiveTailRunning(!liveTailRunning)}
+                    disabledReason={liveTailRunning ? undefined : liveTailDisabledReason}
                 >
-                    <button
-                        type="button"
-                        className="text-muted text-xs flex items-center gap-1 cursor-help bg-transparent border-none p-0"
-                        aria-label="Keyboard shortcuts"
-                    >
-                        <IconKeyboard className="text-base" />
-                        Shortcuts
-                    </button>
-                </Tooltip>
-            </div>
+                    Live tail
+                </LemonButton>
+            </Shortcut>
+            <LemonSegmentedButton
+                value={orderBy}
+                onChange={onChangeOrderBy}
+                options={[
+                    {
+                        value: 'earliest',
+                        label: 'Earliest',
+                    },
+                    {
+                        value: 'latest',
+                        label: 'Latest',
+                    },
+                ]}
+                size="small"
+            />
+            <LemonCheckbox checked={wrapBody} bordered onChange={setWrapBody} label="Wrap message" size="small" />
+            <TimezoneSelect value={timezone} onChange={setTimezone} size="small" />
+            <LogsExportMenu totalLogsCount={totalLogsCount} />
+            <Tooltip
+                title={
+                    <div className="flex flex-col gap-1.5 p-1">
+                        <div className="flex items-center justify-between gap-4">
+                            <span>Navigate</span>
+                            <span className="flex items-center gap-1">
+                                <KeyboardShortcut arrowup />
+                                <KeyboardShortcut arrowdown />
+                                or
+                                <KeyboardShortcut j />
+                                <KeyboardShortcut k />
+                            </span>
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                            <span>Expand</span>
+                            <KeyboardShortcut enter />
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                            <span>Prettify</span>
+                            <KeyboardShortcut p />
+                        </div>
+                        <div className="flex items-center justify-between gap-4">
+                            <span>Refresh</span>
+                            <KeyboardShortcut r />
+                        </div>
+                    </div>
+                }
+            >
+                <button
+                    type="button"
+                    className="text-muted text-xs flex items-center gap-1 cursor-help bg-transparent border-none p-0"
+                    aria-label="Keyboard shortcuts"
+                >
+                    <IconKeyboard className="text-base" />
+                    Shortcuts
+                </button>
+            </Tooltip>
         </div>
     )
 }


### PR DESCRIPTION
## TL;DR

Refactors the logs product UI to extract the full screen button into a dedicated component and reorganizes control placement as part of a broader information architecture review for the logs product.

## Problem

The logs product is undergoing a comprehensive review and redesign of its information architecture. This change supports that effort by decoupling the full screen button logic into a reusable component and restructuring how controls are organized in the filter and query bars.

## Changes

- **Extracted `LogsFullScreenButton` component**: Created a new dedicated component for the full screen functionality, making it reusable and easier to maintain
- **Updated `LogsFilterBar` and `LogsQueryBar`**: Added optional `showFullScreenButton` prop to conditionally render the new button component
- **Reorganized control layout**: Wrapped `LogsQueryControls` and `LogsFullScreenButton` in a flex container with consistent spacing (`gap-1.5`)
- **Refactored `LogsQueryControls`**: Removed live tail button and related keyboard shortcut logic from this component as part of control reorganization
- **Updated imports**: Removed unused imports related to live tail functionality (`IconPauseCircle`, `IconPlayCircle`, `Shortcut`, `keyBinds`, `Scene`)
- **Documentation improvements**: Enhanced JSDoc comment on `LogsQueryControls` to clarify its scope and explain placement rationale for live tail in results bar

## How did you test this code?

Since this is an agent-generated PR, no manual testing was performed. The changes involve component extraction and prop additions that should be validated through:
- Existing component render tests
- Integration tests verifying the optional `showFullScreenButton` prop behavior in both filter and query bars
- Visual regression tests to confirm layout consistency with the new flex container spacing

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*