### PR TITLE
fix(data-warehouse): open add-source in new tab via Link not newInternalTab

### DIFF
--- a/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
+++ b/frontend/src/scenes/data-warehouse/editor/sidebar/QueryDatabase.tsx
@@ -972,18 +972,21 @@ export const QueryDatabase = ({
                                     </DropdownMenuSubContent>
                                 </DropdownMenuSub>
                             ) : null}
-                            <DropdownMenuItem
-                                asChild
-                                onClick={(e) => {
-                                    e.stopPropagation()
-                                    posthog.capture('sql-editor-add-source-clicked', {
-                                        source_type: sourceType,
-                                        location: 'source_type_row',
-                                    })
-                                    newInternalTab(urls.dataWarehouseSourceNew(sourceType))
-                                }}
-                            >
-                                <ButtonPrimitive menuItem>Add new source of this type</ButtonPrimitive>
+                            <DropdownMenuItem asChild>
+                                <Link
+                                    to={urls.dataWarehouseSourceNew(sourceType)}
+                                    target="_blank"
+                                    buttonProps={{ menuItem: true }}
+                                    onClick={(e) => {
+                                        e.stopPropagation()
+                                        posthog.capture('sql-editor-add-source-clicked', {
+                                            source_type: sourceType,
+                                            location: 'source_type_row',
+                                        })
+                                    }}
+                                >
+                                    Add new source of this type
+                                </Link>
                             </DropdownMenuItem>
                         </DropdownMenuGroup>
                     )


### PR DESCRIPTION
## Problem

In the SQL editor's source-type actions menu, the "Edit source" items already use a `<Link target="_blank">`, but the sibling "Add new source of this type" item still routed through `newInternalTab`. Follow-up to the source-menu work — the in-editor "internal tab" concept is gone, so `newInternalTab` is the wrong tool here.

## Changes

Convert "Add new source of this type" to a `<Link target="_blank">`, matching the adjacent edit items. The `sql-editor-add-source-clicked` analytics capture stays in the link's `onClick`.

Scope is just this one menu item. The other `newInternalTab` calls in the file (sources-header `+`, row click, models/endpoints links) are pre-existing and out of scope.

## How did you test this code?

I'm an agent (Claude Code). No manual UI testing. Formatted via lint-staged on commit. Pure JSX swap of one menu item from an `onClick`-driven `newInternalTab` to a `<Link target="_blank">` — same destination URL and same analytics event. No tests added; this is a one-line navigation-mechanism swap with no new logic to regress.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: Claude Code (Opus 4.8). Directed by Daniel.
- Follow-up to the merged source-menu PR after a reviewer noted the editor no longer has internal tabs. Chose `<Link target="_blank">` over `router.push` to keep parity with the edit-source items in the same menu (open in a new browser tab).
