### PR TITLE
feat(insights): add FunnelStepTooltip and switch funnel charts to quill surface

### DIFF
--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
@@ -1,11 +1,16 @@
+import { useValues } from 'kea'
+
 import type { TooltipContext } from '@posthog/quill-charts'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FunnelTooltip } from 'scenes/funnels/FunnelTooltip'
 import { funnelComparePeriodDateRange, getFunnelAggregateConversionRate } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import type { FunnelStepWithConversionMetrics } from '~/types'
 
+import { FunnelStepTooltip } from '../shared/FunnelStepTooltip'
 import type { FunnelBarHorizontalSegmentMeta } from './funnelBarHorizontalTransforms'
 
 interface FunnelBarHorizontalTooltipProps {
@@ -29,6 +34,9 @@ export function FunnelBarHorizontalTooltip({
     resolvedDateRange,
     compareTo,
 }: FunnelBarHorizontalTooltipProps): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+
     const entry = context.seriesData[0]
     if (!entry) {
         return null
@@ -38,20 +46,27 @@ export function FunnelBarHorizontalTooltip({
     const series =
         breakdownIndex != null && step.nested_breakdown?.[breakdownIndex] ? step.nested_breakdown[breakdownIndex] : step
     const aggregateConversionRate = getFunnelAggregateConversionRate(series, step)
+    const comparePeriodDateRange = series.compare_label
+        ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
+        : null
 
-    return (
-        <FunnelTooltip
-            showPersonsModal={showPersonsModal}
-            stepIndex={stepIndex}
-            series={series}
-            groupTypeLabel={groupTypeLabel}
-            breakdownFilter={breakdownFilter}
-            aggregateConversionRate={aggregateConversionRate}
-            comparePeriodDateRange={
-                series.compare_label
-                    ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
-                    : null
-            }
-        />
+    // Horizontal bar chart: cursor right of the bar's end pixel is in the track (drop-off) region.
+    const isDropOffHover =
+        stepIndex > 0 && context.hoverPosition != null && entry.yPixel != null && context.hoverPosition.x > entry.yPixel
+
+    const sharedProps = {
+        showPersonsModal,
+        stepIndex,
+        series,
+        groupTypeLabel,
+        breakdownFilter,
+        aggregateConversionRate,
+        comparePeriodDateRange,
+    }
+
+    return quillTooltipEnabled ? (
+        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} />
+    ) : (
+        <FunnelTooltip {...sharedProps} />
     )
 }

--- a/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelBarHorizontalChart/FunnelBarHorizontalTooltip.tsx
@@ -65,7 +65,7 @@ export function FunnelBarHorizontalTooltip({
     }
 
     return quillTooltipEnabled ? (
-        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} />
+        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} color={entry.color} />
     ) : (
         <FunnelTooltip {...sharedProps} />
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -164,6 +164,7 @@ export function FunnelLineChart({
             funnelsFilter?.showTrendLines,
             showValuesOnSeries,
             legendConfig,
+            TOOLTIP_CONFIG,
         ]
     )
 

--- a/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelLineChart/FunnelLineChart.tsx
@@ -1,17 +1,18 @@
 import { useValues } from 'kea'
 import posthog from 'posthog-js'
-import { useMemo, type ErrorInfo } from 'react'
+import { useCallback, useMemo, type ErrorInfo } from 'react'
 
 import { TimeSeriesLineChart } from '@posthog/quill-charts'
 import type {
     ChartLegendConfig,
     PointClickData,
     TimeSeriesLineChartConfig,
-    TooltipConfig,
     TooltipContext,
 } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
 import { hasBreakdown } from 'scenes/funnels/funnelUtils'
@@ -29,6 +30,8 @@ import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
 import { isFunnelsQuery } from '~/queries/utils'
 import { ChartParams, type FlattenedFunnelStepByBreakdown } from '~/types'
 
+import { InsightSeriesTooltip } from '../../shared/InsightSeriesTooltip'
+import { INSIGHT_TOOLTIP_CONFIG, INSIGHT_TOOLTIP_CONFIG_LEGACY } from '../../shared/tooltipConfig'
 import { AnnotationsLayer } from '../../trends/shared/AnnotationsLayer'
 import { buildBaseLegendConfig } from '../../trends/shared/buildBaseLegendConfig'
 import { FUNNEL_CONVERSION_SERIES_LABEL, type FunnelSeriesMeta } from '../shared/funnelSeriesMeta'
@@ -36,7 +39,6 @@ import { buildFunnelLineSeries, buildFunnelLineTimeSeriesConfig, type IndexedFun
 import { FunnelLineTooltip } from './FunnelLineTooltip'
 import { type FunnelLineChartClickDeps, handleFunnelLineChartClick } from './handleFunnelLineChartClick'
 
-const TOOLTIP_CONFIG: TooltipConfig = { pinnable: true, placement: 'top' }
 const EMPTY_STRINGS: string[] = []
 
 const handleChartError = (error: Error, info: ErrorInfo): void => {
@@ -65,6 +67,9 @@ export function FunnelLineChart({
 }: Omit<ChartParams, 'filters'>): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+    const TOOLTIP_CONFIG = quillTooltipEnabled ? INSIGHT_TOOLTIP_CONFIG : INSIGHT_TOOLTIP_CONFIG_LEGACY
     const { insightProps, insight, canEditInsight } = useValues(insightLogic)
 
     const {
@@ -162,55 +167,110 @@ export function FunnelLineChart({
         ]
     )
 
-    if (!isFunnelsQuery(querySource)) {
-        return null
-    }
-
     const resolvedGroupTypeLabel = resolveGroupTypeLabel(labelGroupType, aggregationLabel)
     const labels = steps[0]?.labels ?? EMPTY_STRINGS
     const annotationDates = steps[0]?.days ?? EMPTY_STRINGS
     const showAnnotations = !inSharedMode && funnelsFilter?.showAnnotations !== false
 
-    const clickDeps: FunnelLineChartClickDeps = {
-        hasPersonsModal: showPersonsModal,
-        querySource,
-        interval,
-        timezone,
-        weekStartDay,
-        resolvedDateRange: insightData?.resolved_date_range ?? null,
-        breakdownFilter,
-        aggregationTargetLabel,
-        cohorts: allCohorts.results,
-        formatPropertyValueForDisplay,
-        openPersonsModal,
-    }
-
-    const onPointClick = (clickData: PointClickData<FunnelSeriesMeta>): void => {
-        if (clickData.series.meta) {
-            handleFunnelLineChartClick(clickData.series.meta, clickData.dataIndex, clickDeps)
-        }
-    }
-
-    const renderTooltip = (ctx: TooltipContext<FunnelSeriesMeta>): JSX.Element => (
-        <FunnelLineTooltip
-            context={ctx}
-            timezone={timezone}
-            interval={interval ?? undefined}
-            breakdownFilter={breakdownFilter ?? undefined}
-            dateRange={insightData?.resolved_date_range ?? undefined}
-            groupTypeLabel={resolvedGroupTypeLabel}
-            onRowClick={
-                showPersonsModal
-                    ? (datum: SeriesDatum) => {
-                          const meta = ctx.seriesData[datum.datasetIndex]?.series.meta
-                          if (meta) {
-                              handleFunnelLineChartClick(meta, datum.dataIndex, clickDeps)
-                          }
-                      }
-                    : undefined
-            }
-        />
+    const clickDeps = useMemo<FunnelLineChartClickDeps>(
+        () => ({
+            hasPersonsModal: showPersonsModal,
+            querySource,
+            interval,
+            timezone,
+            weekStartDay,
+            resolvedDateRange: insightData?.resolved_date_range ?? null,
+            breakdownFilter,
+            aggregationTargetLabel,
+            cohorts: allCohorts.results,
+            formatPropertyValueForDisplay,
+            openPersonsModal,
+        }),
+        [
+            showPersonsModal,
+            querySource,
+            interval,
+            timezone,
+            weekStartDay,
+            insightData?.resolved_date_range,
+            breakdownFilter,
+            aggregationTargetLabel,
+            allCohorts.results,
+            formatPropertyValueForDisplay,
+        ]
     )
+
+    const onPointClick = useCallback(
+        (clickData: PointClickData<FunnelSeriesMeta>): void => {
+            if (clickData.series.meta) {
+                handleFunnelLineChartClick(clickData.series.meta, clickData.dataIndex, clickDeps)
+            }
+        },
+        [clickDeps]
+    )
+
+    const renderTooltip = useCallback(
+        (ctx: TooltipContext<FunnelSeriesMeta>): JSX.Element => {
+            if (quillTooltipEnabled) {
+                return (
+                    <InsightSeriesTooltip
+                        context={ctx}
+                        timezone={timezone}
+                        interval={interval ?? undefined}
+                        breakdownFilter={breakdownFilter ?? undefined}
+                        dateRange={insightData?.resolved_date_range ?? undefined}
+                        groupTypeLabel={resolvedGroupTypeLabel}
+                        renderSeriesOverride={(datum) => datum.label ?? ''}
+                        renderCount={(value) => `${value}%`}
+                        onRowClick={
+                            showPersonsModal
+                                ? (datum) => {
+                                      const meta = ctx.seriesData[datum.datasetIndex]?.series.meta
+                                      if (meta) {
+                                          handleFunnelLineChartClick(meta, datum.dataIndex, clickDeps)
+                                      }
+                                  }
+                                : undefined
+                        }
+                    />
+                )
+            }
+            return (
+                <FunnelLineTooltip
+                    context={ctx}
+                    timezone={timezone}
+                    interval={interval ?? undefined}
+                    breakdownFilter={breakdownFilter ?? undefined}
+                    dateRange={insightData?.resolved_date_range ?? undefined}
+                    groupTypeLabel={resolvedGroupTypeLabel}
+                    onRowClick={
+                        showPersonsModal
+                            ? (datum: SeriesDatum) => {
+                                  const meta = ctx.seriesData[datum.datasetIndex]?.series.meta
+                                  if (meta) {
+                                      handleFunnelLineChartClick(meta, datum.dataIndex, clickDeps)
+                                  }
+                              }
+                            : undefined
+                    }
+                />
+            )
+        },
+        [
+            quillTooltipEnabled,
+            timezone,
+            interval,
+            breakdownFilter,
+            insightData?.resolved_date_range,
+            resolvedGroupTypeLabel,
+            showPersonsModal,
+            clickDeps,
+        ]
+    )
+
+    if (!isFunnelsQuery(querySource)) {
+        return null
+    }
 
     return (
         <TimeSeriesLineChart<FunnelSeriesMeta>

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -7,6 +7,8 @@ import type { PointClickData, TooltipContext } from '@posthog/quill-charts'
 
 import { buildTheme } from 'lib/charts/utils/theme'
 import { ScrollableShadows } from 'lib/components/ScrollableShadows/ScrollableShadows'
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { StepLegend } from 'scenes/funnels/FunnelBarVertical/StepLegend'
 import { funnelDataLogic } from 'scenes/funnels/funnelDataLogic'
 import { funnelPersonsModalLogic } from 'scenes/funnels/funnelPersonsModalLogic'
@@ -47,6 +49,8 @@ export function FunnelStepsBarChart({
     inCardView,
 }: ChartParams): JSX.Element | null {
     const { isDarkModeOn } = useValues(themeLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
     // buildTheme() reads CSS vars; we re-memo on isDarkModeOn so the theme refreshes
     // when the user toggles dark mode even though the function takes no arguments.
     const theme = useMemo(() => buildTheme(), [isDarkModeOn])
@@ -82,10 +86,13 @@ export function FunnelStepsBarChart({
     const isBreakdownCompare = steps[0]?.nested_breakdown?.some(
         (variant) => variant.compare_label != null && hasBreakdown(variant.breakdown_value)
     )
-    const config = useMemo(
-        () => (isBreakdownCompare ? { ...chartConfig, legend: { show: true, interactive: false } } : chartConfig),
-        [isBreakdownCompare]
-    )
+    const config = useMemo(() => {
+        const base = isBreakdownCompare ? { ...chartConfig, legend: { show: true, interactive: false } } : chartConfig
+        if (quillTooltipEnabled) {
+            return { ...base, tooltip: { placement: 'cursor' as const } }
+        }
+        return base
+    }, [isBreakdownCompare, quillTooltipEnabled])
 
     const groupTypeLabel = aggregationLabel(querySource?.aggregation_group_type_index).plural
     const showTime = steps.some((step) => step.average_conversion_time != null)

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarChart.tsx
@@ -89,7 +89,7 @@ export function FunnelStepsBarChart({
     const config = useMemo(() => {
         const base = isBreakdownCompare ? { ...chartConfig, legend: { show: true, interactive: false } } : chartConfig
         if (quillTooltipEnabled) {
-            return { ...base, tooltip: { placement: 'cursor' as const } }
+            return { ...base, tooltip: { pinnable: true, placement: 'cursor' as const } }
         }
         return base
     }, [isBreakdownCompare, quillTooltipEnabled])

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
@@ -64,7 +64,7 @@ export function FunnelStepsBarTooltip({
     }
 
     return quillTooltipEnabled ? (
-        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} />
+        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} color={entry.color} />
     ) : (
         <FunnelTooltip {...sharedProps} />
     )

--- a/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/FunnelStepsBarChart/FunnelStepsBarTooltip.tsx
@@ -1,11 +1,16 @@
+import { useValues } from 'kea'
+
 import type { TooltipContext } from '@posthog/quill-charts'
 
+import { FEATURE_FLAGS } from 'lib/constants'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { FunnelTooltip } from 'scenes/funnels/FunnelTooltip'
 import { funnelComparePeriodDateRange, getFunnelAggregateConversionRate } from 'scenes/funnels/funnelUtils'
 
 import type { BreakdownFilter } from '~/queries/schema/schema-general'
 import type { FunnelStepWithConversionMetrics } from '~/types'
 
+import { FunnelStepTooltip } from '../shared/FunnelStepTooltip'
 import type { FunnelStepsBarSeriesMeta } from './funnelStepsBarTransforms'
 
 interface FunnelStepsBarTooltipProps {
@@ -27,6 +32,9 @@ export function FunnelStepsBarTooltip({
     resolvedDateRange,
     compareTo,
 }: FunnelStepsBarTooltipProps): JSX.Element | null {
+    const { featureFlags } = useValues(featureFlagLogic)
+    const quillTooltipEnabled = !!featureFlags[FEATURE_FLAGS.PRODUCT_ANALYTICS_INSIGHTS_TOOLTIPS]
+
     const stepIndex = context.dataIndex
     const step = steps[stepIndex]
     const entry = context.seriesData[0]
@@ -37,20 +45,27 @@ export function FunnelStepsBarTooltip({
     const breakdownIndex = entry.series.meta?.breakdownIndex ?? 0
     const series = step.nested_breakdown?.[breakdownIndex] ?? step
     const aggregateConversionRate = getFunnelAggregateConversionRate(series, step)
+    const comparePeriodDateRange = series.compare_label
+        ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
+        : null
 
-    return (
-        <FunnelTooltip
-            showPersonsModal={showPersonsModal}
-            stepIndex={stepIndex}
-            series={series}
-            groupTypeLabel={groupTypeLabel}
-            breakdownFilter={breakdownFilter}
-            aggregateConversionRate={aggregateConversionRate}
-            comparePeriodDateRange={
-                series.compare_label
-                    ? funnelComparePeriodDateRange(series.compare_label, resolvedDateRange, compareTo)
-                    : null
-            }
-        />
+    // Vertical bar chart: cursor above the bar's top pixel is in the track (drop-off) region.
+    const isDropOffHover =
+        stepIndex > 0 && context.hoverPosition != null && entry.yPixel != null && context.hoverPosition.y < entry.yPixel
+
+    const sharedProps = {
+        showPersonsModal,
+        stepIndex,
+        series,
+        groupTypeLabel,
+        breakdownFilter,
+        aggregateConversionRate,
+        comparePeriodDateRange,
+    }
+
+    return quillTooltipEnabled ? (
+        <FunnelStepTooltip {...sharedProps} isDropOffHover={isDropOffHover} />
+    ) : (
+        <FunnelTooltip {...sharedProps} />
     )
 }

--- a/products/product_analytics/frontend/insights/funnels/shared/FunnelStepTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/shared/FunnelStepTooltip.tsx
@@ -1,6 +1,6 @@
 import { useValues } from 'kea'
 
-import { TooltipSurface } from '@posthog/quill-charts'
+import { TooltipSurface, TooltipSwatch } from '@posthog/quill-charts'
 
 import { humanFriendlyDuration } from 'lib/utils/durations'
 import { humanFriendlyNumber, percentage } from 'lib/utils/numbers'
@@ -23,6 +23,8 @@ export interface FunnelStepTooltipProps {
     aggregateConversionRate?: number | null
     /** True when the cursor is over the unfilled track area (drop-off region) rather than the bar. */
     isDropOffHover?: boolean
+    /** Series color — renders a swatch dot next to the step header. */
+    color?: string
 }
 
 export function FunnelStepTooltip({
@@ -34,6 +36,7 @@ export function FunnelStepTooltip({
     comparePeriodDateRange,
     aggregateConversionRate,
     isDropOffHover = false,
+    color,
 }: FunnelStepTooltipProps): JSX.Element {
     const { allCohorts } = useValues(cohortsModel)
     const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
@@ -93,7 +96,8 @@ export function FunnelStepTooltip({
 
     return (
         <TooltipSurface>
-            <div className="font-semibold mb-0.5">
+            <div className="flex items-center gap-1.5 font-semibold mb-0.5">
+                {color && <TooltipSwatch color={color} />}
                 Step {stepIndex + 1}: {eventName}
             </div>
             {subLabel && <div className="mb-1 text-xs opacity-50 truncate">{subLabel}</div>}

--- a/products/product_analytics/frontend/insights/funnels/shared/FunnelStepTooltip.tsx
+++ b/products/product_analytics/frontend/insights/funnels/shared/FunnelStepTooltip.tsx
@@ -1,0 +1,115 @@
+import { useValues } from 'kea'
+
+import { TooltipSurface } from '@posthog/quill-charts'
+
+import { humanFriendlyDuration } from 'lib/utils/durations'
+import { humanFriendlyNumber, percentage } from 'lib/utils/numbers'
+import { funnelTooltipHeaderLabel, hasBreakdown } from 'scenes/funnels/funnelUtils'
+import { formatBreakdownLabel, getDisplayNameFromEntityFilter } from 'scenes/insights/utils'
+import { getActionFilterFromFunnelStep } from 'scenes/insights/views/Funnels/funnelStepTableUtils'
+
+import { cohortsModel } from '~/models/cohortsModel'
+import { propertyDefinitionsModel } from '~/models/propertyDefinitionsModel'
+import { BreakdownFilter } from '~/queries/schema/schema-general'
+import { FunnelStepWithConversionMetrics } from '~/types'
+
+export interface FunnelStepTooltipProps {
+    showPersonsModal: boolean
+    stepIndex: number
+    series: FunnelStepWithConversionMetrics
+    groupTypeLabel: string
+    breakdownFilter: BreakdownFilter | null | undefined
+    comparePeriodDateRange?: string | null
+    aggregateConversionRate?: number | null
+    /** True when the cursor is over the unfilled track area (drop-off region) rather than the bar. */
+    isDropOffHover?: boolean
+}
+
+export function FunnelStepTooltip({
+    showPersonsModal,
+    stepIndex,
+    series,
+    groupTypeLabel,
+    breakdownFilter,
+    comparePeriodDateRange,
+    aggregateConversionRate,
+    isDropOffHover = false,
+}: FunnelStepTooltipProps): JSX.Element {
+    const { allCohorts } = useValues(cohortsModel)
+    const { formatPropertyValueForDisplay } = useValues(propertyDefinitionsModel)
+
+    const eventName =
+        getDisplayNameFromEntityFilter(getActionFilterFromFunnelStep(series)) ?? series.name ?? series.action_id
+
+    const breakdownLabel = hasBreakdown(series.breakdown_value)
+        ? formatBreakdownLabel(
+              series.breakdown_value,
+              breakdownFilter,
+              allCohorts.results,
+              formatPropertyValueForDisplay
+          )
+        : null
+
+    const subLabel = funnelTooltipHeaderLabel({
+        breakdownLabel: !series.compare_label || hasBreakdown(series.breakdown_value) ? breakdownLabel : null,
+        compareLabel: series.compare_label,
+        comparePeriodDateRange,
+    })
+
+    const showDropOff = isDropOffHover && stepIndex > 0
+
+    const rows: { label: string; value: string }[] = []
+    if (showDropOff) {
+        rows.push(
+            { label: 'Dropped off', value: humanFriendlyNumber(series.droppedOffFromPrevious) },
+            { label: 'Drop-off from previous', value: percentage(1 - series.conversionRates.fromPrevious, 2, true) },
+            { label: 'Drop-off from start', value: percentage(1 - series.conversionRates.total, 2, true) }
+        )
+    } else {
+        rows.push({ label: stepIndex === 0 ? 'Entered' : 'Converted', value: humanFriendlyNumber(series.count) })
+        if (stepIndex > 0) {
+            rows.push({
+                label: 'Conversion from previous',
+                value: percentage(series.conversionRates.fromPrevious, 2, true),
+            })
+        }
+        rows.push({ label: 'Conversion so far', value: percentage(series.conversionRates.total, 2, true) })
+        if (stepIndex > 0 && aggregateConversionRate != null) {
+            rows.push({ label: 'Baseline conversion rate', value: percentage(aggregateConversionRate, 2, true) })
+        }
+        if (stepIndex > 0 && series.median_conversion_time != null) {
+            rows.push({
+                label: 'Median time from previous',
+                value: humanFriendlyDuration(series.median_conversion_time, { maxUnits: 3 }),
+            })
+        }
+        if (stepIndex > 0 && series.average_conversion_time != null) {
+            rows.push({
+                label: 'Average time from previous',
+                value: humanFriendlyDuration(series.average_conversion_time, { maxUnits: 3 }),
+            })
+        }
+    }
+
+    return (
+        <TooltipSurface>
+            <div className="font-semibold mb-0.5">
+                Step {stepIndex + 1}: {eventName}
+            </div>
+            {subLabel && <div className="mb-1 text-xs opacity-50 truncate">{subLabel}</div>}
+            <div>
+                {rows.map(({ label, value }) => (
+                    <div key={label} className="flex items-center gap-2 min-w-0 py-0.5">
+                        <span className="flex-1 min-w-0 truncate opacity-75">{label}</span>
+                        <strong>{value}</strong>
+                    </div>
+                ))}
+            </div>
+            {showPersonsModal && (
+                <div className="mt-1 pt-1 border-t border-current/25 text-xs opacity-60 text-center">
+                    Click to view {groupTypeLabel}
+                </div>
+            )}
+        </TooltipSurface>
+    )
+}


### PR DESCRIPTION
## Problem

Follows from #67008. Funnel charts (bar vertical, bar horizontal, line) still used the old `FunnelTooltip` surface. This PR adds `FunnelStepTooltip` on the quill `TooltipSurface` and gates it behind the same flag.

## Changes

- **`FunnelStepTooltip`** — new component using quill's `TooltipSurface` directly; shows conversion stats (count, rates, timing) or drop-off stats depending on where the cursor is
- Drop-off detection: vertical bars compare `hoverPosition.y < entry.yPixel`; horizontal bars compare `hoverPosition.x > entry.yPixel` (correct because `yPixel` stores value-axis pixels — for horizontal bars the value axis is x)
- `FunnelStepsBarChart` / `FunnelStepsBarTooltip` / `FunnelBarHorizontalTooltip` / `FunnelLineChart` all gate between old `FunnelTooltip` and new via `quillTooltipEnabled`

Stacks on #67008 — merge that first.

## How did you test this code?

Agent-authored (human-directed). No new tests added — existing funnel chart tests remain on the legacy path until the flag is enabled.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — Built with Claude Code (Sonnet 4.6 1M).