### PR TITLE
feat(customer-analytics): Gate and auto-sync source-backed properties

### DIFF
--- a/products/customer_analytics/backend/COMPROMISES.md
+++ b/products/customer_analytics/backend/COMPROMISES.md
@@ -17,5 +17,12 @@ Shortcuts taken to ship the first version. Revisit when they bite.
   HogQL out of the data-modeling worker's process, since core imports nothing from here. Trade-off:
   core hardcodes this consumer's task name. If a second consumer ever needs the materialization event,
   switch to a core-owned signal (inversion of control) rather than adding another direct dispatch.
+- **No save-time column validation.** Creating/updating a source does not check that `source_column`
+  / `key_column` exist in the view's schema. A bad column surfaces as a per-source sync error (and
+  advances the auto-disable streak) on the next run, not as a 400 on save. Validate against the saved
+  query's `columns` at write time if the delayed feedback bites.
+- **Initial sync is best-effort.** Saving an enabled source enqueues a sync on commit so values
+  populate without waiting for the next materialization. If the broker is down the save still
+  succeeds and the enqueue is dropped (logged to error tracking) — the next materialization recovers.
 - **v2 materialization only.** v1 `run_workflow.py` is frozen and does not dispatch the sync; v1
   teams get it after migrating to v2.

--- a/products/customer_analytics/backend/facade/api.py
+++ b/products/customer_analytics/backend/facade/api.py
@@ -15,6 +15,7 @@ Do NOT:
 - Import DRF, serializers, or HTTP concerns
 """
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Optional, cast
 from uuid import UUID
 
@@ -23,6 +24,7 @@ from django.core.exceptions import ValidationError
 from django.db import IntegrityError, transaction
 from django.db.models import Prefetch, Q
 
+from celery import current_app
 from pydantic import ValidationError as PydanticValidationError
 
 from posthog.api.tagged_item import set_tags_on_object
@@ -380,6 +382,13 @@ def set_external_account_custom_properties(
             error=contracts.ExternalAccountCustomPropertiesError.ACCOUNT_NOT_FOUND
         )
 
+    source_backed = _source_backed_definition_ids(team_id, list(properties.keys()))
+    if source_backed:
+        return contracts.ExternalAccountCustomPropertiesResult(
+            error=contracts.ExternalAccountCustomPropertiesError.SOURCE_MANAGED,
+            error_field=str(next(iter(source_backed))),
+        )
+
     try:
         with transaction.atomic():
             rows = _custom_property_values_logic.set_account_custom_properties_by_id(
@@ -674,6 +683,7 @@ def _to_custom_property_definition_view(
         created_by=definition.created_by_id,
         updated_at=definition.updated_at,
         references=references or [],
+        source=_definition_source_view(definition),
     )
 
 
@@ -705,6 +715,16 @@ def _custom_property_references_by_definition_id(
     }
 
 
+def _definition_source_view(definition: CustomPropertyDefinition) -> contracts.CustomPropertySourceView | None:
+    """The source bound to this definition (reverse one-to-one ``source``), or None. List reads
+    ``select_related("source")`` so this stays a cache hit; detail reads pay one extra query."""
+    try:
+        source = definition.source  # type: ignore[attr-defined]
+    except CustomPropertySource.DoesNotExist:
+        return None
+    return _to_custom_property_source_view(source)
+
+
 def list_custom_property_definitions(
     team_id: int, offset: int, limit: int, *, user_access_control: "UserAccessControl"
 ) -> tuple[list[contracts.CustomPropertyDefinitionView], int]:
@@ -712,7 +732,7 @@ def list_custom_property_definitions(
 
     ``references`` (the workflows referencing each definition) is included only when the caller can
     read workflows — see ``_can_read_workflow_references``."""
-    queryset = CustomPropertyDefinition.objects.filter(team_id=team_id).order_by("name")
+    queryset = CustomPropertyDefinition.objects.filter(team_id=team_id).select_related("source").order_by("name")
     total_count = queryset.count()
     page = queryset[offset : offset + limit]
     references = (
@@ -868,6 +888,26 @@ def _saved_query_belongs_to_team(team_id: int, saved_query_id) -> bool:
     return saved_query_model.objects.filter(id=saved_query_id, team_id=team_id).exclude(deleted=True).exists()
 
 
+def _enqueue_custom_property_sync(team_id: int, saved_query_id: str) -> None:
+    """Dispatch the sync task by name. Enqueue failure must not fail the originating write, so it's swallowed."""
+    try:
+        current_app.send_task(
+            "customer_analytics.process_custom_property_sync",
+            kwargs={"team_id": team_id, "saved_query_id": saved_query_id},
+        )
+    except Exception as e:
+        capture_exception(e)
+
+
+def _enqueue_sync_if_enabled(source: CustomPropertySource) -> None:
+    """Run an initial sync after the source is saved so its values populate immediately rather than
+    waiting for the next materialization. Skips disabled sources and ones whose view was deleted."""
+    if not source.is_enabled or source.saved_query_id is None:
+        return
+    team_id, saved_query_id = source.team_id, str(source.saved_query_id)
+    transaction.on_commit(lambda: _enqueue_custom_property_sync(team_id, saved_query_id))
+
+
 def list_custom_property_sources(
     team_id: int, offset: int, limit: int
 ) -> tuple[list[contracts.CustomPropertySourceView], int]:
@@ -913,6 +953,7 @@ def create_custom_property_source(
         if "unique" not in str(exc).lower() and "duplicate" not in str(exc).lower():
             raise
         raise CustomPropertySourceValidationError("This custom property already has a source.")
+    _enqueue_sync_if_enabled(source)
     return _to_custom_property_source_view(source)
 
 
@@ -926,12 +967,18 @@ def update_custom_property_source(
     if source is None:
         return None
     reenabling = fields.get("is_enabled") is True and not source.is_enabled
+    columns_changed = any(
+        attr in fields and fields[attr] != getattr(source, attr) for attr in ("source_column", "key_column")
+    )
     for attr, value in fields.items():
         setattr(source, attr, value)
     if reenabling:
         source.consecutive_failures = 0
         source.last_sync_error = None
     source.save()
+    # Only re-sync on a change that affects what gets written — not on every (possibly no-op) PATCH.
+    if reenabling or columns_changed:
+        _enqueue_sync_if_enabled(source)
     return _to_custom_property_source_view(source)
 
 
@@ -1499,6 +1546,23 @@ CustomPropertyValueConflict = _custom_property_values_logic.CustomPropertyValueC
 InvalidCustomPropertyValue = _custom_property_values_logic.InvalidCustomPropertyValue
 
 
+def _source_backed_definition_ids(team_id: int, definition_ids: Iterable[str | UUID]) -> set[UUID]:
+    """Definition ids from ``definition_ids`` that are backed by a view sync. Manual writes to these
+    are closed at the API layer (the sync writes them through the logic directly), so callers can't
+    fight the sync over the value."""
+    return set(
+        CustomPropertySource.objects.for_team(team_id)
+        .filter(definition_id__in=definition_ids)
+        .values_list("definition_id", flat=True)
+    )
+
+
+class CustomPropertyValueSourceManaged(Exception):
+    """Raised when a manual write targets a source-backed definition. The view sync writes such
+    definitions through the logic layer directly; the manual API path is closed so the two can't
+    fight over the value (→ 400)."""
+
+
 def _to_custom_property_value(row: "CustomPropertyValue") -> contracts.CustomPropertyValue:
     return contracts.CustomPropertyValue(
         id=row.id,
@@ -1518,6 +1582,10 @@ def set_custom_property_value(
     *,
     created_by_id: int | None = None,
 ) -> contracts.CustomPropertyValue:
+    if _source_backed_definition_ids(team_id, [definition_id]):
+        raise CustomPropertyValueSourceManaged(
+            "This custom property is managed by a data warehouse source and can't be set manually."
+        )
     row = _custom_property_values_logic.set_custom_property_value(
         team_id=team_id,
         account_id=account_id,

--- a/products/customer_analytics/backend/facade/contracts.py
+++ b/products/customer_analytics/backend/facade/contracts.py
@@ -257,7 +257,8 @@ class CustomPropertyDefinitionView:
     Defaults exist so the wrapping serializer can parse partial request bodies (see
     :class:`AccountView`). ``created_by`` is the creator's user id (or ``None``), matching
     the old model serializer's ``PrimaryKeyRelatedField`` output. ``references`` lists where the
-    property is used (workflows), resolved by definition id.
+    property is used (workflows), resolved by definition id. ``source`` is the read-only
+    view-sync binding when one is configured for this definition, else ``None``.
     """
 
     id: UUID | None = None
@@ -269,6 +270,7 @@ class CustomPropertyDefinitionView:
     created_by: int | None = None
     updated_at: datetime | None = None
     references: list[CustomPropertyReference] = field(default_factory=list)
+    source: "CustomPropertySourceView | None" = None
 
 
 @stdlib_dataclass(frozen=True)
@@ -388,6 +390,7 @@ class ExternalAccountCustomPropertiesError(Enum):
     INVALID_VALUE = "invalid_value"
     CONFLICT = "conflict"
     UPDATE_FAILED = "update_failed"
+    SOURCE_MANAGED = "source_managed"
 
 
 @dataclass(frozen=True)
@@ -396,7 +399,8 @@ class ExternalAccountCustomPropertiesResult:
     case to its exact HTTP status and error string without holding write logic.
 
     Exactly one of ``values`` / ``error`` is set. ``error_field`` carries the offending
-    property name for ``DEFINITION_NOT_FOUND`` / ``INVALID_VALUE`` failures; it is None otherwise.
+    property name for ``DEFINITION_NOT_FOUND`` / ``INVALID_VALUE`` / ``SOURCE_MANAGED`` failures;
+    it is None otherwise.
     """
 
     values: list[CustomPropertyValue] | None = None

--- a/products/customer_analytics/backend/presentation/views/external.py
+++ b/products/customer_analytics/backend/presentation/views/external.py
@@ -263,6 +263,10 @@ _CUSTOM_PROPERTIES_ERROR_RESPONSES = {
         "Failed to update custom properties",
         status.HTTP_500_INTERNAL_SERVER_ERROR,
     ),
+    contracts.ExternalAccountCustomPropertiesError.SOURCE_MANAGED: (
+        "This custom property is managed by a data warehouse source and can't be set manually",
+        status.HTTP_400_BAD_REQUEST,
+    ),
 }
 
 

--- a/products/customer_analytics/backend/presentation/views/serializers.py
+++ b/products/customer_analytics/backend/presentation/views/serializers.py
@@ -281,64 +281,6 @@ class CustomPropertyReferenceSerializer(DataclassSerializer):
         fields = ["id", "name", "status", "type"]
 
 
-class CustomPropertyDefinitionSerializer(DataclassSerializer):
-    """A team-scoped definition of a custom account property — the attribute side of the model.
-
-    Holds only the property's shape (name, display type, big-number flag). Per-account values are
-    stored separately, so this serializer never reads or writes account values. The numeric-only
-    big-number rule and the unique-name conflict are enforced behind the facade.
-    """
-
-    id = serializers.UUIDField(read_only=True)
-    name = serializers.CharField(
-        max_length=400,
-        help_text="Human-readable name of the custom property. Unique within the team.",
-    )
-    description = serializers.CharField(
-        required=False,
-        allow_null=True,
-        allow_blank=True,
-        help_text="Optional description of what the property represents.",
-    )
-    display_type = serializers.ChoiceField(
-        choices=CUSTOM_PROPERTY_DISPLAY_TYPE_CHOICES,
-        help_text=(
-            "How the property is interpreted and rendered: 'text', 'number', 'currency', "
-            "'percent', 'date', 'datetime', or 'boolean'."
-        ),
-    )
-    is_big_number = serializers.BooleanField(
-        required=False,
-        default=False,
-        help_text="Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.",
-    )
-    created_at = serializers.DateTimeField(read_only=True)
-    created_by = serializers.IntegerField(read_only=True, allow_null=True)
-    updated_at = serializers.DateTimeField(read_only=True, allow_null=True)
-    references = CustomPropertyReferenceSerializer(
-        many=True,
-        read_only=True,
-        help_text="Workflows that use this property, resolved by definition id.",
-    )
-
-    class Meta:
-        dataclass = CustomPropertyDefinitionView
-        # Pin the OpenAPI component name to the pre-isolation one (DataclassSerializer would
-        # otherwise name it after the wrapped dataclass, ``CustomPropertyDefinitionView``).
-        ref_name = "CustomPropertyDefinition"
-        fields = [
-            "id",
-            "name",
-            "description",
-            "display_type",
-            "is_big_number",
-            "created_at",
-            "created_by",
-            "updated_at",
-            "references",
-        ]
-
-
 class CustomPropertySourceSerializer(DataclassSerializer):
     """Binds a materialized data-warehouse view column to a custom property definition; the view's
     values are synced onto matching accounts on each materialization."""
@@ -393,6 +335,67 @@ class CustomPropertySourceSerializer(DataclassSerializer):
             "created_at",
             "created_by",
             "updated_at",
+        ]
+
+
+class CustomPropertyDefinitionSerializer(DataclassSerializer):
+    """A team-scoped definition of a custom account property — the attribute side of the model.
+
+    Holds only the property's shape (name, display type, big-number flag). Per-account values are
+    stored separately, so this serializer never reads or writes account values.
+    """
+
+    id = serializers.UUIDField(read_only=True)
+    name = serializers.CharField(
+        max_length=400,
+        help_text="Human-readable name of the custom property. Unique within the team.",
+    )
+    description = serializers.CharField(
+        required=False,
+        allow_null=True,
+        allow_blank=True,
+        help_text="Optional description of what the property represents.",
+    )
+    display_type = serializers.ChoiceField(
+        choices=CUSTOM_PROPERTY_DISPLAY_TYPE_CHOICES,
+        help_text=(
+            "How the property is interpreted and rendered: 'text', 'number', 'currency', "
+            "'percent', 'date', 'datetime', or 'boolean'."
+        ),
+    )
+    is_big_number = serializers.BooleanField(
+        required=False,
+        default=False,
+        help_text="Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.",
+    )
+    source = CustomPropertySourceSerializer(  # type: ignore[assignment]
+        read_only=True,
+        allow_null=True,
+        help_text="The data-warehouse view-sync binding feeding this property, or null when values are set manually.",
+    )
+    created_at = serializers.DateTimeField(read_only=True)
+    created_by = serializers.IntegerField(read_only=True, allow_null=True)
+    updated_at = serializers.DateTimeField(read_only=True, allow_null=True)
+    references = CustomPropertyReferenceSerializer(
+        many=True,
+        read_only=True,
+        help_text="Workflows that use this property, resolved by definition id.",
+    )
+
+    class Meta:
+        dataclass = CustomPropertyDefinitionView
+        ref_name = "CustomPropertyDefinition"
+        fields = [
+            "id",
+            "name",
+            "description",
+            "display_type",
+            "is_big_number",
+            "source",
+            "created_at",
+            "created_by",
+            "updated_at",
+            "references",
         ]
 
 

--- a/products/customer_analytics/backend/presentation/views/views.py
+++ b/products/customer_analytics/backend/presentation/views/views.py
@@ -857,6 +857,8 @@ class CustomPropertyValueViewSet(TeamAndOrgViewSetMixin, AccessControlViewSetMix
             return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
         except api.CustomPropertyDefinitionNotFound:
             raise ValidationError({"definition": "Custom property definition not found."})
+        except api.CustomPropertyValueSourceManaged as exc:
+            raise ValidationError({"definition": str(exc)})
         except api.InvalidCustomPropertyValue as exc:
             raise ValidationError({"value": str(exc)})
         except api.CustomPropertyValueConflict as exc:

--- a/products/customer_analytics/backend/test/test_facade.py
+++ b/products/customer_analytics/backend/test/test_facade.py
@@ -6,6 +6,8 @@ from unittest.mock import MagicMock, patch
 
 from django.apps import apps
 
+from parameterized import parameterized
+
 from posthog.models import Organization, Team, User
 from posthog.models.activity_logging.activity_log import ActivityLog
 from posthog.models.tag import Tag
@@ -573,3 +575,76 @@ class TestCustomPropertySourceFacade(TeamScopedTestMixin, BaseTest):
 
         assert facade.delete_custom_property_source(team_id=self.team.id, source_id=source.id) is True
         assert not CustomPropertySource.objects.for_team(self.team.id).filter(id=source.id).exists()
+
+    @parameterized.expand([("enabled", True, True), ("disabled", False, False)])
+    def test_create_enqueues_initial_sync_only_when_enabled(self, _name, is_enabled, expect_enqueued):
+        with patch.object(facade, "current_app") as mock_app, self.captureOnCommitCallbacks(execute=True):
+            self._create(is_enabled=is_enabled)
+
+        if expect_enqueued:
+            mock_app.send_task.assert_called_once_with(
+                "customer_analytics.process_custom_property_sync",
+                kwargs={"team_id": self.team.id, "saved_query_id": str(self.view.id)},
+            )
+        else:
+            mock_app.send_task.assert_not_called()
+
+    def test_reenabling_a_source_enqueues_a_sync(self):
+        source = self._create(is_enabled=False)
+
+        with patch.object(facade, "current_app") as mock_app, self.captureOnCommitCallbacks(execute=True):
+            facade.update_custom_property_source(team_id=self.team.id, source_id=source.id, fields={"is_enabled": True})
+
+        mock_app.send_task.assert_called_once_with(
+            "customer_analytics.process_custom_property_sync",
+            kwargs={"team_id": self.team.id, "saved_query_id": str(self.view.id)},
+        )
+
+    @parameterized.expand(
+        [
+            ("noop", {}, False),
+            ("already_enabled", {"is_enabled": True}, False),
+            ("column_change", {"source_column": "org_id"}, True),
+        ]
+    )
+    def test_update_enqueues_only_on_meaningful_change(self, _name, fields, expect_enqueued):
+        source = self._create()
+
+        with patch.object(facade, "current_app") as mock_app, self.captureOnCommitCallbacks(execute=True):
+            facade.update_custom_property_source(team_id=self.team.id, source_id=source.id, fields=fields)
+
+        if expect_enqueued:
+            mock_app.send_task.assert_called_once()
+        else:
+            mock_app.send_task.assert_not_called()
+
+    def test_external_batch_rejects_source_backed_definition(self):
+        self._create()
+        create_account(team_id=self.team.id, name="Acme", external_id="acme")
+
+        result = facade.set_external_account_custom_properties(
+            self.team.id, "acme", properties={str(self.definition.id): 100}
+        )
+
+        assert result.error == contracts.ExternalAccountCustomPropertiesError.SOURCE_MANAGED
+        assert result.values is None
+
+    def test_get_definition_carries_source(self):
+        uac = UserAccessControl(user=self.user, team=self.team)
+        view = facade.get_custom_property_definition(self.team.id, self.definition.id, user_access_control=uac)
+        assert view is not None
+        assert view.source is None
+
+        source = self._create()
+        view = facade.get_custom_property_definition(self.team.id, self.definition.id, user_access_control=uac)
+        assert view is not None
+        assert view.source is not None
+        assert view.source.id == source.id
+        assert view.source.source_column == "mrr"
+
+    def test_manual_value_write_rejected_on_source_backed_definition(self):
+        self._create()
+        account = create_account(team_id=self.team.id, external_id="org_1")
+
+        with pytest.raises(facade.CustomPropertyValueSourceManaged):
+            facade.set_custom_property_value(self.team.id, account.id, self.definition.id, 42)

--- a/products/customer_analytics/backend/test/test_views.py
+++ b/products/customer_analytics/backend/test/test_views.py
@@ -23,6 +23,7 @@ from products.customer_analytics.backend.models import (
     CustomerJourney,
     CustomerProfileConfig,
     CustomPropertyDefinition,
+    CustomPropertySource,
     DisplayType,
 )
 from products.customer_analytics.backend.models.account import AccountAssignment
@@ -1851,6 +1852,22 @@ class TestCustomPropertyValueViewSet(APIBaseTest):
         response = self.client.get(self.endpoint)
 
         self.assertIn(response.status_code, [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN])
+
+    def test_source_backed_definition_rejects_manual_write(self):
+        saved_query_model = apps.get_model("data_modeling", "DataWarehouseSavedQuery")
+        view = saved_query_model.objects.create(team=self.team, name="v", columns={"k": {}, "c": {}})
+        CustomPropertySource.objects.unscoped().create(
+            team_id=self.team.id,
+            definition_id=self.text_def.id,
+            saved_query=view,
+            source_column="c",
+            key_column="k",
+        )
+
+        response = self._set(self.text_def.id, "manual")
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+        self.assertEqual("definition", response.json()["attr"])
 
 
 class TestCustomPropertySourceViewSet(APIBaseTest):

--- a/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.test.ts
+++ b/products/customer_analytics/frontend/components/Accounts/accountsColumnConfigLogic.test.ts
@@ -19,6 +19,7 @@ function definition(
         created_by: null,
         updated_at: null,
         references: [],
+        source: null,
         ...overrides,
     }
 }

--- a/products/customer_analytics/frontend/generated/api.schemas.ts
+++ b/products/customer_analytics/frontend/generated/api.schemas.ts
@@ -289,109 +289,6 @@ export const CustomPropertyDisplayTypeEnumApi = {
 } as const
 
 /**
- * A place that uses a custom property definition (read-only).
- */
-export interface CustomPropertyReferenceApi {
-    /** Id of the referring entity (e.g. the workflow id). */
-    readonly id: string
-    /** Display name of the referring entity. */
-    readonly name: string
-    /** Status of the referring entity (e.g. workflow status). */
-    readonly status: string
-    /** Kind of reference. Currently always 'workflow'. */
-    readonly type: string
-}
-
-/**
- * A team-scoped definition of a custom account property — the attribute side of the model.
- *
- * Holds only the property's shape (name, display type, big-number flag). Per-account values are
- * stored separately, so this serializer never reads or writes account values. The numeric-only
- * big-number rule and the unique-name conflict are enforced behind the facade.
- */
-export interface CustomPropertyDefinitionApi {
-    readonly id: string
-    /**
-     * Human-readable name of the custom property. Unique within the team.
-     * @maxLength 400
-     */
-    name: string
-    /**
-     * Optional description of what the property represents.
-     * @nullable
-     */
-    description?: string | null
-    /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
-     *
-     * * `text` - text
-     * * `number` - number
-     * * `currency` - currency
-     * * `percent` - percent
-     * * `date` - date
-     * * `datetime` - datetime
-     * * `boolean` - boolean */
-    display_type: CustomPropertyDisplayTypeEnumApi
-    /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
-    is_big_number?: boolean
-    readonly created_at: string
-    /** @nullable */
-    readonly created_by: number | null
-    /** @nullable */
-    readonly updated_at: string | null
-    /** Workflows that use this property, resolved by definition id. */
-    readonly references: readonly CustomPropertyReferenceApi[]
-}
-
-export interface PaginatedCustomPropertyDefinitionListApi {
-    count: number
-    /** @nullable */
-    next?: string | null
-    /** @nullable */
-    previous?: string | null
-    results: CustomPropertyDefinitionApi[]
-}
-
-/**
- * A team-scoped definition of a custom account property — the attribute side of the model.
- *
- * Holds only the property's shape (name, display type, big-number flag). Per-account values are
- * stored separately, so this serializer never reads or writes account values. The numeric-only
- * big-number rule and the unique-name conflict are enforced behind the facade.
- */
-export interface PatchedCustomPropertyDefinitionApi {
-    readonly id?: string
-    /**
-     * Human-readable name of the custom property. Unique within the team.
-     * @maxLength 400
-     */
-    name?: string
-    /**
-     * Optional description of what the property represents.
-     * @nullable
-     */
-    description?: string | null
-    /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
-     *
-     * * `text` - text
-     * * `number` - number
-     * * `currency` - currency
-     * * `percent` - percent
-     * * `date` - date
-     * * `datetime` - datetime
-     * * `boolean` - boolean */
-    display_type?: CustomPropertyDisplayTypeEnumApi
-    /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
-    is_big_number?: boolean
-    readonly created_at?: string
-    /** @nullable */
-    readonly created_by?: number | null
-    /** @nullable */
-    readonly updated_at?: string | null
-    /** Workflows that use this property, resolved by definition id. */
-    readonly references?: readonly CustomPropertyReferenceApi[]
-}
-
-/**
  * Binds a materialized data-warehouse view column to a custom property definition; the view's
  * values are synced onto matching accounts on each materialization.
  */
@@ -430,6 +327,111 @@ export interface CustomPropertySourceApi {
     readonly created_by: number | null
     /** @nullable */
     readonly updated_at: string | null
+}
+
+/**
+ * A place that uses a custom property definition (read-only).
+ */
+export interface CustomPropertyReferenceApi {
+    /** Id of the referring entity (e.g. the workflow id). */
+    readonly id: string
+    /** Display name of the referring entity. */
+    readonly name: string
+    /** Status of the referring entity (e.g. workflow status). */
+    readonly status: string
+    /** Kind of reference. Currently always 'workflow'. */
+    readonly type: string
+}
+
+/**
+ * A team-scoped definition of a custom account property — the attribute side of the model.
+ *
+ * Holds only the property's shape (name, display type, big-number flag). Per-account values are
+ * stored separately, so this serializer never reads or writes account values.
+ */
+export interface CustomPropertyDefinitionApi {
+    readonly id: string
+    /**
+     * Human-readable name of the custom property. Unique within the team.
+     * @maxLength 400
+     */
+    name: string
+    /**
+     * Optional description of what the property represents.
+     * @nullable
+     */
+    description?: string | null
+    /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
+     *
+     * * `text` - text
+     * * `number` - number
+     * * `currency` - currency
+     * * `percent` - percent
+     * * `date` - date
+     * * `datetime` - datetime
+     * * `boolean` - boolean */
+    display_type: CustomPropertyDisplayTypeEnumApi
+    /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
+    is_big_number?: boolean
+    /** The data-warehouse view-sync binding feeding this property, or null when values are set manually. */
+    readonly source: CustomPropertySourceApi | null
+    readonly created_at: string
+    /** @nullable */
+    readonly created_by: number | null
+    /** @nullable */
+    readonly updated_at: string | null
+    /** Workflows that use this property, resolved by definition id. */
+    readonly references: readonly CustomPropertyReferenceApi[]
+}
+
+export interface PaginatedCustomPropertyDefinitionListApi {
+    count: number
+    /** @nullable */
+    next?: string | null
+    /** @nullable */
+    previous?: string | null
+    results: CustomPropertyDefinitionApi[]
+}
+
+/**
+ * A team-scoped definition of a custom account property — the attribute side of the model.
+ *
+ * Holds only the property's shape (name, display type, big-number flag). Per-account values are
+ * stored separately, so this serializer never reads or writes account values.
+ */
+export interface PatchedCustomPropertyDefinitionApi {
+    readonly id?: string
+    /**
+     * Human-readable name of the custom property. Unique within the team.
+     * @maxLength 400
+     */
+    name?: string
+    /**
+     * Optional description of what the property represents.
+     * @nullable
+     */
+    description?: string | null
+    /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
+     *
+     * * `text` - text
+     * * `number` - number
+     * * `currency` - currency
+     * * `percent` - percent
+     * * `date` - date
+     * * `datetime` - datetime
+     * * `boolean` - boolean */
+    display_type?: CustomPropertyDisplayTypeEnumApi
+    /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
+    is_big_number?: boolean
+    /** The data-warehouse view-sync binding feeding this property, or null when values are set manually. */
+    readonly source?: CustomPropertySourceApi | null
+    readonly created_at?: string
+    /** @nullable */
+    readonly created_by?: number | null
+    /** @nullable */
+    readonly updated_at?: string | null
+    /** Workflows that use this property, resolved by definition id. */
+    readonly references?: readonly CustomPropertyReferenceApi[]
 }
 
 export interface PaginatedCustomPropertySourceListApi {

--- a/products/customer_analytics/frontend/generated/api.zod.ts
+++ b/products/customer_analytics/frontend/generated/api.zod.ts
@@ -218,7 +218,7 @@ export const CustomPropertyDefinitionsCreateBody = /* @__PURE__ */ zod
             .describe('Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.'),
     })
     .describe(
-        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
+        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values."
     )
 
 export const customPropertyDefinitionsUpdateBodyNameMax = 400
@@ -246,7 +246,7 @@ export const CustomPropertyDefinitionsUpdateBody = /* @__PURE__ */ zod
             .describe('Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.'),
     })
     .describe(
-        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
+        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values."
     )
 
 export const customPropertyDefinitionsPartialUpdateBodyNameMax = 400
@@ -276,7 +276,7 @@ export const CustomPropertyDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
             .describe('Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.'),
     })
     .describe(
-        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
+        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values."
     )
 
 export const customPropertySourcesCreateBodySourceColumnMax = 400

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
@@ -1,13 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconInfo, IconPencil, IconTrash } from '@posthog/icons'
+import { IconDatabase, IconInfo, IconPencil, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TZLabel } from 'lib/components/TZLabel'
 import { TeamMembershipLevel } from 'lib/constants'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { urls } from 'scenes/urls'
@@ -19,11 +20,20 @@ import type {
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 import { CustomPropertyModal } from './CustomPropertyModal'
-import { labelForDisplayType } from './customPropertyTypes'
+import { CustomPropertySourceModal } from './CustomPropertySourceModal'
+import { labelForDisplayType, type SourceSyncStatusLevel, sourceSyncStatus } from './customPropertyTypes'
+
+const TAG_TYPE_BY_SYNC_LEVEL: Record<SourceSyncStatusLevel, LemonTagType> = {
+    synced: 'success',
+    error: 'danger',
+    disabled: 'muted',
+    pending: 'default',
+}
 
 export function CustomPropertiesConfig(): JSX.Element {
     const { definitions, definitionsLoading } = useValues(customPropertyDefinitionsLogic)
-    const { openCreateModal, openEditModal, deleteDefinition } = useActions(customPropertyDefinitionsLogic)
+    const { openCreateModal, openEditModal, openSourceModal, deleteDefinition } =
+        useActions(customPropertyDefinitionsLogic)
     const restrictionReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
@@ -79,10 +89,37 @@ export function CustomPropertiesConfig(): JSX.Element {
                 ),
         },
         {
+            title: 'Sync',
+            render: (_, definition) => {
+                if (!definition.source) {
+                    return <span className="text-secondary">Manual</span>
+                }
+                const status = sourceSyncStatus(definition.source)
+                return (
+                    <Tooltip title={status.tooltip}>
+                        <span className="flex items-center gap-2">
+                            <LemonTag type={TAG_TYPE_BY_SYNC_LEVEL[status.level]}>{status.label}</LemonTag>
+                            {status.level === 'synced' && definition.source.last_synced_at && (
+                                <TZLabel time={definition.source.last_synced_at} className="text-secondary" />
+                            )}
+                        </span>
+                    </Tooltip>
+                )
+            },
+        },
+        {
             title: '',
             width: 0,
             render: (_, definition) => (
                 <div className="flex gap-1 justify-end">
+                    <LemonButton
+                        size="small"
+                        icon={<IconDatabase />}
+                        tooltip={definition.source ? 'Configure sync' : 'Sync from a view'}
+                        active={!!definition.source}
+                        onClick={() => openSourceModal(definition)}
+                        disabledReason={restrictionReason}
+                    />
                     <LemonButton
                         size="small"
                         icon={<IconPencil />}
@@ -122,6 +159,7 @@ export function CustomPropertiesConfig(): JSX.Element {
                 emptyState="No custom properties yet. Create one to get started."
             />
             <CustomPropertyModal />
+            <CustomPropertySourceModal />
         </div>
     )
 }

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
@@ -1,0 +1,140 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonBanner, LemonButton, LemonModal, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
+
+export function CustomPropertySourceModal(): JSX.Element {
+    const {
+        sourceModalVisible,
+        sourceDefinition,
+        customPropertySourceForm,
+        isCustomPropertySourceFormSubmitting,
+        materializedViews,
+        selectedSourceColumns,
+        savedQueriesLoading,
+        definitionsLoading,
+    } = useValues(customPropertyDefinitionsLogic)
+    const { closeSourceModal, submitCustomPropertySourceForm, removeSource, setCustomPropertySourceFormValue } =
+        useActions(customPropertyDefinitionsLogic)
+
+    const editing = !!sourceDefinition?.source
+    const noViews = !savedQueriesLoading && materializedViews.length === 0
+
+    return (
+        <LemonModal
+            isOpen={sourceModalVisible}
+            onClose={closeSourceModal}
+            title={`Sync “${sourceDefinition?.name ?? ''}” from a view`}
+            description="Pull this property's values from a materialized view column on each materialization, matched to accounts by external ID."
+            footer={
+                <div className="flex justify-between items-center w-full">
+                    <div>
+                        {editing && sourceDefinition && (
+                            <LemonButton
+                                type="secondary"
+                                status="danger"
+                                onClick={() => removeSource({ definition: sourceDefinition })}
+                                loading={definitionsLoading}
+                            >
+                                Remove sync
+                            </LemonButton>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        <LemonButton type="secondary" onClick={closeSourceModal}>
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={submitCustomPropertySourceForm}
+                            loading={isCustomPropertySourceFormSubmitting}
+                            disabledReason={noViews ? 'No materialized views are available' : undefined}
+                        >
+                            {editing ? 'Save' : 'Configure sync'}
+                        </LemonButton>
+                    </div>
+                </div>
+            }
+        >
+            {noViews ? (
+                <LemonBanner type="info">
+                    No materialized views found. Create and materialize a view in the data warehouse first, then it can
+                    feed this property.
+                </LemonBanner>
+            ) : (
+                <Form
+                    logic={customPropertyDefinitionsLogic}
+                    formKey="customPropertySourceForm"
+                    enableFormOnSubmit
+                    className="flex flex-col gap-4"
+                >
+                    <LemonField name="savedQuery" label="View">
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={(newValue) => {
+                                    onChange(newValue)
+                                    // Columns are view-specific, so a view change invalidates the picks.
+                                    setCustomPropertySourceFormValue('sourceColumn', null)
+                                    setCustomPropertySourceFormValue('keyColumn', null)
+                                }}
+                                options={materializedViews.map((view) => ({ value: view.id, label: view.name }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={editing ? 'The view is fixed once a sync is created' : undefined}
+                                placeholder="Select a materialized view"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField
+                        name="sourceColumn"
+                        label="Value column"
+                        help="The column whose value is written to this property."
+                    >
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={onChange}
+                                options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={
+                                    !customPropertySourceForm.savedQuery ? 'Select a view first' : undefined
+                                }
+                                placeholder="Column to read the value from"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField
+                        name="keyColumn"
+                        label="Key column"
+                        help="The column matched against each account's external ID."
+                    >
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={onChange}
+                                options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={
+                                    !customPropertySourceForm.savedQuery ? 'Select a view first' : undefined
+                                }
+                                placeholder="Column matching the account external ID"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField name="isEnabled">
+                        {({ value, onChange }) => (
+                            <LemonSwitch checked={value} onChange={onChange} label="Sync enabled" bordered />
+                        )}
+                    </LemonField>
+                </Form>
+            )}
+        </LemonModal>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -7,12 +7,35 @@ import { userLogic } from 'scenes/userLogic'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type {
+    CustomPropertyDefinitionApi,
+    CustomPropertySourceApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 
 const DEFINITIONS_URL = '/api/projects/:team_id/custom_property_definitions/'
 const DEFINITION_URL = '/api/projects/:team_id/custom_property_definitions/:id/'
+const SAVED_QUERIES_URL = '/api/environments/:team_id/warehouse_saved_queries/'
+const SOURCES_URL = '/api/projects/:team_id/custom_property_sources/'
+const SOURCE_URL = '/api/projects/:team_id/custom_property_sources/:id/'
+
+const buildSource = (overrides: Partial<CustomPropertySourceApi> = {}): CustomPropertySourceApi =>
+    ({
+        id: 'src-1',
+        definition: 'def-1',
+        saved_query: 'view-1',
+        source_column: 'mrr',
+        key_column: 'org_id',
+        is_enabled: true,
+        consecutive_failures: 0,
+        last_synced_at: '2026-01-02T00:00:00Z',
+        last_sync_error: null,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: 1,
+        updated_at: '2026-01-02T00:00:00Z',
+        ...overrides,
+    }) as CustomPropertySourceApi
 
 const buildDefinition = (overrides: Partial<CustomPropertyDefinitionApi> = {}): CustomPropertyDefinitionApi =>
     ({
@@ -21,17 +44,30 @@ const buildDefinition = (overrides: Partial<CustomPropertyDefinitionApi> = {}): 
         description: null,
         display_type: 'currency',
         is_big_number: true,
+        source: null,
         created_at: '2026-01-01T00:00:00Z',
         created_by: 1,
         updated_at: '2026-01-01T00:00:00Z',
         ...overrides,
     }) as CustomPropertyDefinitionApi
 
+// Loosely-typed warehouse view — the logic only reads id/name/columns[].name/is_materialized.
+const buildView = (overrides: Record<string, any> = {}): any => ({
+    id: 'view-1',
+    name: 'billing_view',
+    columns: [{ name: 'org_id' }, { name: 'mrr' }],
+    is_materialized: true,
+    ...overrides,
+})
+
 const defaultMocks = (): Parameters<typeof useMocks>[0] => ({
-    get: { [DEFINITIONS_URL]: { count: 1, results: [buildDefinition()] } },
-    post: { [DEFINITIONS_URL]: buildDefinition({ id: 'def-2' }) },
-    patch: { [DEFINITION_URL]: buildDefinition() },
-    delete: { [DEFINITION_URL]: {} },
+    get: {
+        [DEFINITIONS_URL]: { count: 1, results: [buildDefinition()] },
+        [SAVED_QUERIES_URL]: { count: 1, results: [buildView()] },
+    },
+    post: { [DEFINITIONS_URL]: buildDefinition({ id: 'def-2' }), [SOURCES_URL]: buildSource() },
+    patch: { [DEFINITION_URL]: buildDefinition(), [SOURCE_URL]: buildSource() },
+    delete: { [DEFINITION_URL]: {}, [SOURCE_URL]: {} },
 })
 
 describe('customPropertyDefinitionsLogic', () => {
@@ -143,5 +179,98 @@ describe('customPropertyDefinitionsLogic', () => {
         await expectLogic(logic, () => logic.actions.deleteDefinition({ id: 'def-1' }))
             .toDispatchActions(['deleteDefinitionSuccess'])
             .toMatchValues({ definitions: [] })
+    })
+
+    it('loads warehouse views and hydrates the form when configuring an existing source', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic, () => logic.actions.openSourceModal(buildDefinition({ source: buildSource() })))
+            .toDispatchActions(['loadSavedQueries', 'loadSavedQueriesSuccess'])
+            .toFinishAllListeners()
+
+        expect(logic.values.sourceModalVisible).toBe(true)
+        expect(logic.values.customPropertySourceForm).toEqual({
+            savedQuery: 'view-1',
+            sourceColumn: 'mrr',
+            keyColumn: 'org_id',
+            isEnabled: true,
+        })
+    })
+
+    it('exposes the selected view columns for the pickers', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic, () => logic.actions.openSourceModal(buildDefinition())).toDispatchActions([
+            'loadSavedQueriesSuccess',
+        ])
+        logic.actions.setCustomPropertySourceFormValue('savedQuery', 'view-1')
+        expect(logic.values.selectedSourceColumns).toEqual(['org_id', 'mrr'])
+    })
+
+    it('creates a source for a definition without one', async () => {
+        let postedBody: Record<string, any> | null = null
+        useMocks({
+            ...defaultMocks(),
+            post: {
+                ...defaultMocks().post,
+                [SOURCES_URL]: async ({ request }) => {
+                    postedBody = (await request.json()) as Record<string, any>
+                    return buildSource()
+                },
+            },
+        })
+        mountLogic()
+        logic.actions.openSourceModal(buildDefinition())
+        logic.actions.setCustomPropertySourceFormValues({
+            savedQuery: 'view-1',
+            sourceColumn: 'mrr',
+            keyColumn: 'org_id',
+            isEnabled: true,
+        })
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertySourceForm()).toDispatchActions([
+            'submitCustomPropertySourceFormSuccess',
+            'loadDefinitions',
+            'closeSourceModal',
+        ])
+        expect(postedBody).toEqual({
+            definition: 'def-1',
+            saved_query: 'view-1',
+            source_column: 'mrr',
+            key_column: 'org_id',
+            is_enabled: true,
+        })
+    })
+
+    it('updates an existing source via PATCH without the create-only fields', async () => {
+        let patchedBody: Record<string, any> | null = null
+        useMocks({
+            ...defaultMocks(),
+            patch: {
+                ...defaultMocks().patch,
+                [SOURCE_URL]: async ({ request }) => {
+                    patchedBody = (await request.json()) as Record<string, any>
+                    return buildSource()
+                },
+            },
+        })
+        mountLogic()
+        logic.actions.openSourceModal(buildDefinition({ source: buildSource() }))
+        logic.actions.setCustomPropertySourceFormValue('isEnabled', false)
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertySourceForm()).toDispatchActions([
+            'submitCustomPropertySourceFormSuccess',
+        ])
+        expect(patchedBody).toEqual({ source_column: 'mrr', key_column: 'org_id', is_enabled: false })
+    })
+
+    it('removes a source and closes the modal', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        const definition = buildDefinition({ source: buildSource() })
+        await expectLogic(logic, () => logic.actions.removeSource({ definition })).toDispatchActions([
+            'removeSourceSuccess',
+            'closeSourceModal',
+        ])
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -1,16 +1,22 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
+import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
+
+import type { DataWarehouseSavedQuery } from '~/types'
 
 import {
     customPropertyDefinitionsCreate,
     customPropertyDefinitionsDestroy,
     customPropertyDefinitionsList,
     customPropertyDefinitionsPartialUpdate,
+    customPropertySourcesCreate,
+    customPropertySourcesDestroy,
+    customPropertySourcesPartialUpdate,
 } from 'products/customer_analytics/frontend/generated/api'
 import type {
     CustomPropertyDefinitionApi,
@@ -34,6 +40,20 @@ const DEFAULT_FORM_VALUES: CustomPropertyFormValues = {
     isBigNumber: false,
 }
 
+export interface CustomPropertySourceFormValues {
+    savedQuery: string | null
+    sourceColumn: string | null
+    keyColumn: string | null
+    isEnabled: boolean
+}
+
+const DEFAULT_SOURCE_FORM_VALUES: CustomPropertySourceFormValues = {
+    savedQuery: null,
+    sourceColumn: null,
+    keyColumn: null,
+    isEnabled: true,
+}
+
 export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogicType>([
     path([
         'products',
@@ -51,6 +71,8 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         openCreateModal: true,
         openEditModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
         closeModal: true,
+        openSourceModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
+        closeSourceModal: true,
     }),
     reducers({
         modalVisible: [
@@ -69,6 +91,20 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 closeModal: () => null,
             },
         ],
+        sourceModalVisible: [
+            false,
+            {
+                openSourceModal: () => true,
+                closeSourceModal: () => false,
+            },
+        ],
+        sourceDefinition: [
+            null as CustomPropertyDefinitionApi | null,
+            {
+                openSourceModal: (_, { definition }) => definition,
+                closeSourceModal: () => null,
+            },
+        ],
     }),
     loaders(({ values }) => ({
         definitions: [
@@ -81,6 +117,27 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 deleteDefinition: async ({ id }: { id: string }): Promise<CustomPropertyDefinitionApi[]> => {
                     await customPropertyDefinitionsDestroy(String(values.currentProjectId), id)
                     return values.definitions.filter((definition) => definition.id !== id)
+                },
+                removeSource: async ({
+                    definition,
+                }: {
+                    definition: CustomPropertyDefinitionApi
+                }): Promise<CustomPropertyDefinitionApi[]> => {
+                    if (definition.source) {
+                        await customPropertySourcesDestroy(String(values.currentProjectId), definition.source.id)
+                    }
+                    // Re-fetch so the cleared `source` is reflected — it can't be derived locally.
+                    const response = await customPropertyDefinitionsList(String(values.currentProjectId))
+                    return response.results
+                },
+            },
+        ],
+        savedQueries: [
+            [] as DataWarehouseSavedQuery[],
+            {
+                loadSavedQueries: async (): Promise<DataWarehouseSavedQuery[]> => {
+                    const response = await api.dataWarehouseSavedQueries.list()
+                    return response.results
                 },
             },
         ],
@@ -107,7 +164,51 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 }
             },
         },
+        customPropertySourceForm: {
+            defaults: DEFAULT_SOURCE_FORM_VALUES,
+            errors: ({ savedQuery, sourceColumn, keyColumn }: CustomPropertySourceFormValues) => ({
+                savedQuery: !savedQuery ? 'Select a view' : undefined,
+                sourceColumn: !sourceColumn ? 'Select the value column' : undefined,
+                keyColumn: !keyColumn ? 'Select the key column' : undefined,
+            }),
+            submit: async ({ savedQuery, sourceColumn, keyColumn, isEnabled }: CustomPropertySourceFormValues) => {
+                const definition = values.sourceDefinition
+                if (!definition || !savedQuery || !sourceColumn || !keyColumn) {
+                    return
+                }
+                if (definition.source) {
+                    // saved_query is create-only — only the mutable fields are sent on update.
+                    await customPropertySourcesPartialUpdate(String(values.currentProjectId), definition.source.id, {
+                        source_column: sourceColumn,
+                        key_column: keyColumn,
+                        is_enabled: isEnabled,
+                    })
+                } else {
+                    await customPropertySourcesCreate(String(values.currentProjectId), {
+                        definition: definition.id,
+                        saved_query: savedQuery,
+                        source_column: sourceColumn,
+                        key_column: keyColumn,
+                        is_enabled: isEnabled,
+                    })
+                }
+            },
+        },
     })),
+    selectors({
+        materializedViews: [
+            (s) => [s.savedQueries],
+            (savedQueries: DataWarehouseSavedQuery[]): DataWarehouseSavedQuery[] =>
+                savedQueries.filter((query) => query.is_materialized),
+        ],
+        selectedSourceColumns: [
+            (s) => [s.savedQueries, s.customPropertySourceForm],
+            (savedQueries: DataWarehouseSavedQuery[], form: CustomPropertySourceFormValues): string[] => {
+                const view = savedQueries.find((query) => query.id === form.savedQuery)
+                return (view?.columns ?? []).map((column) => column.name)
+            },
+        ],
+    }),
     listeners(({ actions, values }) => ({
         openCreateModal: () => {
             actions.resetCustomPropertyForm()
@@ -145,6 +246,40 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         loadDefinitionsFailure: ({ error }) => {
             posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.load' })
             lemonToast.error('Failed to load custom properties')
+        },
+        openSourceModal: ({ definition }) => {
+            actions.loadSavedQueries()
+            if (definition.source) {
+                actions.setCustomPropertySourceFormValues({
+                    savedQuery: definition.source.saved_query,
+                    sourceColumn: definition.source.source_column,
+                    keyColumn: definition.source.key_column,
+                    isEnabled: definition.source.is_enabled ?? true,
+                })
+            } else {
+                actions.resetCustomPropertySourceForm()
+            }
+        },
+        submitCustomPropertySourceFormSuccess: () => {
+            lemonToast.success(values.sourceDefinition?.source ? 'Sync updated' : 'Sync configured')
+            actions.loadDefinitions()
+            actions.closeSourceModal()
+        },
+        submitCustomPropertySourceFormFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.submitSource' })
+            lemonToast.error((error as { detail?: string })?.detail ?? 'Failed to save sync configuration')
+        },
+        removeSourceSuccess: () => {
+            lemonToast.success('Sync removed')
+            actions.closeSourceModal()
+        },
+        removeSourceFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.removeSource' })
+            lemonToast.error('Failed to remove sync')
+        },
+        loadSavedQueriesFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.loadSavedQueries' })
+            lemonToast.error('Failed to load data warehouse views')
         },
     })),
     afterMount(({ actions }) => {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
@@ -1,10 +1,14 @@
-import type { CustomPropertyDisplayTypeEnumApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type {
+    CustomPropertyDisplayTypeEnumApi,
+    CustomPropertySourceApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import {
     DISPLAY_TYPE_OPTIONS,
     formatCustomPropertyValue,
     isNumericDisplayType,
     labelForDisplayType,
+    sourceSyncStatus,
 } from './customPropertyTypes'
 
 function definition(
@@ -13,6 +17,14 @@ function definition(
 ): { display_type: CustomPropertyDisplayTypeEnumApi; is_big_number: boolean } {
     return { display_type, is_big_number }
 }
+
+const buildSource = (overrides: Partial<CustomPropertySourceApi>): CustomPropertySourceApi =>
+    ({
+        is_enabled: true,
+        last_sync_error: null,
+        last_synced_at: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }) as CustomPropertySourceApi
 
 describe('customPropertyTypes', () => {
     it('labels each display type with its option label', () => {
@@ -56,5 +68,23 @@ describe('customPropertyTypes', () => {
             expect(formatCustomPropertyValue('enterprise', definition('text'))).toBe('enterprise')
             expect(formatCustomPropertyValue('n/a', definition('number'))).toBe('n/a')
         })
+    })
+
+    it('derives sync status from the source state', () => {
+        expect(sourceSyncStatus(buildSource({})).level).toBe('synced')
+        expect(sourceSyncStatus(buildSource({ last_synced_at: null })).level).toBe('pending')
+        expect(sourceSyncStatus(buildSource({ last_sync_error: 'boom' })).level).toBe('error')
+    })
+
+    it('shows the last error as the reason when a source is auto-disabled', () => {
+        const status = sourceSyncStatus(buildSource({ is_enabled: false, last_sync_error: 'View not found' }))
+        expect(status.level).toBe('disabled')
+        expect(status.tooltip).toBe('View not found')
+    })
+
+    it('explains manual disabling when a disabled source has no error', () => {
+        const status = sourceSyncStatus(buildSource({ is_enabled: false, last_sync_error: null }))
+        expect(status.level).toBe('disabled')
+        expect(status.tooltip).toBe('Syncing is turned off for this source.')
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
@@ -3,6 +3,7 @@ import { humanFriendlyCurrency, humanFriendlyLargeNumber, humanFriendlyNumber, p
 import type {
     CustomPropertyDefinitionApi,
     CustomPropertyDisplayTypeEnumApi,
+    CustomPropertySourceApi,
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 // The backend stores the granular display type directly, so the form value maps 1:1 to the API.
@@ -61,4 +62,31 @@ export function formatCustomPropertyValue(
         default:
             return raw
     }
+}
+
+export type SourceSyncStatusLevel = 'synced' | 'error' | 'disabled' | 'pending'
+
+export interface SourceSyncStatus {
+    level: SourceSyncStatusLevel
+    label: string
+    tooltip?: string
+}
+
+// Derives the displayed sync state from the source's stored fields. The backend records only
+// `is_enabled` + `last_sync_error` + `last_synced_at`; status is computed, not stored.
+export function sourceSyncStatus(source: CustomPropertySourceApi): SourceSyncStatus {
+    if (!source.is_enabled) {
+        return {
+            level: 'disabled',
+            label: 'Disabled',
+            tooltip: source.last_sync_error ?? 'Syncing is turned off for this source.',
+        }
+    }
+    if (source.last_sync_error) {
+        return { level: 'error', label: 'Sync error', tooltip: source.last_sync_error }
+    }
+    if (!source.last_synced_at) {
+        return { level: 'pending', label: 'Awaiting first sync' }
+    }
+    return { level: 'synced', label: 'Synced' }
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -14114,60 +14114,6 @@ export namespace Schemas {
     } as const;
 
     /**
-     * A place that uses a custom property definition (read-only).
-     */
-    export interface CustomPropertyReference {
-      /** Id of the referring entity (e.g. the workflow id). */
-      readonly id: string;
-      /** Display name of the referring entity. */
-      readonly name: string;
-      /** Status of the referring entity (e.g. workflow status). */
-      readonly status: string;
-      /** Kind of reference. Currently always 'workflow'. */
-      readonly type: string;
-    }
-
-    /**
-     * A team-scoped definition of a custom account property — the attribute side of the model.
-     *
-     * Holds only the property's shape (name, display type, big-number flag). Per-account values are
-     * stored separately, so this serializer never reads or writes account values. The numeric-only
-     * big-number rule and the unique-name conflict are enforced behind the facade.
-     */
-    export interface CustomPropertyDefinition {
-      readonly id: string;
-      /**
-         * Human-readable name of the custom property. Unique within the team.
-         * @maxLength 400
-         */
-      name: string;
-      /**
-         * Optional description of what the property represents.
-         * @nullable
-         */
-      description?: string | null;
-      /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
-       *
-       * * `text` - text
-       * * `number` - number
-       * * `currency` - currency
-       * * `percent` - percent
-       * * `date` - date
-       * * `datetime` - datetime
-       * * `boolean` - boolean */
-      display_type: CustomPropertyDisplayTypeEnum;
-      /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
-      is_big_number?: boolean;
-      readonly created_at: string;
-      /** @nullable */
-      readonly created_by: number | null;
-      /** @nullable */
-      readonly updated_at: string | null;
-      /** Workflows that use this property, resolved by definition id. */
-      readonly references: readonly CustomPropertyReference[];
-    }
-
-    /**
      * Binds a materialized data-warehouse view column to a custom property definition; the view's
      * values are synced onto matching accounts on each materialization.
      */
@@ -14206,6 +14152,61 @@ export namespace Schemas {
       readonly created_by: number | null;
       /** @nullable */
       readonly updated_at: string | null;
+    }
+
+    /**
+     * A place that uses a custom property definition (read-only).
+     */
+    export interface CustomPropertyReference {
+      /** Id of the referring entity (e.g. the workflow id). */
+      readonly id: string;
+      /** Display name of the referring entity. */
+      readonly name: string;
+      /** Status of the referring entity (e.g. workflow status). */
+      readonly status: string;
+      /** Kind of reference. Currently always 'workflow'. */
+      readonly type: string;
+    }
+
+    /**
+     * A team-scoped definition of a custom account property — the attribute side of the model.
+     *
+     * Holds only the property's shape (name, display type, big-number flag). Per-account values are
+     * stored separately, so this serializer never reads or writes account values.
+     */
+    export interface CustomPropertyDefinition {
+      readonly id: string;
+      /**
+         * Human-readable name of the custom property. Unique within the team.
+         * @maxLength 400
+         */
+      name: string;
+      /**
+         * Optional description of what the property represents.
+         * @nullable
+         */
+      description?: string | null;
+      /** How the property is interpreted and rendered: 'text', 'number', 'currency', 'percent', 'date', 'datetime', or 'boolean'.
+       *
+       * * `text` - text
+       * * `number` - number
+       * * `currency` - currency
+       * * `percent` - percent
+       * * `date` - date
+       * * `datetime` - datetime
+       * * `boolean` - boolean */
+      display_type: CustomPropertyDisplayTypeEnum;
+      /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
+      is_big_number?: boolean;
+      /** The data-warehouse view-sync binding feeding this property, or null when values are set manually. */
+      readonly source: CustomPropertySource | null;
+      readonly created_at: string;
+      /** @nullable */
+      readonly created_by: number | null;
+      /** @nullable */
+      readonly updated_at: string | null;
+      /** Workflows that use this property, resolved by definition id. */
+      readonly references: readonly CustomPropertyReference[];
     }
 
     /**
@@ -36312,8 +36313,7 @@ export namespace Schemas {
      * A team-scoped definition of a custom account property — the attribute side of the model.
      *
      * Holds only the property's shape (name, display type, big-number flag). Per-account values are
-     * stored separately, so this serializer never reads or writes account values. The numeric-only
-     * big-number rule and the unique-name conflict are enforced behind the facade.
+     * stored separately, so this serializer never reads or writes account values.
      */
     export interface PatchedCustomPropertyDefinition {
       readonly id?: string;
@@ -36339,6 +36339,8 @@ export namespace Schemas {
       display_type?: CustomPropertyDisplayTypeEnum;
       /** Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties. */
       is_big_number?: boolean;
+      /** The data-warehouse view-sync binding feeding this property, or null when values are set manually. */
+      readonly source?: CustomPropertySource | null;
       readonly created_at?: string;
       /** @nullable */
       readonly created_by?: number | null;

--- a/services/mcp/src/generated/customer_analytics/api.ts
+++ b/services/mcp/src/generated/customer_analytics/api.ts
@@ -317,7 +317,7 @@ export const CustomPropertyDefinitionsCreateBody = /* @__PURE__ */ zod
             .describe('Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.'),
     })
     .describe(
-        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
+        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values."
     )
 
 export const CustomPropertyDefinitionsRetrieveParams = /* @__PURE__ */ zod.object({
@@ -363,7 +363,7 @@ export const CustomPropertyDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
             .describe('Abbreviate large numbers (e.g. 10,000 → 10K). Only applies to numeric properties.'),
     })
     .describe(
-        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values. The numeric-only\nbig-number rule and the unique-name conflict are enforced behind the facade."
+        "A team-scoped definition of a custom account property — the attribute side of the model.\n\nHolds only the property's shape (name, display type, big-number flag). Per-account values are\nstored separately, so this serializer never reads or writes account values."
     )
 
 export const CustomPropertyDefinitionsDestroyParams = /* @__PURE__ */ zod.object({


### PR DESCRIPTION
> Stack — merge bottom-up: **model → sync → api → gate → ui**. This PR is **4/5** (base: `…-api`).

## Problem

Source-backed definitions can still be written manually, and a newly configured source doesn't sync until the next materialization.

Part of #60300.

<!-- Closes #ISSUE_ID -->

## Changes

- Reject manual `CustomPropertyValue` writes on source-backed definitions (`CustomPropertyValueSourceManaged`).
- Expose `source` on the custom property definition serializer.
- Run one best-effort sync on source create/update.
- Regenerate API types.

## How did you test this code?

Unit tests: `test_facade.py`, `test_views.py` (gating + initial sync on save). Not re-run this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Authored by PostHog Code (Claude). Slice of #66409, split into an atomic stack.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
