### PR TITLE
fix(cohorts): prevent crash when criterion type has no ROWS entry

### DIFF
--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.test.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.test.tsx
@@ -1,0 +1,38 @@
+import '@testing-library/jest-dom'
+
+import { render } from '@testing-library/react'
+import { Form } from 'kea-forms'
+import posthog from 'posthog-js'
+
+import { cohortEditLogic } from 'scenes/cohorts/cohortEditLogic'
+import { CohortCriteriaRowBuilder } from 'scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder'
+import { BehavioralFilterType } from 'scenes/cohorts/CohortFilters/types'
+
+import { initKeaTests } from '~/test/init'
+import { FilterLogicalOperator } from '~/types'
+
+describe('CohortCriteriaRowBuilder', () => {
+    beforeEach(() => {
+        initKeaTests()
+    })
+
+    it('renders empty and reports the unknown type instead of crashing when type has no ROWS entry', () => {
+        // Guard: a type with no ROWS entry must render empty (not crash on rowShape.fields) and
+        // surface the unknown type so it can't silently vanish from the editor.
+        expect(() => {
+            render(
+                <Form logic={cohortEditLogic} props={{ id: 'new' }} formKey="cohort">
+                    <CohortCriteriaRowBuilder
+                        id="new"
+                        criteria={{}}
+                        type={'unrecognized_type_not_in_rows' as BehavioralFilterType}
+                        groupIndex={0}
+                        index={0}
+                        logicalOperator={FilterLogicalOperator.And}
+                    />
+                </Form>
+            )
+        }).not.toThrow()
+        expect(posthog.captureException).toHaveBeenCalled()
+    })
+})

--- a/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
+++ b/frontend/src/scenes/cohorts/CohortFilters/CohortCriteriaRowBuilder.tsx
@@ -3,6 +3,8 @@ import './CohortCriteriaRowBuilder.scss'
 import clsx from 'clsx'
 import { useActions } from 'kea'
 import { Field as KeaField } from 'kea-forms'
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
 
 import { IconCopy, IconTrash } from '@posthog/icons'
 import { LemonDivider } from '@posthog/lemon-ui'
@@ -38,6 +40,20 @@ export function CohortCriteriaRowBuilder({
 }: CohortCriteriaRowBuilderProps): JSX.Element {
     const { setCriteria, duplicateFilter, removeFilter } = useActions(cohortEditLogic)
     const rowShape = ROWS[type]
+
+    // A criterion type with no ROWS entry (e.g. a backend-only type reaching the editor before
+    // processCohortCriteria normalizes it). Render nothing rather than crash, but surface it so
+    // a future unknown type doesn't silently vanish from the editor. Reported in an effect, not
+    // during render, so it fires once per `type` instead of on every re-render.
+    useEffect(() => {
+        if (!rowShape) {
+            posthog.captureException(new Error(`CohortCriteriaRowBuilder: no ROWS entry for type "${type}"`))
+        }
+    }, [type, rowShape])
+
+    if (!rowShape) {
+        return <></>
+    }
 
     const renderFieldComponent = (_field: Field, i: number): JSX.Element => {
         return (


### PR DESCRIPTION
## Problem

A cohort criterion of type `person_metadata` (e.g. a person's `created_at`) crashes `CohortCriteriaRowBuilder`. `processCohortCriteria` didn't normalize that type, so its raw value (a date string) flowed into `criteriaToBehavioralFilterType`, which returned the date string instead of a valid `ROWS` key. `ROWS[type]` was then undefined and the builder crashed on `rowShape.fields.map()`.

## Changes

- `processCohortCriteria` now treats `BehavioralFilterKey.PersonMetadata` the same as `Cohort` and `Person`, moving the criterion's value into `value_property` so `criteriaToBehavioralFilterType` resolves a real `ROWS` key.
- `CohortCriteriaRowBuilder` renders nothing instead of crashing when a type has no `ROWS` entry, and reports the gap with `posthog.captureException` so an unrecognized type can't silently disappear from the editor.

## How did you test this code?

I'm an agent. Automated tests only:

- `cohortsModel.test.ts`: `processCohort` normalizes a `person_metadata` criterion so its value resolves to a valid `ROWS` key.
- `CohortCriteriaRowBuilder.test.tsx`: an unrecognized type renders without throwing and reports through `posthog.captureException`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Used Claude Code to land the fix and tests, then ran /commit to drop now-redundant inline comments (the rationale already lives in the commit message) and add a `posthog.captureException` call so future unrecognized criterion types get reported instead of silently vanishing.