### PR TITLE
fix(logs): drop-rule rate limit refills per whole second, under-dropping

### DIFF
--- a/nodejs/src/logs/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.test.ts
@@ -251,4 +251,40 @@ describe('LogsSamplingService', () => {
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)
     })
+
+    it('passes a sub-second timestamp to the rate limiter so refill is continuous within a second', async () => {
+        const ruleSet = compileRuleSet([
+            {
+                id: 'rl-1',
+                rule_type: 'rate_limit',
+                scope_service: 'api',
+                scope_path_pattern: null,
+                scope_attribute_filters: [],
+                config: { kb_per_second: 1, burst_kb: 2 },
+            },
+        ])
+        const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', [baseLog('a', 'api', 100)])
+
+        const nowMs = 1_700_000_000_400
+        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(nowMs)
+        const checkRateLimitV3 = jest.fn()
+
+        const mockRedis: RedisV2 = {
+            useClient: jest.fn(() => Promise.resolve(null)),
+            usePipeline: jest.fn((_opts, cb) => {
+                cb({ checkRateLimitV3 } as unknown as RedisClientPipeline)
+                const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
+                return Promise.resolve(pipelineResult)
+            }),
+        }
+
+        const service = new LogsSamplingService(mockRedis, 60)
+        await service.processBuffer(buffer, logsSettings, ruleSet, 99)
+
+        const nowArg = checkRateLimitV3.mock.calls[0]![1]
+        expect(nowArg).toBe(nowMs / 1000)
+        expect(Number.isInteger(nowArg)).toBe(false)
+
+        nowSpy.mockRestore()
+    })
 })

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -245,6 +245,7 @@ export class LogsSamplingService {
         }
 
         const ruleById = new Map(ruleSet.rules.map((r) => [r.id, r]))
+        const nowSeconds = Date.now() / 1000
         type Entry = { indices: number[]; costs: number[]; req: KeyedRateLimitRequest }
         const entries: Entry[] = []
 
@@ -264,6 +265,7 @@ export class LogsSamplingService {
                     cost: totalCost,
                     bucketSize: rl.poolMax,
                     refillRate: rl.refillPerSecond,
+                    now: nowSeconds,
                 },
             })
         }


### PR DESCRIPTION
## Problem

The logs drop-rule rate limiter (the `rate_limit` sampling rules) was dropping more than the configured rate. For a 10 MB/s rule, sustained traffic was admitting ~500 MB/min instead of the expected ~600 MB.

Root cause: `applyRateLimits` didn't pass a timestamp to `KeyedRateLimiterService`, so it fell back to `Math.round(Date.now() / 1000)` — a whole-second clock. `processBuffer` runs once per Kafka message, so under load many messages land in the same rounded second. Every message after the first in a given second saw `timeDiff = 0`, got a refill of 0, and had all its rate-limit records dropped. The entire second's allowance was effectively handed to whichever message happened to be processed first, and any of it that message couldn't use was stranded (the v3 script floor-drains the bucket on overdraft).

This is the second half of the v2→v3 migration in #66981. v2 had the opposite bug (it preserved the full balance on overdraft, so it over-admitted wildly); v3 fixed that but the whole-second clock left it under-admitting.

## Changes

`applyRateLimits` now stamps each request with a sub-second timestamp (`Date.now() / 1000`). With a fractional clock, each message refills against the real elapsed time since the last call for that rule, so `Σ(elapsed × refillRate)` over a second telescopes to exactly `refillRate` — admission converges back to the configured rate regardless of how traffic is split across messages within a second.

The Lua script already handles fractional `now` (plain numeric subtraction), so no script change was needed.

A residual, much smaller loss remains: on overdraft the script keeps only the sub-1 fractional remainder, so each call can still lose up to one record's worth of budget that didn't pack into a whole record. With sub-second time this is bounded by per-message packing (negligible against a 10 MB/s rate) rather than the per-second concentration that was costing ~1/6. Removing it entirely would require deducting the actually-admitted amount instead of `floor(tokensBefore)` — a larger change to the script/client contract, left out of scope here.

## How did you test this code?

I'm an agent (PostHog Code), human-driven. Automated only — no manual testing.

- Ran `nodejs/src/logs/sampling/logs-sampling.service.test.ts` (6 tests, all green).
- Added one case: `passes a sub-second timestamp to the rate limiter so refill is continuous within a second`. It asserts the timestamp handed to the limiter carries sub-second precision. No existing test asserted this — it guards against the `now` field being dropped again, which is exactly the regression being fixed. Verified it fails on the pre-fix code (whole-second fallback) and passes after.

## Docs update

No user-facing docs affected.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed and fixed with PostHog Code (Opus 4.8). Invoked the `/writing-tests` skill before adding the test to apply the value gate, then confirmed the new test fails without the fix and passes with it.

Decision notes: the high-impact lever is the sub-second timestamp (a two-line change), which eliminates the per-second budget concentration. Considered also reworking the overdraft floor-drain to deduct the admitted amount so unpacked whole-token budget rolls forward, but that's a larger contract change for a now-negligible residual, so it was deliberately left out.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
