### PR TITLE
feat(exports): make "View exports" toast button a real link

### DIFF
--- a/frontend/src/lib/components/ExportButton/exportsLogic.ts
+++ b/frontend/src/lib/components/ExportButton/exportsLogic.ts
@@ -8,7 +8,6 @@ import { isLongRunningExportFormat } from 'lib/components/ExportButton/exportSta
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
 import { delay } from 'lib/utils/async'
-import { newInternalTab } from 'lib/utils/newInternalTab'
 import type { SessionRecordingPlayerMode } from 'scenes/session-recordings/player/sessionRecordingPlayerLogic'
 import { urls } from 'scenes/urls'
 
@@ -233,7 +232,8 @@ export const exportsLogic = kea<exportsLogicType>([
                                 lemonToast.success('Export started', {
                                     button: {
                                         label: 'View exports',
-                                        action: () => newInternalTab(urls.exports()),
+                                        to: urls.exports(),
+                                        targetBlank: true,
                                     },
                                 })
                                 actions.addFresh(response)

--- a/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
+++ b/frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx
@@ -26,7 +26,10 @@ export function ToastCloseButton({ closeToast }: { closeToast?: () => void }): J
 
 interface ToastButton {
     label: string
-    action: (() => void) | (() => Promise<void>)
+    action?: (() => void) | (() => Promise<void>)
+    /** Render the button as a real link to this path, so it can be cmd/right-clicked to open in a new window. */
+    to?: string
+    targetBlank?: boolean
     dataAttr?: string
     className?: string
 }
@@ -56,8 +59,10 @@ export function ToastContent({ type, message, button, id }: ToastContentProps): 
             <span className="grow overflow-hidden text-ellipsis">{message}</span>
             {button && (
                 <LemonButton
+                    to={button.to}
+                    targetBlank={button.targetBlank}
                     onClick={() => {
-                        void button.action()
+                        void button.action?.()
                         toast.dismiss(id)
                     }}
                     type="secondary"


### PR DESCRIPTION
## Problem

When an async export (e.g. a session-replay video render) is kicked off, the "Export started" toast offers a "View exports" button. It was a plain button whose `onClick` force-opened the exports page in a new tab. Because it wasn't a real link, you couldn't cmd-click, middle-click, or right-click → "Open in new window" to choose where it opens — and with tabs gone from the app shell, opening it in a controllable new window matters so you don't lose your place.

## Changes

- The "View exports" toast button now renders as a real link (`to`) to the exports page, so it's cmd/right-clickable to open in a new window, and `targetBlank` keeps the default click opening a new tab as before.
- Added optional `to`/`targetBlank` fields to the toast button type (`action` is now optional) — backward compatible with existing `action`-based toast buttons.

## How did you test this code?

I'm an agent. I made the change and verified it locally by inspection; I did not run the frontend test suite or manually exercise the toast (local `node_modules` weren't installed in this environment). No automated tests were added — the change is a small, backward-compatible rendering tweak.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Requested from a Slack thread: make the "View exports" button shown when an export starts a link instead of a button. Implemented by extending the existing `ToastButton` shape (`frontend/src/lib/lemon-ui/LemonToast/LemonToast.tsx`) with `to`/`targetBlank`, rendering via `LemonButton`'s link support, and switching `exportsLogic.ts` from `newInternalTab(urls.exports())` to `to: urls.exports()` with `targetBlank`. Removed the now-unused `newInternalTab` import.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782749295264829?thread_ts=1782749295.264829&cid=C0ACRAMJUAG)*
