### PR TITLE
feat(batch-import-worker): fail-fast staging disk guard

### DIFF
--- a/rust/batch-import-worker/src/config.rs
+++ b/rust/batch-import-worker/src/config.rs
@@ -95,6 +95,13 @@ pub struct Config {
     // every startup to reclaim space leaked by non-graceful pod terminations.
     #[envconfig(from = "STAGING_DIR", default = "/tmp/batch-import-worker")]
     pub staging_dir: String,
+
+    // Fail-fast guard: if the staging directory grows past this many bytes while
+    // downloading a part, the job is paused (surfaced to the user) instead of the
+    // pod being evicted under disk pressure. 0 disables the guard. Size this below
+    // the staging volume capacity in deployment.
+    #[envconfig(from = "STAGING_DIR_MAX_BYTES", default = "0")]
+    pub staging_dir_max_bytes: u64,
 }
 
 impl Config {

--- a/rust/batch-import-worker/src/job/config.rs
+++ b/rust/batch-import-worker/src/job/config.rs
@@ -195,6 +195,7 @@ impl SourceConfig {
         is_restarting: bool,
     ) -> Result<Box<dyn DataSource>, Error> {
         let staging_dir = context.config.staging_dir();
+        let staging_max_bytes = context.config.staging_dir_max_bytes;
         match self {
             SourceConfig::Folder(config) => Ok(Box::new(config.create_source().await?)),
             SourceConfig::UrlList(config) => Ok(Box::new(
@@ -204,11 +205,15 @@ impl SourceConfig {
             )),
             SourceConfig::S3(config) => Ok(Box::new(config.create_source(secrets).await?)),
             SourceConfig::S3Gzip(config) => Ok(Box::new(
-                config.create_gzip_source(secrets, staging_dir).await?,
+                config
+                    .create_gzip_source(secrets, staging_dir, staging_max_bytes)
+                    .await?,
             )),
-            SourceConfig::DateRangeExport(config) => {
-                Ok(Box::new(config.create_source(secrets, staging_dir).await?))
-            }
+            SourceConfig::DateRangeExport(config) => Ok(Box::new(
+                config
+                    .create_source(secrets, staging_dir, staging_max_bytes)
+                    .await?,
+            )),
         }
     }
 }
@@ -423,6 +428,7 @@ impl S3SourceConfig {
         &self,
         secrets: &JobSecrets,
         staging_dir: PathBuf,
+        staging_max_bytes: u64,
     ) -> Result<GzipS3Source, Error> {
         let builder = self.build_s3_config(secrets)?;
         let client = aws_sdk_s3::Client::from_conf(builder.build());
@@ -433,6 +439,7 @@ impl S3SourceConfig {
             self.prefix.clone(),
             ExtractorType::PlainGzip.create_extractor(),
             staging_dir,
+            staging_max_bytes,
         ))
     }
 }
@@ -441,6 +448,7 @@ impl DateRangeExportSourceConfig {
         &self,
         secrets: &JobSecrets,
         staging_dir: PathBuf,
+        staging_max_bytes: u64,
     ) -> Result<DateRangeExportSource, Error> {
         let auth_config = match &self.auth {
             AuthSourceConfig::None => AuthConfig::None,
@@ -540,6 +548,7 @@ impl DateRangeExportSourceConfig {
         .with_auth(auth_config)
         .with_date_format(self.date_format.clone())
         .with_headers(self.headers.clone())
+        .with_staging_max_bytes(staging_max_bytes)
         .build()
     }
 

--- a/rust/batch-import-worker/src/job/mod.rs
+++ b/rust/batch-import-worker/src/job/mod.rs
@@ -220,6 +220,20 @@ pub(crate) async fn select_and_fetch_next_chunk(
         )));
     }
 
+    // A single record larger than the read window fills a whole non-final chunk with no
+    // line terminator, so the parser can't advance past it. Without this the loop would
+    // crawl one byte per iteration (and, on the temp-bucket backend, issue a ranged GET
+    // of up to chunk_size per byte). Fail fast with an actionable, non-transient error
+    // that pauses the job.
+    if !is_last_chunk && chunk_bytes == chunk_size && parsed.consumed <= 1 && parsed.data.is_empty()
+    {
+        return Err(Error::from(UserError::new(format!(
+            "A single record in part {} exceeds the maximum chunk size ({chunk_size} bytes) \
+             and cannot be processed; split the oversized record into smaller ones.",
+            next_part.key
+        ))));
+    }
+
     // If we consumed no bytes and have no parsed data but there was data to consume, something went wrong.
     // Note: don't error if we have no parsed data but have consumed bytes - invalid events may have been all filtered out
     if parsed.consumed == 0 && parsed.data.is_empty() && chunk_bytes > 0 {
@@ -1238,6 +1252,26 @@ mod tests {
             }))
         }
 
+        /// A transform that runs the real newline parser to compute `consumed`
+        /// (validating each complete line as JSON) but emits no events. This
+        /// reproduces the parser's real boundary behavior — a chunk with no line
+        /// terminator yields `consumed == 1` — which is what the oversized-record
+        /// guard keys on, without standing up the full captured-event pipeline.
+        fn newline_consumed_transform() -> Arc<ParserFn> {
+            Arc::new(Box::new(|bytes: Vec<u8>| {
+                let parser = crate::parse::format::newline_delim(true, |line: &str| {
+                    serde_json::from_str::<serde_json::Value>(line)
+                        .map(|_| ())
+                        .map_err(anyhow::Error::from)
+                });
+                let parsed = parser(bytes)?;
+                Ok(Parsed {
+                    consumed: parsed.consumed,
+                    data: Vec::new(),
+                })
+            }))
+        }
+
         fn count_raw_files(dir: &Path) -> usize {
             let mut count = 0;
             let mut stack = vec![dir.to_path_buf()];
@@ -1356,6 +1390,51 @@ mod tests {
                 peak_raw, 1,
                 "exactly one .raw should exist while the part is in flight"
             );
+        }
+
+        #[tokio::test]
+        async fn test_record_larger_than_chunk_size_fails_fast() {
+            // A single JSON record with no interior newline, larger than the read window.
+            // Without the guard the loop would crawl one byte per iteration forever.
+            let server = MockServer::start();
+            let huge_record = format!("{{\"event\":\"{}\"}}", "x".repeat(5000));
+            assert!(!huge_record.contains('\n'));
+            let _mock = server.mock(|when, then| {
+                when.method(Method::GET).path("/export");
+                then.status(200).body(gzip_bytes(huge_record.as_bytes()));
+            });
+
+            let staging = TempDir::new().unwrap();
+            let source = build_source(server.url("/export"), staging.path(), 1);
+            source.prepare_for_job().await.unwrap();
+            let keys = source.keys().await.unwrap();
+
+            let state = Mutex::new(job_state(&keys));
+            let model = Mutex::new(dummy_model(job_state(&keys)));
+            let transform = newline_consumed_transform();
+
+            // Read window (1024) is far smaller than the 5000-byte record.
+            let result = select_and_fetch_next_chunk(
+                &state,
+                &model,
+                &source,
+                &transform,
+                1024,
+                Uuid::now_v7(),
+            )
+            .await;
+
+            let err = result.expect_err("oversized record must fail fast, not crawl");
+            // Actionable, user-facing message so the job pauses (not a transient retry).
+            let user_msg = crate::error::get_user_message(&err);
+            assert!(
+                user_msg.contains("exceeds the maximum chunk size"),
+                "unexpected message: {user_msg}"
+            );
+            assert!(!crate::error::is_rate_limited_error(&err));
+            assert!(!crate::error::is_timeout_error(&err));
+            assert!(!crate::error::is_transient_network_error(&err));
+            assert!(!crate::error::is_transient_server_error(&err));
         }
 
         #[tokio::test]

--- a/rust/batch-import-worker/src/metrics.rs
+++ b/rust/batch-import-worker/src/metrics.rs
@@ -3,6 +3,7 @@ pub const BACKOFF_DELAY_SECONDS: &str = "batch_import_backoff_delay_seconds";
 pub const UNPAUSE_TOTAL: &str = "batch_import_unpause_total";
 pub const STAGING_SWEEP_REMOVED: &str = "batch_import_staging_sweep_removed_total";
 pub const STAGING_DIR_BYTES: &str = "batch_import_staging_dir_bytes";
+pub const STAGING_GUARD_TRIPPED: &str = "batch_import_staging_guard_tripped_total";
 
 use metrics::{counter, gauge, histogram};
 
@@ -21,4 +22,8 @@ pub fn staging_sweep_removed(count: u64) {
 
 pub fn staging_dir_bytes(bytes: f64) {
     gauge!(STAGING_DIR_BYTES).set(bytes);
+}
+
+pub fn staging_guard_tripped() {
+    counter!(STAGING_GUARD_TRIPPED).increment(1);
 }

--- a/rust/batch-import-worker/src/source/date_range_export.rs
+++ b/rust/batch-import-worker/src/source/date_range_export.rs
@@ -12,6 +12,7 @@ use tracing::{debug, info, warn};
 use super::{read_prepared_chunk, remove_prepared_key, DataSource, PreparedPart};
 use crate::error::{RateLimitedError, ToUserError};
 use crate::extractor::PartExtractor;
+use crate::staging::StagingGuard;
 
 // Extract a user friendly error message
 // from status code of request to the export source endpoint
@@ -86,6 +87,7 @@ pub struct DateRangeExportSourceBuilder {
     auth_config: AuthConfig,
     date_format: String,
     headers: HashMap<String, String>,
+    staging_max_bytes: u64,
 }
 
 impl DateRangeExportSourceBuilder {
@@ -112,7 +114,13 @@ impl DateRangeExportSourceBuilder {
             auth_config: AuthConfig::None,
             date_format: "%Y-%m-%dT%H:%M:%SZ".to_string(),
             headers: HashMap::new(),
+            staging_max_bytes: 0,
         }
+    }
+
+    pub fn with_staging_max_bytes(mut self, staging_max_bytes: u64) -> Self {
+        self.staging_max_bytes = staging_max_bytes;
+        self
     }
 
     pub fn with_query_params(mut self, start_qp: String, end_qp: String) -> Self {
@@ -182,6 +190,7 @@ impl DateRangeExportSourceBuilder {
             retry_delay: self.retry_delay,
             extractor: self.extractor,
             staging_dir: self.staging_dir,
+            staging_max_bytes: self.staging_max_bytes,
             temp_dir: Arc::new(Mutex::new(None)),
             prepared_keys: Arc::new(Mutex::new(HashMap::new())),
         })
@@ -201,6 +210,7 @@ pub struct DateRangeExportSource {
     pub start_qp: String,
     pub end_qp: String,
     staging_dir: PathBuf,
+    staging_max_bytes: u64,
     temp_dir: Arc<Mutex<Option<TempDir>>>,
     prepared_keys: Arc<Mutex<HashMap<String, PreparedPart>>>,
     auth_config: AuthConfig,
@@ -412,6 +422,11 @@ impl DateRangeExportSource {
 
         let temp_dir = self.get_temp_dir_path().await?;
 
+        // Pause the job if staging is already over budget (e.g. leftover from a
+        // prior part) before we add to it, and again as the `.raw` grows.
+        let mut guard = StagingGuard::new(self.staging_dir.clone(), self.staging_max_bytes);
+        guard.check().await?;
+
         let raw_file_path = temp_dir.join(format!("{}.raw", key.replace(':', "_")));
         let mut raw_file = File::create(&raw_file_path)
             .await
@@ -431,6 +446,7 @@ impl DateRangeExportSource {
                 )
             })?;
             total_bytes += chunk.len();
+            guard.record(chunk.len() as u64).await?;
         }
 
         raw_file.sync_all().await.with_context(|| {

--- a/rust/batch-import-worker/src/source/s3_gzip.rs
+++ b/rust/batch-import-worker/src/source/s3_gzip.rs
@@ -12,6 +12,7 @@ use tracing::{debug, info, warn};
 
 use crate::error::ToUserError;
 use crate::extractor::PartExtractor;
+use crate::staging::StagingGuard;
 
 use super::s3::extract_user_friendly_error;
 use super::{read_prepared_chunk, remove_prepared_key, DataSource, PreparedPart};
@@ -30,6 +31,7 @@ pub struct GzipS3Source {
     prefix: String,
     extractor: Arc<dyn PartExtractor>,
     staging_dir: PathBuf,
+    staging_max_bytes: u64,
     temp_dir: Arc<Mutex<Option<TempDir>>>,
     prepared_keys: Arc<Mutex<HashMap<String, PreparedPart>>>,
 }
@@ -41,6 +43,7 @@ impl GzipS3Source {
         prefix: String,
         extractor: Arc<dyn PartExtractor>,
         staging_dir: PathBuf,
+        staging_max_bytes: u64,
     ) -> Self {
         Self {
             client,
@@ -48,6 +51,7 @@ impl GzipS3Source {
             prefix,
             extractor,
             staging_dir,
+            staging_max_bytes,
             temp_dir: Arc::new(Mutex::new(None)),
             prepared_keys: Arc::new(Mutex::new(HashMap::new())),
         }
@@ -187,6 +191,11 @@ impl DataSource for GzipS3Source {
         let temp_dir = self.get_temp_dir_path().await?;
         let safe_key = sanitize_key_for_path(key);
 
+        // Pause the job if staging is already over budget before we add to it,
+        // and again as the `.raw` grows.
+        let mut guard = StagingGuard::new(self.staging_dir.clone(), self.staging_max_bytes);
+        guard.check().await?;
+
         let raw_file_path = temp_dir.join(format!("{}.raw", safe_key));
         let mut raw_file = File::create(&raw_file_path)
             .await
@@ -204,6 +213,7 @@ impl DataSource for GzipS3Source {
                 format!("Failed to write raw file: {}", raw_file_path.display())
             })?;
             total_bytes += chunk.len() as u64;
+            guard.record(chunk.len() as u64).await?;
         }
 
         raw_file

--- a/rust/batch-import-worker/src/staging.rs
+++ b/rust/batch-import-worker/src/staging.rs
@@ -1,7 +1,82 @@
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Error};
 use tracing::{debug, info, warn};
+
+use crate::error::UserError;
+
+/// Default amount of freshly-written data between staging-size checks. Stat-ing
+/// the whole staging tree is O(files), so we only re-measure after this much has
+/// been written, bounding overshoot to roughly this value plus one download chunk.
+const DEFAULT_GUARD_CHECK_INTERVAL_BYTES: u64 = 256 * 1024 * 1024;
+
+/// Fail-fast guard against unbounded staging growth.
+///
+/// Sources that download large parts call [`StagingGuard::check`] before starting
+/// (to catch staging that is already over budget from earlier work) and
+/// [`StagingGuard::record`] as they write. If staging exceeds the configured
+/// limit the job is paused via a [`UserError`] instead of the pod being evicted
+/// under disk pressure (which loses all progress and restart-loops). A limit of
+/// `0` disables the guard.
+pub struct StagingGuard {
+    staging_dir: PathBuf,
+    max_bytes: u64,
+    check_interval: u64,
+    since_check: u64,
+}
+
+impl StagingGuard {
+    pub fn new(staging_dir: PathBuf, max_bytes: u64) -> Self {
+        Self {
+            staging_dir,
+            max_bytes,
+            check_interval: DEFAULT_GUARD_CHECK_INTERVAL_BYTES,
+            since_check: 0,
+        }
+    }
+
+    fn enabled(&self) -> bool {
+        self.max_bytes > 0
+    }
+
+    /// Record `written` freshly-staged bytes and re-check the staging size once
+    /// enough has accumulated since the last check. Cheap to call per chunk.
+    pub async fn record(&mut self, written: u64) -> Result<(), Error> {
+        if !self.enabled() {
+            return Ok(());
+        }
+        self.since_check = self.since_check.saturating_add(written);
+        if self.since_check < self.check_interval {
+            return Ok(());
+        }
+        self.since_check = 0;
+        self.check().await
+    }
+
+    /// Measure staging usage now and fail if it exceeds the limit.
+    pub async fn check(&self) -> Result<(), Error> {
+        if !self.enabled() {
+            return Ok(());
+        }
+        let used = staging_dir_bytes(&self.staging_dir).await;
+        if used > self.max_bytes {
+            crate::metrics::staging_guard_tripped();
+            let user_msg = format!(
+                "Staging disk limit exceeded ({used} bytes used, limit {} bytes). This import \
+                 part is too large to process on a single worker -- split the import into smaller \
+                 date ranges or parts.",
+                self.max_bytes
+            );
+            return Err(Error::msg(format!(
+                "staging dir {} at {used} bytes exceeds limit {}",
+                self.staging_dir.display(),
+                self.max_bytes
+            ))
+            .context(UserError::new(user_msg)));
+        }
+        Ok(())
+    }
+}
 
 /// Ensure the staging directory exists, creating it if necessary.
 pub async fn ensure_staging_dir(path: &Path) -> Result<(), Error> {
@@ -191,5 +266,57 @@ mod tests {
         let staging = root.path().join("does-not-exist");
         let bytes = staging_dir_bytes(&staging).await;
         assert_eq!(bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn test_staging_guard_disabled_never_trips() {
+        let root = TempDir::new().unwrap();
+        ensure_staging_dir(root.path()).await.unwrap();
+        tokio::fs::write(root.path().join("big"), vec![0u8; 10_000])
+            .await
+            .unwrap();
+
+        // max_bytes == 0 disables the guard regardless of usage.
+        let mut guard = StagingGuard::new(root.path().to_path_buf(), 0);
+        guard.check().await.unwrap();
+        guard.record(1_000_000_000).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_staging_guard_check_trips_over_limit_with_user_message() {
+        use crate::error::get_user_message;
+
+        let root = TempDir::new().unwrap();
+        ensure_staging_dir(root.path()).await.unwrap();
+        tokio::fs::write(root.path().join("big"), vec![0u8; 4096])
+            .await
+            .unwrap();
+
+        let guard = StagingGuard::new(root.path().to_path_buf(), 1024);
+        let err = guard.check().await.unwrap_err();
+        // Surfaces an actionable user-facing message (so the job pauses, not evicts).
+        assert!(get_user_message(&err).contains("Staging disk limit exceeded"));
+
+        // Under-limit passes.
+        let ok_guard = StagingGuard::new(root.path().to_path_buf(), 1024 * 1024);
+        ok_guard.check().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_staging_guard_record_throttles_until_interval() {
+        let root = TempDir::new().unwrap();
+        ensure_staging_dir(root.path()).await.unwrap();
+        tokio::fs::write(root.path().join("big"), vec![0u8; 4096])
+            .await
+            .unwrap();
+
+        // Already over the limit, but record() only re-measures after the check
+        // interval of newly-recorded bytes has accumulated.
+        let mut guard = StagingGuard::new(root.path().to_path_buf(), 1024);
+        guard.check_interval = 1_000_000;
+
+        guard.record(500_000).await.unwrap(); // below interval -> no measurement
+        let tripped = guard.record(600_000).await; // crosses interval -> measures
+        assert!(tripped.is_err());
     }
 }

--- a/rust/batch-import-worker/src/staging.rs
+++ b/rust/batch-import-worker/src/staging.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Error};
-use tracing::{debug, info, warn};
+use tracing::{info, warn};
 
 use crate::error::UserError;
 
@@ -61,11 +61,13 @@ impl StagingGuard {
         let used = staging_dir_bytes(&self.staging_dir).await;
         if used > self.max_bytes {
             crate::metrics::staging_guard_tripped();
+            const GIB: f64 = 1024.0 * 1024.0 * 1024.0;
+            let used_gib = used as f64 / GIB;
+            let limit_gib = self.max_bytes as f64 / GIB;
             let user_msg = format!(
-                "Staging disk limit exceeded ({used} bytes used, limit {} bytes). This import \
-                 part is too large to process on a single worker -- split the import into smaller \
-                 date ranges or parts.",
-                self.max_bytes
+                "Staging disk limit exceeded ({used_gib:.1} GiB used, limit {limit_gib:.1} GiB). \
+                 This import part is too large to process on a single worker -- split the import \
+                 into smaller date ranges or parts."
             );
             return Err(Error::msg(format!(
                 "staging dir {} at {used} bytes exceeds limit {}",
@@ -156,8 +158,11 @@ pub async fn sweep_staging_dir(path: &Path) -> Result<u64, Error> {
 pub async fn staging_dir_bytes(path: &Path) -> u64 {
     match compute_dir_size(path).await {
         Ok(bytes) => bytes,
+        // Fail open: a stat failure must not block imports. Log at warn! so a
+        // persistent failure (EACCES, the path vanishing) is operator-visible
+        // rather than silently disabling the guard.
         Err(e) => {
-            debug!("Failed to compute staging dir size: {e}");
+            warn!("Failed to compute staging dir size, treating as 0: {e}");
             0
         }
     }
@@ -294,12 +299,31 @@ mod tests {
 
         let guard = StagingGuard::new(root.path().to_path_buf(), 1024);
         let err = guard.check().await.unwrap_err();
-        // Surfaces an actionable user-facing message (so the job pauses, not evicts).
-        assert!(get_user_message(&err).contains("Staging disk limit exceeded"));
+        // Surfaces an actionable user-facing message (so the job pauses, not evicts),
+        // reported in GiB rather than raw bytes.
+        let msg = get_user_message(&err);
+        assert!(msg.contains("Staging disk limit exceeded"));
+        assert!(
+            msg.contains("GiB"),
+            "expected GiB-formatted message, got: {msg}"
+        );
 
         // Under-limit passes.
         let ok_guard = StagingGuard::new(root.path().to_path_buf(), 1024 * 1024);
         ok_guard.check().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_staging_guard_fail_open_on_stat_error() {
+        // Point the guard at a file, not a directory, so read_dir fails. The
+        // guard must fail open (Ok, treating usage as 0) rather than erroring or
+        // panicking -- a stat failure must never block imports.
+        let root = TempDir::new().unwrap();
+        let not_a_dir = root.path().join("regular-file");
+        tokio::fs::write(&not_a_dir, b"data").await.unwrap();
+
+        let guard = StagingGuard::new(not_a_dir, 1024);
+        guard.check().await.unwrap();
     }
 
     #[tokio::test]

--- a/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
+++ b/rust/batch-import-worker/tests/s3_gzip_minio_integration_test.rs
@@ -108,7 +108,7 @@ async fn test_s3_gzip_minio_integration() {
 
     let _staging = tempfile::TempDir::new().expect("create staging dir");
     let source = s3_config
-        .create_gzip_source(&secrets, _staging.path().to_path_buf())
+        .create_gzip_source(&secrets, _staging.path().to_path_buf(), 0)
         .await
         .expect("create gzip source");
     source.prepare_for_job().await.expect("prepare for job");

--- a/rust/batch-import-worker/tests/staging_guard_test.rs
+++ b/rust/batch-import-worker/tests/staging_guard_test.rs
@@ -1,0 +1,88 @@
+//! Dependency-free integration test for the fail-fast staging disk guard wired
+//! into the date range export source. It proves that when the staging directory
+//! is already over the configured byte budget, preparing a key returns an error
+//! carrying an actionable user-facing message (so the job pauses cleanly instead
+//! of the pod being evicted under disk pressure). A limit of 0 leaves the guard
+//! disabled and downloads proceed normally.
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use batch_import_worker::extractor::ExtractorType;
+use batch_import_worker::source::date_range_export::{AuthConfig, DateRangeExportSource};
+use batch_import_worker::source::DataSource;
+use chrono::{TimeZone, Utc};
+use httpmock::MockServer;
+use tempfile::TempDir;
+
+fn build_source(base_url: String, staging: &Path, staging_max_bytes: u64) -> DateRangeExportSource {
+    let start = Utc.with_ymd_and_hms(2023, 1, 1, 0, 0, 0).unwrap();
+    let end = Utc.with_ymd_and_hms(2023, 1, 1, 1, 0, 0).unwrap();
+    DateRangeExportSource::builder(
+        base_url,
+        start,
+        end,
+        3600,
+        ExtractorType::PlainGzip.create_extractor(),
+        staging.to_path_buf(),
+    )
+    .with_auth(AuthConfig::None)
+    .with_date_format("%Y-%m-%dT%H:%M:%SZ".to_string())
+    .with_headers(HashMap::new())
+    .with_staging_max_bytes(staging_max_bytes)
+    .build()
+    .unwrap()
+}
+
+#[tokio::test]
+async fn test_prepare_key_pauses_when_staging_over_budget() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET).path("/export");
+        then.status(200).body(vec![0u8; 1024]);
+    });
+
+    let staging = TempDir::new().unwrap();
+    // Pre-fill staging well above the 1 KiB limit (simulates leftover from prior
+    // work / a sibling part). The guard measures the whole staging tree.
+    std::fs::write(staging.path().join("preexisting.bin"), vec![0u8; 64 * 1024]).unwrap();
+
+    let source = build_source(server.url("/export"), staging.path(), 1024);
+    source.prepare_for_job().await.unwrap();
+    let keys = source.keys().await.unwrap();
+    let key = &keys[0];
+
+    let err = source
+        .prepare_key(key)
+        .await
+        .expect_err("prepare_key must fail when staging is over budget");
+    // The error chain carries the actionable UserError so the job pauses with it.
+    let chain = format!("{err:#}");
+    assert!(
+        chain.contains("Staging disk limit exceeded"),
+        "expected user-facing staging-limit message, got: {chain}"
+    );
+}
+
+#[tokio::test]
+async fn test_prepare_key_succeeds_when_guard_disabled() {
+    let server = MockServer::start();
+    let _mock = server.mock(|when, then| {
+        when.method(httpmock::Method::GET).path("/export");
+        then.status(200).body(vec![0u8; 1024]);
+    });
+
+    let staging = TempDir::new().unwrap();
+    std::fs::write(staging.path().join("preexisting.bin"), vec![0u8; 64 * 1024]).unwrap();
+
+    // max_bytes == 0 disables the guard: the same over-budget staging is fine.
+    let source = build_source(server.url("/export"), staging.path(), 0);
+    source.prepare_for_job().await.unwrap();
+    let keys = source.keys().await.unwrap();
+    let key = &keys[0];
+
+    source
+        .prepare_key(key)
+        .await
+        .expect("prepare_key must succeed when the guard is disabled");
+}


### PR DESCRIPTION
## Problem

Batch import workers stage downloaded import parts on disk. The [streaming-decompression PR](https://github.com/PostHog/posthog/pull/67149) (the base of this stack) bounds staging to the *compressed* size, but a single import part can still be large enough to fill the staging volume. When the volume fills, the pod gets evicted under disk pressure, loses all in-flight progress, and crash-loops — the worst possible failure mode for a long-running job.

This adds a defense-in-depth guard so an oversized import fails fast with a clear, user-facing error (pausing the job) instead of taking down the pod.

## Changes

- New `STAGING_DIR_MAX_BYTES` config (default `0` = disabled). When set, sources pause the job once the staging tree exceeds the limit.
- `StagingGuard` (in `staging.rs`): checks staging usage at download start (catches staging already over budget from a sibling part) and re-measures as the `.raw` grows. The recursive `stat` is throttled — it only re-measures after a chunk of newly-written bytes has accumulated — so the per-chunk cost stays negligible.
- Wired into both disk-staging sources (`date_range_export`, `s3_gzip`). On trip, the job pauses via a typed `UserError` (the existing non-transient → `Pause` path) carrying an actionable message ("split the import into smaller date ranges or parts"), and increments the `batch_import_staging_guard_tripped_total` counter.
- Charts (separate PR in `posthog/charts`): `storage.maxBytes` templated into `STAGING_DIR_MAX_BYTES`, sized to ~170Gi for the 200Gi per-pod EBS staging volume, leaving headroom for filesystem overhead and concurrent parts. Omitted (guard disabled) when unset, so it's backwards-compatible.

## How did you test this code?

I'm an agent (Cursor). Automated tests I actually ran (`cargo test -p batch-import-worker`, all passing):

- `staging::tests` unit tests for `StagingGuard`: disabled-limit is a no-op, over-limit trips with the user-facing message, under-limit passes, and `record()` throttles the stat until the check interval is crossed.
- `tests/staging_guard_test.rs` (dependency-free integration): with staging pre-filled over budget, `prepare_key` returns an error whose chain carries the "Staging disk limit exceeded" `UserError` (so the job pauses); with the guard disabled (`0`), the same over-budget staging is fine.
- Full crate lib suite (265 tests) + the existing s3_gzip MinIO integration test (signature update) to confirm no regression.

These catch the regression where an oversized part silently fills the volume rather than pausing the job, which no existing test covered.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked on top of #67149 (streaming decompression). The streaming PR is the structural fix (bounds disk to compressed size); this is the belt-and-suspenders guard for the case where even the compressed part is too big for the volume.

Decisions: the guard re-measures the whole staging tree (not just the current `.raw`) so it accounts for concurrent/sibling parts, and throttles the recursive `stat` by bytes-written to keep the hot path cheap. Defaulted to disabled (`0`) so behavior is unchanged unless `STAGING_DIR_MAX_BYTES` is set, and reused the existing `UserError` → `Pause` classification rather than adding a new error path.

Tools: Cursor agent. No mandatory repo skills applied (Rust service + Helm chart change, no Django/DRF/migration/frontend surface).