### PR TITLE
refactor(signals): lift report-channel dedup nuances into the harness prompt

### DIFF
--- a/products/signals/backend/scout_harness/prompt.py
+++ b/products/signals/backend/scout_harness/prompt.py
@@ -246,19 +246,28 @@ main failure mode here, so the discipline is **search, then decide**:
 
 - **Search first, every time.** Before authoring anything, call
   `inbox-reports-list` (filter/search by the entity, error, or topic you're about
-  to report on) and read the closest matches with `inbox-reports-retrieve` — plus
-  your `report:<domain>:<entity>` scratchpad pointer from a prior run (see *The
-  `report:` scratchpad entry is a pointer*).
-- **Edit when it already exists.** If a report covers the issue, prefer
-  `signals-scout-edit-report`: `append_note` to add your fresh evidence (additive,
-  audit-friendly, and works on any report — even one you didn't author), or
-  rewrite `title`/`summary` on a report you own. One living report beats three
-  near-duplicates fragmenting the inbox.
-- **Author only when it's genuinely new.** A materially new issue — or a known one
-  with new evidence that changes the verdict — warrants a fresh report. Never
-  retry an `emit_report` that looked like it failed: a retry that actually
-  succeeded the first time silently doubles the report. If unsure whether it
-  landed, look it up with `inbox-reports-list` rather than re-emitting."""
+  to report on) with `ordering=-updated_at` — the default ordering buckets by your
+  own reviewer-match and status first, so without it the most recent duplicate can
+  sort below older rows and you'd miss it — and read the closest matches with
+  `inbox-reports-retrieve`, plus your `report:<domain>:<entity>` scratchpad pointer
+  from a prior run (see *The `report:` scratchpad entry is a pointer*). Don't filter
+  by `source_product=<your product>`: a report you authored persists its backing
+  signals under `source_product=signals_scout`, so a product-named filter matches
+  none of your own reports.
+- **Edit when it already exists *and is still live*.** If a report covers the issue,
+  prefer `signals-scout-edit-report`: `append_note` to add your fresh evidence
+  (additive, audit-friendly, and works on any report — even one you didn't author),
+  or rewrite `title`/`summary` on a report you own. One living report beats three
+  near-duplicates fragmenting the inbox. But `edit_report` can't change a report's
+  status, so appending to a `resolved` / `suppressed` / `failed` report buries a real
+  relapse under a closed item — when the match is no longer live, treat the relapse
+  as genuinely new (author a fresh report and repoint your `report:` pointer at it).
+- **Author only when it's genuinely new.** A materially new issue — or a known one with
+  new evidence that changes the verdict, or a relapse whose prior report is no longer
+  live — warrants a fresh report. Never retry an `emit_report` that looked like it
+  failed: a retry that actually succeeded the first time silently doubles the report.
+  If unsure whether it landed, look it up with `inbox-reports-list` rather than
+  re-emitting."""
 
 _AUTHORING_REPORT_EMIT_ONLY = """# Authoring reports: search the inbox first
 
@@ -268,26 +277,36 @@ main failure mode here, so the discipline is **search, then decide**:
 
 - **Search first, every time.** Before authoring anything, call
   `inbox-reports-list` (filter/search by the entity, error, or topic you're about
-  to report on) and read the closest matches with `inbox-reports-retrieve` — plus
-  your `report:<domain>:<entity>` scratchpad pointer from a prior run (see *The
-  `report:` scratchpad entry is a pointer*).
-- **Don't duplicate an existing report.** This run can't edit reports, so if one
-  already covers the issue, leave it alone — record a `remember(...)` note and
-  skip rather than authoring a near-duplicate.
-- **Author only when it's genuinely new.** A materially new issue warrants a fresh
-  report. Never retry an `emit_report` that looked like it failed: a retry that
-  actually succeeded the first time silently doubles the report. If unsure whether
-  it landed, look it up with `inbox-reports-list` rather than re-emitting."""
+  to report on) with `ordering=-updated_at` (the default ordering can sort the most
+  recent duplicate below older rows) and read the closest matches with
+  `inbox-reports-retrieve`, plus your `report:<domain>:<entity>` scratchpad pointer
+  from a prior run (see *The `report:` scratchpad entry is a pointer*). Don't filter
+  by `source_product=<your product>`: a report you authored persists its backing
+  signals under `source_product=signals_scout`, so a product-named filter matches
+  none of your own reports.
+- **Don't duplicate a *live* report.** This run can't edit reports, so if a still-open
+  report already covers the issue, leave it alone — record a `remember(...)` note and
+  skip rather than authoring a near-duplicate. But a `resolved` / `suppressed` / `failed`
+  report won't resurface and you can't reopen it, so a genuine relapse of a closed report
+  is genuinely new — author a fresh report for it.
+- **Author only when it's genuinely new.** A materially new issue — or a relapse whose
+  prior report is no longer live — warrants a fresh report. Never retry an `emit_report`
+  that looked like it failed: a retry that actually succeeded the first time silently
+  doubles the report. If unsure whether it landed, look it up with `inbox-reports-list`
+  rather than re-emitting."""
 
 _EDITING_REPORT_EDIT_ONLY = """# Editing existing reports
 
 This run updates reports that already exist — it can't author new ones. Find the
 report your evidence bears on, then keep it current:
 
-- **Find it.** `inbox-reports-list` (filter/search by the entity, error, or topic)
-  and `inbox-reports-retrieve` to read the candidate in full. Reuse the
-  `report:<domain>:<entity>` scratchpad entry / `report_id` from a prior run when
-  you have one.
+- **Find it.** `inbox-reports-list` (filter/search by the entity, error, or topic) with
+  `ordering=-updated_at` so the most recently updated match sorts to the top, then
+  `inbox-reports-retrieve` to read the candidate in full. Don't filter by
+  `source_product=<your product>` — a scout-authored report's signals persist under
+  `source_product=signals_scout`, so a product-named filter misses your own reports. Reuse
+  the `report:<domain>:<entity>` scratchpad entry / `report_id` from a prior run when you
+  have one.
 - **Append, or rewrite.** Prefer `append_note` to add fresh evidence — it's
   additive, audit-friendly, and works on any report, even one you didn't author.
   Rewrite `title`/`summary` only on a report you own, and only when the framing is

--- a/products/signals/backend/test/test_scout_harness.py
+++ b/products/signals/backend/test/test_scout_harness.py
@@ -232,6 +232,12 @@ class TestPromptBuilder(BaseTest):
         # discipline re-opens the duplicate / stale-edit failure mode.
         assert "scratchpad entry is a pointer" in prompt
         assert "source of truth" in prompt
+        # The report-channel prompt must carry both dedup nuances: search `ordering=-updated_at`
+        # (else the most recent duplicate sorts below older rows) and don't filter by product name
+        # (a scout's own report-channel signals persist under `source_product=signals_scout`).
+        # Dropping either silently re-opens the duplicate-report failure mode for every report scout.
+        assert "ordering=-updated_at" in prompt
+        assert "source_product=signals_scout" in prompt
         # Signal-only sections (weak-finding schema, tagging taxonomy) are dropped
         # for a report scout — it doesn't fire `emit_signal`.
         assert "signals-scout-emit-signal" not in prompt
@@ -260,6 +266,11 @@ class TestPromptBuilder(BaseTest):
         assert "signals-scout-edit-report" not in prompt
         assert "Authoring reports: search the inbox first" in prompt
         assert "Suggested reviewers route the report" in prompt
+        # The dedup nuances reach the emit-only variant too — not just the both-tools prompt.
+        assert "ordering=-updated_at" in prompt
+        # An emit-only scout can't edit, so a relapse of a CLOSED report must become a fresh report
+        # rather than a skip — otherwise relapses on resolved/suppressed/failed reports are dropped.
+        assert "relapse of a closed report" in prompt
 
     def test_edit_only_report_scout_never_references_emit_tool(self) -> None:
         # The mirror case: an edit_report-only scout must never be told to author via
@@ -276,6 +287,9 @@ class TestPromptBuilder(BaseTest):
         # An edit-only scout can still rescue an unrouted report's reviewers, so the editing guidance
         # carries the in-run member lookup too — even though the standalone author-time deep-dive drops.
         assert "signals-scout-members-list" in prompt
+        # An edit-only scout searches the inbox to find the report to update, so it needs the same
+        # dedup nuance — else the default ordering hides the most recently updated match.
+        assert "ordering=-updated_at" in prompt
 
 
 # Orchestration tests run as plain pytest functions because the async runner uses


### PR DESCRIPTION
## Problem

Three generic report-channel dedup nuances were duplicated across every ported scout (in their bodies and bundled `report.md`): searching with `ordering=-updated_at`, not filtering the dedup search by `source_product=<product>`, and treating a relapse on a closed report as a fresh report. Duplicated guidance drifts.

## Changes

Centralize all three in `build_run_prompt` so every report-channel scout gets them from one source:
- `ordering=-updated_at` (the default ordering can sort the most recent duplicate below older rows).
- Don't filter by `source_product=<product>` — a scout's own report-channel signals persist under `source_product=signals_scout`.
- A relapse on a `resolved`/`suppressed`/`failed` report is a fresh report, since `edit_report` can't change status.

This is the base of a small stack; the follow-ups delete the now-redundant per-scout copies.

## How did you test this code?

I'm an agent (Claude Code). Ran `hogli test products/signals/backend/test/test_scout_harness.py -k 'report or prompt'` → passes. Extended `test_report_channel_renders_report_persona_and_guidance` to assert the prompt carries `ordering=-updated_at` and `source_product=signals_scout` — they're now the prompt's only source, so a future edit dropping them would silently re-open the duplicate-report failure mode fleet-wide.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy directed this while cleaning up the canonical scout report-channel port. Split out from a larger change so each PR does one thing. Skills invoked: `/authoring-signals-scouts`, `/writing-tests`.
