### PR TITLE
feat(flags): log successful flags-cache builds and align metric labels

### DIFF
--- a/rust/feature-flags/src/bin/flags_cache_builder.rs
+++ b/rust/feature-flags/src/bin/flags_cache_builder.rs
@@ -44,7 +44,7 @@ use tracing_subscriber::EnvFilter;
 
 use feature_flags::flags::cache_builder::build_flags_cache;
 use feature_flags::flags::cache_invalidation::FlagsCacheInvalidation;
-use feature_flags::flags::cache_writer::{self, persist_flags_cache};
+use feature_flags::flags::cache_writer::{self, persist_flags_cache, PersistOutcome};
 use feature_flags::server::create_redis_client;
 
 common_alloc::used!();
@@ -442,7 +442,7 @@ async fn process_team(
 ) -> Vec<Offset> {
     match build_with_retry(pg_reader, writer, team_id, cfg).await {
         Ok(()) => {
-            metrics::counter!(BUILDS_TOTAL, "result" => "ok").increment(1);
+            metrics::counter!(BUILDS_TOTAL, "result" => "success").increment(1);
             let latency = (Utc::now() - team_batch.oldest_emitted_at)
                 .num_milliseconds()
                 .max(0) as f64
@@ -450,7 +450,7 @@ async fn process_team(
             metrics::histogram!(E2E_LATENCY_SECONDS).record(latency);
         }
         Err(failure) => {
-            metrics::counter!(BUILDS_TOTAL, "result" => "error", "reason" => failure.category)
+            metrics::counter!(BUILDS_TOTAL, "result" => "failure", "reason" => failure.category)
                 .increment(1);
             tracing::error!(team_id, category = failure.category, error = %failure.message, "Cache build failed after retries; routing to DLQ");
             // The message is a trigger, not a payload, so reconstruct it for the
@@ -466,7 +466,7 @@ async fn process_team(
     // — the later commit subsumes it. A DLQ-produce failure (rare; same cluster
     // as the source topic) therefore loses the triage record, but never flag data:
     // the lazy request-path fill rebuilds on the next /flags request. That failure
-    // is surfaced loudly via the error log above and the DLQ_PRODUCED{result=error}
+    // is surfaced loudly via the error log above and the DLQ_PRODUCED{result=failure}
     // counter — alert on it rather than wedging the partition.
     team_batch.offsets
 }
@@ -518,8 +518,17 @@ async fn build_with_retry(
         attempt += 1;
         let start = Instant::now();
         match build_once(pg_reader, writer, team_id, cfg.cache_ttl_seconds).await {
-            Ok(()) => {
-                metrics::histogram!(BUILD_DURATION_SECONDS).record(start.elapsed().as_secs_f64());
+            Ok(outcome) => {
+                let elapsed = start.elapsed();
+                metrics::histogram!(BUILD_DURATION_SECONDS).record(elapsed.as_secs_f64());
+                tracing::info!(
+                    team_id,
+                    attempt,
+                    duration_ms = elapsed.as_millis() as u64,
+                    size_bytes = outcome.size_bytes,
+                    etag = %outcome.etag,
+                    "Built flags cache"
+                );
                 return Ok(());
             }
             Err(failure) => {
@@ -556,7 +565,7 @@ async fn build_once(
     writer: &HyperCacheWriter,
     team_id: TeamId,
     ttl_seconds: u64,
-) -> Result<(), BuildFailure> {
+) -> Result<PersistOutcome, BuildFailure> {
     let cache = build_flags_cache(pg_reader.clone(), team_id)
         .await
         .map_err(BuildFailure::database)?;
@@ -628,9 +637,9 @@ async fn dlq_produce(
     .await;
 
     match results.into_iter().next() {
-        Some(Ok(())) => metrics::counter!(DLQ_PRODUCED, "result" => "ok").increment(1),
+        Some(Ok(())) => metrics::counter!(DLQ_PRODUCED, "result" => "success").increment(1),
         Some(Err(e)) => {
-            metrics::counter!(DLQ_PRODUCED, "result" => "error").increment(1);
+            metrics::counter!(DLQ_PRODUCED, "result" => "failure").increment(1);
             tracing::error!(team_id = message.team_id, error = %e, "Failed to produce to DLQ");
         }
         None => {}

--- a/rust/feature-flags/src/flags/cache_writer.rs
+++ b/rust/feature-flags/src/flags/cache_writer.rs
@@ -42,6 +42,17 @@ pub fn make_cache_config(
     config
 }
 
+/// What a successful persist wrote, surfaced so callers can log it. Both fields
+/// are computed on the write path anyway (`set_with_etag` returns the etag; the
+/// size is the serialized JSON length), so capturing them is free.
+pub struct PersistOutcome {
+    /// ETag stamped on the entry — `FlagDefinitionsCache` keys on `(team_id, etag)`,
+    /// so this identifies the cache version the request path will read.
+    pub etag: String,
+    /// Serialized cache size in bytes.
+    pub size_bytes: usize,
+}
+
 /// Persist a freshly built flags cache for `team_id` with the given TTL.
 ///
 /// Uses `set_with_etag` (not `set`): `set()` unconditionally DELs the `:etag` key
@@ -56,11 +67,12 @@ pub async fn persist_flags_cache(
     team_id: TeamId,
     cache: &HypercacheFlagsWrapper,
     ttl_seconds: u64,
-) -> Result<(), HyperCacheError> {
+) -> Result<PersistOutcome, HyperCacheError> {
     let key = KeyType::int(team_id);
     let json = serde_json::to_string(cache)?;
-    writer.set_with_etag(&key, &json, ttl_seconds).await?;
-    Ok(())
+    let size_bytes = json.len();
+    let etag = writer.set_with_etag(&key, &json, ttl_seconds).await?;
+    Ok(PersistOutcome { etag, size_bytes })
 }
 
 /// Assemble the hypercache writer the flags binaries use: an S3 client plus the

--- a/rust/feature-flags/src/flags/cache_writer.rs
+++ b/rust/feature-flags/src/flags/cache_writer.rs
@@ -42,14 +42,9 @@ pub fn make_cache_config(
     config
 }
 
-/// What a successful persist wrote, surfaced so callers can log it. Both fields
-/// are computed on the write path anyway (`set_with_etag` returns the etag; the
-/// size is the serialized JSON length), so capturing them is free.
+/// Outcome of a successful persist, for callers that want to log it.
 pub struct PersistOutcome {
-    /// ETag stamped on the entry — `FlagDefinitionsCache` keys on `(team_id, etag)`,
-    /// so this identifies the cache version the request path will read.
     pub etag: String,
-    /// Serialized cache size in bytes.
     pub size_bytes: usize,
 }
 
@@ -59,9 +54,10 @@ pub struct PersistOutcome {
 /// via `delete_etag`, and `FlagDefinitionsCache` keys on `(team_id, etag)`, so a
 /// missing etag forces the in-memory cache bypass on every `/flags` request.
 ///
-/// Returns the typed `HyperCacheError` so callers can attribute a failure to the
-/// Redis vs S3 vs serialization tier (the flags-cache-builder uses this to label
-/// its build-failure metric and DLQ headers for triage).
+/// On success, returns the etag and serialized size so callers can log what was
+/// written. On failure, returns the typed `HyperCacheError` so callers can
+/// attribute it to the Redis vs S3 vs serialization tier (the flags-cache-builder
+/// uses this to label its build-failure metric and DLQ headers for triage).
 pub async fn persist_flags_cache(
     writer: &HyperCacheWriter,
     team_id: TeamId,


### PR DESCRIPTION
## Problem

flags-cache-builder logs cache build failures but not successes, so confirming the binary actually wrote a cache for a given team means reading the BUILDS_TOTAL counter rather than tracing through structured logs. The result label values on BUILDS_TOTAL and DLQ_PRODUCED were also "ok"/"error", a pair that doesn't appear anywhere else in the Rust workspace.

## Changes

`persist_flags_cache` now returns a `PersistOutcome` with the etag and serialized size instead of `()`. Both values already come out of the write path (`set_with_etag` returns the etag, the size is the serialized JSON length), so capturing them costs nothing extra.

`build_with_retry` logs a "Built flags cache" line on each successful build with team_id, attempt, duration_ms, size_bytes, and etag.

BUILDS_TOTAL and DLQ_PRODUCED now use `result="success"`/`result="failure"`, matching the convention `common/kafka`'s producer and consumer already use. The workspace isn't fully consistent here (some crates use `success`/`failed`, others `success`/`error`), but `success`/`failure` is the pair used by the dependency feature-flags already pulls in for its Kafka clients.

`result="ok"` already has a live series for this binary in dev Prometheus. No dashboards or alerts reference it, but the value changes to `result="success"` on deploy, so it's not a continuous series across this change.

## How did you test this code

Ran `cargo check`, `cargo fmt`, and `cargo clippy --all-targets --all-features -- -D warnings` against the flags-cache-builder bin with its feature flag enabled. No automated tests changed; this is logging and metric-label-only, no behavior change to cache building or persistence.

## Automatic notifications
- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?