### PR TITLE
feat(customer-analytics): Add view-sync config UI for custom properties

### DIFF
--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertiesConfig.tsx
@@ -1,13 +1,14 @@
 import { useActions, useValues } from 'kea'
 import { useState } from 'react'
 
-import { IconInfo, IconPencil, IconTrash } from '@posthog/icons'
+import { IconDatabase, IconInfo, IconPencil, IconTrash } from '@posthog/icons'
 import { LemonButton, LemonTable, LemonTableColumns, Tooltip } from '@posthog/lemon-ui'
 
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
 import { TZLabel } from 'lib/components/TZLabel'
 import { TeamMembershipLevel } from 'lib/constants'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
+import { LemonTag, LemonTagType } from 'lib/lemon-ui/LemonTag'
 import { Link } from 'lib/lemon-ui/Link'
 import { Popover } from 'lib/lemon-ui/Popover'
 import { urls } from 'scenes/urls'
@@ -19,11 +20,20 @@ import type {
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 import { CustomPropertyModal } from './CustomPropertyModal'
-import { labelForDisplayType } from './customPropertyTypes'
+import { CustomPropertySourceModal } from './CustomPropertySourceModal'
+import { labelForDisplayType, type SourceSyncStatusLevel, sourceSyncStatus } from './customPropertyTypes'
+
+const TAG_TYPE_BY_SYNC_LEVEL: Record<SourceSyncStatusLevel, LemonTagType> = {
+    synced: 'success',
+    error: 'danger',
+    disabled: 'muted',
+    pending: 'default',
+}
 
 export function CustomPropertiesConfig(): JSX.Element {
     const { definitions, definitionsLoading } = useValues(customPropertyDefinitionsLogic)
-    const { openCreateModal, openEditModal, deleteDefinition } = useActions(customPropertyDefinitionsLogic)
+    const { openCreateModal, openEditModal, openSourceModal, deleteDefinition } =
+        useActions(customPropertyDefinitionsLogic)
     const restrictionReason = useRestrictedArea({
         scope: RestrictionScope.Project,
         minimumAccessLevel: TeamMembershipLevel.Admin,
@@ -79,10 +89,37 @@ export function CustomPropertiesConfig(): JSX.Element {
                 ),
         },
         {
+            title: 'Sync',
+            render: (_, definition) => {
+                if (!definition.source) {
+                    return <span className="text-secondary">Manual</span>
+                }
+                const status = sourceSyncStatus(definition.source)
+                return (
+                    <Tooltip title={status.tooltip}>
+                        <span className="flex items-center gap-2">
+                            <LemonTag type={TAG_TYPE_BY_SYNC_LEVEL[status.level]}>{status.label}</LemonTag>
+                            {status.level === 'synced' && definition.source.last_synced_at && (
+                                <TZLabel time={definition.source.last_synced_at} className="text-secondary" />
+                            )}
+                        </span>
+                    </Tooltip>
+                )
+            },
+        },
+        {
             title: '',
             width: 0,
             render: (_, definition) => (
                 <div className="flex gap-1 justify-end">
+                    <LemonButton
+                        size="small"
+                        icon={<IconDatabase />}
+                        tooltip={definition.source ? 'Configure sync' : 'Sync from a view'}
+                        active={!!definition.source}
+                        onClick={() => openSourceModal(definition)}
+                        disabledReason={restrictionReason}
+                    />
                     <LemonButton
                         size="small"
                         icon={<IconPencil />}
@@ -122,6 +159,7 @@ export function CustomPropertiesConfig(): JSX.Element {
                 emptyState="No custom properties yet. Create one to get started."
             />
             <CustomPropertyModal />
+            <CustomPropertySourceModal />
         </div>
     )
 }

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/CustomPropertySourceModal.tsx
@@ -1,0 +1,140 @@
+import { useActions, useValues } from 'kea'
+import { Form } from 'kea-forms'
+
+import { LemonBanner, LemonButton, LemonModal, LemonSelect, LemonSwitch } from '@posthog/lemon-ui'
+
+import { LemonField } from 'lib/lemon-ui/LemonField'
+
+import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
+
+export function CustomPropertySourceModal(): JSX.Element {
+    const {
+        sourceModalVisible,
+        sourceDefinition,
+        customPropertySourceForm,
+        isCustomPropertySourceFormSubmitting,
+        materializedViews,
+        selectedSourceColumns,
+        savedQueriesLoading,
+        definitionsLoading,
+    } = useValues(customPropertyDefinitionsLogic)
+    const { closeSourceModal, submitCustomPropertySourceForm, removeSource, setCustomPropertySourceFormValue } =
+        useActions(customPropertyDefinitionsLogic)
+
+    const editing = !!sourceDefinition?.source
+    const noViews = !savedQueriesLoading && materializedViews.length === 0
+
+    return (
+        <LemonModal
+            isOpen={sourceModalVisible}
+            onClose={closeSourceModal}
+            title={`Sync “${sourceDefinition?.name ?? ''}” from a view`}
+            description="Pull this property's values from a materialized view column on each materialization, matched to accounts by external ID."
+            footer={
+                <div className="flex justify-between items-center w-full">
+                    <div>
+                        {editing && sourceDefinition && (
+                            <LemonButton
+                                type="secondary"
+                                status="danger"
+                                onClick={() => removeSource({ definition: sourceDefinition })}
+                                loading={definitionsLoading}
+                            >
+                                Remove sync
+                            </LemonButton>
+                        )}
+                    </div>
+                    <div className="flex gap-2">
+                        <LemonButton type="secondary" onClick={closeSourceModal}>
+                            Cancel
+                        </LemonButton>
+                        <LemonButton
+                            type="primary"
+                            onClick={submitCustomPropertySourceForm}
+                            loading={isCustomPropertySourceFormSubmitting}
+                            disabledReason={noViews ? 'No materialized views are available' : undefined}
+                        >
+                            {editing ? 'Save' : 'Configure sync'}
+                        </LemonButton>
+                    </div>
+                </div>
+            }
+        >
+            {noViews ? (
+                <LemonBanner type="info">
+                    No materialized views found. Create and materialize a view in the data warehouse first, then it can
+                    feed this property.
+                </LemonBanner>
+            ) : (
+                <Form
+                    logic={customPropertyDefinitionsLogic}
+                    formKey="customPropertySourceForm"
+                    enableFormOnSubmit
+                    className="flex flex-col gap-4"
+                >
+                    <LemonField name="savedQuery" label="View">
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={(newValue) => {
+                                    onChange(newValue)
+                                    // Columns are view-specific, so a view change invalidates the picks.
+                                    setCustomPropertySourceFormValue('sourceColumn', null)
+                                    setCustomPropertySourceFormValue('keyColumn', null)
+                                }}
+                                options={materializedViews.map((view) => ({ value: view.id, label: view.name }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={editing ? 'The view is fixed once a sync is created' : undefined}
+                                placeholder="Select a materialized view"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField
+                        name="sourceColumn"
+                        label="Value column"
+                        help="The column whose value is written to this property."
+                    >
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={onChange}
+                                options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={
+                                    !customPropertySourceForm.savedQuery ? 'Select a view first' : undefined
+                                }
+                                placeholder="Column to read the value from"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField
+                        name="keyColumn"
+                        label="Key column"
+                        help="The column matched against each account's external ID."
+                    >
+                        {({ value, onChange }) => (
+                            <LemonSelect
+                                value={value}
+                                onChange={onChange}
+                                options={selectedSourceColumns.map((column) => ({ value: column, label: column }))}
+                                loading={savedQueriesLoading}
+                                disabledReason={
+                                    !customPropertySourceForm.savedQuery ? 'Select a view first' : undefined
+                                }
+                                placeholder="Column matching the account external ID"
+                                fullWidth
+                            />
+                        )}
+                    </LemonField>
+                    <LemonField name="isEnabled">
+                        {({ value, onChange }) => (
+                            <LemonSwitch checked={value} onChange={onChange} label="Sync enabled" bordered />
+                        )}
+                    </LemonField>
+                </Form>
+            )}
+        </LemonModal>
+    )
+}

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.test.ts
@@ -7,12 +7,35 @@ import { userLogic } from 'scenes/userLogic'
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
-import type { CustomPropertyDefinitionApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type {
+    CustomPropertyDefinitionApi,
+    CustomPropertySourceApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import { customPropertyDefinitionsLogic } from './customPropertyDefinitionsLogic'
 
 const DEFINITIONS_URL = '/api/projects/:team_id/custom_property_definitions/'
 const DEFINITION_URL = '/api/projects/:team_id/custom_property_definitions/:id/'
+const SAVED_QUERIES_URL = '/api/environments/:team_id/warehouse_saved_queries/'
+const SOURCES_URL = '/api/projects/:team_id/custom_property_sources/'
+const SOURCE_URL = '/api/projects/:team_id/custom_property_sources/:id/'
+
+const buildSource = (overrides: Partial<CustomPropertySourceApi> = {}): CustomPropertySourceApi =>
+    ({
+        id: 'src-1',
+        definition: 'def-1',
+        saved_query: 'view-1',
+        source_column: 'mrr',
+        key_column: 'org_id',
+        is_enabled: true,
+        consecutive_failures: 0,
+        last_synced_at: '2026-01-02T00:00:00Z',
+        last_sync_error: null,
+        created_at: '2026-01-01T00:00:00Z',
+        created_by: 1,
+        updated_at: '2026-01-02T00:00:00Z',
+        ...overrides,
+    }) as CustomPropertySourceApi
 
 const buildDefinition = (overrides: Partial<CustomPropertyDefinitionApi> = {}): CustomPropertyDefinitionApi =>
     ({
@@ -21,17 +44,30 @@ const buildDefinition = (overrides: Partial<CustomPropertyDefinitionApi> = {}): 
         description: null,
         display_type: 'currency',
         is_big_number: true,
+        source: null,
         created_at: '2026-01-01T00:00:00Z',
         created_by: 1,
         updated_at: '2026-01-01T00:00:00Z',
         ...overrides,
     }) as CustomPropertyDefinitionApi
 
+// Loosely-typed warehouse view — the logic only reads id/name/columns[].name/is_materialized.
+const buildView = (overrides: Record<string, any> = {}): any => ({
+    id: 'view-1',
+    name: 'billing_view',
+    columns: [{ name: 'org_id' }, { name: 'mrr' }],
+    is_materialized: true,
+    ...overrides,
+})
+
 const defaultMocks = (): Parameters<typeof useMocks>[0] => ({
-    get: { [DEFINITIONS_URL]: { count: 1, results: [buildDefinition()] } },
-    post: { [DEFINITIONS_URL]: buildDefinition({ id: 'def-2' }) },
-    patch: { [DEFINITION_URL]: buildDefinition() },
-    delete: { [DEFINITION_URL]: {} },
+    get: {
+        [DEFINITIONS_URL]: { count: 1, results: [buildDefinition()] },
+        [SAVED_QUERIES_URL]: { count: 1, results: [buildView()] },
+    },
+    post: { [DEFINITIONS_URL]: buildDefinition({ id: 'def-2' }), [SOURCES_URL]: buildSource() },
+    patch: { [DEFINITION_URL]: buildDefinition(), [SOURCE_URL]: buildSource() },
+    delete: { [DEFINITION_URL]: {}, [SOURCE_URL]: {} },
 })
 
 describe('customPropertyDefinitionsLogic', () => {
@@ -143,5 +179,98 @@ describe('customPropertyDefinitionsLogic', () => {
         await expectLogic(logic, () => logic.actions.deleteDefinition({ id: 'def-1' }))
             .toDispatchActions(['deleteDefinitionSuccess'])
             .toMatchValues({ definitions: [] })
+    })
+
+    it('loads warehouse views and hydrates the form when configuring an existing source', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic, () => logic.actions.openSourceModal(buildDefinition({ source: buildSource() })))
+            .toDispatchActions(['loadSavedQueries', 'loadSavedQueriesSuccess'])
+            .toFinishAllListeners()
+
+        expect(logic.values.sourceModalVisible).toBe(true)
+        expect(logic.values.customPropertySourceForm).toEqual({
+            savedQuery: 'view-1',
+            sourceColumn: 'mrr',
+            keyColumn: 'org_id',
+            isEnabled: true,
+        })
+    })
+
+    it('exposes the selected view columns for the pickers', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        await expectLogic(logic, () => logic.actions.openSourceModal(buildDefinition())).toDispatchActions([
+            'loadSavedQueriesSuccess',
+        ])
+        logic.actions.setCustomPropertySourceFormValue('savedQuery', 'view-1')
+        expect(logic.values.selectedSourceColumns).toEqual(['org_id', 'mrr'])
+    })
+
+    it('creates a source for a definition without one', async () => {
+        let postedBody: Record<string, any> | null = null
+        useMocks({
+            ...defaultMocks(),
+            post: {
+                ...defaultMocks().post,
+                [SOURCES_URL]: async ({ request }) => {
+                    postedBody = (await request.json()) as Record<string, any>
+                    return buildSource()
+                },
+            },
+        })
+        mountLogic()
+        logic.actions.openSourceModal(buildDefinition())
+        logic.actions.setCustomPropertySourceFormValues({
+            savedQuery: 'view-1',
+            sourceColumn: 'mrr',
+            keyColumn: 'org_id',
+            isEnabled: true,
+        })
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertySourceForm()).toDispatchActions([
+            'submitCustomPropertySourceFormSuccess',
+            'loadDefinitions',
+            'closeSourceModal',
+        ])
+        expect(postedBody).toEqual({
+            definition: 'def-1',
+            saved_query: 'view-1',
+            source_column: 'mrr',
+            key_column: 'org_id',
+            is_enabled: true,
+        })
+    })
+
+    it('updates an existing source via PATCH without the create-only fields', async () => {
+        let patchedBody: Record<string, any> | null = null
+        useMocks({
+            ...defaultMocks(),
+            patch: {
+                ...defaultMocks().patch,
+                [SOURCE_URL]: async ({ request }) => {
+                    patchedBody = (await request.json()) as Record<string, any>
+                    return buildSource()
+                },
+            },
+        })
+        mountLogic()
+        logic.actions.openSourceModal(buildDefinition({ source: buildSource() }))
+        logic.actions.setCustomPropertySourceFormValue('isEnabled', false)
+
+        await expectLogic(logic, () => logic.actions.submitCustomPropertySourceForm()).toDispatchActions([
+            'submitCustomPropertySourceFormSuccess',
+        ])
+        expect(patchedBody).toEqual({ source_column: 'mrr', key_column: 'org_id', is_enabled: false })
+    })
+
+    it('removes a source and closes the modal', async () => {
+        useMocks(defaultMocks())
+        mountLogic()
+        const definition = buildDefinition({ source: buildSource() })
+        await expectLogic(logic, () => logic.actions.removeSource({ definition })).toDispatchActions([
+            'removeSourceSuccess',
+            'closeSourceModal',
+        ])
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyDefinitionsLogic.ts
@@ -1,16 +1,22 @@
-import { actions, afterMount, connect, kea, listeners, path, reducers } from 'kea'
+import { actions, afterMount, connect, kea, listeners, path, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
 import { loaders } from 'kea-loaders'
 import posthog from 'posthog-js'
 
+import api from 'lib/api'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { projectLogic } from 'scenes/projectLogic'
+
+import type { DataWarehouseSavedQuery } from '~/types'
 
 import {
     customPropertyDefinitionsCreate,
     customPropertyDefinitionsDestroy,
     customPropertyDefinitionsList,
     customPropertyDefinitionsPartialUpdate,
+    customPropertySourcesCreate,
+    customPropertySourcesDestroy,
+    customPropertySourcesPartialUpdate,
 } from 'products/customer_analytics/frontend/generated/api'
 import type {
     CustomPropertyDefinitionApi,
@@ -34,6 +40,20 @@ const DEFAULT_FORM_VALUES: CustomPropertyFormValues = {
     isBigNumber: false,
 }
 
+export interface CustomPropertySourceFormValues {
+    savedQuery: string | null
+    sourceColumn: string | null
+    keyColumn: string | null
+    isEnabled: boolean
+}
+
+const DEFAULT_SOURCE_FORM_VALUES: CustomPropertySourceFormValues = {
+    savedQuery: null,
+    sourceColumn: null,
+    keyColumn: null,
+    isEnabled: true,
+}
+
 export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogicType>([
     path([
         'products',
@@ -51,6 +71,8 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         openCreateModal: true,
         openEditModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
         closeModal: true,
+        openSourceModal: (definition: CustomPropertyDefinitionApi) => ({ definition }),
+        closeSourceModal: true,
     }),
     reducers({
         modalVisible: [
@@ -69,6 +91,20 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 closeModal: () => null,
             },
         ],
+        sourceModalVisible: [
+            false,
+            {
+                openSourceModal: () => true,
+                closeSourceModal: () => false,
+            },
+        ],
+        sourceDefinition: [
+            null as CustomPropertyDefinitionApi | null,
+            {
+                openSourceModal: (_, { definition }) => definition,
+                closeSourceModal: () => null,
+            },
+        ],
     }),
     loaders(({ values }) => ({
         definitions: [
@@ -81,6 +117,27 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 deleteDefinition: async ({ id }: { id: string }): Promise<CustomPropertyDefinitionApi[]> => {
                     await customPropertyDefinitionsDestroy(String(values.currentProjectId), id)
                     return values.definitions.filter((definition) => definition.id !== id)
+                },
+                removeSource: async ({
+                    definition,
+                }: {
+                    definition: CustomPropertyDefinitionApi
+                }): Promise<CustomPropertyDefinitionApi[]> => {
+                    if (definition.source) {
+                        await customPropertySourcesDestroy(String(values.currentProjectId), definition.source.id)
+                    }
+                    // Re-fetch so the cleared `source` is reflected — it can't be derived locally.
+                    const response = await customPropertyDefinitionsList(String(values.currentProjectId))
+                    return response.results
+                },
+            },
+        ],
+        savedQueries: [
+            [] as DataWarehouseSavedQuery[],
+            {
+                loadSavedQueries: async (): Promise<DataWarehouseSavedQuery[]> => {
+                    const response = await api.dataWarehouseSavedQueries.list()
+                    return response.results
                 },
             },
         ],
@@ -107,7 +164,51 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
                 }
             },
         },
+        customPropertySourceForm: {
+            defaults: DEFAULT_SOURCE_FORM_VALUES,
+            errors: ({ savedQuery, sourceColumn, keyColumn }: CustomPropertySourceFormValues) => ({
+                savedQuery: !savedQuery ? 'Select a view' : undefined,
+                sourceColumn: !sourceColumn ? 'Select the value column' : undefined,
+                keyColumn: !keyColumn ? 'Select the key column' : undefined,
+            }),
+            submit: async ({ savedQuery, sourceColumn, keyColumn, isEnabled }: CustomPropertySourceFormValues) => {
+                const definition = values.sourceDefinition
+                if (!definition || !savedQuery || !sourceColumn || !keyColumn) {
+                    return
+                }
+                if (definition.source) {
+                    // saved_query is create-only — only the mutable fields are sent on update.
+                    await customPropertySourcesPartialUpdate(String(values.currentProjectId), definition.source.id, {
+                        source_column: sourceColumn,
+                        key_column: keyColumn,
+                        is_enabled: isEnabled,
+                    })
+                } else {
+                    await customPropertySourcesCreate(String(values.currentProjectId), {
+                        definition: definition.id,
+                        saved_query: savedQuery,
+                        source_column: sourceColumn,
+                        key_column: keyColumn,
+                        is_enabled: isEnabled,
+                    })
+                }
+            },
+        },
     })),
+    selectors({
+        materializedViews: [
+            (s) => [s.savedQueries],
+            (savedQueries: DataWarehouseSavedQuery[]): DataWarehouseSavedQuery[] =>
+                savedQueries.filter((query) => query.is_materialized),
+        ],
+        selectedSourceColumns: [
+            (s) => [s.savedQueries, s.customPropertySourceForm],
+            (savedQueries: DataWarehouseSavedQuery[], form: CustomPropertySourceFormValues): string[] => {
+                const view = savedQueries.find((query) => query.id === form.savedQuery)
+                return (view?.columns ?? []).map((column) => column.name)
+            },
+        ],
+    }),
     listeners(({ actions, values }) => ({
         openCreateModal: () => {
             actions.resetCustomPropertyForm()
@@ -145,6 +246,40 @@ export const customPropertyDefinitionsLogic = kea<customPropertyDefinitionsLogic
         loadDefinitionsFailure: ({ error }) => {
             posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.load' })
             lemonToast.error('Failed to load custom properties')
+        },
+        openSourceModal: ({ definition }) => {
+            actions.loadSavedQueries()
+            if (definition.source) {
+                actions.setCustomPropertySourceFormValues({
+                    savedQuery: definition.source.saved_query,
+                    sourceColumn: definition.source.source_column,
+                    keyColumn: definition.source.key_column,
+                    isEnabled: definition.source.is_enabled ?? true,
+                })
+            } else {
+                actions.resetCustomPropertySourceForm()
+            }
+        },
+        submitCustomPropertySourceFormSuccess: () => {
+            lemonToast.success(values.sourceDefinition?.source ? 'Sync updated' : 'Sync configured')
+            actions.loadDefinitions()
+            actions.closeSourceModal()
+        },
+        submitCustomPropertySourceFormFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.submitSource' })
+            lemonToast.error((error as { detail?: string })?.detail ?? 'Failed to save sync configuration')
+        },
+        removeSourceSuccess: () => {
+            lemonToast.success('Sync removed')
+            actions.closeSourceModal()
+        },
+        removeSourceFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.removeSource' })
+            lemonToast.error('Failed to remove sync')
+        },
+        loadSavedQueriesFailure: ({ error }) => {
+            posthog.captureException(error, { scope: 'customPropertyDefinitionsLogic.loadSavedQueries' })
+            lemonToast.error('Failed to load data warehouse views')
         },
     })),
     afterMount(({ actions }) => {

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.test.ts
@@ -1,10 +1,14 @@
-import type { CustomPropertyDisplayTypeEnumApi } from 'products/customer_analytics/frontend/generated/api.schemas'
+import type {
+    CustomPropertyDisplayTypeEnumApi,
+    CustomPropertySourceApi,
+} from 'products/customer_analytics/frontend/generated/api.schemas'
 
 import {
     DISPLAY_TYPE_OPTIONS,
     formatCustomPropertyValue,
     isNumericDisplayType,
     labelForDisplayType,
+    sourceSyncStatus,
 } from './customPropertyTypes'
 
 function definition(
@@ -13,6 +17,14 @@ function definition(
 ): { display_type: CustomPropertyDisplayTypeEnumApi; is_big_number: boolean } {
     return { display_type, is_big_number }
 }
+
+const buildSource = (overrides: Partial<CustomPropertySourceApi>): CustomPropertySourceApi =>
+    ({
+        is_enabled: true,
+        last_sync_error: null,
+        last_synced_at: '2026-01-01T00:00:00Z',
+        ...overrides,
+    }) as CustomPropertySourceApi
 
 describe('customPropertyTypes', () => {
     it('labels each display type with its option label', () => {
@@ -56,5 +68,23 @@ describe('customPropertyTypes', () => {
             expect(formatCustomPropertyValue('enterprise', definition('text'))).toBe('enterprise')
             expect(formatCustomPropertyValue('n/a', definition('number'))).toBe('n/a')
         })
+    })
+
+    it('derives sync status from the source state', () => {
+        expect(sourceSyncStatus(buildSource({})).level).toBe('synced')
+        expect(sourceSyncStatus(buildSource({ last_synced_at: null })).level).toBe('pending')
+        expect(sourceSyncStatus(buildSource({ last_sync_error: 'boom' })).level).toBe('error')
+    })
+
+    it('shows the last error as the reason when a source is auto-disabled', () => {
+        const status = sourceSyncStatus(buildSource({ is_enabled: false, last_sync_error: 'View not found' }))
+        expect(status.level).toBe('disabled')
+        expect(status.tooltip).toBe('View not found')
+    })
+
+    it('explains manual disabling when a disabled source has no error', () => {
+        const status = sourceSyncStatus(buildSource({ is_enabled: false, last_sync_error: null }))
+        expect(status.level).toBe('disabled')
+        expect(status.tooltip).toBe('Syncing is turned off for this source.')
     })
 })

--- a/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
+++ b/products/customer_analytics/frontend/scenes/CustomerAnalyticsConfigurationScene/account/customPropertyTypes.ts
@@ -3,6 +3,7 @@ import { humanFriendlyCurrency, humanFriendlyLargeNumber, humanFriendlyNumber, p
 import type {
     CustomPropertyDefinitionApi,
     CustomPropertyDisplayTypeEnumApi,
+    CustomPropertySourceApi,
 } from 'products/customer_analytics/frontend/generated/api.schemas'
 
 // The backend stores the granular display type directly, so the form value maps 1:1 to the API.
@@ -61,4 +62,31 @@ export function formatCustomPropertyValue(
         default:
             return raw
     }
+}
+
+export type SourceSyncStatusLevel = 'synced' | 'error' | 'disabled' | 'pending'
+
+export interface SourceSyncStatus {
+    level: SourceSyncStatusLevel
+    label: string
+    tooltip?: string
+}
+
+// Derives the displayed sync state from the source's stored fields. The backend records only
+// `is_enabled` + `last_sync_error` + `last_synced_at`; status is computed, not stored.
+export function sourceSyncStatus(source: CustomPropertySourceApi): SourceSyncStatus {
+    if (!source.is_enabled) {
+        return {
+            level: 'disabled',
+            label: 'Disabled',
+            tooltip: source.last_sync_error ?? 'Syncing is turned off for this source.',
+        }
+    }
+    if (source.last_sync_error) {
+        return { level: 'error', label: 'Sync error', tooltip: source.last_sync_error }
+    }
+    if (!source.last_synced_at) {
+        return { level: 'pending', label: 'Awaiting first sync' }
+    }
+    return { level: 'synced', label: 'Synced' }
 }


### PR DESCRIPTION
> Stack — merge bottom-up: **model → sync → api → gate → ui**. This PR is **5/5** (base: `…-gate`).

## Problem

No UI to configure a view-backed source or see its sync status.

Part of #60300.

<!-- Closes #ISSUE_ID -->

## Changes

- Add a "Configure source" modal (pick view + column) in the custom properties config.
- Add a Sync status column (synced / pending / error / disabled).
- Extend `customPropertyDefinitionsLogic` (saved-queries loader, source form, remove source).

<!-- If there are frontend changes, please include screenshots. -->

## How did you test this code?

Jest: `customPropertyDefinitionsLogic.test.ts`, `customPropertyTypes.test.ts`. Not re-run this session. UI not manually exercised in this session.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted).

Authored by PostHog Code (Claude). Slice of #66409, split into an atomic stack.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
