### PR TITLE
fix(workflows): redact sensitive data from SES webhook logs

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.test.ts
@@ -1,4 +1,5 @@
 import { defaultConfig } from '~/common/config/config'
+import { logger } from '~/common/utils/logger'
 
 import { SesWebhookHandler } from './ses'
 import { EmailTrackingCodeSigner } from './tracking-code'
@@ -35,6 +36,40 @@ describe('SesWebhookHandler', () => {
             ph_id: [signer.generateShort(baseInvocation)],
         },
     }
+
+    it('does not log recipient addresses or tracking codes', async () => {
+        // Guards the webhook-payload log leak: handleWebhook must log only routing metadata, never
+        // raw bodies/records/envelopes that carry recipient addresses and signed tracking codes.
+        const logged: string[] = []
+        const capture = (...args: unknown[]): void => {
+            logged.push(JSON.stringify(args))
+        }
+        const spies = (['info', 'warn', 'error'] as const).map((level) =>
+            jest.spyOn(logger, level).mockImplementation(capture)
+        )
+        try {
+            const trackingCode = baseMail.headers[0].value
+            const body = [
+                {
+                    eventType: 'Bounce',
+                    mail: baseMail,
+                    bounce: {
+                        bounceType: 'Permanent',
+                        bouncedRecipients: [{ emailAddress: 'to@example.com' }],
+                        timestamp: '2025-10-03T12:00:00Z',
+                    },
+                },
+            ]
+            const result = await handler.handleWebhook({ body, headers: {} })
+            expect(result.status).toBe(200)
+
+            const all = logged.join('\n')
+            expect(all).not.toContain('to@example.com')
+            expect(all).not.toContain(trackingCode)
+        } finally {
+            spies.forEach((spy) => spy.mockRestore())
+        }
+    })
 
     it('parses a raw Open event', async () => {
         const body = [

--- a/nodejs/src/cdp/services/messaging/helpers/ses.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/ses.ts
@@ -303,6 +303,16 @@ export class SesWebhookHandler {
         }
     }
 
+    // Reduce a URL to its host for logging — avoids leaking the SNS subscription token carried
+    // in the SubscribeURL query string.
+    private safeHost(url: string): string {
+        try {
+            return new URL(url).host
+        } catch {
+            return 'invalid'
+        }
+    }
+
     /**
      * Parse incoming body accounting for SNS raw vs envelope
      */
@@ -412,10 +422,17 @@ export class SesWebhookHandler {
             emailAddresses: string[]
         }[]
     }> {
-        logger.info('[SesWebhookHandler] handleWebhook', { body: opts.body, headers: opts.headers })
         const parsed = this.parseIncomingBody(opts.body)
 
-        logger.info('[SesWebhookHandler] parsed', { parsed })
+        // Log only non-sensitive routing metadata. The raw body, parsed envelope, and SES records
+        // carry recipient addresses, subjects, SMTP diagnostics, signed tracking codes, and
+        // subscription tokens — none of which belong in operational logs.
+        logger.info('[SesWebhookHandler] handleWebhook', {
+            mode: parsed.mode,
+            type: 'envelope' in parsed ? parsed.envelope?.Type : undefined,
+            messageId: 'envelope' in parsed ? parsed.envelope?.MessageId : undefined,
+            recordCount: parsed.records?.length ?? 0,
+        })
 
         // When verification is required the message must be a signed SNS envelope. Raw deliveries
         // carry no signature, and prod uses envelope delivery, so reject them to block forged events.
@@ -423,9 +440,8 @@ export class SesWebhookHandler {
             if (!('envelope' in parsed)) {
                 return { status: 403, body: { error: 'Unsigned raw delivery not allowed' } }
             }
-            logger.info('[SesWebhookHandler] verifying signature', { envelope: parsed.envelope })
             const ok = await this.verifySnsSignature(parsed.envelope)
-            logger.info('[SesWebhookHandler] signature verified', { ok })
+            logger.info('[SesWebhookHandler] signature verified', { ok, messageId: parsed.envelope.MessageId })
             if (!ok) {
                 return { status: 403, body: { error: 'Invalid SNS signature' } }
             }
@@ -433,16 +449,15 @@ export class SesWebhookHandler {
 
         // Handle confirmation flow
         if (parsed.mode === 'sns' && 'envelope' in parsed && parsed.envelope?.Type === 'SubscriptionConfirmation') {
-            logger.info('[SesWebhookHandler] confirming subscription', { envelope: parsed.envelope })
+            logger.info('[SesWebhookHandler] confirming subscription', { messageId: parsed.envelope.MessageId })
             // Confirm by visiting SubscribeURL (contained in the *message JSON*, not envelope.Message field here)
             // We need to fetch the inner message JSON to get SubscribeURL
             const env = parsed.envelope
             const inner = parseJSON(env.Message) as { SubscribeURL?: string }
-            logger.info('[SesWebhookHandler] confirming subscription', { inner })
             if (inner.SubscribeURL) {
                 if (!this.isValidSnsSubscribeUrl(inner.SubscribeURL)) {
                     logger.warn('[SesWebhookHandler] Invalid SubscribeURL, rejecting', {
-                        url: inner.SubscribeURL,
+                        host: this.safeHost(inner.SubscribeURL),
                     })
                     return { status: 403, body: { error: 'Invalid SubscribeURL' } }
                 }
@@ -452,7 +467,7 @@ export class SesWebhookHandler {
         }
 
         if (parsed.mode === 'sns' && 'envelope' in parsed && parsed.envelope?.Type === 'UnsubscribeConfirmation') {
-            logger.info('[SesWebhookHandler] confirming unsubscribe', { envelope: parsed.envelope })
+            logger.info('[SesWebhookHandler] confirming unsubscribe', { messageId: parsed.envelope.MessageId })
             return { status: 200, body: { ok: true } }
         }
 
@@ -483,7 +498,7 @@ export class SesWebhookHandler {
         }[] = []
 
         for (const rec of records) {
-            logger.info('[SesWebhookHandler] processing record', { rec })
+            logger.info('[SesWebhookHandler] processing record', { eventType: rec.eventType })
             // Prefer the custom MIME header (carries the full signed code including distinct_id,
             // unbounded). Fall back to the SES EmailTag for messages sent before the header carrier
             // was added, or where the configuration set hasn't enabled `IncludeOriginalHeaders`.
@@ -498,7 +513,10 @@ export class SesWebhookHandler {
             const { functionId, invocationId, teamId, actionId, parentRunId, distinctId, isTest } = parsedCode || {}
 
             if (!functionId && !invocationId) {
-                logger.error('[SesWebhookHandler] handleWebhook: No functionId or invocationId found', { rec })
+                logger.error('[SesWebhookHandler] handleWebhook: No functionId or invocationId found', {
+                    eventType: rec.eventType,
+                    messageId: rec.mail.messageId,
+                })
                 continue
             }
 


### PR DESCRIPTION
## Problem

`SesWebhookHandler.handleWebhook` logged raw SES/SNS payloads at `info` level before any redaction. Those objects carry recipient addresses, subjects, SMTP diagnostics, signed tracking codes (`ph_id` / `X-PostHog-Tracking-Code`), and SNS subscription tokens — so anyone with access to service logs could read sensitive email-delivery data.

This was raised as a follow-up on #65911 ([review thread](https://github.com/PostHog/posthog/pull/65911#discussion_r3494645390)) and confirmed as pre-existing.

## Changes

Stripped the payload dumps from every log call in `handleWebhook`, keeping only non-sensitive routing metadata:

- `{ body, headers }` + `{ parsed }` → one summary line: `mode`, SNS `type`, `messageId`, `recordCount`
- `{ envelope }` (signature / subscription / unsubscribe) → `messageId` only
- `{ inner }` (subscription confirm — held the `SubscribeURL` token) → removed
- Invalid-`SubscribeURL` warn → logs `host` only (new `safeHost` helper), not the token-bearing URL
- per-record `{ rec }` → `eventType`; the no-id error → `eventType` + SES `messageId`

No recipient addresses, subjects, SMTP diagnostics, tracking codes, signatures, or subscription tokens reach the logs anymore.

This is scoped to the logging leak only. The related SNS topic-ARN allowlist + signed-code enforcement is tracked separately in #61644.

## How did you test this code?

I'm an agent; I did not manually test. Automated only:

- Added one regression case to `ses.test.ts` that spies the logger across a `Bounce` and asserts no log call contains the recipient address or the tracking code — guards exactly this leak from creeping back. No existing test asserted anything about logging.
- Full `ses.test.ts` passes (37/37), lint clean, no new typecheck errors.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Directed by the requester — please self-assign as the DRI (I don't have a verified GitHub handle to set the assignee).
- Authored with Claude Code (Opus 4.8). Invoked the `/writing-tests` skill to gate the regression test before adding it.
- Scoping decision: kept this to the logging redaction only and left the topic-ARN/signed-code hardening to #61644, since they're independent concerns and the latter is a production trust-boundary change.