### PR TITLE
fix(deps): enable pnpm exotic-subdep and trust-policy guards

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -26,6 +26,9 @@ packages:
     - '!tools/hedgebox-dummy'
     - rust/cyclotron-node
 
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
+
 catalog:
     # Kea ecosystem - state management
     kea: ^4.0.0-pre.5

--- a/tools/hedgebox-dummy/pnpm-workspace.yaml
+++ b/tools/hedgebox-dummy/pnpm-workspace.yaml
@@ -1,4 +1,6 @@
 packages:
     - '.'
 
+blockExoticSubdeps: true
+trustPolicy: no-downgrade
 minimumReleaseAge: 10080


### PR DESCRIPTION
## Problem

The `semgrep-general` CI job has been failing on `master` across recent pushes (unrelated to any specific PR's diff). The `package_managers.pnpm` ruleset flags both `pnpm-workspace.yaml` and `tools/hedgebox-dummy/pnpm-workspace.yaml` for missing two supply-chain settings: `blockExoticSubdeps` and `trustPolicy`.

## Changes

Add to both `pnpm-workspace.yaml` files:
- `blockExoticSubdeps: true` — restricts git/tarball-URL dependency sources to direct (root-approved) dependencies only, so a transitive dependency can't silently introduce one
- `trustPolicy: no-downgrade` — fails install if a previously-trusted package's published version loses its trust evidence

Both settings require pnpm ≥ 10.26.0 / ≥ 10.21.0 respectively; the repo pins `pnpm@10.29.3`, so no version bump needed.

## How did you test this code?

I'm an agent (Claude Code); no manual testing was done. Automated checks run:
- `pnpm install --frozen-lockfile` — succeeded
- `pnpm install --lockfile-only --force` (forces a full re-resolution, bypassing the "lockfile is up to date" shortcut) — completed with exit 0 and produced a byte-identical `pnpm-lock.yaml`, confirming neither new setting blocks anything in the current dependency tree. The one exotic-sourced dependency in the lockfile (`uWebSockets.js`, a tarball URL pulled in transitively via `ultimate-express`) is explicitly pinned through a root-level `pnpm.overrides` entry, which `blockExoticSubdeps` treats as root-approved.
- Re-ran the `trailofbits` semgrep ruleset against the updated files locally — 0 findings (previously 4 blocking)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated a semgrep CI failure reported via a GitHub Actions run link, traced it to the `semgrep-general` job (community pnpm supply-chain rules, not the new custom `.semgrep/rules` added in a separate PR — those passed their own `semgrep-test-rules` job). Confirmed via `gh run list` that this same job has been failing on `master` for multiple unrelated recent pushes. Applied the fix and verified safety against the real local lockfile/dependency tree before committing.