### PR TITLE
feat(data-warehouse): sync Convex non-default component tables

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/convex.py
@@ -100,6 +100,15 @@ def _headers(deploy_key: str) -> dict[str, str]:
     }
 
 
+# Convex tables can live in non-default components (e.g. an installed `betterAuth` component), which
+# the streaming-export API addresses by component path (the root component is the empty path). We
+# encode `(component_path, table)` into one warehouse table name so component tables round-trip from
+# the schema list back to the per-table API calls; root tables keep their bare name, so existing
+# synced tables are unaffected.
+_ROOT_COMPONENT = ""
+_COMPONENT_TABLE_DELIMITER = "."
+
+
 @retry(
     retry=retry_if_exception_type(ChunkedEncodingError),
     stop=stop_after_attempt(5),
@@ -118,9 +127,56 @@ def _convex_get(url: str, deploy_key: str, params: dict[str, Any], timeout: int)
 
 def get_json_schemas(deploy_url: str, deploy_key: str) -> dict[str, Any]:
     url = f"{deploy_url.rstrip('/')}/api/json_schemas"
-    response = _convex_get(url, deploy_key, {"deltaSchema": "true", "format": "json"}, timeout=30)
+    # byComponent=true groups the response by component so non-default components are discoverable.
+    response = _convex_get(
+        url, deploy_key, {"deltaSchema": "true", "format": "json", "byComponent": "true"}, timeout=30
+    )
     response.raise_for_status()
     return response.json()
+
+
+def iter_component_tables(schemas_response: dict[str, Any]) -> Generator[tuple[str, str]]:
+    """Yield `(component_path, table_name)` for every table; root tables yield `""`.
+
+    `byComponent=true` groups as {component_path: {table: schema}}; older deployments ignore the flag
+    and return the flat {table: schema} shape, where each value is itself a JSON schema.
+    """
+    if not isinstance(schemas_response, dict) or not schemas_response:
+        return
+    # The grouped shape always includes the root component under the "" key, and "" is never a valid
+    # table name — so its presence reliably marks the grouped shape. Only when it's absent do we fall
+    # back to inspecting the first value (a {table: schema} map carries no "type"/"properties").
+    if _ROOT_COMPONENT in schemas_response:
+        grouped = True
+    else:
+        first_value = next(iter(schemas_response.values()))
+        grouped = isinstance(first_value, dict) and "type" not in first_value and "properties" not in first_value
+    if grouped:
+        for component_path, tables in schemas_response.items():
+            if isinstance(tables, dict):
+                for table_name in tables:
+                    yield component_path, table_name
+    else:
+        for table_name in schemas_response:
+            yield _ROOT_COMPONENT, table_name
+
+
+def qualified_table_name(component_path: str, table_name: str) -> str:
+    """Encode a `(component_path, table_name)` pair into a single warehouse table name."""
+    if not component_path:
+        return table_name
+    return f"{component_path}{_COMPONENT_TABLE_DELIMITER}{table_name}"
+
+
+def split_qualified_table_name(name: str) -> tuple[str, str]:
+    """Inverse of `qualified_table_name` — returns `(component_path, table_name)`.
+
+    Splits on the final ".": component path segments join with "/" and table names contain no ".".
+    """
+    component_path, delimiter, table_name = name.rpartition(_COMPONENT_TABLE_DELIMITER)
+    if not delimiter:
+        return _ROOT_COMPONENT, name
+    return component_path, table_name
 
 
 def list_snapshot(
@@ -128,11 +184,14 @@ def list_snapshot(
     deploy_key: str,
     table_name: str,
     resumable_source_manager: ResumableSourceManager[ConvexResumeConfig],
+    component: str = _ROOT_COMPONENT,
 ) -> Generator[list[dict[str, Any]], None, int]:
     """Paginate through a full table snapshot.
 
     Yields batches of documents. Returns the snapshot cursor (as the generator return value)
     which can be used as the starting cursor for document_deltas.
+
+    A non-root `component` reads the table from that component; the root component is the default.
     """
     base_url = f"{deploy_url.rstrip('/')}/api/list_snapshot"
     # Convex returns the snapshot cursor as an opaque {tablet, id} string, not an integer.
@@ -146,6 +205,8 @@ def list_snapshot(
 
     while True:
         params: dict[str, Any] = {"tableName": table_name, "format": "json"}
+        if component:
+            params["component"] = component
         if cursor is not None:
             params["cursor"] = cursor
         if snapshot is not None:
@@ -182,11 +243,14 @@ def document_deltas(
     table_name: str,
     cursor: int,
     resumable_source_manager: ResumableSourceManager[ConvexResumeConfig],
+    component: str = _ROOT_COMPONENT,
 ) -> Generator[list[dict[str, Any]], None, int]:
     """Paginate through incremental document changes since a cursor.
 
     Yields batches of changed documents. Returns the new cursor.
     Deleted documents have _deleted=True.
+
+    A non-root `component` reads the table from that component; the root component is the default.
 
     Raises InvalidWindowError if the cursor is older than Convex's retention window (~30 days).
     """
@@ -210,6 +274,8 @@ def document_deltas(
 
     while True:
         params: dict[str, Any] = {"tableName": table_name, "cursor": current_cursor, "format": "json"}
+        if component:
+            params["component"] = component
 
         response = _convex_get(base_url, deploy_key, params, timeout=60)
 
@@ -289,16 +355,21 @@ def convex_source(
     resumable_source_manager: ResumableSourceManager[ConvexResumeConfig],
 ) -> SourceResponse:
     clean_url = validate_deploy_url(deploy_url)
+    # Decode the warehouse table name into component + bare table for the API; the qualified name
+    # stays as the SourceResponse name so the Delta storage path is stable.
+    component, convex_table_name = split_qualified_table_name(table_name)
 
     def items_generator():
         if should_use_incremental_field and db_incremental_field_last_value is not None:
             cursor = int(db_incremental_field_last_value)
             deltas_manager = resumable_source_manager.with_namespace(_DELTAS_RESUME_NAMESPACE)
-            for batch in document_deltas(clean_url, deploy_key, table_name, cursor, deltas_manager):
+            for batch in document_deltas(
+                clean_url, deploy_key, convex_table_name, cursor, deltas_manager, component=component
+            ):
                 yield _normalize_timestamps(batch)
         else:
             snapshot_manager = resumable_source_manager.with_namespace(_SNAPSHOT_RESUME_NAMESPACE)
-            for batch in list_snapshot(clean_url, deploy_key, table_name, snapshot_manager):
+            for batch in list_snapshot(clean_url, deploy_key, convex_table_name, snapshot_manager, component=component):
                 yield _normalize_timestamps(batch)
 
     return SourceResponse(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/source.py
@@ -21,6 +21,8 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.convex.con
     ConvexResumeConfig,
     convex_source,
     get_json_schemas,
+    iter_component_tables,
+    qualified_table_name,
     validate_credentials as validate_convex_credentials,
     validate_deploy_url,
 )
@@ -85,9 +87,10 @@ You can find your deployment URL and deploy key in your [Convex Dashboard](https
         clean_url = validate_deploy_url(config.deploy_url)
         schemas_response = get_json_schemas(clean_url, config.deploy_key)
 
-        tables: list[str] = []
-        if isinstance(schemas_response, dict):
-            tables = list(schemas_response.keys())
+        tables: list[str] = [
+            qualified_table_name(component_path, table_name)
+            for component_path, table_name in iter_component_tables(schemas_response)
+        ]
 
         incremental_field: list[IncrementalField] = [
             IncrementalField(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -16,7 +16,11 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.convex.con
     _convex_get,
     convex_source,
     document_deltas,
+    get_json_schemas,
+    iter_component_tables,
     list_snapshot,
+    qualified_table_name,
+    split_qualified_table_name,
     validate_credentials,
     validate_deploy_url,
 )
@@ -363,6 +367,102 @@ class TestConvexSource:
         first_params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
         for key, value in expected_first_params.items():
             assert first_params[key] == value
+
+
+class TestComponentSupport:
+    @parameterized.expand(
+        [
+            # Root-component tables keep their bare name so existing synced tables are unaffected.
+            ("root", "", "users", "users"),
+            ("single_component", "betterAuth", "users", "betterAuth.users"),
+            # Convex nests component paths with "/"; the table name is still the segment after the
+            # final ".", so the round-trip must recover the full path.
+            ("nested_component", "parent/child", "users", "parent/child.users"),
+        ]
+    )
+    def test_qualified_table_name_round_trips(
+        self, _name: str, component_path: str, table_name: str, expected_qualified: str
+    ) -> None:
+        qualified = qualified_table_name(component_path, table_name)
+        assert qualified == expected_qualified
+        assert split_qualified_table_name(qualified) == (component_path, table_name)
+
+    @parameterized.expand(
+        [
+            # byComponent shape: {component_path: {table: schema}} — root is the "" key.
+            (
+                "grouped_by_component",
+                {
+                    "": {"users": {"type": "object"}, "messages": {"type": "object"}},
+                    "betterAuth": {"users": {"type": "object"}},
+                },
+                [("", "users"), ("", "messages"), ("betterAuth", "users")],
+            ),
+            # Legacy deployments ignore byComponent and return the flat {table: schema} shape; every
+            # table is then a root-component table.
+            (
+                "legacy_flat",
+                {"users": {"type": "object"}, "messages": {"type": "object"}},
+                [("", "users"), ("", "messages")],
+            ),
+            ("empty", {}, []),
+        ]
+    )
+    def test_iter_component_tables(
+        self, _name: str, schemas_response: dict[str, Any], expected: list[tuple[str, str]]
+    ) -> None:
+        assert sorted(iter_component_tables(schemas_response)) == sorted(expected)
+
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_get_json_schemas_requests_by_component(self, mock_get: Mock) -> None:
+        # Without byComponent=true the API returns only root-component tables, so non-default
+        # components (e.g. betterAuth) become invisible — this guards against that regression.
+        mock_get.return_value.get.return_value = _make_response({})
+
+        get_json_schemas("https://x.convex.cloud", "key")
+
+        assert mock_get.return_value.get.call_args.kwargs["params"]["byComponent"] == "true"
+
+    @parameterized.expand(
+        [
+            # Root tables must not send a component param — the API defaults to the root component.
+            ("root", "users", "users", None),
+            # A component-qualified warehouse table name must read the bare table from its component.
+            ("component", "betterAuth.users", "users", "betterAuth"),
+        ]
+    )
+    @patch("products.warehouse_sources.backend.temporal.data_imports.sources.convex.convex.make_tracked_session")
+    def test_convex_source_routes_to_component(
+        self,
+        _name: str,
+        warehouse_table_name: str,
+        expected_convex_table: str,
+        expected_component: str | None,
+        mock_get: Mock,
+    ) -> None:
+        manager = _make_manager(can_resume=False)
+        mock_get.return_value.get.return_value = _make_response(
+            {"values": [{"_id": "a", "_creationTime": 1}], "cursor": 1, "snapshot": 1, "hasMore": False}
+        )
+
+        response = convex_source(
+            deploy_url="https://x.convex.cloud",
+            deploy_key="key",
+            table_name=warehouse_table_name,
+            team_id=1,
+            job_id="job",
+            should_use_incremental_field=False,
+            db_incremental_field_last_value=None,
+            resumable_source_manager=manager,
+        )
+
+        # The storage name stays qualified so the Delta path is stable per warehouse table.
+        assert response.name == warehouse_table_name
+
+        list(cast(Iterable[Any], response.items()))
+        params = mock_get.return_value.get.call_args_list[0].kwargs["params"]
+        assert params["tableName"] == expected_convex_table
+        assert params.get("component") == expected_component
 
 
 class TestConvexNonRetryableErrors:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/convex/tests/test_convex.py
@@ -405,6 +405,13 @@ class TestComponentSupport:
                 {"users": {"type": "object"}, "messages": {"type": "object"}},
                 [("", "users"), ("", "messages")],
             ),
+            # `type`/`properties` are valid Convex table names: the "" root key must classify the
+            # response as grouped, not a schema-key inspection that misfires on such a table.
+            (
+                "grouped_with_table_named_type",
+                {"": {"type": {"type": "object"}}, "betterAuth": {"users": {"type": "object"}}},
+                [("", "type"), ("betterAuth", "users")],
+            ),
             ("empty", {}, []),
         ]
     )


### PR DESCRIPTION
## Problem

Convex lets you install [components](https://docs.convex.dev/components) — self-contained packages (e.g. `betterAuth`) that bring their own tables, living outside the default "app" component. Our Convex warehouse connector could only ever see the root component, so a customer using `betterAuth` for auth couldn't sync user-profile data that lives there. There was no workaround on our side.

The cause is the streaming-export API contract:

- `/api/json_schemas` returns a flat `{table: schema}` map by default. Tables in non-default components don't appear cleanly.
- `/api/list_snapshot` and `/api/document_deltas` accept an optional `component` selector. Per Convex's own API ([`SelectionArg::SingleTable`](https://github.com/get-convex/convex-backend/blob/main/crates/fivetran_source/src/api_types/mod.rs)), *"if not provided, the table is assumed to be in the root component."* We only ever sent `tableName`, so every read defaulted to root.

https://posthoghelp.zendesk.com/agent/tickets/61357 (moved to PostHog: https://us.posthog.com/project/2/support/tickets/62344)

## Changes

- Request `byComponent=true` on `/api/json_schemas` so discovery returns `{component_path: {table: schema}}` (root component is the `""` key). Falls back to the legacy flat shape for older deployments.
- Thread an optional `component` path through `list_snapshot` / `document_deltas`, sent only for non-root tables (root keeps the API default).
- Encode `(component_path, table)` into a single warehouse table name (`component.table`) and decode it at the API boundary. `.` is a safe, lossless separator: Convex component and table names are identifiers (no `.`), nested component paths join with `/`, and the storage layer normalizes any delimiter away regardless.

**Backwards compatible:** root-component tables keep their bare name, so existing synced tables are untouched and need no resync. Component tables show up as new, selectable schemas (`betterAuth.users`).

## How did you test this code?

I'm an agent (PostHog Code), Luke directed the work. Automated only — no manual sync against a live deployment yet.

Added `TestComponentSupport` to `test_convex.py` (4 parameterized groups), each guarding a specific regression:

- **`get_json_schemas` requests `byComponent=true`** — dropping the flag silently reintroduces the original root-only bug.
- **qualified-name round-trip** (root / single / nested component) — a delimiter slip would route component tables back to root and silently lose data.
- **`iter_component_tables`** over grouped + legacy-flat + empty responses.
- **end-to-end `convex_source` routing** — a component-qualified name sends `component` + the bare `tableName`; a root name sends no `component`; the storage name stays qualified.

`hogli test` → 61 passed. Ruff clean.

**Verification gap (why this is a draft):** I verified the wire contract against Convex's open-source backend, but haven't run a sync against a real deployment with an installed component. Worth a one-off sync against a Convex deployment with a `betterAuth` (or any) component before marking ready.

## Docs update

Follow-up: the user-facing Convex source doc on posthog.com should mention component tables — not included here (different repo).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started as a customer-claim verification — a customer reported this bug and linked their own Airbyte-connector fix. Rather than take their word, I confirmed the behavior directly against Convex's open-source backend ([`streaming_export.rs`](https://github.com/get-convex/convex-backend/blob/main/crates/local_backend/src/streaming_export.rs), [`api_types/mod.rs`](https://github.com/get-convex/convex-backend/blob/main/crates/fivetran_source/src/api_types/mod.rs)), which documents both `byComponent` and the root-component default verbatim.

Skills invoked: `/implementing-warehouse-sources`, `/writing-tests`, `/simplify` (4-agent reuse/simplification/efficiency/altitude pass).

Key decision — **naming scheme**: encode the component into the warehouse table name rather than wiring up a first-class namespace. The `schema_metadata` mechanism the SQL sources use is SQL-only plumbing; for non-SQL sources `inputs.schema_name` is the only routing signal that reaches `source_for_pipeline`, so string-encoding is the framework norm here, not a hack. Chose `.` to match the SQL `namespace.table` display convention; decode splits on the *last* dot to support nested Convex paths. The decode lives in `convex_source` (the boundary that talks to the API), keeping `source_for_pipeline` a straight pass-through.

This is an Airbyte-independent reimplementation, not a port — our connector differs from Airbyte's (resumable sync, partitioning, timestamp normalization), so the approach is shared but the code is ours.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from [this inbox report](https://us.posthog.com/project/2/inbox/reports/019f7f6c-e2a6-715c-b71a-94ed95b79551).*

