### PR TITLE
chore(engineering-analytics): trim verbose comments in facade and presentation

### DIFF
--- a/products/engineering_analytics/backend/facade/api.py
+++ b/products/engineering_analytics/backend/facade/api.py
@@ -1,19 +1,12 @@
-"""Facade for engineering_analytics.
+"""Facade for engineering_analytics — the only module other products and the DRF layer import.
 
-The ONLY module other products (and the DRF presentation layer) import for
-runtime PR/CI analytics. Public functions take a team plus PostHog-convention
-parameters and return canonical contract types.
-
-``repo`` is an optional ``owner/name`` filter, applied against the curated repo
-identity (mapped from ``base.repo.full_name``). ``branch`` is an optional exact
-``head_branch`` filter for workflow health. ``date_from`` / ``date_to`` accept
-relative strings (``-30d``) or ISO8601 and are resolved against the team timezone.
-``source_id`` selects a specific connected GitHub source when the team has more than
-one; it defaults to the oldest connected source. ``user_access_control`` enforces the
-requesting user's per-source warehouse access (pass the request's; ``None`` for system
-contexts). Each function resolves the team's authorized curated read handle once, here,
-then delegates to the read layer — source selection and access control live in this layer,
-not in the query builders below it.
+Public functions take a team plus PostHog-convention params and return canonical contracts. Param
+contracts: ``repo`` is an optional ``owner/name`` filter; ``branch`` an exact ``head_branch`` filter
+(workflow health); ``date_from`` / ``date_to`` accept relative strings (``-30d``) or ISO8601, resolved
+against the team timezone; ``source_id`` selects a connected GitHub source (defaults to the oldest);
+``user_access_control`` enforces the requesting user's per-source warehouse access (``None`` for system
+contexts). Each function resolves the authorized curated read handle once here — source selection and
+access control live in this layer, not the query builders.
 """
 
 from typing import TYPE_CHECKING
@@ -45,10 +38,8 @@ if TYPE_CHECKING:
 def _authorized_source(
     team: Team, source_id: str | None, user_access_control: "UserAccessControl | None"
 ) -> "CuratedGitHubSource":
-    """Resolve this caller's curated read handle — the single place source selection and per-source
-    warehouse access control happen. ``user_access_control`` (None for system/Temporal/CLI contexts)
-    filters out sources the requesting user can't access; ``source_id`` selects a specific source,
-    else the oldest connected. Raises ``GitHubSourceNotConnectedError`` / ``ValueError`` (bad source_id).
+    """Resolve the caller's curated read handle — the one place source selection and per-source access
+    control happen. Raises ``GitHubSourceNotConnectedError`` / ``ValueError`` (bad source_id).
     """
     return logic.CuratedGitHubSource.for_team(team, source_id=source_id, user_access_control=user_access_control)
 
@@ -200,9 +191,8 @@ def get_quarantine(
     source_id: str | None = None,
     user_access_control: "UserAccessControl | None" = None,
 ) -> QuarantineFile:
-    # Quarantine resolves its source lazily (DEBUG reads the local checkout, an explicit ``repo`` needs
-    # no source) so it stays fail-open where the curated reads above don't — ``source_id`` /
-    # ``user_access_control`` only matter when it falls back to the connected source's most-active repo.
+    # Quarantine resolves its source lazily and stays fail-open (unlike the curated reads): source_id /
+    # user_access_control only matter when it falls back to the connected source's most-active repo.
     return logic.build_quarantine(team=team, repo=repo, source_id=source_id, user_access_control=user_access_control)
 
 

--- a/products/engineering_analytics/backend/facade/contracts.py
+++ b/products/engineering_analytics/backend/facade/contracts.py
@@ -1,24 +1,13 @@
 """Contract types for engineering_analytics.
 
-Framework-free frozen dataclasses that define the canonical data model this
-product exposes — Author, RepoRef, PullRequest, WorkflowRun — plus the
-``pr_lifecycle`` deep-tool return types. No Django imports.
+Framework-free frozen dataclasses defining the canonical data model this product exposes (Author,
+RepoRef, PullRequest, WorkflowRun) plus the ``pr_lifecycle`` deep-tool types. Every surface (MCP tools,
+DRF endpoints, UI) returns these; the curated HogQL runs privately behind them. Deep-tool caveats ride
+as a ``metric_quality`` field; aggregate endpoints carry theirs in honest field names.
 
-Every surface — the named MCP tools, the DRF read endpoints, and the UI — returns
-these typed contracts. The product runs its curated HogQL privately behind them;
-nothing is registered as a global view. Where a caveat is load-bearing on a deep
-tool it rides as a ``metric_quality`` field (``pr_lifecycle``); the aggregate
-endpoints carry their caveats in honest field names (``open_to_merge_seconds``)
-and serializer/tool docs.
-
-These use ``pydantic.dataclasses.dataclass`` rather than the stdlib variant: same
-``is_dataclass()`` compatibility (so ``DataclassSerializer`` keeps working) but
-with runtime validation on construction, so a mapper that hands back the wrong
-shape fails at the facade boundary instead of producing malformed JSON later.
-
-Provider-specific shapes (GitHub column names, nesting) never reach here — the
-read layer maps them into these types. Reviewers, deploys, and file paths are
-intentionally absent until the warehouse data that backs them lands.
+Uses ``pydantic.dataclasses.dataclass`` (not stdlib) for runtime validation on construction, so a
+mapper handing back the wrong shape fails at the facade boundary instead of emitting malformed JSON.
+Provider-specific shapes never reach here — the read layer maps them in.
 """
 
 from datetime import date, datetime
@@ -28,11 +17,9 @@ from pydantic.dataclasses import dataclass
 
 
 class GitHubSourceNotConnectedError(Exception):
-    """Raised when a team has no GitHub warehouse source — the curated queries
-    reference ``github_*`` tables that aren't in the catalog. Surfaces as a clear
-    4xx so the UI prompts to connect a source and an agent gets an actionable
-    error instead of a misleading empty result. Framework-free; the presentation
-    layer translates it to an HTTP response.
+    """Raised when a team has no GitHub warehouse source. Surfaces as a 4xx so the UI prompts to
+    connect a source rather than returning a misleading empty result. Framework-free; the presentation
+    layer maps it to an HTTP response.
     """
 
     DEFAULT_MESSAGE = "Connect a GitHub data warehouse source to use engineering analytics."
@@ -68,15 +55,14 @@ class WorkflowConclusion(StrEnum):
 
 
 class MetricQuality(StrEnum):
-    """How much to trust a metric, surfaced on a deep-tool return so an
-    autonomous caller can act on the result without paraphrasing a caveat.
+    """How much to trust a metric, surfaced on a deep-tool return so an autonomous caller can act
+    without paraphrasing a caveat.
 
-    - ``precise``: computed directly from the data, no known approximation.
-    - ``coarse``: a usable approximation with a known systematic gap (e.g. the
-      read layer's ``open_to_merge_seconds`` combines draft and ready-for-review
-      time).
-    - ``partial``: real but incomplete, because backing data hasn't landed yet
-      (e.g. ``pr_lifecycle`` has no review/comment events).
+    - ``precise``: computed directly, no known approximation.
+    - ``coarse``: usable approximation with a known systematic gap (e.g. ``open_to_merge_seconds``
+      fuses draft and ready-for-review time).
+    - ``partial``: real but incomplete because backing data hasn't landed (e.g. ``pr_lifecycle`` has
+      no review/comment events).
     """
 
     PRECISE = "precise"
@@ -131,9 +117,8 @@ class QuarantineRequestAction(StrEnum):
 
 @dataclass(frozen=True)
 class GitHubSource:
-    """A connected GitHub warehouse source the team can analyze. ``id`` is what a
-    caller passes back as ``source_id`` to select this source; ``repo`` and
-    ``prefix`` are display labels so a picker can tell two sources apart.
+    """A connected GitHub warehouse source. ``id`` is passed back as ``source_id`` to select it;
+    ``repo`` and ``prefix`` are display labels so a picker can tell two sources apart.
     """
 
     id: str
@@ -177,12 +162,11 @@ class WorkflowRun:
     id: int
     workflow_name: str
     head_sha: str
-    # None while a run is still in progress — it has no conclusion yet.
+    # None while a run is still in progress.
     conclusion: WorkflowConclusion | None
     run_started_at: datetime
     updated_at: datetime
-    # None until the run completes — the curated builder only computes a duration
-    # for completed runs (see workflow_runs.build_query).
+    # None until the run completes (duration is only computed for completed runs).
     duration_seconds: int | None
 
 
@@ -200,12 +184,11 @@ class WorkflowRunDetail:
     head_branch: str
     # Raw run status: 'queued', 'in_progress', 'completed', ... (passthrough).
     status: str
-    # Raw conclusion passthrough ('success' / 'failure' / 'timed_out' / 'cancelled' / 'skipped' /
-    # 'action_required' / ...), or None while still in progress. Kept as a str (not WorkflowConclusion)
-    # because the data carries conclusions outside that enum.
+    # Raw conclusion passthrough ('success' / 'failure' / 'timed_out' / ...), or None while in progress.
+    # A str not WorkflowConclusion because the data carries conclusions outside that enum.
     conclusion: str | None
-    # None for a queued/barely-started run whose timestamp the warehouse hasn't landed yet — the curated
-    # builder parses these with the OrNull variant, so a sparse row maps to None rather than failing.
+    # None for a queued/barely-started run whose timestamp hasn't landed; the OrNull parse maps a sparse
+    # row to None rather than failing.
     run_started_at: datetime | None
     updated_at: datetime | None
     # None until the run completes — duration is only computed for completed runs.
@@ -287,13 +270,11 @@ class RunCost:
 class PRCostSummary:
     """Estimated CI spend for one PR, summed over the jobs of all its workflow runs.
 
-    Billable runners only: provider-hosted runners (free GitHub-hosted minutes) and non-Linux tiers
-    carry no honest figure and are counted in ``excluded_jobs`` rather than mis-costed. The dollar
-    figure comes from the (currently Depot-shaped) cost model in ``logic.cost``; the contract stays
-    provider-neutral so other CI providers can slot in. ``jobs_available`` is False when the optional
-    job-level source (``github_workflow_jobs``) isn't synced — every figure is then zero/None and the
-    UI hides the cost cards. ``estimated_cost_usd`` is None when nothing was costable, so a PR with
-    only unsettled jobs reads as "no figure yet", not ``$0.00``.
+    Billable runners only: provider-hosted (free GitHub-hosted) and non-Linux tiers carry no honest
+    figure and land in ``excluded_jobs`` rather than mis-costed. ``jobs_available`` is False when the
+    optional job-level source isn't synced (every figure then zero/None, UI hides the cost cards).
+    ``estimated_cost_usd`` is None when nothing was costable, so a PR with only unsettled jobs reads as
+    "no figure yet", not ``$0.00``.
     """
 
     jobs_available: bool
@@ -333,9 +314,8 @@ class PRLifecycle:
 
 @dataclass(frozen=True)
 class CIStatusRollup:
-    """A PR's CI, collapsed from the latest workflow run per workflow on its head
-    SHA. Counts can lag until the ``workflow_run`` webhook settles a run that
-    completes after newer runs land (SPEC §9) — treat ``pending`` as unsettled.
+    """A PR's CI, collapsed from the latest run per workflow on its head SHA. Counts can lag until the
+    ``workflow_run`` webhook settles a late-completing run (SPEC §9) — treat ``pending`` as unsettled.
     """
 
     runs: int
@@ -376,11 +356,9 @@ class PullRequestListItem:
 
 @dataclass(frozen=True)
 class PullRequestList:
-    """A page of the PR list plus an explicit truncation signal. ``items`` is capped
-    at ``limit`` (newest first); ``truncated`` is True when more pull requests match
-    than the cap. Surfaced so a consumer never mistakes a capped page for the whole
-    set — the aggregate counts in ``CICardSummary`` can legitimately exceed
-    ``len(items)`` when ``truncated`` is True.
+    """A page of the PR list plus a truncation signal. ``items`` is capped at ``limit`` (newest first);
+    ``truncated`` is True when more match than the cap, so a consumer never mistakes a capped page for
+    the whole set — ``CICardSummary`` counts can legitimately exceed ``len(items)``.
     """
 
     items: list[PullRequestListItem]
@@ -404,11 +382,9 @@ class CICardSummary:
 
 @dataclass(frozen=True)
 class WorkflowHealthBucket:
-    """One time bucket of a workflow's run history; empty buckets are zero-filled. The
-    bucket width (hour / day / week) is set per item in ``WorkflowHealthItem.granularity``
-    to fit the window. ``failures`` is decisive failures only (failure / timed_out),
-    matching the CI rollup — skipped, cancelled, and action_required runs are neither
-    successes nor failures, so they must not be treated as non-passing.
+    """One time bucket of a workflow's run history; empty buckets are zero-filled. Bucket width
+    (hour / day / week) is set per item in ``WorkflowHealthItem.granularity``. ``failures`` is decisive
+    failures only (failure / timed_out) — skipped/cancelled/action_required are neither pass nor fail.
     """
 
     # Bucket start, aligned to the granularity (top of hour / midnight / Monday).
@@ -503,14 +479,12 @@ class WorkflowHealthItem:
     p50_seconds: float | None
     p95_seconds: float | None
     last_failure_at: datetime | None
-    # Whether the most recent completed run was a decisive failure (failure / timed_out).
-    # None when nothing has completed in the window. Drives the OK/RED status badge — a
-    # bool, not the raw conclusion, because the data carries conclusions outside
-    # WorkflowConclusion (e.g. action_required) that would fail validation here.
+    # Whether the most recent completed run was a decisive failure (failure / timed_out); None when
+    # nothing completed. Drives the OK/RED badge. A bool not the raw conclusion because the data carries
+    # conclusions outside WorkflowConclusion (e.g. action_required) that would fail validation.
     latest_run_failed: bool | None
-    # Raw conclusion of that most recent completed run ('success' / 'cancelled' / 'skipped' / ...), so the
-    # UI can tell a real pass from a cancelled/skipped run (both have latest_run_failed false). None when
-    # nothing has completed. A str, not WorkflowConclusion, because the data carries values outside the enum.
+    # Raw conclusion of that run ('success' / 'cancelled' / 'skipped' / ...), so the UI can tell a real
+    # pass from a cancelled/skipped run (both have latest_run_failed false). None when nothing completed.
     latest_run_conclusion: str | None
     # Bucket width of the history series, chosen to fit the window: 'hour', 'day', or 'week'.
     granularity: str

--- a/products/engineering_analytics/backend/facade/temporal.py
+++ b/products/engineering_analytics/backend/facade/temporal.py
@@ -1,9 +1,7 @@
-"""Temporal wiring exposed across the product boundary.
+"""Temporal wiring exposed across the product boundary — the only import surface core may use.
 
-Core registers these on the general-purpose worker and the schedule registry — see
-``posthog/management/commands/start_temporal_worker.py`` and ``posthog/temporal/schedule.py``. The
-internals live under ``backend/logic/job_logs/`` (isolated); this facade is the only import surface
-core may use.
+Core registers these on the general-purpose worker and the schedule registry. Internals live under
+``backend/logic/job_logs/``.
 """
 
 from products.engineering_analytics.backend.logic.job_logs.schedule import create_github_job_logs_coordinator_schedule

--- a/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
+++ b/products/engineering_analytics/backend/management/commands/seed_engineering_analytics.py
@@ -1,22 +1,16 @@
 """Seed the engineering analytics warehouse tables from the checked-in GitHub fixture.
 
-Loads ``products/engineering_analytics/fixtures/github_pull_requests.json`` and
-``github_workflow_runs.json`` (a real PostHog/posthog snapshot captured with
-``fixtures/fetch.py``) into the team's data warehouse behind a connected GitHub
-source, exactly as a real sync would: a GitHub ``ExternalDataSource`` with a
-``--prefix``, plus ``pull_requests`` / ``workflow_runs`` ``ExternalDataSchema`` rows
-pointing at the materialized ``<prefix>github_pull_requests`` /
-``<prefix>github_workflow_runs`` tables. The product resolves those names per team
-(``logic.sources``), so seeding under a non-default prefix exercises the resolver
-rather than the old hardcoded ``github_*`` names.
+Loads ``github_pull_requests.json`` / ``github_workflow_runs.json`` (a real PostHog/posthog snapshot
+captured with ``fixtures/fetch.py``) into the team's data warehouse behind a connected GitHub source,
+exactly as a real sync would: a GitHub ``ExternalDataSource`` with a ``--prefix`` plus
+``ExternalDataSchema`` rows pointing at the materialized ``<prefix>github_*`` tables. The product
+resolves those names per team (``logic.sources``), so seeding under a non-default prefix exercises the
+resolver rather than the old hardcoded ``github_*`` names.
 
-Timestamps are rebased so the newest fixture row lands at "now" — the queries
-window on server-side now(), so an unshifted old snapshot would render empty.
-Pass --keep-dates for the faithful snapshot instead.
-
-Re-running replaces this seed source's tables, but a table owned by a different
-(real) connected source is never touched. Local/dev only: requires the dev object
-storage and ClickHouse from the hogli stack.
+Timestamps are rebased so the newest fixture row lands at "now" (the queries window on server-side
+now(), so an unshifted old snapshot renders empty); pass --keep-dates for the faithful snapshot.
+Re-running replaces this seed source's tables but never touches a table owned by a real source.
+Local/dev only: requires the dev object storage and ClickHouse from the hogli stack.
 
 Usage:
     python manage.py seed_engineering_analytics --team-id 1
@@ -66,8 +60,8 @@ RUN_DATE_FIELDS = ("created_at", "run_started_at", "updated_at")
 
 # Marks the GitHub source this command owns, so re-seeding never clobbers a real source.
 SEED_SOURCE_ID = "engineering_analytics_seed"
-# Default prefix is non-trivial on purpose: it proves the product resolves the real
-# per-team table name rather than assuming the bare ``github_*`` names.
+# Non-trivial default prefix on purpose: proves the product resolves the real per-team table name
+# rather than assuming the bare ``github_*`` names.
 DEFAULT_PREFIX = "eng_analytics_seed"
 
 
@@ -241,8 +235,8 @@ def _demo_multi_push(
 
 
 def _warehouse_endpoint() -> str:
-    # ClickHouse runs in docker, so a localhost object-storage endpoint must be
-    # rewritten to the docker host (same approach as the demo data generator).
+    # ClickHouse runs in docker, so a localhost object-storage endpoint must be rewritten to the docker
+    # host (same approach as the demo data generator).
     endpoint = settings.OBJECT_STORAGE_ENDPOINT.rstrip("/")
     parsed = urlparse(endpoint)
     if parsed.hostname not in {"localhost", "127.0.0.1"}:

--- a/products/engineering_analytics/backend/presentation/serializers.py
+++ b/products/engineering_analytics/backend/presentation/serializers.py
@@ -1,10 +1,8 @@
 """DRF serializers for engineering_analytics.
 
-Output-only serializers that turn the facade's frozen dataclasses into JSON via
-``DataclassSerializer``. Field types are auto-derived from the contract types;
-``help_text`` is added through ``Meta.extra_kwargs`` so it flows downstream into
-the OpenAPI spec, generated TypeScript types, and the ``pr_lifecycle`` MCP tool
-schema.
+Output-only serializers turning the facade's frozen dataclasses into JSON via ``DataclassSerializer``.
+Field types are auto-derived from the contracts; ``help_text`` (via ``Meta.extra_kwargs``) flows into
+the OpenAPI spec, generated TypeScript types, and the ``pr_lifecycle`` MCP tool schema.
 """
 
 from rest_framework_dataclasses.serializers import DataclassSerializer

--- a/products/engineering_analytics/backend/presentation/views.py
+++ b/products/engineering_analytics/backend/presentation/views.py
@@ -1,8 +1,7 @@
 """DRF views for engineering_analytics.
 
-Named, typed read endpoints over the curated PR/CI query builders. Each action
-runs curated HogQL privately (no global view registration) and returns a typed
-contract. These same endpoints back both the MCP tools and the UI:
+Named, typed read endpoints over the curated PR/CI query builders. Each action runs curated HogQL
+privately and returns a typed contract; these endpoints back both the MCP tools and the UI:
 
 - ``ci_cards`` — backlog headline counts.
 - ``pull_requests`` — PR list with head-SHA CI rollup.
@@ -52,8 +51,8 @@ _DATE_FROM = OpenApiParameter(
     description="Window start: relative ('-30d', '-8w') or ISO8601. Defaults to -30d.",
 )
 
-# Workflow health defaults to a tighter window than the PR list (a CI-health "now" view), so it
-# advertises its own default rather than reusing _DATE_FROM's -30d.
+# Workflow health uses a tighter default than the PR list (a CI-health "now" view), so it advertises
+# its own default rather than reusing _DATE_FROM's -30d.
 _WORKFLOW_DATE_FROM = OpenApiParameter(
     name="date_from",
     type=OpenApiTypes.STR,

--- a/products/engineering_analytics/fixtures/fetch.py
+++ b/products/engineering_analytics/fixtures/fetch.py
@@ -1,16 +1,13 @@
 #!/usr/bin/env python3
 """Snapshot a bounded subset of a GitHub repo into the engineering analytics fixture.
 
-Fetches recent pull requests and workflow runs via the `gh` CLI (uses your
-existing `gh auth` token) and writes them, trimmed to the fields the curated
-warehouse views read, to JSON files next to this script:
+Fetches recent pull requests and workflow runs via the `gh` CLI (uses your existing `gh auth` token),
+trimmed to the fields the curated warehouse views read, into JSON files next to this script:
 
 - github_pull_requests.json
 - github_workflow_runs.json
 
-Load the result into a local PostHog stack with:
-
-    python manage.py seed_engineering_analytics --team-id <id>
+Load into a local PostHog stack with ``python manage.py seed_engineering_analytics --team-id <id>``.
 
 Usage:
     python products/engineering_analytics/fixtures/fetch.py
@@ -103,8 +100,8 @@ def fetch_window_runs(repo: str, cutoff: datetime, max_runs: int) -> list[dict[s
 
 
 def fetch_head_sha_runs(repo: str, prs: list[dict[str, Any]], max_lookups: int) -> list[dict[str, Any]]:
-    # The PR list joins CI status by head SHA, so open PRs need their head runs
-    # even when those fall outside the windowed fetch.
+    # The PR list joins CI status by head SHA, so open PRs need their head runs even when those fall
+    # outside the windowed fetch.
     runs: list[dict[str, Any]] = []
     open_shas = [pr["head"]["sha"] for pr in prs if pr["state"] == "open"][:max_lookups]
     for index, sha in enumerate(open_shas, start=1):


### PR DESCRIPTION
## Problem

Part of splitting the engineering-analytics UX work into stamphog-sized PRs (each ≤ 500 changed lines and ≤ 20 files, so auto-review doesn't bounce them as "too large"). Stacked manually on `rauln/eng-analytics-6-be-logic`.

## Changes

Comment/docstring-only cleanup of the backend facade, presentation (serializers/views), management command, and fixtures. Left `help_text=`/`@extend_schema` args untouched, so no OpenAPI/generated-types drift.

## How did you test this code?

I'm an agent (Claude Code). The full change was verified live in the running app (renamed scene, green/grey/purple GitHub state tags, title→detail link with GitHub moved to the `#id` ref) before splitting; this PR is one slice mechanically carved from that verified tree, so it's byte-identical to the reviewed whole. CI covers lint/typecheck/tests. No new automated tests — the change is presentational/comment-only.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @rnegron. One slice of a 7-PR stack reorganizing the engineering-analytics product; base branch `rauln/eng-analytics-6-be-logic`.
---
### 📚 Stack (review bottom-up; each ≤ 500 lines / 20 files for stamphog)
1. [rename → Engineering analytics](https://github.com/PostHog/posthog/pull/67102)
2. [GitHub-colored PR state + cleaner rows](https://github.com/PostHog/posthog/pull/67103)
3. [trim comments — components](https://github.com/PostHog/posthog/pull/67104)
4. [trim comments — scenes/lib](https://github.com/PostHog/posthog/pull/67105)
5. [trim comments — queries](https://github.com/PostHog/posthog/pull/67106)
6. [trim comments — logic](https://github.com/PostHog/posthog/pull/67107)
7. [trim comments — facade/presentation](https://github.com/PostHog/posthog/pull/67108)

Supersedes the combined [PR #66877](https://github.com/PostHog/posthog/pull/66877) (kept open until these are verified).