### PR TITLE
feat(mcp): capture executed HogQL on execute-sql tool-call events

### DIFF
--- a/services/mcp/src/hono/tool-executor.ts
+++ b/services/mcp/src/hono/tool-executor.ts
@@ -40,6 +40,19 @@ interface ExecMetricState {
     innerToolName: string | undefined
 }
 
+const EXECUTE_SQL_TOOL_NAME = 'execute-sql'
+
+// The executed HogQL is the one tool argument worth keeping on the event: paired with
+// $mcp_intent it yields (intent, query) rows for offline evals. Other tools' args stay
+// off the event. Returns {} for non-execute-sql so the spread is a no-op.
+function executeSqlEventProps(toolName: string, validatedArgs: unknown): Record<string, unknown> {
+    if (toolName !== EXECUTE_SQL_TOOL_NAME) {
+        return {}
+    }
+    const query = (validatedArgs as { query?: unknown }).query
+    return typeof query === 'string' ? { $mcp_query: query } : {}
+}
+
 export class ToolExecutor {
     private readonly catalog: ToolCatalog
     private readonly instructionsBuilder: InstructionsBuilder
@@ -221,6 +234,7 @@ export class ToolExecutor {
                 {
                     input_tokens: estimateTokens(validation.data),
                     output_tokens: estimateResponseTokens(response),
+                    ...executeSqlEventProps(tool.name, validation.data),
                 },
                 intentMeta
             )
@@ -231,7 +245,14 @@ export class ToolExecutor {
             stop({ status: 'error' })
             classifyToolError(error, tool.name)
 
-            void trackToolCall(tool.name, Date.now() - startMs, true, state, undefined, intentMeta)
+            void trackToolCall(
+                tool.name,
+                Date.now() - startMs,
+                true,
+                state,
+                executeSqlEventProps(tool.name, validation.data),
+                intentMeta
+            )
 
             const sessionUuid = await state.reqCtx.getEffectiveSessionUuid(state.requestContext)
             return handleToolError(error, tool.name, state.distinctId, sessionUuid)


### PR DESCRIPTION
## Problem

MCP analytics records the agent's stated intent (`$mcp_intent`) on every `$mcp_tool_call` event, but not the tool arguments. For `execute-sql` it would be useful to also capture the HogQl written by the LLM to compare with the intent. 

## Changes

- Adds a `$mcp_query` property to `$mcp_tool_call` events for `execute-sql`, carrying the verbatim query right next to `$mcp_intent`. Direct calls only, on both the success and error paths.
- Routed through the existing `extraProperties` argument on `trackToolCall`, so there is no new event and no schema migration. A small pure helper (`executeSqlEventProps`) returns the property only for `execute-sql` and is a no-op for every other tool.
- 
## How did you test this code?

I am an agent (Claude Code). Automated checks I actually ran on the changed package:

- `pnpm typecheck` — clean for this file. The single error in the run is a pre-existing, unrelated issue in a product_analytics frontend file.
- `pnpm exec oxlint` and `oxfmt` on the changed file — 0 warnings, 0 errors.

No automated test was added for this path (there is no existing test for the tool-call capture today). The helper is a pure function and could get a focused unit test if reviewers want one. I did not run a manual end-to-end MCP call.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Agent and tools: Claude Code (Opus 4.8); session linked below. No repo code-shaping skills were invoked for this change.
- Decisions: chose the existing `extraProperties` path over a new event or a schema change to keep it additive and migration-free. Scoped to direct-mode `execute-sql` because the single-exec inner query is not reachable at that layer and direct calls are the majority in production. Captured on both success and error so failed queries also pair with intent. Kept the query verbatim per direction, and flagged the privacy tradeoff above for reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HHNqSqPGjvFfgv6ahQn7hQ
