### PR TITLE
chore(engineering-analytics): trim verbose comments in queries

### DIFF
--- a/products/engineering_analytics/backend/logic/queries/__init__.py
+++ b/products/engineering_analytics/backend/logic/queries/__init__.py
@@ -1,8 +1,7 @@
 """HogQL queries for engineering_analytics.
 
-Each module embeds the curated query builders (``backend/logic/views``) as
-subqueries via ``_curated`` and runs them with ``execute_hogql_query`` — the
-product reads its data privately, never registering a global HogQL view. The raw
-``github_*`` warehouse tables are named only inside those curated builders;
-everything returned here is shaped into canonical contract types.
+Each module embeds the curated query builders (``backend/logic/views``) as subqueries via ``_curated``
+and runs them with ``execute_hogql_query`` — the product reads privately, never registering a global
+view. Raw ``github_*`` tables are named only inside the curated builders; everything returned here is
+shaped into canonical contract types.
 """

--- a/products/engineering_analytics/backend/logic/queries/_curated.py
+++ b/products/engineering_analytics/backend/logic/queries/_curated.py
@@ -1,16 +1,13 @@
 """The curated read layer over a team's GitHub warehouse tables.
 
-``CuratedGitHubSource`` binds one team to its resolved ``pull_requests`` / ``workflow_runs``
-table names (see ``logic.sources``) and is the single object the query modules use: it hands
-out the curated ``SELECT`` subqueries and the CI rollup CTE, and runs the assembled HogQL.
-The resolved table names live inside it, so the query layer never threads or re-derives them.
-The product reads its data privately this way — nothing is registered as a global HogQL view,
-keeping it off the per-query catalog hot path.
+``CuratedGitHubSource`` binds one team to its resolved ``pull_requests`` / ``workflow_runs`` table
+names (see ``logic.sources``) and is the single object the query modules use: it hands out the curated
+``SELECT`` subqueries and the CI rollup CTE, and runs the assembled HogQL. The product reads privately
+this way — nothing is registered as a global HogQL view.
 
-Every SQL fragment is built from trusted constants and the resolved table identifiers (which
-the resolver has validated to ``[A-Za-z_][A-Za-z0-9_]*``). User-supplied values must always
-flow through ``ast.Constant`` placeholders in the calling query, never be string-substituted
-into these fragments.
+Every SQL fragment is built from trusted constants and the resolved table identifiers (validated to
+``[A-Za-z_][A-Za-z0-9_]*``). User-supplied values must always flow through ``ast.Constant``
+placeholders, never be string-substituted into these fragments.
 """
 
 from typing import TYPE_CHECKING
@@ -35,9 +32,8 @@ class CuratedGitHubSource:
     """A team's curated GitHub read layer, bound to its resolved warehouse tables.
 
     Construct once per request with ``for_team`` — it resolves the table names and raises
-    ``GitHubSourceNotConnectedError`` when the team has no connected GitHub source, so the
-    "is a source connected" decision lives in exactly one place (the resolver). The query
-    modules then ask the returned instance for the curated subqueries and run HogQL through it.
+    ``GitHubSourceNotConnectedError`` when no source is connected, so that decision lives in one place.
+    Query modules then ask the instance for the curated subqueries and run HogQL through it.
     """
 
     def __init__(
@@ -79,9 +75,8 @@ class CuratedGitHubSource:
     def runs_cte(self) -> str:
         """CTE materializing the curated workflow-runs source once.
 
-        ``ci_rollup`` and ``runs_by_pr`` both derive from the same runs source; reading them from
-        this shared CTE keeps the (JSON- and timestamp-parsing) source to a single scan per query
-        instead of inlining — and re-parsing — it once per rollup.
+        ``ci_rollup`` and ``runs_by_pr`` both derive from it; the shared CTE keeps the JSON/timestamp
+        parsing to a single scan per query instead of re-parsing it once per rollup.
         """
         return f"runs AS {self.run_source()}"
 
@@ -116,28 +111,21 @@ class CuratedGitHubSource:
         """
 
     def pr_rollup_query(self, select: str) -> str:
-        """Compose a pull-requests query that reads ``FROM __PR_SOURCE__ AS pr LEFT JOIN ci_rollup``.
-
-        Prefixes ``select`` with the CI rollup CTE and fills its ``__PR_SOURCE__`` placeholder
-        with the curated pull-requests source — the two steps the cards and PR-list queries always
-        do together.
+        """Compose a pull-requests query: prefix ``select`` with the CI rollup CTE and fill its
+        ``__PR_SOURCE__`` placeholder — the two steps the cards and PR-list queries always do together.
         """
         return self._compose_pr_query([self.runs_cte(), self.ci_rollup_cte()], select)
 
     def runs_by_pr_cte(self) -> str:
         """CTE: per-PR activity from the workflow runs attributed to each PR.
 
-        A run records the PR(s) it ran for in ``pull_requests``; the curated run source surfaces
-        the first as ``pr_number``. ``pushes`` counts the distinct head SHAs that triggered CI
-        (CI triggers), ``rerun_cycles`` the runs that were a 2nd+ attempt. Fork-PR runs have no
-        association (``pr_number = 0``) and are excluded.
+        A run records the PR(s) it ran for; the curated source surfaces the first as ``pr_number``.
+        ``pushes`` counts distinct head SHAs (CI triggers), ``rerun_cycles`` the 2nd+ attempts. Fork-PR
+        runs (``pr_number = 0``) are excluded.
 
-        Keyed on ``(repo_owner, repo_name, pr_number)``, not ``pr_number`` alone: PR numbers
-        restart per repository, so the PR-list join is qualified by repo to stay correct — as
-        repo-safe as the head-SHA join in ``ci_rollup_cte``. A resolved source is a single repo
-        today (the warehouse GitHub source syncs one ``owner/repo``), so the qualifier is a no-op
-        now; it keeps the rollup correct if a source ever spans repos, instead of silently
-        cross-attributing runs to a same-numbered PR in another repo.
+        Keyed on ``(repo_owner, repo_name, pr_number)``, not ``pr_number`` alone: PR numbers restart per
+        repo, so the join is repo-qualified to stay correct. A resolved source is one repo today, so the
+        qualifier is a no-op now; it keeps the rollup correct if a source ever spans repos.
         """
         return f"""
             runs_by_pr AS (
@@ -171,14 +159,11 @@ class CuratedGitHubSource:
         """Parse + execute a curated HogQL query for this team.
 
         Mirrors the two paths the data warehouse team intends for ``hogql-warehouse-access-control``
-        (#61686). Request-driven reads (the common case — the views thread the requesting user through)
-        forward that user so HogQL honors the per-table warehouse ACL: access is enforced twice over —
-        the resolver (``for_team``) already filtered the source to what this user may read, and now the
-        table-level ACL is honored too, so a user denied a backing ``DataWarehouseTable`` is blocked
-        rather than let through. The facade also documents a userless path (``user_access_control=None``)
-        for system / Temporal / CLI contexts; that build has no user to honor the ACL with and would fail
-        closed (strip every warehouse table), so those reads bypass it — the warehouse team's sanctioned
-        escape hatch for userless callers.
+        (#61686). Request-driven reads forward the requesting user so HogQL honors the per-table
+        warehouse ACL — access is enforced twice (the resolver already filtered the source, the
+        table-level ACL is honored too). A userless path (``user_access_control=None``) for
+        system/Temporal/CLI has no user to honor the ACL with and would fail closed (strip every
+        warehouse table), so those reads bypass it — the warehouse team's sanctioned escape hatch.
         """
         uac = self._user_access_control
         with tags_context(product=Product.ENGINEERING_ANALYTICS, feature=Feature.QUERY, team_id=self._team.pk):
@@ -186,13 +171,11 @@ class CuratedGitHubSource:
                 query=parse_select(sql, placeholders=placeholders),
                 team=self._team,
                 query_type=query_type,
-                # Forward the real user, not just the access control: a userless build drops the access
-                # control and fails closed (see _compute_system_table_access_decision), so the user is what
-                # lets HogQL honor the per-table warehouse ACL.
+                # Forward the real user, not just the access control: a userless build fails closed (see
+                # _compute_system_table_access_decision), so the user is what lets HogQL honor the ACL.
                 user=uac.user if uac is not None else None,
                 user_access_control=uac,
-                # No user means a system / Temporal / CLI caller (the facade's documented userless path).
-                # There is no principal to honor the ACL with, so bypass it rather than fail closed and
-                # strip the tables — bypass is set ONLY in this genuinely userless case.
+                # No user = system/Temporal/CLI (the documented userless path): no principal to honor the
+                # ACL, so bypass rather than fail closed and strip tables. Set ONLY in this case.
                 bypass_warehouse_access_control=uac is None,
             )

--- a/products/engineering_analytics/backend/logic/queries/_run_detail.py
+++ b/products/engineering_analytics/backend/logic/queries/_run_detail.py
@@ -1,8 +1,8 @@
 """Shared mapping of the curated workflow-run columns into ``WorkflowRunDetail``.
 
 ``pr_runs`` / ``workflow_run`` / ``workflow_run_list`` all select the same run columns and build the
-same contract. Centralizing the column list and the row mapper keeps a future field add from being
-applied to two of the three call sites and silently mis-mapping a column.
+same contract. Centralizing the column list and row mapper keeps a future field add from being applied
+to only some call sites and silently mis-mapping a column.
 """
 
 from typing import Any

--- a/products/engineering_analytics/backend/logic/queries/pr_cost.py
+++ b/products/engineering_analytics/backend/logic/queries/pr_cost.py
@@ -1,11 +1,10 @@
 """HogQL assembly of a PR's estimated CI cost, summed over the jobs of all its runs.
 
-Cost is job-level: a run fans into parallel jobs on different runner tiers, so per-PR cost is a sum
-over jobs (see ``logic.cost``). This joins the optional jobs source (``_curated.jobs_source``) to the
-runs source to bring each job's ``workflow_name`` alongside its ``labels`` / elapsed, then aggregates
-in Python twice: once over all jobs (the whole-PR rollup) and once per workflow (the per-workflow cost
-column). When the jobs source isn't synced, ``jobs_source()`` is None and this returns an empty summary
-(``jobs_available=False``) so the UI hides the cost cards instead of erroring.
+Cost is job-level (a run fans into parallel jobs on different tiers, so per-PR cost is a sum over jobs;
+see ``logic.cost``). Joins the optional jobs source to the runs source to bring each job's
+``workflow_name`` alongside its ``labels`` / elapsed, then aggregates in Python — once over all jobs
+and once per workflow. When the jobs source isn't synced, returns an empty summary
+(``jobs_available=False``) so the UI hides the cost cards.
 """
 
 import json
@@ -24,10 +23,10 @@ from products.engineering_analytics.backend.facade.contracts import (
 from products.engineering_analytics.backend.logic.cost import PRCostAggregate, aggregate_pr_cost, runner_descriptor
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
 
-# Pre-aggregated per (workflow, run, attempt, runner-label) — a raw per-job SELECT has no LIMIT, so HogQL
-# caps it at DEFAULT_RETURNED_ROWS (100) and silently drops the rest, undercounting any PR with >100 jobs.
-# Each group carries finished/elapsed/unfinished, expanded back into per-job tuples (cost is linear in
-# elapsed) so the run- and workflow-level rollups stay exact. Same shape as the PR-list cost query.
+# Pre-aggregated per (workflow, run, attempt, runner-label): a raw per-job SELECT has no LIMIT, so HogQL
+# caps it at DEFAULT_RETURNED_ROWS (100) and silently drops the rest. Each group carries
+# finished/elapsed/unfinished, re-expanded into per-job tuples (cost is linear in elapsed) so the
+# rollups stay exact.
 _SELECT = """
     SELECT
         r.workflow_name, r.id AS run_id, r.run_attempt, j.labels,
@@ -104,11 +103,9 @@ def query_pr_cost(
     )
 
 
-# Pre-aggregated in SQL (per PR × runner-label combo) so the row count stays small — a raw per-job
-# SELECT over every PR's jobs blows past HogQL's default row cap and silently truncates. Each group
-# carries finished/elapsed/unfinished, which is expanded back into per-job tuples (cost is linear in
-# elapsed) so the pure aggregate_pr_cost still produces the exact rollup. Scoped to the PR numbers the
-# list is actually showing so a team with deep CI history doesn't pay an all-time jobs×runs join per page.
+# Pre-aggregated per PR × runner-label so the row count stays under HogQL's default cap (a raw per-job
+# SELECT would silently truncate). Groups re-expand into per-job tuples (cost is linear in elapsed) so
+# aggregate_pr_cost still produces the exact rollup. Scoped to the visible PR numbers, not all-time.
 _LIST_SELECT = """
     SELECT
         r.repo_owner, r.repo_name, r.pr_number, j.labels,
@@ -129,8 +126,8 @@ def query_pr_list_costs(
     """Per-PR billable cost across the given PR numbers' runs, keyed by (repo_owner, repo_name, pr_number).
 
     Empty when the jobs source isn't synced or no PR numbers are given. One grouped pass over jobs ⋈ runs
-    so the PR list can show a cost/minutes column per row without a query per PR; scoped to the visible PR
-    numbers so the scan tracks the page, not the team's whole CI history.
+    so the PR list can show a cost column without a query per PR; scoped to the visible PRs so the scan
+    tracks the page, not the team's whole CI history.
     """
     jobs_source = curated.jobs_source()
     if jobs_source is None or not pr_numbers:
@@ -174,8 +171,7 @@ def query_workflow_window_costs(
 ) -> dict[str, PRCostAggregate]:
     """Per-workflow billable cost over [date_from, date_to] (optional branch), keyed by workflow_name.
 
-    Empty when the jobs source isn't synced. Mirrors the PR-list cost: grouped per workflow×label in SQL,
-    expanded back through aggregate_pr_cost.
+    Empty when the jobs source isn't synced. Same grouped+expand shape as the PR-list cost.
     """
     jobs_source = curated.jobs_source()
     if jobs_source is None:
@@ -283,9 +279,8 @@ def _expand_jobs(
 ) -> list[tuple[list[str], float | None]]:
     """Re-expand a (labels, finished, elapsed_total, unfinished) group into per-job (labels, elapsed)
     tuples for aggregate_pr_cost. Elapsed is split evenly across finished jobs — cost is linear in
-    elapsed, so the summed cost/minutes/counts are identical to costing each real job. The SQL sums
-    ``greatest(duration_seconds, 0)`` so a single clock-skewed negative duration can't cancel its
-    group-mates' elapsed before the split — matching aggregate_pr_cost's per-job ``max(0, elapsed)``."""
+    elapsed, so the totals are identical to costing each real job. The SQL sums ``greatest(duration, 0)``
+    so a clock-skewed negative can't cancel its group-mates' elapsed before the split."""
     per = (elapsed_total / finished) if finished else 0.0
     return [(labels, per)] * finished + [(labels, None)] * unfinished
 

--- a/products/engineering_analytics/backend/logic/queries/pr_lifecycle.py
+++ b/products/engineering_analytics/backend/logic/queries/pr_lifecycle.py
@@ -1,11 +1,8 @@
 """HogQL assembly of a single PR's lifecycle over the curated query builders.
 
-Embeds the curated ``github_pull_requests`` / ``github_workflow_runs`` builders
-as subqueries (via ``_curated``) — the product runs this privately rather than
-registering a global view. The curated SELECTs already carry the derived columns
-(canonical ``state``, ``is_bot``, repo identity, ``head_sha``), so this layer only
-shapes the rows into the ``PRLifecycle`` contract; no GitHub-isms or domain rules
-live here.
+Embeds the curated ``github_pull_requests`` / ``github_workflow_runs`` builders as subqueries (via
+``_curated``). The curated SELECTs already carry the derived columns (canonical ``state``, ``is_bot``,
+repo identity, ``head_sha``), so this layer only shapes rows into the ``PRLifecycle`` contract.
 """
 
 from datetime import datetime
@@ -106,11 +103,9 @@ def query_pr_lifecycle(
     def add(
         kind: PRLifecycleEventKind, at: datetime | None, *, detail: str | None = None, run_id: int | None = None
     ) -> None:
-        # Timestamps come from parseDateTimeBestEffort, which yields NULL on a malformed/missing
-        # value, so `at` can be None. Skip those events — a timeline can't place an event with no
-        # time, and `at` is non-nullable on the contract, so building one would raise. Guarding
-        # here keeps a single bad run timestamp from failing the whole PR's lifecycle (and the
-        # sort below never sees a None key).
+        # parseDateTimeBestEffort yields NULL on a bad/missing timestamp, so `at` can be None. Skip
+        # those — `at` is non-nullable on the contract, and this keeps one bad run timestamp from
+        # failing the whole lifecycle (and the sort never sees a None key).
         if at is not None:
             events.append(PRLifecycleEvent(kind=kind, at=at, detail=detail, run_id=run_id))
 

--- a/products/engineering_analytics/backend/logic/queries/pr_runs.py
+++ b/products/engineering_analytics/backend/logic/queries/pr_runs.py
@@ -1,13 +1,11 @@
 """HogQL assembly of all workflow runs attributed to a PR, across its commits.
 
-Unlike ``pr_lifecycle`` (which scopes to the PR's current head SHA), this returns every run attributed
-to the PR — so the detail page can show CI across all of the PR's pushes, grouped by commit. Newest run
-first. Run-level only.
+Unlike ``pr_lifecycle`` (scoped to the PR's current head SHA), this returns every run attributed to
+the PR, so the detail page can show CI across all pushes. Newest first. Run-level only.
 
-Attribution is the curated ``pr_number``, i.e. the FIRST PR in a run's ``pull_requests`` association
-(see ``views/workflow_runs.py``). A run that lists this PR only in a later slot — uncommon: one head
-commit tied to several open PRs — is credited to its first PR instead and won't appear here. That's the
-same deliberate v1 simplification the rollup uses; it's a friction signal, not billing.
+Attribution is the curated ``pr_number`` — the FIRST PR in a run's ``pull_requests`` association (see
+``views/workflow_runs.py``). A run listing this PR only in a later slot is credited to its first PR
+instead and won't appear here — the same v1 simplification the rollup uses; a friction signal, not billing.
 """
 
 from posthog.hogql import ast

--- a/products/engineering_analytics/backend/logic/queries/pull_request_list.py
+++ b/products/engineering_analytics/backend/logic/queries/pull_request_list.py
@@ -1,10 +1,8 @@
 """Curated query: PR list with head-SHA CI rollup.
 
-All open PRs plus any merged or closed since ``date_from`` (the recency floor for
-finished work; open PRs are always included regardless of age). Ordered newest
-first, capped at ``_LIMIT``. The query fetches ``_LIMIT + 1`` rows so an overflow is
-detectable, and the result reports ``truncated`` rather than silently dropping the
-tail (the aggregate counts in ``ci_cards`` can then legitimately exceed the list).
+All open PRs plus any merged or closed since ``date_from`` (open PRs always included regardless of
+age). Newest first, capped at ``_LIMIT``. Fetches ``_LIMIT + 1`` rows so overflow is detectable and
+reports ``truncated`` rather than silently dropping the tail.
 """
 
 from datetime import datetime

--- a/products/engineering_analytics/backend/logic/queries/workflow_health.py
+++ b/products/engineering_analytics/backend/logic/queries/workflow_health.py
@@ -1,13 +1,11 @@
 """Curated query: per-workflow CI health over a window.
 
-Run counts, success rate, and duration percentiles per ``workflow_name`` for runs
-started within ``[date_from, date_to]`` (``date_to`` optional), optionally scoped to
-a single ``head_branch``. Rates and percentiles are over completed runs only, so they
-are ``None`` for a window with no completed runs.
+Run counts, success rate, and duration percentiles per ``workflow_name`` for runs started within
+``[date_from, date_to]`` (``date_to`` optional), optionally scoped to a single ``head_branch``. Rates
+and percentiles are over completed runs only, so ``None`` for a window with none.
 
-The per-bucket history adapts its granularity to the window length (hour / day / week)
-so the trend sparkline keeps a readable number of points — per-day buckets are useless
-for a 24h window and far too many for a year.
+The per-bucket history adapts its granularity to the window length (hour / day / week) so the trend
+sparkline keeps a readable number of points.
 """
 
 import math
@@ -189,8 +187,8 @@ def _window_buckets(date_from: datetime, date_to: datetime | None, granularity: 
 def _normalize(value: datetime | date, granularity: Granularity) -> datetime:
     """Align a timestamp to its bucket start, tz-naive, so query rows and the zero-fill series key alike.
 
-    ClickHouse can hand the bucket back as a ``date`` (date/week truncation) or a ``datetime``
-    (hour truncation); widen the former so both sides key on the same type.
+    ClickHouse can return the bucket as a ``date`` (date/week truncation) or ``datetime`` (hour); widen
+    the former so both sides key on the same type.
     """
     naive = value.replace(tzinfo=None) if isinstance(value, datetime) else datetime(value.year, value.month, value.day)
     if granularity == "hour":

--- a/products/engineering_analytics/backend/logic/queries/workflow_jobs.py
+++ b/products/engineering_analytics/backend/logic/queries/workflow_jobs.py
@@ -1,15 +1,13 @@
-"""HogQL assembly of a run's jobs, for the expandable job breakdown on the run rows.
+"""HogQL assembly of a run's jobs, for the expandable job breakdown.
 
-Reads the curated jobs subquery (``_curated.jobs_source``) for one ``run_id``. Job-level data is an
-optional source — when it isn't synced, ``jobs_source()`` is None and this returns ``[]`` so the UI
-degrades to an empty breakdown instead of erroring. Per-job cost is derived from the runner tier
-(parsed from ``labels``) and elapsed time via the pure cost model (``logic.cost``).
+Reads the curated jobs subquery (``_curated.jobs_source``) for one ``run_id``. Jobs are an optional
+source — when unsynced, returns ``[]`` so the UI degrades to an empty breakdown. Per-job cost is
+derived from the runner tier (parsed from ``labels``) and elapsed via the cost model (``logic.cost``).
 
 A re-run carries several attempts under one ``run_id``; scoping to a single ``run_attempt`` keeps a
-row's statuses, durations, and costs from merging across attempts (and double-counting cost). The
-caller passes the attempt it's showing; when omitted, the run's latest attempt is read from the runs
-source (not the synced job rows) so a default lookup tracks the canonical attempt even when only older
-attempts' jobs have synced — returning an empty breakdown rather than stale jobs for that case.
+row's statuses/durations/costs from merging across attempts. The caller passes the attempt it's
+showing; when omitted, the run's latest attempt is read from the runs source (not the synced job rows)
+so a default lookup tracks the canonical attempt even when only older attempts' jobs have synced.
 """
 
 import json
@@ -21,9 +19,8 @@ from products.engineering_analytics.backend.facade.contracts import WorkflowJob
 from products.engineering_analytics.backend.logic.cost import estimate_job_cost_usd, runner_descriptor
 from products.engineering_analytics.backend.logic.queries._curated import CuratedGitHubSource
 
-# Explicit high LIMIT: without it HogQL caps at DEFAULT_RETURNED_ROWS (100), and since the rows are ordered
-# by start, a run with >100 jobs (matrix builds, re-run attempts) would silently drop its latest-starting
-# jobs — the breakdown would then miss jobs and not add up to the run's cost.
+# Explicit high LIMIT: without it HogQL caps at DEFAULT_RETURNED_ROWS (100); ordered by start, a run with
+# >100 jobs (matrix builds, re-runs) would silently drop its latest jobs and not add up to the run's cost.
 _SELECT = """
     SELECT id, run_id, run_attempt, name, status, conclusion, labels, runner_name, started_at, completed_at, duration_seconds
     FROM __JOBS_SOURCE__ AS j

--- a/products/engineering_analytics/backend/logic/queries/workflow_run.py
+++ b/products/engineering_analytics/backend/logic/queries/workflow_run.py
@@ -1,8 +1,8 @@
 """HogQL assembly of a single workflow run, for the run detail page.
 
 Embeds the curated ``github_workflow_runs`` builder as a subquery (via ``_curated``) and selects one
-run by its GitHub Actions ``id``. Run-level only — per-job/step data isn't in the warehouse yet. A run
-can have multiple attempts (re-runs) sharing the same id; the latest attempt is the canonical row.
+run by its GitHub Actions ``id``. Run-level only. A run can have multiple attempts (re-runs) sharing
+the same id; the latest attempt is the canonical row.
 """
 
 from posthog.hogql import ast

--- a/products/engineering_analytics/backend/logic/queries/workflow_run_list.py
+++ b/products/engineering_analytics/backend/logic/queries/workflow_run_list.py
@@ -1,9 +1,8 @@
 """HogQL assembly of a single workflow's recent runs, for the workflow detail (runs list) page.
 
 Embeds the curated ``github_workflow_runs`` builder as a subquery (via ``_curated``) and lists runs of
-one ``workflow_name`` within a repo, newest first. Run-level only — per-job/step data isn't in the
-warehouse yet. Re-runs share a run id; each attempt is its own row here (the detail page collapses to
-the latest attempt), so the list mirrors what GitHub Actions shows.
+one ``workflow_name`` within a repo, newest first. Run-level only. Re-runs share a run id; each attempt
+is its own row here, so the list mirrors what GitHub Actions shows.
 """
 
 from datetime import datetime


### PR DESCRIPTION
## Problem

Part of splitting the engineering-analytics UX work into stamphog-sized PRs (each ≤ 500 changed lines and ≤ 20 files, so auto-review doesn't bounce them as "too large"). Stacked manually on `rauln/eng-analytics-4-fe-scenes`.

## Changes

Comment/docstring-only cleanup of the backend curated query builders. No code, SQL, or signatures changed.

## How did you test this code?

I'm an agent (Claude Code). The full change was verified live in the running app (renamed scene, green/grey/purple GitHub state tags, title→detail link with GitHub moved to the `#id` ref) before splitting; this PR is one slice mechanically carved from that verified tree, so it's byte-identical to the reviewed whole. CI covers lint/typecheck/tests. No new automated tests — the change is presentational/comment-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @rnegron. One slice of a 7-PR stack reorganizing the engineering-analytics product; base branch `rauln/eng-analytics-4-fe-scenes`.
---
### 📚 Stack (review bottom-up; each ≤ 500 lines / 20 files for stamphog)
1. [rename → Engineering analytics](https://github.com/PostHog/posthog/pull/67102)
2. [GitHub-colored PR state + cleaner rows](https://github.com/PostHog/posthog/pull/67103)
3. [trim comments — components](https://github.com/PostHog/posthog/pull/67104)
4. [trim comments — scenes/lib](https://github.com/PostHog/posthog/pull/67105)
5. [trim comments — queries](https://github.com/PostHog/posthog/pull/67106)
6. [trim comments — logic](https://github.com/PostHog/posthog/pull/67107)
7. [trim comments — facade/presentation](https://github.com/PostHog/posthog/pull/67108)

Supersedes the combined [PR #66877](https://github.com/PostHog/posthog/pull/66877) (kept open until these are verified).