### PR TITLE
fix(logs): override record_count header when drop rules remove rows

### DIFF
--- a/nodejs/src/logs/logs-ingestion-consumer.test.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.test.ts
@@ -1775,9 +1775,11 @@ describe('LogsIngestionConsumer', () => {
 
                 const uncompressed = parseInt(outputHeaders()!.bytes_uncompressed, 10)
                 const compressed = parseInt(outputHeaders()!.bytes_compressed, 10)
+                const recordCount = parseInt(outputHeaders()!.record_count, 10)
                 if (!enabled) {
                     expect(uncompressed).toBe(1000)
                     expect(compressed).toBe(500)
+                    expect(recordCount).toBe(2)
                     return
                 }
                 expect(uncompressed).toBeGreaterThan(0)
@@ -1785,6 +1787,8 @@ describe('LogsIngestionConsumer', () => {
                 expect(compressed).toBeGreaterThan(0)
                 expect(compressed).toBeLessThan(500)
                 expect(compressed / uncompressed).toBeCloseTo(0.5, 5)
+                // The dropped info row is removed from the count exactly; only the error row survives.
+                expect(recordCount).toBe(1)
             })
         })
     })

--- a/nodejs/src/logs/logs-ingestion-consumer.ts
+++ b/nodejs/src/logs/logs-ingestion-consumer.ts
@@ -577,6 +577,7 @@ export class LogsIngestionConsumer {
 
                         let bytesUncompressedHeaderOverride: number | undefined
                         let bytesCompressedHeaderOverride: number | undefined
+                        let recordCountHeaderOverride: number | undefined
 
                         // Drop rules removed rows from this message — credit billing by the dropped
                         // content fraction. `bytesReceived` stays gross (what was sent); `bytesAllowed`
@@ -628,8 +629,9 @@ export class LogsIngestionConsumer {
                                     )
                                 }
 
-                                // Scale both size headers down by the same dropped content fraction so
-                                // downstream accounting sees only the surviving bytes.
+                                // Scale both size headers down by the same dropped content fraction, and
+                                // reduce the record count by the exact number of rows dropped, so
+                                // downstream accounting sees only the surviving rows and bytes.
                                 const compressedCredit = billingByteReductionForDrops(
                                     message.bytesCompressed,
                                     resolved.contentBytesDropped,
@@ -637,6 +639,7 @@ export class LogsIngestionConsumer {
                                 )
                                 bytesUncompressedHeaderOverride = Math.max(0, header - contentCredit)
                                 bytesCompressedHeaderOverride = Math.max(0, message.bytesCompressed - compressedCredit)
+                                recordCountHeaderOverride = Math.max(0, message.recordCount - resolved.recordsDropped)
                             }
                         }
 
@@ -671,6 +674,9 @@ export class LogsIngestionConsumer {
                                         : {}),
                                     ...(bytesCompressedHeaderOverride !== undefined
                                         ? { bytes_compressed: bytesCompressedHeaderOverride.toString() }
+                                        : {}),
+                                    ...(recordCountHeaderOverride !== undefined
+                                        ? { record_count: recordCountHeaderOverride.toString() }
                                         : {}),
                                 },
                             },


### PR DESCRIPTION
## Problem

In the logs ingestion consumer, when drop rules remove rows from a message and billing prorating is enabled (`LOGS_BILLING_PRORATE_ENABLED`), we scale the `bytes_uncompressed` and `bytes_compressed` Kafka headers down by the dropped content fraction so downstream accounting only sees the surviving bytes. But the `record_count` header was left untouched at the original pre-drop value, so downstream accounting saw more rows than actually survived the drops.

## Changes

Reduce the forwarded `record_count` header by the exact number of rows dropped (`message.recordCount - resolved.recordsDropped`), inside the same `billingProrateEnabled` block that already overrides the byte headers. Counts are exact (we know how many rows were dropped), so unlike the byte headers there's no need to pro-rate by fraction.

## How did you test this code?

I'm an agent (PostHog Code). I did not run anything manually — relying on CI.

Extended the existing parameterized drop-rule test in `logs-ingestion-consumer.test.ts` (one message, info row dropped, error row survives) to also assert `record_count`: it stays `2` in shadow mode (gross, unchanged) and becomes `1` in enabled mode. This guards the exact regression — previously no test asserted the output `record_count` header in the prorate path, so dropping the override would have gone unnoticed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tool: PostHog Code (Claude Opus 4.8). Frank flagged that the consumer overrides the bytes-uncompressed header on row drops but not the row-count header, and asked for the fix.
- Skills invoked: `/writing-tests` to gate the test change (decided to extend the existing parameterized prorate test rather than add a new one).
- The byte headers are pro-rated by the dropped content fraction (an estimate); the record count is reduced exactly by `recordsDropped`, since that value is known precisely. Kept the change gated behind `billingProrateEnabled` for consistency with the existing byte-header overrides.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
