### PR TITLE
feat(cli): accept dSYM bundles in symbol-sets upload

### DIFF
--- a/cli/.sampo/changesets/symbol-sets-accept-dsym.md
+++ b/cli/.sampo/changesets/symbol-sets-accept-dsym.md
@@ -1,0 +1,5 @@
+---
+cargo/posthog-cli: minor
+---
+
+`symbol-sets upload` now also accepts Apple `.dSYM` bundles, packaging them through the same path as `dsym upload` (uppercase UUID chunk_ids, `AppleDsym` container). A single `posthog-cli symbol-sets upload --directory <dir>` run uploads both Linux ELF debug symbols and macOS dSYMs, so native symbol uploads no longer need a different command per platform. The dSYM branch shells out to `dwarfdump` (Xcode, macOS-only); when it is unavailable the bundle is reported and skipped while ELF symbols in the same directory still upload. The standalone `dsym upload` command is unchanged.

--- a/cli/README.md
+++ b/cli/README.md
@@ -32,6 +32,18 @@ These variables can also be loaded from a dotenv-style file via `--dotenv-file <
 
 Full precedence: CLI args → process env → `--dotenv-file` → `~/.posthog/credentials.json` (from `posthog-cli login`).
 
+## Uploading native debug symbols
+
+`posthog-cli symbol-sets upload --directory <dir>` scans a directory for native debug symbols and uploads them so PostHog can symbolicate native stack frames.
+A single command handles both desktop/server formats:
+
+- **Linux (ELF):** executables, shared libraries, and `objcopy --only-keep-debug` companions that carry a GNU build id. This branch is cross-platform.
+- **macOS (Apple `.dSYM`):** dSYM bundles are packaged through the same path as `posthog-cli dsym upload`. That path shells out to `dwarfdump` (bundled with Xcode), so it only runs on macOS — if `dwarfdump` is missing, the bundle is reported and skipped while any ELF symbols in the same directory still upload.
+
+Pass `--include-source` to bundle the referenced source files for richer context around frames.
+
+The standalone `posthog-cli dsym upload` command is unchanged and still recommended for dSYM-only Xcode build phases, where it also reads release and version metadata from each bundle's `Info.plist`.
+
 ## Skipping uploads (dry run)
 
 Pass `--dry-run` before the subcommand (`posthog-cli --dry-run hermes upload ...`), or set `POSTHOG_CLI_DRY_RUN=true`, to turn the upload commands — `sourcemap`, `dsym`, `hermes`, and `proguard` — into a no-op.
@@ -51,6 +63,8 @@ Commands require different API scopes. Make sure to set these scopes on your per
 | ----------------------------- | ------------------------------------------ |
 | `query`                       | `query:read`                               |
 | `sourcemap`                   | `error_tracking:write`                     |
+| `symbol-sets`                 | `error_tracking:write`                     |
+| `dsym`                        | `error_tracking:write`                     |
 | `exp endpoints list/get/pull` | `endpoint:read`                            |
 | `exp endpoints push`          | `endpoint:write`, `insight_variable:write` |
 | `exp endpoints run`           | `query:read`                               |

--- a/cli/src/debug_symbols/mod.rs
+++ b/cli/src/debug_symbols/mod.rs
@@ -6,7 +6,7 @@ use symbolic::debuginfo::{Archive, FileFormat, ObjectKind};
 use tracing::{info, warn};
 
 use crate::api::symbol_sets::SymbolSetUpload;
-use crate::dsym::source_bundle;
+use crate::dsym::{source_bundle, DsymFile};
 
 pub mod upload;
 
@@ -33,7 +33,7 @@ pub struct DiscoveryReport {
     pub without_debug_info: Vec<PathBuf>,
     /// ELFs with debug info but no GNU build id (cannot be uploaded)
     pub missing_build_id: Vec<PathBuf>,
-    /// dSYM bundles spotted while scanning (handled by `dsym upload`)
+    /// Apple dSYM bundles spotted while scanning (packaged via the dsym path)
     pub dsym_bundles: Vec<PathBuf>,
     /// Split-DWARF artifacts spotted while scanning (unsupported)
     pub split_dwarf: Vec<PathBuf>,
@@ -285,6 +285,10 @@ fn parse_candidate(path: &Path) -> Result<Option<Candidate>> {
 /// Render guidance for files that couldn't be uploaded; returns an error when
 /// nothing usable was found at all.
 pub fn report_problems(report: &DiscoveryReport, directory: &Path) -> Result<()> {
+    // ELF debug files and dSYM bundles are both uploaded by `symbol-sets upload`
+    // now, so the only genuinely empty case is when neither was found.
+    let nothing_to_upload = report.files.is_empty() && report.dsym_bundles.is_empty();
+
     if !report.split_dwarf.is_empty() {
         warn!(
             "Found {} split-DWARF file(s) (.dwp/.dwo), which aren't supported yet. \
@@ -317,37 +321,78 @@ pub fn report_problems(report: &DiscoveryReport, directory: &Path) -> Result<()>
              via RUSTFLAGS; in Go: `-ldflags=-B=gobuildid`); most C/C++/Rust \
              toolchains add this by default, Go does not."
         );
-        // Only fail the run when there's nothing valid to upload; otherwise a
-        // stray build-id-less helper binary would block every valid symbol.
-        if report.files.is_empty() {
+        // Only fail the run when there's nothing valid to upload at all;
+        // otherwise a stray build-id-less helper binary would block every valid
+        // symbol, including any dSYM bundles found alongside it.
+        if nothing_to_upload {
             anyhow::bail!("{guidance}");
         }
         warn!("{guidance}");
     }
 
-    if report.files.is_empty() {
-        if !report.dsym_bundles.is_empty() {
-            anyhow::bail!(
-                "No ELF debug symbols found in {}, but {} dSYM bundle(s) were. \
-                 Use `posthog-cli dsym upload` for Apple dSYMs.",
-                directory.display(),
-                report.dsym_bundles.len()
-            );
-        }
+    if nothing_to_upload {
         anyhow::bail!(
-            "No ELF files with debug info found in {}",
+            "No ELF files with debug info or dSYM bundles found in {}",
             directory.display()
         );
     }
 
-    if !report.dsym_bundles.is_empty() {
-        warn!(
-            "Skipping {} dSYM bundle(s); use `posthog-cli dsym upload` for those.",
-            report.dsym_bundles.len()
-        );
-    }
-
     Ok(())
+}
+
+/// Package any discovered Apple `.dSYM` bundles into uploads, reusing the exact
+/// same code path as `posthog-cli dsym upload` (uppercase `LC_UUID` chunk_ids,
+/// `AppleDsym` container). A bundle that fails to process — most often because
+/// `dwarfdump` is unavailable, since it ships with Xcode and is macOS-only — is
+/// logged and skipped rather than aborting the run, so a mixed ELF + dSYM
+/// directory still uploads its ELF symbols on Linux.
+///
+/// Uploads come back with no release id; the caller stamps one (if any) after it
+/// knows there is something to upload, so a fully-skipped run leaves no release.
+pub fn package_dsym_bundles(bundles: &[PathBuf], include_source: bool) -> Vec<SymbolSetUpload> {
+    let mut uploads = Vec::new();
+    for bundle in bundles {
+        match DsymFile::new(bundle, include_source) {
+            Ok(dsym_file) => {
+                info!(
+                    "Processing dSYM {} (UUIDs: {})",
+                    bundle.display(),
+                    dsym_file.uuids().join(", ")
+                );
+                uploads.extend(dsym_file.into_uploads());
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to process dSYM {}: {e} (skipping)",
+                    bundle.display()
+                );
+            }
+        }
+    }
+    uploads
+}
+
+/// Coalesce uploads that share a chunk_id, keeping the first occurrence.
+///
+/// ELF chunk_ids are lowercase (derived by `symbolic`) and Mach-O dSYM chunk_ids
+/// are uppercase (to match what the SDK and `dsym upload` emit), so the two
+/// formats never collide — this only merges the same dSYM UUID appearing in more
+/// than one bundle. Casing is preserved exactly and must never be normalized:
+/// the SDK matches chunk_ids case-sensitively, per format.
+pub fn dedup_uploads_by_chunk_id(uploads: Vec<SymbolSetUpload>) -> Vec<SymbolSetUpload> {
+    let mut seen = std::collections::HashSet::new();
+    let mut deduped = Vec::with_capacity(uploads.len());
+    for upload in uploads {
+        if seen.insert(upload.chunk_id.clone()) {
+            deduped.push(upload);
+        } else {
+            warn!(
+                "Duplicate chunk id {} across symbol sets; keeping the first",
+                upload.chunk_id
+            );
+        }
+    }
+    deduped
 }
 
 /// Extract the debug id of an ELF file, e.g. for testing parity with the SDK.

--- a/cli/src/debug_symbols/upload.rs
+++ b/cli/src/debug_symbols/upload.rs
@@ -5,7 +5,7 @@ use tracing::info;
 
 use crate::{
     api::{self, releases::ReleaseBuilder, symbol_sets::SymbolSetUpload},
-    debug_symbols::{discover, report_problems},
+    debug_symbols::{dedup_uploads_by_chunk_id, discover, package_dsym_bundles, report_problems},
     sourcemaps::args::{pack_version, ReleaseArgs, UploadConflictArgs},
     utils::git::get_git_info,
 };
@@ -14,7 +14,8 @@ use crate::{
 pub struct Args {
     /// The directory to scan for native debug symbol files (e.g. target/release).
     /// ELF executables, shared libraries, and `objcopy --only-keep-debug`
-    /// companions with debug info are uploaded; everything else is skipped.
+    /// companions with debug info are uploaded, as are Apple `.dSYM` bundles
+    /// (macOS only — needs `dwarfdump` from Xcode); everything else is skipped.
     #[arg(short, long)]
     pub directory: PathBuf,
 
@@ -56,9 +57,46 @@ pub fn upload(args: &Args) -> Result<()> {
     let report = discover(&directory)?;
     report_problems(&report, &directory)?;
 
-    info!("Found {} debug symbol file(s)", report.files.len());
+    info!(
+        "Found {} ELF debug file(s) and {} dSYM bundle(s)",
+        report.files.len(),
+        report.dsym_bundles.len()
+    );
 
-    // Set up release info: explicit flags win, git info is metadata/fallback
+    // Package everything first, with no release id yet, so we only create a
+    // release once we know there's something to upload. dSYM packaging
+    // logs-and-skips failures (e.g. a missing dwarfdump), so a dSYM-only
+    // directory can yield zero uploads — creating the release up front would
+    // leave a release record behind with no symbols attached to it.
+    let mut uploads: Vec<SymbolSetUpload> = Vec::new();
+    for file in report.files {
+        info!(
+            "Processing {} (debug id {})",
+            file.path.display(),
+            file.debug_id
+        );
+        uploads.push(file.into_upload(None, *include_source)?);
+    }
+
+    // Apple dSYM bundles run through the same packaging path as
+    // `posthog-cli dsym upload` (uppercase UUID chunk_ids, AppleDsym container);
+    // a bundle that can't be processed (e.g. no dwarfdump on Linux) is skipped
+    // with a warning so any ELF symbols above still upload.
+    uploads.extend(package_dsym_bundles(&report.dsym_bundles, *include_source));
+
+    // ELF (lowercase) and dSYM (uppercase) chunk_ids can't collide, but the same
+    // dSYM UUID can appear in more than one bundle — keep one upload per chunk_id.
+    let mut uploads = dedup_uploads_by_chunk_id(uploads);
+
+    if uploads.is_empty() {
+        anyhow::bail!(
+            "No debug symbols could be packaged for upload from {}",
+            directory.display()
+        );
+    }
+
+    // Now that there's something to upload, set up the release (explicit flags
+    // win, git info is metadata/fallback) and stamp it on every set.
     let mut release_builder = ReleaseBuilder::default();
     if let Ok(Some(git_info)) = get_git_info(Some(directory.clone())) {
         release_builder.with_git(git_info);
@@ -74,16 +112,11 @@ pub fn upload(args: &Args) -> Result<()> {
         .can_create()
         .then(|| release_builder.fetch_or_create())
         .transpose()?;
-    let release_id = created_release.map(|r| r.id.to_string());
-
-    let mut uploads: Vec<SymbolSetUpload> = Vec::new();
-    for file in report.files {
-        info!(
-            "Processing {} (debug id {})",
-            file.path.display(),
-            file.debug_id
-        );
-        uploads.push(file.into_upload(release_id.clone(), *include_source)?);
+    if let Some(release) = created_release {
+        let release_id = release.id.to_string();
+        for upload in &mut uploads {
+            upload.release_id = Some(release_id.clone());
+        }
     }
 
     info!("Uploading {} debug symbol file(s)...", uploads.len());

--- a/cli/src/download.rs
+++ b/cli/src/download.rs
@@ -16,9 +16,10 @@ use crate::{api::symbol_sets, invocation_context::context};
 
 #[derive(Subcommand)]
 pub enum SymbolSetsSubcommand {
-    /// Upload native (ELF) debug symbols from a directory. ELF executables,
-    /// shared libraries, and `objcopy --only-keep-debug` companions with debug
-    /// info are uploaded; other files (dSYM bundles, etc.) are reported and skipped.
+    /// Upload native debug symbols from a directory. ELF executables, shared
+    /// libraries, and `objcopy --only-keep-debug` companions with debug info are
+    /// uploaded, as are Apple `.dSYM` bundles (macOS only — needs `dwarfdump`
+    /// from Xcode); other files are reported and skipped.
     Upload(crate::debug_symbols::upload::Args),
     /// Download and extract a symbol set (sourcemap, hermes, proguard, or dSYM)
     Download(DownloadArgs),

--- a/cli/tests/debug_symbols.rs
+++ b/cli/tests/debug_symbols.rs
@@ -1,14 +1,56 @@
 use std::io::Read;
 use std::path::{Path, PathBuf};
 
-use posthog_cli::debug_symbols::{discover, elf_debug_id};
-use posthog_symbol_data::{read_symbol_data, ElfDebugInfo};
+use posthog_cli::api::symbol_sets::SymbolSetUpload;
+use posthog_cli::debug_symbols::{
+    dedup_uploads_by_chunk_id, discover, elf_debug_id, package_dsym_bundles, report_problems,
+};
+use posthog_symbol_data::{read_symbol_data, AppleDsym, ElfDebugInfo};
 
 /// The native ELF fixtures shared with cymbal's symbolication tests; built by
 /// tests/static/native/build.sh, with debug ids derived the same way cymbal
 /// derives them when resolving frames.
 fn fixtures_dir() -> PathBuf {
     Path::new(env!("CARGO_MANIFEST_DIR")).join("../rust/cymbal/tests/static/native")
+}
+
+/// The Apple dSYM fixtures shared with cymbal's symbolication tests.
+fn apple_fixtures_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("../rust/cymbal/tests/static/apple")
+}
+
+/// `dwarfdump` ships with Xcode and only exists on macOS; the dSYM packaging
+/// path shells out to it, so tests that exercise real bundles gate on this.
+/// Require a *successful* exit, not just a spawn: on macOS `/usr/bin/dwarfdump`
+/// is an `xcrun` shim that runs but exits non-zero when the Command Line Tools
+/// aren't installed, and that would let the test run without a working tool.
+fn dwarfdump_available() -> bool {
+    std::process::Command::new("dwarfdump")
+        .arg("--version")
+        .output()
+        .is_ok_and(|out| out.status.success())
+}
+
+fn copy_dir_all(src: &Path, dst: &Path) {
+    std::fs::create_dir_all(dst).unwrap();
+    for entry in std::fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let to = dst.join(entry.file_name());
+        if entry.file_type().unwrap().is_dir() {
+            copy_dir_all(&entry.path(), &to);
+        } else {
+            std::fs::copy(entry.path(), &to).unwrap();
+        }
+    }
+}
+
+/// Read the 4-byte magic of the `dwarf` entry inside a symbol_data ZIP payload.
+fn dwarf_magic(inner_zip: &[u8]) -> [u8; 4] {
+    let mut zip = zip::ZipArchive::new(std::io::Cursor::new(inner_zip.to_vec())).unwrap();
+    let mut dwarf = zip.by_name("dwarf").unwrap();
+    let mut magic = [0u8; 4];
+    dwarf.read_exact(&mut magic).unwrap();
+    magic
 }
 
 #[test]
@@ -114,4 +156,129 @@ fn classifies_elfs_without_debug_info_or_build_id() {
     let report = discover(dir.path()).unwrap();
     assert_eq!(report.files.len(), 1);
     assert!(posthog_cli::debug_symbols::report_problems(&report, dir.path()).is_ok());
+}
+
+#[test]
+fn dsym_only_directory_is_uploadable() {
+    // A directory with only a dSYM bundle (no ELF) used to be a hard error
+    // pointing at `dsym upload`; `symbol-sets upload` now packages dSYMs itself,
+    // so reporting should succeed without that guidance.
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("MyApp.app.dSYM/Contents/Resources/DWARF")).unwrap();
+
+    let report = discover(dir.path()).unwrap();
+    assert!(report.files.is_empty());
+    assert_eq!(report.dsym_bundles.len(), 1);
+    assert!(report_problems(&report, dir.path()).is_ok());
+}
+
+#[test]
+fn empty_directory_errors_on_both_formats() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::write(dir.path().join("notes.txt"), "nothing to see").unwrap();
+
+    let report = discover(dir.path()).unwrap();
+    let err = report_problems(&report, dir.path()).unwrap_err();
+    assert!(
+        err.to_string()
+            .contains("No ELF files with debug info or dSYM bundles"),
+        "got: {err}"
+    );
+}
+
+#[test]
+fn dedup_preserves_per_format_chunk_id_casing() {
+    // ELF chunk_ids are lowercase, Mach-O dSYM chunk_ids uppercase. The SAME uuid
+    // in both cases must NOT be merged — the SDK matches case-sensitively, per
+    // format — while an exact duplicate (one uuid found in two bundles) coalesces
+    // to the first occurrence.
+    let lower = "77c2f55f-c959-487a-9601-6a715a9bb5de";
+    let upper = "77C2F55F-C959-487A-9601-6A715A9BB5DE";
+    let mk = |chunk_id: &str, data: &[u8]| SymbolSetUpload {
+        chunk_id: chunk_id.to_string(),
+        release_id: None,
+        data: data.to_vec(),
+    };
+
+    let deduped = dedup_uploads_by_chunk_id(vec![
+        mk(lower, b"elf"),
+        mk(upper, b"dsym-bundle-a"),
+        mk(upper, b"dsym-bundle-b"),
+    ]);
+
+    assert_eq!(
+        deduped.len(),
+        2,
+        "case-distinct ids stay separate; only the exact-duplicate uppercase id merges"
+    );
+    let ids: Vec<&str> = deduped.iter().map(|u| u.chunk_id.as_str()).collect();
+    assert!(
+        ids.contains(&lower),
+        "lowercase ELF id must survive unchanged"
+    );
+    assert!(
+        ids.contains(&upper),
+        "uppercase dSYM id must survive unchanged"
+    );
+    let kept_upper = deduped.iter().find(|u| u.chunk_id == upper).unwrap();
+    assert_eq!(
+        kept_upper.data, b"dsym-bundle-a",
+        "dedup keeps the first occurrence"
+    );
+}
+
+#[test]
+fn packages_elf_and_dsym_from_one_directory() {
+    // The dSYM half shells out to `dwarfdump` (Xcode, macOS-only); on Linux CI
+    // it's absent, so skip there. The ELF-only path is covered by the tests above.
+    if !dwarfdump_available() {
+        eprintln!("skipping packages_elf_and_dsym_from_one_directory: dwarfdump unavailable");
+        return;
+    }
+
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::copy(
+        fixtures_dir().join("test_binary_pie"),
+        dir.path().join("test_binary_pie"),
+    )
+    .unwrap();
+    copy_dir_all(
+        &apple_fixtures_dir().join("test_binary.dSYM"),
+        &dir.path().join("test_binary.dSYM"),
+    );
+
+    let report = discover(dir.path()).unwrap();
+    assert_eq!(report.files.len(), 1, "one ELF discovered");
+    assert_eq!(report.dsym_bundles.len(), 1, "one dSYM bundle discovered");
+    assert!(report_problems(&report, dir.path()).is_ok());
+
+    // Mirror the upload flow: package ELF + dSYM, then dedup across both formats.
+    let mut uploads: Vec<SymbolSetUpload> = report
+        .files
+        .into_iter()
+        .map(|f| f.into_upload(None, false).unwrap())
+        .collect();
+    uploads.extend(package_dsym_bundles(&report.dsym_bundles, false));
+    let uploads = dedup_uploads_by_chunk_id(uploads);
+    assert_eq!(uploads.len(), 2, "one ELF + one dSYM upload");
+
+    // ELF: lowercase chunk_id, ElfDebugInfo container, ELF binary inside.
+    let elf = uploads
+        .iter()
+        .find(|u| u.chunk_id == "850c70a2-6592-a70c-3e49-c0e443794d23")
+        .expect("ELF upload present with lowercase debug id");
+    let elf_inner: ElfDebugInfo = read_symbol_data(&elf.data).unwrap();
+    assert_eq!(&dwarf_magic(&elf_inner.data), b"\x7fELF");
+
+    // dSYM: UPPERCASE chunk_id, AppleDsym container, Mach-O binary inside.
+    let dsym = uploads
+        .iter()
+        .find(|u| u.chunk_id == "77C2F55F-C959-487A-9601-6A715A9BB5DE")
+        .expect("dSYM upload present with uppercase UUID");
+    let dsym_inner: AppleDsym = read_symbol_data(&dsym.data).unwrap();
+    assert_ne!(
+        &dwarf_magic(&dsym_inner.data),
+        b"\x7fELF",
+        "dSYM dwarf entry must be a Mach-O binary, not ELF"
+    );
 }


### PR DESCRIPTION
## Problem

Native debug symbol uploads needed a different command per platform: `symbol-sets upload` for Linux ELF, `dsym upload` for macOS Apple dSYMs — easy to pick the wrong one when shipping cross-platform native binaries.

## Changes

`symbol-sets upload` now also accepts Apple `.dSYM` bundles (it already detected them while scanning — it just skipped them and pointed at `dsym upload`):

- ELF + dSYM in one directory upload as a single batch, de-duplicated by chunk_id.
- dSYM packaging reuses the existing `dsym` path verbatim, preserving the per-format chunk_id casing the SDK matches case-sensitively — lowercase ELF, UPPERCASE Mach-O; the merge never normalizes.
- The release is created only after packaging yields at least one upload, so a fully-skipped run leaves no empty release.

No server change (cymbal detects the `ElfDebugInfo`/`AppleDsym` container from the bytes). The standalone `dsym upload` is unchanged.

**Caveat:** the dSYM branch shells out to `dwarfdump` (Xcode, macOS-only); on Linux those bundles are skipped with a warning while ELF still uploads.

## How did you test this code?

Agent (Claude Code), automated checks only — no manual testing:

- `cargo test --all-features` — 125 passed, incl. new tests for the casing/dedup invariant, dSYM-only/empty-dir reporting, and an end-to-end ELF+dSYM packaging test (gated on `dwarfdump`, so it runs on macOS and skips on Linux CI).
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check` — clean.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

`cli/README.md` (new section + scope rows), updated `--help` text, and a `cargo/posthog-cli: minor` sampo changeset.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (`/pr-closeout`). Delegates `.dSYM` handling to the already-tested `dsym` packaging path rather than reimplementing Mach-O parsing — reusing `DsymFile::into_uploads()` verbatim preserves the case-sensitive per-format chunk_id contract. Codex autoreview ran to clean; it caught (and I fixed) release creation happening before packaging (could leave an empty release on a fully-skipped dSYM run) and a test gate that checked `dwarfdump` spawn but not exit status.