### PR TITLE
fix(billing): show billing tabs consistently regardless of entry point

### DIFF
--- a/frontend/src/scenes/billing/Billing.tsx
+++ b/frontend/src/scenes/billing/Billing.tsx
@@ -70,11 +70,15 @@ export function Billing(): JSX.Element {
     })
 
     useEffect(() => {
-        if (location.pathname === urls.organizationBilling() && featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]) {
+        // Always send the bare /organization/billing URL to the canonical section URL. The tabbed
+        // usage/spend experience is gated inside BillingSection, so this redirect must not depend on
+        // feature-flag load timing — otherwise navigating here (e.g. via the command palette) before
+        // flags resolve would strand the user on the section-less page.
+        if (location.pathname === urls.organizationBilling()) {
             router.actions.replace(urls.organizationBillingSection('overview'), searchParams)
             return
         }
-    }, [featureFlags, location.pathname, searchParams])
+    }, [location.pathname, searchParams])
 
     useEffect(() => {
         if (billing) {

--- a/frontend/src/scenes/billing/BillingSection.tsx
+++ b/frontend/src/scenes/billing/BillingSection.tsx
@@ -2,6 +2,7 @@ import './Billing.scss'
 
 import { useValues } from 'kea'
 import { router } from 'kea-router'
+import { useEffect } from 'react'
 
 import { LemonTabs } from '@posthog/lemon-ui'
 
@@ -29,20 +30,29 @@ const tabs: { key: BillingSectionId; label: string }[] = [
 
 export function BillingSection(): JSX.Element {
     const { location, searchParams } = useValues(router)
-    const { featureFlags } = useValues(featureFlagLogic)
+    const { featureFlags, receivedFeatureFlags } = useValues(featureFlagLogic)
 
     // The usage/spend dashboards are intentionally hidden from large orgs (the breakdown queries are
     // slow there) via this flag. Force the overview when it's off so these orgs land on the same
     // simple billing page regardless of how they navigated in.
     const usageSpendDashboardsEnabled = !!featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
 
-    const section = !usageSpendDashboardsEnabled
-        ? 'overview'
-        : location.pathname.includes('spend')
-          ? 'spend'
-          : location.pathname.includes('usage')
-            ? 'usage'
-            : 'overview'
+    const rawSection: BillingSectionId = location.pathname.includes('spend')
+        ? 'spend'
+        : location.pathname.includes('usage')
+          ? 'usage'
+          : 'overview'
+
+    const section: BillingSectionId = usageSpendDashboardsEnabled ? rawSection : 'overview'
+
+    // Normalise the URL for flag-off orgs that deep-link straight to a usage/spend section. Wait for
+    // flags to actually load (they're persisted, so could be stale) before redirecting, so a flag-on
+    // user isn't bounced off their section while flags are still resolving.
+    useEffect(() => {
+        if (receivedFeatureFlags && !usageSpendDashboardsEnabled && rawSection !== 'overview') {
+            router.actions.replace(urls.organizationBillingSection('overview'), searchParams)
+        }
+    }, [receivedFeatureFlags, usageSpendDashboardsEnabled, rawSection, searchParams])
 
     const handleTabChange = (key: BillingSectionId): void => {
         const newUrl = urls.organizationBillingSection(key)

--- a/frontend/src/scenes/billing/BillingSection.tsx
+++ b/frontend/src/scenes/billing/BillingSection.tsx
@@ -5,6 +5,8 @@ import { router } from 'kea-router'
 
 import { LemonTabs } from '@posthog/lemon-ui'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { SceneExport } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
 
@@ -27,12 +29,20 @@ const tabs: { key: BillingSectionId; label: string }[] = [
 
 export function BillingSection(): JSX.Element {
     const { location, searchParams } = useValues(router)
+    const { featureFlags } = useValues(featureFlagLogic)
 
-    const section = location.pathname.includes('spend')
-        ? 'spend'
-        : location.pathname.includes('usage')
-          ? 'usage'
-          : 'overview'
+    // The usage/spend dashboards are intentionally hidden from large orgs (the breakdown queries are
+    // slow there) via this flag. Force the overview when it's off so these orgs land on the same
+    // simple billing page regardless of how they navigated in.
+    const usageSpendDashboardsEnabled = !!featureFlags[FEATURE_FLAGS.USAGE_SPEND_DASHBOARDS]
+
+    const section = !usageSpendDashboardsEnabled
+        ? 'overview'
+        : location.pathname.includes('spend')
+          ? 'spend'
+          : location.pathname.includes('usage')
+            ? 'usage'
+            : 'overview'
 
     const handleTabChange = (key: BillingSectionId): void => {
         const newUrl = urls.organizationBillingSection(key)
@@ -63,7 +73,7 @@ export function BillingSection(): JSX.Element {
 
     return (
         <div className="flex flex-col">
-            <LemonTabs activeKey={section} onChange={handleTabChange} tabs={tabs} />
+            {usageSpendDashboardsEnabled && <LemonTabs activeKey={section} onChange={handleTabChange} tabs={tabs} />}
 
             {section === 'overview' && <Billing />}
             {section === 'usage' && <BillingUsage />}


### PR DESCRIPTION
## Problem

The billing tabs (Overview / Usage / Spend) intermittently disappeared depending on how you navigated to billing. Reaching `/organization/billing` (notably via the Cmd+K command palette) could land you on a section-less page with no tabs, while a direct link to `/organization/billing/overview` always showed them.

Root cause: two scenes back billing — `/organization/billing` renders the tab-less `Billing` scene, and `/organization/billing/:section` renders the tabbed `BillingSection`. The only thing taking you from the former to the latter was a render-time `useEffect` redirect gated on the `usage-spend-dashboards` feature flag. That flag intentionally hides the usage/spend dashboards from large orgs (their breakdown queries are slow), but it also gated the redirect — so the tabs showed inconsistently:
- For a flag-off org, the redirect never fired, yet `BillingSection` rendered the tabs unconditionally for anyone reaching the section URL directly.
- The redirect also raced feature-flag loading, so a client-side navigation before flags resolved could skip it.

## Changes

- `Billing.tsx`: the bare-URL redirect to `/overview` is now unconditional, so it no longer depends on feature-flag load timing.
- `BillingSection.tsx`: the tab bar and usage/spend sections are now gated on `usage-spend-dashboards`. When the flag is off, the section is forced to the overview and the tab bar is hidden — so flag-off orgs consistently get the same plain billing overview regardless of entry point, keeping the large-org performance guard intact.

## How did you test this code?

I'm an agent — I have not run manual testing or the local app. The change is a small frontend control-flow adjustment; I did not add automated tests because the billing scenes have only logic-level tests today and mounting these heavily-connected scenes in jest would be brittle. Reviewer verification: with the flag on, both `/organization/billing` and the command palette entry should land on `/overview` with tabs; with the flag off, all billing entry points should show the overview without tabs.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack report that billing tabs disappeared when navigating via the command palette but reappeared via a direct link. Traced it to the split `Billing` / `BillingSection` scenes and the flag-gated `useEffect` redirect. Considered three directions: (a) make the tabs GA by dropping the gate — rejected, it would expose the slow usage/spend dashboards to large orgs the flag exists to protect; (b) only harden the flag-on path; (c) make the experience consistently flag-driven — chosen, since it fixes the inconsistency for every entry point while preserving the performance guard. Settled on an unconditional redirect plus gating the tab content inside `BillingSection`, which also removes the flag-load race from the redirect path.

No skills were required for this change.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08ERRQT41E/p1782834682776519?thread_ts=1782834682.776519&cid=C08ERRQT41E)*
