### PR TITLE
feat(flags): throttle remote_config PSAK usage per key and per team

### DIFF
--- a/posthog/test/test_rate_limit.py
+++ b/posthog/test/test_rate_limit.py
@@ -30,7 +30,10 @@ from posthog.rate_limit import (
     get_route_from_path,
 )
 
-from products.feature_flags.backend.api.feature_flag import RemoteConfigThrottle
+from products.feature_flags.backend.api.feature_flag import (
+    RemoteConfigProjectSecretApiKeyTeamThrottle,
+    RemoteConfigThrottle,
+)
 
 
 class TestUserAPI(APIBaseTest):
@@ -715,6 +718,26 @@ class TestUserAPI(APIBaseTest):
             self.assertEqual(throttle.rate, "1200/minute")
             self.assertEqual(throttle.num_requests, 1200)
             self.assertEqual(throttle.duration, 60)  # 1 minute in seconds
+
+    def test_remote_config_team_throttle_uses_custom_rate_for_team(self):
+        throttle = RemoteConfigProjectSecretApiKeyTeamThrottle()
+
+        mock_view = Mock()
+        mock_request = Mock()
+
+        with (
+            patch("products.feature_flags.backend.api.feature_flag.REMOTE_CONFIG_RATE_LIMITS", {123: "1200/minute"}),
+            patch.object(throttle, "safely_get_team_id_from_view", return_value=123),
+            patch.object(throttle.__class__.__bases__[0], "allow_request", return_value=True),
+        ):
+            result = throttle.allow_request(mock_request, mock_view)
+
+            self.assertTrue(result)
+            # The per-team throttle must apply the team's REMOTE_CONFIG_RATE_LIMITS override too, not
+            # just the per-key throttle, otherwise a configured per-team cap silently has no effect.
+            self.assertEqual(throttle.rate, "1200/minute")
+            self.assertEqual(throttle.num_requests, 1200)
+            self.assertEqual(throttle.duration, 60)
 
     @parameterized.expand(
         [

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -570,8 +570,10 @@ def _apply_remote_config_team_rate_override(throttle, view) -> None:
         try:
             custom_rate = REMOTE_CONFIG_RATE_LIMITS.get(team_id)
             if custom_rate:
+                num_requests, duration = throttle.parse_rate(custom_rate)
                 throttle.rate = custom_rate
-                throttle.num_requests, throttle.duration = throttle.parse_rate(throttle.rate)
+                throttle.num_requests = num_requests
+                throttle.duration = duration
         except Exception:
             logger.exception("Error getting team-specific rate limit for team %s", team_id)
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -562,6 +562,20 @@ def check_flag_limits_for_team(
 REMOTE_CONFIG_DEFAULT_RATE = "600/minute"
 
 
+def _apply_remote_config_team_rate_override(throttle, view) -> None:
+    # Raise or lower a specific team's remote_config cap via REMOTE_CONFIG_RATE_LIMITS. On any
+    # lookup/parse failure, leave the default rate in place rather than failing the request.
+    team_id = throttle.safely_get_team_id_from_view(view)
+    if team_id:
+        try:
+            custom_rate = REMOTE_CONFIG_RATE_LIMITS.get(team_id)
+            if custom_rate:
+                throttle.rate = custom_rate
+                throttle.num_requests, throttle.duration = throttle.parse_rate(throttle.rate)
+        except Exception:
+            logger.exception("Error getting team-specific rate limit for team %s", team_id)
+
+
 class RemoteConfigThrottle(PersonalOrProjectSecretApiKeyRateThrottle):
     # Per-key throttle; the PSAK-aware base also throttles PSAK requests, which the plain
     # PersonalApiKeyRateThrottle would let through.
@@ -569,18 +583,7 @@ class RemoteConfigThrottle(PersonalOrProjectSecretApiKeyRateThrottle):
     rate = REMOTE_CONFIG_DEFAULT_RATE
 
     def allow_request(self, request, view):
-        logger = logging.getLogger(__name__)
-
-        team_id = self.safely_get_team_id_from_view(view)
-        if team_id:
-            try:
-                custom_rate = REMOTE_CONFIG_RATE_LIMITS.get(team_id)
-                if custom_rate:
-                    self.rate = custom_rate
-                    self.num_requests, self.duration = self.parse_rate(self.rate)
-            except Exception:
-                logger.exception(f"Error getting team-specific rate limit for team {team_id}")
-
+        _apply_remote_config_team_rate_override(self, view)
         return super().allow_request(request, view)
 
 
@@ -591,16 +594,7 @@ class RemoteConfigProjectSecretApiKeyTeamThrottle(ProjectSecretApiKeyTeamRateThr
     rate = REMOTE_CONFIG_DEFAULT_RATE
 
     def allow_request(self, request, view):
-        logger = logging.getLogger(__name__)
-        team_id = self.safely_get_team_id_from_view(view)
-        if team_id:
-            try:
-                custom_rate = REMOTE_CONFIG_RATE_LIMITS.get(team_id)
-                if custom_rate:
-                    self.rate = custom_rate
-                    self.num_requests, self.duration = self.parse_rate(self.rate)
-            except Exception:
-                logger.exception(f"Error getting team-specific rate limit for team {team_id}")
+        _apply_remote_config_team_rate_override(self, view)
         return super().allow_request(request, view)
 
 

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -557,8 +557,8 @@ def check_flag_limits_for_team(
         )
 
 
-# Default per-key and per-team cap for remote_config. Per-team overrides come from
-# REMOTE_CONFIG_RATE_LIMITS and only apply to the per-key throttle below.
+# Default per-key and per-team cap for remote_config. Both throttles below respect
+# per-team overrides from REMOTE_CONFIG_RATE_LIMITS.
 REMOTE_CONFIG_DEFAULT_RATE = "600/minute"
 
 
@@ -586,10 +586,22 @@ class RemoteConfigThrottle(PersonalOrProjectSecretApiKeyRateThrottle):
 
 class RemoteConfigProjectSecretApiKeyTeamThrottle(ProjectSecretApiKeyTeamRateThrottle):
     # Per-team aggregate cap stacked alongside the per-key RemoteConfigThrottle so a project can't
-    # multiply its budget by minting many keys. Defense-in-depth for the new credential — real SDK
-    # volume hits the Rust flags service, not this endpoint.
+    # multiply its budget by minting many keys. Defense-in-depth for the new credential.
     scope = "feature_flag_remote_config_psak_team"
     rate = REMOTE_CONFIG_DEFAULT_RATE
+
+    def allow_request(self, request, view):
+        logger = logging.getLogger(__name__)
+        team_id = self.safely_get_team_id_from_view(view)
+        if team_id:
+            try:
+                custom_rate = REMOTE_CONFIG_RATE_LIMITS.get(team_id)
+                if custom_rate:
+                    self.rate = custom_rate
+                    self.num_requests, self.duration = self.parse_rate(self.rate)
+            except Exception:
+                logger.exception(f"Error getting team-specific rate limit for team {team_id}")
+        return super().allow_request(request, view)
 
 
 class EvaluationTagsChecker:

--- a/products/feature_flags/backend/api/feature_flag.py
+++ b/products/feature_flags/backend/api/feature_flag.py
@@ -62,7 +62,12 @@ from posthog.models.property import Property
 from posthog.permissions import TeamSecretTokenPermission, get_authenticator_scopes, is_service_auth
 from posthog.ph_client import feature_enabled_or_false
 from posthog.queries.base import determine_parsed_date_for_property_matching
-from posthog.rate_limit import BurstRateThrottle, ClickHouseBurstRateThrottle, ClickHouseSustainedRateThrottle
+from posthog.rate_limit import (
+    ClickHouseBurstRateThrottle,
+    ClickHouseSustainedRateThrottle,
+    PersonalOrProjectSecretApiKeyRateThrottle,
+    ProjectSecretApiKeyTeamRateThrottle,
+)
 from posthog.rbac.access_control_api_mixin import AccessControlViewSetMixin
 from posthog.rbac.user_access_control import UserAccessControlSerializerMixin
 from posthog.settings.feature_flags import REMOTE_CONFIG_RATE_LIMITS
@@ -552,9 +557,16 @@ def check_flag_limits_for_team(
         )
 
 
-class RemoteConfigThrottle(BurstRateThrottle):
+# Default per-key and per-team cap for remote_config. Per-team overrides come from
+# REMOTE_CONFIG_RATE_LIMITS and only apply to the per-key throttle below.
+REMOTE_CONFIG_DEFAULT_RATE = "600/minute"
+
+
+class RemoteConfigThrottle(PersonalOrProjectSecretApiKeyRateThrottle):
+    # Per-key throttle; the PSAK-aware base also throttles PSAK requests, which the plain
+    # PersonalApiKeyRateThrottle would let through.
     scope = "feature_flag_remote_config"
-    rate = "600/minute"
+    rate = REMOTE_CONFIG_DEFAULT_RATE
 
     def allow_request(self, request, view):
         logger = logging.getLogger(__name__)
@@ -570,6 +582,14 @@ class RemoteConfigThrottle(BurstRateThrottle):
                 logger.exception(f"Error getting team-specific rate limit for team {team_id}")
 
         return super().allow_request(request, view)
+
+
+class RemoteConfigProjectSecretApiKeyTeamThrottle(ProjectSecretApiKeyTeamRateThrottle):
+    # Per-team aggregate cap stacked alongside the per-key RemoteConfigThrottle so a project can't
+    # multiply its budget by minting many keys. Defense-in-depth for the new credential — real SDK
+    # volume hits the Rust flags service, not this endpoint.
+    scope = "feature_flag_remote_config_psak_team"
+    rate = REMOTE_CONFIG_DEFAULT_RATE
 
 
 class EvaluationTagsChecker:
@@ -4055,7 +4075,7 @@ class FeatureFlagViewSet(
             ProjectSecretAPIKeyAuthentication,
         ],
         permission_classes=[TeamSecretTokenPermission],
-        throttle_classes=[RemoteConfigThrottle],
+        throttle_classes=[RemoteConfigThrottle, RemoteConfigProjectSecretApiKeyTeamThrottle],
     )
     def remote_config(self, request: request.Request, **kwargs):
         response = self._remote_config_response(request, **kwargs)

--- a/products/feature_flags/backend/api/test/test_feature_flag.py
+++ b/products/feature_flags/backend/api/test/test_feature_flag.py
@@ -2190,6 +2190,47 @@ class TestFeatureFlag(APIBaseTest, ClickhouseTestMixin):
         buckets = client.hgetall(f"posthog:remote_config_requests:{self.team.pk}")
         self.assertEqual(sum(int(count) for count in buckets.values()), 1)
 
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    @patch("products.feature_flags.backend.api.feature_flag.RemoteConfigThrottle.rate", new="2/minute")
+    def test_remote_config_throttles_project_secret_api_key_requests(self, *_args):
+        # PSAK requests carry no personal API key, so a plain PersonalApiKeyRateThrottle would let
+        # them through unthrottled. RemoteConfigThrottle's PSAK-aware base must throttle them per key.
+        self._create_remote_config_flag()
+        token, _ = _make_feature_flag_psak(self.team, label="throttle")
+        self.client.logout()
+        cache.clear()
+
+        url = f"/api/projects/{self.team.id}/feature_flags/my-remote-config-flag/remote_config"
+        headers = {"authorization": f"Bearer {token}"}
+        for _ in range(2):
+            self.assertEqual(self.client.get(url, headers=headers).status_code, status.HTTP_200_OK)
+        self.assertEqual(self.client.get(url, headers=headers).status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+
+    @patch("posthog.rate_limit.is_rate_limit_enabled", return_value=True)
+    @patch(
+        "products.feature_flags.backend.api.feature_flag.RemoteConfigProjectSecretApiKeyTeamThrottle.rate",
+        new="2/minute",
+    )
+    def test_remote_config_team_throttle_caps_across_multiple_psaks(self, *_args):
+        # The per-team throttle exists to stop a project from multiplying its budget by minting keys.
+        # The per-key throttle stays at its default, so the only way the third request trips is the
+        # shared per-team bucket — two distinct keys, one team.
+        self._create_remote_config_flag()
+        token_a, _ = _make_feature_flag_psak(self.team, label="teamcapa")
+        token_b, _ = _make_feature_flag_psak(self.team, label="teamcapb")
+        self.client.logout()
+        cache.clear()
+
+        url = f"/api/projects/{self.team.id}/feature_flags/my-remote-config-flag/remote_config"
+        for _ in range(2):
+            self.assertEqual(
+                self.client.get(url, headers={"authorization": f"Bearer {token_a}"}).status_code, status.HTTP_200_OK
+            )
+        self.assertEqual(
+            self.client.get(url, headers={"authorization": f"Bearer {token_b}"}).status_code,
+            status.HTTP_429_TOO_MANY_REQUESTS,
+        )
+
     def test_remote_config_returns_response_even_if_shadow_raises(self):
         # The throwaway Rust shadow (phase 2) must never break the live endpoint, even if it raises.
         self.team.rotate_secret_token_and_save(user=self.user, is_impersonated_session=False)


### PR DESCRIPTION
## Problem

When #66557 added `ProjectSecretAPIKeyAuthentication` to `remote_config`, `RemoteConfigThrottle` was still based on `BurstRateThrottle`, which throttles by personal API key. PSAK requests carry no personal API key, so they passed through unthrottled. A project could also mint multiple PSAKs to multiply its per-key budget beyond the intended cap.

Part of #66176.

## Changes

- `RemoteConfigThrottle` now extends `PersonalOrProjectSecretApiKeyRateThrottle` instead of `BurstRateThrottle`, so PSAK requests count against the per-key throttle.
- Adds `RemoteConfigProjectSecretApiKeyTeamThrottle` stacked alongside the per-key throttle, capping the combined rate across all PSAKs for a given team.

## How did you test this code?

Two new tests in `TestFeatureFlag`:

- `test_remote_config_throttles_project_secret_api_key_requests`: a PSAK hitting the rate limit returns 429.
- `test_remote_config_team_throttle_caps_across_multiple_psaks`: two distinct keys for the same team; the per-team cap fires on the third request regardless of which key issues it.

Both use the `_make_feature_flag_psak` helper added in #66557.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Stacked on #66557 using Claude Code (Opus 4.8). After identifying that #66557 left `RemoteConfigThrottle` on the PSAK-unaware `BurstRateThrottle` base and added no per-team cap, only those two missing pieces were applied here. The per-key throttle base swap and the new team throttle class were tested against the full `remote_config` suite (26 tests passing) before committing.