### PR TITLE
fix(replay): return partial session summaries instead of discarding them

### DIFF
--- a/services/mcp/src/tools/replay/sessionRecordingSummarize.ts
+++ b/services/mcp/src/tools/replay/sessionRecordingSummarize.ts
@@ -42,6 +42,9 @@ type SseEvent = SummaryEvent | ErrorEvent | DoneEvent
 
 type SseResult = WithPostHogUrl<Record<string, SessionResult>>
 
+const STILL_GENERATING_MESSAGE =
+    'Summary still generating (first-time summaries call an AI model and take ~5 min each). Completed summaries are cached — call session-recording-summarize again with the same session_ids to retrieve them instantly and finish the rest.'
+
 /**
  * Hand-written session-recording-summarize tool that uses SSE streaming
  * to avoid gateway timeouts on long-running summary generation (~5 min).
@@ -63,36 +66,49 @@ const sessionRecordingSummarize = (): ToolBase<typeof schema, SseResult> =>
             }
 
             const results: Record<string, SessionResult> = {}
-            let sawDone = false
 
-            await context.api.requestSSE<SseEvent>({
-                method: 'POST',
-                path: `/api/environments/${encodeURIComponent(String(projectId))}/session_summaries/stream_batch/`,
-                body,
-                onEvent: (event, data) => {
-                    if (event === 'summary') {
-                        const d = data as SummaryEvent
-                        if (d.session_id && d.summary) {
-                            results[d.session_id] = d.summary
-                        }
-                    } else if (event === 'error') {
-                        const d = data as ErrorEvent
-                        if (d.session_id) {
-                            results[d.session_id] = {
-                                error: d.error,
-                                error_message: d.error_message,
+            try {
+                await context.api.requestSSE<SseEvent>({
+                    method: 'POST',
+                    path: `/api/environments/${encodeURIComponent(String(projectId))}/session_summaries/stream_batch/`,
+                    body,
+                    onEvent: (event, data) => {
+                        if (event === 'summary') {
+                            const d = data as SummaryEvent
+                            if (d.session_id && d.summary) {
+                                results[d.session_id] = d.summary
+                            }
+                        } else if (event === 'error') {
+                            const d = data as ErrorEvent
+                            if (d.session_id) {
+                                results[d.session_id] = {
+                                    error: d.error,
+                                    error_message: d.error_message,
+                                }
                             }
                         }
-                    } else if (event === 'done') {
-                        sawDone = true
-                    }
-                },
-            })
+                    },
+                })
+            } catch (error) {
+                // The stream was cut short — most often the overall timeout firing before a long batch
+                // finishes. If nothing arrived at all it's a genuine failure (auth, validation, server
+                // error), so surface it. Otherwise keep the summaries that did complete; the unfinished
+                // ones are filled in as `incomplete` below.
+                if (Object.keys(results).length === 0) {
+                    throw error
+                }
+            }
 
-            if (!sawDone) {
-                throw new Error(
-                    `SSE stream ended without a done event — results may be incomplete (received ${Object.keys(results).length}/${params.session_ids.length} sessions)`
-                )
+            // Any session without a result is still generating. Report it per-session (matching the
+            // tool's contract) instead of failing the whole call — completed summaries are cached, so
+            // calling again with the same IDs returns them instantly and continues the rest.
+            for (const sessionId of params.session_ids) {
+                if (!(sessionId in results)) {
+                    results[sessionId] = {
+                        error: 'incomplete',
+                        error_message: STILL_GENERATING_MESSAGE,
+                    }
+                }
             }
 
             return withPostHogUrl(context, results, '/replay')

--- a/services/mcp/tests/tools/sessionRecordingSummarize.test.ts
+++ b/services/mcp/tests/tools/sessionRecordingSummarize.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest'
+
+import sessionRecordingSummarize from '@/tools/replay/sessionRecordingSummarize'
+import type { Context } from '@/tools/types'
+
+type Emit = (event: string, data: unknown) => void
+type SseDriver = (emit: Emit) => void | Promise<void>
+
+/** Minimal Context whose requestSSE is driven by `driver` — it emits SSE events, then may throw. */
+function makeContext(driver: SseDriver): Context {
+    return {
+        api: {
+            requestSSE: async (opts: { onEvent: Emit }) => {
+                await driver(opts.onEvent)
+            },
+            getProjectBaseUrl: () => 'https://us.posthog.com/project/1',
+        },
+        stateManager: {
+            getProjectId: async () => '1',
+        },
+    } as unknown as Context
+}
+
+const tool = sessionRecordingSummarize()
+
+describe('session-recording-summarize handler', () => {
+    it('keeps completed summaries and marks the rest incomplete when the stream is cut short', async () => {
+        const context = makeContext((emit) => {
+            emit('summary', { session_id: 's1', summary: { outcome: 'good' } })
+            throw new Error('SSE stream timed out after 600000ms')
+        })
+
+        const result = (await tool.handler(context, { session_ids: ['s1', 's2', 's3'] })) as Record<string, any>
+
+        expect(result.s1).toEqual({ outcome: 'good' })
+        expect(result.s2.error).toBe('incomplete')
+        expect(result.s3.error).toBe('incomplete')
+        expect(result._posthogUrl).toContain('/replay')
+    })
+
+    it('rethrows when the stream fails before producing anything (auth / validation / server error)', async () => {
+        const context = makeContext(() => {
+            throw new Error('SSE request failed: 403 permission_denied')
+        })
+
+        await expect(tool.handler(context, { session_ids: ['s1', 's2'] })).rejects.toThrow('403')
+    })
+
+    it('returns partial results when the stream ends without a done event', async () => {
+        const context = makeContext((emit) => {
+            emit('summary', { session_id: 's1', summary: { outcome: 'good' } })
+            emit('summary', { session_id: 's2', summary: { outcome: 'bad' } })
+            // stream ends cleanly, no `done` event
+        })
+
+        const result = (await tool.handler(context, { session_ids: ['s1', 's2'] })) as Record<string, any>
+
+        expect(result.s1).toEqual({ outcome: 'good' })
+        expect(result.s2).toEqual({ outcome: 'bad' })
+    })
+
+    it('preserves real per-session errors instead of overwriting them with incomplete', async () => {
+        const context = makeContext((emit) => {
+            emit('summary', { session_id: 's1', summary: { outcome: 'good' } })
+            emit('error', { session_id: 's2', error: 'no_events_or_too_short', error_message: 'too short' })
+            throw new Error('SSE stream timed out after 600000ms')
+        })
+
+        const result = (await tool.handler(context, { session_ids: ['s1', 's2', 's3'] })) as Record<string, any>
+
+        expect(result.s2.error).toBe('no_events_or_too_short')
+        expect(result.s3.error).toBe('incomplete')
+    })
+
+    it('returns every summary with no incomplete markers on a fully completed batch', async () => {
+        const context = makeContext((emit) => {
+            emit('summary', { session_id: 's1', summary: { outcome: 'good' } })
+            emit('summary', { session_id: 's2', summary: { outcome: 'bad' } })
+            emit('done', { completed: ['s1', 's2'], failed: [] })
+        })
+
+        const result = (await tool.handler(context, { session_ids: ['s1', 's2'] })) as Record<string, any>
+
+        expect(result.s1).toEqual({ outcome: 'good' })
+        expect(result.s2).toEqual({ outcome: 'bad' })
+    })
+})


### PR DESCRIPTION
## Problem

The `session-recording-summarize` MCP tool generates summaries one session at a time over a long-lived SSE stream and accumulates them as they arrive. If the stream was cut short before the final `done` event — most often the client's 10-minute cap firing before a large batch finishes (the backend processes ~10 sessions at a time, ~5 min each when uncached) — the handler threw and **discarded every summary it had already received**. The caller got a hard error and zero results, even though many summaries had completed and are cached server-side. That's the "failing frequently" behaviour customers report.

## Changes

The handler now keeps the summaries that completed and marks the unfinished sessions as `error: "incomplete"`, matching the tool's existing per-session contract. Because completed summaries are cached, the `incomplete` message tells the caller to re-invoke with the same IDs — the cached ones return instantly and the rest continue.

Genuine failures (auth, the Cloud-only gate, validation, 5xx) fail before any event is streamed, so a zero-event stream still rethrows the original error — those stay loud rather than being masked as "incomplete".

The change is handler-only — it does not touch the shared `requestSSE` primitive, raise the timeout, or add stream retries.

Not touched here: the tool's description currently steers users toward the Replay Vision beta (`vision-scanners-scan-session`, added in #62727), which is likely why some users ask for beta access for what is actually a reliability bug. Flagged for #team-replay to decide separately.

## How did you test this code?

I'm an agent. I added a unit test file (`sessionRecordingSummarize.test.ts`, 5 cases) and ran it — all pass. Each case targets a regression the old code allowed:

- partial summaries are returned (not discarded) when the stream times out mid-batch — the core bug
- a zero-event failure still throws — guards against masking auth/validation/server errors as "incomplete"
- a stream that ends without a `done` event returns partial results instead of throwing
- real per-session errors (e.g. `no_events_or_too_short`) are not overwritten by `incomplete`
- a fully-completed batch returns unchanged, with no spurious `incomplete` markers

Also ran the existing `requestSSE` suite (10 cases, green) plus lint/format. Typecheck surfaces only pre-existing, unrelated `@posthog/quill-charts` errors — none in the changed files.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Investigated from a support ticket where a customer reported the tool "failing frequently" and asked for Replay Vision beta access as a workaround. Root-caused it to the handler discarding already-completed summaries on any stream interruption, rather than a capacity or beta-access problem.

Chose the minimal fix: return partial results in the handler. Rejected alternatives — raising the 10-minute cap (just moves the boundary, risks gateway idle limits), adding whole-stream retries (doubles worst-case latency; the server-side cache already gives idempotent resumption), and plumbing an `onOpen` signal through `requestSSE` (unnecessary — hard failures reliably produce zero events, which is a robust enough signal to distinguish them from partial timeouts). No repo skills were required for this change.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
