### PR TITLE
fix(experiments): add key to sortable Read column in slowest queries

### DIFF
--- a/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
+++ b/frontend/src/scenes/instance/QueryPerformance/QueryPerformance.tsx
@@ -265,6 +265,7 @@ export function QueryPerformance(): JSX.Element {
         },
         {
             title: 'Read',
+            key: 'read_bytes',
             width: 130,
             sorter: (a, b) => groupBytes(a) - groupBytes(b),
             render: function Read(_, item): JSX.Element {


### PR DESCRIPTION
The "Read" column in the staff-only query-performance table defines a custom `sorter` but no `key`/`dataIndex`, which LemonTable requires for sorting — the scene crashes with "Column `key` or `dataIndex` must be defined for sorting". Adds `key: 'read_bytes'`.

## 🤖 Agent context

Internal staff-only tooling. One-line fix; the sorter ranks by a derived group-bytes total so a `key` (not a `dataIndex`) is the right identifier. Covered by typecheck; verified the column still renders and sorts.
