### PR TITLE
feat(llm-gateway): register the sherlockhog product

### DIFF
--- a/services/llm-gateway/src/llm_gateway/products/config.py
+++ b/services/llm-gateway/src/llm_gateway/products/config.py
@@ -93,6 +93,17 @@ PRODUCTS: Final[dict[str, ProductConfig]] = {
         allow_api_keys=False,
         billable=True,
     ),
+    # SherlockHog (https://github.com/PostHog/SherlockHog) — the internal SRE
+    # bot. Authenticates with a personal API key (not OAuth), so no application
+    # IDs are needed. It pins claude-opus-4-8 but can be repointed via
+    # ANTHROPIC_MODEL and uses Bedrock fallback, so all models are permitted.
+    # Internal infra tooling — not billed to a customer credit bucket.
+    "sherlockhog": ProductConfig(
+        allowed_application_ids=None,
+        allowed_models=None,
+        allow_api_keys=True,
+        billable=False,
+    ),
     "wizard": ProductConfig(
         allowed_application_ids=frozenset({WIZARD_US_APP_ID, WIZARD_EU_APP_ID}),
         allowed_models=None,


### PR DESCRIPTION
## What

Adds a `sherlockhog` entry to the LLMGateway product config (`services/llm-gateway/src/llm_gateway/products/config.py`).

```python
"sherlockhog": ProductConfig(
    allowed_application_ids=None,
    allowed_models=None,
    allow_api_keys=True,
    billable=False,
),
```

## Why

[SherlockHog](https://github.com/PostHog/SherlockHog) (the internal SRE bot) is moving to talk to Anthropic **exclusively through LLMGateway** (companion PRs: PostHog/SherlockHog#73 and the charts wiring). Its requests go to `/sherlockhog/v1/messages`; without a product entry the gateway rejects them with `400 Invalid product 'sherlockhog'`.

Config rationale:
- **`allow_api_keys=True`** — SherlockHog authenticates with a personal API key (not OAuth), so no `allowed_application_ids` are needed.
- **`allowed_models=None`** — it pins `claude-opus-4-8` but can be repointed via `ANTHROPIC_MODEL` and uses Bedrock fallback (`x-posthog-use-bedrock-fallback: true`), so all models are permitted (a restricted list would have to also include `BEDROCK_MODELS` for the fallback path).
- **`billable=False`** — internal infra tooling, not billed to a customer credit bucket.

## Test plan

- `python -m py_compile` clean; AST check confirms `sherlockhog` is in `PRODUCTS` / `ALLOWED_PRODUCTS`.
- Existing `tests/test_product_config.py` is derived/parametrized over `PRODUCTS` (e.g. `ALLOWED_PRODUCTS == frozenset(PRODUCTS.keys())`, and it validates each product resolves to itself), so the addition is covered without new assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)