### PR TITLE
chore(engineering-analytics): trim verbose comments in logic

### DIFF
--- a/products/engineering_analytics/backend/logic/__init__.py
+++ b/products/engineering_analytics/backend/logic/__init__.py
@@ -1,10 +1,8 @@
 """Orchestration for engineering_analytics.
 
-Resolves caller inputs (PostHog-convention date strings, ``owner/name`` repo) and binds the
-team to its curated GitHub read layer (``CuratedGitHubSource``, which resolves the warehouse
-table names), then returns canonical contract types. The curated query builders
-(``backend/logic/views``) own all GitHub-shaped mapping and domain rules; this layer deals
-only in canonical types.
+Resolves caller inputs (date strings, ``owner/name`` repo), binds the team to its curated read layer
+(``CuratedGitHubSource``), and returns canonical contracts. The curated builders (``backend/logic/views``)
+own all GitHub-shaped mapping; this layer deals only in canonical types.
 """
 
 from datetime import datetime
@@ -43,22 +41,20 @@ from products.engineering_analytics.backend.logic.sources import list_github_sou
 if TYPE_CHECKING:
     from posthog.rbac.user_access_control import UserAccessControl
 
-# Default recency window when a caller omits date_from. Relative strings (-30d) and
-# ISO8601 are both accepted and resolved against the team's timezone.
+# Default recency window when a caller omits date_from.
 _DEFAULT_WINDOW = "-30d"
 
-# Workflow health defaults to a tighter window than the PR backlog — CI health is a "right now"
-# question, and the short window also buckets by hour for a live-looking trend.
+# Tighter window than the PR backlog — CI health is a "right now" question, and the short window
+# buckets by hour for a live-looking trend.
 _DEFAULT_WORKFLOW_WINDOW = "-24h"
 
-# workflow_health zero-fills one daily entry per workflow per day in the window, so an
-# unbounded range would materialize an enormous response. A year is plenty for trends.
+# workflow_health zero-fills one entry per workflow per day, so an unbounded range would materialize
+# an enormous response. A year is plenty for trends.
 _MAX_WINDOW_DAYS = 366
 
 
-# Each builder operates on an already-resolved CuratedGitHubSource: source selection and per-source
-# warehouse access control happen once at the facade, which hands these builders the authorized
-# handle. They validate their own inputs (dates, repo) and read PR/CI data through the handle.
+# Each builder operates on an already-resolved CuratedGitHubSource (source selection + access control
+# happened once at the facade); they validate their own inputs and read through the handle.
 def build_pr_lifecycle(*, curated: CuratedGitHubSource, pr_number: int, repo: str | None) -> PRLifecycle | None:
     owner, name = _split_repo(repo)
     if not (owner and name):
@@ -140,8 +136,8 @@ def build_ci_cards(*, curated: CuratedGitHubSource) -> CICardSummary:
     return query_ci_cards(curated=curated)
 
 
-# Listing the team's connected sources is its own concern (no curated read handle): it threads the
-# requesting user's access control so the picker can't enumerate sources the user can't access.
+# Listing sources is its own concern (no curated read handle): threads the user's access control so
+# the picker can't enumerate sources the user can't access.
 def build_github_sources(*, team: Team, user_access_control: "UserAccessControl | None" = None) -> list[GitHubSource]:
     return list_github_sources(team=team, user_access_control=user_access_control)
 
@@ -176,8 +172,8 @@ def _split_repo(repo: str | None) -> tuple[str | None, str | None]:
     if not repo:
         return None, None
     owner, _, name = repo.partition("/")
-    # A half-specified repo (bare org, trailing/leading slash) would otherwise drop
-    # the filter silently and return a PR from the wrong repo — fail loudly instead.
+    # A half-specified repo would otherwise drop the filter silently and return a PR from the wrong
+    # repo — fail loudly instead.
     if not (owner and name):
         raise ValueError(f"repo must be in 'owner/name' format, got: {repo!r}")
     return owner, name

--- a/products/engineering_analytics/backend/logic/cost.py
+++ b/products/engineering_analytics/backend/logic/cost.py
@@ -1,38 +1,29 @@
 """Depot CI cost model for engineering_analytics.
 
-Estimates the Depot dollar cost of CI from GitHub Actions job data. GitHub's jobs
-API exposes wall-clock (``started_at`` -> ``completed_at``) and the requested runner
-``labels`` -- not Depot's billed minutes -- so every figure here is an estimate:
-``elapsed_minutes x tier_multiplier x reference_rate``. This mirrors the model the
-DevEx Depot cost tooling already uses (list price, per-vCPU multiplier ladder).
+Estimates the Depot dollar cost of CI from GitHub Actions job data. GitHub's jobs API exposes
+wall-clock and the requested runner ``labels`` -- not Depot's billed minutes -- so every figure is an
+estimate: ``elapsed_minutes x tier_multiplier x reference_rate`` (mirrors the DevEx Depot cost tooling).
 
-GitHub/Depot specifics (the ``depot-*`` label shapes, the rate ladder) live here in
-the read layer per SPEC section 3; provider-neutral contract types stay in
-``facade/contracts.py``.
-
-Cost is fundamentally job-level: a workflow run fans into parallel jobs on different
-runner tiers, so per-PR cost is a sum over jobs. ``github_workflow_runs`` alone -- one
-wall-clock window, no runner label -- cannot produce it. These functions are pure and
-source-agnostic so they are unit-tested today and wired to the ``github_workflow_jobs``
-warehouse source once it lands (see SPEC section 6/9).
+GitHub/Depot specifics (label shapes, rate ladder) live here per SPEC §3; provider-neutral contract
+types stay in ``facade/contracts.py``. Cost is job-level (a run fans into parallel jobs on different
+tiers, so per-PR cost is a sum over jobs); ``github_workflow_runs`` alone can't produce it. These
+functions are pure and source-agnostic -- unit-tested today, wired to ``github_workflow_jobs`` once it
+lands (SPEC §6/9).
 """
 
 from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import StrEnum
 
-# Depot list price for one billed minute at the 2-vCPU base tier. Depot bills 2cpu
-# at 1x and doubles the multiplier per vCPU doubling, so billed = elapsed x multiplier
-# and cost = elapsed_minutes x REFERENCE_RATE_USD_PER_MIN x multiplier. Hardcoded for
-# v1 like KNOWN_BOT_HANDLES; a team-scoped rate + negotiated-discount config is the
-# documented follow-up (SPEC section 7).
+# Depot list price per billed minute at the 2-vCPU base tier (1x; multiplier doubles per vCPU doubling,
+# so cost = elapsed_minutes x rate x multiplier). Hardcoded for v1; a team-scoped rate + discount config
+# is the documented follow-up (SPEC §7).
 REFERENCE_RATE_USD_PER_MIN = 0.004
 
 # Depot billing multiplier per vCPU count (2cpu = 1x, doubling each step).
 _MULTIPLIER_BY_VCPU: dict[int, int] = {2: 1, 4: 2, 8: 4, 16: 8, 32: 16, 64: 32}
 
-# A Depot Linux runner with no explicit size suffix is the 2-vCPU default
-# (e.g. ``depot-ubuntu-latest``).
+# A Depot Linux runner with no explicit size suffix is the 2-vCPU default (``depot-ubuntu-latest``).
 _DEFAULT_DEPOT_VCPU = 2
 
 # Depot runner labels are ``depot-<os>-...`` — the prefix is what makes a runner Depot-billed.
@@ -71,11 +62,9 @@ class RunnerTier:
 def classify_runner(labels: list[str]) -> RunnerTier | None:
     """Classify the runner a job ran on from its ``labels``.
 
-    Prefers a real Depot runner (only Depot runners are Depot-billed), else a github-hosted
-    runner; returns ``None`` when no label names a recognized OS. A Depot runner label is
-    ``depot-<os>-...`` — anchored to the prefix AND a known OS token so organizational/cache
-    labels that merely contain "depot" (``depot-only``, ``depot-docker-cache``) or a
-    ``depot-`` prefixed non-runner label (``depot-cache-linux``) are not costed as a runner.
+    Prefers a real Depot runner (only Depot is Depot-billed), else github-hosted; ``None`` when no
+    label names a recognized OS. A Depot label is anchored to the ``depot-`` prefix AND a known OS
+    token so labels that merely contain "depot" (``depot-only``, ``depot-cache-linux``) aren't costed.
     """
     hosted_os: RunnerOS | None = None
     for label in labels:
@@ -99,11 +88,9 @@ def _os_from_label(label: str) -> RunnerOS | None:
 def _depot_vcpu(label: str) -> int:
     """vCPU count from a Depot label's optional trailing size segment.
 
-    Depot labels are ``depot-<os>-<version>[-<vcpu>]`` (e.g. ``depot-ubuntu-22.04-4``), so the
-    size is the segment after the version and is only ever the 4th-or-later segment. A
-    bare-integer OS version (``depot-macos-14``, ``depot-windows-2022``) sits in the version
-    slot and must not be read as a core count — hence the explicit segment position rather
-    than a trailing-digits regex, which would mis-read those non-Linux versions as vCPUs.
+    Depot labels are ``depot-<os>-<version>[-<vcpu>]``, so the size is only ever the 4th-or-later
+    segment. A bare-integer OS version (``depot-macos-14``) sits in the version slot and must not be
+    read as a core count — hence the segment-position check rather than a trailing-digits regex.
     """
     segments = label.split("-")
     # isdecimal (not isdigit): isdigit accepts unicode digits like superscripts that int() rejects.
@@ -120,10 +107,9 @@ def billing_multiplier(tier: RunnerTier) -> int:
 def runner_descriptor(labels: list[str]) -> tuple[str, str]:
     """Provider + human tier label for a job's runner, for display badges.
 
-    Returns ``(provider, label)`` where provider is ``'github_hosted'`` (free for open source),
-    ``'self_hosted'`` (billable — currently Depot), or ``'unknown'``. Provider-neutral on purpose so
-    other CI providers slot in. The label is the tier: ``'16-core'`` for self-hosted Linux, the raw
-    ``runs-on`` (e.g. ``'ubuntu-latest'``) for GitHub-hosted, or the OS for non-Linux self-hosted.
+    Returns ``(provider, label)`` where provider is ``'github_hosted'`` (free), ``'self_hosted'``
+    (billable — currently Depot), or ``'unknown'``. The label is the tier: ``'16-core'`` for
+    self-hosted Linux, the raw ``runs-on`` for GitHub-hosted, or the OS for non-Linux self-hosted.
     """
     tier = classify_runner(labels)
     if tier is None:
@@ -138,13 +124,11 @@ def runner_descriptor(labels: list[str]) -> tuple[str, str]:
 def estimate_job_cost_usd(labels: list[str], elapsed_seconds: float | None) -> float | None:
     """Estimated Depot dollar cost for one job, or ``None`` when no honest figure exists.
 
-    ``None`` means "no Depot cost to report": the job is github-hosted, its runner can't be
-    classified, it ran on a non-Linux Depot tier (macOS / Windows — separate price tiers not
-    modeled yet, so excluded rather than mis-costed at the Linux rate), OR its elapsed time is
-    unknown (a queued / not-yet-started job). That last case is deliberately distinct from a
-    job that ran for no measurable time (``started_at == completed_at`` or clock skew), which
-    is a real, measured ``0.0``: a consumer summing per-PR cost skips ``None`` jobs, so a queued
-    job is never silently shown as ``$0.00``.
+    ``None`` means "no Depot cost to report": github-hosted, unclassifiable runner, a non-Linux Depot
+    tier (macOS/Windows not modeled yet), OR unknown elapsed time (queued/not-started). That last case
+    is deliberately distinct from a job that ran for no measurable time (``started_at == completed_at``
+    or clock skew), a real measured ``0.0`` — summing skips ``None`` jobs, so a queued job is never
+    shown as ``$0.00``.
     """
     tier = classify_runner(labels)
     if tier is None or tier.provider is not RunnerProvider.DEPOT or tier.os is not RunnerOS.LINUX:
@@ -160,12 +144,10 @@ def estimate_job_cost_usd(labels: list[str], elapsed_seconds: float | None) -> f
 class PRCostAggregate:
     """One PR's job costs rolled up — billable (self-hosted Linux) runners only.
 
-    ``billable_seconds`` and ``estimated_cost_usd`` cover only the costed jobs (billable Linux,
-    finished). ``unsettled_jobs`` are billable Linux jobs with no elapsed time (still queued/running)
-    — excluded from cost so a not-yet-finished job is never shown as ``$0.00``. ``excluded_jobs`` ran
-    on provider-hosted (GitHub-hosted, free) or non-Linux runners, which carry no billable figure here.
-    ``estimated_cost_usd`` is ``None`` when no job was costable, distinguishing "nothing to cost" from
-    a real ``$0.00``.
+    ``billable_seconds`` / ``estimated_cost_usd`` cover only the costed jobs (billable Linux, finished).
+    ``unsettled_jobs`` are billable Linux jobs with no elapsed (still queued/running), excluded from
+    cost. ``excluded_jobs`` ran on provider-hosted or non-Linux runners. ``estimated_cost_usd`` is
+    ``None`` when no job was costable, distinguishing "nothing to cost" from a real ``$0.00``.
     """
 
     billable_seconds: float
@@ -176,12 +158,11 @@ class PRCostAggregate:
 
 
 def aggregate_pr_cost(jobs: Iterable[tuple[list[str], float | None]]) -> PRCostAggregate:
-    """Sum per-job cost over a PR's jobs, partitioning each job by why it does (or doesn't) count.
+    """Sum per-job cost over a PR's jobs, partitioning each by why it does (or doesn't) count.
 
-    Each input is one job's ``(labels, elapsed_seconds)``. A job counts toward cost only when its
-    runner classifies as a billable self-hosted Linux tier AND it has elapsed time; everything else
-    lands in ``unsettled_jobs`` (self-hosted Linux, no elapsed) or ``excluded_jobs`` (provider-hosted /
-    non-Linux). The billable classification is currently Depot-shaped (the only modeled provider).
+    Each input is one job's ``(labels, elapsed_seconds)``. A job counts only when its runner is a
+    billable self-hosted Linux tier AND it has elapsed time; else it lands in ``unsettled_jobs``
+    (Linux, no elapsed) or ``excluded_jobs`` (provider-hosted / non-Linux). Currently Depot-shaped.
     """
     billable_seconds = 0.0
     total_cost = 0.0

--- a/products/engineering_analytics/backend/logic/job_logs/__init__.py
+++ b/products/engineering_analytics/backend/logic/job_logs/__init__.py
@@ -1,7 +1,7 @@
 """Fetch GitHub Actions failure logs and ship them into the Logs product.
 
-A scheduled coordinator finds recently-failed CI jobs, and a per-job workflow fetches each job's
-log from GitHub (under the shared egress limiter) and emits it line-by-line into the Logs product.
+A scheduled coordinator finds recently-failed CI jobs; a per-job workflow fetches each job's log from
+GitHub (under the shared egress limiter) and emits it line-by-line into the Logs product.
 """
 
 from products.engineering_analytics.backend.logic.job_logs.emitter import JobLogsEmitter

--- a/products/engineering_analytics/backend/logic/job_logs/coordinator.py
+++ b/products/engineering_analytics/backend/logic/job_logs/coordinator.py
@@ -1,12 +1,10 @@
 """Find recently-failed CI jobs and fan out one idempotent log-fetch workflow per job.
 
-Per-job workflow id (``gh-logs-{team}-{job}``, reuse ``ALLOW_DUPLICATE_FAILED_ONLY``) means each
-job's log is fetched and emitted at most once, re-running only after a failed attempt.
-
-Discovery queries the raw ``{prefix}github_workflow_jobs`` table (the curated read layer doesn't
-expose jobs yet). The coordinator is registered on the schedule but no-ops until
-``OTLP_LOGS_INGEST_ENDPOINT`` is set (see ``_discover_failed_jobs``), so it activates automatically
-once the Logs endpoint is deployed, regardless of deploy order.
+Per-job workflow id (``gh-logs-{team}-{job}``, ``ALLOW_DUPLICATE_FAILED_ONLY``) means each job's log is
+fetched and emitted at most once, re-running only after a failed attempt. Discovery queries the raw
+``{prefix}github_workflow_jobs`` table (the curated read layer doesn't expose jobs yet). The coordinator
+no-ops until ``OTLP_LOGS_INGEST_ENDPOINT`` is set, so it activates automatically once the Logs endpoint
+is deployed, regardless of deploy order.
 """
 
 import re
@@ -39,8 +37,8 @@ from products.warehouse_sources.backend.types import ExternalDataSourceType
 
 logger = structlog.get_logger(__name__)
 
-# How far back to look each tick. With the per-job workflow id (one fetch per job) this bounds
-# re-scanning without a separate "already fetched" store.
+# How far back to look each tick. With the per-job workflow id this bounds re-scanning without a
+# separate "already fetched" store.
 DEFAULT_LOOKBACK = timedelta(hours=2)
 _PREFIX = re.compile(r"^[A-Za-z0-9_]*$")  # warehouse source prefixes; guards the table identifier
 # Cap total jobs returned per tick — the activity hands them back as one Temporal payload (~2 MiB
@@ -49,11 +47,10 @@ MAX_DISCOVERED_JOBS = 2000
 
 
 def _query_failed_jobs(team: Team, prefix: str, cutoff_iso: str) -> list[dict[str, Any]]:
-    # Window on completed_at (when the job finished), not created_at: a queued or long-running job
-    # can be created well before it fails, and a created_at window would miss it. completed_at is an
-    # ISO-8601 string and is always set for a failed (completed) job, so a lexical comparison against
-    # the cutoff is chronological. The table name is a trusted identifier (validated prefix + fixed
-    # suffix); user values flow through the placeholder, never the f-string.
+    # Window on completed_at, not created_at: a long-running job can be created well before it fails.
+    # completed_at is an always-set ISO-8601 string, so a lexical comparison against the cutoff is
+    # chronological. The table name is a trusted identifier (validated prefix + fixed suffix); user
+    # values flow through the placeholder, never the f-string.
     table = f"{prefix}github_workflow_jobs"
     sql = f"""
         SELECT id AS job_id, run_id, head_branch AS branch, conclusion

--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -1,9 +1,8 @@
-"""Ship fetched CI log content into Logs via OTLP — one record per line so each line is
-independently searchable, countable, and groupable. Emits through the OpenTelemetry SDK to the
-internal ``capture-logs`` endpoint (``/i/v1/logs``) with the destination team's project token as the
-``Authorization: Bearer`` — the token is what routes records to that team's Logs, so there's no
-public-internet round-trip. Each record carries the job attributes, the line's GitHub timestamp, and
-a severity from GitHub's ``##[error]`` / ``##[warning]`` markers.
+"""Ship fetched CI log content into Logs via OTLP — one record per line so each is independently
+searchable, countable, and groupable. Emits through the OpenTelemetry SDK to the internal
+``capture-logs`` endpoint with the destination team's project token as ``Authorization: Bearer`` — the
+token routes records to that team's Logs, so there's no public-internet round-trip. Each record carries
+the job attributes, the line's GitHub timestamp, and a severity from ``##[error]`` / ``##[warning]``.
 
 A Temporal activity is short-lived, so callers MUST ``flush()`` before returning (use the context
 manager) — the batch processor would otherwise drop buffered records.

--- a/products/engineering_analytics/backend/logic/job_logs/thinning.py
+++ b/products/engineering_analytics/backend/logic/job_logs/thinning.py
@@ -1,17 +1,12 @@
 """Thin a GitHub Actions job log down to its failure-relevant lines.
 
-A failed job's log is mostly noise (dependency downloads, hundreds of passing migrations) around a
-small failure region. We keep that region — lines matching a high-precision failure marker plus
-context — and a short tail fallback; everything else collapses to a ``... N lines omitted ...``
-marker, turning multi-MB logs into a few hundred lines without losing the cause.
+A failed job's log is mostly noise around a small failure region. We keep that region (lines matching a
+high-precision failure marker plus context) and a short tail fallback; everything else collapses to a
+``... N lines omitted ...`` marker, turning multi-MB logs into a few hundred lines without losing the cause.
 
-Pure transform, decoupled from fetch/emit: all-jobs ingestion can later thin *non-failure* logs by
-passing a different ``ThinningConfig``. (A structured alternative — the check-run annotations API or
-JUnit XML — is a cleaner future upgrade but depends on per-workflow instrumentation we don't control.)
-
-Markers are exact, case-sensitive substrings, deliberately high-precision: bare ``error`` / ``failed``
-are NOT markers — real logs are full of them (``errortracking`` migrations, ``0 failed`` summaries)
-and they would defeat the thinning.
+Pure transform, decoupled from fetch/emit: all-jobs ingestion can later thin non-failure logs via a
+different ``ThinningConfig``. Markers are exact, case-sensitive substrings, deliberately high-precision:
+bare ``error`` / ``failed`` are NOT markers — real logs are full of them and they would defeat the thinning.
 """
 
 import dataclasses

--- a/products/engineering_analytics/backend/logic/quarantine.py
+++ b/products/engineering_analytics/backend/logic/quarantine.py
@@ -64,19 +64,18 @@ QUARANTINE_FILENAME = ".test_quarantine.json"
 
 _SCHEMA_VERSION = 1
 _DEFAULT_RUNNER = "pytest"
-# Matches DEFAULT_GRACE_DAYS in the quarantine contract: an expired entry stays
-# inert for this long before `quarantine check` makes its removal mandatory.
+# Matches DEFAULT_GRACE_DAYS in the contract: an expired entry stays inert this long before
+# `quarantine check` makes its removal mandatory.
 _GRACE_DAYS = 7
 _EXPIRING_SOON_DAYS = 7
 _ENTRY_FIELDS = ("id", "runner", "reason", "owner", "issue", "added", "expires", "mode")
 
-# SSRF hardening: both halves of `owner/name` must look like a GitHub slug
-# before they are interpolated into the fetch URL.
+# SSRF hardening: both halves of `owner/name` must look like a GitHub slug before interpolation.
 _REPO_PART_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,99}$")
 _FETCH_TIMEOUT_SECONDS = 3
 _CACHE_TTL_SECONDS = 60
-# A real quarantine file is tens of KB; this is generous headroom while bounding how
-# much a hostile public repo can make us buffer, cache, and parse from one request.
+# Generous headroom (a real file is tens of KB) while bounding what a hostile public repo can make us
+# buffer, cache, and parse.
 _MAX_QUARANTINE_BYTES = 5 * 1024 * 1024
 
 # Most urgent first; ties broken by soonest expiry, then id.

--- a/products/engineering_analytics/backend/logic/sources.py
+++ b/products/engineering_analytics/backend/logic/sources.py
@@ -1,18 +1,13 @@
 """Resolve a team's GitHub warehouse tables at query time.
 
-A warehouse table's real name is ``ExternalDataSource.prefix + <synced endpoint table>``,
-and ``prefix`` is free text the user sets when connecting the source. The product can
-therefore never assume a fixed ``github_*`` table name — a team that connected GitHub
-with prefix ``devex_eng_analytics`` lands its data in ``devex_eng_analyticsgithub_pull_requests``.
+A warehouse table's real name is ``ExternalDataSource.prefix + <synced endpoint table>``, and
+``prefix`` is free text set when connecting the source — so the product can never assume a fixed
+``github_*`` name (prefix ``devex_eng_analytics`` lands ``devex_eng_analyticsgithub_pull_requests``).
 
 This resolver walks the team's connected GitHub source(s) to their ``pull_requests`` /
-``workflow_runs`` schemas and returns the actual ``DataWarehouseTable`` names the curated
-builders should read. Names are resolved exactly once per request (in the logic layer)
-and threaded down into the builders, so a request hits the warehouse models a single time.
-
-A team can connect GitHub more than once (e.g. one source per repository). A caller may pass
-``source_id`` to read a specific source; otherwise the oldest connected source with both
-endpoints synced is used.
+``workflow_runs`` schemas and returns the actual ``DataWarehouseTable`` names. Resolved once per
+request and threaded into the builders. A team can connect GitHub more than once; ``source_id`` reads
+a specific source, else the oldest with both endpoints synced.
 """
 
 import re
@@ -31,19 +26,16 @@ from products.warehouse_sources.backend.facade.types import ExternalDataSourceTy
 if TYPE_CHECKING:
     from posthog.rbac.user_access_control import UserAccessControl
 
-# GitHub source endpoints (``ExternalDataSchema.name``) backing the curated builders. The
-# materialized table for each is ``prefix + "github_" + endpoint``, e.g. with prefix
-# ``devex_eng_analytics`` the pull-requests table is ``devex_eng_analyticsgithub_pull_requests``.
+# GitHub source endpoints (``ExternalDataSchema.name``) backing the curated builders. The materialized
+# table is ``prefix + "github_" + endpoint``.
 PULL_REQUESTS_SCHEMA = "pull_requests"
 WORKFLOW_RUNS_SCHEMA = "workflow_runs"
-# Job-level CI (queue time, per-job duration, runner tier). Optional — the source/sync lands
-# separately, so reads must degrade gracefully (no jobs) rather than require it like the pair above.
+# Job-level CI (queue time, per-job duration, runner tier). Optional — lands separately, so reads must
+# degrade gracefully rather than require it like the pair above.
 WORKFLOW_JOBS_SCHEMA = "workflow_jobs"
 
-# Resolved names are interpolated into HogQL ``FROM`` clauses. Warehouse table names are
-# always plain identifiers (the prefix is validated to ``[A-Za-z0-9_]`` at connect time and
-# the rest is the fixed ``github_<endpoint>`` suffix), so reject anything else defensively
-# rather than trust an unexpected name into SQL.
+# Resolved names are interpolated into HogQL ``FROM`` clauses. Table names are always plain identifiers
+# (validated prefix + fixed ``github_<endpoint>`` suffix), so reject anything else defensively.
 _IDENTIFIER = re.compile(r"\A[A-Za-z_][A-Za-z0-9_]*\Z")
 
 
@@ -62,18 +54,14 @@ def resolve_github_tables(
 ) -> GitHubTables:
     """Resolve the team's curated GitHub table names from its warehouse models.
 
-    With ``source_id``, reads that specific connected GitHub source; otherwise picks the
-    oldest source with both endpoints synced (oldest = the team's first/established connection)
-    — deterministic when a team has more than one GitHub source (e.g. one per repository).
-    Raises ``GitHubSourceNotConnectedError`` when no matching usable source exists (the
-    presentation layer maps it to a 400, so the UI prompts to connect a source and an agent gets
-    an actionable error), or ``ValueError`` when ``source_id`` is not a UUID.
+    With ``source_id``, reads that specific source; else the oldest with both endpoints synced
+    (deterministic when a team has more than one). Raises ``GitHubSourceNotConnectedError`` when no
+    usable source exists (presentation maps it to 400) or ``ValueError`` when ``source_id`` isn't a UUID.
 
-    ``user_access_control`` enforces the requesting user's per-source warehouse RBAC (applied in
-    ``_github_sources``): a denied ``source_id`` raises (400) and the default-oldest path skips it.
-    The curated HogQL runs team-scoped with no user and HogQL does not enforce per-user ACL on
-    warehouse tables, so honoring it here is the only way the read path can. ``None`` (system/
-    Temporal/CLI contexts with no request user) skips filtering — team scoping still holds.
+    ``user_access_control`` enforces the user's per-source warehouse RBAC: a denied ``source_id`` raises
+    and the default path skips it. The curated HogQL runs team-scoped with no user and doesn't enforce
+    per-user ACL on warehouse tables, so honoring it here is the only way the read path can. ``None``
+    (system/Temporal/CLI) skips filtering — team scoping still holds.
     """
     sources = _github_sources(team, user_access_control)
     if source_id is not None:
@@ -82,12 +70,10 @@ def resolve_github_tables(
         tables = _synced_table_names(team=team, source=source)
         pull_requests = tables.get(PULL_REQUESTS_SCHEMA)
         workflow_runs = tables.get(WORKFLOW_RUNS_SCHEMA)
-        # Both endpoints are required together, by design: every read surface (cards, PR list,
-        # lifecycle) joins workflow_runs for CI status and the push / re-run rollup, so a source
-        # with only pull_requests synced can't serve a complete result. The trade-off is that a
-        # half-synced source makes the whole product 400 (e.g. while workflow_runs is still
-        # backfilling) instead of degrading to PRs-without-CI. Relaxing this to a graceful
-        # PR-only mode (null CI columns) is a deliberate future change, not handled here.
+        # Both endpoints required together by design: every read surface joins workflow_runs for CI
+        # status and the push / re-run rollup, so a pull_requests-only source can't serve a complete
+        # result. Trade-off: a half-synced source 400s the whole product instead of degrading to
+        # PRs-without-CI. A graceful PR-only mode is a deliberate future change, not handled here.
         if pull_requests and workflow_runs:
             # workflow_jobs is optional — included when synced, None otherwise (jobs degrade to empty).
             return GitHubTables(
@@ -103,11 +89,10 @@ def resolve_github_tables(
 def list_github_sources(*, team: Team, user_access_control: "UserAccessControl | None" = None) -> list[GitHubSource]:
     """The team's connected GitHub sources the caller may access, as selectable refs, oldest first.
 
-    Lists every non-deleted GitHub source the user can access — including ones whose endpoints aren't
-    fully synced yet — so a source picker shows everything they connected; selecting an unusable one
-    surfaces the same connect prompt ``resolve_github_tables`` drives. Sources the user can't access
-    (``user_access_control``) are filtered out, so the picker can't enumerate them. Each ``id`` is
-    what the caller passes back as ``source_id`` to read that source.
+    Lists every non-deleted GitHub source the user can access — including not-fully-synced ones — so a
+    picker shows everything they connected; selecting an unusable one surfaces the same connect prompt.
+    Inaccessible sources (``user_access_control``) are filtered out. Each ``id`` is passed back as
+    ``source_id`` to read that source.
     """
     return [
         GitHubSource(
@@ -123,9 +108,8 @@ def _github_sources(team: Team, user_access_control: "UserAccessControl | None" 
     """The team's non-deleted GitHub sources the caller may access, oldest first — the order
     ``resolve_github_tables`` defaults from, so a picker's first entry matches the default source.
 
-    ``user_access_control`` applies the requesting user's per-source warehouse RBAC, so neither the
-    resolver nor the picker can reach a source the user can't access; ``None`` (system/Temporal/CLI
-    contexts) skips it, leaving team scoping. This is the single place that access scope is decided.
+    ``user_access_control`` applies the user's per-source warehouse RBAC; ``None`` (system/Temporal/CLI)
+    skips it, leaving team scoping. The single place access scope is decided.
     """
     sources = (
         ExternalDataSource.objects.filter(team_id=team.pk, source_type=ExternalDataSourceType.GITHUB)

--- a/products/engineering_analytics/backend/logic/views/__init__.py
+++ b/products/engineering_analytics/backend/logic/views/__init__.py
@@ -1,9 +1,7 @@
 """Curated query builders over the GitHub warehouse snapshots.
 
-``pull_requests`` and ``workflow_runs`` each expose a ``build_query(table_name)``
-returning the curated ``SELECT`` over the raw GitHub table whose per-team name is
-resolved by ``logic.sources`` and passed in. All PR/CI domain rules (bot detection,
-repo identity, label extraction, honest metric naming) are defined here exactly once.
-Query modules embed these as subqueries via ``logic.queries._curated`` — nothing is
-registered as a global HogQL view.
+``pull_requests`` and ``workflow_runs`` each expose ``build_query(table_name)`` returning the curated
+``SELECT`` over the raw GitHub table (per-team name resolved by ``logic.sources``). All PR/CI domain
+rules (bot detection, repo identity, labels, honest metric naming) live here exactly once. Query
+modules embed these as subqueries via ``logic.queries._curated``; nothing is a global HogQL view.
 """

--- a/products/engineering_analytics/backend/logic/views/pull_requests.py
+++ b/products/engineering_analytics/backend/logic/views/pull_requests.py
@@ -1,23 +1,15 @@
 """Curated pull-requests query builder.
 
-Maps the raw GitHub pull-requests warehouse snapshot (GitHub's PR JSON, landed
-verbatim) into honest, query-able columns. This is the ONLY place PR domain rules
-live — bot detection, repo identity from ``base.repo.full_name``, label extraction,
-the canonical PR state, and the coarse open-to-merge duration. The source table name
-is resolved per-team and passed in (see ``logic.sources``); it is never hardcoded,
-because a warehouse table's name is ``prefix + "github_pull_requests"`` and the prefix
-is user-chosen. Every query module embeds this ``SELECT`` as a subquery (see
-``_curated``) rather than re-deriving the columns from JSON; nothing registers it as a
-global HogQL view, so the product stays off the per-query catalog hot path.
+Maps the raw GitHub pull-requests snapshot (PR JSON, landed verbatim) into honest query-able columns.
+The ONLY place PR domain rules live — bot detection, repo identity from ``base.repo.full_name``, label
+extraction, canonical PR state, the coarse open-to-merge duration. The source table name is resolved
+per-team and passed in (see ``logic.sources``); never hardcoded.
 
-The real GitHub source lands timestamps as **strings** and the nested objects
-(``user`` / ``head`` / ``base`` / ``labels``) as **Nullable** JSON, so this builder
-runs in two layers: an inner SELECT parses each timestamp with
-``parseDateTimeBestEffort`` and unwraps the Nullable JSON with ``ifNull`` (a
-Nullable column cannot feed ``JSONExtractArrayRaw`` / ``splitByChar`` — ClickHouse
-rejects an Array nested inside a Nullable); the outer SELECT then derives state, repo
-identity, labels and the duration off those parsed columns. Splitting the layers also
-avoids referencing a same-SELECT alias as another expression's input.
+The real source lands timestamps as strings and nested objects (``user`` / ``head`` / ``base`` /
+``labels``) as Nullable JSON, so this runs in two layers: an inner SELECT parses timestamps with
+``parseDateTimeBestEffort`` and unwraps Nullable JSON with ``ifNull`` (ClickHouse rejects an Array
+nested inside a Nullable); the outer SELECT derives state, repo identity, labels, and the duration off
+the parsed columns. Splitting also avoids referencing a same-SELECT alias as another expression's input.
 """
 
 # Bots whose handle does not carry GitHub's automatic ``[bot]`` suffix. Kept

--- a/products/engineering_analytics/backend/logic/views/source_schema.py
+++ b/products/engineering_analytics/backend/logic/views/source_schema.py
@@ -1,23 +1,18 @@
 """Column schemas of the raw GitHub warehouse snapshots the curated views read.
 
-These mirror what the GitHub warehouse source actually lands: scalar columns plus
-the nested API objects (``user``, ``head``, ``base``, ``labels``, ``repository``,
-``pull_requests``) stored verbatim as JSON strings, and timestamps as strings.
+Mirrors what the GitHub warehouse source lands: scalar columns plus nested API objects (``user``,
+``head``, ``base``, ``labels``, ``repository``, ``pull_requests``) stored verbatim as JSON strings, and
+timestamps as strings.
 
-**Every column is ``Nullable`` — the data-imports pipeline lands the whole GitHub
-snapshot as nullable, with no exceptions** (verified against the real connected
-source). The curated builders therefore parse timestamps with
-``parseDateTimeBestEffort`` (NULL-safe) and ``ifNull``-unwrap any Nullable column
-before an array function (``JSONExtractArrayRaw`` / ``splitByChar``), because
+**Every column is ``Nullable`` — the data-imports pipeline lands the whole snapshot as nullable**
+(verified against the real source). The curated builders therefore parse timestamps with
+``parseDateTimeBestEffort`` and ``ifNull``-unwrap any Nullable column before an array function, because
 ClickHouse rejects an Array nested inside a Nullable.
 
-This file is the single source of truth for the table shape, shared by the seed
-command and the warehouse tests. It must stay a faithful replica of prod: the
-original idealized shape (non-null scalars, ``DateTime64`` timestamps) passed every
-local test while production 500'd on the real nullable table. Keeping it exactly as
-nullable as prod is what makes the warehouse tests catch a Nullable-handling
-regression locally / in CI instead of only after deploy. If you add a column here,
-type it ``Nullable(...)`` unless you have confirmed the pipeline lands it non-null.
+Single source of truth for the table shape, shared by the seed command and the warehouse tests. It must
+stay a faithful replica of prod: the original idealized shape (non-null scalars, ``DateTime64``) passed
+every local test while prod 500'd on the real nullable table. If you add a column, type it
+``Nullable(...)`` unless you've confirmed the pipeline lands it non-null.
 """
 
 PULL_REQUESTS_COLUMNS: dict[str, dict[str, str]] = {
@@ -51,11 +46,9 @@ WORKFLOW_RUNS_COLUMNS: dict[str, dict[str, str]] = {
     "repository": {"clickhouse": "Nullable(String)", "hogql": "StringDatabaseField"},
 }
 
-# Contract for the incoming ``github_workflow_jobs`` warehouse source (job-level CI: queue
-# time, per-job duration, runner tier, retries) — the substrate per-PR Depot cost wires to.
-# The source must land exactly this shape; ``run_id`` joins back to ``github_workflow_runs``
-# for per-PR attribution, ``labels`` carries the runner tier the cost model parses. Same
-# Nullable/string discipline as above — timestamps are strings, ``labels``/``steps`` are JSON.
+# Contract for the incoming ``github_workflow_jobs`` source (job-level CI: queue time, per-job duration,
+# runner tier). ``run_id`` joins back to ``github_workflow_runs`` for per-PR attribution; ``labels``
+# carries the runner tier the cost model parses. Same Nullable/string discipline as above.
 WORKFLOW_JOBS_COLUMNS: dict[str, dict[str, str]] = {
     "id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField"},
     "run_id": {"clickhouse": "Nullable(Int64)", "hogql": "IntegerDatabaseField"},

--- a/products/engineering_analytics/backend/logic/views/workflow_jobs.py
+++ b/products/engineering_analytics/backend/logic/views/workflow_jobs.py
@@ -1,17 +1,12 @@
 """Curated workflow-jobs query builder.
 
-Maps the raw GitHub workflow-jobs warehouse snapshot (``WORKFLOW_JOBS_COLUMNS`` in
-``source_schema``) into honest job-level columns: ``status`` / ``conclusion`` pass through
-unchanged, ``duration_seconds`` is computed only for completed jobs, and ``labels`` (the
-runner-tier JSON the cost model parses) is unwrapped from its Nullable column. ``run_id`` joins
-back to ``github_workflow_runs``. The source table name is resolved per-team and passed in (see
-``logic.sources``); it is never hardcoded.
+Maps the raw GitHub workflow-jobs snapshot (``WORKFLOW_JOBS_COLUMNS``) into honest job-level columns:
+``status`` / ``conclusion`` pass through, ``duration_seconds`` is computed only for completed jobs, and
+``labels`` (the runner-tier JSON) is unwrapped from its Nullable column. ``run_id`` joins back to
+``github_workflow_runs``. The source table name is resolved per-team and passed in; never hardcoded.
 
 Same two-layer shape as ``workflow_runs``: the inner SELECT parses timestamps with
-``parseDateTimeBestEffortOrNull`` (a queued/running job has no start/finish) and unwraps Nullable
-JSON with ``ifNull``; the outer SELECT derives the duration off the parsed columns.
-
-Embedded as a subquery by the jobs query module (see ``_curated``); nothing registers a global view.
+``parseDateTimeBestEffortOrNull`` and unwraps Nullable JSON with ``ifNull``; the outer derives duration.
 """
 
 

--- a/products/engineering_analytics/backend/logic/views/workflow_runs.py
+++ b/products/engineering_analytics/backend/logic/views/workflow_runs.py
@@ -1,33 +1,19 @@
 """Curated workflow-runs query builder.
 
-Maps the raw GitHub workflow-runs warehouse snapshot into honest CI columns:
-``status`` and ``conclusion`` are passed through unchanged (a conclusion can be
-stale until the ``workflow_run`` webhook settles it — see SPEC §9), and
-``duration_seconds`` is only computed for completed runs. ``head_sha`` is the
-canonical join key back to the pull-requests builder for a PR's CI status, while
-``pr_number`` keys the per-PR push / re-run rollup and ``run_attempt`` distinguishes
-re-runs. The source table name is resolved per-team and passed in (see
-``logic.sources``); it is never hardcoded, because a warehouse table's name carries
-the user-chosen source prefix.
+Maps the raw GitHub workflow-runs snapshot into honest CI columns: ``status`` and ``conclusion`` pass
+through (a conclusion can be stale until the ``workflow_run`` webhook settles it — SPEC §9), and
+``duration_seconds`` is only computed for completed runs. ``head_sha`` is the join key back to the
+pull-requests builder; ``pr_number`` keys the per-PR push / re-run rollup; ``run_attempt`` distinguishes
+re-runs. The source table name is resolved per-team and passed in; never hardcoded.
 
-``pr_number`` is the FIRST entry of the run's ``pull_requests`` association. Two cases:
-a run with no association (fork PRs, and pushes to a branch with no open PR) extracts
-``0`` (filtered out of the rollup, which only counts ``pr_number > 0``); a run shared
-across more than one PR (uncommon — one head tied to multiple open PRs) is credited to
-its first PR only, not fanned out across all of them. That's a deliberate v1
-simplification — the rollup is an approximate friction signal (pushes / re-runs), not
-billing — kept until the job-level source (SPEC §6) replaces this attribution.
+``pr_number`` is the FIRST entry of the run's ``pull_requests`` association. No association (fork PRs,
+pushes to a branch with no open PR) extracts ``0`` (filtered out of the rollup); a run shared across
+multiple PRs is credited to its first only. A deliberate v1 simplification — the rollup is an
+approximate friction signal, not billing — kept until the job-level source (SPEC §6) replaces it.
 
-The real GitHub source lands timestamps as **strings** and ``repository`` /
-``pull_requests`` as **Nullable** JSON, so this builder runs in two layers: an inner
-SELECT parses each timestamp with ``parseDateTimeBestEffort`` and unwraps the
-Nullable JSON with ``ifNull`` (a Nullable column cannot feed ``JSONExtractArrayRaw`` /
-``splitByChar`` — ClickHouse rejects an Array nested inside a Nullable); the outer
-SELECT derives the duration and repo identity off those parsed columns, which also
-avoids referencing a same-SELECT alias as another expression's input.
-
-Every query module embeds this ``SELECT`` as a subquery (see ``_curated``);
-nothing registers it as a global HogQL view.
+Two-layer like the PR builder: the inner SELECT parses timestamps with ``parseDateTimeBestEffort`` and
+unwraps Nullable JSON with ``ifNull`` (ClickHouse rejects an Array nested inside a Nullable); the outer
+derives duration and repo identity, also avoiding referencing a same-SELECT alias.
 """
 
 


### PR DESCRIPTION
## Problem

Part of splitting the engineering-analytics UX work into stamphog-sized PRs (each ≤ 500 changed lines and ≤ 20 files, so auto-review doesn't bounce them as "too large"). Stacked manually on `rauln/eng-analytics-5-be-queries`.

## Changes

Comment/docstring-only cleanup of the backend logic (cost, quarantine, sources, views, job_logs). No code or signatures changed.

## How did you test this code?

I'm an agent (Claude Code). The full change was verified live in the running app (renamed scene, green/grey/purple GitHub state tags, title→detail link with GitHub moved to the `#id` ref) before splitting; this PR is one slice mechanically carved from that verified tree, so it's byte-identical to the reviewed whole. CI covers lint/typecheck/tests. No new automated tests — the change is presentational/comment-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @rnegron. One slice of a 7-PR stack reorganizing the engineering-analytics product; base branch `rauln/eng-analytics-5-be-queries`.
---
### 📚 Stack (review bottom-up; each ≤ 500 lines / 20 files for stamphog)
1. [rename → Engineering analytics](https://github.com/PostHog/posthog/pull/67102)
2. [GitHub-colored PR state + cleaner rows](https://github.com/PostHog/posthog/pull/67103)
3. [trim comments — components](https://github.com/PostHog/posthog/pull/67104)
4. [trim comments — scenes/lib](https://github.com/PostHog/posthog/pull/67105)
5. [trim comments — queries](https://github.com/PostHog/posthog/pull/67106)
6. [trim comments — logic](https://github.com/PostHog/posthog/pull/67107)
7. [trim comments — facade/presentation](https://github.com/PostHog/posthog/pull/67108)

Supersedes the combined [PR #66877](https://github.com/PostHog/posthog/pull/66877) (kept open until these are verified).