### PR TITLE
fix(clickhouse): guard log_comment in ops_query_log_archive_mv

### DIFF
--- a/posthog/clickhouse/migrations/0284_query_log_archive_ops_mv_log_comment_guard.py
+++ b/posthog/clickhouse/migrations/0284_query_log_archive_ops_mv_log_comment_guard.py
@@ -1,0 +1,29 @@
+from posthog.clickhouse.client.connection import NodeRole
+from posthog.clickhouse.client.migration_tools import run_sql_with_exceptions
+from posthog.clickhouse.query_log_archive import (
+    QUERY_LOG_ARCHIVE_OPS_MV,
+    QUERY_LOG_ARCHIVE_OPS_MV_SQL,
+    WRITABLE_QUERY_LOG_ARCHIVE_TABLE,
+)
+
+# Same fan-out as the MV's creating migration (0273): the slim MV runs on every
+# cluster, copying that cluster's system.query_log into writable_query_log_archive.
+ALL_ROLES = [
+    NodeRole.DATA,
+    NodeRole.ENDPOINTS,
+    NodeRole.AUX,
+    NodeRole.AI_EVENTS,
+    NodeRole.SESSIONS,
+    NodeRole.OPS,
+]
+
+# Wrap log_comment in if(isValidJSON(...), ..., '{}') so a non-JSON log_comment
+# can't break the JSON column in writable_query_log_archive. Recreate the MV to
+# converge clusters still on the unguarded definition.
+operations = [
+    run_sql_with_exceptions(f"DROP TABLE IF EXISTS {QUERY_LOG_ARCHIVE_OPS_MV}", node_roles=ALL_ROLES),
+    run_sql_with_exceptions(
+        QUERY_LOG_ARCHIVE_OPS_MV_SQL(view_name=QUERY_LOG_ARCHIVE_OPS_MV, dest_table=WRITABLE_QUERY_LOG_ARCHIVE_TABLE),
+        node_roles=ALL_ROLES,
+    ),
+]

--- a/posthog/clickhouse/migrations/max_migration.txt
+++ b/posthog/clickhouse/migrations/max_migration.txt
@@ -1,1 +1,1 @@
-0283_metric_events
+0284_query_log_archive_ops_mv_log_comment_guard

--- a/posthog/clickhouse/query_log_archive.py
+++ b/posthog/clickhouse/query_log_archive.py
@@ -817,7 +817,7 @@ SELECT
     stack_trace,
 
     JSONExtractInt(log_comment, 'team_id') as team_id,
-    log_comment,
+    if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
     ProfileEvents
 FROM system.query_log
 WHERE

--- a/posthog/clickhouse/test/__snapshots__/test_schema.ambr
+++ b/posthog/clickhouse/test/__snapshots__/test_schema.ambr
@@ -3640,7 +3640,7 @@
       stack_trace,
   
       JSONExtractInt(log_comment, 'team_id') as team_id,
-      log_comment,
+      if(isValidJSON(log_comment), log_comment, '{}') AS log_comment,
       ProfileEvents
   FROM system.query_log
   WHERE


### PR DESCRIPTION
## Problem

`ops_query_log_archive_mv` copies `system.query_log.log_comment` into the JSON `log_comment` column of `writable_query_log_archive`. Prod (and the declarative HCL golden) already wrap it as `if(isValidJSON(log_comment), log_comment, '{}')` so a non-JSON `log_comment` can't corrupt the column — but the repo's MV definition was never updated to match, so the migration that creates the MV still produces the unguarded form. The repo and prod have silently diverged.

## Changes

- Update `MV_SELECT_SQL_OPS` in `query_log_archive.py` to the guarded expression, so fresh installs and the schema snapshot produce the same MV prod runs.
- Add migration `0284` that drops and recreates `ops_query_log_archive_mv` on every cluster the MV runs on (same `node_roles` fan-out as its creating migration `0273`), converging any cluster still on the unguarded definition.
- Refresh the `test_schema.ambr` snapshot (one line).

## How did you test this code?

I'm an agent. Automated checks I actually ran:

- Booted the multinode ClickHouse stack, applied `0284` via `manage.py migrate_clickhouse`, then introspected the OPS node and diffed it against the HCL golden — result `no differences` (the MV now carries the guard on all roles).
- `manage.py test_ch_migrations_are_safe` — passes (`max_migration.txt` bumped, no number conflicts).
- `pytest posthog/clickhouse/test/test_schema.py` — passes; exactly one snapshot updated.
- `ruff check` / `ruff format` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code while building a CI gate that compares migrated OPS/LOGS ClickHouse schema against the declarative HCL golden (separate PR). That gate surfaced this MV as a real desync — golden/prod guarded, repo unguarded — so this fixes the repo side. Invoked the repo `/clickhouse-migrations` skill; followed `0273`'s drop+recreate pattern and role fan-out rather than an `ALTER ... MODIFY QUERY`. Convergence was verified live against the multinode stack before opening this PR.
