### PR TITLE
chore(insights): ship winning add-to-dashboard variant, drop flag

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5635,19 +5635,19 @@ snapshots:
     scenes-app-insights-boldnumber--compare-null-previous--dark:
         hash: v1.k794b7964.ccab3f6785db86e659c4186e305b97ba81c7bda8c51e7fd5c05e179be4393fde.C-X-Y3nG_88O1MxV0YKV52bqS_DKlvdLVHa5HDj0GRI
     scenes-app-insights-boldnumber--compare-null-previous--light:
-        hash: v1.k794b7964.785007f2c0354ca71f02f79eedc11b2fd48d97aab007f2b1e252bc102ddd94ad.uPVYk4rJBkgswqvx1leCKTQvPsRP1ahBR7wdAjOpxxQ
+        hash: v1.k794b7964.85173aab5e9a6a8a3de473d9468ef5b2011cf7629cce5110ded66a1e84a5924e.ibso83XZvHqvXpQXINbWEkUaZB3T7GQTEEEiSxTI8sU
     scenes-app-insights-boldnumber--default--dark:
-        hash: v1.k794b7964.52d5a5cdd707d7a78fb3c505f004956e32f33e50953ac510d0cc932773ade3cc.b0oelePabjdwnPE3Lgm0rqM2WRzef6kakrukwq_Ekos
+        hash: v1.k794b7964.9d78077565031ebd7b5a0cc88e7869f586eaa1e7e39c3441fdb350225de226d3.KJs76lHsNKrY4OHHJpB2Zz8Qv4Iyg21szMxa_V1OTNw
     scenes-app-insights-boldnumber--default--light:
-        hash: v1.k794b7964.81f205b47382c368f40c35aa70de8df86ee70f6a559822c507d78aad82eb3d06.-bwL4_vIt9WdYeFZrSEnNTZZ92RXRmdQ5u_h1JGwyv4
+        hash: v1.k794b7964.16f15c20513daaa8d7794d0a02bd8a36dc36baf40665466ba2170eadc25b7331.bq3n2Fqp7irhEBSmNWhjD_cRYjhPU1l_bncIKMOR2bs
     scenes-app-insights-boldnumber--empty-result--dark:
         hash: v1.k794b7964.5cfecce464cf0a7c39180db4e18e872a5cc2bee9b39f7aac6523335d2dfca338.k-PcU5Nz8u1w6A15afd1uRtEXZATYzg9Ac1ZAZYxymI
     scenes-app-insights-boldnumber--empty-result--light:
         hash: v1.k794b7964.43dd405458463a51299237ee08a8a6d4d800a90e7c8c780b482dc4869221f3d1.wXplXiK-YmHa2PibOdk7Ho2POfSR8zftI8scyBO8v7E
     scenes-app-insights-error-empty-states--empty--dark:
-        hash: v1.k794b7964.0368a42b05ce1ff1d84ee0a9452a0b8b3d28877b8ffcc408a0647cba07889ae1.foa5cNmmNsSXL-P_pWyfu6N4vdAwiQCgCmLq0-TCV1Y
+        hash: v1.k794b7964.0a16503cde7cf4af5c1caa6f057b9f738db3d1c2c3638713152d7964a0f91ef7.Bk-ftck_vh3VWD6uGffqnaTL0tiohdqg0qjd0-5xFbo
     scenes-app-insights-error-empty-states--empty--light:
-        hash: v1.k794b7964.92c8fb304c0601de4d84a18678870a40c35c564e46b77acd5d67f43106ed7c40.B5nsQBFrl5RQa5KF1Wu8Hf7u_3-WE0gU616WAFM6prw
+        hash: v1.k794b7964.28ca413b2b017196afab536768f08af713dd42f40c161d4e9b32835eadc1a60c.M5Kbp4QFXL9KvJHTG71DTboRyaoCNlTeCfvm8Qy8Lvs
     scenes-app-insights-error-empty-states--estimated-query-execution-time-too-long--dark:
         hash: v1.k794b7964.b9422f5449cc4322a2711ea01cbe37125ef573d616a60847393d82b0e32c35ce.1ztGhvMfdYM7xrcsqPGPzZIeMlEsI3awB6hZsuwDWN8
     scenes-app-insights-error-empty-states--estimated-query-execution-time-too-long--light:
@@ -5657,21 +5657,21 @@ snapshots:
     scenes-app-insights-error-empty-states--funnel-single-step--light:
         hash: v1.k794b7964.9c5df35b0f9a37a777f699a31ac22e00fb92e70df42ba53b7e9bf8cc4f46b26b.WaPac1RajKdQQdH_8InxPTcyUumG2G9jLUjImYxa3NI
     scenes-app-insights-error-empty-states--long-loading--dark:
-        hash: v1.k794b7964.14e42bd6366be9a25f39949ee99d702a1c0c080f649245f2aadde1160de4de07.zLR54ZqGTQ_PSCYRduAQBXdJbqYZVkhJCkOIdKYnS08
+        hash: v1.k794b7964.6fab30956ed25188d1d8c2fc98a5af54e458b58dc10c82401e0e10a833608e5c.NIC92d8iTk_V-j4qZ7MlJILmVhCLFhxs5fQBL1s58P8
     scenes-app-insights-error-empty-states--long-loading--light:
-        hash: v1.k794b7964.bc38196e0f4667d4ffcea70574dc5800a0b485c05f8a10c4b256ebfd190c503c.yxj4ggN_Gb_emZvBr-d6kM7HexA1pBrqHUQspTs6aLM
+        hash: v1.k794b7964.8607802c97bc7effd42e5ed3a999ed449e834af2f7e5dd1da6cccb40167c162b.0eHHgtIXZkUPqaVHpwG_Rj-Zvo46FRgcVvE6IpJ0CO8
     scenes-app-insights-error-empty-states--query-server-error--dark:
-        hash: v1.k794b7964.57499c5a390ee60c42fce51c65836c956a7835030de67d2be8c3da7d6e015b80.4yDwEGWym0PgXsrkjIAlkVb0bRJnmRQkiXueOZBiAq0
+        hash: v1.k794b7964.005abe2e0f539238af2ca253bbe731693b8c471e2644ffbfd2a05a6342fdc985.1ZcewTlj1LmJTbtfqPMAz_1GHXRJLLxAuM_Gsjm2vmw
     scenes-app-insights-error-empty-states--query-server-error--light:
-        hash: v1.k794b7964.00b63f71c46b269e4a0b02f60b7bba736136f63c1fb9c0980d4d05e3e936a433.x-Twbcyn3EAi2ZDIbhE0kVRvbLE_dqjxJ8q2tWeU9Sg
+        hash: v1.k794b7964.f5d559930cab224457d1036ff94cfaf4af434d46a7f3a0d089f2dfce09428cff.trKJVpcHaVPzaDpTunTGkEJhTy6PcXgiSWM60e7_MyI
     scenes-app-insights-error-empty-states--server-error--dark:
-        hash: v1.k794b7964.0368a42b05ce1ff1d84ee0a9452a0b8b3d28877b8ffcc408a0647cba07889ae1.nlvBufFIcinhNJezNIG_ja_X2TB1MX_kjIV4kFYybHc
+        hash: v1.k794b7964.0a16503cde7cf4af5c1caa6f057b9f738db3d1c2c3638713152d7964a0f91ef7.qtboW48IKHyIdDou3rip3SAQiFQOwgAMxefsjbej52Q
     scenes-app-insights-error-empty-states--server-error--light:
-        hash: v1.k794b7964.92c8fb304c0601de4d84a18678870a40c35c564e46b77acd5d67f43106ed7c40.LiFU6oxFvsCnYw5JCtLAmvlFnVbYtuBLDMO4E64WYmc
+        hash: v1.k794b7964.28ca413b2b017196afab536768f08af713dd42f40c161d4e9b32835eadc1a60c.qejFZv_WRs4jylwDZ1aJ_lAv-e1OHMP3M9up7t97z2Y
     scenes-app-insights-error-empty-states--validation-error--dark:
-        hash: v1.k794b7964.0368a42b05ce1ff1d84ee0a9452a0b8b3d28877b8ffcc408a0647cba07889ae1.-wN8XAWe2GAioSmjQDEb5k3oGenTaB2mFhVkroDDe4M
+        hash: v1.k794b7964.0a16503cde7cf4af5c1caa6f057b9f738db3d1c2c3638713152d7964a0f91ef7.Z2deDot9QeAjXaZq8PQAsayIINn3c8weG6w0cfk0QrI
     scenes-app-insights-error-empty-states--validation-error--light:
-        hash: v1.k794b7964.92c8fb304c0601de4d84a18678870a40c35c564e46b77acd5d67f43106ed7c40.dRaYnRLbmYUMOvH8PMSu33em-0hXHbajbOFCw7EBVwQ
+        hash: v1.k794b7964.28ca413b2b017196afab536768f08af713dd42f40c161d4e9b32835eadc1a60c.GOWYv_1ExD8dSYxoAvHYhRnUsjnoX5hOqTDC8HZVA88
     scenes-app-insights-funnels--funnel-historical-trends--dark:
         hash: v1.k794b7964.8956eece27221be6f587d4bed7e33b43e9f3a667ee8044bb0bbb9cd86f3aa521.asPDbCCVy9PvK11TeV3SmyTgF_24mykNk2VznI-sOZs
     scenes-app-insights-funnels--funnel-historical-trends--light:
@@ -5709,21 +5709,21 @@ snapshots:
     scenes-app-insights-funnels--funnel-left-to-right-edit-viewports--wide--light:
         hash: v1.k794b7964.a6545e07243ed209cc192018c823885f18258634f9da9c5ef7ed0aefc2bf88f1.3QGxHpuDQiT3BnolocywC5Fdo34arGKBD4qwH4nPJLk
     scenes-app-insights-funnels--funnel-time-to-convert--dark:
-        hash: v1.k794b7964.c744f53550b964a531653504150021418f1e4f3a97b49a5bdc630702c4f1e647.lWgC3HqBecT9i-QNSnIiRtqRCiPyxwGXhJgSphsG2ow
+        hash: v1.k794b7964.a1852ab9b8a4d2d939972856b57ec3418ddf3d8be8d03201c55e34d8cabfab54.5eYkxgR5CciZdyg1_tktcrkIIjgS6DPOwQA-36Z5XP4
     scenes-app-insights-funnels--funnel-time-to-convert--light:
-        hash: v1.k794b7964.f0730fcb1d08b5df4e3e2ae2550f64fa8e8004f071afb98c265e5a625ce72fa8.toiNd_1mVMjdF0AC2kmaIqI1icSdCKiKbfurbk0HrdE
+        hash: v1.k794b7964.cce281a791bc60937692a4edbed457f95bc5118486369b77259bf84307f7670a._SM9lanWzqPLe8UxSgmpXIcgZhpN5JL39Y-fJObg-mU
     scenes-app-insights-funnels--funnel-time-to-convert-edit--dark:
         hash: v1.k794b7964.7a3728a95dd81e93f026c6c69db9d1da26b8c4aab77b068ecc0bcce807a55710.A5wiWqJrAxvZqtboWNIokPtQRw-TCC3p8iKdoaQOgcY
     scenes-app-insights-funnels--funnel-time-to-convert-edit--light:
         hash: v1.k794b7964.4a49e714bf961497ba430d4290fb351da53cc55f6ac6199b795ab3d1dd62812b.qJRXzfJgfbShZLndjjG-jDpuOSzvMHG_P0sdd9sc7GE
     scenes-app-insights-funnels--funnel-top-to-bottom--dark:
-        hash: v1.k794b7964.8db1258f34ede6ad267bc642a8bcba755e453f49fbeddba9b7be8ed9923e8bb1.A_UiEvt5CZGmM1Mb_iqjGsY-7lOKcsD_RBsdBGhpOzI
+        hash: v1.k794b7964.f26d9ad5be280fff963bf5611f2d0f48ef49f405d7e24083a2c50088575415be.A1Mv1sLP5laq8TqQShQ0SUPbrBxM9xnHXczoQ5H5u7c
     scenes-app-insights-funnels--funnel-top-to-bottom--light:
-        hash: v1.k794b7964.6c7299d79e6b47b447ac89c59181a858642fff6d2cbe202746787ed645da695a.43An8Y9wLoEYkKi_HxPHtOZbp2l6vp-plyHsAgJ_VWA
+        hash: v1.k794b7964.65f39ec0218992362c2dd59acbeb3c5b9e6f92aef779bf2c1d5c6a57171e59c8.LRcv3H9x-gf11-7hr5iwst7OnwclFtukFoK6d95FUJY
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown--dark:
-        hash: v1.k794b7964.19e2593b56e521ad80a40bc3db42d3fec504130f8c9a0dc5d475e10bef3f1d8a.dg6LNB92YBP6JL665lynHN21pcG7yx-lIPCMjg5_M_s
+        hash: v1.k794b7964.6354b5b8c1c488f50dbeaef4e17eeb0103d99d59c8085f5bfa57c76fdcd12c8c.8yIxXJFrMG_esuPFThFIMTQMNb6N8xDQLnSbTSPSMLs
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown--light:
-        hash: v1.k794b7964.4814867d6c7efd058bdab01f85af64c31bc1a4ef1bcdd6d85089ed2db0314a3b.aiYtHieenoIr9bTqDRUzETLqIkkp-2PKa6Qvk4a2p58
+        hash: v1.k794b7964.1a8d68aff3a5ae58525d0b98636f5ff6423510580344ff490bb16a47b72e45f1.qdbMAsQNwka4BpMORz8xDdhA9pVzVk2tC9at3ZEvttk
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown-edit--dark:
         hash: v1.k794b7964.68dab4828cba7093dab2123f3408385346662c89e5ed0c13e259e17bfd2b3c15.Sj_jCbechXIz_aE8a1G5YXoCkMHonhuxA9STkYYzI0Y
     scenes-app-insights-funnels--funnel-top-to-bottom-breakdown-edit--light:
@@ -5745,9 +5745,9 @@ snapshots:
     scenes-app-insights-loading-messages--loading-messages--light:
         hash: v1.k794b7964.6e7f58555ec0ab4517c718a4062f7ec433c2f849c5870fbdf7f4a1c86c7d7462.ic0QxTM26TV5twnRajAcxcCfwKuZJbvilyt80dyUN5k
     scenes-app-insights-regionmap--default--dark:
-        hash: v1.k794b7964.21b9e4027a5913d2376146381c664363809897d9ce1b4d65635952d3717aa57e.xHSrrPG13gLq3TvF-JCmn7wvxbsbdLTDjZAd0yfcqAQ
+        hash: v1.k794b7964.1da35c2684f9c0b6ab0043c27cfa880693ad3a31bba2aaeffa101dca5427c4d7.AV2LBdDhvM_G28U2qGXNMKF8hEbKcexDdk3I7Lz4X5M
     scenes-app-insights-regionmap--default--light:
-        hash: v1.k794b7964.3f1a9d207ebf19f7c689b7fe693b7f9465cce7fcb2469e8c5e85221070c2b6ce.iMRM2OPxtCb5VKtz_806oAbils17MRdOYJwpdhSBzB0
+        hash: v1.k794b7964.0fc087d30ae9b4b341417f7460206ad0ddce950d917d70c185b0e53af910df5e.Hw0uXbsBSckfNznt7240Z0dQNoSaQrQFqc8N6Dg2P-s
     scenes-app-insights-side-panel-actions--saved-data-visualization--dark:
         hash: v1.k794b7964.b834f72783ae78a05359b8807e901cfda0a8e64acf6cbf1ad3cd237082a9d89c.VJ76055jUdsM0mOSOwDhgUxnsYtnb2Ts7whfLdD81XA
     scenes-app-insights-side-panel-actions--saved-data-visualization--light:
@@ -5765,13 +5765,13 @@ snapshots:
     scenes-app-insights-side-panel-actions--unsaved-insight--light:
         hash: v1.k794b7964.7180b4983b5642a68739131ded6c6384da02a0ded7222a61b953528408c0d8da.SMleSIwURAK37u45AflJdlFC9lvQimCdvghXz4PxSF0
     scenes-app-insights-sqllinechart--sql-line-chart--dark:
-        hash: v1.k794b7964.733c97d687bd48371884a604f2f767300bc2d185494e6f7ecf02faacea08a2f2.E8RDDT5TN8xSbobDRw7nQzkj55V8nBkdanQYk1Q-NYc
+        hash: v1.k794b7964.c1510d1a19d645a1d3d6717f0d665b9c31379159b1a1de5f09f436f6d4ef6d0f.-H-VCnMnmizs4B7LUq6LY59XExob2CrFJiXQIdxuCdE
     scenes-app-insights-sqllinechart--sql-line-chart--light:
-        hash: v1.k794b7964.79d06321e6cd3dc03f28d8f9a7eb2bc66f196c1b83a82e76aa5e63a24100b025.7CrJm0pehWugGKFBkHBlL2qqmueBxhHD3Hx6j4whYYk
+        hash: v1.k794b7964.c236f3e9bad412e3dc7d886e6db18099d93d014e73977f770d9f38583c5c2e32.DNapPGv2bx3r2nRs0mo3i6k0O9mEa-UDpzUv62pI7fY
     scenes-app-insights-sqllinechart--sql-line-chart-breakdown--dark:
-        hash: v1.k794b7964.486007121c9a82df768c7474916477a3e46e69b49b83401da0fa51bdd6279300.UTIVI6M2LJyrUd-l5ym6crCCsGmzZ8xrdtoI1TfBrDA
+        hash: v1.k794b7964.ba4e1d24477b6548df14769a52b8d9f0d7e802f7693126e0151a38ac95c38ea8.qAuALdtNOYU-NtW_2ZjB1LKSHJg6s09NASuyT2gCyUI
     scenes-app-insights-sqllinechart--sql-line-chart-breakdown--light:
-        hash: v1.k794b7964.c11566cd09e1284b866c92a29482b1fdc6cf206b0b5e1fb46f2e553c19549a57.Xk4vP5_LzV-5_uSJWDNKR9YIEzfduyKuetdlsGn3FIs
+        hash: v1.k794b7964.f2e9f656635894faf2ac200c88a0f3b041d7e5358e9987d9d47f2a51889ba57a.vLh4a9B244w18IpAd9c5at_CczehzQilRmCNgEGtlBg
     scenes-app-insights-sqllinechart--sql-line-chart-trend-line-quill--dark:
         hash: v1.k794b7964.576ceec72a168753a7fb85e57c7e1c7f45660ae22926efcd3c1ab99141e5508d.AZaZxEtUZgaYwWWuutcC6gIFyyRh3cH7CFmVuquQOeE
     scenes-app-insights-sqllinechart--sql-line-chart-trend-line-quill--light:
@@ -5785,17 +5785,17 @@ snapshots:
     scenes-app-insights-trendsboxplot--trends-box-plot-edit--light:
         hash: v1.k794b7964.0f04f4d2f31d4cd168f602fdf52c6c4dd671e13ebdcb3f2d55e474d5150bef89.6dyqUrim2JP9x4p2RvB43VD4zeGVHGi-hmPKPQe_Heg
     scenes-app-insights-trendsmetric--trends-metric--dark:
-        hash: v1.k794b7964.78702e7b3a96182cce0f0093fd66d6a6b3ca7d9a61cda74804a033eb2a19d1e2.SnoS_KhAKCQGWymkhwtZ8ygxj2FzF-GN7Gm5HF36m5U
+        hash: v1.k794b7964.44332a801ecd9083ae76774bb2cc986605eb5ff6a46841ab12b1fab684e5638e.cCOT-aG-98aDgh3wgIT83xrxoxnjLw18tGRzCDTKu7c
     scenes-app-insights-trendsmetric--trends-metric--light:
-        hash: v1.k794b7964.b10fade93852ef1aee28349f66d294eea60679613154dfe2ec8275c41ceaa1e5.1VA5kRv9PTPPo2JsE9IRux68ErPP_lMA-nBjsezc47I
+        hash: v1.k794b7964.ff706471d9c029d34ac7ee3b9d840589e2116b6d352ba52cd3d22a77ffb7588c.kIwiyCGFlQpFf06ubsCEjGYJ1LkAv_kxGavV3_SCXKA
     scenes-app-insights-trendsmetric--trends-metric-edit--dark:
         hash: v1.k794b7964.957dbfd7fd5b3f7510b51c464a35605745b266f8ca63503b64364d15b4d77787.a0bKcs8Bh_bOBQvPrHTL_mov6TFcCJcg9Af_z6ZIAa4
     scenes-app-insights-trendsmetric--trends-metric-edit--light:
         hash: v1.k794b7964.0e72de519e0e573ebbcc5a288110f9ceaa9dc7263fbf67740e54d29e1c5d8cc7.lSOvCInp4FxiQs9_TUcneesPfcILOl7IzP12esglg6s
     scenes-app-insights-trendspie--trends-world-map--dark:
-        hash: v1.k794b7964.7c2513dd39a38ed590ab0ece1c30ff2eab34ed2c60599de28f90a3e698961c1e.BjXUZxRmeRGqVc-DkahiGNwhDsIQRdLm5xQhd1ykhXk
+        hash: v1.k794b7964.24a0a59ce81e70e40240094f193daf433e68d0ef358344e0d55ae8c5d49dc58e.wt9fVNv-xJEdE8mMpuP2-8KHacxBGboNbJZSLs0NKJU
     scenes-app-insights-trendspie--trends-world-map--light:
-        hash: v1.k794b7964.c19ba4d6c010a3d6756839b4b26d00017492a4fdd0b6df8e483ba7b7a3c0c979.Ez8iZh7Jbt7DCX_nqgTpIifrG_x2FOHfLiG2LKhyd6U
+        hash: v1.k794b7964.84b4ceb7ebfaf16029a9578b8a82164b383710cc059e6569942f17f1919c1f41.muG_6ukuFlmANSA4cmKKhBwJl8timjFCNGuuNogrun8
     scenes-app-insights-trendspie--trends-world-map-edit--dark:
         hash: v1.k794b7964.ee5568ad7c36562de11087860c424d458d38f9ab78086e13190a2d344c94886e.Phxh-Ba38MPL53L_jYU4xpEEnTv_7jfXmJZa8vWL3ME
     scenes-app-insights-trendspie--trends-world-map-edit--light:
@@ -5833,21 +5833,21 @@ snapshots:
     scenes-app-insights-trendsvalue--trends-area-edit--light:
         hash: v1.k794b7964.bbe607825ccefaca49d3c49d7bb44c51d7b339ad9efd70700956a0d88e257d47.7eOWo5lXZmPfq4lEPRXcDc3n3qiQGi7mOi1zqzRp27s
     scenes-app-insights-trendsvalue--trends-number--dark:
-        hash: v1.k794b7964.52d5a5cdd707d7a78fb3c505f004956e32f33e50953ac510d0cc932773ade3cc.QrQ3hXksznsix9wKPgq_rD43hvjoUAYF4JNBoGQxz1o
+        hash: v1.k794b7964.9d78077565031ebd7b5a0cc88e7869f586eaa1e7e39c3441fdb350225de226d3.tXX6ZXygLOFeVwCdPQB6LGZafsrBZg8JhTn9EoL4JRI
     scenes-app-insights-trendsvalue--trends-number--light:
-        hash: v1.k794b7964.81f205b47382c368f40c35aa70de8df86ee70f6a559822c507d78aad82eb3d06.llcUV5Lp_ohjPh_13FwyQ-pZVfb4uH1PtablCFgoZCo
+        hash: v1.k794b7964.16f15c20513daaa8d7794d0a02bd8a36dc36baf40665466ba2170eadc25b7331.jEiuOSVAqsxKoB8zHDl2cVX_MH7oavipyYa4-ySGafQ
     scenes-app-insights-trendsvalue--trends-number-edit--dark:
         hash: v1.k794b7964.2e41cf590580dde4f71c9e873f3f9ff8062e6618d93fcd903eb226d4d5566595.dwYk0h2JWHQ_S3E7XxGqArXzTVQHObt0Br9ToX4kIEw
     scenes-app-insights-trendsvalue--trends-number-edit--light:
         hash: v1.k794b7964.c1ebfcff1a0a4ffffc3428a849bde39da217c60555938f755e4c89ac24108867.yviTX2UGvNfnD4G3Ko_Ad6NDFDtDNHNCTXwBigmXaF8
     scenes-app-insights-trendsvalue--trends-table--dark:
-        hash: v1.k794b7964.760194380b159b1fd712e703393a9b25e6be1d53b45078169b4218a0869d2665.CadWQfiDWQGTrw0d_TLvyBueDrD-pCNW4LHXeVVV78U
+        hash: v1.k794b7964.070b7b8115a09c9a809a4c0790b22ed3bdc5d2b2a373601e64e2c441bc569e9f.KY7BBb3rnx5GhU8f9YBB0iYnkuDXFw1UARPJcGVT1Ic
     scenes-app-insights-trendsvalue--trends-table--light:
-        hash: v1.k794b7964.3fe9e04283703a914a561cdfe9f61bb98da4fe8c44dede07f028d329463b5fa0.uBdrmDvcfwgkL-bxDVhl5t0lB17H__fs4tnReJN6dvc
+        hash: v1.k794b7964.bcd18c818eeefc1f93fb23f71fb5ddfb542ecf87cf422395a945e8b9f13e05b7.ggyPWFqrkHmf-tTiniSy4b7RBN-pqxZsSHivj9qahq0
     scenes-app-insights-trendsvalue--trends-table-breakdown--dark:
         hash: v1.k794b7964.6fc3a57221ef65dd56c092fa16a78467ada20fc36e2dd9feadc80c9ce8188c17.-ni-J3yVe4RYt0jvEU2D19wbUVgXDCOOmHLsgCnM4gQ
     scenes-app-insights-trendsvalue--trends-table-breakdown--light:
-        hash: v1.k794b7964.abb6eb77363c56063abf959a0b6494fb7dae80701957ce9f6a244dc4ef84d292.X31gO4UC3kRkxTXBvj7Vq3MapKGzreq21oFp36n6m_c
+        hash: v1.k794b7964.a55d6c85fc0c9c9c608b71a7376e58a854ccc4e5628135dc72102ed40138ede5.LR6K5i_Jt9Z-dR_onXO2WH33TErvVz02NXhtAtMqOvU
     scenes-app-insights-trendsvalue--trends-table-breakdown-edit--dark:
         hash: v1.k794b7964.665c9ac032ac36ccd570c703c43c81a1e350a655e5d9735b2955e7108b37829d.SM7LNoV_fNzapk6M2ZNZal87EjYZs5IdclJhowOXUKs
     scenes-app-insights-trendsvalue--trends-table-breakdown-edit--light:
@@ -5885,17 +5885,17 @@ snapshots:
     scenes-app-insights-trendsvalue--trends-value-edit-viewports--wide--light:
         hash: v1.k794b7964.68cbf9d2c4eee61b8eef5141e734aae405e6d105d89fb69d0c6441ce078cc5b2.8LLKevlrrLubcwVZ2fcxipRqdisU9Q4x1uPbdxb56r8
     scenes-app-insights-user-paths--user-paths--dark:
-        hash: v1.k794b7964.6de0562db52b17d70d574d61eadbc16b27721788c4d7a29dd58cce2f94939b24.PohcqbSYCzy3s9OGIAFCEK-J-Dzrr_Fc6EtRb579xTU
+        hash: v1.k794b7964.6227638fc42b43ae77fa111cc36a04cde3fecbd438ebd56efdc814c799d2d765.3xLCR4E7zkOyYKUnsbRjo0nZWK6j0R1R-CbH0qiA9TA
     scenes-app-insights-user-paths--user-paths--light:
-        hash: v1.k794b7964.9743b1e6ab003f02136a8e887553ac0ffcc1b80ec02df987cf82a8d383d5db6e.FdaGKm2NcD1nGv9LhrCWoI1dX03hMRGvcun8x_d3Suw
+        hash: v1.k794b7964.fd07d310c818925a95dff7ccd84d4063fee4a3587ba760f465638cfdfd947521.fjEeUb3_EbX1fUjhoCp0N9X5h1vOvyuHeEU5Dh8-P-0
     scenes-app-insights-user-paths--user-paths-edit--dark:
         hash: v1.k794b7964.537566c9e0c21fc6468d15414104f087148a870e9284374e58367429f43e28a7.hX4JIEOMK9t-tjgv_Gcrpzonaq8H76OYkybgMQoLUJU
     scenes-app-insights-user-paths--user-paths-edit--light:
         hash: v1.k794b7964.945a70defcfb101b7b2799e62693b90635feb31571dfe77d9613574c9484543a.Gmg4jcHFzDvYOcp4IOxNHt5RyrQkUwYbJfRbRJbTu5g
     scenes-app-insights-worldmap--default--dark:
-        hash: v1.k794b7964.7c2513dd39a38ed590ab0ece1c30ff2eab34ed2c60599de28f90a3e698961c1e.8KDuVJqKRXpbx6CjzV3XsYcuKhHUvS7AvAJmA0qMg8Y
+        hash: v1.k794b7964.24a0a59ce81e70e40240094f193daf433e68d0ef358344e0d55ae8c5d49dc58e.63wyzQTZ6_jHUUS9I7aoW0RorIEsG8hrN32IQxGQSDM
     scenes-app-insights-worldmap--default--light:
-        hash: v1.k794b7964.c19ba4d6c010a3d6756839b4b26d00017492a4fdd0b6df8e483ba7b7a3c0c979.AHuX5vDwY0FLv9I5NuvPfoazaytArdUqYZLmhQO8Pa0
+        hash: v1.k794b7964.84b4ceb7ebfaf16029a9578b8a82164b383710cc059e6569942f17f1919c1f41.jyENq8yugUQDhk-k9t9zwylCRpAEKsSdwGgYUeDUJ9g
     scenes-app-legal-documents--legal-documents-list--dark:
         hash: v1.k794b7964.588a97be73b42aec3fdd93e4535f7046702b31c49cd197738720260eef417602.bl7OWu-_oywQ7s9QyNn-Hw3oN2K7Ag1nnX7rkaLJGTU
     scenes-app-legal-documents--legal-documents-list--light:

--- a/frontend/src/lib/constants.tsx
+++ b/frontend/src/lib/constants.tsx
@@ -328,7 +328,6 @@ export const FEATURE_FLAGS = {
     HOGQL_WAREHOUSE_ACCESS_CONTROL: 'hogql-warehouse-access-control', // owner: @a-lider #team-platform-features, gates per-object access control for warehouse tables and views
     IDENTITY_MATCHING: 'identity-matching', // owner: @fercgomes #team-growth, gates new identity matching scene on marketing analytics
     INBOX_SLACK_NOTIFICATIONS: 'inbox-slack-notifications', // owner: #team-self-driving, gates the Slack notifications config card in the inbox
-    INSIGHT_ADD_TO_DASHBOARD_AAB: 'insight-add-to-dashboard-aab', // owner: @pauldambra #team-product-analytics multivariate=control,control_2,test
     INSIGHT_SUBSCRIBE_PROMINENT_BUTTON: 'insight-subscribe-prominent-button', // owner: @mattp #team-analytics-platform multivariate=control,test
     INTER_PROJECT_TRANSFERS: 'inter-project-transfers', // owner: @reecejones #team-platform-features
     JS_SNIPPET_VERSIONING: 'js-snippet-versioning', // owner: #team-client-libraries

--- a/frontend/src/scenes/insights/InsightPageHeader.tsx
+++ b/frontend/src/scenes/insights/InsightPageHeader.tsx
@@ -57,9 +57,6 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
     )
     const { openAddToDashboardModal, saveAndAddToDashboard } = useActions(insightModalsLogic(insightLogicProps))
 
-    // B branch of the add-to-dashboard A/A/B test (control + control_2 keep current behavior).
-    const isAddToDashboardTest = useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')
-
     // A saved insight with its own short_id — the precondition for every view-mode action in this header.
     const isPersistedInsight = !!isSavedInsight && !!insight.short_id
 
@@ -170,7 +167,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                             </LemonButton>
                         )}
 
-                        {insightMode !== ItemMode.Edit && isAddToDashboardTest && isPersistedInsight && (
+                        {insightMode !== ItemMode.Edit && isPersistedInsight && (
                             <LemonButton
                                 type="secondary"
                                 size="small"
@@ -235,11 +232,7 @@ export function InsightPageHeader({ insightLogicProps }: { insightLogicProps: In
                                 // insight id, so saving a brand-new insight navigates to its real id and re-keys the
                                 // modal logic, dropping the open state. New insights use the view-mode button instead.
                                 // `saveAndAddToDashboard` owns the save-then-open ordering (see insightModalsLogic).
-                                onSaveAndAddToDashboard={
-                                    isAddToDashboardTest && isPersistedInsight
-                                        ? () => saveAndAddToDashboard()
-                                        : undefined
-                                }
+                                onSaveAndAddToDashboard={isPersistedInsight ? () => saveAndAddToDashboard() : undefined}
                             />
                         )}
                     </>


### PR DESCRIPTION
## Problem

Experiment 377997 — "Insight 'Add to dashboard' affordances (A/A/B)" — concluded **won** on the `test` variant. The two control arms (`control`, `control_2`) kept the existing behavior; `test` added a prominent "Add to dashboard" button in insight view mode and a "Save & add to dashboard" option in the save dropdown.

Now that the winner is decided, the flag is dead weight: it's already serving `test` at 100% in PostHog, so the gating just adds a branch and a stale constant.

## Changes

- `InsightPageHeader.tsx` — remove the `useFeatureFlag('INSIGHT_ADD_TO_DASHBOARD_AAB', 'test')` check. The winning affordances are now unconditional for persisted insights.
- `constants.tsx` — remove the `INSIGHT_ADD_TO_DASHBOARD_AAB` flag constant.

No behavior change for users already on the `test` variant (everyone, since the flag is at 100%).

## How did you test this code?

I'm an agent (PostHog Code). I did not manually test in a browser. Automated checks run:

- `oxfmt` on the two changed files — clean
- `tsgo --noEmit` (frontend typescript:check) — no new errors in the changed files (pre-existing errors in `products/workflows/` are unrelated)
- lint-staged feature-flag lint on commit — clean

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Paul directed the work; assigned as DRI.

- Tool: PostHog Code (Claude Opus). Skill invoked: `/cleaning-up-stale-feature-flags` to frame the code-first-then-flag workflow.
- Confirmed via the PostHog MCP that experiment 377997 is stopped and concluded `won`, and that the linked flag already serves `test` at 100%, before removing the code gating.
- Follow-up agreed with Paul: **delete** the `insight-add-to-dashboard-aab` flag in PostHog only *after* this ships — deleting before deploy risks the affordances vanishing for any instance still gating on the flag.
- Note: the repo-wide `format` script (`oxlint --fix-dangerously`) mutated unrelated files' hook dependency arrays and broke one file; reverted those and formatted only the changed files with `oxfmt`.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
