### PR TITLE
fix(flags): make recent feature flags selectable in match criteria

### DIFF
--- a/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/hooks/useTaxonomicGroupsContext.test.tsx
@@ -101,4 +101,36 @@ describe('useTaxonomicGroupsContext', () => {
         expect(types.has(TaxonomicFilterGroupType.HogQLExpression)).toBe(true)
         expect(types.has(TaxonomicFilterGroupType.SuggestedFilters)).toBe(true)
     })
+
+    it.each([
+        {
+            description: 'an active flag is selectable',
+            flag: { id: 1, key: 'my-flag', name: 'My flag', active: true },
+            expectedDisabled: false,
+            expectedName: 'my-flag',
+        },
+        {
+            description: 'an explicitly inactive flag is disabled',
+            flag: { id: 1, key: 'my-flag', name: 'My flag', active: false },
+            expectedDisabled: true,
+            expectedName: 'my-flag (disabled)',
+        },
+        {
+            // Recents/pinned entries are persisted stripped to { name, id }, so they carry no
+            // `active` field; a missing `active` must not read as disabled or recently-used
+            // flags can no longer be picked as flag-dependency match criteria in this (rebuild)
+            // group definition either. See the same guard in taxonomicFilterLogic.test.ts.
+            description: 'a recently-used flag missing the active field stays selectable',
+            flag: { name: '732889', id: 732889 },
+            expectedDisabled: false,
+            expectedName: '732889',
+        },
+    ])('Feature Flags group getIsDisabled/getName: $description', ({ flag, expectedDisabled, expectedName }) => {
+        const { result } = renderHook(() => useTaxonomicGroupsContext({}), { wrapper })
+        const groups = buildTaxonomicGroups(result.current)
+        const flagGroup = groups.find((g) => g.type === TaxonomicFilterGroupType.FeatureFlags)
+        expect(flagGroup?.getIsDisabled).toBeDefined() // oxlint-disable-line jest/no-restricted-matchers
+        expect(flagGroup?.getIsDisabled?.(flag as any)).toBe(expectedDisabled)
+        expect(flagGroup?.getName?.(flag as any)).toBe(expectedName)
+    })
 })

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1203,6 +1203,49 @@ describe('taxonomicFilterLogic', () => {
         })
     })
 
+    describe('Feature Flags group keeps recently-used flags selectable', () => {
+        let flagLogic: ReturnType<typeof taxonomicFilterLogic.build>
+
+        beforeEach(() => {
+            flagLogic = taxonomicFilterLogic({
+                taxonomicFilterLogicKey: 'featureFlagDependencyTest',
+                taxonomicGroupTypes: [TaxonomicFilterGroupType.FeatureFlags],
+            })
+            flagLogic.mount()
+        })
+
+        afterEach(() => {
+            flagLogic.unmount()
+        })
+
+        it.each([
+            {
+                description: 'an active flag is selectable',
+                flag: { id: 1, key: 'my-flag', name: 'My flag', active: true },
+                expected: false,
+            },
+            {
+                description: 'an explicitly inactive flag is disabled',
+                flag: { id: 1, key: 'my-flag', name: 'My flag', active: false },
+                expected: true,
+            },
+            {
+                // Recents/pinned entries are persisted stripped to { name, id }, so they carry no
+                // `active` field; a missing `active` must not read as disabled or recently-used
+                // flags can no longer be picked as flag-dependency match criteria.
+                description: 'a recently-used flag missing the active field stays selectable',
+                flag: { name: '732889', id: 732889 },
+                expected: false,
+            },
+        ])('getIsDisabled: $description', ({ flag, expected }) => {
+            const flagGroup = flagLogic.values.taxonomicGroups.find(
+                (g) => g.type === TaxonomicFilterGroupType.FeatureFlags
+            )
+            expect(flagGroup?.getIsDisabled).toBeDefined() // oxlint-disable-line jest/no-restricted-matchers
+            expect(flagGroup?.getIsDisabled?.(flag as any)).toBe(expected)
+        })
+    })
+
     describe('SQL expression (HogQLExpression) group commits its value', () => {
         let hogqlLogic: ReturnType<typeof taxonomicFilterLogic.build>
         const onChange = jest.fn()

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.test.ts
@@ -1222,27 +1222,32 @@ describe('taxonomicFilterLogic', () => {
             {
                 description: 'an active flag is selectable',
                 flag: { id: 1, key: 'my-flag', name: 'My flag', active: true },
-                expected: false,
+                expectedDisabled: false,
+                expectedName: 'my-flag',
             },
             {
                 description: 'an explicitly inactive flag is disabled',
                 flag: { id: 1, key: 'my-flag', name: 'My flag', active: false },
-                expected: true,
+                expectedDisabled: true,
+                expectedName: 'my-flag (disabled)',
             },
             {
                 // Recents/pinned entries are persisted stripped to { name, id }, so they carry no
                 // `active` field; a missing `active` must not read as disabled or recently-used
-                // flags can no longer be picked as flag-dependency match criteria.
+                // flags can no longer be picked as flag-dependency match criteria. The same guard
+                // applies to getName, which would otherwise render "732889 (disabled)".
                 description: 'a recently-used flag missing the active field stays selectable',
                 flag: { name: '732889', id: 732889 },
-                expected: false,
+                expectedDisabled: false,
+                expectedName: '732889',
             },
-        ])('getIsDisabled: $description', ({ flag, expected }) => {
+        ])('getIsDisabled/getName: $description', ({ flag, expectedDisabled, expectedName }) => {
             const flagGroup = flagLogic.values.taxonomicGroups.find(
                 (g) => g.type === TaxonomicFilterGroupType.FeatureFlags
             )
             expect(flagGroup?.getIsDisabled).toBeDefined() // oxlint-disable-line jest/no-restricted-matchers
-            expect(flagGroup?.getIsDisabled?.(flag as any)).toBe(expected)
+            expect(flagGroup?.getIsDisabled?.(flag as any)).toBe(expectedDisabled)
+            expect(flagGroup?.getName?.(flag as any)).toBe(expectedName)
         })
     })
 

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1296,6 +1296,7 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         ),
                         // Recently-used entries are stored stripped of `active`, so treat only an explicit
                         // `false` as disabled — otherwise recent flags are wrongly disabled and unselectable.
+                        // Keep in sync with the Feature Flags group in utils/buildTaxonomicGroups.tsx.
                         getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
                         localItemsSearch: (items, query) => {
                             if (!query) {

--- a/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/taxonomicFilterLogic.tsx
@@ -1284,15 +1284,19 @@ export const taxonomicFilterLogic = kea<taxonomicFilterLogicType>([
                         endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
                         getName: (featureFlag: FeatureFlagType) => {
                             const name = featureFlag.key || featureFlag.name
-                            const isInactive = !featureFlag.active
+                            const isInactive = featureFlag.active === false
                             return isInactive ? `${name} (disabled)` : name
                         },
                         getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
                         getPopoverHeader: () => `Feature Flags`,
                         getIcon: (featureFlag: FeatureFlagType) => (
-                            <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
+                            <IconFlag
+                                className={clsx('size-4', featureFlag.active === false && 'text-muted-alt opacity-50')}
+                            />
                         ),
-                        getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
+                        // Recently-used entries are stored stripped of `active`, so treat only an explicit
+                        // `false` as disabled — otherwise recent flags are wrongly disabled and unselectable.
+                        getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
                         localItemsSearch: (items, query) => {
                             if (!query) {
                                 return items

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -831,6 +831,7 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             ),
             // Recently-used entries are stored stripped of `active`, so treat only an explicit
             // `false` as disabled — otherwise recent flags are wrongly disabled and unselectable.
+            // Keep in sync with the Feature Flags group in taxonomicFilterLogic.tsx.
             getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
             localItemsSearch: (items: TaxonomicDefinitionTypes[], query: string): TaxonomicDefinitionTypes[] => {
                 // Note: This function doesn't have direct access to the current value

--- a/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
+++ b/frontend/src/lib/components/TaxonomicFilter/utils/buildTaxonomicGroups.tsx
@@ -821,15 +821,17 @@ export function buildTaxonomicGroups(ctx: BuildTaxonomicGroupsContext): Taxonomi
             endpoint: combineUrl(`api/projects/${projectId}/feature_flags/`).url,
             getName: (featureFlag: FeatureFlagType) => {
                 const name = featureFlag.key || featureFlag.name
-                const isInactive = !featureFlag.active
+                const isInactive = featureFlag.active === false
                 return isInactive ? `${name} (disabled)` : name
             },
             getValue: (featureFlag: FeatureFlagType) => featureFlag.id || '',
             getPopoverHeader: () => `Feature Flags`,
             getIcon: (featureFlag: FeatureFlagType) => (
-                <IconFlag className={clsx('size-4', !featureFlag.active && 'text-muted-alt opacity-50')} />
+                <IconFlag className={clsx('size-4', featureFlag.active === false && 'text-muted-alt opacity-50')} />
             ),
-            getIsDisabled: (featureFlag: FeatureFlagType) => !featureFlag.active,
+            // Recently-used entries are stored stripped of `active`, so treat only an explicit
+            // `false` as disabled — otherwise recent flags are wrongly disabled and unselectable.
+            getIsDisabled: (featureFlag: FeatureFlagType) => featureFlag.active === false,
             localItemsSearch: (items: TaxonomicDefinitionTypes[], query: string): TaxonomicDefinitionTypes[] => {
                 // Note: This function doesn't have direct access to the current value
                 // The actual filtering logic needs to be implemented in the infinite list logic


### PR DESCRIPTION
## Problem

Feature-flag release conditions let you match on another feature flag (flag dependencies), picked through the TaxonomicFilter. The picker also surfaces a "Feature Flags - recent" section of recently-used flags. Flags in the recent section were **not selectable**, even when the exact same flag was selectable from the main "Feature Flags" section.

Closes #66492

## Changes

The `Feature Flags` group is the only TaxonomicFilter group with a `getIsDisabled` predicate, written as `!featureFlag.active`. Recently-used entries are persisted stripped down to `{ name, id }` with no `active` field, so `!undefined === true` marked every recent flag as disabled. Disabled rows short-circuit both the click (`InfiniteList`) and keyboard (`infiniteListLogic`) selection paths, so recent flags couldn't be picked — while a flag chosen from the main list (which carries live `active: true`) worked.

Fix: treat only an explicit `active === false` as inactive in the group's `getIsDisabled` / `getName` / `getIcon` predicates. Applied in **both** the legacy (`taxonomicFilterLogic`) and rebuild (`buildTaxonomicGroups`) group definitions so the experiment arms stay in parity. For live flags `boolean === false` is equivalent to `!boolean`, so active/inactive behaviour is unchanged; only recents (unknown state) flip from "disabled" back to "selectable".

## How did you test this code?

I'm an agent and did not manually click through the UI. Automated tests I actually ran:

- Added a parameterized regression test to `taxonomicFilterLogic.test.ts` ("Feature Flags group keeps recently-used flags selectable"): the group disables an explicitly inactive flag but keeps an active flag **and** a recent flag (missing `active`) selectable. I confirmed it catches the exact regression — reverting `getIsDisabled` to `!featureFlag.active` makes the recent-flag case fail (`Received: true, Expected: false`). No existing test exercised this group's disabled predicate against a stripped recent item.
- Full `frontend/src/lib/components/TaxonomicFilter/` suite: 24 suites / 505 tests pass.
- `oxfmt` (no changes) and `oxlint` (0 errors) on the changed files.

Typecheck: the change is type-trivial (`FeatureFlagType.active` is `boolean`). The project's `tsgo` checker isn't available in my sandbox and stock `tsc` OOMs on the full project, so the authoritative typecheck runs in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code (Opus 4.8), directed by @gustavohstrassburger. Skills invoked: `/modifying-taxonomic-filter` (flagged the legacy/rebuild mirroring requirement and the three-variant blast radius) and `/writing-tests` (the test value gate).

Root-causing notes for reviewers: `getIsDisabled` is the only `active`-reading gate that blocks selection, and recents are stored as `{ name, id }` so `active` is simply absent. I considered persisting `active`/`key` into the recents snapshot instead, but rejected it — the snapshot is intentionally minimal and generic across all groups, and a stored `active` would go stale. The rebuild menu doesn't consume `getIsDisabled` today, but I mirrored the change into `buildTaxonomicGroups` anyway to keep the two group definitions identical.

@greptile
