### PR TITLE
feat(surveys): add optional approval workflow before launch

### DIFF
--- a/frontend/src/scenes/approvals/utils.ts
+++ b/frontend/src/scenes/approvals/utils.ts
@@ -3,6 +3,7 @@ export const ApprovalActionKey = {
     FEATURE_FLAG_ENABLE: 'feature_flag.enable',
     FEATURE_FLAG_DISABLE: 'feature_flag.disable',
     FEATURE_FLAG_UPDATE: 'feature_flag.update',
+    SURVEY_LAUNCH: 'survey.launch',
 } as const
 
 export type ApprovalActionKeyType = (typeof ApprovalActionKey)[keyof typeof ApprovalActionKey]
@@ -31,6 +32,10 @@ export const APPROVAL_ACTIONS: Record<string, ApprovalActionConfig> = {
         description: 'update feature flag fields',
         contextDescriptions: { experiment: 'update this experiment' },
     },
+    [ApprovalActionKey.SURVEY_LAUNCH]: {
+        label: 'Launch survey',
+        description: 'launch this survey',
+    },
 }
 
 export function getApprovalActionLabel(actionKey: string): string {
@@ -50,11 +55,13 @@ export function getApprovalActionDescription(actionKey: string, context?: Approv
 
 export const ApprovalResourceType = {
     FEATURE_FLAG: 'feature_flag',
+    SURVEY: 'survey',
 } as const
 
 // Maps resource types to display names and URL builders
 const APPROVAL_RESOURCE_CONFIG: Record<string, { label: string; urlBuilder: (id: string) => string }> = {
     [ApprovalResourceType.FEATURE_FLAG]: { label: 'Feature flag', urlBuilder: (id) => `/feature_flags/${id}` },
+    [ApprovalResourceType.SURVEY]: { label: 'Survey', urlBuilder: (id) => `/surveys/${id}` },
 }
 
 export function getApprovalResourceUrl(actionKey: string, resourceId: string | null): string | null {

--- a/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyDraftContent.tsx
+++ b/frontend/src/scenes/surveys/SurveyViewRedesign/SurveyDraftContent.tsx
@@ -4,7 +4,9 @@ import { IconCheck, IconRocket } from '@posthog/icons'
 import { LemonButton } from '@posthog/lemon-ui'
 
 import { BuilderHog1 } from 'lib/components/hedgehogs'
+import { PendingChangeRequestBanner } from 'scenes/approvals/PendingChangeRequestBanner'
 import { LaunchSurveyButton } from 'scenes/surveys/components/LaunchSurveyButton'
+import { NEW_SURVEY } from 'scenes/surveys/constants'
 import { surveyLogic } from 'scenes/surveys/surveyLogic'
 
 import { Survey, SurveyType } from '~/types'
@@ -91,6 +93,12 @@ export function SurveyDraftContent({ onSeeSurveyDetails }: { onSeeSurveyDetails?
                         </p>
                     </div>
                 </div>
+
+                {survey.id && survey.id !== NEW_SURVEY.id && (
+                    <div className="w-full max-w-2xl">
+                        <PendingChangeRequestBanner resourceType="survey" resourceId={survey.id} />
+                    </div>
+                )}
 
                 <div className="flex items-center gap-2">
                     <LaunchSurveyButton>Launch survey</LaunchSurveyButton>

--- a/frontend/src/scenes/surveys/surveyLogic.tsx
+++ b/frontend/src/scenes/surveys/surveyLogic.tsx
@@ -7,6 +7,7 @@ import posthog from 'posthog-js'
 import { lemonToast } from '@posthog/lemon-ui'
 
 import api from 'lib/api'
+import { handleApprovalRequired } from 'lib/approvals/utils'
 import { tryShowMCPHint } from 'lib/components/MCPHint/mcpHintLogic'
 import { SetupTaskId, globalSetupLogic } from 'lib/components/ProductSetup'
 import { FEATURE_FLAGS } from 'lib/constants'
@@ -1174,6 +1175,13 @@ export const surveyLogic = kea<surveyLogicType>([
                 globalSetupLogic.findMounted()?.actions.markTaskAsCompleted(SetupTaskId.LaunchSurvey)
 
                 actions.loadSurveys()
+            },
+            launchSurveyFailure: ({ errorObject }) => {
+                // When an approval policy gates launches, the API replies 409 instead of launching.
+                // Surface that as "submitted for approval" and refresh the pending-request banner.
+                if (props.id !== NEW_SURVEY.id && handleApprovalRequired(errorObject, 'survey', props.id)) {
+                    return
+                }
             },
             stopSurveySuccess: () => {
                 actions.loadSurveys()

--- a/products/approvals/backend/actions/registry.py
+++ b/products/approvals/backend/actions/registry.py
@@ -11,10 +11,12 @@ def register_actions():
         EnableFeatureFlagAction,
         UpdateFeatureFlagAction,
     )
+    from products.approvals.backend.actions.surveys import LaunchSurveyAction
 
     ACTION_REGISTRY[EnableFeatureFlagAction.key] = EnableFeatureFlagAction
     ACTION_REGISTRY[DisableFeatureFlagAction.key] = DisableFeatureFlagAction
     ACTION_REGISTRY[UpdateFeatureFlagAction.key] = UpdateFeatureFlagAction
+    ACTION_REGISTRY[LaunchSurveyAction.key] = LaunchSurveyAction
 
 
 def get_action(action_key: str) -> Optional[type[BaseAction]]:

--- a/products/approvals/backend/actions/surveys.py
+++ b/products/approvals/backend/actions/surveys.py
@@ -105,7 +105,11 @@ class LaunchSurveyAction(BaseAction):
             return True
 
         stored_updated_at = intent_data.get("preconditions", {}).get("updated_at")
-        if stored_updated_at is not None and instance.updated_at and instance.updated_at.isoformat() != stored_updated_at:
+        if (
+            stored_updated_at is not None
+            and instance.updated_at
+            and instance.updated_at.isoformat() != stored_updated_at
+        ):
             return True
 
         return False

--- a/products/approvals/backend/actions/surveys.py
+++ b/products/approvals/backend/actions/surveys.py
@@ -173,7 +173,7 @@ class LaunchSurveyAction(BaseAction):
             ):
                 if managed_flag is not None and managed_flag.active != should_be_active:
                     managed_flag.active = should_be_active
-                    managed_flag.save()
+                    managed_flag.save(update_fields=["active"])
 
             log_activity(
                 organization_id=survey.team.organization_id,

--- a/products/approvals/backend/actions/surveys.py
+++ b/products/approvals/backend/actions/surveys.py
@@ -1,0 +1,204 @@
+from typing import Any, Optional
+
+from django.db import transaction
+from django.utils import timezone
+from django.utils.dateparse import parse_datetime
+
+from posthog.models.activity_logging.activity_log import Change, Detail, log_activity
+
+from products.approvals.backend.actions.base import BaseAction
+from products.approvals.backend.exceptions import ApplyFailed, PreconditionFailed
+from products.surveys.backend.models import Survey
+
+
+def _survey_should_have_active_flags(survey: Survey) -> bool:
+    """Mirror of SurveySerializer._should_survey_flags_be_active — a survey's managed flags
+    are active exactly while it is running (launched, not ended, not archived)."""
+    return bool(survey.start_date) and not survey.end_date and not survey.archived
+
+
+class LaunchSurveyAction(BaseAction):
+    """Gate launching a survey — the draft -> running transition (setting `start_date`).
+
+    Surveys can be launched two ways, and both are gated:
+    - a PATCH that sets `start_date` (goes through SurveySerializerCreateUpdateOnly.update), and
+    - the dedicated `POST /surveys/:id/launch/` viewset action (no request body).
+    """
+
+    key = "survey.launch"
+    version = 1
+    description = "Launch a survey"
+    resource_type = "survey"
+    intent_fields = ["start_date"]
+
+    @staticmethod
+    def _is_serializer_context(view: Any) -> bool:
+        return hasattr(view, "context") and isinstance(view.context, dict) and "request" in view.context
+
+    @classmethod
+    def detect(cls, request: Any, view: Any, *args: Any, **kwargs: Any) -> bool:
+        try:
+            survey = cls._get_instance(view, *args, **kwargs)
+        except Exception:
+            return False
+
+        if survey is None:
+            return False
+
+        # Only the initial draft -> running transition is gated. A survey that is already
+        # launched (re-launch no-op), archived, or being resumed is out of scope.
+        if survey.start_date is not None or survey.archived:
+            return False
+
+        # On the PATCH/serializer path, it is only a launch if the request actually sets
+        # start_date — a plain edit of a draft must pass through ungated. The dedicated
+        # launch action carries no body, so reaching it is itself the launch intent.
+        if cls._is_serializer_context(view) and not request.data.get("start_date"):
+            return False
+
+        return cls._get_team(view) is not None
+
+    @classmethod
+    def extract_intent(cls, request: Any, view: Any, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        survey = cls._get_instance(view, *args, **kwargs)
+
+        if cls._is_serializer_context(view):
+            full_request_data = dict(request.data)
+            requested_start = full_request_data.get("start_date")
+        else:
+            # Dedicated launch action: launch starts the survey now.
+            requested_start = timezone.now().isoformat()
+            full_request_data = {"start_date": requested_start}
+
+        return {
+            "survey_id": str(survey.id),
+            "survey_name": survey.name,
+            "current_state": {"start_date": survey.start_date.isoformat() if survey.start_date else None},
+            "gated_changes": {"start_date": requested_start},
+            "full_request_data": full_request_data,
+            "preconditions": {
+                "updated_at": survey.updated_at.isoformat() if survey.updated_at else None,
+            },
+        }
+
+    @classmethod
+    def validate_intent(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> tuple[bool, Optional[dict[str, Any]]]:
+        # The only gated change is the launch transition itself, which the action controls;
+        # there is no client-supplied field to validate against a serializer. Launchability
+        # (archived / already ended / staleness) is enforced at apply time against a locked row.
+        if not intent_data.get("survey_id"):
+            return False, {"survey": "Missing survey reference"}
+        return True, None
+
+    @classmethod
+    def check_staleness(
+        cls,
+        intent_data: dict[str, Any],
+        context: Optional[dict[str, Any]] = None,
+    ) -> bool:
+        instance = context.get("instance") if context else None
+        if instance is None:
+            return True
+
+        stored_updated_at = intent_data.get("preconditions", {}).get("updated_at")
+        if stored_updated_at is not None and instance.updated_at and instance.updated_at.isoformat() != stored_updated_at:
+            return True
+
+        return False
+
+    @classmethod
+    def prepare_context(cls, change_request: Any, base_context: dict[str, Any]) -> dict[str, Any]:
+        context = base_context.copy()
+
+        survey_id = change_request.intent.get("survey_id") or change_request.resource_id
+        if survey_id:
+            try:
+                context["instance"] = Survey.objects.get(id=survey_id, team_id=change_request.team_id)
+            except Survey.DoesNotExist:
+                pass
+
+        return context
+
+    @classmethod
+    def apply(cls, validated_intent: dict[str, Any], user: Any, context: Optional[dict[str, Any]] = None) -> Survey:
+        survey_id = validated_intent["survey_id"]
+
+        with transaction.atomic():
+            # nosemgrep: idor-lookup-without-team (survey_id from validated change request intent, originally team-scoped)
+            survey = Survey.objects.select_for_update().get(id=survey_id)
+
+            stored_updated_at = validated_intent.get("preconditions", {}).get("updated_at")
+            if stored_updated_at and survey.updated_at and survey.updated_at.isoformat() != stored_updated_at:
+                raise PreconditionFailed(
+                    f"Survey was modified since approval was requested "
+                    f"(expected updated_at {stored_updated_at}, got {survey.updated_at.isoformat()})"
+                )
+
+            if survey.archived:
+                raise ApplyFailed("Cannot launch an archived survey")
+
+            now = timezone.now()
+            if survey.end_date is not None and survey.end_date <= now:
+                raise ApplyFailed("Cannot launch a survey whose end date has already passed")
+
+            # Idempotency: already launched.
+            if survey.start_date is not None:
+                return survey
+
+            requested_start = validated_intent.get("gated_changes", {}).get("start_date")
+            start_date = parse_datetime(requested_start) if isinstance(requested_start, str) else None
+            if start_date is None:
+                start_date = now
+
+            previous_start = survey.start_date
+            survey.start_date = start_date
+            survey.save(update_fields=["start_date"])
+
+            # Mirror the serializer's launch-time lifecycle sync: a running survey's managed
+            # flags must be active so it is actually shown. The user-owned linked_flag is left
+            # untouched, exactly as the serializer leaves it.
+            should_be_active = _survey_should_have_active_flags(survey)
+            for managed_flag in (
+                survey.targeting_flag,
+                survey.internal_targeting_flag,
+                survey.internal_response_sampling_flag,
+            ):
+                if managed_flag is not None and managed_flag.active != should_be_active:
+                    managed_flag.active = should_be_active
+                    managed_flag.save()
+
+            log_activity(
+                organization_id=survey.team.organization_id,
+                team_id=survey.team_id,
+                user=user,
+                was_impersonated=False,
+                item_id=survey.id,
+                scope="Survey",
+                activity="launched",
+                detail=Detail(
+                    name=survey.name,
+                    changes=[
+                        Change(
+                            type="Survey",
+                            action="changed",
+                            field="start_date",
+                            before=previous_start,
+                            after=survey.start_date,
+                        )
+                    ],
+                ),
+            )
+
+        return survey
+
+    @classmethod
+    def get_display_data(cls, intent_data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "description": f"Launch survey '{intent_data.get('survey_name', 'unknown')}'",
+            "before": intent_data.get("current_state", {}),
+            "after": intent_data.get("gated_changes", {}),
+        }

--- a/products/approvals/backend/decorators.py
+++ b/products/approvals/backend/decorators.py
@@ -174,9 +174,12 @@ def _build_context(view_or_serializer, team, organization, request) -> dict[str,
 
 
 def _extract_resource_id(request, args: tuple, kwargs: dict) -> Optional[str]:
-    """Extract resource ID from request context."""
-    if request.method == "POST":
-        return None
+    """Extract resource ID from request context.
+
+    Prefer an explicit reference: the serializer instance arg (update) or a detail-route pk
+    (a detail viewset action such as `POST .../launch/`). A create — POST with neither — has
+    no resource yet and correctly yields None.
+    """
     if args and hasattr(args[0], "id"):
         return str(args[0].id)
     if kwargs.get("pk"):

--- a/products/approvals/backend/tests/test_survey_launch_action.py
+++ b/products/approvals/backend/tests/test_survey_launch_action.py
@@ -28,7 +28,9 @@ class TestLaunchSurveyActionDetect(APIBaseTest):
 
     def _viewset_view(self, survey: Survey) -> MagicMock:
         view = MagicMock()
-        view.context = None  # not a serializer
+        # A real DRF viewset has no `context` instance attribute, so `_get_instance`
+        # falls through to `get_object()`. Delete it so `hasattr` is False as in production.
+        del view.context
         view.get_object.return_value = survey
         view.team = self.team
         return view

--- a/products/approvals/backend/tests/test_survey_launch_action.py
+++ b/products/approvals/backend/tests/test_survey_launch_action.py
@@ -1,0 +1,258 @@
+from datetime import timedelta
+
+from posthog.test.base import APIBaseTest
+from unittest.mock import MagicMock
+
+from django.utils import timezone
+
+from parameterized import parameterized
+from rest_framework import status
+
+from posthog.constants import AvailableFeature
+
+from products.approvals.backend.actions.surveys import LaunchSurveyAction
+from products.approvals.backend.models import ApprovalPolicy, ChangeRequest, ChangeRequestState
+from products.surveys.backend.models import Survey
+
+
+class TestLaunchSurveyActionDetect(APIBaseTest):
+    def _create_survey(self, **kwargs) -> Survey:
+        defaults = {"team": self.team, "name": "Test survey", "type": "popover", "created_by": self.user}
+        defaults.update(kwargs)
+        return Survey.objects.create(**defaults)
+
+    def _serializer_view(self, request: MagicMock) -> MagicMock:
+        view = MagicMock()
+        view.context = {"request": request, "get_team": lambda: self.team}
+        return view
+
+    def _viewset_view(self, survey: Survey) -> MagicMock:
+        view = MagicMock()
+        view.context = None  # not a serializer
+        view.get_object.return_value = survey
+        view.team = self.team
+        return view
+
+    def _request(self, data: dict) -> MagicMock:
+        request = MagicMock()
+        request.method = "PATCH"
+        request.data = data
+        return request
+
+    def test_detect_true_when_patch_sets_start_date_on_draft(self):
+        survey = self._create_survey()
+        request = self._request({"start_date": timezone.now().isoformat()})
+        assert LaunchSurveyAction.detect(request, self._serializer_view(request), survey) is True
+
+    def test_detect_false_for_plain_edit_of_draft(self):
+        survey = self._create_survey()
+        request = self._request({"name": "Renamed"})
+        assert LaunchSurveyAction.detect(request, self._serializer_view(request), survey) is False
+
+    def test_detect_false_when_already_launched(self):
+        survey = self._create_survey(start_date=timezone.now())
+        request = self._request({"start_date": timezone.now().isoformat()})
+        assert LaunchSurveyAction.detect(request, self._serializer_view(request), survey) is False
+
+    def test_detect_false_for_archived_survey(self):
+        survey = self._create_survey(archived=True)
+        request = self._request({"start_date": timezone.now().isoformat()})
+        assert LaunchSurveyAction.detect(request, self._serializer_view(request), survey) is False
+
+    def test_detect_true_on_dedicated_launch_action_for_draft(self):
+        # The dedicated launch action carries no body; reaching it is the launch intent.
+        survey = self._create_survey()
+        request = MagicMock(method="POST", data={})
+        assert LaunchSurveyAction.detect(request, self._viewset_view(survey), request) is True
+
+    def test_detect_false_on_dedicated_launch_action_when_already_launched(self):
+        survey = self._create_survey(start_date=timezone.now())
+        request = MagicMock(method="POST", data={})
+        assert LaunchSurveyAction.detect(request, self._viewset_view(survey), request) is False
+
+
+class TestSurveyLaunchApprovalGate(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.organization_membership.level = 8  # admin
+        self.organization_membership.save()
+        self.organization.available_product_features = [
+            {"key": AvailableFeature.APPROVALS, "name": AvailableFeature.APPROVALS}
+        ]
+        self.organization.save()
+
+    def _create_survey(self, **kwargs) -> Survey:
+        defaults = {"team": self.team, "name": "Launch me", "type": "popover", "created_by": self.user}
+        defaults.update(kwargs)
+        return Survey.objects.create(**defaults)
+
+    def _create_policy(self, **kwargs) -> ApprovalPolicy:
+        defaults = {
+            "organization": self.organization,
+            "team": self.team,
+            "action_key": "survey.launch",
+            "approver_config": {"quorum": 1, "users": [self.user.id]},
+            "allow_self_approve": True,
+            "expires_after": timedelta(days=14),
+            "enabled": True,
+        }
+        defaults.update(kwargs)
+        return ApprovalPolicy.objects.create(**defaults)
+
+    def _patch_launch(self, survey: Survey):
+        return self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"start_date": timezone.now().isoformat()},
+            format="json",
+        )
+
+    def test_patch_launch_passes_through_without_policy(self):
+        survey = self._create_survey()
+        response = self._patch_launch(survey)
+        assert response.status_code == status.HTTP_200_OK
+        survey.refresh_from_db()
+        assert survey.start_date is not None
+        assert not ChangeRequest.objects.filter(action_key="survey.launch").exists()
+
+    def test_patch_launch_passes_through_when_feature_disabled(self):
+        self.organization.available_product_features = []
+        self.organization.save()
+        self._create_policy()
+        survey = self._create_survey()
+        response = self._patch_launch(survey)
+        assert response.status_code == status.HTTP_200_OK
+        survey.refresh_from_db()
+        assert survey.start_date is not None
+
+    def test_patch_launch_is_gated_and_then_applied_on_approval(self):
+        self._create_policy()
+        survey = self._create_survey()
+
+        response = self._patch_launch(survey)
+        assert response.status_code == status.HTTP_409_CONFLICT
+        assert response.json()["code"] == "approval_required"
+        survey.refresh_from_db()
+        assert survey.start_date is None  # held, not launched
+
+        cr = ChangeRequest.objects.get(action_key="survey.launch", resource_id=str(survey.id))
+        assert cr.state == ChangeRequestState.PENDING
+
+        approve = self.client.post(f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/")
+        assert approve.status_code == status.HTTP_200_OK
+
+        cr.refresh_from_db()
+        assert cr.state == ChangeRequestState.APPLIED
+        survey.refresh_from_db()
+        assert survey.start_date is not None  # launched
+
+    def test_dedicated_launch_action_is_also_gated(self):
+        # Closing the bypass: the dedicated endpoint must not skip approval.
+        self._create_policy()
+        survey = self._create_survey()
+
+        response = self.client.post(f"/api/projects/{self.team.id}/surveys/{survey.id}/launch/")
+        assert response.status_code == status.HTTP_409_CONFLICT
+        survey.refresh_from_db()
+        assert survey.start_date is None
+
+        cr = ChangeRequest.objects.get(action_key="survey.launch")
+        assert cr.resource_id == str(survey.id)  # detail-route pk captured despite POST
+
+    def test_reject_leaves_survey_as_draft(self):
+        self._create_policy()
+        survey = self._create_survey()
+        self._patch_launch(survey)
+        cr = ChangeRequest.objects.get(action_key="survey.launch")
+
+        reject = self.client.post(
+            f"/api/environments/{self.team.id}/change_requests/{cr.id}/reject/",
+            data={"reason": "not yet"},
+            format="json",
+        )
+        assert reject.status_code == status.HTTP_200_OK
+        cr.refresh_from_db()
+        assert cr.state == ChangeRequestState.REJECTED
+        survey.refresh_from_db()
+        assert survey.start_date is None
+
+    def test_duplicate_launch_request_is_rejected(self):
+        self._create_policy()
+        survey = self._create_survey()
+        first = self._patch_launch(survey)
+        assert first.status_code == status.HTTP_409_CONFLICT
+
+        second = self._patch_launch(survey)
+        assert second.status_code == status.HTTP_409_CONFLICT
+        assert second.json()["code"] == "change_request_pending"
+        assert ChangeRequest.objects.filter(action_key="survey.launch", resource_id=str(survey.id)).count() == 1
+
+    def test_plain_edit_of_draft_is_not_gated(self):
+        self._create_policy()
+        survey = self._create_survey()
+        response = self.client.patch(
+            f"/api/projects/{self.team.id}/surveys/{survey.id}/",
+            data={"description": "just editing"},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_200_OK
+        assert not ChangeRequest.objects.filter(action_key="survey.launch").exists()
+
+    def test_stale_survey_fails_to_apply(self):
+        self._create_policy()
+        survey = self._create_survey()
+        self._patch_launch(survey)
+        cr = ChangeRequest.objects.get(action_key="survey.launch")
+
+        # Survey is modified after the request is raised, invalidating the precondition.
+        survey.name = "Edited after request"
+        survey.save()
+
+        approve = self.client.post(f"/api/environments/{self.team.id}/change_requests/{cr.id}/approve/")
+        # Quorum is reached but application fails the precondition check.
+        cr.refresh_from_db()
+        assert cr.state == ChangeRequestState.FAILED
+        survey.refresh_from_db()
+        assert survey.start_date is None
+        assert approve.status_code in (status.HTTP_200_OK, status.HTTP_409_CONFLICT)
+
+
+class TestLaunchSurveyActionApply(APIBaseTest):
+    def _create_survey(self, **kwargs) -> Survey:
+        defaults = {"team": self.team, "name": "Apply me", "type": "popover", "created_by": self.user}
+        defaults.update(kwargs)
+        return Survey.objects.create(**defaults)
+
+    def _intent(self, survey: Survey, start_date=None) -> dict:
+        start = (start_date or timezone.now()).isoformat()
+        return {
+            "survey_id": str(survey.id),
+            "survey_name": survey.name,
+            "current_state": {"start_date": None},
+            "gated_changes": {"start_date": start},
+            "full_request_data": {"start_date": start},
+            "preconditions": {"updated_at": survey.updated_at.isoformat()},
+        }
+
+    def test_apply_launches_survey(self):
+        survey = self._create_survey()
+        result = LaunchSurveyAction.apply(self._intent(survey), user=self.user)
+        survey.refresh_from_db()
+        assert survey.start_date is not None
+        assert result.id == survey.id
+
+    def test_apply_is_idempotent_when_already_launched(self):
+        survey = self._create_survey(start_date=timezone.now())
+        existing_start = survey.start_date
+        LaunchSurveyAction.apply(self._intent(survey), user=self.user)
+        survey.refresh_from_db()
+        assert survey.start_date == existing_start
+
+    @parameterized.expand([("targeting_flag",), ("internal_targeting_flag",), ("internal_response_sampling_flag",)])
+    def test_apply_activates_managed_flag(self, flag_attr: str):
+        from products.feature_flags.backend.models.feature_flag import FeatureFlag
+
+        flag = FeatureFlag.objects.create(team=self.team, key=f"survey-{flag_attr}", created_by=self.user, active=False)
+        survey = self._create_survey(**{flag_attr: flag})
+        LaunchSurveyAction.apply(self._intent(survey), user=self.user)
+        flag.refresh_from_db()
+        assert flag.active is True

--- a/products/surveys/backend/api/survey.py
+++ b/products/surveys/backend/api/survey.py
@@ -61,6 +61,8 @@ from posthog.utils_cors import cors_response
 
 from products.actions.backend.api.action import ActionSerializer, ActionStepJSONSerializer
 from products.actions.backend.models.action import Action
+from products.approvals.backend.decorators import approval_gate
+from products.approvals.backend.mixins import ApprovalHandlingMixin
 from products.feature_flags.backend.api.feature_flag import (
     BEHAVIOURAL_COHORT_FOUND_ERROR_CODE,
     FeatureFlagSerializer,
@@ -1606,6 +1608,7 @@ class SurveySerializerCreateUpdateOnly(serializers.ModelSerializer):
 
         return instance
 
+    @approval_gate(["survey.launch"])
     def update(self, instance: Survey, validated_data):
         before_update = Survey.objects.get(pk=instance.pk)
         user = self.context["request"].user
@@ -2065,7 +2068,7 @@ class SurveyFilterSet(FilterSet):
         ],
     ),
 )
-class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
+class SurveyViewSet(ApprovalHandlingMixin, TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.ModelViewSet):
     scope_object = "survey"
     queryset = Survey.objects.select_related(
         "linked_flag", "linked_insight", "targeting_flag", "internal_targeting_flag"
@@ -2157,6 +2160,7 @@ class SurveyViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMixin, viewsets.
         responses={200: SurveySerializer},
     )
     @action(methods=["POST"], detail=True, required_scopes=["survey:write"])
+    @approval_gate(["survey.launch"])
     def launch(self, request: request.Request, **kwargs: Any) -> Response:
         survey = self.get_object()
         now = datetime.now(UTC)

--- a/products/surveys/frontend/generated/api.ts
+++ b/products/surveys/frontend/generated/api.ts
@@ -61,6 +61,13 @@ export const getSurveysListUrl = (projectId: string, params?: SurveysListParams)
         : `/api/projects/${projectId}/surveys/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysList = async (
     projectId: string,
     params?: SurveysListParams,
@@ -76,6 +83,13 @@ export const getSurveysCreateUrl = (projectId: string) => {
     return `/api/projects/${projectId}/surveys/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysCreate = async (
     projectId: string,
     surveySerializerCreateUpdateOnlySchemaApi: NonReadonly<SurveySerializerCreateUpdateOnlySchemaApi>,
@@ -93,6 +107,13 @@ export const getSurveysRetrieveUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<SurveyApi> => {
     return apiMutator<SurveyApi>(getSurveysRetrieveUrl(projectId, id), {
         ...options,
@@ -104,6 +125,13 @@ export const getSurveysUpdateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysUpdate = async (
     projectId: string,
     id: string,
@@ -122,6 +150,13 @@ export const getSurveysPartialUpdateUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysPartialUpdate = async (
     projectId: string,
     id: string,
@@ -140,6 +175,13 @@ export const getSurveysDestroyUrl = (projectId: string, id: string) => {
     return `/api/projects/${projectId}/surveys/${id}/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysDestroy = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysDestroyUrl(projectId, id), {
         ...options,
@@ -151,6 +193,13 @@ export const getSurveysActivityRetrieveUrl = (projectId: string, id: string) => 
     return `/api/projects/${projectId}/surveys/${id}/activity/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysActivityRetrieve = async (projectId: string, id: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysActivityRetrieveUrl(projectId, id), {
         ...options,
@@ -207,6 +256,13 @@ export const getSurveysGenerateTranslationsCreateUrl = (projectId: string, id: s
     return `/api/projects/${projectId}/surveys/${id}/generate_translations/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysGenerateTranslationsCreate = async (
     projectId: string,
     id: string,
@@ -406,6 +462,13 @@ export const getSurveysSummaryHeadlineCreateUrl = (projectId: string, id: string
     return `/api/projects/${projectId}/surveys/${id}/summary_headline/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysSummaryHeadlineCreate = async (
     projectId: string,
     id: string,
@@ -424,6 +487,13 @@ export const getSurveysAllActivityRetrieveUrl = (projectId: string) => {
     return `/api/projects/${projectId}/surveys/activity/`
 }
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysAllActivityRetrieve = async (projectId: string, options?: RequestInit): Promise<void> => {
     return apiMutator<void>(getSurveysAllActivityRetrieveUrl(projectId), {
         ...options,

--- a/products/surveys/frontend/generated/api.zod.ts
+++ b/products/surveys/frontend/generated/api.zod.ts
@@ -9,6 +9,13 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysCreateBodyNameMax = 400
 
 export const surveysCreateBodyTargetingFlagFiltersOneEarlyExitDefault = false
@@ -839,6 +846,13 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysUpdateBodyNameMax = 400
 
 export const surveysUpdateBodyResponsesLimitMin = 0
@@ -938,6 +952,13 @@ export const SurveysUpdateBody = /* @__PURE__ */ zod
     })
     .describe('Mixin for serializers to add user access control fields')
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysPartialUpdateBodyNameMax = 400
 
 export const surveysPartialUpdateBodyTargetingFlagFiltersOneEarlyExitDefault = false
@@ -1877,6 +1898,13 @@ export const SurveysDuplicateToProjectsCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysGenerateTranslationsCreateBodyOverwriteDefault = false
 
 export const SurveysGenerateTranslationsCreateBody = /* @__PURE__ */ zod.object({
@@ -2119,6 +2147,13 @@ export const SurveysSummarizeResponsesCreateBody = /* @__PURE__ */ zod.object({
         .describe('When true, bypass cached summaries and regenerate. Defaults to false.'),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const surveysSummaryHeadlineCreateBodyNameMax = 400
 
 export const surveysSummaryHeadlineCreateBodyResponsesLimitMin = 0

--- a/services/mcp/src/generated/surveys/api.ts
+++ b/services/mcp/src/generated/surveys/api.ts
@@ -8,6 +8,13 @@
  */
 import * as zod from 'zod'
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const SurveysListParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
@@ -33,6 +40,13 @@ export const SurveysListQueryParams = /* @__PURE__ */ zod.object({
         .describe('* `popover` - popover\n* `widget` - widget\n* `external_survey` - external survey\n* `api` - api'),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const SurveysCreateParams = /* @__PURE__ */ zod.object({
     project_id: zod
         .string()
@@ -859,6 +873,13 @@ export const SurveysCreateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const SurveysRetrieveParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod
@@ -868,6 +889,13 @@ export const SurveysRetrieveParams = /* @__PURE__ */ zod.object({
         ),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const SurveysPartialUpdateParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod
@@ -1696,6 +1724,13 @@ export const SurveysPartialUpdateBody = /* @__PURE__ */ zod.object({
     form_content: zod.unknown().optional(),
 })
 
+/**
+ * Mixin for ViewSets to handle ApprovalRequired exceptions from decorated serializers.
+ *
+ * This mixin intercepts ApprovalRequired exceptions raised by the @approval_gate decorator
+ * on serializer methods and converts them into proper HTTP 409 Conflict responses with
+ * change request details.
+ */
 export const SurveysDestroyParams = /* @__PURE__ */ zod.object({
     id: zod.string().describe('A UUID string identifying this survey.'),
     project_id: zod

--- a/tach.toml
+++ b/tach.toml
@@ -168,6 +168,7 @@ depends_on = [
     "posthog",
     "products.feature_flags",
     "products.notifications",
+    "products.surveys",
 ]
 layer = "modules"
 
@@ -607,6 +608,7 @@ depends_on = [
     "ee",
     "posthog",
     "products.actions",
+    "products.approvals",
     "products.feature_flags",
     "products.product_analytics",
     "products.product_tours",


### PR DESCRIPTION
## Problem

Some teams need a separation of duties on surveys: an editor can build and edit a survey, but launching it to real users should require sign-off from a designated reviewer. There's no native way to enforce that today — anyone with `editor` access can launch instantly, and the only workaround (linking a gated feature flag) can't be enforced and conflates "approved to launch" with "who sees it".

Closes #67127

## Changes

Gates the survey **draft → running** transition (setting `start_date`) behind the existing approvals engine in `products/approvals`, which was already built to be resource-agnostic. Surveys become its second consumer after feature flags — no new approval models, policy types, or review UI.

- **`LaunchSurveyAction`** (`products/approvals/backend/actions/surveys.py`) — implements the `BaseAction` contract for `survey.launch`. `detect()` handles both launch paths; `apply()` sets `start_date` under `select_for_update`, checks an `updated_at` precondition (surveys have no `version`), is idempotent, and mirrors the serializer's launch-time managed-flag `active` sync.
- **Both launch paths are gated** so the API can't be used to bypass approval: the serializer `update()` (the PATCH the UI uses) and the dedicated `POST /surveys/:id/launch/` action. `ApprovalHandlingMixin` on the viewset turns the held request into a `409`.
- **`_extract_resource_id`** now resolves a detail-route `pk` on POST actions (it previously returned `None` for any POST). A create still yields `None`; this lets the dedicated launch action attach the correct `resource_id`.
- **Frontend**: registers the `survey` resource type / `survey.launch` action in `scenes/approvals/utils.ts`, surfaces the `409` on launch as "submitted for approval" via the existing `handleApprovalRequired`, and shows the existing `PendingChangeRequestBanner` on the draft view.

The whole thing is inert unless an org admin enables an `ApprovalPolicy` for `survey.launch` — zero behavior change otherwise.

### Key design decision

`apply()` sets `start_date` directly rather than re-running `SurveySerializerCreateUpdateOnly` (the pattern the feature-flag action uses). The survey serializer's launch path transitively creates feature flags through a nested, also-gated `FeatureFlagSerializer` and mutates `request.method`, which is fragile to re-run under the approval service's lightweight request shim. Setting `start_date` + syncing managed-flag `active` reproduces the same observable end state with far less surface area. Flagged here because it's the main thing to sanity-check.

## How did you test this code?

I'm an agent. I added automated tests in `products/approvals/backend/tests/test_survey_launch_action.py`:

- **Detect** unit tests — launch detected on a draft (both PATCH and dedicated-action paths); not detected for plain edits, already-launched, or archived surveys.
- **End-to-end gate** — with a policy: PATCH launch returns `409` and the survey stays a draft; self-approval applies it and `start_date` gets set. The dedicated launch endpoint is gated too and records the right `resource_id`. Reject leaves it a draft. Duplicate requests are rejected. No policy / feature disabled → passes straight through. Plain draft edits aren't gated. A survey edited after the request fails the precondition on apply.
- **Apply** unit tests — launches, is idempotent, and activates each managed flag.

I could **not** run them in this environment: this is a fresh clone with no Python venv, Postgres, or ClickHouse, and the frontend has no `node_modules`, so backend tests, `typecheck`, lint, and `hogli build:openapi` were not run. Needs a CI pass and a reviewer eye on the frontend wiring before this leaves draft.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — directed by a PostHog teammate via the linked Slack thread. Left unassigned because I couldn't verify their GitHub handle this session; owning team please assign the DRI.

Built by the PostHog Slack agent. Approach: studied the feature-flag approvals implementation and reused it wholesale rather than building survey-specific approval logic — the engine's `resource_type`/`action_key` are already generic. Main decision was the `apply()` strategy (above): re-running the survey serializer under the service request shim was tried-on-paper and rejected as too fragile, in favor of a direct, self-contained `start_date` set. The `_extract_resource_id` tweak was needed because the shared helper returned `None` for all POSTs, which would have broken the dedicated launch action's change-request linkage.

The mandated `/improving-drf-endpoints` and `/writing-tests` repo skills aren't loadable in this harness; I followed their rule files (`.claude/rules`) manually — schema annotations preserved on the gated action, `help_text` unchanged, and the test value-gate applied (each group named above catches a distinct regression).

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C07QD3LT8U9/p1782830407421099?thread_ts=1782830407.421099&cid=C07QD3LT8U9)*
