### PR TITLE
revert: "fix(logs): drop-rule rate limit refills per whole second, under-dropping"

### DIFF
--- a/nodejs/src/logs/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.test.ts
@@ -251,40 +251,4 @@ describe('LogsSamplingService', () => {
         const [, , kept] = await decodeLogRecords(result.value)
         expect(kept).toHaveLength(2)
     })
-
-    it('passes a sub-second timestamp to the rate limiter so refill is continuous within a second', async () => {
-        const ruleSet = compileRuleSet([
-            {
-                id: 'rl-1',
-                rule_type: 'rate_limit',
-                scope_service: 'api',
-                scope_path_pattern: null,
-                scope_attribute_filters: [],
-                config: { kb_per_second: 1, burst_kb: 2 },
-            },
-        ])
-        const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', [baseLog('a', 'api', 100)])
-
-        const nowMs = 1_700_000_000_400
-        const nowSpy = jest.spyOn(Date, 'now').mockReturnValue(nowMs)
-        const checkRateLimitV3 = jest.fn()
-
-        const mockRedis: RedisV2 = {
-            useClient: jest.fn(() => Promise.resolve(null)),
-            usePipeline: jest.fn((_opts, cb) => {
-                cb({ checkRateLimitV3 } as unknown as RedisClientPipeline)
-                const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
-                return Promise.resolve(pipelineResult)
-            }),
-        }
-
-        const service = new LogsSamplingService(mockRedis, 60)
-        await service.processBuffer(buffer, logsSettings, ruleSet, 99)
-
-        const nowArg = checkRateLimitV3.mock.calls[0]![1]
-        expect(nowArg).toBe(nowMs / 1000)
-        expect(Number.isInteger(nowArg)).toBe(false)
-
-        nowSpy.mockRestore()
-    })
 })

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -245,7 +245,6 @@ export class LogsSamplingService {
         }
 
         const ruleById = new Map(ruleSet.rules.map((r) => [r.id, r]))
-        const nowSeconds = Date.now() / 1000
         type Entry = { indices: number[]; costs: number[]; req: KeyedRateLimitRequest }
         const entries: Entry[] = []
 
@@ -265,7 +264,6 @@ export class LogsSamplingService {
                     cost: totalCost,
                     bucketSize: rl.poolMax,
                     refillRate: rl.refillPerSecond,
-                    now: nowSeconds,
                 },
             })
         }


### PR DESCRIPTION
Reverts PostHog/posthog#67065

since this PR for some reason it's dropping way too much 
<img width="802" height="150" alt="image" src="https://github.com/user-attachments/assets/0a366d47-2125-424c-b623-8dcac3d66c59" />
