### PR TITLE
feat(phai): show checkpoint size and per-conversation compact button in admin

### DIFF
--- a/posthog/admin/admins/conversation_admin.py
+++ b/posthog/admin/admins/conversation_admin.py
@@ -1,5 +1,9 @@
 from django.contrib import admin, messages
-from django.urls import reverse
+from django.db.models import Count, Sum
+from django.db.models.functions import Length
+from django.shortcuts import redirect
+from django.template.defaultfilters import filesizeformat
+from django.urls import path, reverse
 from django.utils.html import format_html
 
 from products.posthog_ai.backend.models.assistant import Conversation
@@ -18,6 +22,7 @@ class ConversationAdmin(admin.ModelAdmin):
     # isn't guaranteed registered when ConversationAdmin's system checks run (admin.E039).
     # raw_id_fields needs no registered target admin and still avoids the full-table <select>.
     raw_id_fields = ("task",)
+    readonly_fields = ("checkpoint_storage",)
     ordering = ("-updated_at",)
     actions = ["compact_checkpoints"]
 
@@ -28,6 +33,14 @@ class ConversationAdmin(admin.ModelAdmin):
         # Conversation is soft-deleted by the app; don't expose a cascading hard-delete here.
         return False
 
+    def get_urls(self):
+        compact_url = path(
+            "<path:object_id>/compact/",
+            self.admin_site.admin_view(self.compact_view),
+            name="posthog_ai_conversation_compact",
+        )
+        return [compact_url, *super().get_urls()]
+
     @admin.display(description="Team")
     def team_link(self, conversation: Conversation):
         return format_html(
@@ -35,6 +48,41 @@ class ConversationAdmin(admin.ModelAdmin):
             reverse("admin:posthog_team_change", args=[conversation.team_id]),
             conversation.team.name,
         )
+
+    @admin.display(description="Checkpoint storage")
+    def checkpoint_storage(self, conversation: Conversation):
+        if conversation.pk is None:
+            return "—"
+        # Blobs hold the bulk of a thread's bytes; query them via `thread`, not the `checkpoint` FK.
+        blobs = conversation.blobs.aggregate(count=Count("id"), total_bytes=Sum(Length("blob")))
+        return format_html(
+            '{} checkpoints, {} blobs ({}) &nbsp; <a class="button" href="{}">Compact now</a>',
+            conversation.checkpoints.count(),
+            blobs["count"] or 0,
+            filesizeformat(blobs["total_bytes"] or 0),
+            reverse("admin:posthog_ai_conversation_compact", args=[conversation.pk]),
+        )
+
+    def compact_view(self, request, object_id: str):
+        conversation = self.get_object(request, object_id)
+        if conversation is None:
+            self.message_user(request, "Conversation not found.", messages.ERROR)
+            return redirect("admin:posthog_ai_conversation_changelist")
+        # Bypasses the sweep's rollout allowlist — this is a deliberate staff override.
+        result = compact_thread(str(conversation.id))
+        if result.compacted:
+            self.message_user(
+                request,
+                f"Compacted — reclaimed {result.checkpoints_deleted} checkpoints and {result.blobs_deleted} blobs.",
+                messages.SUCCESS,
+            )
+        else:
+            self.message_user(
+                request,
+                "Nothing compacted (not idle, awaiting approval, or already compact).",
+                messages.WARNING,
+            )
+        return redirect("admin:posthog_ai_conversation_change", object_id)
 
     @admin.action(description="Compact checkpoints (keep latest, reclaim storage)")
     def compact_checkpoints(self, request, queryset) -> None:

--- a/posthog/admin/admins/conversation_admin.py
+++ b/posthog/admin/admins/conversation_admin.py
@@ -1,6 +1,9 @@
 from django.contrib import admin, messages
+from django.core.exceptions import PermissionDenied
 from django.db.models import Count, Sum
 from django.db.models.functions import Length
+from django.http import HttpResponseNotAllowed
+from django.middleware.csrf import get_token
 from django.shortcuts import redirect
 from django.template.defaultfilters import filesizeformat
 from django.urls import path, reverse
@@ -9,6 +12,8 @@ from django.utils.html import format_html
 from products.posthog_ai.backend.models.assistant import Conversation
 
 from ee.hogai.django_checkpoint.compaction import compact_thread
+
+_COMPACT_SKIP_REASON = "not idle, awaiting approval, or nothing to compact"
 
 
 @admin.register(Conversation)
@@ -33,6 +38,11 @@ class ConversationAdmin(admin.ModelAdmin):
         # Conversation is soft-deleted by the app; don't expose a cascading hard-delete here.
         return False
 
+    def changeform_view(self, request, object_id=None, form_url="", extra_context=None):
+        # Stash the request so checkpoint_storage can mint a CSRF token for its POST form.
+        self._current_request = request
+        return super().changeform_view(request, object_id, form_url, extra_context)
+
     def get_urls(self):
         compact_url = path(
             "<path:object_id>/compact/",
@@ -53,12 +63,19 @@ class ConversationAdmin(admin.ModelAdmin):
     def checkpoint_storage(self, conversation: Conversation):
         # Blobs hold the bulk of a thread's bytes; query them via `thread`, not the `checkpoint` FK.
         blobs = conversation.blobs.aggregate(count=Count("id"), total_bytes=Sum(Length("blob")))
+        request = getattr(self, "_current_request", None)
+        # POST form rather than a link: compaction deletes rows, so it must not run on a GET.
         return format_html(
-            '{} checkpoints, {} blobs ({}) &nbsp; <a class="button" href="{}">Compact now</a>',
+            "{} checkpoints, {} blobs ({}) &nbsp;"
+            '<form method="post" action="{}" style="display: inline">'
+            '<input type="hidden" name="csrfmiddlewaretoken" value="{}">'
+            '<button type="submit" class="button">Compact now</button>'
+            "</form>",
             conversation.checkpoints.count(),
             blobs["count"] or 0,
             filesizeformat(blobs["total_bytes"] or 0),
             reverse("admin:posthog_ai_conversation_compact", args=[conversation.pk]),
+            get_token(request) if request is not None else "",
         )
 
     def compact_view(self, request, object_id: str):
@@ -66,6 +83,10 @@ class ConversationAdmin(admin.ModelAdmin):
         if conversation is None:
             self.message_user(request, "Conversation not found.", messages.ERROR)
             return redirect("admin:posthog_ai_conversation_changelist")
+        if not self.has_change_permission(request, conversation):
+            raise PermissionDenied
+        if request.method != "POST":
+            return HttpResponseNotAllowed(["POST"])
         # Bypasses the sweep's rollout allowlist — this is a deliberate staff override.
         result = compact_thread(str(conversation.id))
         if result.compacted:
@@ -75,11 +96,7 @@ class ConversationAdmin(admin.ModelAdmin):
                 messages.SUCCESS,
             )
         else:
-            self.message_user(
-                request,
-                "Nothing compacted (not idle, awaiting approval, or already compact).",
-                messages.WARNING,
-            )
+            self.message_user(request, f"Nothing compacted ({_COMPACT_SKIP_REASON}).", messages.WARNING)
         return redirect("admin:posthog_ai_conversation_change", object_id)
 
     @admin.action(description="Compact checkpoints (keep latest, reclaim storage)")
@@ -97,6 +114,6 @@ class ConversationAdmin(admin.ModelAdmin):
         self.message_user(
             request,
             f"Compacted {compacted} conversation(s) — reclaimed {checkpoints} checkpoints "
-            f"and {blobs} blobs. Skipped {skipped} (not idle, awaiting approval, or nothing to compact).",
+            f"and {blobs} blobs. Skipped {skipped} ({_COMPACT_SKIP_REASON}).",
             messages.SUCCESS if compacted else messages.WARNING,
         )

--- a/posthog/admin/admins/conversation_admin.py
+++ b/posthog/admin/admins/conversation_admin.py
@@ -51,8 +51,6 @@ class ConversationAdmin(admin.ModelAdmin):
 
     @admin.display(description="Checkpoint storage")
     def checkpoint_storage(self, conversation: Conversation):
-        if conversation.pk is None:
-            return "—"
         # Blobs hold the bulk of a thread's bytes; query them via `thread`, not the `checkpoint` FK.
         blobs = conversation.blobs.aggregate(count=Count("id"), total_bytes=Sum(Length("blob")))
         return format_html(

--- a/posthog/admin/admins/conversation_admin.py
+++ b/posthog/admin/admins/conversation_admin.py
@@ -9,9 +9,13 @@ from django.template.defaultfilters import filesizeformat
 from django.urls import path, reverse
 from django.utils.html import format_html
 
+from structlog import get_logger
+
 from products.posthog_ai.backend.models.assistant import Conversation
 
 from ee.hogai.django_checkpoint.compaction import compact_thread
+
+logger = get_logger()
 
 _COMPACT_SKIP_REASON = "not idle, awaiting approval, or nothing to compact"
 
@@ -61,6 +65,7 @@ class ConversationAdmin(admin.ModelAdmin):
 
     @admin.display(description="Checkpoint storage")
     def checkpoint_storage(self, conversation: Conversation):
+        # Change-page only — do not add to list_display: the bytea Length() sum would run per row.
         # Blobs hold the bulk of a thread's bytes; query them via `thread`, not the `checkpoint` FK.
         blobs = conversation.blobs.aggregate(count=Count("id"), total_bytes=Sum(Length("blob")))
         request = getattr(self, "_current_request", None)
@@ -69,7 +74,7 @@ class ConversationAdmin(admin.ModelAdmin):
             "{} checkpoints, {} blobs ({}) &nbsp;"
             '<form method="post" action="{}" style="display: inline">'
             '<input type="hidden" name="csrfmiddlewaretoken" value="{}">'
-            '<button type="submit" class="button">Compact now</button>'
+            '<button type="submit" class="button" data-attr="conversation-admin-compact-now">Compact now</button>'
             "</form>",
             conversation.checkpoints.count(),
             blobs["count"] or 0,
@@ -89,6 +94,14 @@ class ConversationAdmin(admin.ModelAdmin):
             return HttpResponseNotAllowed(["POST"])
         # Bypasses the sweep's rollout allowlist — this is a deliberate staff override.
         result = compact_thread(str(conversation.id))
+        logger.info(
+            "admin_compact_conversation",
+            conversation_id=str(conversation.id),
+            compacted=result.compacted,
+            checkpoints_deleted=result.checkpoints_deleted,
+            blobs_deleted=result.blobs_deleted,
+            triggered_by=request.user.email,
+        )
         if result.compacted:
             self.message_user(
                 request,
@@ -97,7 +110,7 @@ class ConversationAdmin(admin.ModelAdmin):
             )
         else:
             self.message_user(request, f"Nothing compacted ({_COMPACT_SKIP_REASON}).", messages.WARNING)
-        return redirect("admin:posthog_ai_conversation_change", object_id)
+        return redirect("admin:posthog_ai_conversation_change", conversation.id)
 
     @admin.action(description="Compact checkpoints (keep latest, reclaim storage)")
     def compact_checkpoints(self, request, queryset) -> None:

--- a/posthog/admin/test_conversation_admin.py
+++ b/posthog/admin/test_conversation_admin.py
@@ -1,0 +1,89 @@
+from posthog.test.base import BaseTest
+from unittest.mock import patch
+
+from django.contrib.admin.sites import AdminSite
+from django.contrib.messages import constants as message_constants
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.core.exceptions import PermissionDenied
+from django.http import HttpResponseNotAllowed
+from django.test import RequestFactory
+
+from parameterized import parameterized
+
+from posthog.admin.admins.conversation_admin import ConversationAdmin
+
+from products.posthog_ai.backend.models.assistant import Conversation
+
+from ee.hogai.django_checkpoint.compaction import CompactionResult
+
+
+def _attach_messages(request) -> None:
+    request.session = {}
+    request._messages = FallbackStorage(request)
+
+
+class TestConversationAdminCompactView(BaseTest):
+    def setUp(self) -> None:
+        super().setUp()
+        # is_superuser is a read-only property returning is_staff, so staff => has change permission.
+        self.user.is_staff = True
+        self.user.save()
+        self.factory = RequestFactory()
+        self.admin = ConversationAdmin(Conversation, AdminSite())
+        self.conversation = Conversation.objects.create(team=self.team, user=self.user)
+        self.compact_url = f"/admin/posthog_ai/conversation/{self.conversation.id}/compact/"
+
+    def _request(self, method: str):
+        request = getattr(self.factory, method)(self.compact_url)
+        request.user = self.user
+        _attach_messages(request)
+        return request
+
+    @patch("posthog.admin.admins.conversation_admin.compact_thread")
+    def test_get_is_rejected_and_does_not_compact(self, mock_compact) -> None:
+        response = self.admin.compact_view(self._request("get"), str(self.conversation.id))
+        assert isinstance(response, HttpResponseNotAllowed)
+        mock_compact.assert_not_called()
+
+    @patch("posthog.admin.admins.conversation_admin.compact_thread")
+    def test_post_without_change_permission_is_denied_and_does_not_compact(self, mock_compact) -> None:
+        with patch.object(self.admin, "has_change_permission", return_value=False):
+            with self.assertRaises(PermissionDenied):
+                self.admin.compact_view(self._request("post"), str(self.conversation.id))
+        mock_compact.assert_not_called()
+
+    @patch("posthog.admin.admins.conversation_admin.compact_thread")
+    def test_missing_conversation_redirects_to_changelist_without_compacting(self, mock_compact) -> None:
+        response = self.admin.compact_view(self._request("post"), "01920000-0000-0000-0000-000000000000")
+        assert response.status_code == 302
+        assert response.url.endswith("/conversation/")
+        mock_compact.assert_not_called()
+
+    @parameterized.expand(
+        [
+            (
+                CompactionResult(compacted=True, checkpoints_deleted=3, blobs_deleted=5),
+                message_constants.SUCCESS,
+                "reclaimed 3 checkpoints and 5 blobs",
+            ),
+            (
+                CompactionResult(compacted=False),
+                message_constants.WARNING,
+                "Nothing compacted",
+            ),
+        ]
+    )
+    @patch("posthog.admin.admins.conversation_admin.compact_thread")
+    def test_post_compacts_and_reports(self, result, expected_level, expected_substr, mock_compact) -> None:
+        mock_compact.return_value = result
+        request = self._request("post")
+
+        response = self.admin.compact_view(request, str(self.conversation.id))
+
+        mock_compact.assert_called_once_with(str(self.conversation.id))
+        assert response.status_code == 302
+        assert str(self.conversation.id) in response.url
+        messages = list(request._messages)
+        assert len(messages) == 1
+        assert messages[0].level == expected_level
+        assert expected_substr in messages[0].message


### PR DESCRIPTION
## Problem

Max's LangGraph conversation checkpoints can grow large, and #66320 added a `compact_thread` primitive plus a **bulk** changelist action to reclaim that storage. But there was no way to see how big a single conversation actually is, and the only trigger lived behind the changelist Actions dropdown — not on the per-conversation change page where you naturally land when inspecting one thread.

## Changes

Adds two things to the `Conversation` change page in Django admin (staff-only):

- A **"Checkpoint storage"** readout: `N checkpoints, M blobs (X MB)`. Size is computed in Postgres (`SUM(LENGTH(blob))` over the thread's blobs) so the binary payloads are never pulled into Python.
- A **"Compact now"** button that runs the existing `compact_thread` primitive on that single conversation, reports reclaimed checkpoint/blob counts, and redirects back.

No new compaction logic — this reuses `compact_thread` (the same function the bulk action already calls) and follows the existing `TeamAdmin.get_urls()` + readonly-display-field pattern. The primitive's safety guards still apply, so a mid-run, approval-pending, or interrupted conversation is skipped, never corrupted.

## How did you test this code?

I'm an agent (PostHog Code). This environment has no local Postgres/Docker, so I could not run the full `manage.py check` or render the page. I verified by reasoning: the `readonly_fields` entry is a real method on the admin (no `admin.E039`-class risk — no new FK/autocomplete added), and `SUM(LENGTH(blob))` is valid over a `bytea` column. `ruff check` and `ruff format` pass. CI's `build:openapi` runs the full system check and is the authoritative validation.

No tests added: the admin display + button are thin glue over the already-tested `compact_thread` (`ee/hogai/django_checkpoint/test/test_compaction.py`).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with PostHog Code, directed by @pauldambra. Follows #66320 (which shipped `compact_thread` + the bulk action); this PR adds the missing per-object size display and on-page compact trigger. No skills were required (no migration, serializer, or DRF change). Chose `raw_id`/method-based rendering to avoid the registered-target-admin dependency that `autocomplete_fields` carries.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
