### PR TITLE
feat(insights): wire trends/retention/stickiness charts to InsightSeriesTooltip

### DIFF
--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -58,9 +58,8 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
     const { insightProps } = useValues(insightLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const TOOLTIP_CONFIG = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-        ? INSIGHT_TOOLTIP_CONFIG
-        : INSIGHT_TOOLTIP_CONFIG_LEGACY
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
 
     const {
@@ -106,8 +105,6 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
         },
         [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
     )
-
-    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<RetentionSeriesMeta>) => {

--- a/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionBarChart/RetentionBarChart.tsx
@@ -3,9 +3,12 @@ import posthog from 'posthog-js'
 import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { TimeSeriesBarChart } from '@posthog/quill-charts'
-import type { PointClickData, TooltipConfig, TooltipContext } from '@posthog/quill-charts'
+import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { roundToDecimal } from 'lib/utils/numbers'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
@@ -16,6 +19,8 @@ import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import {
     buildRetentionBarChartConfig,
     buildRetentionSeries,
@@ -27,8 +32,6 @@ import { RetentionTooltip } from '../shared/RetentionTooltip'
 interface RetentionBarChartProps {
     inSharedMode?: boolean
 }
-
-const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 const EMPTY_GOAL_LINES: GoalLine[] = []
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
@@ -54,6 +57,10 @@ function resolveGroupTypeLabel(
 export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { isDarkModeOn } = useValues(themeLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const TOOLTIP_CONFIG = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+        ? INSIGHT_TOOLTIP_CONFIG
+        : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
 
     const {
@@ -100,20 +107,46 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
         [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
     )
 
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+
     const renderTooltip = useCallback(
-        (ctx: TooltipContext<RetentionSeriesMeta>) => (
-            <RetentionTooltip
-                context={ctx}
-                xAxisLabels={xAxisLabels}
-                period={period}
-                selectedInterval={selectedInterval}
-                shouldShowMeanPerBreakdown={shouldShowMeanPerBreakdown}
-                isPercentage={isPercentage}
-                groupTypeLabel={groupTypeLabel}
-                onRowClick={canClick ? onRowClick : undefined}
-            />
-        ),
+        (ctx: TooltipContext<RetentionSeriesMeta>) => {
+            if (quillTooltipEnabled) {
+                const altTitle =
+                    selectedInterval !== null
+                        ? `${period ?? ''} ${selectedInterval}`
+                        : (xAxisLabels[ctx.dataIndex] ?? ctx.label)
+                return (
+                    <InsightSeriesTooltip
+                        context={ctx}
+                        altTitle={altTitle}
+                        renderCount={(value) =>
+                            isPercentage ? `${roundToDecimal(value)}%` : `${roundToDecimal(value)}`
+                        }
+                        renderSeriesOverride={(datum) => {
+                            const showCohortPrefix = selectedInterval !== null || !shouldShowMeanPerBreakdown
+                            return showCohortPrefix ? `Cohort ${datum.label ?? ''}` : (datum.label ?? '')
+                        }}
+                        groupTypeLabel={groupTypeLabel}
+                        onRowClick={canClick ? onRowClick : undefined}
+                    />
+                )
+            }
+            return (
+                <RetentionTooltip
+                    context={ctx}
+                    xAxisLabels={xAxisLabels}
+                    period={period}
+                    selectedInterval={selectedInterval}
+                    shouldShowMeanPerBreakdown={shouldShowMeanPerBreakdown}
+                    isPercentage={isPercentage}
+                    groupTypeLabel={groupTypeLabel}
+                    onRowClick={canClick ? onRowClick : undefined}
+                />
+            )
+        },
         [
+            quillTooltipEnabled,
             xAxisLabels,
             period,
             selectedInterval,
@@ -144,7 +177,7 @@ export function RetentionBarChart({ inSharedMode = false }: RetentionBarChartPro
 
     const barConfig = useMemo(
         () => buildRetentionBarChartConfig({ isPercentage, goalLines, series, tooltip: TOOLTIP_CONFIG }),
-        [isPercentage, goalLines, series]
+        [isPercentage, goalLines, series, TOOLTIP_CONFIG]
     )
 
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -58,9 +58,8 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
     const { insightProps } = useValues(insightLogic)
     const { isDarkModeOn } = useValues(themeLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const TOOLTIP_CONFIG = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-        ? INSIGHT_TOOLTIP_CONFIG
-        : INSIGHT_TOOLTIP_CONFIG_LEGACY
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
 
     const {
@@ -109,8 +108,6 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
         },
         [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
     )
-
-    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<RetentionSeriesMeta>) => {

--- a/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
+++ b/products/product_analytics/frontend/insights/retention/RetentionLineChart/RetentionLineChart.tsx
@@ -3,9 +3,12 @@ import posthog from 'posthog-js'
 import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
-import type { PointClickData, TooltipConfig, TooltipContext } from '@posthog/quill-charts'
+import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
+import { roundToDecimal } from 'lib/utils/numbers'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
 import { retentionGraphLogic } from 'scenes/retention/retentionGraphLogic'
@@ -16,6 +19,8 @@ import { groupsModel } from '~/models/groupsModel'
 import type { GoalLine } from '~/queries/schema/schema-general'
 import type { GroupTypeIndex, LabelGroupType } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import {
     buildRetentionLineChartConfig,
     buildRetentionSeries,
@@ -27,8 +32,6 @@ import { RetentionTooltip } from '../shared/RetentionTooltip'
 interface RetentionLineChartProps {
     inSharedMode?: boolean
 }
-
-const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 const EMPTY_GOAL_LINES: GoalLine[] = []
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
@@ -54,6 +57,10 @@ function resolveGroupTypeLabel(
 export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartProps): JSX.Element | null {
     const { insightProps } = useValues(insightLogic)
     const { isDarkModeOn } = useValues(themeLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const TOOLTIP_CONFIG = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+        ? INSIGHT_TOOLTIP_CONFIG
+        : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
 
     const {
@@ -103,20 +110,46 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
         [shouldShowMeanPerBreakdown, isIntervalView, series, openModal]
     )
 
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+
     const renderTooltip = useCallback(
-        (ctx: TooltipContext<RetentionSeriesMeta>) => (
-            <RetentionTooltip
-                context={ctx}
-                xAxisLabels={xAxisLabels}
-                period={period}
-                selectedInterval={selectedInterval}
-                shouldShowMeanPerBreakdown={shouldShowMeanPerBreakdown}
-                isPercentage={isPercentage}
-                groupTypeLabel={groupTypeLabel}
-                onRowClick={canClick ? onRowClick : undefined}
-            />
-        ),
+        (ctx: TooltipContext<RetentionSeriesMeta>) => {
+            if (quillTooltipEnabled) {
+                const altTitle =
+                    selectedInterval !== null
+                        ? `${period ?? ''} ${selectedInterval}`
+                        : (xAxisLabels[ctx.dataIndex] ?? ctx.label)
+                return (
+                    <InsightSeriesTooltip
+                        context={ctx}
+                        altTitle={altTitle}
+                        renderCount={(value) =>
+                            isPercentage ? `${roundToDecimal(value)}%` : `${roundToDecimal(value)}`
+                        }
+                        renderSeriesOverride={(datum) => {
+                            const showCohortPrefix = selectedInterval !== null || !shouldShowMeanPerBreakdown
+                            return showCohortPrefix ? `Cohort ${datum.label ?? ''}` : (datum.label ?? '')
+                        }}
+                        groupTypeLabel={groupTypeLabel}
+                        onRowClick={canClick ? onRowClick : undefined}
+                    />
+                )
+            }
+            return (
+                <RetentionTooltip
+                    context={ctx}
+                    xAxisLabels={xAxisLabels}
+                    period={period}
+                    selectedInterval={selectedInterval}
+                    shouldShowMeanPerBreakdown={shouldShowMeanPerBreakdown}
+                    isPercentage={isPercentage}
+                    groupTypeLabel={groupTypeLabel}
+                    onRowClick={canClick ? onRowClick : undefined}
+                />
+            )
+        },
         [
+            quillTooltipEnabled,
             xAxisLabels,
             period,
             selectedInterval,
@@ -148,7 +181,7 @@ export function RetentionLineChart({ inSharedMode = false }: RetentionLineChartP
     const lineConfig = useMemo(
         () =>
             buildRetentionLineChartConfig({ isPercentage, goalLines, showTrendLines, series, tooltip: TOOLTIP_CONFIG }),
-        [isPercentage, goalLines, showTrendLines, series]
+        [isPercentage, goalLines, showTrendLines, series, TOOLTIP_CONFIG]
     )
 
     if (filteredTrendSeries.length === 0 && hasValidBreakdown) {

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -31,6 +31,7 @@ import {
     resolveGroupTypeLabel,
     type TrendsSeriesMeta,
 } from '../../trends/shared/trendsSeriesMeta'
+import { TrendsTooltip } from '../../trends/shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from '../StickinessLineChart/handleStickinessChartClick'
 import {
@@ -51,9 +52,8 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const tooltipConfig = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-        ? STICKINESS_TOOLTIP_CONFIG
-        : INSIGHT_TOOLTIP_CONFIG_LEGACY
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const tooltipConfig = quillTooltipEnabled ? STICKINESS_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
     const quillLegendEnabled = !!legendConfig
@@ -162,22 +162,21 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
                       handleStickinessChartClick(seriesKey, datum.dataIndex, clickDeps)
                   }
                 : undefined
-            return (
-                <InsightSeriesTooltip
-                    context={ctx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    trendsFilter={trendsFilter}
-                    showPercentView={true}
-                    isPercentStackView={false}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel={resolvedGroupTypeLabel}
-                    formatCompareLabel={formatCompareLabel}
-                    onRowClick={onRowClick}
-                    altTitle={altTitle}
-                />
-            )
+            const sharedProps = {
+                context: ctx,
+                timezone,
+                interval: interval ?? undefined,
+                breakdownFilter: breakdownFilter ?? undefined,
+                trendsFilter,
+                showPercentView: true as const,
+                isPercentStackView: false as const,
+                baseCurrency,
+                groupTypeLabel: resolvedGroupTypeLabel,
+                formatCompareLabel,
+                onRowClick,
+                altTitle,
+            }
+            return quillTooltipEnabled ? <InsightSeriesTooltip {...sharedProps} /> : <TrendsTooltip {...sharedProps} />
         },
         [
             timezone,
@@ -191,6 +190,7 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
             hasClickHandler,
             clickDeps,
             altTitle,
+            quillTooltipEnabled,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessBarChart/StickinessBarChart.tsx
@@ -5,6 +5,8 @@ import { TimeSeriesBarChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -20,6 +22,8 @@ import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { makeChartErrorHandler } from '../../trends/shared/chartErrorHandler'
 import { getTrendsSeriesDisplayLabel } from '../../trends/shared/getTrendsSeriesDisplayLabel'
 import {
@@ -27,7 +31,6 @@ import {
     resolveGroupTypeLabel,
     type TrendsSeriesMeta,
 } from '../../trends/shared/trendsSeriesMeta'
-import { TrendsTooltip } from '../../trends/shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from '../StickinessLineChart/handleStickinessChartClick'
 import {
@@ -47,6 +50,10 @@ const handleChartError = makeChartErrorHandler('stickiness-bar-chart')
 export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps } = useValues(insightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const tooltipConfig = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+        ? STICKINESS_TOOLTIP_CONFIG
+        : INSIGHT_TOOLTIP_CONFIG_LEGACY
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
     const quillLegendEnabled = !!legendConfig
@@ -112,12 +119,12 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
                 yAxisScaleType,
                 isGrouped,
                 valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
-                tooltip: STICKINESS_TOOLTIP_CONFIG,
+                tooltip: tooltipConfig,
             }),
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, isGrouped, showValuesOnSeries, legendConfig]
+        [yAxisScaleType, isGrouped, showValuesOnSeries, legendConfig, tooltipConfig]
     )
 
     // Close over the primitives so the click memos don't invalidate when unrelated
@@ -156,13 +163,12 @@ export function StickinessBarChart({ context }: StickinessBarChartProps): JSX.El
                   }
                 : undefined
             return (
-                <TrendsTooltip
+                <InsightSeriesTooltip
                     context={ctx}
                     timezone={timezone}
                     interval={interval ?? undefined}
                     breakdownFilter={breakdownFilter ?? undefined}
                     trendsFilter={trendsFilter}
-                    formula={formula}
                     showPercentView={true}
                     isPercentStackView={false}
                     baseCurrency={baseCurrency}

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -5,6 +5,8 @@ import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type { PointClickData, Series, TimeSeriesLineChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
 import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipUtils'
@@ -19,6 +21,8 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { makeChartErrorHandler } from '../../trends/shared/chartErrorHandler'
 import { getTrendsSeriesDisplayLabel } from '../../trends/shared/getTrendsSeriesDisplayLabel'
 import {
@@ -26,7 +30,6 @@ import {
     resolveGroupTypeLabel,
     type TrendsSeriesMeta,
 } from '../../trends/shared/trendsSeriesMeta'
-import { TrendsTooltip } from '../../trends/shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from './handleStickinessChartClick'
 import {
@@ -47,6 +50,10 @@ const handleChartError = makeChartErrorHandler('stickiness-line-chart')
 export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps } = useValues(insightLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const tooltipConfig = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+        ? STICKINESS_TOOLTIP_CONFIG
+        : INSIGHT_TOOLTIP_CONFIG_LEGACY
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
     const quillLegendEnabled = !!legendConfig
@@ -114,12 +121,12 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                 yAxisScaleType,
                 valueLabels: showValuesOnSeries ? { formatter: stickinessPercentFormatter } : false,
                 showCrosshair: true,
-                tooltip: STICKINESS_TOOLTIP_CONFIG,
+                tooltip: tooltipConfig,
             }),
             // Interactive legend is a component concern, kept out of the pure transform.
             legend: legendConfig,
         }),
-        [yAxisScaleType, showValuesOnSeries, legendConfig]
+        [yAxisScaleType, showValuesOnSeries, legendConfig, tooltipConfig]
     )
 
     const canHandleClick = !!context?.onDataPointClick || !!hasPersonsModal
@@ -154,13 +161,12 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                   }
                 : undefined
             return (
-                <TrendsTooltip
+                <InsightSeriesTooltip
                     context={ctx}
                     timezone={timezone}
                     interval={interval ?? undefined}
                     breakdownFilter={breakdownFilter ?? undefined}
                     trendsFilter={trendsFilter}
-                    formula={formula}
                     showPercentView={true}
                     isPercentStackView={false}
                     baseCurrency={baseCurrency}

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/StickinessLineChart.tsx
@@ -30,6 +30,7 @@ import {
     resolveGroupTypeLabel,
     type TrendsSeriesMeta,
 } from '../../trends/shared/trendsSeriesMeta'
+import { TrendsTooltip } from '../../trends/shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../../trends/shared/useInsightsLegendConfig'
 import { handleStickinessChartClick } from './handleStickinessChartClick'
 import {
@@ -51,9 +52,8 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
     const theme = useMemo(() => buildTheme(), [])
     const { insightProps } = useValues(insightLogic)
     const { featureFlags } = useValues(featureFlagLogic)
-    const tooltipConfig = featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
-        ? STICKINESS_TOOLTIP_CONFIG
-        : INSIGHT_TOOLTIP_CONFIG_LEGACY
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const tooltipConfig = quillTooltipEnabled ? STICKINESS_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
 
     const legendConfig = useInsightsLegendConfig({ insightProps })
     const quillLegendEnabled = !!legendConfig
@@ -160,22 +160,21 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
                       handleStickinessChartClick(seriesKey, datum.dataIndex, clickDeps)
                   }
                 : undefined
-            return (
-                <InsightSeriesTooltip
-                    context={ctx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    trendsFilter={trendsFilter}
-                    showPercentView={true}
-                    isPercentStackView={false}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel={resolvedGroupTypeLabel}
-                    formatCompareLabel={context?.formatCompareLabel}
-                    onRowClick={onRowClick}
-                    altTitle={altTitle}
-                />
-            )
+            const sharedProps = {
+                context: ctx,
+                timezone,
+                interval: interval ?? undefined,
+                breakdownFilter: breakdownFilter ?? undefined,
+                trendsFilter,
+                showPercentView: true as const,
+                isPercentStackView: false as const,
+                baseCurrency,
+                groupTypeLabel: resolvedGroupTypeLabel,
+                formatCompareLabel: context?.formatCompareLabel,
+                onRowClick,
+                altTitle,
+            }
+            return quillTooltipEnabled ? <InsightSeriesTooltip {...sharedProps} /> : <TrendsTooltip {...sharedProps} />
         },
         [
             timezone,
@@ -189,6 +188,7 @@ export function StickinessLineChart({ context }: StickinessLineChartProps): JSX.
             canHandleClick,
             clickDeps,
             altTitle,
+            quillTooltipEnabled,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
+++ b/products/product_analytics/frontend/insights/stickiness/StickinessLineChart/stickinessChartTransforms.ts
@@ -6,6 +6,7 @@ import type { SeriesDatum } from 'scenes/insights/InsightTooltip/insightTooltipU
 
 import { ChartDisplayType } from '~/types'
 
+import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { COMPARE_PREVIOUS_DIM_OPACITY, dimHexColor } from '../../trends/shared/compareDimming'
 import { humanizeSeriesLabel } from '../../trends/shared/humanizeSeriesLabel'
 
@@ -90,9 +91,7 @@ export function stickinessPercentFormatter(value: number): string {
     return `${value.toFixed(1)}%`
 }
 
-/** Stickiness adapters pin their tooltip to the top with pinnable rows. Shared so the
- *  line and bar ports stay consistent. */
-export const STICKINESS_TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
+export const STICKINESS_TOOLTIP_CONFIG = INSIGHT_TOOLTIP_CONFIG
 
 /** Stickiness `date` is an interval-count integer (1, 2, …), not a date.
  *  Render "Stickiness on {interval} {day}" so InsightTooltip doesn't try to

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -495,6 +495,70 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
             { timeout: 5000 }
         )
     })
+
+    it('keeps the previous-period identifier glyph opaque while dimming only the row ribbon', async () => {
+        // Give the previous period the larger aggregated_value so it sorts topmost (DESC) and is the
+        // bar hovered at plotTop. Its series color arrives pre-dimmed (rgba .5); the ribbon should keep
+        // that dim to mark the period, but the SeriesLetter glyph must render at full opacity.
+        const action = { id: '$pageview', type: 'events', name: '$pageview', order: 0 }
+        const compareResults = {
+            results: [
+                {
+                    action,
+                    label: '$pageview',
+                    count: 50,
+                    aggregated_value: 50,
+                    data: [50],
+                    labels: ['Day 1'],
+                    days: ['2024-06-10'],
+                    compare: true,
+                    compare_label: 'current',
+                },
+                {
+                    action,
+                    label: '$pageview',
+                    count: 500,
+                    aggregated_value: 500,
+                    data: [500],
+                    labels: ['Day 1'],
+                    days: ['2024-06-03'],
+                    compare: true,
+                    compare_label: 'previous',
+                },
+            ],
+        }
+        renderInsight({
+            query: aggregatedBar({ compareFilter: { compare: true } }),
+            // Pin to the legacy InsightTooltip path — the glyph/ribbon assertions are specific
+            // to that rendering and will get a quill-flavoured equivalent when the flag ships.
+            featureFlags: { [FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]: false },
+            mocks: {
+                additionalMockResponses: [{ match: (q) => q.kind === NodeKind.TrendsQuery, response: compareResults }],
+            },
+        })
+        const canvas = await screen.findByRole('img', { name: /chart with/i }, { timeout: 5000 })
+        const wrapper = canvas.parentElement!
+        // Topmost band is the previous period (largest aggregated_value, sorted DESC). Aim at the
+        // band centre — the bar's hittable region sits inside the band's padding.
+        const previousBandY = dimensions.plotTop + dimensions.plotHeight / 4
+
+        // Re-fire the hover each tick until the chart commits its scales and the tooltip populates —
+        // a single mouseMove before the chart settles is silently dropped.
+        await waitFor(
+            () => {
+                fireEvent.mouseMove(wrapper, { clientX: dimensions.plotLeft + 30, clientY: previousBandY })
+                const glyph = chart.getTooltip()?.querySelector<HTMLElement>('.graph-series-glyph')
+                expect(glyph).toBeTruthy()
+                // The identifier glyph stays opaque — no alpha channel bled in from the dimmed color.
+                expect(glyph!.style.color).not.toMatch(/rgba/)
+                expect(glyph!.style.borderColor).not.toMatch(/rgba/)
+                // The left ribbon still carries the half-opacity previous-period color.
+                const ribbon = glyph!.closest('tr')!.style.getPropertyValue('--row-ribbon-color')
+                expect(ribbon).toMatch(/rgba\([^)]*0?\.5\)/)
+            },
+            { timeout: 8000 }
+        )
+    }, 12000)
 })
 
 describe('TrendsBarChart (ActionsUnstackedBar)', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.test.tsx
@@ -495,67 +495,6 @@ describe('TrendsBarChart (ActionsBarValue)', () => {
             { timeout: 5000 }
         )
     })
-
-    it('keeps the previous-period identifier glyph opaque while dimming only the row ribbon', async () => {
-        // Give the previous period the larger aggregated_value so it sorts topmost (DESC) and is the
-        // bar hovered at plotTop. Its series color arrives pre-dimmed (rgba .5); the ribbon should keep
-        // that dim to mark the period, but the SeriesLetter glyph must render at full opacity.
-        const action = { id: '$pageview', type: 'events', name: '$pageview', order: 0 }
-        const compareResults = {
-            results: [
-                {
-                    action,
-                    label: '$pageview',
-                    count: 50,
-                    aggregated_value: 50,
-                    data: [50],
-                    labels: ['Day 1'],
-                    days: ['2024-06-10'],
-                    compare: true,
-                    compare_label: 'current',
-                },
-                {
-                    action,
-                    label: '$pageview',
-                    count: 500,
-                    aggregated_value: 500,
-                    data: [500],
-                    labels: ['Day 1'],
-                    days: ['2024-06-03'],
-                    compare: true,
-                    compare_label: 'previous',
-                },
-            ],
-        }
-        renderInsight({
-            query: aggregatedBar({ compareFilter: { compare: true } }),
-            mocks: {
-                additionalMockResponses: [{ match: (q) => q.kind === NodeKind.TrendsQuery, response: compareResults }],
-            },
-        })
-        const canvas = await screen.findByRole('img', { name: /chart with/i }, { timeout: 5000 })
-        const wrapper = canvas.parentElement!
-        // Topmost band is the previous period (largest aggregated_value, sorted DESC). Aim at the
-        // band centre — the bar's hittable region sits inside the band's padding.
-        const previousBandY = dimensions.plotTop + dimensions.plotHeight / 4
-
-        // Re-fire the hover each tick until the chart commits its scales and the tooltip populates —
-        // a single mouseMove before the chart settles is silently dropped.
-        await waitFor(
-            () => {
-                fireEvent.mouseMove(wrapper, { clientX: dimensions.plotLeft + 30, clientY: previousBandY })
-                const glyph = chart.getTooltip()?.querySelector<HTMLElement>('.graph-series-glyph')
-                expect(glyph).toBeTruthy()
-                // The identifier glyph stays opaque — no alpha channel bled in from the dimmed color.
-                expect(glyph!.style.color).not.toMatch(/rgba/)
-                expect(glyph!.style.borderColor).not.toMatch(/rgba/)
-                // The left ribbon still carries the half-opacity previous-period color.
-                const ribbon = glyph!.closest('tr')!.style.getPropertyValue('--row-ribbon-color')
-                expect(ribbon).toMatch(/rgba\([^)]*0?\.5\)/)
-            },
-            { timeout: 8000 }
-        )
-    }, 12000)
 })
 
 describe('TrendsBarChart (ActionsUnstackedBar)', () => {

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -31,6 +31,8 @@ import { QueryContext } from '~/queries/types'
 import { getStackBreakdownValues } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
 import { getTrendsSeriesDisplayLabel } from '../shared/getTrendsSeriesDisplayLabel'
@@ -39,7 +41,6 @@ import { handleTrendsChartClick, type TrendsChartClickDeps } from '../shared/han
 import { TrendsAlertOverlays } from '../shared/TrendsAlertOverlays'
 import { trendsFilterToYFormatterConfig } from '../shared/trendsAxisFormat'
 import { buildTrendsSeriesMeta, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
-import { TrendsTooltip } from '../shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../shared/useInsightsLegendConfig'
 import { getAggregatedDisplayLabel as getAggregatedDisplayLabelFn } from './getAggregatedDisplayLabel'
 import { handleTrendsBarAggregatedChartClick } from './handleTrendsBarAggregatedChartClick'
@@ -57,7 +58,7 @@ interface TrendsBarChartProps {
 }
 
 const EMPTY_LABELS: string[] = []
-const TIME_SERIES_TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
+const TIME_SERIES_TOOLTIP_CONFIG = INSIGHT_TOOLTIP_CONFIG
 const AGGREGATED_TOOLTIP_CONFIG = { pinnable: false }
 
 type AggregationLabelFn = (groupTypeIndex: number | null | undefined) => { plural: string }
@@ -375,14 +376,13 @@ export function TrendsBarChart({
                   }
                 : undefined
             return (
-                <TrendsTooltip
+                <InsightSeriesTooltip
                     context={tooltipCtx}
                     timezone={timezone}
                     interval={interval ?? undefined}
                     breakdownFilter={breakdownFilter ?? undefined}
                     dateRange={insightData?.resolved_date_range ?? undefined}
                     trendsFilter={trendsFilter}
-                    formula={formula}
                     showPercentView={isStickiness}
                     isPercentStackView={isPercentStackView}
                     baseCurrency={baseCurrency}

--- a/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsBarChart/TrendsBarChart.tsx
@@ -13,6 +13,8 @@ import {
 import type { BarChartConfig, PointClickData, TimeSeriesBarChartConfig, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { percentage } from 'lib/utils/numbers'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
@@ -32,7 +34,7 @@ import { getStackBreakdownValues } from '~/queries/utils'
 import { ChartDisplayType } from '~/types'
 
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
-import { INSIGHT_TOOLTIP_CONFIG } from '../../shared/tooltipConfig'
+import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
 import { getTrendsSeriesDisplayLabel } from '../shared/getTrendsSeriesDisplayLabel'
@@ -41,6 +43,7 @@ import { handleTrendsChartClick, type TrendsChartClickDeps } from '../shared/han
 import { TrendsAlertOverlays } from '../shared/TrendsAlertOverlays'
 import { trendsFilterToYFormatterConfig } from '../shared/trendsAxisFormat'
 import { buildTrendsSeriesMeta, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
+import { TrendsTooltip } from '../shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../shared/useInsightsLegendConfig'
 import { getAggregatedDisplayLabel as getAggregatedDisplayLabelFn } from './getAggregatedDisplayLabel'
 import { handleTrendsBarAggregatedChartClick } from './handleTrendsBarAggregatedChartClick'
@@ -58,7 +61,6 @@ interface TrendsBarChartProps {
 }
 
 const EMPTY_LABELS: string[] = []
-const TIME_SERIES_TOOLTIP_CONFIG = INSIGHT_TOOLTIP_CONFIG
 const AGGREGATED_TOOLTIP_CONFIG = { pinnable: false }
 
 type AggregationLabelFn = (groupTypeIndex: number | null | undefined) => { plural: string }
@@ -88,6 +90,9 @@ export function TrendsBarChart({
     embedded = false,
 }: TrendsBarChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const TIME_SERIES_TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const { insightProps, insight } = useValues(insightLogic)
 
     // Time-series bars (vertical) render the in-chart legend; the aggregated bar-value layout has
@@ -247,6 +252,7 @@ export function TrendsBarChart({
             showValuesOnSeries,
             valueLabelFormatter,
             legendConfig,
+            quillTooltipEnabled,
         ]
     )
 
@@ -375,22 +381,25 @@ export function TrendsBarChart({
                       }
                   }
                 : undefined
-            return (
-                <InsightSeriesTooltip
-                    context={tooltipCtx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    dateRange={insightData?.resolved_date_range ?? undefined}
-                    trendsFilter={trendsFilter}
-                    showPercentView={isStickiness}
-                    isPercentStackView={isPercentStackView}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel={resolvedGroupTypeLabel}
-                    formatCompareLabel={context?.formatCompareLabel}
-                    onRowClick={onRowClick}
-                    showHeader={isAggregated ? false : undefined}
-                />
+            const sharedProps = {
+                context: tooltipCtx,
+                timezone,
+                interval: interval ?? undefined,
+                breakdownFilter: breakdownFilter ?? undefined,
+                dateRange: insightData?.resolved_date_range ?? undefined,
+                trendsFilter,
+                showPercentView: isStickiness,
+                isPercentStackView,
+                baseCurrency,
+                groupTypeLabel: resolvedGroupTypeLabel,
+                formatCompareLabel: context?.formatCompareLabel,
+                onRowClick,
+                showHeader: isAggregated ? (false as const) : undefined,
+            }
+            return quillTooltipEnabled ? (
+                <InsightSeriesTooltip {...sharedProps} />
+            ) : (
+                <TrendsTooltip {...sharedProps} formula={formula} />
             )
         },
         [
@@ -408,6 +417,7 @@ export function TrendsBarChart({
             canHandleClick,
             clickDeps,
             isAggregated,
+            quillTooltipEnabled,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLifecycleChart/TrendsLifecycleChart.tsx
@@ -6,6 +6,8 @@ import type { ChartLegendConfig, PointClickData, TooltipContext } from '@posthog
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { getBarColorFromStatus } from 'lib/colors'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
 import { InsightEmptyState } from 'scenes/insights/EmptyStates'
 import { insightLogic } from 'scenes/insights/insightLogic'
@@ -19,6 +21,7 @@ import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import type { LifecycleToggle } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { buildBaseLegendConfig } from '../shared/buildBaseLegendConfig'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
@@ -37,7 +40,8 @@ interface TrendsLifecycleChartProps {
 }
 
 const EMPTY_LABELS: string[] = []
-const LIFECYCLE_TOOLTIP_CONFIG = { pinnable: true, placement: 'top' as const }
+const LIFECYCLE_TOOLTIP_CONFIG = { placement: 'cursor' as const }
+const LIFECYCLE_TOOLTIP_CONFIG_LEGACY = { pinnable: true, placement: 'top' as const }
 
 const handleChartError = makeChartErrorHandler('trends-lifecycle-chart')
 
@@ -49,6 +53,8 @@ const renderLifecycleSeriesLabel = (datum: SeriesDatum): React.ReactNode => datu
 
 export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLifecycleChartProps): JSX.Element | null {
     const theme = useMemo(() => buildTheme(), [])
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { insightProps, insight, canEditInsight } = useValues(insightLogic)
 
     const {
@@ -113,7 +119,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
                 timezone,
                 allDays: currentPeriodResult?.days ?? [],
                 valueLabels: showValuesOnSeries || showPercentagesOnSeries ? { formatter: valueLabelFormatter } : false,
-                tooltip: LIFECYCLE_TOOLTIP_CONFIG,
+                tooltip: quillTooltipEnabled ? LIFECYCLE_TOOLTIP_CONFIG : LIFECYCLE_TOOLTIP_CONFIG_LEGACY,
                 legend: legendConfig,
             }),
         [
@@ -130,6 +136,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             showPercentagesOnSeries,
             valueLabelFormatter,
             legendConfig,
+            quillTooltipEnabled,
         ]
     )
 
@@ -173,26 +180,28 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<TrendsSeriesMeta>) => {
+            const sharedProps = {
+                context: ctx,
+                timezone,
+                interval: interval ?? undefined,
+                breakdownFilter: breakdownFilter ?? undefined,
+                dateRange: insightData?.resolved_date_range ?? undefined,
+                trendsFilter,
+                formula,
+                baseCurrency,
+                groupTypeLabel: 'Users' as const,
+                renderSeriesOverride: renderLifecycleSeriesLabel,
+            }
             const onRowClick = canHandleClick
                 ? (datum: SeriesDatum) => {
                       const seriesKey = ctx.seriesData[datum.datasetIndex].series.key
                       handleTrendsChartClick(seriesKey, datum.dataIndex, clickDeps, LIFECYCLE_PERSONS_MODAL_OPTIONS)
                   }
                 : undefined
-            return (
-                <TrendsTooltip
-                    context={ctx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    dateRange={insightData?.resolved_date_range ?? undefined}
-                    trendsFilter={trendsFilter}
-                    formula={formula}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel="Users"
-                    onRowClick={onRowClick}
-                    renderSeriesOverride={renderLifecycleSeriesLabel}
-                />
+            return quillTooltipEnabled ? (
+                <InsightSeriesTooltip {...sharedProps} sortedByValue={false} hideZeroRows onRowClick={onRowClick} />
+            ) : (
+                <TrendsTooltip {...sharedProps} onRowClick={onRowClick} />
             )
         },
         [
@@ -203,6 +212,7 @@ export function TrendsLifecycleChart({ context, inSharedMode = false }: TrendsLi
             trendsFilter,
             formula,
             baseCurrency,
+            quillTooltipEnabled,
             canHandleClick,
             clickDeps,
         ]

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.test.tsx
@@ -43,13 +43,12 @@ afterEach(() => {
 
 describe('TrendsLineChart', () => {
     describe('tooltips', () => {
-        it('shows the series value and glyph for a single series', async () => {
+        it('shows the series value for a single series', async () => {
             renderInsight({ query: buildTrendsQuery() })
 
             const tooltip = await chart.hoverTooltip(2)
 
             expect(tooltip.row('Pageview')).toContain('134')
-            expect(tooltip.element.querySelector('.graph-series-glyph')).toBeInTheDocument()
         })
 
         it('shows each series with its own value for multiple series', async () => {
@@ -66,9 +65,6 @@ describe('TrendsLineChart', () => {
 
             expect(tooltip.row('Pageview')).toContain('134')
             expect(tooltip.row('Napped')).toContain('5')
-
-            const glyphs = tooltip.element.querySelectorAll('.graph-series-glyph')
-            expect(glyphs.length).toBe(2)
         })
 
         it('sorts tooltip rows by descending value regardless of series order', async () => {
@@ -186,22 +182,6 @@ describe('TrendsLineChart', () => {
             const tooltip = await chart.hoverTooltip(2)
 
             expect(tooltip.row('Pageview')).toMatch(/%/)
-        })
-
-        it('hides series glyph for formula insights', async () => {
-            renderInsight({
-                query: buildTrendsQuery({
-                    trendsFilter: { formula: 'A + B' },
-                    series: [
-                        { kind: NodeKind.EventsNode, event: '$pageview', name: '$pageview' },
-                        { kind: NodeKind.EventsNode, event: 'Napped', name: 'Napped' },
-                    ],
-                }),
-            })
-
-            const tooltip = await chart.hoverTooltip(2)
-
-            expect(tooltip.element.querySelector('.graph-series-glyph')).not.toBeInTheDocument()
         })
 
         it('shows zero-count series alongside active ones', async () => {
@@ -681,10 +661,8 @@ describe('TrendsLineChart', () => {
             expect(tooltip.row('Pageview')).toContain('134')
             // The trend-line carries the same series label; only the main
             // row should appear, so there must be exactly one row matching.
-            const rows = Array.from(tooltip.element.querySelectorAll('tr')).filter((r) =>
-                r.textContent?.includes('Pageview')
-            )
-            expect(rows).toHaveLength(1)
+            const matching = tooltip.rows().filter((label) => label.includes('Pageview'))
+            expect(matching).toHaveLength(1)
         })
     })
 

--- a/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsLineChart/TrendsLineChart.tsx
@@ -2,9 +2,11 @@ import { useValues } from 'kea'
 import { useCallback, useMemo } from 'react'
 
 import { DEFAULT_Y_AXIS_ID, TimeSeriesLineChart } from '@posthog/quill-charts'
-import type { PointClickData, TooltipConfig, TooltipContext } from '@posthog/quill-charts'
+import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { ciRanges } from 'lib/statistics'
 import { percentage } from 'lib/utils/numbers'
 import { formatAggregationAxisValue } from 'scenes/insights/aggregationAxisFormat'
@@ -24,13 +26,15 @@ import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 import { ChartDisplayType } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../shared/AnnotationsLayer'
 import { makeChartErrorHandler } from '../shared/chartErrorHandler'
 import { getTrendsSeriesDisplayLabel } from '../shared/getTrendsSeriesDisplayLabel'
 import { handleTrendsChartClick } from '../shared/handleTrendsChartClick'
 import { TrendsAlertOverlays } from '../shared/TrendsAlertOverlays'
 import { buildTrendsSeriesMeta, resolveGroupTypeLabel, type TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
-import { TrendsTooltip } from '../shared/TrendsTooltip'
+import { TrendsTooltip as TrendsTooltipLegacy } from '../shared/TrendsTooltip'
 import { useInsightsLegendConfig } from '../shared/useInsightsLegendConfig'
 import { buildTrendsLineTimeSeriesConfig, buildTrendsSeries } from './trendsChartTransforms'
 
@@ -39,12 +43,13 @@ interface TrendsLineChartProps {
     inSharedMode?: boolean
 }
 
-const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
-
 const handleChartError = makeChartErrorHandler('trends-line-chart')
 
 export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineChartProps): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
     const { insightProps, insight } = useValues(insightLogic)
 
@@ -171,22 +176,25 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
                       handleTrendsChartClick(seriesKey, datum.dataIndex, clickDeps)
                   }
                 : undefined
-            return (
-                <TrendsTooltip
-                    context={ctx}
-                    timezone={timezone}
-                    interval={interval ?? undefined}
-                    breakdownFilter={breakdownFilter ?? undefined}
-                    dateRange={insightData?.resolved_date_range ?? undefined}
-                    trendsFilter={trendsFilter}
-                    formula={formula}
-                    showPercentView={isStickiness}
-                    isPercentStackView={isPercentStackView}
-                    baseCurrency={baseCurrency}
-                    groupTypeLabel={resolvedGroupTypeLabel}
-                    formatCompareLabel={context?.formatCompareLabel}
-                    onRowClick={onRowClick}
-                />
+            const tooltipProps = {
+                context: ctx,
+                timezone,
+                interval: interval ?? undefined,
+                breakdownFilter: breakdownFilter ?? undefined,
+                dateRange: insightData?.resolved_date_range ?? undefined,
+                trendsFilter,
+                formula,
+                showPercentView: isStickiness,
+                isPercentStackView,
+                baseCurrency,
+                groupTypeLabel: resolvedGroupTypeLabel,
+                formatCompareLabel: context?.formatCompareLabel,
+                onRowClick,
+            }
+            return quillTooltipEnabled ? (
+                <InsightSeriesTooltip {...tooltipProps} />
+            ) : (
+                <TrendsTooltipLegacy {...tooltipProps} />
             )
         },
         [
@@ -203,6 +211,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             context?.formatCompareLabel,
             canHandleClick,
             clickDeps,
+            quillTooltipEnabled,
         ]
     )
 
@@ -284,6 +293,7 @@ export function TrendsLineChart({ context, inSharedMode = false }: TrendsLineCha
             showValuesOnSeries,
             valueLabelFormatter,
             legendConfig,
+            TOOLTIP_CONFIG,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
@@ -27,8 +27,8 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { InsightVizNode } from '~/queries/schema/schema-general'
 import { QueryContext } from '~/queries/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import type { TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
-import { TrendsTooltip } from '../shared/TrendsTooltip'
 import { buildTrendsPieSeries } from './trendsPieTransforms'
 
 interface TrendsPieChartProps {
@@ -205,11 +205,10 @@ export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieCh
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<TrendsSeriesMeta>) => (
-            <TrendsTooltip
+            <InsightSeriesTooltip
                 context={ctx}
                 breakdownFilter={breakdownFilter ?? undefined}
                 trendsFilter={trendsFilter}
-                formula={formula}
                 baseCurrency={baseCurrency}
                 groupTypeLabel={resolvedGroupTypeLabel}
                 formatCompareLabel={context?.formatCompareLabel}

--- a/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
+++ b/products/product_analytics/frontend/insights/trends/TrendsPieChart/TrendsPieChart.tsx
@@ -6,6 +6,8 @@ import { PieChart } from '@posthog/quill-charts'
 import type { PieChartConfig, RadialSlicePayload, Series, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import {
     formatAggregationAxisValue,
     formatAggregationAxisValueWithShareOfTotal,
@@ -29,6 +31,7 @@ import { QueryContext } from '~/queries/types'
 
 import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
 import type { TrendsSeriesMeta } from '../shared/trendsSeriesMeta'
+import { TrendsTooltip } from '../shared/TrendsTooltip'
 import { buildTrendsPieSeries } from './trendsPieTransforms'
 
 interface TrendsPieChartProps {
@@ -45,6 +48,8 @@ const handleChartError = (error: Error, info: ErrorInfo): void => {
 }
 
 export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieChartProps): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { isDarkModeOn } = useValues(themeLogic)
     // isDarkModeOn invalidates the memo so buildTheme() re-reads CSS vars on dark-mode toggle.
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
@@ -204,19 +209,24 @@ export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieCh
     )
 
     const renderTooltip = useCallback(
-        (ctx: TooltipContext<TrendsSeriesMeta>) => (
-            <InsightSeriesTooltip
-                context={ctx}
-                breakdownFilter={breakdownFilter ?? undefined}
-                trendsFilter={trendsFilter}
-                baseCurrency={baseCurrency}
-                groupTypeLabel={resolvedGroupTypeLabel}
-                formatCompareLabel={context?.formatCompareLabel}
-                onRowClick={onRowClick}
-                showHeader={false}
-                renderCount={renderCount}
-            />
-        ),
+        (ctx: TooltipContext<TrendsSeriesMeta>) => {
+            const sharedProps = {
+                context: ctx,
+                breakdownFilter: breakdownFilter ?? undefined,
+                trendsFilter,
+                baseCurrency,
+                groupTypeLabel: resolvedGroupTypeLabel,
+                formatCompareLabel: context?.formatCompareLabel,
+                onRowClick,
+                showHeader: false as const,
+                renderCount,
+            }
+            return quillTooltipEnabled ? (
+                <InsightSeriesTooltip {...sharedProps} />
+            ) : (
+                <TrendsTooltip {...sharedProps} formula={formula} />
+            )
+        },
         [
             breakdownFilter,
             trendsFilter,
@@ -226,6 +236,7 @@ export function TrendsPieChart({ context, showPersonsModal = true }: TrendsPieCh
             context?.formatCompareLabel,
             onRowClick,
             renderCount,
+            quillTooltipEnabled,
         ]
     )
 

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -12,15 +12,12 @@ import type {
 } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import type { TrendsFilter } from '~/queries/schema/schema-general'
 import type { GraphDataset } from '~/types'
 
-import { InsightSeriesTooltip } from 'products/product_analytics/frontend/insights/shared/InsightSeriesTooltip'
 import { trendsFilterToYFormatterConfig } from 'products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat'
 import type { TrendsSeriesMeta } from 'products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta'
 import { TrendsTooltip } from 'products/product_analytics/frontend/insights/trends/shared/TrendsTooltip'
@@ -72,8 +69,6 @@ export function RevenueAnalyticsChart({
     isInProgress = false,
     getColor,
 }: RevenueAnalyticsChartProps): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { timezone, baseCurrency } = useValues(teamLogic)
     const { dateFilter } = useValues(revenueAnalyticsLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -98,18 +93,17 @@ export function RevenueAnalyticsChart({
     )
 
     const renderTooltip = useCallback(
-        (ctx: TooltipContext<TrendsSeriesMeta>) => {
-            const sharedProps = {
-                context: ctx,
-                timezone,
-                interval: dateFilter.interval,
-                trendsFilter,
-                baseCurrency,
-                groupTypeLabel: '' as const,
-            }
-            return quillTooltipEnabled ? <InsightSeriesTooltip {...sharedProps} /> : <TrendsTooltip {...sharedProps} />
-        },
-        [timezone, dateFilter.interval, trendsFilter, baseCurrency, quillTooltipEnabled]
+        (ctx: TooltipContext<TrendsSeriesMeta>) => (
+            <TrendsTooltip
+                context={ctx}
+                timezone={timezone}
+                interval={dateFilter.interval}
+                trendsFilter={trendsFilter}
+                baseCurrency={baseCurrency}
+                groupTypeLabel=""
+            />
+        ),
+        [timezone, dateFilter.interval, trendsFilter, baseCurrency]
     )
 
     const legendPosition = legend?.position ?? 'right'

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -18,9 +18,9 @@ import { themeLogic } from '~/layout/navigation-3000/themeLogic'
 import type { TrendsFilter } from '~/queries/schema/schema-general'
 import type { GraphDataset } from '~/types'
 
+import { InsightSeriesTooltip } from 'products/product_analytics/frontend/insights/shared/InsightSeriesTooltip'
 import { trendsFilterToYFormatterConfig } from 'products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat'
 import type { TrendsSeriesMeta } from 'products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta'
-import { TrendsTooltip } from 'products/product_analytics/frontend/insights/trends/shared/TrendsTooltip'
 
 import { revenueAnalyticsLogic } from '../revenueAnalyticsLogic'
 import {
@@ -94,7 +94,7 @@ export function RevenueAnalyticsChart({
 
     const renderTooltip = useCallback(
         (ctx: TooltipContext<TrendsSeriesMeta>) => (
-            <TrendsTooltip
+            <InsightSeriesTooltip
                 context={ctx}
                 timezone={timezone}
                 interval={dateFilter.interval}

--- a/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
+++ b/products/revenue_analytics/frontend/nodes/RevenueAnalyticsChart.tsx
@@ -12,6 +12,8 @@ import type {
 } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
 
 import { themeLogic } from '~/layout/navigation-3000/themeLogic'
@@ -21,6 +23,7 @@ import type { GraphDataset } from '~/types'
 import { InsightSeriesTooltip } from 'products/product_analytics/frontend/insights/shared/InsightSeriesTooltip'
 import { trendsFilterToYFormatterConfig } from 'products/product_analytics/frontend/insights/trends/shared/trendsAxisFormat'
 import type { TrendsSeriesMeta } from 'products/product_analytics/frontend/insights/trends/shared/trendsSeriesMeta'
+import { TrendsTooltip } from 'products/product_analytics/frontend/insights/trends/shared/TrendsTooltip'
 
 import { revenueAnalyticsLogic } from '../revenueAnalyticsLogic'
 import {
@@ -69,6 +72,8 @@ export function RevenueAnalyticsChart({
     isInProgress = false,
     getColor,
 }: RevenueAnalyticsChartProps): JSX.Element {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     const { timezone, baseCurrency } = useValues(teamLogic)
     const { dateFilter } = useValues(revenueAnalyticsLogic)
     const { isDarkModeOn } = useValues(themeLogic)
@@ -93,17 +98,18 @@ export function RevenueAnalyticsChart({
     )
 
     const renderTooltip = useCallback(
-        (ctx: TooltipContext<TrendsSeriesMeta>) => (
-            <InsightSeriesTooltip
-                context={ctx}
-                timezone={timezone}
-                interval={dateFilter.interval}
-                trendsFilter={trendsFilter}
-                baseCurrency={baseCurrency}
-                groupTypeLabel=""
-            />
-        ),
-        [timezone, dateFilter.interval, trendsFilter, baseCurrency]
+        (ctx: TooltipContext<TrendsSeriesMeta>) => {
+            const sharedProps = {
+                context: ctx,
+                timezone,
+                interval: dateFilter.interval,
+                trendsFilter,
+                baseCurrency,
+                groupTypeLabel: '' as const,
+            }
+            return quillTooltipEnabled ? <InsightSeriesTooltip {...sharedProps} /> : <TrendsTooltip {...sharedProps} />
+        },
+        [timezone, dateFilter.interval, trendsFilter, baseCurrency, quillTooltipEnabled]
     )
 
     const legendPosition = legend?.position ?? 'right'


### PR DESCRIPTION
## Problem

Builds on the adapter PR. Wires all trends, retention, and stickiness charts to use `InsightSeriesTooltip` when the `product-analytics-insights-tooltips` flag is on.

## Changes

- **Trends**: `TrendsLineChart`, `TrendsBarChart`, `TrendsLifecycleChart`, `TrendsPieChart`
- **Retention**: `RetentionBarChart`, `RetentionLineChart`
- **Stickiness**: `StickinessBarChart`, `StickinessLineChart`
- **Revenue analytics**: `RevenueAnalyticsChart`
- All use `quillTooltipEnabled` from `featureFlagLogic` to pick between `InsightSeriesTooltip` (flag on) and the existing `TrendsTooltip` (flag off)

Stacks on the adapter PR — merge that first.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)