### PR TITLE
fix(visual-review): composite split/blend on a shared canvas when sizes differ

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -4212,6 +4212,10 @@ snapshots:
         hash: v1.k794b7964.f234d8bba15a289ddcb3f7344727caa2ec9359787701b7a4aed7e9956b2d21cd.8wKBjxsi-RYHaS6deJvY80dmc3qK40nOhl8ln1ZF-dU
     lemon-ui-visual-image-diff-viewer--new-snapshot--light:
         hash: v1.k794b7964.8eaf961359bfd2691a63ba1e0f98bad8da5d1d2f7598ce140a5cc361f656fdea.nVw_NtDUWN8hjco2koeQvjHQ6MPktn54QYMj-_6kzOA
+    lemon-ui-visual-image-diff-viewer--size-mismatch--dark:
+        hash: v1.k794b7964.a40dcffd115e0b79fa03d10d28b2ef52f61a765311cf126e3ebdd1c41d330b12.zRJ3GIxDGnQUNPMhKnh3vwR55w4zTmjuDkBgCGj9ySQ
+    lemon-ui-visual-image-diff-viewer--size-mismatch--light:
+        hash: v1.k794b7964.3e407459b75f886f4e174f7383d59cc7d1d0120880cf1bc35b191d719cf6fdc5.eFu6nM5QtbAbI-x7VCx3zQYEjla2WWHIYsd33Sq5oCY
     lemon-ui-visual-image-diff-viewer--small-image--dark:
         hash: v1.k794b7964.13781e9369ccfad5542a85edfbd547e4d6d770df8b5e5d0d8ec540e50608d453.RPeQpda22EpHoIa5b4UePdKIimFuTS9NAwcGP9ccfpM
     lemon-ui-visual-image-diff-viewer--small-image--light:
@@ -6801,13 +6805,13 @@ snapshots:
     scenes-app-tasks--empty--light:
         hash: v1.k794b7964.0f6cd8ff0b64d8ab73e1b52609e2d6f87831dad09bc8cef9e70cb1ad02721572.S-jlFvTMeb5xsf9f91lZsEXJikHQglCzmPq-dtm5U4g
     scenes-app-tasks--list-load-error--dark:
-        hash: v1.k794b7964.9566449737abdd51fde7d6056dc2aba9dfbc52df4e7d9ec026971e82adab1bfa.9mb2jTWhyqCPIfIPMjs6zvJegIBX1y5G9ArWSVOQFo4
+        hash: v1.k794b7964.679a98a2b40a0dd971f839bd05911a4731d9e260f7b3d84653444ba7f948d640.iWHOKIrhMSK9juLbhRrtU3MavkWhPELVhaAAMcqQ3Lw
     scenes-app-tasks--list-load-error--light:
         hash: v1.k794b7964.6206b9e3ba160ae9e49dd71ce75498ce51f900728b362140b02b15d4c75391fa.ApdMVwb1IsI_tfNk_a10Btf7Zm0LfVFFEFQtEGAkexg
     scenes-app-tasks--list-with-composer--dark:
-        hash: v1.k794b7964.ff98c916a8383d1a3db3d0b030e52b2bab714a41079e9d7d850d30f7232c03bf.2F3aP-7dlnPEOtrnABy8WmXw1V89hzYyWsru0kQox2c
+        hash: v1.k794b7964.bf8b6abf4b61c5a5a753a4a4b65a68a826083843c72ce5c84874a5f8b1a351f0.8_E1dRIEkR4aBflwi38DbZ24Bb-O8JlxNhV7r0ftFCM
     scenes-app-tasks--list-with-composer--light:
-        hash: v1.k794b7964.60972cd63c5c83da427e4b0743611c5d177ad985e8a08545808b4742ea960fbd.qwyV74M2FYn04RKZc6vNzqYCchdX_0stBFjGdfvI8Lg
+        hash: v1.k794b7964.645d8fb5c766ad02d84cde4622a5bbe7234addd10bcc9ee7c228cd522fc44527.LY9de-ZX-ogFSxm5PbmeU4XHXNOlvoXQoxXCHUqszVM
     scenes-app-tasks--loading--dark:
         hash: v1.k794b7964.69ddc531a9bf89b2b8ce29129535d0620558ec64b185f8e9d7db92f9736382d3.vUeBrUbNn9khUb2I-gcmXW5XdrRPbdMFFJ5LHeEEjTQ
     scenes-app-tasks--loading--light:
@@ -6817,17 +6821,17 @@ snapshots:
     scenes-app-tasks--mobile-list--light:
         hash: v1.k794b7964.a42e7297c99d46bf03e8ba9c7576b164e120a41c914d1d52824823140b8fae92.nCFkmftkVPQYI7UqGBF84D6YQ52LTeSiWkz6w_K_YWM
     scenes-app-tasks--mobile-new-task--dark:
-        hash: v1.k794b7964.04a9d2be080fb6586920169a05f14d1ee3fecab3a7bff2b54991540eeda24903.i5EHYx6N-QK-ooccoLVdyP0zpRT4Y7amJnLbP-6kXNg
+        hash: v1.k794b7964.de22e10e282dd787afc1fc4784d1aef6064b32b7c3bed6b3bced8ba776264cf2.UCqKfpWcRlmvwmvML2DjdyVQCwj3zUZpXlKA8wxMgVs
     scenes-app-tasks--mobile-new-task--light:
-        hash: v1.k794b7964.365b32bd25aaa19ef2b7e35db06b67fe57d09ce1f39890b4201080345cbc4fb3.CuVZNBxkDEtv9uVsE3Q1hQslA4Tqdut3NuB3xzATMYM
+        hash: v1.k794b7964.cf669044c3c0e2b6d870e588a22f58be3032bec6d90a2c1c3b1ee1412a491661.3mNJ_P0G8pSfhi3oEkjsTKKG7wVSFB9jdY7ujjDXj7k
     scenes-app-tasks--mobile-task-selected--dark:
         hash: v1.k794b7964.7a885468ce6eee10b0835ef0b76f5c5dd45d35d90273d972bcb8023d9c943b62.4O4SeGjvj3rHSH0F5LinWCoJv7oGd0UgG39TRxQQeEo
     scenes-app-tasks--mobile-task-selected--light:
         hash: v1.k794b7964.00797fdb57fa653b857ff7fdf25637a36d62cb154d37cecee705687ef02b17d3.M87ub65d6ey1Ny2hpCl6o-NLyohPeBZFZ6Mg7BmEIso
     scenes-app-tasks--new-task--dark:
-        hash: v1.k794b7964.11d853c9700358fc6fdca22552310c0e0dc473e86520ac6d12e5cb2eb7214c33.P5DdwQnae3_j0W-lKLUWqLwPdEdJP36bn10EIHFQp7E
+        hash: v1.k794b7964.bf8b6abf4b61c5a5a753a4a4b65a68a826083843c72ce5c84874a5f8b1a351f0.4_xbfeooSsTCGwEbJXXSsU9vEwOIJ51xCba_zMO0sL8
     scenes-app-tasks--new-task--light:
-        hash: v1.k794b7964.25133a1f325d13995ce3308d3373d31db214be56bc0ba1a7165f1351cc57463f.rw15Q9WFmYC5WA1DkSKApJMz0Zf0VmfsPXZilsqqZuw
+        hash: v1.k794b7964.645d8fb5c766ad02d84cde4622a5bbe7234addd10bcc9ee7c228cd522fc44527.fZHCwOXXgxl4XaSatDo2KaYmaFJ4cYUkRcsr2yOyPUE
     scenes-app-tasks--new-task-with-repository--dark:
         hash: v1.k794b7964.0b91a374f31195a572e4dc9ba06538fb24aa469715053646c59d6dcf55ce9d0a.mPiBMxgeYR2VFvWiyCVIqAffHpa1eWlmq1j6CelnInM
     scenes-app-tasks--new-task-with-repository--light:
@@ -6981,9 +6985,9 @@ snapshots:
     scenes-other-billing--billing-purchase-credits-modal--light:
         hash: v1.k794b7964.b5764f97504ff981a389efeec44dd4d86929f243fa3b99ab0516eb4bcddac2ad.k8EFOT3n4tKgKEC5-ciAKGmKQX4emuSKvVCOkG8TU7g
     scenes-other-billing--billing-unsubscribe-modal--dark:
-        hash: v1.k794b7964.7ea59c3b121732aad1f8ad5ec5f33eed306dfcd0c992b515541d6daddc9d5661.hHqqTxmzBhip204qeGiGjJz_2goglvSA5UlYGkbE2BY
+        hash: v1.k794b7964.bf23362f8d3eeaca42a81d90bffb0cfcad3d69db0c9548640205ea9d40cfd5c0.miqhMAHIL6Fb68ndgIpZa_csUkJtcg_PRk0NZq8BWsQ
     scenes-other-billing--billing-unsubscribe-modal--light:
-        hash: v1.k794b7964.f428982e8db3a7c8211c24350c1961614de906b6c0792e126f5a36adb7657fe5.lrIEyvhewbhXyW2rGHoJ9wtQ7vLk79vezl8Gd9IUsBI
+        hash: v1.k794b7964.2a3cd2eda6c147df2726e32164cce02a40cb94b48977d290e996b9987fad26fa.4rL_eJ3eah3KmxtMuEYAD0Ps42GQvnaTNoZj7FhGImA
     scenes-other-billing--billing-with-credit-cta--dark:
         hash: v1.k794b7964.959bdf4d047f8c5f1af0453848d5632b2dfcaaab80fe6d9cb3aa58dcb08fe760.vLS-1KEmdcBoEcV4l87e7jlR2VMAMvykgIITrkvqLCM
     scenes-other-billing--billing-with-credit-cta--light:
@@ -7379,7 +7383,7 @@ snapshots:
     scenes-other-verify-email--verify-email-success--dark:
         hash: v1.k794b7964.3b3f89da26026aafaeeb04b79b1c2f7f21b91d56acf7ad76a2242d46086463a7.sZSf6K-ItZuZiZHSzBmxiTU7sRbos5joJvbfVAyp-O8
     scenes-other-verify-email--verify-email-success--light:
-        hash: v1.k794b7964.1f24128f80808357aa6070f0d8ee2f4be9d5a338464ece4281d91049ab30156b.vhIUV_oRaIecJw0IVkeBeCAZu0ttwQ_fL-f6gfT7Xi8
+        hash: v1.k794b7964.31c0b25a6a0afe09b9de15ab8898bea420ea2c7732a94d4a24e08ae82a88a841.dcrA_mJ4lJtg5-KKuG6y-19qF3x3Zl973M0-ucq1994
     scenes-other-verify-email--verifying-email--dark:
         hash: v1.k794b7964.201433ed7ef608260796ca59a45e699ae75ad798a5c570d7288ca0d1b3d6eee2.Wj1ulHeBOQK9_FUTFUaczGiHoi_aDiG_m2Kampdomc4
     scenes-other-verify-email--verifying-email--light:

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.stories.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.stories.tsx
@@ -124,8 +124,32 @@ const smallCurrentSvg = `
 </svg>
 `
 
+// Same width as the baseline (1400) but taller (1120 vs 860) — exercises the
+// shared-canvas split/blend path where the canvas grows downward and the
+// shorter baseline keeps its top-left origin.
+const tallerCurrentSvg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1120" viewBox="0 0 1400 1120">
+  <defs>
+    <linearGradient id="bgD" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#f2f9f8"/>
+      <stop offset="1" stop-color="#e5f2f1"/>
+    </linearGradient>
+  </defs>
+  <rect width="1400" height="1120" fill="url(#bgD)"/>
+  <rect x="70" y="80" width="1260" height="960" rx="18" fill="#ffffff" stroke="#cfe2de"/>
+  <rect x="70" y="80" width="1260" height="70" rx="18" fill="#edf7f4"/>
+  <rect x="100" y="106" width="180" height="20" rx="10" fill="#c9ebe3"/>
+  <rect x="110" y="190" width="1180" height="560" rx="12" fill="#f6fbfa" stroke="#d5ebe6"/>
+  <rect x="140" y="220" width="520" height="180" rx="8" fill="#e7f4f1"/>
+  <rect x="700" y="220" width="560" height="500" rx="8" fill="#e6f4f1"/>
+  <rect x="110" y="780" width="1180" height="230" rx="12" fill="#dff1ec" stroke="#b7ded3"/>
+  <text x="140" y="910" fill="#5f8f85" font-size="30" font-family="Arial">New section added below the fold</text>
+</svg>
+`
+
 const baselineImage = toSvgDataUri(baselineSvg)
 const currentImage = toSvgDataUri(currentSvg)
+const tallerCurrentImage = toSvgDataUri(tallerCurrentSvg)
 const diffImage = toSvgDataUri(diffSvg)
 const newSnapshotImage = toSvgDataUri(newSnapshotSvg)
 const smallBaselineImage = toSvgDataUri(smallBaselineSvg)
@@ -155,6 +179,32 @@ export const NewSnapshot: Story = {
         diffUrl: null,
         diffPercentage: null,
         result: 'new',
+    },
+    render: (args) => (
+        <div className="p-6 bg-bg-light min-h-screen">
+            <div className="mx-auto max-w-[1240px]">
+                <VisualImageDiffViewer {...args} />
+            </div>
+        </div>
+    ),
+}
+
+// Baseline and current share a width but differ in height. In split mode the
+// two are composited on a shared canvas at one scale, top-left anchored, so
+// the added section reads as the page growing taller rather than both sides
+// being squashed to the smaller image's size.
+export const SizeMismatch: Story = {
+    args: {
+        baselineUrl: baselineImage,
+        currentUrl: tallerCurrentImage,
+        diffUrl: null,
+        diffPercentage: 18.2,
+        result: 'changed',
+        baselineWidth: 1400,
+        baselineHeight: 860,
+        currentWidth: 1400,
+        currentHeight: 1120,
+        mode: 'split',
     },
     render: (args) => (
         <div className="p-6 bg-bg-light min-h-screen">

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.stories.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.stories.tsx
@@ -147,9 +147,20 @@ const tallerCurrentSvg = `
 </svg>
 `
 
+// Diff image sized to the shared canvas (1400×1120), so the diff overlay
+// exercises the full-canvas (`h-full`) path — the added bottom section is the
+// primary change region.
+const tallerDiffSvg = `
+<svg xmlns="http://www.w3.org/2000/svg" width="1400" height="1120" viewBox="0 0 1400 1120">
+  <rect width="1400" height="1120" fill="transparent"/>
+  <rect x="110" y="780" width="1180" height="230" rx="12" fill="#ff4d9a" fill-opacity="0.5"/>
+</svg>
+`
+
 const baselineImage = toSvgDataUri(baselineSvg)
 const currentImage = toSvgDataUri(currentSvg)
 const tallerCurrentImage = toSvgDataUri(tallerCurrentSvg)
+const tallerDiffImage = toSvgDataUri(tallerDiffSvg)
 const diffImage = toSvgDataUri(diffSvg)
 const newSnapshotImage = toSvgDataUri(newSnapshotSvg)
 const smallBaselineImage = toSvgDataUri(smallBaselineSvg)
@@ -197,7 +208,7 @@ export const SizeMismatch: Story = {
     args: {
         baselineUrl: baselineImage,
         currentUrl: tallerCurrentImage,
-        diffUrl: null,
+        diffUrl: tallerDiffImage,
         diffPercentage: 18.2,
         result: 'changed',
         baselineWidth: 1400,

--- a/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
+++ b/frontend/src/lib/components/VisualImageDiffViewer/VisualImageDiffViewer.tsx
@@ -26,6 +26,16 @@ export interface VisualImageDiffViewerProps {
     /** Natural image width — images under 600px on both axes render at 2x with pixelated scaling */
     imageWidth?: number
     imageHeight?: number
+    /**
+     * Natural per-side dimensions. When baseline and current differ in size,
+     * split/blend composite both onto a shared canvas (the union of the two
+     * sizes) at one scale, anchored top-left, instead of rescaling each to
+     * fill the frame. Fall back to `imageWidth`/`imageHeight` when unset.
+     */
+    baselineWidth?: number
+    baselineHeight?: number
+    currentWidth?: number
+    currentHeight?: number
     mode?: ComparisonMode
     onModeChange?: (mode: ComparisonMode) => void
     /**
@@ -267,6 +277,10 @@ export function VisualImageDiffViewer({
     className,
     imageWidth,
     imageHeight,
+    baselineWidth,
+    baselineHeight,
+    currentWidth,
+    currentHeight,
     diffOverlayBoxes,
     diffOverlayWidth,
     diffOverlayHeight,
@@ -286,14 +300,58 @@ export function VisualImageDiffViewer({
     const supportsComparison = isComparisonResult(result)
     const hasBothImages = Boolean(baselineUrl && currentUrl)
     const hasDiffImage = Boolean(diffUrl)
+
+    // Natural per-side dimensions, falling back to the single size the caller
+    // already passes for matched-size snapshots.
+    const baselineNaturalWidth = baselineWidth ?? imageWidth
+    const baselineNaturalHeight = baselineHeight ?? imageHeight
+    const currentNaturalWidth = currentWidth ?? imageWidth
+    const currentNaturalHeight = currentHeight ?? imageHeight
+    // Shared compositing canvas = union of both sizes. split/blend overlay
+    // both images onto it at one scale, anchored top-left: when widths match
+    // the canvas only grows downward, when heights match it only grows to the
+    // right, and the smaller image keeps its top-left origin with the extra
+    // area left empty — so a size change reads as growth, not a rescale.
+    const canvasWidth =
+        baselineNaturalWidth !== undefined && currentNaturalWidth !== undefined
+            ? Math.max(baselineNaturalWidth, currentNaturalWidth)
+            : (baselineNaturalWidth ?? currentNaturalWidth)
+    const canvasHeight =
+        baselineNaturalHeight !== undefined && currentNaturalHeight !== undefined
+            ? Math.max(baselineNaturalHeight, currentNaturalHeight)
+            : (baselineNaturalHeight ?? currentNaturalHeight)
+    // Only set an explicit aspect ratio (and thus absolute-positioned image
+    // layers) when both canvas dims are known; otherwise fall back to letting
+    // the base image size the stage in normal flow.
+    const stageAspectRatio = canvasWidth && canvasHeight ? `${canvasWidth} / ${canvasHeight}` : undefined
+
     const isSmallImage =
-        imageWidth !== undefined &&
-        imageWidth < SMALL_IMAGE_THRESHOLD &&
-        (imageHeight === undefined || imageHeight < SMALL_IMAGE_THRESHOLD)
+        canvasWidth !== undefined &&
+        canvasWidth < SMALL_IMAGE_THRESHOLD &&
+        (canvasHeight === undefined || canvasHeight < SMALL_IMAGE_THRESHOLD)
     const pixelatedStyle = isSmallImage
-        ? { imageRendering: 'pixelated' as const, width: (imageWidth ?? 0) * 2, maxWidth: '100%' }
+        ? { imageRendering: 'pixelated' as const, width: (canvasWidth ?? 0) * 2, maxWidth: '100%' }
         : {}
     const pixelatedClass = isSmallImage ? '' : 'max-w-full'
+
+    // One image layer on the shared canvas. When the canvas size is known the
+    // layer is absolutely positioned at its true fraction of the canvas
+    // (top-left anchored); otherwise it falls back to filling the stage width.
+    const layerClass = stageAspectRatio ? 'block bg-black/5' : 'w-full h-auto block bg-black/5'
+    const layerStyle = (naturalWidth?: number, naturalHeight?: number): React.CSSProperties => {
+        const pixelated = isSmallImage ? { imageRendering: 'pixelated' as const } : {}
+        if (stageAspectRatio && canvasWidth && canvasHeight && naturalWidth && naturalHeight) {
+            return {
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: `${(naturalWidth / canvasWidth) * 100}%`,
+                height: `${(naturalHeight / canvasHeight) * 100}%`,
+                ...pixelated,
+            }
+        }
+        return pixelated
+    }
 
     const [internalMode, setInternalMode] = useState<ComparisonMode>('sideBySide')
     const requestedMode = controlledMode ?? internalMode
@@ -446,9 +504,9 @@ export function VisualImageDiffViewer({
         return (
             <div className="p-3 flex justify-center">
                 <div
-                    className="overflow-hidden rounded-lg border bg-bg-light inline-block max-w-full relative"
+                    className="overflow-hidden rounded-lg border bg-bg-light w-full max-w-full relative"
                     // eslint-disable-next-line react/forbid-dom-props
-                    style={isSmallImage ? { width: (imageWidth ?? 0) * 2, maxWidth: '100%' } : undefined}
+                    style={isSmallImage ? { width: (canvasWidth ?? 0) * 2, maxWidth: '100%' } : undefined}
                 >
                     {/* Base header — blend: both labels; split: "Before" left-aligned */}
                     <div className="flex items-center justify-between px-2 py-1 border-b bg-bg-3000 text-[11px] font-semibold uppercase tracking-wide">
@@ -465,15 +523,22 @@ export function VisualImageDiffViewer({
                         )}
                     </div>
 
-                    {/* Base image area */}
-                    <div ref={overlayRef} className="relative overflow-hidden">
+                    {/* Base image area — sized to the shared canvas so both the
+                     * baseline and the clipped "After" overlay composite at one
+                     * scale (see layerStyle). */}
+                    <div
+                        ref={overlayRef}
+                        className="relative overflow-hidden"
+                        // eslint-disable-next-line react/forbid-dom-props
+                        style={stageAspectRatio ? { aspectRatio: stageAspectRatio } : undefined}
+                    >
                         {baselineUrl ? (
                             <img
                                 src={baselineUrl}
                                 alt="Before snapshot"
-                                className="w-full h-auto bg-black/5 block"
+                                className={layerClass}
                                 // eslint-disable-next-line react/forbid-dom-props
-                                style={isSmallImage ? { imageRendering: 'pixelated' as const } : undefined}
+                                style={layerStyle(baselineNaturalWidth, baselineNaturalHeight)}
                             />
                         ) : (
                             <EmptyImageState title="Before snapshot missing" />
@@ -485,9 +550,12 @@ export function VisualImageDiffViewer({
                                 <img
                                     src={activeOverlayUrl}
                                     alt="Flicker frame"
-                                    className="w-full h-auto bg-black/5 block"
+                                    className={layerClass}
                                     // eslint-disable-next-line react/forbid-dom-props
-                                    style={isSmallImage ? { imageRendering: 'pixelated' as const } : undefined}
+                                    style={layerStyle(
+                                        flickerCurrentVisible ? currentNaturalWidth : baselineNaturalWidth,
+                                        flickerCurrentVisible ? currentNaturalHeight : baselineNaturalHeight
+                                    )}
                                 />
                             </div>
                         )}
@@ -504,9 +572,9 @@ export function VisualImageDiffViewer({
                                 <img
                                     src={activeOverlayUrl}
                                     alt="After snapshot"
-                                    className="w-full h-auto bg-black/5 block"
+                                    className={layerClass}
                                     // eslint-disable-next-line react/forbid-dom-props
-                                    style={isSmallImage ? { imageRendering: 'pixelated' as const } : undefined}
+                                    style={layerStyle(currentNaturalWidth, currentNaturalHeight)}
                                 />
                             </div>
                         )}
@@ -515,7 +583,7 @@ export function VisualImageDiffViewer({
                             <img
                                 src={diffUrl as string}
                                 alt="Diff overlay"
-                                className="absolute top-0 left-0 w-full h-auto mix-blend-screen pointer-events-none"
+                                className="absolute top-0 left-0 w-full h-full mix-blend-screen pointer-events-none"
                                 // eslint-disable-next-line react/forbid-dom-props
                                 style={{ opacity: diffOverlayOpacity / 100 }}
                             />
@@ -575,13 +643,17 @@ export function VisualImageDiffViewer({
                             <div className="flex items-center justify-end px-2 py-1 border-b bg-bg-3000 text-[11px] font-semibold uppercase tracking-wide">
                                 <span>After</span>
                             </div>
-                            <div className="relative">
+                            <div
+                                className="relative overflow-hidden"
+                                // eslint-disable-next-line react/forbid-dom-props
+                                style={stageAspectRatio ? { aspectRatio: stageAspectRatio } : undefined}
+                            >
                                 <img
                                     src={activeOverlayUrl}
                                     alt="After snapshot"
-                                    className="w-full h-auto bg-black/5 block"
+                                    className={layerClass}
                                     // eslint-disable-next-line react/forbid-dom-props
-                                    style={isSmallImage ? { imageRendering: 'pixelated' as const } : undefined}
+                                    style={layerStyle(currentNaturalWidth, currentNaturalHeight)}
                                 />
                                 {/* Second copy of the bbox overlay inside the
                                  * clipped After half so the boxes stay visible

--- a/frontend/src/lib/utils/apiHost.ts
+++ b/frontend/src/lib/utils/apiHost.ts
@@ -1,5 +1,6 @@
 import { getBackendHost } from 'lib/oauth/oauthClient'
 
+import { inStorybook, inStorybookTestRunner } from './dom'
 import { getAppContext } from './getAppContext'
 
 /**
@@ -36,7 +37,7 @@ export function liveEventsHostOrigin(): string | null {
         return 'https://live.eu.posthog.com'
     } else if (appOrigin === 'https://app.dev.posthog.dev') {
         return 'https://live.dev.posthog.dev'
-    } else if (process.env.STORYBOOK) {
+    } else if (inStorybook() || inStorybookTestRunner()) {
         return 'http://localhost:6006'
     }
 

--- a/frontend/src/scenes/authentication/verify-email/variants/legacy/LegacyVerifyEmail.tsx
+++ b/frontend/src/scenes/authentication/verify-email/variants/legacy/LegacyVerifyEmail.tsx
@@ -11,6 +11,7 @@ import { BridgePage } from 'lib/components/BridgePage/BridgePage'
 import { HeartHog, MailHog } from 'lib/components/hedgehogs'
 import { supportLogic } from 'lib/components/Support/supportLogic'
 import { Spinner } from 'lib/lemon-ui/Spinner/Spinner'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { urls } from 'scenes/urls'
 
 import { verifyEmailLogic } from '../../verifyEmailLogic'
@@ -170,10 +171,10 @@ function VerifyEmail(): JSX.Element {
                         {view === 'success' && (
                             <div aria-hidden className="VerifyEmail__ProgressBar">
                                 <div
-                                    className={clsx(
-                                        'VerifyEmail__ProgressBarTrack',
-                                        process.env.STORYBOOK && 'VerifyEmail__ProgressBarTrack--static'
-                                    )}
+                                    className={clsx('VerifyEmail__ProgressBarTrack', {
+                                        'VerifyEmail__ProgressBarTrack--static':
+                                            inStorybook() || inStorybookTestRunner(),
+                                    })}
                                 />
                             </div>
                         )}

--- a/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
+++ b/frontend/src/scenes/billing/UnsubscribeSurveyModal.tsx
@@ -19,6 +19,7 @@ import {
 import { HeartHog } from 'lib/components/hedgehogs'
 import { useHogfetti } from 'lib/components/Hogfetti/Hogfetti'
 import { supportLogic } from 'lib/components/Support/supportLogic'
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
 import { humanFriendlyCurrency } from 'lib/utils/numbers'
 
 import { BillingProductV2AddonType, BillingProductV2Type } from '~/types'
@@ -54,8 +55,8 @@ export const UnsubscribeSurveyModal = ({
     const { deactivateProduct, resetUnsubscribeError } = useActions(billingLogic)
     const { unsubscribeError, billingLoading, billing } = useValues(billingLogic)
     const { openSupportForm } = useActions(supportLogic)
-    const [randomizedReasons] = useState(
-        process?.env.STORYBOOK ? UNSUBSCRIBE_REASONS : randomizeReasons(UNSUBSCRIBE_REASONS)
+    const [randomizedReasons] = useState(() =>
+        inStorybook() || inStorybookTestRunner() ? UNSUBSCRIBE_REASONS : randomizeReasons(UNSUBSCRIBE_REASONS)
     )
 
     const textAreaNotEmpty = surveyResponse[SurveyEventProperties.SURVEY_RESPONSE]?.length > 0

--- a/frontend/src/scenes/max/maxLogic.tsx
+++ b/frontend/src/scenes/max/maxLogic.tsx
@@ -8,7 +8,7 @@ import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast/LemonToast'
 import { trackedActionToUrl } from 'lib/logic/scenes/trackedActionToUrl'
 import { tabUiStateLogic } from 'lib/logic/tabUiStateLogic'
-import { uuid } from 'lib/utils/dom'
+import { inStorybook, inStorybookTestRunner, uuid } from 'lib/utils/dom'
 import { objectsEqual } from 'lib/utils/objects'
 import { Scene } from 'scenes/sceneTypes'
 import { urls } from 'scenes/urls'
@@ -327,7 +327,7 @@ export const maxLogic = kea<maxLogicType>([
         headline: [
             (s) => [s.conversation, s.toolHeadlines, s.frontendConversationId],
             (conversation, toolHeadlines, frontendConversationId) => {
-                if (process.env.STORYBOOK) {
+                if (inStorybook() || inStorybookTestRunner()) {
                     return HEADLINES[0] // Preventing UI snapshots from being different every time
                 }
 

--- a/products/posthog_ai/frontend/components/welcome/welcomeDefaults.ts
+++ b/products/posthog_ai/frontend/components/welcome/welcomeDefaults.ts
@@ -1,6 +1,8 @@
 // Default, overridable content for the Welcome primitive. Shipped here so both consumers (the tasks
 // composer and the new PostHog AI welcome) share one source; pass your own list to override.
 
+import { inStorybook, inStorybookTestRunner } from 'lib/utils/dom'
+
 export const DEFAULT_HEADLINES: readonly string[] = [
     'How can I help you build?',
     'What are you curious about?',
@@ -17,7 +19,7 @@ export function pickHeadline(headlines: readonly string[] = DEFAULT_HEADLINES, s
     if (headlines.length === 0) {
         return ''
     }
-    if (process.env.STORYBOOK) {
+    if (inStorybook() || inStorybookTestRunner()) {
         return headlines[0]
     }
     const index = seed !== undefined ? seed % headlines.length : Math.floor(Math.random() * headlines.length)

--- a/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
+++ b/products/visual_review/frontend/components/SnapshotDiffViewer.tsx
@@ -233,6 +233,10 @@ export function SnapshotDiffViewer({
                         result={(snapshot.result || 'unchanged') as VisualDiffResult}
                         imageWidth={width ?? undefined}
                         imageHeight={height ?? undefined}
+                        baselineWidth={snapshot.baseline_artifact?.width ?? undefined}
+                        baselineHeight={snapshot.baseline_artifact?.height ?? undefined}
+                        currentWidth={snapshot.current_artifact?.width ?? undefined}
+                        currentHeight={snapshot.current_artifact?.height ?? undefined}
                         mode={comparisonMode}
                         onModeChange={setComparisonMode}
                         className="min-h-[200px]"


### PR DESCRIPTION
## Problem

In the visual review product, when a snapshot's baseline and current images have different dimensions, **split** and **blend** modes were hard to read. Both `<img>`s were forced to the same rendered width (`w-full`), and the container was sized by the "Before" image — so two differently sized screenshots ended up the same on-screen size. The size change disappeared, and because the two sides were scaled by different factors, the split wipe compared mismatched pixels.

## Changes

`VisualImageDiffViewer` now composites both images onto a **shared canvas** — the union of the two natural sizes (`max(width)` × `max(height)`) — at a single scale, anchored top-left:

- Same width, taller current → canvas grows **downward**; the shorter image keeps its top origin and the extra area below is empty.
- Same height, wider current → canvas grows to the **right**, left-anchored.
- The split wipe and blend overlay now line up pixel-for-pixel because both sides share one scale.

Matched-size snapshots are unaffected — the canvas collapses to the single image size and rendering is unchanged. The component takes optional `baselineWidth/Height` and `currentWidth/Height` props (wired through from `SnapshotDiffViewer` via the existing artifact dimensions); when absent it falls back to the previous behavior.

A `SizeMismatch` Storybook story is added (same width, taller current, split mode) to capture the new layout in visual regression.

## How did you test this code?

I'm an agent (PostHog Slack app). I did **not** manually test in a browser. Automated checks I actually ran on the changed files:

- `oxlint --quiet` — 0 warnings / 0 errors
- `oxfmt --check` — formatting clean
- `tsgo --noEmit` — no type errors in the changed files (the repo-wide run reports only pre-existing missing-`*Type.ts` typegen errors, none in these files)

The new `SizeMismatch` story exercises the size-mismatch split path, which no existing story covered (all prior stories used equal-size images).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built by the PostHog Slack app (Claude) at @rafaeelaudibert's request, originating from a Slack thread. The investigation first explored a fix in the `pixelhog` library, but tracing the product showed split mode never touches pixelhog — it composites the full-resolution artifacts in the browser — so the fix belongs here in the frontend. The chosen approach is a CSS shared-canvas (`aspect-ratio` stage + absolutely-positioned percentage-sized image layers) rather than rescaling images, which keeps one scale factor across both sides so the wipe stays aligned.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09G8QA6740/p1782857980848279)*
