### PR TITLE
feat(replay-vision): lay out scorer charts side by side

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -222,6 +222,18 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
     if (!showChart && !typeOverview) {
         return null
     }
+    // Scorer puts its line chart and score-distribution histogram side by side to reclaim vertical space.
+    if (scannerType === 'scorer' && showChart) {
+        return (
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+                {/* min-w-0 lets the canvas line chart shrink inside the grid track */}
+                <div className="min-w-0">
+                    <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />
+                </div>
+                {typeOverview}
+            </div>
+        )
+    }
     return (
         <div className="space-y-4">
             {showChart && <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />}

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -223,14 +223,14 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
         return null
     }
     // Scorer puts its line chart and score-distribution histogram side by side to reclaim vertical space.
-    if (scannerType === 'scorer' && showChart) {
+    if (scannerType === 'scorer') {
         return (
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
-                {/* min-w-0 lets the canvas line chart shrink inside the grid track */}
+                {/* min-w-0 lets the canvas charts shrink inside their grid tracks instead of overflowing */}
                 <div className="min-w-0">
                     <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />
                 </div>
-                {typeOverview}
+                <div className="min-w-0">{typeOverview}</div>
             </div>
         )
     }


### PR DESCRIPTION
## Problem

On a scorer-type Replay Vision scanner page (Observations tab), the score overview stacks two panels vertically: the "Score percentiles over time" line chart on top, and the "Score distribution" histogram below it. Stacked this way it's too tall and pushes the observation list far down the page.

## Changes

For scorer scanners, the line chart and the histogram now sit side by side in a responsive two-column grid (`grid grid-cols-1 lg:grid-cols-2`) rather than stacked. They collapse back to a single column below the `lg` breakpoint so the charts don't get cramped on narrow viewports — matching the existing `ClassifierOverview` layout. The line-chart cell gets `min-w-0` so its Chart.js canvas shrinks to the grid track instead of overflowing.

Monitor, classifier, and summarizer overviews are untouched. The change is confined to the layout wrapper in `ScannerOverview` — the chart components themselves are unchanged.

## How did you test this code?

I'm an agent. I did not run the frontend typecheck or the app — the frontend dev tooling (`oxlint`/`oxfmt`, `node_modules`) isn't installed in this environment. The change is a small, self-contained Tailwind layout edit consistent with patterns already in the file. Please run `pnpm --filter=@posthog/frontend typescript:check` and eyeball a scorer scanner's Observations tab before merging.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Kim directed this work: the scorer overview's stacked line-chart-over-histogram layout was too tall, and asked to place the two charts horizontally next to each other. Authored with Claude Code (Opus 4.8) in plan mode. No skills were required — this is a single-file frontend layout change. Reused the responsive two-column grid pattern already established by `ClassifierOverview` in the same file rather than introducing a new flex layout, for consistency.
