### PR TITLE
feat(data-management): add wizard hint to ingestion warnings page

### DIFF
--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -1,15 +1,18 @@
 import { useActions, useValues } from 'kea'
 
-import { IconOpenSidebar } from '@posthog/icons'
+import { IconOpenSidebar, IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
 
+import { CommandBlock } from 'lib/components/CommandBlock/CommandBlock'
 import { ReadingHog } from 'lib/components/hedgehogs'
+import { AgentBadgeRotator } from 'lib/components/MCPHint/AgentBadgeRotator'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
 import { Sparkline } from 'lib/components/Sparkline'
 import { TZLabel } from 'lib/components/TZLabel'
 import ViewRecordingButton from 'lib/components/ViewRecordingButton/ViewRecordingButton'
 import { LemonTable } from 'lib/lemon-ui/LemonTable'
 import { Link } from 'lib/lemon-ui/Link'
+import { useWizardCommand } from 'scenes/onboarding/shared/SetupWizardBanner'
 import { sceneConfigurations } from 'scenes/scenes'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -307,6 +310,48 @@ const WARNING_TYPE_RENDERER = {
     },
 }
 
+/**
+ * Agent-flavored nudge shown above the warnings table: pushes the
+ * `npx @posthog/wizard ingestion-warnings` CLI, which finds the code behind each
+ * warning and fixes the instrumentation producing it. Mirrors the warehouse / MCP
+ * hint cards.
+ */
+function IngestionWarningsWizardHint(): JSX.Element | null {
+    const { wizardCommand, isCloudOrDev } = useWizardCommand('ingestion-warnings')
+
+    // The wizard CLI only targets cloud (US/EU) and dev instances — self-hosted has no
+    // preconfigured endpoint, so hide it rather than show a command that can't work.
+    if (!isCloudOrDev) {
+        return null
+    }
+
+    return (
+        <div className="rounded-lg border border-dashed border-primary bg-bg-light p-4 flex flex-col gap-3">
+            <div className="flex items-center gap-2">
+                <IconSparkles className="size-4 shrink-0" />
+                <h4 className="m-0 text-sm font-semibold">
+                    Let <AgentBadgeRotator /> fix these warnings for you
+                </h4>
+            </div>
+            <div className="text-sm text-default">
+                Ingestion warnings can't be fixed after the fact — the events are already dropped or degraded. Run this
+                in your project and the wizard traces each warning back to the code producing it and fixes the
+                instrumentation.
+            </div>
+            <div className="pt-1">
+                <CommandBlock
+                    command={wizardCommand}
+                    copyLabel="Ingestion warnings wizard command"
+                    ariaLabel="Copy ingestion warnings wizard command"
+                    size="sm"
+                    decoration="rainbow"
+                    className="bg-surface-secondary border border-primary !m-0 hover:border-accent"
+                />
+            </div>
+        </div>
+    )
+}
+
 export function IngestionWarningsView(): JSX.Element {
     const { data, dataLoading, summaryDatasets, dates, searchQuery, showProductIntro } =
         useValues(ingestionWarningsLogic)
@@ -344,6 +389,7 @@ export function IngestionWarningsView(): JSX.Element {
                 />
             ) : (
                 <SceneSection>
+                    <IngestionWarningsWizardHint />
                     <LemonInput
                         fullWidth
                         value={searchQuery}

--- a/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
+++ b/frontend/src/scenes/data-management/ingestion-warnings/IngestionWarningsView.tsx
@@ -1,4 +1,5 @@
 import { useActions, useValues } from 'kea'
+import posthog from 'posthog-js'
 
 import { IconOpenSidebar, IconSparkles } from '@posthog/icons'
 import { LemonButton, LemonInput } from '@posthog/lemon-ui'
@@ -346,6 +347,7 @@ function IngestionWarningsWizardHint(): JSX.Element | null {
                     size="sm"
                     decoration="rainbow"
                     className="bg-surface-secondary border border-primary !m-0 hover:border-accent"
+                    onCopy={() => posthog.capture('ingestion warnings wizard hint command copied')}
                 />
             </div>
         </div>


### PR DESCRIPTION
## Problem

The ingestion warnings page tells users which events PostHog had to drop, mis-merge, or degrade — but offers no path to fix them beyond a per-row docs link. These warnings can't be fixed after the fact (the data is already gone); the fix always lives in the instrumentation producing the events.

## Changes

Adds an agent-flavored hint card above the warnings table that surfaces the new `npx @posthog/wizard@latest ingestion-warnings` command. The wizard skill queries the project's firing warnings, traces each back to the producing code, and fixes the instrumentation.

- Mirrors the existing `WarehouseWizardHint` / MCP hint card style (dashed card, `AgentBadgeRotator`, rainbow `CommandBlock`).
- Reuses the shared `useWizardCommand('ingestion-warnings')` hook, so the region flag (`--region eu`) is handled and it's hidden on self-hosted (no preconfigured wizard endpoint).
- Only shown in the non-empty state (when there are warnings to act on).

Backed by the wizard command in PostHog/wizard#775 and the skill in PostHog/context-mill#207.

## How did you test this code?

I'm an agent (PostHog Slack app). I have **not** run the frontend typecheck/format locally — this was authored in a sparse checkout without frontend deps installed, so I relied on matching the existing `WarehouseWizardHint` pattern (same imports, props, and Tailwind classes). Needs a CI format/typecheck pass before marking ready.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — requested in the linked Slack thread. DRI should self-assign; I didn't set an assignee because I couldn't verify the requester's GitHub handle this session.

Authored by the PostHog Slack app from a [Slack thread](https://posthog.slack.com/archives/C0A7NDJ4DND/p1782832077766109?thread_ts=1782832077.766109&cid=C0A7NDJ4DND). This is one of three PRs implementing the feature end-to-end: the context-mill skill (PostHog/context-mill#207), the wizard command (PostHog/wizard#775), and this page hint. The hint component reuses `useWizardCommand` rather than reconstructing the npx command inline, and is non-dismissible (it only renders when warnings exist, so it isn't naggy on a clean project).