### PR TITLE
feat(mcp-analytics): track onboarding activation via product intents

### DIFF
--- a/frontend/src/queries/schema.json
+++ b/frontend/src/queries/schema.json
@@ -32184,6 +32184,8 @@
                 "llm_dataset_created",
                 "llm_evaluation_created",
                 "llm_prompt_created",
+                "mcp_analytics_viewed",
+                "mcp_analytics_connected",
                 "logs_docs_viewed",
                 "logs_set_filters",
                 "logs_settings_opened",

--- a/frontend/src/queries/schema/schema-general.ts
+++ b/frontend/src/queries/schema/schema-general.ts
@@ -7787,6 +7787,10 @@ export enum ProductIntentContext {
     LLM_EVALUATION_CREATED = 'llm_evaluation_created',
     LLM_PROMPT_CREATED = 'llm_prompt_created',
 
+    // MCP Analytics
+    MCP_ANALYTICS_VIEWED = 'mcp_analytics_viewed',
+    MCP_ANALYTICS_CONNECTED = 'mcp_analytics_connected',
+
     // Logs
     LOGS_DOCS_VIEWED = 'logs_docs_viewed',
     LOGS_SET_FILTERS = 'logs_set_filters',

--- a/posthog/models/product_intent/product_intent.py
+++ b/posthog/models/product_intent/product_intent.py
@@ -206,6 +206,24 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
         # Activated when the user has engaged with the dashboard (15s dwell) or viewed a trace
         return contexts.get("llm_analytics_viewed", 0) >= 1 or contexts.get("llm_analytics_trace_viewed", 0) >= 1
 
+    def has_activated_mcp_analytics(self) -> bool:
+        # The instrumented MCP server is sending tool calls (registers the $mcp_tool_call
+        # definition in this team) and the user has opened the dashboard at least once.
+        has_tool_call = EventDefinition.objects.filter(team=self.team, name="$mcp_tool_call").exists()
+        if not has_tool_call:
+            return False
+
+        intent = ProductIntent.objects.filter(
+            team=self.team,
+            product_type="mcp_analytics",
+        ).first()
+
+        if not intent:
+            return False
+
+        contexts = intent.contexts or {}
+        return contexts.get("mcp_analytics_viewed", 0) >= 1
+
     def has_activated_workflows(self) -> bool:
         # At least one workflow needs to be active (not just drafted)
         return HogFlow.objects.filter(team=self.team, status=HogFlow.State.ACTIVE).exists()
@@ -228,6 +246,7 @@ class ProductIntent(UUIDTModel, RootTeamMixin):
             "product_analytics": self.has_activated_product_analytics,
             "surveys": self.has_activated_surveys,
             "llm_analytics": self.has_activated_llm_analytics,
+            "mcp_analytics": self.has_activated_mcp_analytics,
             "workflows": self.has_activated_workflows,
         }
 

--- a/posthog/models/test/test_product_intent.py
+++ b/posthog/models/test/test_product_intent.py
@@ -771,6 +771,40 @@ class TestProductIntent(BaseTest):
 
         assert self.product_intent.has_activated_llm_analytics() is False
 
+    def _make_mcp_tool_call_event_definition(self) -> EventDefinition:
+        return EventDefinition.objects.create(team=self.team, name="$mcp_tool_call")
+
+    def _make_mcp_intent(self, contexts: dict) -> ProductIntent:
+        ProductIntent.objects.filter(team=self.team, product_type=ProductKey.MCP_ANALYTICS).delete()
+        return ProductIntent.objects.create(
+            team=self.team,
+            product_type=ProductKey.MCP_ANALYTICS,
+            contexts=contexts,
+        )
+
+    def test_has_activated_mcp_analytics_with_tool_calls_and_dashboard_viewed(self):
+        self._make_mcp_tool_call_event_definition()
+        intent = self._make_mcp_intent({"mcp_analytics_viewed": 1})
+
+        assert intent.has_activated_mcp_analytics() is True
+
+    def test_has_not_activated_mcp_analytics_without_tool_calls(self):
+        intent = self._make_mcp_intent({"mcp_analytics_viewed": 5})
+
+        assert intent.has_activated_mcp_analytics() is False
+
+    def test_has_not_activated_mcp_analytics_with_tool_calls_but_no_engagement(self):
+        self._make_mcp_tool_call_event_definition()
+        intent = self._make_mcp_intent({})
+
+        assert intent.has_activated_mcp_analytics() is False
+
+    def test_has_not_activated_mcp_analytics_without_intent(self):
+        self._make_mcp_tool_call_event_definition()
+        ProductIntent.objects.filter(team=self.team, product_type=ProductKey.MCP_ANALYTICS).delete()
+
+        assert self.product_intent.has_activated_mcp_analytics() is False
+
     def test_has_activated_workflows_with_active_workflow(self):
         self.product_intent.product_type = ProductKey.WORKFLOWS
         self.product_intent.save()

--- a/posthog/schema_enums.py
+++ b/posthog/schema_enums.py
@@ -2647,6 +2647,8 @@ class ProductIntentContext(StrEnum):
     LLM_DATASET_CREATED = "llm_dataset_created"
     LLM_EVALUATION_CREATED = "llm_evaluation_created"
     LLM_PROMPT_CREATED = "llm_prompt_created"
+    MCP_ANALYTICS_VIEWED = "mcp_analytics_viewed"
+    MCP_ANALYTICS_CONNECTED = "mcp_analytics_connected"
     LOGS_DOCS_VIEWED = "logs_docs_viewed"
     LOGS_SET_FILTERS = "logs_set_filters"
     LOGS_SETTINGS_OPENED = "logs_settings_opened"

--- a/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
+++ b/products/mcp_analytics/frontend/mcpAnalyticsOnboardingLogic.ts
@@ -2,8 +2,9 @@ import { afterMount, kea, listeners, path, selectors } from 'kea'
 import { loaders } from 'kea-loaders'
 
 import api from 'lib/api'
+import { addProductIntent } from 'lib/utils/product-intents'
 
-import { HogQLQueryResponse, NodeKind } from '~/queries/schema/schema-general'
+import { HogQLQueryResponse, NodeKind, ProductIntentContext, ProductKey } from '~/queries/schema/schema-general'
 
 import type { mcpAnalyticsOnboardingLogicType } from './mcpAnalyticsOnboardingLogicType'
 
@@ -84,6 +85,17 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
     }),
     listeners(({ values, cache }) => ({
         loadSignalsSuccess: () => {
+            // Mark the diagnostic middle of the funnel: the SDK is connected but no
+            // tool calls have landed yet. Separates an install problem (never
+            // instrumented) from a traffic problem (wired up, but the server isn't
+            // being called). Registered once per mount so the poll doesn't repeat it.
+            if (values.onboardingState === 'connected-no-calls' && !cache.registeredConnected) {
+                cache.registeredConnected = true
+                void addProductIntent({
+                    product_type: ProductKey.MCP_ANALYTICS,
+                    intent_context: ProductIntentContext.MCP_ANALYTICS_CONNECTED,
+                })
+            }
             // Once tool calls show up the gate flips for good — stop polling.
             if (values.isOnboarded) {
                 cache.disposables.dispose('poll')
@@ -92,6 +104,12 @@ export const mcpAnalyticsOnboardingLogic = kea<mcpAnalyticsOnboardingLogicType>(
     })),
     afterMount(({ actions, cache }) => {
         actions.loadSignals()
+        // Register product intent so activation lands in the standard cross-customer
+        // funnel (`has_activated_mcp_analytics` flips once tool calls arrive too).
+        void addProductIntent({
+            product_type: ProductKey.MCP_ANALYTICS,
+            intent_context: ProductIntentContext.MCP_ANALYTICS_VIEWED,
+        })
         cache.disposables.add(() => {
             const id = window.setInterval(() => actions.loadSignals(), POLL_INTERVAL_MS)
             return () => clearInterval(id)


### PR DESCRIPTION
## Problem

The MCP analytics beta has a healthy opt-in curve (~28 new external customers/week) but we couldn't see how many actually *activate* — instrument their server and get events flowing — or, more importantly, **where** people fall off. Customer `$mcp_*` events land in the customer's own project and are invisible from our instance, so the activation funnel was unmeasurable.

## Changes

`mcpAnalyticsOnboardingLogic` already computes a per-project onboarding state from the `$mcp_initialize` / `$mcp_tool_call` signals, but only used it to gate the scene UI. Rather than invent a bespoke phone-home event, this wires MCP analytics into the **standard product-intent system** every other product uses, and captures the funnel's diagnostic shape:

- **Frontend:** register intent on the onboarding scene via `addProductIntent`, with two contexts:
  - `MCP_ANALYTICS_VIEWED` — dashboard opened (top of funnel; also satisfies the activation check).
  - `MCP_ANALYTICS_CONNECTED` — SDK connected but no tool calls yet. This is the diagnostic middle: it separates an **install problem** (never instrumented) from a **traffic problem** (wired up, but the server isn't being called). Registered once per mount so the 20s poll doesn't repeat it.
  Both emit the standard `user showed product intent` event.
- **Backend:** add `ProductIntent.has_activated_mcp_analytics`, mirroring `llm_analytics` — activated once the team has a `$mcp_tool_call` event definition **and** has opened the dashboard. Registered in the activation-check map so the standard `product intent marked activated` event fires.

Net effect: activation lands in the same cross-customer funnel as every other product, and the **opened → connected → activated** breakdown shows *where* onboarding leaks — instead of a one-off event only this dashboard knew about. Adds `MCP_ANALYTICS_VIEWED` / `MCP_ANALYTICS_CONNECTED` to `ProductIntentContext` (schema regenerated via `hogli build:schema`).

Deliberately out of scope: **retention** (lives in the customer's project, invisible from here) and a **wizard-install funnel step** (the install command doesn't emit telemetry to our project yet — a cross-repo change for later).

## How did you test this code?

I'm an agent (PostHog Code, Opus 4.8), human-directed. Added 4 cases to `test_product_intent.py` covering `has_activated_mcp_analytics` — activated (tool calls + viewed) and the three negative paths (no tool calls, no engagement, no intent row); mirrors the existing `llm_analytics` coverage and guards the new activation gate. **All 70 tests in the file pass locally** (`hogli test posthog/models/test/test_product_intent.py`); pre-commit `ty` typecheck passes. The `MCP_ANALYTICS_CONNECTED` context adds no backend logic (it's a funnel marker only), so no extra backend test. I did **not** run the app manually; the frontend change is intent registration through an existing typed helper.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- internal instrumentation only, no user-facing docs -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Lucas asked whether customers are using the MCP analytics beta and how to measure activation. Investigation (via the PostHog MCP against the dogfood project) showed ~70 external opt-ins but only ~3–5 external projects/week engaging, with true activation unmeasurable. First cut used a bespoke `posthog.capture`; on review we switched to the standard product-intent system. A second review pass added the `connected-no-calls` funnel marker so the data can actually be *iterated on* (diagnose where onboarding leaks), not just measured.

- Tools/agent: PostHog Code (Opus 4.8); PostHog MCP for the data investigation.
- Skills invoked: `/writing-tests` (gate for the activation tests).
- Decision: modeled the backend check on `has_activated_llm_analytics`; encoded the funnel via intent contexts rather than a bespoke event so it plugs into standard growth tooling. Explicitly scoped out retention and wizard-install telemetry.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
