### PR TITLE
fix(postgres): treat hot-standby-disabled replica as non-retryable

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/source.py
@@ -442,6 +442,20 @@ class PostgresSource(SQLSource[PostgresSourceConfig], SSHTunnelMixin, ValidateDa
                 "connect until the database is available again. Upgrade your provider's plan or wait "
                 "for the quota to reset, then re-enable the sync."
             ),
+            # A physical standby / read replica started with `hot_standby = off` refuses every
+            # connection while in recovery, raising SQLSTATE 57P03 "FATAL: the database system is not
+            # accepting connections / DETAIL: Hot standby mode is disabled". It will never serve read
+            # queries until hot_standby is enabled (a config change + restart) or the replica is
+            # promoted to primary, so a whole-activity retry re-hits the same wall every time. Match
+            # the stable DETAIL, NOT the broad "the database system is not accepting connections" — that
+            # message also fires transiently while a server is starting up, shutting down, or failing
+            # over and must stay retryable (see the "the database system is starting up" mapping above).
+            "Hot standby mode is disabled": (
+                "PostHog connected to a PostgreSQL standby (read replica) that isn't accepting "
+                'connections because hot standby is turned off ("Hot standby mode is disabled"). '
+                "Enable hot_standby on the replica and restart it, or point this source at the primary "
+                "database, then re-enable the sync."
+            ),
             # A single recovery conflict ("conflict with recovery") is transient and retried in-process,
             # so it stays retryable. This abort is only raised once those retries are exhausted — by then
             # the condition is sustained and a whole-activity retry just re-reads from offset 0 into the

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -305,6 +305,10 @@ class TestPostgresSourceNonRetryableErrors:
             # Mid-stream SSL/connection drops during schema discovery — the pooler culled an idle
             # connection or the socket died. A fresh attempt reconnects, so these must stay retryable.
             "consuming input failed: SSL connection has been closed unexpectedly",
+            # The socket-level variant of the same TLS drop (network blip / idle cull mid-stream). It
+            # triggers the offset-chunking recovery and must stay retryable — only the reconnect wall it
+            # can hit on a hot-standby-disabled replica is non-retryable (see the permanent cases below).
+            "consuming input failed: SSL SYSCALL error: EOF detected",
             "the connection is lost",
         ],
     )
@@ -334,6 +338,10 @@ class TestPostgresSourceNonRetryableErrors:
             # Manager), not PostgreSQL's "password authentication failed for user". Newlines are
             # normalized to spaces upstream, so the real message arrives as the doubled single line.
             'connection failed: connection to server at "127.0.0.1", port 35425 failed: FATAL:  The password that was provided for the role postgres is wrong. connection to server at "127.0.0.1", port 35425 failed: FATAL:  This RDS Proxy requires TLS connections',
+            # A read replica started with `hot_standby = off` refuses every connection (SQLSTATE 57P03).
+            # Newlines are normalized to spaces upstream, so the FATAL/DETAIL pair arrives on one line.
+            # Permanent until the replica's config changes or it's promoted — must not keep retrying.
+            'connection failed: connection to server at "10.0.0.1", port 5432 failed: FATAL:  the database system is not accepting connections DETAIL:  Hot standby mode is disabled.',
         ],
     )
     def test_permanent_connection_errors_are_non_retryable(self, source, error_msg):


### PR DESCRIPTION
## Problem

A Postgres data-warehouse import surfaced [`OperationalError: consuming input failed: SSL SYSCALL error: EOF detected`](https://us.posthog.com/project/2/error_tracking/019f1a66-c00a-74c3-b03f-78025343ecda) from the Postgres source.

Reading the full event, the headline SSL EOF is **not** the failure — it's a mid-stream connection drop that the source already handles: it's classified as transient and kicks off the `offset_chunking` recovery, which reconnects and resumes. The exception that actually escapes and fails the activity is the *reconnect*, which hits:

```
FATAL:  the database system is not accepting connections
DETAIL:  Hot standby mode is disabled.
```

That's SQLSTATE 57P03 from a physical standby / read replica started with `hot_standby = off`. Such a replica refuses **every** connection for its entire life in recovery — it will never serve read queries until `hot_standby` is enabled (a config change + restart) or it's promoted to primary. It wasn't matched by any transient predicate, so it propagated out of the recovery loop, failed the activity, and Temporal re-hit the same wall on every whole-activity retry — burning the retry budget and re-surfacing in error tracking.

## Changes

Add `"Hot standby mode is disabled"` to `PostgresSource.get_non_retryable_errors()` with an actionable message (enable `hot_standby` and restart the replica, or point the source at the primary).

Key decision: match the **stable DETAIL** `"Hot standby mode is disabled"`, **not** the broad `"the database system is not accepting connections"`. The broad 57P03 message also fires transiently while a server is starting up, shutting down, or failing over — the source already keeps `"the database system is starting up"` retryable on purpose — so matching it would wrongly disable syncs on a transient blip. The DETAIL is specific to the persistent hot-standby-off misconfiguration.

The transient SSL EOF that triggers the recovery stays retryable and untouched.

## How did you test this code?

I'm an agent. I ran the source's non-retryable error suite — `TestPostgresSourceNonRetryableErrors` (90 cases) — and it passes, plus `ruff check`/`ruff format`.

Test changes are parametrized cases on existing tests, not new functions:
- A permanent case asserting the real (host-redacted) `...not accepting connections ... Hot standby mode is disabled.` message is classified non-retryable — catches a regression where the key is dropped, or where someone matches the broad transient message instead of the persistent DETAIL.
- A transient case asserting `consuming input failed: SSL SYSCALL error: EOF detected` stays retryable — guards that this fix doesn't accidentally make the mid-stream drop (which drives the recovery) permanent.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Pulled the issue and a representative event via the PostHog MCP error-tracking tools, traced the full stack through `get_rows` → `offset_chunking` → `get_connection` → `_connect_with_options_fallback`, and confirmed the failure originates in the postgres source. Verified `get_non_retryable_errors` matching semantics (case-sensitive substring against the `\n\r\t`-normalized error string) in `external_data_job.py` before choosing the DETAIL substring. Considered and rejected a code-level retry (the condition is persistent, not transient) and rejected matching the broad 57P03 message (it's transient on startup/failover). Invoked the `/writing-tests` skill before adding tests. Checked open PRs (including @Gilbert09's) for duplicates — none address this.