### PR TITLE
fix(replay): keep vision scanner on-demand table interactable while polling

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4845,9 +4845,9 @@ snapshots:
     scenes-app-customer-analytics-accounts--row-expanded-empty--light:
         hash: v1.k794b7964.904bd5b939f99d43408ae3a8a814a3c299bd57bf13a0fd1d98ff6033fd66e343.K1Z16ICEF6-O9kIej8kGnYyarloq2oZH5rdtmx-8Hu0
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--dark:
-        hash: v1.k794b7964.d2efe33a50fa0f2e076fdc40334333e45ec2344b58b9c4d3df6cc5cc0bb073f0.LRIIMBC3WY2eC_ZVjlb4n7UfX_XbsMH1lCn4pWnUOJE
+        hash: v1.k794b7964.dbe806f797399ea2451bdf08b2a0bc1a413ea4d65e1a244e859a6f17a330005d.i8IfnQ9ONhYyodW5HPR_2GSN7q1dcVA3cPUtXyNi_ro
     scenes-app-customer-analytics-accounts--row-expanded-links-disabled--light:
-        hash: v1.k794b7964.5eb51441627289ebe42cecd9311d5a1f5b625a1d37ddd8daa3138e24f46ee90f.2YABFnnFmj-6o1atsqYxtPAru8WdKTRJZ8ubbnNzgU4
+        hash: v1.k794b7964.f82e5d3d3f153d31ba1ef5b668ebb5ab8aab000fe4acb42252f89e9f56a838bc.GkNSIp0tMmvNDlRasel6bRQBgice_VcLKHISDWHGnnU
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--dark:
         hash: v1.k794b7964.53af994a2a4dfb2f883e27ed73be8d55e1177b97f5c8b622708dfcdbe5f33d2a.A7AJRK9hY-yytJMNPghuLYtOJIoj0VBJidseMubwZWs
     scenes-app-customer-analytics-accounts--row-expanded-usage-not-found--light:

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
@@ -137,7 +137,11 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
             } catch {
                 // Best-effort enrichment — on failure we just leave the rows scannable.
             } finally {
-                setRefreshingObservations(false)
+                // Only the foreground path touches the flag — a background poll resolving mid-flight must
+                // not clear an overlay a concurrent foreground fetch is still showing.
+                if (!background) {
+                    setRefreshingObservations(false)
+                }
             }
         },
         [visibleIdsKey, currentTeamId, scannerId]

--- a/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerRunTab.tsx
@@ -108,34 +108,40 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
     // in-progress rows show a spinner, settled rows link to the result. Refetch after each scan and poll while
     // anything visible is still running (or queued), so a row swaps spinner → "View observation" on its own.
     const [observationBySession, setObservationBySession] = useState<Map<string, RowObservation>>(new Map())
-    // Drives the table's loading bar on each status refetch so the user sees the periodic refresh.
+    // Drives the table's loading bar on foreground refetches (initial load, post-scan). Background polls
+    // reload silently so the table stays interactable instead of blanking on each tick.
     const [refreshingObservations, setRefreshingObservations] = useState(false)
     const visibleIdsKey = sessionRecordings.map((recording) => recording.id).join(',')
 
-    const refetchObservations = useCallback(async () => {
-        const ids = visibleIdsKey ? visibleIdsKey.split(',') : []
-        if (!currentTeamId || ids.length === 0) {
-            return
-        }
-        setRefreshingObservations(true)
-        try {
-            const response = await visionScannersObservationsList(String(currentTeamId), scannerId, {
-                session_id: visibleIdsKey,
-                limit: ids.length,
-            })
-            setObservationBySession((prev) => {
-                const next = new Map(prev)
-                for (const observation of response.results ?? []) {
-                    next.set(observation.session_id, { id: observation.id, status: observation.status })
-                }
-                return next
-            })
-        } catch {
-            // Best-effort enrichment — on failure we just leave the rows scannable.
-        } finally {
-            setRefreshingObservations(false)
-        }
-    }, [visibleIdsKey, currentTeamId, scannerId])
+    const refetchObservations = useCallback(
+        async (background = false) => {
+            const ids = visibleIdsKey ? visibleIdsKey.split(',') : []
+            if (!currentTeamId || ids.length === 0) {
+                return
+            }
+            if (!background) {
+                setRefreshingObservations(true)
+            }
+            try {
+                const response = await visionScannersObservationsList(String(currentTeamId), scannerId, {
+                    session_id: visibleIdsKey,
+                    limit: ids.length,
+                })
+                setObservationBySession((prev) => {
+                    const next = new Map(prev)
+                    for (const observation of response.results ?? []) {
+                        next.set(observation.session_id, { id: observation.id, status: observation.status })
+                    }
+                    return next
+                })
+            } catch {
+                // Best-effort enrichment — on failure we just leave the rows scannable.
+            } finally {
+                setRefreshingObservations(false)
+            }
+        },
+        [visibleIdsKey, currentTeamId, scannerId]
+    )
 
     // Initial load + whenever a scan is triggered (which creates a new pending observation to pick up).
     useEffect(() => {
@@ -176,7 +182,8 @@ function RecordingsList({ scannerId }: { scannerId: string }): JSX.Element {
         const interval = setInterval(() => {
             // Skip polling while the browser tab is backgrounded; it resumes on the next tick when visible again.
             if (document.visibilityState === 'visible') {
-                void refetchObservations()
+                // Background reload — keeps the table interactable instead of blanking it each tick.
+                void refetchObservations(true)
             }
         }, 4000)
         return () => clearInterval(interval)


### PR DESCRIPTION
## Problem

On the Replay Vision scanner page, the **On-demand** tab's recordings table polls observation statuses every 4s while any visible row is running or a scan is queued. Each poll dropped the whole `LemonTable` into its loading-overlay state — blanking the table and blocking interaction (sort, click, paginate) every tick.

This is the same symptom #66837 fixed for the main **Observations** tab, just in a different place: the On-demand tab's polling lives in local React component state (`RecordingsList` in `ScannerRunTab.tsx`) rather than kea.

## Changes

The poll called `refetchObservations()`, which unconditionally set the local `refreshingObservations` state to `true` — and that boolean drives the table's `loading` prop.

- `refetchObservations` now takes a `background` flag.
- The loading flag only flips `true` for **foreground** refetches — initial load and post-scan refresh.
- The 4s in-flight poll passes `background = true`, so rows swap in place without the overlay. `rowKey="id"` keeps row identity stable across the swap.

Net effect: the table still refreshes on the same 4s cadence while observations are in flight, but it stays fully interactable instead of blanking each tick. The initial load and post-scan loading feedback are unchanged.

## How did you test this code?

I'm an agent (Claude Code). I did **not** manually exercise the UI, and I could not run typecheck/format locally (this environment has no `node_modules` installed). The change is a minimal, type-safe addition of an optional boolean param with a default; CI will run typecheck and lint.

No automated test was added: the fixed logic is local React component state, and there is no existing React-render test for `ScannerRunTab` / `RecordingsList` (all `products/replay_vision/frontend` tests are kea logic tests). A regression test would require introducing RTL rendering with mocked API + fake timers — heavier than the kea reducer test #66837 added, and deliberately left out of scope per the requester.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Implemented with Claude Code at the requester's direction. The ask was to replicate the #66837 fix (silent background polling so the table stays interactable) for the scanner page's On-demand tab. Tracing showed the On-demand tab's polling is independent of the main tab's kea wiring — it lives entirely in `RecordingsList`'s local React state with a `setInterval`-driven 4s poll — so the fix mirrors #66837's intent (a `background` flag that suppresses the loading overlay on polls) applied to component state rather than a kea reducer. No skills were invoked.
