### PR TITLE
feat(admin): add password reset email functionality to user admin

### DIFF
--- a/posthog/admin/admins/user_admin.py
+++ b/posthog/admin/admins/user_admin.py
@@ -22,7 +22,7 @@ from posthog.api.two_factor_reset import TwoFactorResetVerifier
 from posthog.models import User
 from posthog.models.webauthn_credential import WebauthnCredential
 from posthog.session.activity import revoke_other_sessions
-from posthog.tasks.email import send_two_factor_reset_email
+from posthog.tasks.email import send_password_reset, send_two_factor_reset_email
 
 
 class UserChangeForm(DjangoUserChangeForm):
@@ -220,6 +220,27 @@ class UserAdmin(DjangoUserAdmin):
             # Redirect back to the change form
             return HttpResponseRedirect(reverse("admin:posthog_user_change", args=[object_id]))
 
+        if request.POST.get("send_password_reset") == "1":
+            try:
+                if user:
+                    # Persist the timestamp before generating the token — it's folded into the token
+                    # hash (PasswordResetTokenGenerator._make_hash_value), so saving must come first.
+                    user.requested_password_reset_at = datetime.datetime.now(datetime.UTC)
+                    user.save(update_fields=["requested_password_reset_at"])
+
+                    token = password_reset_token_generator.make_token(user)
+                    send_password_reset.delay(user.pk, token)
+
+                    self.log_change(request, user, "Sent password reset email.")
+                    messages.success(request, f"Password reset email sent to {user.email}")
+                else:
+                    messages.warning(request, "User not found.")
+            except Exception as e:
+                messages.error(request, f"Failed to send password reset email: {str(e)}")
+
+            # Redirect back to the change form
+            return HttpResponseRedirect(reverse("admin:posthog_user_change", args=[object_id]))
+
         if request.POST.get("send_2fa_reset") == "1":
             try:
                 if user:
@@ -252,6 +273,16 @@ class UserAdmin(DjangoUserAdmin):
             return HttpResponseRedirect(reverse("admin:posthog_user_change", args=[object_id]))
 
         return super().change_view(request, object_id, form_url, extra_context)
+
+    def user_change_password(self, request, id, form_url=""):
+        # We don't let admins set passwords directly (change_password_form is None), but Django's
+        # inherited get_urls() still registers this route — which would 500 on NoneType form.
+        # Redirect to the change page where the "email them a reset link" button lives instead.
+        messages.info(
+            request,
+            'Admins can\'t set passwords directly. Use the "Reset password" button on the user page to email the user a reset link.',
+        )
+        return HttpResponseRedirect(reverse("admin:posthog_user_change", args=[id]))
 
     def delete_user_sessions(self, user):
         return revoke_other_sessions(user, keep_session_key=None)

--- a/posthog/admin/test_user_admin.py
+++ b/posthog/admin/test_user_admin.py
@@ -2,10 +2,14 @@ import uuid
 from importlib import import_module
 
 from posthog.test.base import BaseTest
+from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.admin.sites import AdminSite
 from django.contrib.auth import SESSION_KEY
+from django.contrib.messages.storage.fallback import FallbackStorage
+from django.test import RequestFactory
+from django.urls import reverse
 
 from posthog.admin.admins.user_admin import UserAdmin
 from posthog.models import User
@@ -38,3 +42,42 @@ class TestUserAdminSessions(BaseTest):
         self.assertEqual(count, 2)
         self.assertFalse(Session.objects.filter(session_key__in=keys).exists())
         self.assertTrue(Session.objects.filter(session_key=other_key).exists())  # other user untouched
+
+
+class TestUserAdminPasswordReset(BaseTest):
+    def setUp(self):
+        super().setUp()
+        self.admin = UserAdmin(User, AdminSite())
+
+    def _make_user(self) -> User:
+        return User.objects.create(email=f"test-{uuid.uuid4()}@example.com", distinct_id=str(uuid.uuid4()))
+
+    def _request(self, method: str = "post", data: dict | None = None):
+        request = getattr(RequestFactory(), method)("/", data or {})
+        request.user = self.user
+        request.session = {}
+        request._messages = FallbackStorage(request)
+        return request
+
+    def test_user_change_password_redirects_instead_of_erroring(self):
+        # Guards the reported 500: change_password_form is None, so without this override Django's
+        # inherited password view crashes with TypeError instead of redirecting to the change page.
+        user = self._make_user()
+
+        response = self.admin.user_change_password(self._request(method="get"), user.pk)
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.url, reverse("admin:posthog_user_change", args=[user.pk]))
+
+    @patch("posthog.admin.admins.user_admin.send_password_reset")
+    def test_send_password_reset_sets_timestamp_and_dispatches_email(self, mock_send_password_reset):
+        user = self._make_user()
+        self.assertIsNone(user.requested_password_reset_at)
+
+        response = self.admin.change_view(self._request(data={"send_password_reset": "1"}), str(user.pk))
+
+        self.assertEqual(response.status_code, 302)
+        user.refresh_from_db()
+        self.assertIsNotNone(user.requested_password_reset_at)
+        mock_send_password_reset.delay.assert_called_once()
+        self.assertEqual(mock_send_password_reset.delay.call_args.args[0], user.pk)

--- a/posthog/admin/test_user_admin.py
+++ b/posthog/admin/test_user_admin.py
@@ -80,4 +80,8 @@ class TestUserAdminPasswordReset(BaseTest):
         user.refresh_from_db()
         self.assertIsNotNone(user.requested_password_reset_at)
         mock_send_password_reset.delay.assert_called_once()
-        self.assertEqual(mock_send_password_reset.delay.call_args.args[0], user.pk)
+        user_pk, token = mock_send_password_reset.delay.call_args.args[:2]
+        self.assertEqual(user_pk, user.pk)
+        # A usable reset token must be forwarded — an empty/None token would email a dead link.
+        self.assertIsInstance(token, str)
+        self.assertTrue(token)

--- a/posthog/templates/admin/posthog/user/change_form.html
+++ b/posthog/templates/admin/posthog/user/change_form.html
@@ -38,6 +38,15 @@
                 document.getElementById("send_2fa_reset").submit();
         });
 
+        // Django's ReadOnlyPasswordHashWidget renders a native "Reset password" button linking to
+        // ../password/ (which we don't support). Repurpose it to email the user a reset link instead.
+        document.querySelector(".field-password a.button")?.addEventListener("click", (event) => {
+            // prevent anchor tag from navigating to ../password/
+            event.preventDefault();
+            if (window.confirm("Send password reset email? This will let the user set a new password."))
+                document.getElementById("send_password_reset").submit();
+        });
+
         // Add read-only toggle to loginas modal
         const reasonField = document.getElementById("loginas-reason");
         if (reasonField) {
@@ -90,6 +99,11 @@
     <form method="POST" id="send_2fa_reset">
         {% csrf_token %}
         <input type="hidden" name="send_2fa_reset" value="1" />
+    </form>
+
+    <form method="POST" id="send_password_reset">
+        {% csrf_token %}
+        <input type="hidden" name="send_password_reset" value="1" />
     </form>
 
 {% endblock %}


### PR DESCRIPTION
## Problem
Admin users attempting to reset passwords through the Django admin interface were encountering errors. The admin interface had a "Reset password" button inherited from Django's default user admin, but PostHog's implementation didn't support direct password changes by admins—it should instead email users a reset link.

## Changes
- **Import new email task**: Add `send_password_reset` to imports from `posthog.tasks.email`
- **Add password reset handler**: New logic in `UserAdmin.change_view()` that:
  - Sets `requested_password_reset_at` timestamp on the user (required for token generation)
  - Generates a password reset token
  - Dispatches `send_password_reset` email task asynchronously
  - Logs the action and shows success message
- **Override password change route**: Add `user_change_password()` method to intercept Django's inherited `/change/<id>/password/` route and redirect to the user change page with an informational message
- **Update admin template**: Repurpose Django's native "Reset password" button to submit a hidden form that triggers the email flow instead of navigating to the unsupported password change route
- **Add tests**: Two new test cases verify:
  - The password change route redirects without error
  - Password reset email flow sets the timestamp and dispatches the task

## How did you test this code?
manually + new tests

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*