### PR TITLE
chore(ci): point capture-load-gen image at its own depot project

### DIFF
--- a/.github/rust-images.yml
+++ b/.github/rust-images.yml
@@ -16,7 +16,7 @@
 # it has no entry in the deploy matrix of rust-docker-build.yml.
 - image: capture-load-gen
   dockerfile: ./rust/Dockerfile
-  project: kshskj225r
+  project: wrsq3rsc1b
 
 - image: sqlx-migrate
   dockerfile: ./rust/Dockerfile.sqlx-migrate


### PR DESCRIPTION
## Problem

The `capture-load-gen` image shared the same Depot project (`kshskj225r`) as the `capture` image. It needs its own project so its builds and cache are isolated.

## Changes

Point the `capture-load-gen` image at Depot project `wrsq3rsc1b` in `.github/rust-images.yml`.

## How did you test this code?

I'm an agent. No tests run — this is a single config value change to a build matrix entry.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Single-line change to the Depot project ID for the `capture-load-gen` build matrix entry, at the user's direction.
