### PR TITLE
fix(metrics): read ingest series_fingerprint, drop the MV hashing

### DIFF
--- a/bin/clickhouse-metrics.sql
+++ b/bin/clickhouse-metrics.sql
@@ -240,7 +240,8 @@ CREATE OR REPLACE TABLE kafka_metrics_avro
     `is_monotonic` Nullable(UInt8),
     `resource_attributes` Map(String, String),
     `instrumentation_scope` Nullable(String),
-    `attributes` Map(String, String)
+    `attributes` Map(String, String),
+    `series_fingerprint` Nullable(Int64)
 )
 ENGINE = Kafka('kafka:9092', 'clickhouse_metrics', 'clickhouse-metrics-avro', 'Avro')
 SETTINGS
@@ -280,19 +281,19 @@ AS SELECT
     toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id
 FROM kafka_metrics_avro settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
 
--- Two MVs on the existing kafka_metrics_avro: every clickhouse_metrics point
--- fans into metric_series (labels, deduped) and metric_samples (the tiny row),
--- alongside kafka_metrics_avro_mv -> metrics1. The series_fingerprint is computed
--- identically in both (over the JSON-decoded label maps) so the query-time join
--- matches; keep it in sync with SERIES_FINGERPRINT_SQL in metric_events.py.
+-- Two MVs on the existing kafka_metrics_avro: every clickhouse_metrics point fans
+-- into metric_series (labels, deduped) and metric_samples (the tiny row), alongside
+-- kafka_metrics_avro_mv -> metrics1. series_fingerprint is assigned ONCE at ingest
+-- (capture-logs) and shipped in the Avro payload; both MVs read it verbatim — they do
+-- NOT recompute it. ClickHouse never computes the identity (no cityHash64 over the
+-- maps), so the two tables cannot disagree and the hash cannot collapse. The Avro
+-- `long` carries the u64 bits as signed; reinterpretAsUInt64 restores them.
 drop table if exists kafka_metrics_avro_to_metric_series;
 CREATE MATERIALIZED VIEW kafka_metrics_avro_to_metric_series TO metric_series1
 AS SELECT
     toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id,
     ifNull(metric_name, '') as metric_name,
-    cityHash64(ifNull(metric_name, ''), ifNull(service_name, ''),
-               mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)),
-               mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes))) as series_fingerprint,
+    reinterpretAsUInt64(ifNull(series_fingerprint, 0)) as series_fingerprint,
     ifNull(metric_type, '') as metric_type,
     ifNull(unit, '') as unit,
     ifNull(service_name, '') as service_name,
@@ -306,9 +307,7 @@ CREATE MATERIALIZED VIEW kafka_metrics_avro_to_metric_samples TO metric_samples1
 AS SELECT
     toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id,
     ifNull(metric_name, '') as metric_name,
-    cityHash64(ifNull(metric_name, ''), ifNull(service_name, ''),
-               mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)),
-               mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes))) as series_fingerprint,
+    reinterpretAsUInt64(ifNull(series_fingerprint, 0)) as series_fingerprint,
     timestamp,
     ifNull(value, 0) as value,
     trace_id,

--- a/bin/clickhouse-metrics.sql
+++ b/bin/clickhouse-metrics.sql
@@ -288,32 +288,40 @@ FROM kafka_metrics_avro settings min_insert_block_size_rows=0, min_insert_block_
 -- NOT recompute it. ClickHouse never computes the identity (no cityHash64 over the
 -- maps), so the two tables cannot disagree and the hash cannot collapse. The Avro
 -- `long` carries the u64 bits as signed; reinterpretAsUInt64 restores them.
+-- Rows with a NULL series_fingerprint (a producer that predates the ingest change, or
+-- a rollback) are dropped, not coerced to 0: coalescing to a shared id would collapse
+-- every such series onto one ReplacingMergeTree row with arbitrary labels — silent join
+-- corruption. Dropped rows are recoverable by replaying the topic once ingest is live.
 drop table if exists kafka_metrics_avro_to_metric_series;
 CREATE MATERIALIZED VIEW kafka_metrics_avro_to_metric_series TO metric_series1
 AS SELECT
     toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id,
     ifNull(metric_name, '') as metric_name,
-    reinterpretAsUInt64(ifNull(series_fingerprint, 0)) as series_fingerprint,
+    reinterpretAsUInt64(assumeNotNull(series_fingerprint)) as series_fingerprint,
     ifNull(metric_type, '') as metric_type,
     ifNull(unit, '') as unit,
     ifNull(service_name, '') as service_name,
     mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), resource_attributes)) AS resource_attributes,
     mapSort(mapApply((k, v) -> (k, JSONExtractString(v)), attributes)) AS attributes,
     timestamp as last_seen
-FROM kafka_metrics_avro settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
+FROM kafka_metrics_avro
+WHERE series_fingerprint IS NOT NULL
+settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
 
 drop table if exists kafka_metrics_avro_to_metric_samples;
 CREATE MATERIALIZED VIEW kafka_metrics_avro_to_metric_samples TO metric_samples1
 AS SELECT
     toInt32OrZero(_headers.value[indexOf(_headers.name, 'team_id')]) as team_id,
     ifNull(metric_name, '') as metric_name,
-    reinterpretAsUInt64(ifNull(series_fingerprint, 0)) as series_fingerprint,
+    reinterpretAsUInt64(assumeNotNull(series_fingerprint)) as series_fingerprint,
     timestamp,
     ifNull(value, 0) as value,
     trace_id,
     span_id,
     ifNull(trace_flags, 0) as trace_flags
-FROM kafka_metrics_avro settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
+FROM kafka_metrics_avro
+WHERE series_fingerprint IS NOT NULL
+settings min_insert_block_size_rows=0, min_insert_block_size_bytes=0;
 
 -- Kafka consumer lag tracking
 create or replace table metrics_kafka_metrics

--- a/posthog/clickhouse/metrics/metric_events.py
+++ b/posthog/clickhouse/metrics/metric_events.py
@@ -7,19 +7,21 @@ from posthog.clickhouse.table_engines import Distributed, MergeTreeEngine, Repla
 # number, so inlining the label maps on every row would dwarf the data ~100x).
 #
 # - metric_series: one row per unique (metric, label-set), labels stored ONCE,
-#   keyed by a fingerprint. Deduped via ReplacingMergeTree.
-# - metric_samples: the hot table — tiny rows (fingerprint + timestamp + value),
-#   plus an inline trace_id so a spike can still pivot to its trace (empty for
-#   most points, so it compresses to ~nothing). Joined to metric_series on the
-#   fingerprint at query time.
+#   keyed by series_fingerprint. Deduped via ReplacingMergeTree.
+# - metric_samples: the hot table — tiny rows (series_fingerprint + timestamp +
+#   value), plus an inline trace_id so a spike can still pivot to its trace (empty
+#   for most points, so it compresses to ~nothing). Joined to metric_series on
+#   series_fingerprint at query time.
+#
+# series_fingerprint is assigned ONCE at ingest (rust/capture-logs computes it over
+# the canonical label set and ships it in the Avro payload); the ingest MVs store it
+# verbatim and never recompute it. This is the TSDB / Snuffle-default approach — the
+# storage engine must not compute identity, or two independent MVs diverge (and the
+# stored-map MV context corrupts the hash). See docs/internal/metrics for the history.
 #
 # Distinct from `metrics1` (pre-aggregated rollups for dashboards/alerts): this
 # keeps every raw sample, for exact quantiles, per-emission drill-down, and the
 # metric->trace pivot. Lives on the logs ClickHouse cluster next to logs/traces.
-#
-# The fingerprint must be computed identically wherever samples/series are
-# written (see the ingest MV); keep this expression and that MV in sync.
-SERIES_FINGERPRINT_SQL = "cityHash64(metric_name, service_name, mapSort(resource_attributes), mapSort(attributes))"
 
 SAMPLES_TABLE_NAME = "metric_samples1"
 SAMPLES_DISTRIBUTED_TABLE_NAME = "metric_samples"


### PR DESCRIPTION
## Problem

`metric_series` and `metric_samples` are joined on `series_fingerprint`, but it was recomputed independently in two ClickHouse materialized views. Recomputing identity in the storage engine is fragile — the two MVs can produce different values for the same row, and an MV that hashes a map column it also materializes can produce an inconsistent hash — which breaks the join.

## Changes

The ingest layer now assigns `series_fingerprint` at write time (stacked PR #67195), so ClickHouse just stores it.

- `kafka_metrics_avro` gains a `series_fingerprint Nullable(Int64)` column.
- Both ingest MVs read `reinterpretAsUInt64(series_fingerprint)` (the Avro `long` carries the u64 bits) instead of computing `cityHash64(...)` over the label maps. Labels are still decoded and stored on `metric_series`, but nothing hashes them, so the two tables agree by construction.
- Removes the now-unused `SERIES_FINGERPRINT_SQL` constant.

Storage tables are unchanged. The ingest Avro/Kafka tables and their MVs are hand-managed (not migrations), so production roll-out is manual DDL applied **after** the ingest change deploys.

## How did you test this code?

Agent (PostHog Code), automated only — no manual testing. Validated the new DDL against a local ClickHouse: the MV `SELECT` expressions type-check, and the rust→Avro→ClickHouse round-trip is bit-exact (`reinterpretAsUInt64` of the signed Avro `long` recovers the original u64 id). The series↔samples agreement is now structural — both MVs read the same stored column — so there is no cheap MV-level unit test to add beyond the ingest golden test in #67195; a SQL-source-scraping test would violate the testing conventions.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked on #67195. Together they move metric-series identity out of ClickHouse and into ingestion (TSDB / Snuffle-default). Considered and rejected: computing the hash in ClickHouse with explicit casts or a decoder-MV chain (still produced an inconsistent/collapsing hash in practice), and a pure wide-table store (regresses the disk win the series/samples split exists for). No repo skills were invoked. Requires #67195 deployed first.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
