### PR TITLE
fix(cdp): match recording-api tls posture for cdp-rerun-worker clickhouse client

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-rerun-worker.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-rerun-worker.consumer.ts
@@ -64,13 +64,9 @@ export class CdpRerunWorkerConsumer extends CdpConsumerBase<PluginsServerConfig>
         await this.jobQueues.hog_function.startAsProducer()
         await this.jobQueues.hog_flow.startAsProducer()
 
-        // Dedicated ClickHouse client for the paginator. The cluster's certs
-        // are issued for an internal hostname that doesn't match the one we
-        // dial in (`CLICKHOUSE_HOST` is typically a service-discovery name),
-        // so we override `checkServerIdentity` to no-op the hostname check
-        // while leaving the rest of the chain — signature, CA trust, expiry —
-        // verified. This is a narrower bypass than `rejectUnauthorized: false`,
-        // which would accept any cert from any signer.
+        // Dedicated ClickHouse client for the paginator. Internal ClickHouse
+        // uses self-signed certs with a hostname mismatch, same as the
+        // session-replay recording-api client.
         const chScheme = this.config.CLICKHOUSE_SECURE ? 'https' : 'http'
         const chPort = this.config.CLICKHOUSE_SECURE ? 8443 : 8123
         this.clickhouseClient = createClickHouseClient({
@@ -82,12 +78,7 @@ export class CdpRerunWorkerConsumer extends CdpConsumerBase<PluginsServerConfig>
             max_open_connections: 10,
             ...(this.config.CLICKHOUSE_SECURE
                 ? {
-                      http_agent: new https.Agent({
-                          keepAlive: true,
-                          maxSockets: 10,
-                          // Hostname-only bypass — full chain validation still runs.
-                          checkServerIdentity: () => undefined,
-                      }),
+                      http_agent: new https.Agent({ rejectUnauthorized: false, keepAlive: true, maxSockets: 10 }), // nosemgrep: problem-based-packs.insecure-transport.js-node.bypass-tls-verification.bypass-tls-verification
                   }
                 : {}),
         })


### PR DESCRIPTION
## Problem

The `cdp-rerun-worker` ClickHouse client uses a deliberately narrow TLS bypass (`checkServerIdentity: () => undefined`) that skips only hostname verification while keeping full certificate-chain validation. In prod the internal ClickHouse CA is not in Node's default trust store, so chain validation fails (`self-signed certificate in certificate chain` / `unable to verify the first certificate`), every paginator page throws, and no reruns execute. This is the same posture session-replay's recording-api hit and resolved in [#51888](https://github.com/PostHog/posthog/pull/51888).

## Changes

Swap the rerun paginator's ClickHouse `https.Agent` to `rejectUnauthorized: false` with a nosemgrep waiver, matching `nodejs/src/session-replay/recording-api/recording-api.ts:127`. The narrower bypass originated in [#58825 (review comment)](https://github.com/PostHog/posthog/pull/58825#discussion_r3259852742); it keeps chain validation, which is exactly what fails against the internal self-signed cert in prod. Proper cert plumbing was tried and reverted in [#51888](https://github.com/PostHog/posthog/pull/51888) (dev-only cert, prod `*.prod.posthog.dev` vs `*.prod-us.posthog.dev` hostname mismatch), so `rejectUnauthorized: false` is the established Node-side posture for internal ClickHouse.

## How did you test this code?

I'm an agent (Claude Code). No code paths change beyond the `https.Agent` options, so CI typecheck + the node test suite cover it. This targets a live prod incident: the rerun worker has been failing every paginator page with chain-validation errors, so no reruns run. Post-deploy smoke test (dev): tail the rerun worker pod logs for the absence of "self-signed certificate", trigger a rerun on a hog function and a hog flow, and confirm the wrapper job drains.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

None.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at Daniel Marchuk's direction after a prod incident. The fix matches [#51888](https://github.com/PostHog/posthog/pull/51888)'s conclusion from session-replay's recording-api; the narrower bypass it replaces came from [#58825](https://github.com/PostHog/posthog/pull/58825#discussion_r3259852742). No repo skills were invoked. Tracked separately (not in this PR): an infra-side fix for the ClickHouse cert hostname mismatch, and moving the rerun worker's ClickHouse reads to Django so the Node worker drops its direct CH dependency entirely.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ALDbBbGi8Cie41tsrUtWy1)_