### PR TITLE
fix(llma): show success toast when provider key validates

### DIFF
--- a/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
+++ b/products/ai_observability/frontend/settings/llmProviderKeysLogic.ts
@@ -431,7 +431,9 @@ export const llmProviderKeysLogic = kea<llmProviderKeysLogicType>([
                         `/api/environments/${teamId}/llm_analytics/provider_keys/${id}/validate/`,
                         {}
                     )
-                    if (response.state !== 'ok') {
+                    if (response.state === 'ok') {
+                        lemonToast.success('Key validated successfully')
+                    } else {
                         lemonToast.error(`Key validation failed: ${response.error_message || 'Unknown error'}`)
                     }
                     return values.providerKeys.map((key: LLMProviderKey) => (key.id === id ? response : key))


### PR DESCRIPTION
## Problem

In **Settings → AI observability → Bring your own key (BYOK)**, clicking the **Validate** button on a provider key gave no feedback when validation succeeded. The button only showed an error toast when the returned `state !== 'ok'`; on a successful `200` (`state: 'ok'`) it showed nothing. When re-validating a key that already displayed the green "Valid" tag, the row didn't visibly change either, so the click appeared to do nothing. Reported via Slack.

## Changes

`validateProviderKey` in `llmProviderKeysLogic.ts` now shows a `lemonToast.success('Key validated successfully')` on the success path, mirroring the existing error toast. The state tag continues to update as before.

## How did you test this code?

I'm an agent. I traced the click handler → kea loader → backend `validate` action to confirm the success path had no user feedback. I did not run the app manually. No automated test added — this is a one-line UX feedback change to a kea listener; an existing test asserting toast calls would be testing the toast library rather than a realistic regression.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed from a Slack thread reporting that the Validate button "doesn't do anything" on a 200 response. Confirmed the backend returns the serialized key with `state: 'ok'` and that the frontend only toasted on failure, leaving the success case silent (and visually unchanged when the key was already valid). Fix adds the missing success toast.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C0ACRAMJUAG/p1782851696356939?thread_ts=1782851696.356939&cid=C0ACRAMJUAG)*
