### PR TITLE
chore(error-tracking): lock native symbolication as load-relative

### DIFF
--- a/rust/cymbal/src/core/types/langs/native.rs
+++ b/rust/cymbal/src/core/types/langs/native.rs
@@ -71,9 +71,16 @@ pub fn find_debug_image<'a>(
     Err(NativeError::NoMatchingDebugImage)
 }
 
-/// Offset of `instruction_addr` from the image's runtime load address. The
-/// symcache contains addresses relative to the binary's VM base, so the load
-/// offset is all that's needed for lookup.
+/// Offset of `instruction_addr` from the image's runtime load address, i.e. the
+/// address the symcache is keyed by.
+///
+/// `image_vmaddr` is intentionally NOT added here. `symbolic` rebases symcache
+/// entries to the image's preferred base, and the SDK reports `image_addr` as
+/// the *actual* load address (preferred base + ASLR slide), so
+/// `instruction_addr - image_addr` already yields the symcache-relative address.
+/// Adding `image_vmaddr` would double-count the preferred base and break every
+/// image with a nonzero one — see
+/// `test_native_symbolication_is_load_relative_with_nonzero_vmaddr`.
 pub fn calculate_relative_addr(
     instruction_addr: u64,
     debug_image: &DebugImage,
@@ -916,6 +923,58 @@ mod test {
         // inside inner_function with the image loaded at 0x100000000.
         let frame = RawFrame::Native(native_frame_at(0x100000334, 0x100000000));
         let debug_images = vec![debug_image_at(chunk_id, 0x100000000)];
+
+        let resolved = frame
+            .resolve(1, &catalog, &debug_images, 15)
+            .await
+            .unwrap()
+            .pop()
+            .unwrap();
+
+        assert!(resolved.resolved, "{:?}", resolved.resolve_failure);
+        assert_eq!(resolved.resolved_name.as_deref(), Some("inner_function"));
+    }
+
+    /// Symbolication must be purely load-relative: `image_vmaddr` (the image's
+    /// stated/preferred base) must NOT be added to the lookup address.
+    ///
+    /// `symbolic` rebases every symcache entry relative to the object's
+    /// preferred base at conversion time, so the symcache is keyed by
+    /// `svma - image_vmaddr`. The SDK already folds the preferred base into
+    /// `image_addr` (it reports the *actual* runtime load address), so
+    /// `instruction_addr - image_addr` recovers that same relative address and
+    /// the `image_vmaddr` term cancels out. Re-adding it would push every
+    /// lookup past the end of the symcache and break symbolication for all
+    /// images with a nonzero preferred base — every macOS/iOS Mach-O binary and
+    /// every non-PIE ELF.
+    ///
+    /// This exercises an ASLR-slid Mach-O image (nonzero `__TEXT` vmaddr *and* a
+    /// nonzero slide, so `image_addr != image_vmaddr`) — the case no other test
+    /// covers and the one a spurious `+ image_vmaddr` "fix" would silently break.
+    #[sqlx::test(migrations = "./tests/test_migrations")]
+    async fn test_native_symbolication_is_load_relative_with_nonzero_vmaddr(db: sqlx::PgPool) {
+        use crate::frames::RawFrame;
+
+        const DSYM_ZIP: &[u8] =
+            include_bytes!("../../../../tests/static/apple/test_binary.dSYM.zip");
+        let wrapped = posthog_symbol_data::write_symbol_data(posthog_symbol_data::AppleDsym {
+            data: DSYM_ZIP.to_vec(),
+        })
+        .unwrap();
+
+        let chunk_id = "f70b89dc-3eb9-d3aa-d6a0-3b0c87cb0c45";
+        let catalog = catalog_for_chunk(&db, chunk_id, wrapped).await;
+
+        // __TEXT preferred base 0x100000000, inner_function at relative 0x334.
+        // Simulate an ASLR slide: the image actually loaded 0x1000000 higher, so
+        // the SDK reports image_addr = actual base and image_vmaddr = stated base.
+        let preferred_base = 0x100000000u64;
+        let actual_base = preferred_base + 0x1000000;
+
+        let frame = RawFrame::Native(native_frame_at(actual_base + 0x334, actual_base));
+        let mut image = debug_image_at(chunk_id, actual_base);
+        image.image_vmaddr = Some(format!("0x{preferred_base:x}"));
+        let debug_images = vec![image];
 
         let resolved = frame
             .resolve(1, &catalog, &debug_images, 15)


### PR DESCRIPTION
tl;dr small doc + test additions to stop confusing agents thinking this is wrong

-- ai


## Problem

cymbal symbolicates native (Rust/C/C++/Swift) stack frames server-side by mapping each frame's absolute instruction address into an uploaded debug-symbol set. The lookup offset is computed in `calculate_relative_addr` as `instruction_addr - image_addr`.

A review of the posthog-rs native-capture work ([PostHog/posthog-rs#158](https://github.com/PostHog/posthog-rs/pull/158)) flagged that `DebugImage.image_vmaddr` (the image's stated/preferred base) is parsed but unused, and proposed adding it: `relative_addr = (instruction_addr - image_addr) + image_vmaddr`.

That proposed change is incorrect — and, worse, **invisible to the existing test suite**: every native fixture leaves `image_vmaddr` unset (defaulting to 0), so such a regression passes CI while breaking production symbolication for every image with a nonzero preferred base (every macOS/iOS Mach-O binary, every non-PIE ELF).

## Changes

No production-logic change — `calculate_relative_addr` stays load-relative. This PR locks that invariant in:

- **Adds** `test_native_symbolication_is_load_relative_with_nonzero_vmaddr`: resolves an ASLR-slid Mach-O image whose `__TEXT` preferred base is nonzero *and* differs from the runtime load address (`image_addr != image_vmaddr`) — the case no existing fixture exercises, and the one a spurious `+ image_vmaddr` would break.
- **Documents** on `calculate_relative_addr` why `image_vmaddr` is intentionally omitted: `symbolic` rebases symcache entries to the preferred base at conversion time, and the SDK already folds that base into `image_addr` (the actual runtime load address), so subtracting `image_addr` recovers the symcache-relative address and the `image_vmaddr` term cancels out.

## How did you test this code?

I'm an agent; listing only what I actually ran (against `master`, local Postgres for the `#[sqlx::test]` cases):

- `cargo test -p cymbal --lib langs::native::test` — 23 passed (22 existing + the new guard).
- `cargo fmt -p cymbal -- --check` — clean.
- `cargo clippy -p cymbal --lib --tests` — clean (one pre-existing, unrelated `js-source-scopes` patch warning).

To confirm the guard catches the regression it claims to: I temporarily applied the proposed `+ image_vmaddr` change in a throwaway worktree and reran — the new test failed (`Symbol not found at address: 0x100000333`) while all existing native tests stayed green, proving both that the change is a regression and that the existing suite could not catch it. Reverted before committing.

Regression this catches that no existing test did: any change making the native lookup non-load-relative (e.g. adding `image_vmaddr`) for an image with a nonzero preferred base.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing behavior change; no docs update needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated with Claude Code (Opus 4.8). The task arrived as "add `image_vmaddr` to `calculate_relative_addr`," but tracing the symcache address-space convention through `symbolic-debuginfo` (it rebases addresses to the object's preferred base; the Mach-O/PE doc comments state addresses are "relative to the actual start of the image") and `findshlibs` (the SDK emits `image_addr = actual_load_addr`, `image_vmaddr = stated_load_addr`) shows the `image_vmaddr` term cancels — so the proposed fix would double-count the preferred base. Confirmed empirically (see testing). Outcome: no change to the lookup; add a guard test + doc instead.

Focused Rust test addition; no special skills required. `skip-agent-review` / `skip-inkeep-docs` are likely appropriate (test + doc only).
