### PR TITLE
fix(max): capture posthog_ai query events under identified distinct_id

### DIFF
--- a/ee/hogai/chat_agent/memory/nodes.py
+++ b/ee/hogai/chat_agent/memory/nodes.py
@@ -109,6 +109,7 @@ class MemoryInitializerContextMixin(AssistantContextMixin):
             )
             return runner.run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                user=self._user,
                 analytics_props={"source": EventSource.POSTHOG_AI},
             )
 

--- a/ee/hogai/chat_agent/query_planner/nodes.py
+++ b/ee/hogai/chat_agent/query_planner/nodes.py
@@ -108,7 +108,7 @@ class QueryPlannerNode(TaxonomyUpdateDispatcherNodeMixin, AssistantNode):
                 "react_property_filters": self._get_react_property_filters_prompt(),
                 "react_human_in_the_loop": HUMAN_IN_THE_LOOP_PROMPT,
                 "groups": self._team_group_types,
-                "events": format_events_yaml(events_in_context, self._team),
+                "events": format_events_yaml(events_in_context, self._team, user=self._user),
                 "project_datetime": self.project_now,
                 "project_timezone": self.project_timezone,
                 "project_name": self._team.name,

--- a/ee/hogai/chat_agent/query_planner/toolkit.py
+++ b/ee/hogai/chat_agent/query_planner/toolkit.py
@@ -233,6 +233,7 @@ class TaxonomyAgentToolkit:
         ):
             response = runner.run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                user=self._user,
                 analytics_props={"source": EventSource.POSTHOG_AI},
             )
         return response, verbose_name
@@ -432,6 +433,7 @@ class TaxonomyAgentToolkit:
         ):
             response = ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                user=self._user,
                 analytics_props={"source": EventSource.POSTHOG_AI},
             )
 

--- a/ee/hogai/chat_agent/rag/nodes.py
+++ b/ee/hogai/chat_agent/rag/nodes.py
@@ -133,6 +133,7 @@ class InsightRagContextNode(AssistantNode):
                 ):
                     response = runner.run(
                         ExecutionMode.RECENT_CACHE_CALCULATE_BLOCKING_IF_STALE,
+                        user=self._user,
                         analytics_props={"source": EventSource.POSTHOG_AI},
                     )
                 if isinstance(response, CachedVectorSearchQueryResponse) and response.results:
@@ -180,6 +181,7 @@ class InsightRagContextNode(AssistantNode):
         """
         TeamTaxonomyQueryRunner(TeamTaxonomyQuery(), self._team).run(
             ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE,
+            user=self._user,
             analytics_props={"source": EventSource.POSTHOG_AI},
         )
 

--- a/ee/hogai/chat_agent/rag/test/test_nodes.py
+++ b/ee/hogai/chat_agent/rag/test/test_nodes.py
@@ -69,7 +69,7 @@ class TestInsightRagContextNode(ClickhouseTestMixin, BaseTest):
 
         # Check run was called with the correct execution mode
         mock_runner_instance.run.assert_called_once_with(
-            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE, analytics_props=ANY
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE, user=self.user, analytics_props=ANY
         )
 
     def test_injects_action(self, cohere_mock, embed_mock):

--- a/ee/hogai/chat_agent/taxonomy/toolkit.py
+++ b/ee/hogai/chat_agent/taxonomy/toolkit.py
@@ -276,6 +276,7 @@ class TaxonomyAgentToolkit:
             # Use cache-first execution mode for optimal performance
             response = runner.run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                user=self._user,
                 analytics_props={"source": EventSource.POSTHOG_AI},
             )
         return response, verbose_name
@@ -705,6 +706,7 @@ class TaxonomyAgentToolkit:
         ):
             return ActorsPropertyTaxonomyQueryRunner(query, self._team).run(
                 ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+                user=self._user,
                 analytics_props={"source": EventSource.POSTHOG_AI},
             )
 

--- a/ee/hogai/tools/read_taxonomy/core.py
+++ b/ee/hogai/tools/read_taxonomy/core.py
@@ -102,7 +102,7 @@ def execute_taxonomy_query(query: ReadTaxonomyQuery, toolkit: TaxonomyAgentToolk
     """
     match query:
         case ReadEvents():
-            return format_events_yaml([], team, limit=query.limit, offset=query.offset)
+            return format_events_yaml([], team, limit=query.limit, offset=query.offset, user=toolkit._user)
         case ReadEventProperties():
             result = toolkit.retrieve_event_or_action_properties(query.event_name)
             return f"{result}\n\n{DYNAMIC_EVENT_PROPERTIES_HINT}"

--- a/ee/hogai/utils/helpers.py
+++ b/ee/hogai/utils/helpers.py
@@ -40,7 +40,7 @@ from posthog.schema import (
 from posthog.event_usage import EventSource
 from posthog.hogql_queries.ai.team_taxonomy_query_runner import TeamTaxonomyQueryRunner
 from posthog.hogql_queries.query_runner import ExecutionMode
-from posthog.models import Team
+from posthog.models import Team, User
 from posthog.taxonomy.taxonomy import CORE_FILTER_DEFINITIONS_BY_GROUP
 
 from ee.hogai.utils.anthropic import SUPPORTED_ANTHROPIC_BLOCKS
@@ -175,11 +175,13 @@ def _process_events_data(
     team: Team,
     limit: int | None = None,
     offset: int | None = None,
+    user: User | None = None,
 ) -> tuple[list[dict], dict[str, str], bool]:
     """Common logic for processing events and building event data."""
     query = TeamTaxonomyQuery(limit=limit, offset=offset)
     response = TeamTaxonomyQueryRunner(query, team).run(
         ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+        user=user,
         analytics_props={"source": EventSource.POSTHOG_AI},
     )
 
@@ -232,8 +234,8 @@ def _process_events_data(
     return processed_events, event_to_description, has_more
 
 
-def format_events_xml(events_in_context: list[MaxEventContext], team: Team) -> str:
-    processed_events, _, _ = _process_events_data(events_in_context, team)
+def format_events_xml(events_in_context: list[MaxEventContext], team: Team, user: User | None = None) -> str:
+    processed_events, _, _ = _process_events_data(events_in_context, team, user=user)
 
     root = ET.Element("defined_events")
     for event_data in processed_events:
@@ -252,8 +254,9 @@ def format_events_yaml(
     team: Team,
     limit: int | None = None,
     offset: int | None = None,
+    user: User | None = None,
 ) -> str:
-    processed_events, _, has_more = _process_events_data(events_in_context, team, limit=limit, offset=offset)
+    processed_events, _, has_more = _process_events_data(events_in_context, team, limit=limit, offset=offset, user=user)
 
     formatted_events = ["events:"]
     for event_data in processed_events:

--- a/ee/hogai/utils/test/test_format_events_prompt.py
+++ b/ee/hogai/utils/test/test_format_events_prompt.py
@@ -379,5 +379,21 @@ class TestFormatEventsPrompt(BaseTest):
         mock_runner_class.assert_called_once_with(TeamTaxonomyQuery(), self.team)
         mock_runner_class.return_value.run.assert_called_once_with(
             ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+            user=None,
+            analytics_props=ANY,
+        )
+
+    @patch("ee.hogai.utils.helpers.TeamTaxonomyQueryRunner")
+    def test_format_events_xml_threads_user_to_runner(self, mock_runner_class):
+        # The user must reach run() so "query executed" is captured under the identified
+        # distinct_id rather than falling back to the team UUID (an anonymous person).
+        self._setup_mock_runner(mock_runner_class, [])
+
+        events_in_context: list[MaxEventContext] = []
+        format_events_xml(events_in_context, self.team, user=self.user)
+
+        mock_runner_class.return_value.run.assert_called_once_with(
+            ExecutionMode.RECENT_CACHE_CALCULATE_ASYNC_IF_STALE_AND_BLOCKING_ON_MISS,
+            user=self.user,
             analytics_props=ANY,
         )


### PR DESCRIPTION
## Problem

Server-side product events emitted by PostHog AI (Max) and tagged `source: posthog_ai` — dominated by `query executed` — were being captured under the project's `Team.uuid` instead of the user's identified `distinct_id`. Because that UUID is never run through `$identify`, it resolves to a brand-new, permanently anonymous person with no email/name/role, so any insight that joins on person properties silently drops most PostHog AI users and biases every MCP-vs-AI-vs-Web comparison.

The root cause: Max's chat-agent query runners are constructed with only `(query, team)` and never passed the user. When `QueryRunner.run()` captures the event it resolves `distinct_id = str(user.distinct_id) if user else str(self.team.uuid)`, so the missing user makes it fall back to the team UUID (minted right after the org UUID, which is why it looked like a sequential "account" UUID in the data). MCP and web don't hit this because they capture via `report_user_action(request.user, ...)`, which always uses the identified `distinct_id`.

## Changes

Thread `self._user` into the interactive query-runner `run()` calls across the query planner, taxonomy, RAG, and memory toolkits/nodes, and add an optional `user` parameter to the `format_events_xml` / `format_events_yaml` helpers (and the shared `_process_events_data`) so the team-taxonomy prompt query is attributed to the user as well.

Out of scope: genuinely userless batch/scheduled paths (LLM-traces summarizer, experiment summary service, the Temporal session-replay activity) still fall back to the team UUID — they have no request user to attribute to. The `insight created` / `dashboard created` / `alert created` events already capture under the identified `distinct_id` via `report_user_action(self._user, ...)` and were not affected.

## How did you test this code?

I'm an agent. I could not run the DB-backed test suite in my sandbox (no Postgres available), so CI will exercise it. Automated tests changed: updated the existing `format_events_xml` runner-parameter assertion and added `test_format_events_xml_threads_user_to_runner`, which asserts the user reaches `run()` so the captured event uses the identified `distinct_id` rather than the team-UUID fallback. `ruff check` and `ruff format` pass on all changed files.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a Slack thread reporting that `source=posthog_ai` events resolve to anonymous, email-less persons. Used the PostHog Slack app (Claude Code) to trace the capture path: confirmed via `posthog/hogql_queries/query_runner.py` that the `distinct_id` falls back to `str(self.team.uuid)` when no user is threaded through, and that the affected `source: posthog_ai` events all originate from Max toolkits/nodes that construct runners without a user. Chose to thread the existing `self._user` into each interactive `run()` call rather than `$identify`-ing the team UUID, since the identified `distinct_id` is already available at every interactive call site and makes person-on-events carry email/role for free.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0B29PTTLBU/p1782816379424039)*
