### PR TITLE
fix: polish notification cards and web analytics digest

### DIFF
--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -742,6 +742,14 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             },
         ],
         hasUnread: [(s) => [s.unreadCount], (unreadCount) => unreadCount > 0],
+        // Unread among the rows actually loaded into the panel. The panel's "Mark all as read"
+        // button and Unread tab key off this — not `inAppUnreadCount`, a separately-fetched server
+        // total that's hand-patched at several call sites — so they can never drift from the
+        // visible rows. `inAppUnreadCount` stays the source for the global bell badge.
+        loadedUnreadCount: [
+            (s) => [s.inAppNotifications],
+            (inAppNotifications): number => inAppNotifications.filter((n) => !n.read).length,
+        ],
         projectNameForNotification: [
             (s) => [s.currentTeamId, s.currentOrganization],
             (currentTeamId, currentOrganization) => {

--- a/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
+++ b/frontend/src/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic.tsx
@@ -22,13 +22,7 @@ import { urls } from 'scenes/urls'
 
 import { connectToNotificationsSSE } from '~/layout/navigation-3000/sidepanel/panels/activity/notificationsSSE'
 import { ChangesResponse } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelActivityLogic'
-import {
-    InAppNotification,
-    InsightShortId,
-    ResourceEditedEvent,
-    SidePanelTab,
-    WebAnalyticsDigestMetadata,
-} from '~/types'
+import { InAppNotification, InsightShortId, ResourceEditedEvent } from '~/types'
 
 import {
     notificationsList,
@@ -45,7 +39,6 @@ import {
 import { RESOURCE_EDITED_EVENT_TYPE, resourceEditedLogic } from 'products/notifications/frontend/resourceEditedLogic'
 
 import { sidePanelContextLogic } from '../../sidePanelContextLogic'
-import { sidePanelStateLogic } from '../../sidePanelStateLogic'
 import type { sidePanelNotificationsLogicType } from './sidePanelNotificationsLogicType'
 
 const LEGACY_POLL_TIMEOUT = 5 * 60 * 1000
@@ -97,21 +90,6 @@ export function buildNotificationSourcePath(notification: InAppNotification): st
     return notification.source_url || null
 }
 
-export function buildWebAnalyticsDigestMaxPrompt(metadata: WebAnalyticsDigestMetadata | null): string {
-    if (!metadata) {
-        return '!Summarize my web analytics for the last 7 days and tell me what changed and why.'
-    }
-    const metricsLine = metadata.metrics
-        .map((metric) => {
-            const change = metric.change
-                ? ` (${metric.change.direction === 'Up' ? 'up' : 'down'} ${metric.change.percent}%)`
-                : ''
-            return `${metric.label} ${metric.value}${change}`
-        })
-        .join(', ')
-    return `!Here's my web analytics digest for ${metadata.period_label.toLowerCase()} on ${metadata.project_name}: ${metricsLine}. What are the most important changes, and what should I dig into?`
-}
-
 // When the recap experience is enabled, send digest clicks to the recap page instead of the raw
 // dashboard. The digest's source_url is `/project/{id}/web?...`; only the `/web` segment is rewritten.
 export function withRecapSourceUrl(notification: InAppNotification): InAppNotification {
@@ -143,14 +121,7 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             organizationLogic,
             ['currentOrganization'],
         ],
-        actions: [
-            sidePanelStateLogic,
-            ['openSidePanel'],
-            teamLogic,
-            ['loadCurrentTeamSuccess'],
-            resourceEditedLogic,
-            ['resourceEdited'],
-        ],
+        actions: [teamLogic, ['loadCurrentTeamSuccess'], resourceEditedLogic, ['resourceEdited']],
     })),
     actions({
         togglePolling: (pageIsVisible: boolean) => ({ pageIsVisible }),
@@ -171,8 +142,6 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
         markAsRead: (id: string) => ({ id }),
         toggleRead: (id: string) => ({ id }),
         navigateToNotification: (notification: InAppNotification) => ({ notification }),
-        viewWebAnalyticsFromDigest: (notification: InAppNotification) => ({ notification }),
-        askMaxAboutDigest: (notification: InAppNotification) => ({ notification }),
         loadMoreNotifications: true,
         loadMoreNotificationsSuccess: (count: number) => ({ count }),
         loadGroupChildren: (group: NotificationGroup) => ({ group }),
@@ -608,26 +577,6 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                     },
                 })
             },
-            viewWebAnalyticsFromDigest: ({ notification }) => {
-                const recapEnabled = !!values.featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_RECAP]
-                posthog.capture('web_analytics_digest_notification_clicked', {
-                    cta: recapEnabled ? 'view_recap' : 'view_web_analytics',
-                    notification_id: notification.id,
-                    team_id: notification.team_id,
-                })
-                actions.navigateToNotification(recapEnabled ? withRecapSourceUrl(notification) : notification)
-            },
-            askMaxAboutDigest: ({ notification }) => {
-                posthog.capture('web_analytics_digest_notification_clicked', {
-                    cta: 'ask_max',
-                    notification_id: notification.id,
-                    team_id: notification.team_id,
-                })
-                if (!notification.read) {
-                    actions.markAsRead(notification.id)
-                }
-                actions.openSidePanel(SidePanelTab.Max, buildWebAnalyticsDigestMaxPrompt(notification.metadata))
-            },
             markAsRead: async ({ id }) => {
                 try {
                     await notificationsMarkReadCreate((values.currentProjectId ?? '').toString(), id)
@@ -642,6 +591,8 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
                 if (!notification) {
                     return
                 }
+                // Keep the unread count (gates the badge + "Mark all as read") in sync with the toggle
+                actions.setInAppUnreadCount(Math.max(0, values.inAppUnreadCount + (notification.read ? -1 : 1)))
                 const projectId = (values.currentProjectId ?? '').toString()
                 try {
                     if (notification.read) {
@@ -803,10 +754,17 @@ export const sidePanelNotificationsLogic = kea<sidePanelNotificationsLogicType>(
             },
         ],
         sourcePathForNotification: [
-            () => [],
-            () =>
-                (notification: InAppNotification): string | null =>
-                    buildNotificationSourcePath(notification),
+            (s) => [s.featureFlags],
+            (featureFlags) =>
+                (notification: InAppNotification): string | null => {
+                    // When the recap flag is on, the digest links to the recap page instead of the raw dashboard
+                    const recapEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_RECAP]
+                    const target =
+                        recapEnabled && notification.notification_type === 'web_analytics_digest'
+                            ? withRecapSourceUrl(notification)
+                            : notification
+                    return buildNotificationSourcePath(target)
+                },
         ],
         groups: [
             (s) => [s.inAppNotifications, s.loadedGroupKeys],

--- a/frontend/src/lib/components/NotificationsMenu/NotificationGroupRow.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationGroupRow.tsx
@@ -1,17 +1,46 @@
 import { useActions, useValues } from 'kea'
 
-import { IconCheckCircle, IconChevronRight } from '@posthog/icons'
-import { Tooltip } from '@posthog/lemon-ui'
+import { IconChevronRight } from '@posthog/icons'
 
-import { NotificationRow } from 'lib/components/NotificationsMenu/NotificationRow'
-import { getNotificationIcon } from 'lib/components/NotificationsMenu/notificationToasts'
+import {
+    NotificationReadToggle,
+    NotificationRow,
+    NotificationTitle,
+} from 'lib/components/NotificationsMenu/NotificationRow'
 import { dayjs } from 'lib/dayjs'
-import { IconRadioButtonUnchecked } from 'lib/lemon-ui/icons'
 
 import {
     NotificationGroup,
     sidePanelNotificationsLogic,
 } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
+
+function NotificationGroupControls({
+    count,
+    allRead,
+    expanded,
+    onToggleRead,
+    onToggleExpand,
+}: {
+    count: number
+    allRead: boolean
+    expanded: boolean
+    onToggleRead: (e: React.MouseEvent) => void
+    onToggleExpand: (e: React.MouseEvent) => void
+}): JSX.Element {
+    return (
+        <div className="shrink-0 flex items-center gap-1">
+            <span className="text-[10px] text-muted bg-fill-highlight-100 px-1.5 py-px rounded">{count}</span>
+            <NotificationReadToggle read={allRead} onToggle={onToggleRead} target="group" />
+            <button
+                className="shrink-0 flex size-5 items-center justify-center rounded text-secondary hover:bg-fill-highlight-200 hover:text-primary"
+                onClick={onToggleExpand}
+                aria-label={expanded ? 'Collapse group' : 'Expand group'}
+            >
+                <IconChevronRight className={`size-4 transition-transform ${expanded ? 'rotate-90' : ''}`} />
+            </button>
+        </div>
+    )
+}
 
 export function NotificationGroupRow({
     group,
@@ -47,52 +76,30 @@ export function NotificationGroupRow({
     return (
         <div className="flex flex-col">
             <div
-                className={`flex items-start gap-2.5 p-2 rounded cursor-pointer transition-colors ${
+                className={`flex items-start gap-2 p-2 rounded cursor-pointer transition-colors ${
                     allRead ? 'hover:bg-fill-highlight-100' : 'bg-fill-highlight-50 hover:bg-fill-highlight-100'
                 }`}
                 onClick={handleExpand}
             >
-                <div className="shrink-0 mt-0.5">{getNotificationIcon(group.representative.notification_type)}</div>
                 <div className="flex-1 min-w-0">
-                    <div className="flex items-start justify-between gap-1">
-                        <span className="text-xs leading-snug font-semibold">{group.representative.title}</span>
-                        <div className="flex items-center gap-1 shrink-0">
-                            <span className="text-[10px] text-muted bg-fill-highlight-100 px-1.5 py-px rounded">
-                                {group.count}
-                            </span>
-                            <Tooltip title={allRead ? 'Mark group as unread' : 'Mark group as read'}>
-                                <button
-                                    className="group/read min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 cursor-pointer"
-                                    onClick={handleToggleRead}
-                                >
-                                    {allRead ? (
-                                        <IconCheckCircle className="size-4 text-success" />
-                                    ) : (
-                                        <>
-                                            <IconRadioButtonUnchecked className="size-4 text-muted opacity-40 group-hover/read:hidden" />
-                                            <IconCheckCircle className="size-4 text-muted opacity-60 hidden group-hover/read:block" />
-                                        </>
-                                    )}
-                                </button>
-                            </Tooltip>
-                            <button
-                                className="min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 text-secondary hover:text-primary"
-                                onClick={handleExpand}
-                                aria-label={isExpanded ? 'Collapse group' : 'Expand group'}
-                            >
-                                <IconChevronRight
-                                    className={`size-4 transition-transform ${isExpanded ? 'rotate-90' : ''}`}
-                                />
-                            </button>
-                        </div>
-                    </div>
+                    <NotificationTitle
+                        notificationType={group.representative.notification_type}
+                        title={group.representative.title}
+                    />
                     <div className="text-xs text-secondary mt-2 line-clamp-1">
                         {group.count} notifications · latest {dayjs(group.last_seen).fromNow()}
                     </div>
                 </div>
+                <NotificationGroupControls
+                    count={group.count}
+                    allRead={allRead}
+                    expanded={isExpanded}
+                    onToggleRead={handleToggleRead}
+                    onToggleExpand={handleExpand}
+                />
             </div>
             {isExpanded && (
-                <div className="pl-6 pr-1 flex flex-col gap-px border-l-2 border-fill-highlight-100 ml-3 my-1">
+                <div className="ml-3 pl-3 flex flex-col gap-1 border-l-2 border-fill-highlight-100 my-1">
                     {isLoading && !group.full_children_loaded && <div className="text-xs text-muted p-2">Loading…</div>}
                     {group.children.map((child) => (
                         <NotificationRow key={child.id} notification={child} onNavigate={onNavigate} />

--- a/frontend/src/lib/components/NotificationsMenu/NotificationGroupRow.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationGroupRow.tsx
@@ -55,9 +55,7 @@ export function NotificationGroupRow({
                 <div className="shrink-0 mt-0.5">{getNotificationIcon(group.representative.notification_type)}</div>
                 <div className="flex-1 min-w-0">
                     <div className="flex items-start justify-between gap-1">
-                        <span className={`text-xs leading-snug ${allRead ? 'text-secondary' : 'font-semibold'}`}>
-                            {group.representative.title}
-                        </span>
+                        <span className="text-xs leading-snug font-semibold">{group.representative.title}</span>
                         <div className="flex items-center gap-1 shrink-0">
                             <span className="text-[10px] text-muted bg-fill-highlight-100 px-1.5 py-px rounded">
                                 {group.count}
@@ -88,7 +86,7 @@ export function NotificationGroupRow({
                             </button>
                         </div>
                     </div>
-                    <div className="text-xs text-secondary mt-0.5 line-clamp-1">
+                    <div className="text-xs text-secondary mt-2 line-clamp-1">
                         {group.count} notifications · latest {dayjs(group.last_seen).fromNow()}
                     </div>
                 </div>

--- a/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
@@ -1,5 +1,4 @@
 import { useActions, useValues } from 'kea'
-import { useState } from 'react'
 
 import { IconCheckCircle } from '@posthog/icons'
 import { Tooltip } from '@posthog/lemon-ui'
@@ -8,7 +7,6 @@ import { getNotificationDescriber } from 'lib/components/NotificationsMenu/notif
 import { getNotificationIcon } from 'lib/components/NotificationsMenu/notificationToasts'
 import { dayjs } from 'lib/dayjs'
 import { IconRadioButtonUnchecked } from 'lib/lemon-ui/icons'
-import { IconOpenInNew } from 'lib/lemon-ui/icons'
 
 import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
 import { InAppNotification } from '~/types'
@@ -73,7 +71,6 @@ export function NotificationRow({
 }): JSX.Element {
     const { navigateToNotification, toggleRead } = useActions(sidePanelNotificationsLogic)
     const { projectNameForNotification, sourcePathForNotification } = useValues(sidePanelNotificationsLogic)
-    const [expanded, setExpanded] = useState(false)
 
     const otherProjectName = projectNameForNotification(notification)
     const describer = getNotificationDescriber(notification)
@@ -81,8 +78,11 @@ export function NotificationRow({
     const rich = !!describer?.takesOverRow && !!notification.metadata
 
     const hasNavigationTarget = !!sourcePathForNotification(notification)
-    const handleNavigate = (e: React.MouseEvent): void => {
-        e.stopPropagation()
+    const handleOpen = (): void => {
+        // Clicking the card marks it read and navigates to its source
+        if (!notification.read) {
+            toggleRead(notification.id)
+        }
         if (hasNavigationTarget) {
             navigateToNotification(notification)
             onNavigate?.()
@@ -96,60 +96,20 @@ export function NotificationRow({
 
     return (
         <div
-            className={`flex items-start gap-2.5 p-2 rounded transition-colors ${rich ? '' : 'cursor-pointer'} ${
+            className={`relative flex items-start gap-2.5 p-2 rounded cursor-pointer transition-colors ${
                 notification.read ? 'hover:bg-fill-highlight-100' : 'bg-fill-highlight-50 hover:bg-fill-highlight-100'
             }`}
-            onClick={rich ? undefined : () => notification.body && setExpanded(!expanded)}
+            onClick={handleOpen}
         >
             <div className="shrink-0 mt-0.5">{getNotificationIcon(notification.notification_type)}</div>
             <div className="flex-1 min-w-0">
-                <div className="flex items-start justify-between gap-1">
-                    {rich ? (
-                        <span className="text-[10px] font-semibold uppercase tracking-wide text-muted mt-1">
-                            Web analytics digest
-                        </span>
-                    ) : (
-                        <span
-                            className={`text-xs leading-snug ${notification.read ? 'text-secondary' : 'font-semibold'}`}
-                        >
-                            {notification.title}
-                        </span>
-                    )}
-                    <div className="flex items-center gap-1 shrink-0">
-                        {!rich && hasNavigationTarget && (
-                            <Tooltip title="Go to source">
-                                <button
-                                    className="min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 text-secondary hover:text-primary cursor-pointer"
-                                    onClick={handleNavigate}
-                                >
-                                    <IconOpenInNew className="size-4" />
-                                </button>
-                            </Tooltip>
-                        )}
-                        <Tooltip title={notification.read ? 'Mark as unread' : 'Mark as read'}>
-                            <button
-                                className="group/read min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 cursor-pointer"
-                                onClick={handleToggleRead}
-                            >
-                                {notification.read ? (
-                                    <IconCheckCircle className="size-4 text-success" />
-                                ) : (
-                                    <>
-                                        <IconRadioButtonUnchecked className="size-4 text-muted opacity-40 group-hover/read:hidden" />
-                                        <IconCheckCircle className="size-4 text-muted opacity-60 hidden group-hover/read:block" />
-                                    </>
-                                )}
-                            </button>
-                        </Tooltip>
-                    </div>
-                </div>
+                {/* pr-7 keeps the title clear of the absolutely-positioned read toggle */}
+                <span className="block pr-7 text-xs leading-snug font-semibold">
+                    {rich ? 'Web analytics digest' : notification.title}
+                </span>
                 {rich
                     ? customBody
-                    : notification.body && (
-                          <div className={`text-xs text-secondary mt-0.5 ${expanded ? '' : 'line-clamp-1'}`}>
-                              {notification.body}
-                          </div>
-                      )}
+                    : notification.body && <div className="text-xs text-secondary mt-2">{notification.body}</div>}
                 <div className="flex items-center gap-1.5 mt-2">
                     <span className="text-[10px] text-muted">{dayjs(notification.created_at).fromNow()}</span>
                     {otherProjectName && (
@@ -161,6 +121,21 @@ export function NotificationRow({
                     )}
                 </div>
             </div>
+            <Tooltip title={notification.read ? 'Mark as unread' : 'Mark as read'}>
+                <button
+                    className="group/read absolute top-1.5 right-1.5 min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 cursor-pointer"
+                    onClick={handleToggleRead}
+                >
+                    {notification.read ? (
+                        <IconCheckCircle className="size-4 text-success" />
+                    ) : (
+                        <>
+                            <IconRadioButtonUnchecked className="size-4 text-muted opacity-40 group-hover/read:hidden" />
+                            <IconCheckCircle className="size-4 text-muted opacity-60 hidden group-hover/read:block" />
+                        </>
+                    )}
+                </button>
+            </Tooltip>
         </div>
     )
 }

--- a/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationRow.tsx
@@ -62,6 +62,59 @@ export const REALTIME_NOTIFICATION_TYPE_META: Record<string, { label: string; de
     },
 }
 
+export function NotificationTitle({
+    notificationType,
+    title,
+}: {
+    notificationType: string
+    title: string
+}): JSX.Element {
+    // Float the icon so wrapped lines flow back under it (not a hanging indent),
+    // break "Prefix: Name" titles at the colon
+    const splitAt = title.indexOf(': ')
+    return (
+        <span className="block text-xs leading-snug font-semibold">
+            {getNotificationIcon(notificationType, 'size-3.5 mt-px mr-1.5 float-left')}
+            {splitAt === -1 ? (
+                title
+            ) : (
+                <>
+                    <span className="whitespace-nowrap">{title.slice(0, splitAt + 1)}</span>{' '}
+                    <span className="whitespace-nowrap">{title.slice(splitAt + 2)}</span>
+                </>
+            )}
+        </span>
+    )
+}
+
+export function NotificationReadToggle({
+    read,
+    onToggle,
+    target,
+}: {
+    read: boolean
+    onToggle: (e: React.MouseEvent) => void
+    target?: string
+}): JSX.Element {
+    return (
+        <Tooltip title={`Mark ${target ? `${target} ` : ''}as ${read ? 'unread' : 'read'}`}>
+            <button
+                className="group/read shrink-0 flex size-5 items-center justify-center rounded hover:bg-fill-highlight-200 cursor-pointer"
+                onClick={onToggle}
+            >
+                {read ? (
+                    <IconCheckCircle className="size-4 text-success" />
+                ) : (
+                    <>
+                        <IconRadioButtonUnchecked className="size-4 text-muted opacity-40 group-hover/read:hidden" />
+                        <IconCheckCircle className="size-4 text-muted opacity-60 hidden group-hover/read:block" />
+                    </>
+                )}
+            </button>
+        </Tooltip>
+    )
+}
+
 export function NotificationRow({
     notification,
     onNavigate,
@@ -96,20 +149,21 @@ export function NotificationRow({
 
     return (
         <div
-            className={`relative flex items-start gap-2.5 p-2 rounded cursor-pointer transition-colors ${
+            className={`flex items-start gap-2 p-2 rounded cursor-pointer transition-colors ${
                 notification.read ? 'hover:bg-fill-highlight-100' : 'bg-fill-highlight-50 hover:bg-fill-highlight-100'
             }`}
             onClick={handleOpen}
         >
-            <div className="shrink-0 mt-0.5">{getNotificationIcon(notification.notification_type)}</div>
             <div className="flex-1 min-w-0">
-                {/* pr-7 keeps the title clear of the absolutely-positioned read toggle */}
-                <span className="block pr-7 text-xs leading-snug font-semibold">
-                    {rich ? 'Web analytics digest' : notification.title}
-                </span>
+                <NotificationTitle
+                    notificationType={notification.notification_type}
+                    title={rich ? 'Web analytics digest' : notification.title}
+                />
                 {rich
                     ? customBody
-                    : notification.body && <div className="text-xs text-secondary mt-2">{notification.body}</div>}
+                    : notification.body && (
+                          <div className="text-xs text-secondary mt-2 text-pretty">{notification.body}</div>
+                      )}
                 <div className="flex items-center gap-1.5 mt-2">
                     <span className="text-[10px] text-muted">{dayjs(notification.created_at).fromNow()}</span>
                     {otherProjectName && (
@@ -121,21 +175,7 @@ export function NotificationRow({
                     )}
                 </div>
             </div>
-            <Tooltip title={notification.read ? 'Mark as unread' : 'Mark as read'}>
-                <button
-                    className="group/read absolute top-1.5 right-1.5 min-w-[26px] min-h-[26px] flex items-center justify-center rounded hover:bg-fill-highlight-200 cursor-pointer"
-                    onClick={handleToggleRead}
-                >
-                    {notification.read ? (
-                        <IconCheckCircle className="size-4 text-success" />
-                    ) : (
-                        <>
-                            <IconRadioButtonUnchecked className="size-4 text-muted opacity-40 group-hover/read:hidden" />
-                            <IconCheckCircle className="size-4 text-muted opacity-60 hidden group-hover/read:block" />
-                        </>
-                    )}
-                </button>
-            </Tooltip>
+            <NotificationReadToggle read={notification.read} onToggle={handleToggleRead} />
         </div>
     )
 }

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -18,7 +18,7 @@ import { notificationsMenuLogic } from './notificationsMenuLogic'
 export function NotificationsPanel(): JSX.Element {
     const { activeTab } = useValues(notificationsMenuLogic)
     const { setActiveTab } = useActions(notificationsMenuLogic)
-    const { groups, inAppUnreadCount, importantChangesLoading, hasMoreNotifications, isLoadingMore } =
+    const { groups, loadedUnreadCount, importantChangesLoading, hasMoreNotifications, isLoadingMore } =
         useValues(sidePanelNotificationsLogic)
     const { markAllAsRead, loadMoreNotifications } = useActions(sidePanelNotificationsLogic)
     const { closePanel } = useActions(panelLayoutLogic)
@@ -46,12 +46,12 @@ export function NotificationsPanel(): JSX.Element {
                     onClick={() => setActiveTab('unread')}
                 >
                     Unread
-                    {inAppUnreadCount > 0 && (
-                        <span className="ml-1 text-[10px] text-danger font-bold">{inAppUnreadCount}</span>
+                    {loadedUnreadCount > 0 && (
+                        <span className="ml-1 text-[10px] text-danger font-bold">{loadedUnreadCount}</span>
                     )}
                 </button>
             </div>
-            {inAppUnreadCount > 0 && (
+            {loadedUnreadCount > 0 && (
                 <LemonButton size="xsmall" type="secondary" onClick={() => markAllAsRead()} className="ml-auto">
                     Mark all as read
                 </LemonButton>

--- a/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/NotificationsPanel.tsx
@@ -73,7 +73,7 @@ export function NotificationsPanel(): JSX.Element {
                     </div>
                 ) : filteredGroups.length > 0 ? (
                     <>
-                        <div className="flex flex-col gap-px">
+                        <div className="flex flex-col gap-1">
                             {filteredGroups.map((group: NotificationGroup) => (
                                 <NotificationGroupRow
                                     key={group.group_key}

--- a/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
@@ -1,11 +1,3 @@
-import { useValues } from 'kea'
-
-import { IconArrowRight, IconSparkles } from '@posthog/icons'
-import { LemonButton } from '@posthog/lemon-ui'
-
-import { FEATURE_FLAGS } from 'lib/constants'
-import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
-
 import { WebAnalyticsDigestMetadata, WebAnalyticsDigestMetric, WebAnalyticsDigestMetricChange } from '~/types'
 
 function TrendPill({ change }: { change: WebAnalyticsDigestMetricChange | null }): JSX.Element | null {
@@ -21,17 +13,7 @@ function TrendPill({ change }: { change: WebAnalyticsDigestMetricChange | null }
     )
 }
 
-export function WebAnalyticsDigestNotification({
-    metadata,
-    onOpen,
-    onAskMax,
-}: {
-    metadata: WebAnalyticsDigestMetadata
-    onOpen: (e: React.MouseEvent) => void
-    onAskMax: (e: React.MouseEvent) => void
-}): JSX.Element {
-    const { featureFlags } = useValues(featureFlagLogic)
-    const recapEnabled = !!featureFlags[FEATURE_FLAGS.WEB_ANALYTICS_RECAP]
+export function WebAnalyticsDigestNotification({ metadata }: { metadata: WebAnalyticsDigestMetadata }): JSX.Element {
     const byKey = (key: string): WebAnalyticsDigestMetric | undefined => metadata.metrics.find((m) => m.key === key)
     const hero = byKey('visitors')
     const pageviews = byKey('pageviews')
@@ -42,30 +24,18 @@ export function WebAnalyticsDigestNotification({
         .join(' · ')
 
     return (
-        <div className="mt-1 flex flex-col gap-2.5">
+        <div className="mt-2 flex flex-col gap-1.5">
             {hero && (
-                <div className="flex items-baseline gap-2">
+                <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
                     <span className="text-3xl font-bold leading-none tabular-nums">{hero.value}</span>
-                    <span className="text-sm text-secondary">{hero.label.toLowerCase()}</span>
-                    <TrendPill change={hero.change} />
+                    {/* Keep label + trend together so the pill wraps below the number instead of clipping the panel edge */}
+                    <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
+                        <span className="text-sm text-secondary">{hero.label.toLowerCase()}</span>
+                        <TrendPill change={hero.change} />
+                    </span>
                 </div>
             )}
-            {subline && <div className="text-xs text-muted">{subline}</div>}
-            <div className="flex flex-col gap-1.5">
-                <LemonButton
-                    type="primary"
-                    size="small"
-                    fullWidth
-                    center
-                    sideIcon={<IconArrowRight />}
-                    onClick={onOpen}
-                >
-                    {recapEnabled ? 'See your weekly recap' : 'View web analytics'}
-                </LemonButton>
-                <LemonButton type="secondary" size="small" fullWidth center icon={<IconSparkles />} onClick={onAskMax}>
-                    Ask PostHog AI
-                </LemonButton>
-            </div>
+            {subline && <div className="text-xs text-secondary">{subline}</div>}
         </div>
     )
 }

--- a/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
@@ -27,7 +27,7 @@ export function WebAnalyticsDigestNotification({ metadata }: { metadata: WebAnal
         <div className="mt-2 flex flex-col gap-1.5">
             {hero && (
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                    <span className="text-xl font-bold leading-none tabular-nums">{hero.value}</span>
+                    <span className="text-lg font-bold leading-none tabular-nums">{hero.value}</span>
                     {/* Keep label + trend together so the pill wraps below the number instead of clipping the panel edge */}
                     <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
                         <span className="text-sm text-secondary">{hero.label.toLowerCase()}</span>

--- a/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/WebAnalyticsDigestNotification.tsx
@@ -27,7 +27,7 @@ export function WebAnalyticsDigestNotification({ metadata }: { metadata: WebAnal
         <div className="mt-2 flex flex-col gap-1.5">
             {hero && (
                 <div className="flex flex-wrap items-baseline gap-x-2 gap-y-0.5">
-                    <span className="text-3xl font-bold leading-none tabular-nums">{hero.value}</span>
+                    <span className="text-xl font-bold leading-none tabular-nums">{hero.value}</span>
                     {/* Keep label + trend together so the pill wraps below the number instead of clipping the panel edge */}
                     <span className="inline-flex items-baseline gap-2 whitespace-nowrap">
                         <span className="text-sm text-secondary">{hero.label.toLowerCase()}</span>

--- a/frontend/src/lib/components/NotificationsMenu/notificationDescribers.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/notificationDescribers.tsx
@@ -1,8 +1,5 @@
-import { useActions } from 'kea'
-
 import { WebAnalyticsDigestNotification } from 'lib/components/NotificationsMenu/WebAnalyticsDigestNotification'
 
-import { sidePanelNotificationsLogic } from '~/layout/navigation-3000/sidepanel/panels/activity/sidePanelNotificationsLogic'
 import { InAppNotification } from '~/types'
 
 export interface NotificationDescriberProps {
@@ -15,28 +12,12 @@ export interface NotificationDescriber {
     Component: (props: NotificationDescriberProps) => JSX.Element | null
 }
 
-function WebAnalyticsDigestDescriber({ notification, onNavigate }: NotificationDescriberProps): JSX.Element | null {
-    const { viewWebAnalyticsFromDigest, askMaxAboutDigest } = useActions(sidePanelNotificationsLogic)
-
+function WebAnalyticsDigestDescriber({ notification }: NotificationDescriberProps): JSX.Element | null {
     if (!notification.metadata) {
         return null
     }
 
-    return (
-        <WebAnalyticsDigestNotification
-            metadata={notification.metadata}
-            onOpen={(e) => {
-                e.stopPropagation()
-                viewWebAnalyticsFromDigest(notification)
-                onNavigate?.()
-            }}
-            onAskMax={(e) => {
-                e.stopPropagation()
-                askMaxAboutDigest(notification)
-                onNavigate?.()
-            }}
-        />
-    )
+    return <WebAnalyticsDigestNotification metadata={notification.metadata} />
 }
 
 export const NOTIFICATION_DESCRIBERS: Record<string, NotificationDescriber> = {

--- a/frontend/src/lib/components/NotificationsMenu/notificationToasts.tsx
+++ b/frontend/src/lib/components/NotificationsMenu/notificationToasts.tsx
@@ -1,3 +1,5 @@
+import { ComponentType } from 'react'
+
 import {
     IconBug,
     IconCheckCircle,
@@ -18,23 +20,27 @@ import { notificationsMenuLogic } from 'lib/components/NotificationsMenu/notific
 
 import { InAppNotification } from '~/types'
 
-const NOTIFICATION_TYPE_ICONS: Record<string, JSX.Element> = {
-    comment_mention: <IconComment className="size-5 text-primary shrink-0" />,
-    alert_firing: <IconWarning className="size-5 text-warning shrink-0" />,
-    approval_requested: <IconCheckCircle className="size-5 text-success shrink-0" />,
-    approval_resolved: <IconCheckCircle className="size-5 text-success shrink-0" />,
-    pipeline_failure: <IconPlug className="size-5 text-danger shrink-0" />,
-    issue_assigned: <IconBug className="size-5 text-primary shrink-0" />,
-    experiment_concluded: <IconFlask className="size-5 text-primary shrink-0" />,
-    project_created: <IconFolder className="size-5 text-primary shrink-0" />,
-    usage_spike: <IconTrending className="size-5 text-warning shrink-0" />,
-    reminder: <IconClock className="size-5 text-primary shrink-0" />,
-    web_analytics_digest: <IconPieChart className="size-5 text-primary shrink-0" />,
-    achievement_unlocked: <IconStar className="size-5 text-warning shrink-0" />,
+const NOTIFICATION_TYPE_ICONS: Record<string, { Icon: ComponentType<{ className?: string }>; color: string }> = {
+    comment_mention: { Icon: IconComment, color: 'text-primary' },
+    alert_firing: { Icon: IconWarning, color: 'text-warning' },
+    approval_requested: { Icon: IconCheckCircle, color: 'text-success' },
+    approval_resolved: { Icon: IconCheckCircle, color: 'text-success' },
+    pipeline_failure: { Icon: IconPlug, color: 'text-danger' },
+    issue_assigned: { Icon: IconBug, color: 'text-primary' },
+    experiment_concluded: { Icon: IconFlask, color: 'text-primary' },
+    project_created: { Icon: IconFolder, color: 'text-primary' },
+    usage_spike: { Icon: IconTrending, color: 'text-warning' },
+    reminder: { Icon: IconClock, color: 'text-primary' },
+    web_analytics_digest: { Icon: IconPieChart, color: 'text-primary' },
+    achievement_unlocked: { Icon: IconStar, color: 'text-warning' },
 }
 
-export function getNotificationIcon(notificationType: string): JSX.Element {
-    return NOTIFICATION_TYPE_ICONS[notificationType] ?? <IconNotification className="size-5 text-secondary shrink-0" />
+export function getNotificationIcon(notificationType: string, className: string = 'size-5'): JSX.Element {
+    const { Icon, color } = NOTIFICATION_TYPE_ICONS[notificationType] ?? {
+        Icon: IconNotification,
+        color: 'text-secondary',
+    }
+    return <Icon className={`${className} ${color} shrink-0`} />
 }
 
 export function showCriticalNotificationToast(notification: InAppNotification): void {


### PR DESCRIPTION
## Problem

The web analytics digest notification had two CTA buttons (**View web analytics** / **Ask PostHog AI**) that feel too shouty. 

I think when something's happening with your traffic, the first instinct is just to see what's going on, and then dig in with PostHog AI if you want. So having an "Ask PostHog AI" button right there in the notification doesn't add much value. It's also inconsistent with every other notification and breaks the style (secondary button on muted card looks bad) 

How it was:
<img width="3082" height="2606" alt="2026-06-30 19 35 22" src="https://github.com/user-attachments/assets/2b2078f6-9eea-4623-9496-16bc83c91262" />

## Changes

Cleaned up the notifications panel design!

- **Clicking a notification now opens its source and marks it read** — instead of expanding/collapsing the description (which is now always expanded). This removes the need for a separate "Go to source" button and frees up more space for the title.
- **Removed the CTAs from the web analytics digest.** The card keeps its rich body (visitors, trend, sub-metrics) and opens web analytics on click like any other notification. 
- **Fixed the "Mark all as read" button being out of sync** with the read/unread state. Toggling a single notification's read state didn't update the unread count. 
- **Kept the read/unread checkbox** (pinned top-right). It's satisfying to click through items in the list 😊

## How did you test this code?

Created different notification types via django shell -> clicked around
<img width="3082" height="2606" alt="2026-06-30 19 24 19" src="https://github.com/user-attachments/assets/300960a1-45d7-45d0-9d04-da421067522b" />


## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

Iterated on the card design. The big call was **dropping the digest's bespoke CTA layout entirely** rather than restyling it — a few button-type/placement variants were tried (primary/tertiary combos, full-width, outline cards) before landing on "make it behave like every other notification." Digest Recap routing that used to live on the now-removed button was preserved by moving it into the `sourcePathForNotification` selector, still gated on `WEB_ANALYTICS_RECAP`.

Mostly deleting the dead digest actions and the Max-prompt builder. The read/unread checkbox was a deliberate keep. 
