### PR TITLE
chore(cohorts): improve hogvm exec o11y

### DIFF
--- a/rust/cohort-stream-processor/src/hogvm/executor.rs
+++ b/rust/cohort-stream-processor/src/hogvm/executor.rs
@@ -132,9 +132,11 @@ fn outcome_to_bool(outcome: EvalOutcome) -> bool {
             // distinct name once at info — the counter already tracks volume, so a per-event line
             // would be spam.
             counter!(STAGE1_HOGVM_UNKNOWN_FUNCTION).increment(1);
-            if !SEEN_UNKNOWN_FNS.contains(name.as_str()) {
+            // Steady state is a read-only `contains` (no allocation; the same handful of names recur
+            // forever). Only on first sight do we clone-and-insert: `insert` returns `true` for
+            // exactly one thread, so the log fires once even when several race past `contains` at once.
+            if !SEEN_UNKNOWN_FNS.contains(name.as_str()) && SEEN_UNKNOWN_FNS.insert(name.clone()) {
                 info!(function = %name, "cohort bytecode called a function with no registered Rust native");
-                SEEN_UNKNOWN_FNS.insert(name); // move in — name unused after the log
             }
             false
         }

--- a/rust/cohort-stream-processor/src/hogvm/executor.rs
+++ b/rust/cohort-stream-processor/src/hogvm/executor.rs
@@ -4,14 +4,20 @@
 //! The hot path reuses one [`CohortEvaluator`] per event: the STL context and globals are set once
 //! and only the program is swapped per condition, amortizing the context build across all conditions.
 
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
+use dashmap::DashSet;
 use hogvm::{sync_execute, ExecutionContext, Program, VmError};
 use metrics::counter;
 use serde_json::Value;
-use tracing::debug;
+use tracing::info;
 
 use crate::observability::metrics::{STAGE1_HOGVM_ERROR, STAGE1_HOGVM_UNKNOWN_FUNCTION};
+
+/// Unknown-native function names already logged once. Bounded by the HogQL native surface
+/// (~hundreds max), so it never grows without bound; keeps the per-event unknown-function path
+/// observable in prod logs without a line per event.
+static SEEN_UNKNOWN_FNS: LazyLock<DashSet<String>> = LazyLock::new(DashSet::new);
 
 /// HogVM stack ceiling for cohort evaluation. `with_defaults` caps the stack at 128, far below real
 /// cohort bytecode: a `person.properties.X IN (...)` leaf compiles to a tuple build that pushes every
@@ -122,15 +128,69 @@ fn outcome_to_bool(outcome: EvalOutcome) -> bool {
         EvalOutcome::Matched(matched) => matched,
         EvalOutcome::UnknownFunction(name) => {
             // `name` is bytecode-derived from user cohort filters; keep it out of the metric label
-            // (bounded counter) and surface the specific function only in a debug log.
+            // (bounded counter) and surface the specific function in a log instead. Log each
+            // distinct name once at info — the counter already tracks volume, so a per-event line
+            // would be spam.
             counter!(STAGE1_HOGVM_UNKNOWN_FUNCTION).increment(1);
-            debug!(function = %name, "cohort bytecode called a function with no registered Rust native");
+            if !SEEN_UNKNOWN_FNS.contains(name.as_str()) {
+                info!(function = %name, "cohort bytecode called a function with no registered Rust native");
+                SEEN_UNKNOWN_FNS.insert(name); // move in — name unused after the log
+            }
             false
         }
-        EvalOutcome::VmError(_) => {
-            counter!(STAGE1_HOGVM_ERROR).increment(1);
+        EvalOutcome::VmError(error) => {
+            counter!(STAGE1_HOGVM_ERROR, "reason" => vm_error_reason(&error)).increment(1);
             false
         }
+    }
+}
+
+/// Collapse a [`VmError`] into a bounded `reason` label for [`STAGE1_HOGVM_ERROR`]. The bucket set is
+/// fixed and small so the Prometheus series count stays constant; the `_` arm keeps the match total
+/// over the `#[non_exhaustive]` enum and folds in `VmError::Other`. `UnknownFunction`/`UnknownSymbol`
+/// are normally routed to [`EvalOutcome::UnknownFunction`] (separate counter) — mapped here only for
+/// totality in case [`classify_failure`] ever changes.
+fn vm_error_reason(error: &VmError) -> &'static str {
+    match error {
+        VmError::InvalidValue(..)
+        | VmError::CannotCoerce(..)
+        | VmError::InvalidNumber(_)
+        | VmError::IntegerOverflow => "type_coercion",
+
+        VmError::StackOverflow | VmError::StackUnderflow | VmError::StackIndexOutOfBounds => {
+            "stack"
+        }
+
+        VmError::NotImplemented(_) => "not_implemented",
+
+        VmError::UnknownGlobal(_) | VmError::UnknownProperty(_) => "unknown_ref",
+
+        VmError::NotAnOperation(_)
+        | VmError::InvalidOperation(_)
+        | VmError::EndOfProgram(_)
+        | VmError::InvalidBytecode(_)
+        | VmError::InvalidCall(_)
+        | VmError::NotEnoughArguments(..)
+        | VmError::CaptureOutOfBounds(_)
+        | VmError::NoFrame => "program",
+
+        VmError::UncaughtException(..) | VmError::InvalidException => "exception",
+
+        VmError::DivisionByZero
+        | VmError::HeapIndexOutOfBounds
+        | VmError::UseAfterFree
+        | VmError::ExpectedObject
+        | VmError::UnexpectedPopTry
+        | VmError::InvalidIndex
+        | VmError::CycleDetected
+        | VmError::IndexOutOfBounds(..)
+        | VmError::OutOfResource(_)
+        | VmError::NativeCallFailed(_)
+        | VmError::InvalidRegex(..) => "runtime",
+
+        VmError::UnknownFunction(_) | VmError::UnknownSymbol(_) => "unknown_function",
+
+        _ => "other", // VmError::Other + any future #[non_exhaustive] variant
     }
 }
 
@@ -410,6 +470,40 @@ mod tests {
             json!(OP_RETURN),
         ]);
         bc
+    }
+
+    #[test]
+    fn vm_error_reason_buckets_one_representative_per_class() {
+        // One representative `VmError` per bucket. Catches a forgotten or mis-bucketed variant: a
+        // new `#[non_exhaustive]` variant left unhandled silently falls into `other`, and moving an
+        // existing variant (e.g. `DivisionByZero` out of `runtime`) breaks the label breakdown.
+        let cases: [(VmError, &str); 11] = [
+            (
+                VmError::InvalidValue("a".into(), "b".into()),
+                "type_coercion",
+            ),
+            (VmError::IntegerOverflow, "type_coercion"),
+            (VmError::StackOverflow, "stack"),
+            (VmError::NotImplemented("x".into()), "not_implemented"),
+            (VmError::UnknownGlobal("g".into()), "unknown_ref"),
+            (VmError::InvalidBytecode("b".into()), "program"),
+            (
+                VmError::UncaughtException("t".into(), "m".into()),
+                "exception",
+            ),
+            (VmError::DivisionByZero, "runtime"),
+            // The `max_steps` blowup (`vm.rs` synthesizes `OutOfResource`) must stay visible.
+            (VmError::OutOfResource("steps".into()), "runtime"),
+            (VmError::UnknownFunction("f".into()), "unknown_function"),
+            (VmError::Other("o".into()), "other"),
+        ];
+        for (error, expected) in &cases {
+            assert_eq!(
+                vm_error_reason(error),
+                *expected,
+                "wrong bucket for {error:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/cohort-stream-processor/src/observability/metrics.rs
+++ b/rust/cohort-stream-processor/src/observability/metrics.rs
@@ -124,7 +124,9 @@ pub const STORE_MERGE_MALFORMED_TOTAL: &str = "store_merge_malformed_total";
 /// Cohort bytecode invoked a symbol with no registered native (counter). The function name is
 /// logged, not labelled, to keep cardinality bounded.
 pub const STAGE1_HOGVM_UNKNOWN_FUNCTION: &str = "stage1_hogvm_unknown_function_total";
-/// Any other VM/program failure during cohort evaluation, coerced to `false` (counter).
+/// Any other VM/program failure during cohort evaluation, coerced to `false`, labelled by `reason`
+/// (a bounded semantic bucket: `type_coercion`|`stack`|`program`|`runtime`|… — see
+/// `vm_error_reason`) (counter).
 pub const STAGE1_HOGVM_ERROR: &str = "stage1_hogvm_error_total";
 /// `properties`/`person_properties` JSON parse failure, labelled by `field` (counter).
 pub const STAGE1_GLOBALS_PARSE_ERROR: &str = "stage1_globals_parse_error_total";


### PR DESCRIPTION
## Problem

`cohort-stream-processor` runs a non trivial rate of HogVM bytecode evaluation errors in prod shadow, but both error paths are blind. Every non unknown function `VmError` collapses into one label free `stage1_hogvm_error_total` counter, so we can't tell a coercion miss from a stack blowup from a step limit. The unknown native path bumps a label free counter and logs the function name only at `debug!`, filtered out in prod, so we never learn which natives are missing.

## Changes

Observability only patch scoped entirely to `cohort-stream-processor`; the shared `hogvm` crate is untouched, so cymbal and other consumers are unaffected. A new private `vm_error_reason` classifier adds a bounded `reason` label to `stage1_hogvm_error_total`, collapsing all 33 `VmError` variants into nine fixed `&'static str` buckets (`type_coercion`, `stack`, `not_implemented`, `unknown_ref`, `program`, `exception`, `runtime`, `unknown_function`, `other`) so the series count stays constant. The unknown function log moves from `debug!` to `info!`, deduped via a `LazyLock<DashSet<String>>` so each distinct missing native logs once then stays silent while the counter keeps recording every occurrence. Behavior is unchanged: every path still returns the same `bool` (`false` on error or unknown function), so there is no cohort membership or shadow parity impact, and the hot path stays allocation free in steady state.

## How did you test this code?

New parameterized `vm_error_reason` mapping test pinning one representative `VmError` per bucket; it catches a forgotten or mis bucketed variant, the one realistic regression here, which no existing test covered.

## Docs update

No.