### PR TITLE
fix(error-tracking): run embedding activity synchronously

### DIFF
--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -5,6 +5,7 @@ from django.conf import settings
 from django.db import transaction
 from django.utils.dateparse import parse_datetime
 
+import posthoganalytics
 from temporalio import activity
 
 from posthog.hogql import ast
@@ -15,8 +16,7 @@ from posthog.event_usage import groups
 from posthog.exceptions_capture import capture_exception
 from posthog.models import Team
 from posthog.ph_client import ph_scoped_capture
-from posthog.sync import database_sync_to_async
-from posthog.temporal.common.scoped import scoped_temporal
+from posthog.temporal.common.utils import close_db_connections
 
 from products.error_tracking.backend.indexed_embedding import EMBEDDING_TABLES
 from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2
@@ -327,23 +327,24 @@ def _merge_fingerprint_into_closest_issue(
 
 
 @activity.defn
-@scoped_temporal()
-async def merge_similar_fingerprints_activity(
+@posthoganalytics.scoped()
+@close_db_connections
+def merge_similar_fingerprints_activity(
     inputs: FingerprintEmbeddingResultInputs,
 ) -> FingerprintEmbeddingMergeResult:
     model_name: str | None = None
     try:
-        team = await Team.objects.aget(id=inputs.team_id)
+        team = Team.objects.get(id=inputs.team_id)
         model_name = _input_model_name(inputs)
 
         start = time.monotonic()
-        closest_fingerprints = await database_sync_to_async(_query_closest_fingerprints)(team, inputs, model_name)
+        closest_fingerprints = _query_closest_fingerprints(team, inputs, model_name)
         query_duration_seconds = time.monotonic() - start
         query_duration_ms = query_duration_seconds * 1000
 
         # Keep emitting candidate metrics for every run; merging is gated separately by configuration.
         _report_closest_fingerprint_metrics(team, inputs, closest_fingerprints, model_name, query_duration_ms)
-        merged_count = await database_sync_to_async(_merge_fingerprint_into_closest_issue)(
+        merged_count = _merge_fingerprint_into_closest_issue(
             team,
             inputs.fingerprint,
             closest_fingerprints,

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -5,7 +5,7 @@ from typing import cast
 
 import pytest
 from posthog.test.base import BaseTest
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
@@ -255,8 +255,7 @@ class TestFingerprintEmbeddingResultActivity:
         assert properties["rank_2_fingerprint"] == "fingerprint-2"
         assert properties["rank_3_fingerprint"] == "fingerprint-3"
 
-    @pytest.mark.asyncio
-    async def test_merge_activity_reports_distances(self) -> None:
+    def test_merge_activity_reports_distances(self) -> None:
         closest_fingerprints = [
             SimilarFingerprintDistance(fingerprint="fingerprint-1", distance=0.01),
             SimilarFingerprintDistance(fingerprint="fingerprint-2", distance=0.02),
@@ -265,8 +264,8 @@ class TestFingerprintEmbeddingResultActivity:
 
         with (
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.Team.objects.aget",
-                new=AsyncMock(return_value=MagicMock()),
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.Team.objects.get",
+                return_value=MagicMock(),
             ),
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities._query_closest_fingerprints",
@@ -276,7 +275,7 @@ class TestFingerprintEmbeddingResultActivity:
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities._report_closest_fingerprint_metrics"
             ),
         ):
-            result = await merge_similar_fingerprints_activity(_inputs())
+            result = merge_similar_fingerprints_activity(_inputs())
 
         assert result.merged_count == 0
         assert result.query_duration_ms is not None


### PR DESCRIPTION
## Problem

The fingerprint embedding merge Temporal activity is mostly synchronous Django and HogQL work, but it was implemented as an async activity that wrapped blocking work with sync-to-async helpers. That can serialize or stall activity execution and increase the chance of worker starvation under load.

## Changes

Convert merge_similar_fingerprints_activity to a sync Temporal activity:

- Use the regular Django ORM call path inside the activity thread pool.
- Replace async Temporal scoping with sync posthoganalytics.scoped().
- Add close_db_connections for Temporal worker DB connection hygiene.
- Update the existing activity test to call the sync function directly.

## How did you test this code?

Agent-run checks:

- ruff check products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py --fix
- ruff format products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
- ./bin/hogli test products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py::TestFingerprintEmbeddingResultActivity::test_merge_activity_reports_distances
- Commit hooks: bin/hogli lint:python:fix, bin/hogli format:python, uv run ty check

I also ran the full file with ./bin/hogli test products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py; the runnable tests passed, but three tests errored during local ClickHouse setup with Connection reset by peer (clickhouse:9000) before test execution.

The changed test is an existing coverage point for the activity returning the nearest fingerprint distances after the implementation moved from async to sync.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed; this is an internal Temporal activity implementation fix.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Agent work was performed in pi for the Error tracking CLI profile. Skills invoked: /error-tracking, /writing-tests, and /pr.

The activity was initially adjusted to use pooled sync-to-async wrappers, then converted to a fully sync Temporal activity because the code path is dominated by blocking Django, HogQL, and capture calls. This keeps the work in the Temporal activity executor instead of the async event loop and follows the existing pattern used by nearby Error tracking Temporal activities.