### PR TITLE
fix(logs): rate-limit drop rules debit only what's admitted

### DIFF
--- a/nodejs/src/common/redis/redis-token-bucket-partial.lua.ts
+++ b/nodejs/src/common/redis/redis-token-bucket-partial.lua.ts
@@ -1,0 +1,103 @@
+import { Redis } from 'ioredis'
+
+// Partial-admission token-bucket script.
+//
+// Unlike V2/V3 (which make one all-or-nothing decision on a single `cost`), this
+// script is told the per-record costs of a batch and admits the longest record
+// prefix that fits the current budget. Crucially it debits *exactly* what it
+// admits and carries the rest forward (capped at poolMax) — so unspent budget is
+// never destroyed and never double-counted. This is what V2 and V3 each got wrong
+// for the logs drop-rule limiter:
+//   - V2 preserved the full balance on overdraft → never debited under sustained
+//     overload → admitted ~poolMax every call (way too much).
+//   - V3 floor-drained the balance on overdraft → destroyed accrued budget every
+//     call → a record larger than one call's refill could never be admitted (way
+//     too little / total starvation).
+// The caller does an identical prefix walk over the same costs, so both sides
+// agree on which records are kept.
+//
+// ARGV: now(s, may be fractional), poolMax, fillRate, expiry(s), totalCost, costs...
+const LUA_TOKEN_BUCKET_PARTIAL = `
+local key = KEYS[1]
+local now = tonumber(ARGV[1])
+local poolMax = tonumber(ARGV[2])
+local fillRate = tonumber(ARGV[3])
+local expiry = tonumber(ARGV[4])
+local totalCost = tonumber(ARGV[5])
+
+local existing = redis.call('hmget', key, 'ts', 'pool')
+local rawBefore = existing[1]
+local rawPool = existing[2]
+
+local before
+local tokensBefore
+if rawBefore == false then
+  before = false
+  tokensBefore = poolMax
+else
+  before = tonumber(rawBefore)
+  local timeDiff = now - before
+  if timeDiff < 0 then timeDiff = 0 end
+  local currentTokens
+  if rawPool == false then currentTokens = poolMax else currentTokens = tonumber(rawPool) end
+  -- Carry-forward bucket: accrue refill but never beyond the burst pool.
+  tokensBefore = currentTokens + timeDiff * fillRate
+  if tokensBefore > poolMax then tokensBefore = poolMax end
+end
+
+local budget = math.floor(tokensBefore)
+if budget < 0 then budget = 0 end
+
+local spent
+local keptCount
+local n = #ARGV - 5
+if budget >= totalCost then
+  -- Whole batch fits — no need to walk individual records.
+  spent = totalCost
+  keptCount = n
+else
+  -- Admit the longest record prefix whose cumulative cost fits the budget, then
+  -- stop. Records past the first one that doesn't fit are dropped and their
+  -- budget is carried forward (below), not destroyed. The early break keeps the
+  -- loop O(admitted prefix) rather than O(batch) in the hot rate-limited path.
+  spent = 0
+  keptCount = 0
+  for i = 6, #ARGV do
+    local c = tonumber(ARGV[i])
+    if spent + c <= budget then
+      spent = spent + c
+      keptCount = keptCount + 1
+    else
+      break
+    end
+  end
+end
+
+local poolToStore = tokensBefore - spent
+if poolToStore < 0 then poolToStore = 0 end
+if poolToStore > poolMax then poolToStore = poolMax end
+
+-- Don't regress ts when now < before; otherwise advance to now.
+local tsToWrite
+if before ~= false and now < before then
+  tsToWrite = before
+else
+  tsToWrite = now
+end
+redis.call('hset', key, 'ts', tsToWrite, 'pool', poolToStore)
+
+-- Match V3's TTL strategy: ceiling at (expiry * 2), refreshed only on creation
+-- or once the remaining TTL drops below expiry/2.
+if before == false or redis.call('pttl', key) < (expiry * 500) then
+  redis.call('expire', key, expiry * 2)
+end
+
+return {keptCount, spent}
+`
+
+export const defineLuaTokenBucketPartial = (client: Redis) => {
+    client.defineCommand('checkRateLimitPartial', {
+        numberOfKeys: 1,
+        lua: LUA_TOKEN_BUCKET_PARTIAL,
+    })
+}

--- a/nodejs/src/common/redis/redis-v2.ts
+++ b/nodejs/src/common/redis/redis-v2.ts
@@ -7,12 +7,23 @@ import { logger } from '~/common/utils/logger'
 import { captureException } from '~/common/utils/posthog'
 
 import { defineLuaTokenBucketGuarded } from './redis-token-bucket-guarded.lua'
+import { defineLuaTokenBucketPartial } from './redis-token-bucket-partial.lua'
 import { defineLuaTokenBucketV2 } from './redis-token-bucket-v2.lua'
 import { defineLuaTokenBucketV3 } from './redis-token-bucket-v3.lua'
 
-type WithCheckRateLimit<TV2, TV3, TGuarded> = {
+type WithCheckRateLimit<TV2, TV3, TGuarded, TPartial> = {
     checkRateLimitV2: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV2
     checkRateLimitV3: (key: string, now: number, cost: number, poolMax: number, fillRate: number, expiry: number) => TV3
+    /** Variadic: (key, now, poolMax, fillRate, expiry, totalCost, ...perRecordCosts). Returns [keptCount, spent]. */
+    checkRateLimitPartial: (
+        key: string,
+        now: number,
+        poolMax: number,
+        fillRate: number,
+        expiry: number,
+        totalCost: number,
+        ...costs: number[]
+    ) => TPartial
     checkGuardedRateLimit: (
         cooldownKey: string,
         counterKey: string,
@@ -29,10 +40,15 @@ type WithCheckRateLimit<TV2, TV3, TGuarded> = {
 }
 
 export type RedisClientPipeline = Pipeline &
-    WithCheckRateLimit<[number, number], [number, number], [number, number, number]>
+    WithCheckRateLimit<[number, number], [number, number], [number, number, number], [number, number]>
 
 export type RedisClient = Omit<Redis, 'pipeline'> &
-    WithCheckRateLimit<Promise<[number, number]>, Promise<[number, number]>, Promise<[number, number, number]>> & {
+    WithCheckRateLimit<
+        Promise<[number, number]>,
+        Promise<[number, number]>,
+        Promise<[number, number, number]>,
+        Promise<[number, number]>
+    > & {
         pipeline: () => RedisClientPipeline
     }
 
@@ -59,6 +75,7 @@ export const createRedisV2PoolFromConfig = (config: RedisPoolConfig): RedisV2 =>
                 defineLuaTokenBucketV2(client)
                 defineLuaTokenBucketV3(client)
                 defineLuaTokenBucketGuarded(client)
+                defineLuaTokenBucketPartial(client)
 
                 return client as RedisClient
             },

--- a/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.test.ts
@@ -553,4 +553,69 @@ describe('KeyedRateLimiterService', () => {
             expect(next[0][1].isRateLimited).toBe(true)
         })
     })
+
+    describe('rateLimitPartial (carry-forward + exact debit)', () => {
+        it('admits the whole batch when it fits and debits exactly the total', async () => {
+            const limiter = buildLimiter('partial-fits')
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            const res = await limiter.rateLimitPartial([{ id: 'team-1', costs: [10, 20, 30] }])
+
+            expect(res[0]).toEqual({ keptCount: 3, spent: 60 })
+            expect((await readBucket(`${limiter.getKeyPrefix()}/team-1`)).pool).toBe('40')
+        })
+
+        it('admits only the fitting prefix on overload and carries the unspent budget forward', async () => {
+            // Budget 100, batch [40,40,40]: 40+40 fit, the third (→120) does not.
+            // V2 would never debit (pool stays 100); V3 would floor-drain (pool→~0).
+            // The correct bucket debits exactly 80 and keeps the remaining 20.
+            const limiter = buildLimiter('partial-overload')
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            const res = await limiter.rateLimitPartial([{ id: 'team-1', costs: [40, 40, 40] }])
+
+            expect(res[0]).toEqual({ keptCount: 2, spent: 80 })
+            expect((await readBucket(`${limiter.getKeyPrefix()}/team-1`)).pool).toBe('20')
+        })
+
+        it('eventually admits an item larger than a single refill instead of starving it', async () => {
+            // The exact V3 floor-drain regression: an item costing more than one
+            // refill interval's worth must accumulate budget across calls, not be
+            // wiped every call. bucketSize 100, refillRate 10/s, item cost 25.
+            const limiter = buildLimiter('partial-starve', { bucketSize: 100, refillRate: 10 })
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            // Drain the initial full bucket.
+            await limiter.rateLimitPartial([{ id: 'team-1', costs: [100] }])
+
+            const keptOverTime: number[] = []
+            for (let i = 0; i < 3; i++) {
+                advanceTime(1000) // +10 tokens each second
+                const res = await limiter.rateLimitPartial([{ id: 'team-1', costs: [25] }])
+                keptOverTime.push(res[0].keptCount)
+            }
+
+            // 10 < 25, 20 < 25, 30 ≥ 25 → admitted on the third try (floor-drain: never).
+            expect(keptOverTime).toEqual([0, 0, 1])
+        })
+
+        it('caps sustained-overload admission at refillRate per interval', async () => {
+            const limiter = buildLimiter('partial-sustained', { bucketSize: 100, refillRate: 10 })
+            await deleteKeysWithPrefix(redis, limiter.getKeyPrefix())
+
+            // Drain the initial burst so we measure steady-state refill, not the pool.
+            await limiter.rateLimitPartial([{ id: 'team-1', costs: [100] }])
+
+            const overflowing = Array.from({ length: 50 }, () => 1) // 50 ≫ 10/s refill
+            const keptPerSecond: number[] = []
+            for (let i = 0; i < 5; i++) {
+                advanceTime(1000)
+                const res = await limiter.rateLimitPartial([{ id: 'team-1', costs: overflowing }])
+                keptPerSecond.push(res[0].keptCount)
+            }
+
+            // Exactly refillRate admitted each second — not ~0 (V3) and not ~bucketSize (V2).
+            expect(keptPerSecond).toEqual([10, 10, 10, 10, 10])
+        })
+    })
 })

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -49,6 +49,24 @@ export type KeyedRateLimit = {
     isRateLimited: boolean
 }
 
+export interface KeyedRateLimitPartialRequest {
+    id: string
+    /** Per-item costs in admission order. The bucket admits the longest fitting prefix. */
+    costs: number[]
+    bucketSize?: number
+    refillRate?: number
+    ttlSeconds?: number
+    /** Override the request timestamp (seconds, may be fractional for sub-second refill). */
+    now?: number
+}
+
+export type KeyedRateLimitPartial = {
+    /** Number of leading items admitted (the rest were dropped). */
+    keptCount: number
+    /** Cost actually debited from the bucket (sum of the admitted prefix). */
+    spent: number
+}
+
 export interface KeyedRateLimiter {
     /**
      * Rate-limit a batch of requests.
@@ -153,6 +171,87 @@ export class KeyedRateLimiterService implements KeyedRateLimiter {
         }
         if (limited > 0) {
             requestsTotal.inc({ name: this.config.name, method: 'rateLimitMany', outcome: 'limited' }, limited)
+        }
+        return out
+    }
+
+    /**
+     * Partial-admission rate limiter. Each request carries the per-item costs of a
+     * batch; the bucket admits the longest leading prefix that fits the budget,
+     * debits exactly that, and carries the unspent remainder forward (capped at
+     * bucketSize). Unlike rateLimitMany — which authorizes a single aggregate cost
+     * all-or-nothing and leaves partial admission to the caller — the debit here
+     * always matches what the caller will keep, so accrued budget is neither
+     * destroyed nor double-spent under sustained overload. One Lua call per request.
+     */
+    public async rateLimitPartial(requests: KeyedRateLimitPartialRequest[]): Promise<KeyedRateLimitPartial[]> {
+        if (requests.length === 0) {
+            return []
+        }
+
+        const resolved = requests.map((req) => {
+            const bucketSize = req.bucketSize ?? this.config.bucketSize
+            const refillRate = req.refillRate ?? this.config.refillRate
+            const ttlSeconds = req.ttlSeconds ?? this.config.ttlSeconds
+            if (bucketSize == null || refillRate == null || ttlSeconds == null) {
+                throw new Error(
+                    `KeyedRateLimiterService(${this.config.name}): missing bucketSize/refillRate/ttlSeconds for ${req.id}`
+                )
+            }
+            const now = req.now ?? Math.round(Date.now() / 1000)
+            const totalCost = req.costs.reduce((a, b) => a + b, 0)
+            return { req, bucketSize, refillRate, ttlSeconds, now, totalCost }
+        })
+
+        const res = await this.redis.usePipeline(
+            { name: `keyed-rate-limiter-partial:${this.config.name}`, failOpen: true },
+            (pipeline) => {
+                resolved.forEach((r) => {
+                    pipeline.checkRateLimitPartial(
+                        `${this.keyPrefix}/${r.req.id}`,
+                        r.now,
+                        r.bucketSize,
+                        r.refillRate,
+                        r.ttlSeconds,
+                        r.totalCost,
+                        ...r.req.costs
+                    )
+                })
+            }
+        )
+
+        redisCallsTotal.inc({ name: this.config.name, method: 'rateLimitPartial' }, requests.length)
+
+        if (!res) {
+            if (this.config.failOpen === false) {
+                throw new Error(`KeyedRateLimiterService(${this.config.name}): rate-limit pipeline failed`)
+            }
+            // Fail open: admit every item.
+            requestsTotal.inc(
+                { name: this.config.name, method: 'rateLimitPartial', outcome: 'allowed' },
+                requests.length
+            )
+            return resolved.map((r) => ({ keptCount: r.req.costs.length, spent: r.totalCost }))
+        }
+
+        let allowed = 0
+        let limited = 0
+        const out: KeyedRateLimitPartial[] = resolved.map((r, index) => {
+            const [tokenRes] = getRedisPipelineResults(res, index, 1)
+            const keptCount = Number(tokenRes[1]?.[0] ?? r.req.costs.length)
+            const spent = Number(tokenRes[1]?.[1] ?? r.totalCost)
+            if (keptCount < r.req.costs.length) {
+                limited++
+            } else {
+                allowed++
+            }
+            return { keptCount, spent }
+        })
+        if (allowed > 0) {
+            requestsTotal.inc({ name: this.config.name, method: 'rateLimitPartial', outcome: 'allowed' }, allowed)
+        }
+        if (limited > 0) {
+            requestsTotal.inc({ name: this.config.name, method: 'rateLimitPartial', outcome: 'limited' }, limited)
         }
         return out
     }

--- a/nodejs/src/common/services/keyed-rate-limiter.service.ts
+++ b/nodejs/src/common/services/keyed-rate-limiter.service.ts
@@ -198,7 +198,9 @@ export class KeyedRateLimiterService implements KeyedRateLimiter {
                     `KeyedRateLimiterService(${this.config.name}): missing bucketSize/refillRate/ttlSeconds for ${req.id}`
                 )
             }
-            const now = req.now ?? Math.round(Date.now() / 1000)
+            // Fractional default to match the contract: rounding to whole seconds
+            // can over-refill across a rounding boundary, the bug this path fixes.
+            const now = req.now ?? Date.now() / 1000
             const totalCost = req.costs.reduce((a, b) => a + b, 0)
             return { req, bucketSize, refillRate, ttlSeconds, now, totalCost }
         })

--- a/nodejs/src/logs/sampling/logs-sampling.service.test.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.test.ts
@@ -52,7 +52,7 @@ function baseLog(uuid: string, serviceName: string, bytesUncompressed: number | 
 }
 
 describe('LogsSamplingService', () => {
-    it('batches rate_limit lines and drops when tokensBefore is below pending count', async () => {
+    it('batches rate_limit lines and drops lines past the admitted prefix', async () => {
         const ruleSet = compileRuleSet([
             {
                 id: 'rl-1',
@@ -72,9 +72,10 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitPartial: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
-                const pipelineResult: [Error | null, any][] = [[null, [2, 0] as const]]
+                // [keptCount, spent]: admit the first 2 of 3 records (records-mode, 1 token each).
+                const pipelineResult: [Error | null, any][] = [[null, [2, 2] as const]]
                 return Promise.resolve(pipelineResult)
             }),
         }
@@ -105,7 +106,7 @@ describe('LogsSamplingService', () => {
             },
         ])
         // 3 rows: 250 bytes, 750 bytes, null (old-producer message).
-        // Token budget of 1 → first row admitted, the other two dropped.
+        // Only the first row is admitted, the other two dropped.
         const buffer = await encodeLogRecords(LOG_RECORD_AVRO, 'zstandard', [
             baseLog('a', 'api', 250),
             baseLog('b', 'api', 750),
@@ -115,9 +116,10 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitPartial: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
-                const pipelineResult: [Error | null, any][] = [[null, [1, 0] as const]]
+                // [keptCount, spent]: admit the first record only (records-mode, 1 token each).
+                const pipelineResult: [Error | null, any][] = [[null, [1, 1] as const]]
                 return Promise.resolve(pipelineResult)
             }),
         }
@@ -154,9 +156,10 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitPartial: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
-                const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
+                // [keptCount, spent]: admit the first 2 rows (300+400), drop the 3rd.
+                const pipelineResult: [Error | null, any][] = [[null, [2, 700] as const]]
                 return Promise.resolve(pipelineResult)
             }),
         }
@@ -200,9 +203,10 @@ describe('LogsSamplingService', () => {
         const mockRedis: RedisV2 = {
             useClient: jest.fn(() => Promise.resolve(null)),
             usePipeline: jest.fn((_opts, cb) => {
-                const pipeline = { checkRateLimitV3: jest.fn() } as unknown as RedisClientPipeline
+                const pipeline = { checkRateLimitPartial: jest.fn() } as unknown as RedisClientPipeline
                 cb(pipeline)
-                const pipelineResult: [Error | null, any][] = [[null, [1024, 0] as const]]
+                // [keptCount, spent]: admit the first 2 rows (200 + null→0), drop the 3rd.
+                const pipelineResult: [Error | null, any][] = [[null, [2, 200] as const]]
                 return Promise.resolve(pipelineResult)
             }),
         }

--- a/nodejs/src/logs/sampling/logs-sampling.service.ts
+++ b/nodejs/src/logs/sampling/logs-sampling.service.ts
@@ -2,7 +2,7 @@ import { trace } from '@opentelemetry/api'
 import { Counter } from 'prom-client'
 
 import { type RedisV2 } from '~/common/redis/redis-v2'
-import { KeyedRateLimitRequest, KeyedRateLimiterService } from '~/common/services/keyed-rate-limiter.service'
+import { KeyedRateLimitPartialRequest, KeyedRateLimiterService } from '~/common/services/keyed-rate-limiter.service'
 import { instrumented } from '~/common/tracing/tracing-utils'
 import { logger } from '~/common/utils/logger'
 import { type PiiScrubStats } from '~/logs/log-pii-scrub'
@@ -98,10 +98,7 @@ export class LogsSamplingService {
     private rateLimiter: KeyedRateLimiterService
 
     constructor(redis: RedisV2, ttlSeconds: number) {
-        this.rateLimiter = new KeyedRateLimiterService(
-            { name: 'logs-sampling-rate', ttlSeconds, scriptVersion: 'v3' },
-            redis
-        )
+        this.rateLimiter = new KeyedRateLimiterService({ name: 'logs-sampling-rate', ttlSeconds }, redis)
     }
 
     @instrumented({
@@ -228,9 +225,10 @@ export class LogsSamplingService {
 
     /**
      * Maps a recordIndex -> keep (true) or drop (false) decision per rate_limit rule.
-     * Each rule's pending lines share one Lua call; lines are admitted while their
-     * accumulated cost stays within the pre-batch token budget. Cost is one token
-     * per record (`costUnit: 'records'`) or each record's `bytes_uncompressed`
+     * Each rule's pending lines share one Lua call: the bucket admits the longest
+     * leading run of lines whose accumulated cost fits the current token budget,
+     * debits exactly that, and carries the unspent remainder forward. Cost is one
+     * token per record (`costUnit: 'records'`) or each record's `bytes_uncompressed`
      * (`costUnit: 'bytes'`); rows missing the field contribute 0.
      */
     private async applyRateLimits(
@@ -245,7 +243,11 @@ export class LogsSamplingService {
         }
 
         const ruleById = new Map(ruleSet.rules.map((r) => [r.id, r]))
-        type Entry = { indices: number[]; costs: number[]; req: KeyedRateLimitRequest }
+        // Fractional seconds so sub-second refill accumulates continuously — whole-
+        // second rounding over-refills (a 0.2s gap that rounds across a second
+        // boundary credits a full second) and under-drops.
+        const nowSeconds = Date.now() / 1000
+        type Entry = { indices: number[]; req: KeyedRateLimitPartialRequest }
         const entries: Entry[] = []
 
         for (const [ruleId, indices] of pendingByRule) {
@@ -255,15 +257,14 @@ export class LogsSamplingService {
             }
             const costs =
                 rl.costUnit === 'bytes' ? indices.map((idx) => recordBytes(records[idx]!)) : indices.map(() => 1)
-            const totalCost = costs.reduce((a, b) => a + b, 0)
             entries.push({
                 indices,
-                costs,
                 req: {
                     id: `${teamId}/${ruleId}`,
-                    cost: totalCost,
+                    costs,
                     bucketSize: rl.poolMax,
                     refillRate: rl.refillPerSecond,
+                    now: nowSeconds,
                 },
             })
         }
@@ -277,20 +278,13 @@ export class LogsSamplingService {
             return keepByIndex
         }
 
-        const results = await this.rateLimiter.rateLimitMany(entries.map((e) => e.req))
+        const results = await this.rateLimiter.rateLimitPartial(entries.map((e) => e.req))
 
         for (let i = 0; i < entries.length; i++) {
-            const { indices, costs } = entries[i]!
-            const tokensBefore = results[i]?.[1].tokensBefore ?? 0
-            const budget = Math.max(0, Math.floor(tokensBefore))
-            let spent = 0
+            const { indices } = entries[i]!
+            const keptCount = results[i]?.keptCount ?? indices.length
             for (let j = 0; j < indices.length; j++) {
-                const next = spent + costs[j]!
-                const admit = next <= budget
-                keepByIndex.set(indices[j]!, admit)
-                if (admit) {
-                    spent = next
-                }
+                keepByIndex.set(indices[j]!, j < keptCount)
             }
         }
 


### PR DESCRIPTION
## Problem

The logs drop-rule **rate limiter** was wrong in both directions. The limiter authorized a whole message's cost in one all-or-nothing Lua call (`rateLimitMany`), but the caller then admitted only a partial record prefix up to `floor(tokensBefore)`. The Lua never learned how much was actually admitted, so it stored a balance based on the whole-batch decision — and the two halves disagreed:

- **V2** preserved the full balance on overdraft, so it never debited under sustained overload. Every message — and every concurrent message hitting the same `{team}/{rule}` key (messages process concurrently via `pLimit`) — re-admitted roughly a whole `poolMax`. Result: **way too much** got through.
- **V3** (the more recent switch) floor-drained the balance to its fractional remainder on overdraft, destroying accrued budget on every call. A record larger than one call's worth of refill could never accumulate enough budget to ever be admitted. Result: **way too little** — effectively starvation for small/frequent batches.

A quick simulation of the exact Lua math + admission loop, at 10 MB/s configured and 31 MB/s offered, showed V3 collapsing to ~0.24 MB/s for small SDK batches while V2 ran 2–2.5× over.

## Changes

Replace the split-brain path with a single atomic `rateLimitPartial` primitive backed by a new Lua script (`redis-token-bucket-partial.lua.ts`). It's handed the per-record costs and:

- refills the bucket, capping accrual at the burst pool,
- admits the longest leading record prefix whose cumulative cost fits the budget,
- debits **exactly** what it admits, and **carries the unspent remainder forward** (so accrued budget is never destroyed and never double-spent),
- returns `[keptCount, spent]`; the caller keeps the first `keptCount` records.

Both sides walk the same costs, so the debit always matches what's kept. There's an O(1) fast path when the whole batch fits, and the rate-limited path early-breaks at the first record that doesn't fit (keeping the Lua loop cheap in the hot path). Fractional `now` (seconds) is passed so sub-second refill accrues continuously instead of jumping a full second across a rounding boundary.

The same simulation shows this lands on the configured rate for every batch size (≈9.93 MB/s ≈ 10 + residual burst), where V3 collapsed to ~0.24.

## How did you test this code?

I'm an agent (PostHog Code); I have not manually exercised this in a running stack. Automated tests I actually ran locally, all green:

- **`keyed-rate-limiter.service.test.ts`** — 4 new real-Redis cases for `rateLimitPartial`: whole batch fits + exact debit; overload admits the fitting prefix and carries the unspent budget forward (`pool` ends at `20`, not `0` or `100` — the precise V3-vs-V2 contrast); an item larger than a single refill is *eventually* admitted (`[0, 0, 1]` — the exact V3 starvation regression, which floor-drain would leave at `0` forever); sustained overload caps admission at exactly `refillRate` per interval (`[10,10,10,10,10]` — guards against both "too much" and "too little"). Full file 36/36 pass.
- **`logs-sampling.service.test.ts`** — the 5 existing caller tests, updated to the new `checkRateLimitPartial` → `[keptCount, spent]` contract; they still assert per-rule drop counts, byte attribution, null-`bytes_uncompressed` handling, and fail-open. 5/5 pass.
- `tsc --noEmit`, eslint, prettier, and the ingestion module-boundary check are clean on the changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No user-facing docs change — this is an ingestion-internal correctness fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Daniel directed the investigation and chose the approach; assigned as DRI.

Built with PostHog Code (Claude). Root-caused the over/under behavior to split-brain accounting between the atomic Lua decision (whole-batch cost) and the caller's partial-prefix admission, validated each variant (V2 preserve-balance, V3 floor-drain, proposed carry-forward) with a standalone simulation of the Lua math before writing any code. Considered a simpler "all-or-nothing per message" fix but rejected it: it starves any rule whose limit is small enough that a single message exceeds the burst pool (e.g. a 1 KB/s limit). Chose the byte-exact partial-admit design instead, which handles low limits and large messages.

Notable context for reviewers: this branch was cut from latest `master` (the prod lineage with the V3 switch), not from the diverged worktree branch it was investigated on. The `/writing-tests` skill was invoked before touching the test files. Fractional `now` is re-introduced here deliberately — it was reverted previously because it sat on top of the broken floor-drain; on this carry-forward bucket it's correct and necessary (whole-second rounding over-refills across a boundary and under-drops).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
