### PR TITLE
feat(customer-analytics): Add custom property source config API

### DIFF
--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -18,6 +18,7 @@ Do NOT:
 from typing import TYPE_CHECKING, Any, Optional, cast
 from uuid import UUID
 
+from django.apps import apps
 from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Prefetch, Q
@@ -43,6 +44,7 @@ from products.customer_analytics.backend.models import (
     CustomerJourney,
     CustomerProfileConfig,
     CustomPropertyDefinition,
+    CustomPropertySource,
 )
 from products.customer_analytics.backend.models.account import AccountProperties as _ModelAccountProperties
 from products.notebooks.backend.facade import (
@@ -834,6 +836,111 @@ def delete_custom_property_definition(
     return True
 
 
+# --- CustomPropertySource ---
+
+
+class CustomPropertySourceValidationError(Exception):
+    """Raised when a source's saved_query isn't a usable view for the team, or the definition is
+    already source-backed (→ 400)."""
+
+
+def _to_custom_property_source_view(source: CustomPropertySource) -> contracts.CustomPropertySourceView:
+    return contracts.CustomPropertySourceView(
+        id=source.id,
+        definition=source.definition_id,
+        saved_query=source.saved_query_id,
+        source_column=source.source_column,
+        key_column=source.key_column,
+        is_enabled=source.is_enabled,
+        consecutive_failures=source.consecutive_failures,
+        last_synced_at=source.last_synced_at,
+        last_sync_error=source.last_sync_error,
+        created_at=source.created_at,
+        created_by=source.created_by_id,
+        updated_at=source.updated_at,
+    )
+
+
+def _saved_query_belongs_to_team(team_id: int, saved_query_id) -> bool:
+    """Whether the saved query exists for this team and isn't soft-deleted. Uses ``apps.get_model`` so
+    customer_analytics never imports data_modeling (which isn't a dependency)."""
+    saved_query_model = apps.get_model("data_modeling", "DataWarehouseSavedQuery")
+    return saved_query_model.objects.filter(id=saved_query_id, team_id=team_id).exclude(deleted=True).exists()
+
+
+def list_custom_property_sources(
+    team_id: int, offset: int, limit: int
+) -> tuple[list[contracts.CustomPropertySourceView], int]:
+    """Custom-property sources for the team, newest first. Returns ``(page, total_count)``."""
+    queryset = CustomPropertySource.objects.for_team(team_id).order_by("-created_at")
+    total_count = queryset.count()
+    page = queryset[offset : offset + limit]
+    return [_to_custom_property_source_view(s) for s in page], total_count
+
+
+def get_custom_property_source(team_id: int, source_id: str) -> contracts.CustomPropertySourceView | None:
+    source = CustomPropertySource.objects.for_team(team_id).filter(id=source_id).first()
+    return _to_custom_property_source_view(source) if source is not None else None
+
+
+def create_custom_property_source(
+    *,
+    team_id: int,
+    definition_id: str | UUID,
+    saved_query_id: str | UUID,
+    source_column: str,
+    key_column: str,
+    is_enabled: bool,
+    user: "User",
+) -> contracts.CustomPropertySourceView:
+    if not _saved_query_belongs_to_team(team_id, saved_query_id):
+        raise CustomPropertySourceValidationError("Saved query not found for this team.")
+    if _get_team_scoped(CustomPropertyDefinition, team_id, definition_id) is None:
+        raise CustomPropertySourceValidationError("Custom property definition not found for this team.")
+    try:
+        source = CustomPropertySource.objects.for_team(team_id).create(
+            team_id=team_id,
+            created_by=user,
+            definition_id=definition_id,
+            saved_query_id=saved_query_id,
+            source_column=source_column,
+            key_column=key_column,
+            is_enabled=is_enabled,
+        )
+    except IntegrityError as exc:
+        # Both FKs are team-validated above, so the only expected violation is the definition's
+        # one-to-one uniqueness; re-raise anything else instead of mislabeling it as a duplicate.
+        if "unique" not in str(exc).lower() and "duplicate" not in str(exc).lower():
+            raise
+        raise CustomPropertySourceValidationError("This custom property already has a source.")
+    return _to_custom_property_source_view(source)
+
+
+def update_custom_property_source(
+    *, team_id: int, source_id: str, fields: dict[str, Any]
+) -> contracts.CustomPropertySourceView | None:
+    """Apply ``fields`` (source_column / key_column / is_enabled) to a team-scoped source. Re-enabling
+    (is_enabled False→True) resets the failure streak and clears the last error. Returns None (→ 404)
+    when no source matches."""
+    source = CustomPropertySource.objects.for_team(team_id).filter(id=source_id).first()
+    if source is None:
+        return None
+    reenabling = fields.get("is_enabled") is True and not source.is_enabled
+    for attr, value in fields.items():
+        setattr(source, attr, value)
+    if reenabling:
+        source.consecutive_failures = 0
+        source.last_sync_error = None
+    source.save()
+    return _to_custom_property_source_view(source)
+
+
+def delete_custom_property_source(*, team_id: int, source_id: str) -> bool:
+    """Delete a team-scoped source. Returns False when none matched (→ 404)."""
+    deleted, _ = CustomPropertySource.objects.for_team(team_id).filter(id=source_id).delete()
+    return deleted > 0
+
+
 # --- CustomerJourney ---
 
 
@@ -1350,7 +1457,7 @@ def delete_account_notebook(
 # --- shared resolution / access helpers for the CRUD paths ---
 
 
-def _get_team_scoped(model, team_id: int, pk: str):
+def _get_team_scoped(model, team_id: int, pk: str | UUID):
     """Fetch a team-scoped row by pk, or None (malformed/absent). Used by the
     profile-config path, whose old viewset returned 404 for both."""
     try:

--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -272,6 +272,31 @@ class CustomPropertyDefinitionView:
 
 
 @stdlib_dataclass(frozen=True)
+class CustomPropertySourceView:
+    """A custom-property source: binds a materialized view's column to a definition, feeding its
+    values on each materialization.
+
+    ``definition`` / ``saved_query`` are ids (the definition this feeds, and the data-warehouse
+    saved query read from). ``last_sync_error`` is null when the last run succeeded or hasn't run.
+    Defaults exist so the wrapping serializer can parse partial request bodies (see
+    :class:`AccountView`).
+    """
+
+    id: UUID | None = None
+    definition: UUID | None = None
+    saved_query: UUID | None = None
+    source_column: str = ""
+    key_column: str = ""
+    is_enabled: bool = True
+    consecutive_failures: int = 0
+    last_synced_at: datetime | None = None
+    last_sync_error: str | None = None
+    created_at: datetime | None = None
+    created_by: int | None = None
+    updated_at: datetime | None = None
+
+
+@stdlib_dataclass(frozen=True)
 class AccountNotebookView:
     """An account notebook as returned by the nested account-notebooks endpoints.
 

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -35,6 +35,7 @@ from products.customer_analytics.backend.facade.contracts import (
     CustomerProfileConfigView,
     CustomPropertyDefinitionView,
     CustomPropertyReference,
+    CustomPropertySourceView,
 )
 
 # Scope (value, label) pairs, kept in sync with ``CustomerProfileConfig.Scope``. Declared
@@ -336,6 +337,78 @@ class CustomPropertyDefinitionSerializer(DataclassSerializer):
             "updated_at",
             "references",
         ]
+
+
+class CustomPropertySourceSerializer(DataclassSerializer):
+    """Binds a materialized data-warehouse view column to a custom property definition; the view's
+    values are synced onto matching accounts on each materialization."""
+
+    id = serializers.UUIDField(read_only=True)
+    definition = serializers.UUIDField(
+        help_text="UUID of the custom property definition this source feeds. One source per definition."
+    )
+    saved_query = serializers.UUIDField(
+        help_text="UUID of the data-warehouse saved query (materialized view) to read values from."
+    )
+    source_column = serializers.CharField(
+        max_length=400, help_text="Column in the view whose value is written to the property."
+    )
+    key_column = serializers.CharField(
+        max_length=400, help_text="Column in the view whose value matches an account's external_id."
+    )
+    is_enabled = serializers.BooleanField(
+        required=False,
+        default=True,
+        help_text=(
+            "Whether the source syncs. Auto-disabled after repeated failures or a missing view; "
+            "re-enabling resets the failure count."
+        ),
+    )
+    consecutive_failures = serializers.IntegerField(
+        read_only=True, help_text="Consecutive failed sync runs; the source auto-disables at the cap."
+    )
+    last_synced_at = serializers.DateTimeField(
+        read_only=True, allow_null=True, help_text="When the most recent sync run finished."
+    )
+    last_sync_error = serializers.CharField(
+        read_only=True, allow_null=True, help_text="Error summary from the last run, or null if it succeeded."
+    )
+    created_at = serializers.DateTimeField(read_only=True)
+    created_by = serializers.IntegerField(read_only=True, allow_null=True)
+    updated_at = serializers.DateTimeField(read_only=True, allow_null=True)
+
+    class Meta:
+        dataclass = CustomPropertySourceView
+        ref_name = "CustomPropertySource"
+        fields = [
+            "id",
+            "definition",
+            "saved_query",
+            "source_column",
+            "key_column",
+            "is_enabled",
+            "consecutive_failures",
+            "last_synced_at",
+            "last_sync_error",
+            "created_at",
+            "created_by",
+            "updated_at",
+        ]
+
+
+class CustomPropertySourceUpdateSerializer(serializers.Serializer):
+    """Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
+    they are intentionally absent — only these reach the facade's update."""
+
+    source_column = serializers.CharField(
+        max_length=400, required=False, help_text="Column in the view whose value is written to the property."
+    )
+    key_column = serializers.CharField(
+        max_length=400, required=False, help_text="Column in the view whose value matches an account's external_id."
+    )
+    is_enabled = serializers.BooleanField(
+        required=False, help_text="Whether the source syncs; re-enabling it resets the failure count."
+    )
 
 
 @extend_schema_field({"oneOf": [{"type": "string"}, {"type": "number"}, {"type": "boolean"}]})

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -37,6 +37,8 @@ from products.customer_analytics.backend.presentation.views.serializers import (
     CustomerJourneySerializer,
     CustomerProfileConfigSerializer,
     CustomPropertyDefinitionSerializer,
+    CustomPropertySourceSerializer,
+    CustomPropertySourceUpdateSerializer,
     CustomPropertyValueSerializer,
     CustomPropertyValueWriteSerializer,
 )
@@ -281,6 +283,70 @@ def _custom_property_definition_write_fields(validated, raw_data: dict) -> dict:
     if "is_big_number" in raw_data:
         fields["is_big_number"] = validated.is_big_number
     return fields
+
+
+class CustomPropertySourceViewSet(
+    TeamAndOrgViewSetMixin,
+    AccessControlViewSetMixin,
+    _FacadePaginationMixin,
+    viewsets.ModelViewSet,
+):
+    scope_object = "account"
+    serializer_class = CustomPropertySourceSerializer
+    queryset = None  # data is reached through the facade; declared for router/schema only
+
+    def list(self, request: Request, *args, **kwargs) -> Response:
+        return self._paginate_via_facade(
+            request,
+            lambda offset, limit: api.list_custom_property_sources(self.team_id, offset=offset, limit=limit),
+            CustomPropertySourceSerializer,
+        )
+
+    def retrieve(self, request: Request, *args, **kwargs) -> Response:
+        source = api.get_custom_property_source(self.team_id, self.kwargs["pk"])
+        if source is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(CustomPropertySourceSerializer(instance=source).data)
+
+    def create(self, request: Request, *args, **kwargs) -> Response:
+        serializer = CustomPropertySourceSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        data = serializer.validated_data
+        try:
+            source = api.create_custom_property_source(
+                team_id=self.team_id,
+                definition_id=data.definition,
+                saved_query_id=data.saved_query,
+                source_column=data.source_column,
+                key_column=data.key_column,
+                is_enabled=data.is_enabled,
+                user=cast(User, request.user),
+            )
+        except api.CustomPropertySourceValidationError as e:
+            raise ValidationError(str(e))
+        return Response(CustomPropertySourceSerializer(instance=source).data, status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=CustomPropertySourceUpdateSerializer)
+    def update(self, request: Request, *args, **kwargs) -> Response:
+        write = CustomPropertySourceUpdateSerializer(data=request.data, partial=kwargs.pop("partial", False))
+        write.is_valid(raise_exception=True)
+        source = api.update_custom_property_source(
+            team_id=self.team_id, source_id=self.kwargs["pk"], fields=write.validated_data
+        )
+        if source is None:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(CustomPropertySourceSerializer(instance=source).data)
+
+    @extend_schema(request=CustomPropertySourceUpdateSerializer)
+    def partial_update(self, request: Request, *args, **kwargs) -> Response:
+        kwargs["partial"] = True
+        return self.update(request, *args, **kwargs)
+
+    def destroy(self, request: Request, *args, **kwargs) -> Response:
+        deleted = api.delete_custom_property_source(team_id=self.team_id, source_id=self.kwargs["pk"])
+        if not deleted:
+            return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class CustomerJourneyViewSet(

--- a/products/customer_analytics/backend/routes.py
+++ b/products/customer_analytics/backend/routes.py
@@ -9,6 +9,7 @@ from products.customer_analytics.backend.presentation.views.views import (
     CustomerJourneyViewSet,
     CustomerProfileConfigViewSet,
     CustomPropertyDefinitionViewSet,
+    CustomPropertySourceViewSet,
     CustomPropertyValueViewSet,
 )
 
@@ -33,6 +34,12 @@ def register_routes(routers: RouterRegistry) -> None:
         r"custom_property_definitions",
         CustomPropertyDefinitionViewSet,
         "project_custom_property_definitions",
+        ["team_id"],
+    )
+    routers.projects.register(
+        r"custom_property_sources",
+        CustomPropertySourceViewSet,
+        "project_custom_property_sources",
         ["team_id"],
     )
     project_accounts_router, environment_accounts_router = routers.register_legacy_dual_route(

--- a/products/customer_analytics/backend/test/test_facade.py
+++ b/products/customer_analytics/backend/test/test_facade.py
@@ -1,7 +1,12 @@
+from uuid import uuid4
+
+import pytest
 from posthog.test.base import BaseTest
 from unittest.mock import MagicMock, patch
 
-from posthog.models import Organization, User
+from django.apps import apps
+
+from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.tag import Tag
 from posthog.models.tagged_item import TaggedItem
@@ -11,8 +16,9 @@ from products.customer_analytics.backend.facade import (
     api as facade,
     contracts,
 )
-from products.customer_analytics.backend.models import Account
+from products.customer_analytics.backend.models import Account, CustomPropertyDefinition, CustomPropertySource
 from products.customer_analytics.backend.models.account import AccountAssignment, AccountProperties
+from products.customer_analytics.backend.models.team_scoped_test_base import TeamScopedTestMixin
 from products.customer_analytics.backend.test.factories import create_account
 from products.notebooks.backend.models import Notebook, ResourceNotebook
 from products.product_analytics.backend.models.insight import Insight
@@ -485,3 +491,85 @@ class TestCustomerAnalyticsCRUDFacade(BaseTest):
             )
             is None
         )
+
+
+class TestCustomPropertySourceFacade(TeamScopedTestMixin, BaseTest):
+    def setUp(self):
+        super().setUp()
+        saved_query_model = apps.get_model("data_modeling", "DataWarehouseSavedQuery")
+        self.view = saved_query_model.objects.create(
+            team=self.team, name="billing_view", columns={"org_id": {}, "mrr": {}}
+        )
+        self.definition = CustomPropertyDefinition.objects.create(team=self.team, name="MRR")
+
+    def _create(self, **overrides):
+        kwargs: dict = {
+            "team_id": self.team.id,
+            "definition_id": self.definition.id,
+            "saved_query_id": self.view.id,
+            "source_column": "mrr",
+            "key_column": "org_id",
+            "is_enabled": True,
+            "user": self.user,
+        }
+        kwargs.update(overrides)
+        return facade.create_custom_property_source(**kwargs)
+
+    def test_create_returns_contract(self):
+        result = self._create()
+
+        assert isinstance(result, contracts.CustomPropertySourceView)
+        assert result.definition == self.definition.id
+        assert result.saved_query == self.view.id
+        assert result.source_column == "mrr"
+        assert result.is_enabled is True
+        assert result.id is not None
+        assert CustomPropertySource.objects.for_team(self.team.id).filter(id=result.id).exists()
+
+    def test_create_rejects_saved_query_from_another_team(self):
+        saved_query_model = apps.get_model("data_modeling", "DataWarehouseSavedQuery")
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_view = saved_query_model.objects.create(team=other_team, name="other_view", columns={})
+
+        with pytest.raises(facade.CustomPropertySourceValidationError):
+            self._create(saved_query_id=other_view.id)
+
+    def test_create_rejects_definition_from_another_team(self):
+        other_team = Team.objects.create(organization=self.organization, name="Other")
+        other_definition = CustomPropertyDefinition.objects.create(team=other_team, name="Other MRR")
+
+        with pytest.raises(facade.CustomPropertySourceValidationError):
+            self._create(definition_id=other_definition.id)
+
+    def test_create_rejects_second_source_for_same_definition(self):
+        self._create()
+
+        with pytest.raises(facade.CustomPropertySourceValidationError):
+            self._create()
+
+    def test_update_reenable_resets_failure_streak_and_clears_error(self):
+        source = self._create()
+        CustomPropertySource.objects.filter(id=source.id).update(
+            is_enabled=False, consecutive_failures=5, last_sync_error="boom"
+        )
+
+        result = facade.update_custom_property_source(
+            team_id=self.team.id, source_id=source.id, fields={"is_enabled": True}
+        )
+        assert result is not None
+
+        assert result.is_enabled is True
+        assert result.consecutive_failures == 0
+        assert result.last_sync_error is None
+
+    def test_update_returns_none_for_missing_source(self):
+        result = facade.update_custom_property_source(
+            team_id=self.team.id, source_id=str(uuid4()), fields={"is_enabled": False}
+        )
+        assert result is None
+
+    def test_delete_removes_source(self):
+        source = self._create()
+
+        assert facade.delete_custom_property_source(team_id=self.team.id, source_id=source.id) is True
+        assert not CustomPropertySource.objects.for_team(self.team.id).filter(id=source.id).exists()

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -5,6 +5,8 @@ from freezegun import freeze_time
 from posthog.test.base import APIBaseTest
 from unittest.mock import patch
 
+from django.apps import apps
+
 from parameterized import parameterized
 from rest_framework import status
 
@@ -1849,3 +1851,37 @@ class TestCustomPropertyValueViewSet(APIBaseTest):
         response = self.client.get(self.endpoint)
 
         self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+
+class TestCustomPropertySourceViewSet(APIBaseTest):
+    def setUp(self):
+        super().setUp()
+        self.endpoint = f"/api/projects/{self.team.id}/custom_property_sources/"
+        saved_query_model = apps.get_model("data_modeling", "DataWarehouseSavedQuery")
+        self.view = saved_query_model.objects.create(
+            team=self.team, name="billing_view", columns={"org_id": {}, "mrr": {}}
+        )
+        self.definition = create_custom_property_definition(team_id=self.team.id, name="MRR")
+
+    def test_create_list_and_toggle_round_trip(self):
+        created = self.client.post(
+            self.endpoint,
+            {
+                "definition": str(self.definition.id),
+                "saved_query": str(self.view.id),
+                "source_column": "mrr",
+                "key_column": "org_id",
+            },
+            format="json",
+        )
+        assert created.status_code == status.HTTP_201_CREATED, created.content
+        source_id = created.json()["id"]
+        assert created.json()["is_enabled"] is True
+
+        listed = self.client.get(self.endpoint)
+        assert listed.status_code == status.HTTP_200_OK
+        assert [s["id"] for s in listed.json()["results"]] == [source_id]
+
+        toggled = self.client.patch(f"{self.endpoint}{source_id}/", {"is_enabled": False}, format="json")
+        assert toggled.status_code == status.HTTP_200_OK
+        assert toggled.json()["is_enabled"] is False

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -391,6 +391,94 @@ export interface PatchedCustomPropertyDefinitionApi {
     readonly references?: readonly CustomPropertyReferenceApi[]
 }
 
+/**
+ * Binds a materialized data-warehouse view column to a custom property definition; the view's
+ * values are synced onto matching accounts on each materialization.
+ */
+export interface CustomPropertySourceApi {
+    readonly id: string
+    /** UUID of the custom property definition this source feeds. One source per definition. */
+    definition: string
+    /** UUID of the data-warehouse saved query (materialized view) to read values from. */
+    saved_query: string
+    /**
+     * Column in the view whose value is written to the property.
+     * @maxLength 400
+     */
+    source_column: string
+    /**
+     * Column in the view whose value matches an account's external_id.
+     * @maxLength 400
+     */
+    key_column: string
+    /** Whether the source syncs. Auto-disabled after repeated failures or a missing view; re-enabling resets the failure count. */
+    is_enabled?: boolean
+    /** Consecutive failed sync runs; the source auto-disables at the cap. */
+    readonly consecutive_failures: number
+    /**
+     * When the most recent sync run finished.
+     * @nullable
+     */
+    readonly last_synced_at: string | null
+    /**
+     * Error summary from the last run, or null if it succeeded.
+     * @nullable
+     */
+    readonly last_sync_error: string | null
+    readonly created_at: string
+    /** @nullable */
+    readonly created_by: number | null
+    /** @nullable */
+    readonly updated_at: string | null
+}
+
+export interface PaginatedCustomPropertySourceListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CustomPropertySourceApi[]
+}
+
+/**
+ * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
+ * they are intentionally absent — only these reach the facade's update.
+ */
+export interface CustomPropertySourceUpdateApi {
+    /**
+     * Column in the view whose value is written to the property.
+     * @maxLength 400
+     */
+    source_column?: string
+    /**
+     * Column in the view whose value matches an account's external_id.
+     * @maxLength 400
+     */
+    key_column?: string
+    /** Whether the source syncs; re-enabling it resets the failure count. */
+    is_enabled?: boolean
+}
+
+/**
+ * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
+ * they are intentionally absent — only these reach the facade's update.
+ */
+export interface PatchedCustomPropertySourceUpdateApi {
+    /**
+     * Column in the view whose value is written to the property.
+     * @maxLength 400
+     */
+    source_column?: string
+    /**
+     * Column in the view whose value matches an account's external_id.
+     * @maxLength 400
+     */
+    key_column?: string
+    /** Whether the source syncs; re-enabling it resets the failure count. */
+    is_enabled?: boolean
+}
+
 export interface CustomerJourneyApi {
     readonly id: string
     insight: number
@@ -674,6 +762,17 @@ export type AccountsNotebooksListParams = {
 }
 
 export type CustomPropertyDefinitionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number
+}
+
+export type CustomPropertySourcesListParams = {
     /**
      * Number of results to return per page.
      */

--- a/products/customer_analytics/frontend/generated/api.ts
+++ b/products/customer_analytics/frontend/generated/api.ts
@@ -15,6 +15,9 @@ import type {
     AccountsNotebooksListParams,
     CustomPropertyDefinitionApi,
     CustomPropertyDefinitionsListParams,
+    CustomPropertySourceApi,
+    CustomPropertySourceUpdateApi,
+    CustomPropertySourcesListParams,
     CustomPropertyValueApi,
     CustomPropertyValueWriteApi,
     CustomerJourneyApi,
@@ -26,11 +29,13 @@ import type {
     PaginatedAccountListApi,
     PaginatedAccountNotebookListApi,
     PaginatedCustomPropertyDefinitionListApi,
+    PaginatedCustomPropertySourceListApi,
     PaginatedCustomerJourneyListApi,
     PaginatedCustomerProfileConfigListApi,
     PaginatedGroupUsageMetricListApi,
     PatchedAccountApi,
     PatchedCustomPropertyDefinitionApi,
+    PatchedCustomPropertySourceUpdateApi,
     PatchedCustomerJourneyApi,
     PatchedCustomerProfileConfigApi,
     PatchedGroupUsageMetricApi,
@@ -381,6 +386,116 @@ export const customPropertyDefinitionsDestroy = async (
     options?: RequestInit
 ): Promise<void> => {
     return apiMutator<void>(getCustomPropertyDefinitionsDestroyUrl(projectId, id), {
+        ...options,
+        method: 'DELETE',
+    })
+}
+
+export const getCustomPropertySourcesListUrl = (projectId: string, params?: CustomPropertySourcesListParams) => {
+    const normalizedParams = new URLSearchParams()
+
+    Object.entries(params || {}).forEach(([key, value]) => {
+        if (value !== undefined) {
+            normalizedParams.append(key, value === null ? 'null' : String(value))
+        }
+    })
+
+    const stringifiedParams = normalizedParams.toString()
+
+    return stringifiedParams.length > 0
+        ? `/api/projects/${projectId}/custom_property_sources/?${stringifiedParams}`
+        : `/api/projects/${projectId}/custom_property_sources/`
+}
+
+export const customPropertySourcesList = async (
+    projectId: string,
+    params?: CustomPropertySourcesListParams,
+    options?: RequestInit
+): Promise<PaginatedCustomPropertySourceListApi> => {
+    return apiMutator<PaginatedCustomPropertySourceListApi>(getCustomPropertySourcesListUrl(projectId, params), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCustomPropertySourcesCreateUrl = (projectId: string) => {
+    return `/api/projects/${projectId}/custom_property_sources/`
+}
+
+export const customPropertySourcesCreate = async (
+    projectId: string,
+    customPropertySourceApi: NonReadonly<CustomPropertySourceApi>,
+    options?: RequestInit
+): Promise<CustomPropertySourceApi> => {
+    return apiMutator<CustomPropertySourceApi>(getCustomPropertySourcesCreateUrl(projectId), {
+        ...options,
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(customPropertySourceApi),
+    })
+}
+
+export const getCustomPropertySourcesRetrieveUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/custom_property_sources/${id}/`
+}
+
+export const customPropertySourcesRetrieve = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<CustomPropertySourceApi> => {
+    return apiMutator<CustomPropertySourceApi>(getCustomPropertySourcesRetrieveUrl(projectId, id), {
+        ...options,
+        method: 'GET',
+    })
+}
+
+export const getCustomPropertySourcesUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/custom_property_sources/${id}/`
+}
+
+export const customPropertySourcesUpdate = async (
+    projectId: string,
+    id: string,
+    customPropertySourceUpdateApi?: CustomPropertySourceUpdateApi,
+    options?: RequestInit
+): Promise<CustomPropertySourceApi> => {
+    return apiMutator<CustomPropertySourceApi>(getCustomPropertySourcesUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(customPropertySourceUpdateApi),
+    })
+}
+
+export const getCustomPropertySourcesPartialUpdateUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/custom_property_sources/${id}/`
+}
+
+export const customPropertySourcesPartialUpdate = async (
+    projectId: string,
+    id: string,
+    patchedCustomPropertySourceUpdateApi?: PatchedCustomPropertySourceUpdateApi,
+    options?: RequestInit
+): Promise<CustomPropertySourceApi> => {
+    return apiMutator<CustomPropertySourceApi>(getCustomPropertySourcesPartialUpdateUrl(projectId, id), {
+        ...options,
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json', ...options?.headers },
+        body: JSON.stringify(patchedCustomPropertySourceUpdateApi),
+    })
+}
+
+export const getCustomPropertySourcesDestroyUrl = (projectId: string, id: string) => {
+    return `/api/projects/${projectId}/custom_property_sources/${id}/`
+}
+
+export const customPropertySourcesDestroy = async (
+    projectId: string,
+    id: string,
+    options?: RequestInit
+): Promise<void> => {
+    return apiMutator<void>(getCustomPropertySourcesDestroyUrl(projectId, id), {
         ...options,
         method: 'DELETE',
     })

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -279,6 +279,89 @@ export const CustomPropertyDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
         "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
     )
 
+export const customPropertySourcesCreateBodySourceColumnMax = 400
+
+export const customPropertySourcesCreateBodyKeyColumnMax = 400
+
+export const customPropertySourcesCreateBodyIsEnabledDefault = true
+
+export const CustomPropertySourcesCreateBody = /* @__PURE__ */ zod
+    .object({
+        definition: zod
+            .uuid()
+            .describe('UUID of the custom property definition this source feeds. One source per definition.'),
+        saved_query: zod
+            .uuid()
+            .describe('UUID of the data-warehouse saved query (materialized view) to read values from.'),
+        source_column: zod
+            .string()
+            .max(customPropertySourcesCreateBodySourceColumnMax)
+            .describe('Column in the view whose value is written to the property.'),
+        key_column: zod
+            .string()
+            .max(customPropertySourcesCreateBodyKeyColumnMax)
+            .describe("Column in the view whose value matches an account's external_id."),
+        is_enabled: zod
+            .boolean()
+            .default(customPropertySourcesCreateBodyIsEnabledDefault)
+            .describe(
+                'Whether the source syncs. Auto-disabled after repeated failures or a missing view; re-enabling resets the failure count.'
+            ),
+    })
+    .describe(
+        "Binds a materialized data-warehouse view column to a custom property definition; the view's\nvalues are synced onto matching accounts on each materialization."
+    )
+
+export const customPropertySourcesUpdateBodySourceColumnMax = 400
+
+export const customPropertySourcesUpdateBodyKeyColumnMax = 400
+
+export const CustomPropertySourcesUpdateBody = /* @__PURE__ */ zod
+    .object({
+        source_column: zod
+            .string()
+            .max(customPropertySourcesUpdateBodySourceColumnMax)
+            .optional()
+            .describe('Column in the view whose value is written to the property.'),
+        key_column: zod
+            .string()
+            .max(customPropertySourcesUpdateBodyKeyColumnMax)
+            .optional()
+            .describe("Column in the view whose value matches an account's external_id."),
+        is_enabled: zod
+            .boolean()
+            .optional()
+            .describe('Whether the source syncs; re-enabling it resets the failure count.'),
+    })
+    .describe(
+        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+    )
+
+export const customPropertySourcesPartialUpdateBodySourceColumnMax = 400
+
+export const customPropertySourcesPartialUpdateBodyKeyColumnMax = 400
+
+export const CustomPropertySourcesPartialUpdateBody = /* @__PURE__ */ zod
+    .object({
+        source_column: zod
+            .string()
+            .max(customPropertySourcesPartialUpdateBodySourceColumnMax)
+            .optional()
+            .describe('Column in the view whose value is written to the property.'),
+        key_column: zod
+            .string()
+            .max(customPropertySourcesPartialUpdateBodyKeyColumnMax)
+            .optional()
+            .describe("Column in the view whose value matches an account's external_id."),
+        is_enabled: zod
+            .boolean()
+            .optional()
+            .describe('Whether the source syncs; re-enabling it resets the failure count.'),
+    })
+    .describe(
+        "Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so\nthey are intentionally absent — only these reach the facade's update."
+    )
+
 export const customerJourneysCreateBodyNameMax = 400
 
 export const CustomerJourneysCreateBody = /* @__PURE__ */ zod.object({

--- a/products/customer_analytics/mcp/tools.yaml
+++ b/products/customer_analytics/mcp/tools.yaml
@@ -305,6 +305,24 @@ tools:
     custom-property-definitions-update:
         operation: custom_property_definitions_update
         enabled: false
+    custom-property-sources-create:
+        operation: custom_property_sources_create
+        enabled: false
+    custom-property-sources-destroy:
+        operation: custom_property_sources_destroy
+        enabled: false
+    custom-property-sources-list:
+        operation: custom_property_sources_list
+        enabled: false
+    custom-property-sources-partial-update:
+        operation: custom_property_sources_partial_update
+        enabled: false
+    custom-property-sources-retrieve:
+        operation: custom_property_sources_retrieve
+        enabled: false
+    custom-property-sources-update:
+        operation: custom_property_sources_update
+        enabled: false
     customer-journeys-create:
         operation: customer_journeys_create
         enabled: false

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14168,6 +14168,66 @@ export namespace Schemas {
     }
 
     /**
+     * Binds a materialized data-warehouse view column to a custom property definition; the view's
+     * values are synced onto matching accounts on each materialization.
+     */
+    export interface CustomPropertySource {
+      readonly id: string;
+      /** UUID of the custom property definition this source feeds. One source per definition. */
+      definition: string;
+      /** UUID of the data-warehouse saved query (materialized view) to read values from. */
+      saved_query: string;
+      /**
+         * Column in the view whose value is written to the property.
+         * @maxLength 400
+         */
+      source_column: string;
+      /**
+         * Column in the view whose value matches an account's external_id.
+         * @maxLength 400
+         */
+      key_column: string;
+      /** Whether the source syncs. Auto-disabled after repeated failures or a missing view; re-enabling resets the failure count. */
+      is_enabled?: boolean;
+      /** Consecutive failed sync runs; the source auto-disables at the cap. */
+      readonly consecutive_failures: number;
+      /**
+         * When the most recent sync run finished.
+         * @nullable
+         */
+      readonly last_synced_at: string | null;
+      /**
+         * Error summary from the last run, or null if it succeeded.
+         * @nullable
+         */
+      readonly last_sync_error: string | null;
+      readonly created_at: string;
+      /** @nullable */
+      readonly created_by: number | null;
+      /** @nullable */
+      readonly updated_at: string | null;
+    }
+
+    /**
+     * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
+     * they are intentionally absent — only these reach the facade's update.
+     */
+    export interface CustomPropertySourceUpdate {
+      /**
+         * Column in the view whose value is written to the property.
+         * @maxLength 400
+         */
+      source_column?: string;
+      /**
+         * Column in the view whose value matches an account's external_id.
+         * @maxLength 400
+         */
+      key_column?: string;
+      /** Whether the source syncs; re-enabling it resets the failure count. */
+      is_enabled?: boolean;
+    }
+
+    /**
      * An account's current value for a custom property (read shape).
      */
     export interface CustomPropertyValue {
@@ -31148,6 +31208,15 @@ export namespace Schemas {
       results: CustomPropertyDefinition[];
     }
 
+    export interface PaginatedCustomPropertySourceList {
+      count: number;
+      /** @nullable */
+      next?: string | null;
+      /** @nullable */
+      previous?: string | null;
+      results: CustomPropertySource[];
+    }
+
     export interface PaginatedCustomerJourneyList {
       count: number;
       /** @nullable */
@@ -36258,6 +36327,25 @@ export namespace Schemas {
       readonly updated_at?: string | null;
       /** Workflows that use this property, resolved by definition id. */
       readonly references?: readonly CustomPropertyReference[];
+    }
+
+    /**
+     * Writable fields for updating a source. ``definition`` and ``saved_query`` are create-only, so
+     * they are intentionally absent — only these reach the facade's update.
+     */
+    export interface PatchedCustomPropertySourceUpdate {
+      /**
+         * Column in the view whose value is written to the property.
+         * @maxLength 400
+         */
+      source_column?: string;
+      /**
+         * Column in the view whose value matches an account's external_id.
+         * @maxLength 400
+         */
+      key_column?: string;
+      /** Whether the source syncs; re-enabling it resets the failure count. */
+      is_enabled?: boolean;
     }
 
     export interface PatchedCustomerJourney {
@@ -60958,6 +61046,17 @@ export namespace Schemas {
     };
 
     export type CustomPropertyDefinitionsListParams = {
+    /**
+     * Number of results to return per page.
+     */
+    limit?: number;
+    /**
+     * The initial index from which to return the results.
+     */
+    offset?: number;
+    };
+
+    export type CustomPropertySourcesListParams = {
     /**
      * Number of results to return per page.
      */


### PR DESCRIPTION
> Stack — merge bottom-up: **model → sync → api → gate → ui**. This PR is **3/5** (base: `…-sync`).

## Problem

No API to configure which view column backs a custom property definition.

Part of #60300.

<!-- Closes #ISSUE_ID -->

## Changes

- Add `CustomPropertySource` facade contract + CRUD facade functions.
- Add source-config serializer, viewset, and route.
- Regenerate frontend + MCP API types.

## How did you test this code?

Unit tests: `test_facade.py`, `test_views.py` (source CRUD). Not re-run this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Authored by PostHog Code (Claude). Slice of #66409, split into an atomic stack. Generated type files (`api.schemas.ts`, `api.ts`, `api.zod.ts`, MCP `generated.ts`) come from `hogli build:openapi` — review the serializer, not the generated output.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
