### PR TITLE
fix(data-modeling): exclude duckgres shadow from matview failure digest

### DIFF
--- a/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
+++ b/ee/clickhouse/queries/test/__snapshots__/test_breakdown_props.ambr
@@ -79,36 +79,6 @@
   OFFSET 0
   '''
 # ---
-# name: TestBreakdownProps.test_breakdown_person_props_materialized
-  '''
-  
-  SELECT "pmat_$browser" AS value,
-         count(*) as count
-  FROM events e
-  INNER JOIN
-    (SELECT distinct_id,
-            argMax(person_id, version) as person_id
-     FROM person_distinct_id2
-     WHERE team_id = 99999
-     GROUP BY distinct_id
-     HAVING argMax(is_deleted, version) = 0) AS pdi ON e.distinct_id = pdi.distinct_id
-  INNER JOIN
-    (SELECT id,
-            argMax(pmat_$browser, version) as pmat_$browser
-     FROM person
-     WHERE team_id = 99999
-     GROUP BY id
-     HAVING max(is_deleted) = 0 SETTINGS optimize_aggregation_in_order = 1) person ON pdi.person_id = person.id
-  WHERE team_id = 99999
-    AND event = '$pageview'
-    AND toTimeZone(timestamp, 'UTC') >= toDateTime('2019-12-21 00:00:00', 'UTC')
-    AND toTimeZone(timestamp, 'UTC') <= toDateTime('2020-01-04 23:59:59', 'UTC')
-  GROUP BY value
-  ORDER BY count DESC, value DESC
-  LIMIT 6
-  OFFSET 0
-  '''
-# ---
 # name: TestBreakdownProps.test_breakdown_person_props_with_entity_filter_and_or_props_with_partial_pushdown
   '''
   

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -751,8 +751,7 @@ def send_matview_failure_digest() -> None:
     cutoff = timezone.now() - datetime.timedelta(hours=24)
 
     # Latest DataModelingJob is the failure source of truth — v2 MaterializeViewWorkflow doesn't update SavedQuery.status.
-    # Exclude the duckgres shadow: it shares saved_query_id and stamps last_run_at, so a shadow failure would otherwise
-    # masquerade as the model's latest result and email a false alert for a model whose real materialization is healthy.
+    # The duckgres shadow shares saved_query_id and finalizes after ClickHouse, so it must not stand in for the serving job.
     latest_job = (
         DataModelingJob.objects.filter(saved_query_id=OuterRef("id"))
         .exclude(engine=DataModelingJobEngine.DUCKGRES)
@@ -836,7 +835,6 @@ def send_team_matview_failure_digest(team_id: int, failed_query_ids: list[str], 
     all_ids = list(set(failed_query_ids + paused_query_ids))
     queries = {str(sq.id): sq for sq in DataWarehouseSavedQuery.objects.filter(id__in=all_ids, team_id=team_id)}
 
-    # Exclude the duckgres shadow so a shadow failure can't surface as the model's latest result.
     latest_jobs: dict[str, DataModelingJob] = {}
     for latest_job in (
         DataModelingJob.objects.filter(saved_query_id__in=all_ids)

--- a/posthog/tasks/email.py
+++ b/posthog/tasks/email.py
@@ -738,7 +738,11 @@ def send_external_data_failure_digest(team_id: int, schemas: list[dict[str, Any]
 @shared_task(ignore_result=True)
 @skip_team_scope_audit
 def send_matview_failure_digest() -> None:
-    from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
+    from products.data_modeling.backend.facade.models import (
+        DataModelingJob,
+        DataModelingJobEngine,
+        DataWarehouseSavedQuery,
+    )
 
     if not is_email_available(with_absolute_urls=True):
         logger.warning("Email service is not available for materialized view digest")
@@ -747,9 +751,13 @@ def send_matview_failure_digest() -> None:
     cutoff = timezone.now() - datetime.timedelta(hours=24)
 
     # Latest DataModelingJob is the failure source of truth — v2 MaterializeViewWorkflow doesn't update SavedQuery.status.
-    latest_job = DataModelingJob.objects.filter(
-        saved_query_id=OuterRef("id"),
-    ).order_by("-last_run_at")
+    # Exclude the duckgres shadow: it shares saved_query_id and stamps last_run_at, so a shadow failure would otherwise
+    # masquerade as the model's latest result and email a false alert for a model whose real materialization is healthy.
+    latest_job = (
+        DataModelingJob.objects.filter(saved_query_id=OuterRef("id"))
+        .exclude(engine=DataModelingJobEngine.DUCKGRES)
+        .order_by("-last_run_at")
+    )
 
     failed_queries = (
         DataWarehouseSavedQuery.objects.filter(deleted=False, sync_frequency_interval__isnull=False)
@@ -806,7 +814,11 @@ def send_matview_failure_digest() -> None:
 @shared_task(**EMAIL_TASK_KWARGS)
 @skip_team_scope_audit
 def send_team_matview_failure_digest(team_id: int, failed_query_ids: list[str], paused_query_ids: list[str]) -> None:
-    from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
+    from products.data_modeling.backend.facade.models import (
+        DataModelingJob,
+        DataModelingJobEngine,
+        DataWarehouseSavedQuery,
+    )
 
     if not is_email_available(with_absolute_urls=True):
         return
@@ -824,9 +836,11 @@ def send_team_matview_failure_digest(team_id: int, failed_query_ids: list[str], 
     all_ids = list(set(failed_query_ids + paused_query_ids))
     queries = {str(sq.id): sq for sq in DataWarehouseSavedQuery.objects.filter(id__in=all_ids, team_id=team_id)}
 
+    # Exclude the duckgres shadow so a shadow failure can't surface as the model's latest result.
     latest_jobs: dict[str, DataModelingJob] = {}
     for latest_job in (
         DataModelingJob.objects.filter(saved_query_id__in=all_ids)
+        .exclude(engine=DataModelingJobEngine.DUCKGRES)
         .order_by("saved_query_id", "-last_run_at")
         .distinct("saved_query_id")
     ):

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -1954,6 +1954,44 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         else:
             assert len(mocked_email_messages) == 0
 
+    def test_send_matview_failure_digest_ignores_duckgres_shadow(self, MockEmailMessage: MagicMock) -> None:
+        from products.data_modeling.backend.facade.models import (
+            DataModelingJob,
+            DataModelingJobEngine,
+            DataWarehouseSavedQuery,
+        )
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        self.user.partial_notification_settings = {"materialized_view_sync_failed": True}
+        self.user.save()
+
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="healthy_view_with_failing_shadow",
+            query={"query": "SELECT 1"},
+            sync_frequency_interval=dt.timedelta(hours=1),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.COMPLETED,
+            last_run_at=timezone.now() - dt.timedelta(hours=2),
+        )
+        # duckgres shadow failed more recently than the healthy ClickHouse run — must not alert the customer
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.FAILED,
+            engine=DataModelingJobEngine.DUCKGRES,
+            error="duckgres translation gap",
+            last_run_at=timezone.now() - dt.timedelta(hours=1),
+        )
+
+        send_matview_failure_digest()
+
+        assert len(mocked_email_messages) == 0
+
     def test_send_matview_failure_digest_not_sent_by_default(self, MockEmailMessage: MagicMock) -> None:
         from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery
 

--- a/posthog/tasks/test/test_email.py
+++ b/posthog/tasks/test/test_email.py
@@ -1978,7 +1978,6 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
             status=DataModelingJob.Status.COMPLETED,
             last_run_at=timezone.now() - dt.timedelta(hours=2),
         )
-        # duckgres shadow failed more recently than the healthy ClickHouse run — must not alert the customer
         DataModelingJob.objects.create(
             team=self.team,
             saved_query=saved_query,
@@ -1991,6 +1990,48 @@ class TestEmail(APIBaseTest, ClickhouseTestMixin):
         send_matview_failure_digest()
 
         assert len(mocked_email_messages) == 0
+
+    def test_send_matview_failure_digest_shows_clickhouse_error_not_newer_shadow(
+        self, MockEmailMessage: MagicMock
+    ) -> None:
+        from products.data_modeling.backend.facade.models import (
+            DataModelingJob,
+            DataModelingJobEngine,
+            DataWarehouseSavedQuery,
+        )
+
+        mocked_email_messages = mock_email_messages(MockEmailMessage)
+
+        self.user.partial_notification_settings = {"materialized_view_sync_failed": True}
+        self.user.save()
+
+        saved_query = DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name="failing_view",
+            query={"query": "SELECT 1"},
+            sync_frequency_interval=dt.timedelta(hours=1),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.FAILED,
+            error="clickhouse boom",
+            last_run_at=timezone.now() - dt.timedelta(hours=2),
+        )
+        DataModelingJob.objects.create(
+            team=self.team,
+            saved_query=saved_query,
+            status=DataModelingJob.Status.FAILED,
+            engine=DataModelingJobEngine.DUCKGRES,
+            error="duckgres boom",
+            last_run_at=timezone.now() - dt.timedelta(hours=1),
+        )
+
+        send_matview_failure_digest()
+
+        assert len(mocked_email_messages) == 1
+        assert "clickhouse boom" in mocked_email_messages[0].html_body
+        assert "duckgres boom" not in mocked_email_messages[0].html_body
 
     def test_send_matview_failure_digest_not_sent_by_default(self, MockEmailMessage: MagicMock) -> None:
         from products.data_modeling.backend.facade.models import DataModelingJob, DataWarehouseSavedQuery


### PR DESCRIPTION
## Problem

The materialized-view failure digest emails customers about models whose materialization is failing. It picks the latest `DataModelingJob` per saved query ordered by `last_run_at`, with **no engine filter** (`posthog/tasks/email.py`, `send_matview_failure_digest` + `send_team_matview_failure_digest`).

The duckgres shadow runs alongside the ClickHouse materialization in the same workflow, shares the `saved_query_id`, and finalizes *after* the ClickHouse job — so on any run where the shadow fails, the duckgres FAILED job is the newest job for that saved query. The digest then reports the model as failed and emails the customer, **even though the real (ClickHouse) materialization succeeded**. Duckgres has known translation-gap failures, so this produces false "your model is failing" alerts for healthy models on every shadow-enabled team.

This is a pre-existing bug, independent of any in-flight suspension work.

## Changes

Exclude the duckgres (shadow) engine from both latest-job lookups in the digest, so it reflects the serving (ClickHouse) materialization only.

Note: for managed-warehouse teams whose *serving* engine is duckgres (`duckgres_only`), their failures won't surface in this digest — acceptable for now since that path is early beta; can be revisited (prefer-serving-engine) if/when those digests matter.

## How did you test this code?

Agent-authored. Only automated tests were run. Added `test_send_matview_failure_digest_ignores_duckgres_shadow`: a scheduled saved query with a COMPLETED ClickHouse job and a *more recent* FAILED duckgres job sends **no** email. Without the engine exclusion the newer duck FAILED job flags the model and the assertion fails — that's the regression it guards. The existing digest scenario tests (ClickHouse failures still alert, recovered views skipped) stay green.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assignee is the DRI.

- Built with Claude Code. Skill invoked: `/writing-tests`.
- Surfaced by a multi-perspective review of the data-modeling node-suspension stack (qa-team reviewer), which traced the false-alert path through this digest. The suspension PRs carry a narrower band-aid (only the suspension *wording* was gated to ClickHouse); this is the root fix for the underlying engine-unaware digest and ships separately off master.
- Decision: chose the simple `.exclude(DUCKGRES)` over a prefer-serving-engine ordering — simpler, and the duckgres-only digest gap is acceptable at this beta stage.
