### PR TITLE
feat(flags): point feature flags secure API key UI at PSAK creation

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -6509,9 +6509,9 @@ snapshots:
     scenes-app-settings-environment--settings-environment-error-tracking-configuration--light:
         hash: v1.k794b7964.2f40238b917b2e66cf31cca3dbe5c92a33d5f1c5eb0d1645a4178f87cd789580.9Y8shA4VVl68EO_EkKUyYwRr3yBNPd-w1EgPr3VTQhY
     scenes-app-settings-environment--settings-environment-feature-flags--dark:
-        hash: v1.k794b7964.4a627c125b4196ab9adfe9389e8fa20e9ba68c9110af68d1087ac9b6325da406.WVq_ojXXs-K3q725sJPCE3y4bmi1S_bf1T72JHY5vvE
+        hash: v1.k794b7964.30b8626c10b8092ae04aa1a4abff45097cfe74c5d378ea7609d918bcaec06957.5xPcL7DEHhwH7ESDwgyw1SgA7MiXV7YTD5yBl4wksF8
     scenes-app-settings-environment--settings-environment-feature-flags--light:
-        hash: v1.k794b7964.92334bc6fd2dd55af190426919a3b9e4d4adbfc11fb5b403c43e41ff5c807e0f.7rSxSA5cE1O6khSCYNePcBiM4iSKmdKYTzDOIbT-C3A
+        hash: v1.k794b7964.07f99df02068a82b0d18065303ed1f16b0bf65b43b4f12795a0979d16c00db41.mqz62rGGXnDqQO-HnIvh7mDs2oq_su7o8YwJKA0upo0
     scenes-app-settings-environment--settings-environment-heatmaps--dark:
         hash: v1.k794b7964.c5ae4e689d776785d04e8bde3a6675b2c0fc0ceeb813ad432d07bacd9facccc3.owsMNyDWX9zci-keIbmIuPyrbcpcucyoljX1RDy0n8g
     scenes-app-settings-environment--settings-environment-heatmaps--light:

--- a/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
@@ -2,13 +2,17 @@ import { useActions, useValues } from 'kea'
 import { Form } from 'kea-forms'
 
 import { IconRefresh, IconTrash } from '@posthog/icons'
-import { LemonButton, LemonDialog, LemonSwitch, LemonTextArea } from '@posthog/lemon-ui'
+import { LemonButton, LemonDialog, LemonSwitch, LemonTag, LemonTextArea } from '@posthog/lemon-ui'
 
 import { CodeSnippet } from 'lib/components/CodeSnippet'
 import { RestrictionScope, useRestrictedArea } from 'lib/components/RestrictedArea'
-import { TeamMembershipLevel } from 'lib/constants'
+import { FEATURE_FLAGS, TeamMembershipLevel } from 'lib/constants'
+import { LemonBanner } from 'lib/lemon-ui/LemonBanner'
 import { LemonField } from 'lib/lemon-ui/LemonField'
+import { Link } from 'lib/lemon-ui/Link'
+import { featureFlagLogic } from 'lib/logic/featureFlagLogic'
 import { teamLogic } from 'scenes/teamLogic'
+import { urls } from 'scenes/urls'
 
 import { featureFlagConfirmationSettingsLogic } from './featureFlagConfirmationSettingsLogic'
 
@@ -93,7 +97,10 @@ export function FlagChangeConfirmationSettings(): JSX.Element {
 
 export function FlagsSecureApiKeys(): JSX.Element {
     const { currentTeam, isTeamTokenResetAvailable } = useValues(teamLogic)
+    const { featureFlags } = useValues(featureFlagLogic)
     const { deleteSecretTokenBackup, rotateSecretToken } = useActions(teamLogic)
+
+    const projectSecretApiKeysEnabled = !!featureFlags[FEATURE_FLAGS.PROJECT_SECRET_API_KEYS]
 
     const openResetDialog = (): void => {
         const verb = currentTeam?.secret_api_token ? 'Rotate' : 'Generate'
@@ -137,8 +144,22 @@ export function FlagsSecureApiKeys(): JSX.Element {
 
     return (
         <div className="space-y-2">
-            <h3 className="mt-0 mb-1 text-sm font-semibold text-muted">
-                Primary Key <span className="text-green-700 text-xs ml-2">(Active)</span>
+            {projectSecretApiKeysEnabled && (
+                <LemonBanner type="warning">
+                    <p className="mb-1">
+                        This feature flags secure API key is deprecated. Create a{' '}
+                        <strong>project secret API key</strong> with the <strong>feature_flag:read</strong> scope (the
+                        "Local feature flag evaluation" preset) instead. It's hashed at rest, scoped, and rotatable
+                        without affecting your primary key.
+                    </p>
+                    <Link to={urls.settings('environment-secret-api-keys', 'environment-secret-api-keys')}>
+                        Create a project secret API key
+                    </Link>
+                </LemonBanner>
+            )}
+            <h3 className="mt-4 mb-1 text-sm font-semibold text-muted flex items-center gap-2">
+                Primary Key <span className="text-green-700 text-xs">(Active)</span>
+                {projectSecretApiKeysEnabled && <LemonTag type="warning">Deprecated</LemonTag>}
             </h3>
             <CodeSnippet
                 actions={

--- a/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
@@ -101,6 +101,7 @@ export function FlagsSecureApiKeys(): JSX.Element {
     const { deleteSecretTokenBackup, rotateSecretToken } = useActions(teamLogic)
 
     const projectSecretApiKeysEnabled = !!featureFlags[FEATURE_FLAGS.PROJECT_SECRET_API_KEYS]
+    const hasLegacyKey = !!(currentTeam?.secret_api_token || currentTeam?.secret_api_token_backup)
 
     const openResetDialog = (): void => {
         const verb = currentTeam?.secret_api_token ? 'Rotate' : 'Generate'
@@ -142,6 +143,20 @@ export function FlagsSecureApiKeys(): JSX.Element {
         })
     }
 
+    // Teams without a legacy key shouldn't be offered to create a deprecated credential
+    if (projectSecretApiKeysEnabled && !hasLegacyKey) {
+        return (
+            <LemonBanner type="warning">
+                <p className="mb-1">
+                    The feature flags secure API key is deprecated. Create a <strong>project secret API key</strong>{' '}
+                    with the <strong>feature_flag:read</strong> scope (the "Local feature flag evaluation" preset)
+                    instead. It's hashed at rest, scoped, and rotatable.
+                </p>
+                <Link to={urls.settings('environment-secret-api-keys')}>Create a project secret API key</Link>
+            </LemonBanner>
+        )
+    }
+
     return (
         <div className="space-y-2">
             {projectSecretApiKeysEnabled && (
@@ -152,9 +167,7 @@ export function FlagsSecureApiKeys(): JSX.Element {
                         "Local feature flag evaluation" preset) instead. It's hashed at rest, scoped, and rotatable
                         without affecting your primary key.
                     </p>
-                    <Link to={urls.settings('environment-secret-api-keys', 'environment-secret-api-keys')}>
-                        Create a project secret API key
-                    </Link>
+                    <Link to={urls.settings('environment-secret-api-keys')}>Create a project secret API key</Link>
                 </LemonBanner>
             )}
             <h3

--- a/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
+++ b/frontend/src/scenes/feature-flags/FeatureFlagSettings.tsx
@@ -157,7 +157,11 @@ export function FlagsSecureApiKeys(): JSX.Element {
                     </Link>
                 </LemonBanner>
             )}
-            <h3 className="mt-4 mb-1 text-sm font-semibold text-muted flex items-center gap-2">
+            <h3
+                className={`${
+                    projectSecretApiKeysEnabled ? 'mt-4' : 'mt-0'
+                } mb-1 text-sm font-semibold text-muted flex items-center gap-2`}
+            >
                 Primary Key <span className="text-green-700 text-xs">(Active)</span>
                 {projectSecretApiKeysEnabled && <LemonTag type="warning">Deprecated</LemonTag>}
             </h3>

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -15,8 +15,9 @@ import { FilterTestAccountsConfiguration as RevenueAnalyticsFilterTestAccountsCo
 import { GoalsConfiguration } from '@posthog/products-revenue-analytics/frontend/settings/GoalsConfiguration'
 
 import { BaseCurrency } from 'lib/components/BaseCurrency/BaseCurrency'
+import { FlaggedFeature } from 'lib/components/FlaggedFeature'
 import { FEATURE_SUPPORT } from 'lib/components/SupportedPlatforms/featureSupport'
-import { OrganizationMembershipLevel } from 'lib/constants'
+import { FEATURE_FLAGS, OrganizationMembershipLevel } from 'lib/constants'
 import { MAX_LOOKBACK_DAYS, MIN_LOOKBACK_DAYS } from 'scenes/experiments/constants'
 import { DefaultMinimumDetectableEffect } from 'scenes/experiments/DefaultMinimumDetectableEffect'
 import { GitHub, Linear, Slack } from 'scenes/integrations/definitions'
@@ -677,8 +678,18 @@ export const SETTINGS_MAP: SettingSection[] = [
             {
                 id: 'feature-flag-secure-api-key',
                 title: 'Feature flags secure API key',
-                description:
-                    'Deprecated. This key is still usable for local evaluation of feature flags or remote config settings, but new integrations should use a project secret API key with the feature_flag:read scope instead.',
+                description: (
+                    <FlaggedFeature
+                        flag={FEATURE_FLAGS.PROJECT_SECRET_API_KEYS}
+                        fallback="Use this key for local evaluation of feature flags or remote config settings. Replaces personal API keys for local evaluation."
+                    >
+                        Deprecated. This key is still usable for local evaluation of feature flags or remote config
+                        settings, but new integrations should use a project secret API key with the feature_flag:read
+                        scope instead.
+                    </FlaggedFeature>
+                ),
+                searchDescription:
+                    'Use this key for local evaluation of feature flags or remote config settings. Replaces personal API keys for local evaluation.',
                 docsUrl: 'https://posthog.com/docs/feature-flags/local-evaluation',
                 component: <FlagsSecureApiKeys />,
                 keywords: ['api key', 'secret', 'local evaluation', 'remote config'],

--- a/frontend/src/scenes/settings/SettingsMap.tsx
+++ b/frontend/src/scenes/settings/SettingsMap.tsx
@@ -678,7 +678,7 @@ export const SETTINGS_MAP: SettingSection[] = [
                 id: 'feature-flag-secure-api-key',
                 title: 'Feature flags secure API key',
                 description:
-                    'Use this key for local evaluation of feature flags or remote config settings. Replaces personal API keys for local evaluation.',
+                    'Deprecated. This key is still usable for local evaluation of feature flags or remote config settings, but new integrations should use a project secret API key with the feature_flag:read scope instead.',
                 docsUrl: 'https://posthog.com/docs/feature-flags/local-evaluation',
                 component: <FlagsSecureApiKeys />,
                 keywords: ['api key', 'secret', 'local evaluation', 'remote config'],


### PR DESCRIPTION
## Problem

The "Feature flags secure API key" section in project settings shows the legacy team secret token (`Team.secret_api_token`), a plaintext credential used for local feature flag evaluation and remote config. Project secret API keys (PSAKs) are now the supported replacement: hashed at rest, scoped, and rotatable without rolling the whole credential. The settings UI didn't point users at PSAKs anywhere, so anyone setting up local evaluation today still lands on the legacy key.

<img width="707" height="378" alt="Screenshot 2026-06-30 at 5 41 54 PM" src="https://github.com/user-attachments/assets/22597f23-7834-4f70-af6e-644f747e5b10" />

Part of #66177 (frontend and docs phase of the PSAK migration tracked in #63111). The docs update for SDK and local evaluation guides lives in the posthog.com repo and is tracked separately.

## Changes

- Added a deprecation banner to the legacy key section that links to the project secret API key settings and names the `feature_flag:read` scope ("Local feature flag evaluation" preset) to create.
- Tagged the primary key as "Deprecated".
- Updated the setting's description text to point at PSAKs.
- The legacy key stays visible, rotatable, and fully functional, nothing about its behavior changes.
- The banner and tag only render when the `PROJECT_SECRET_API_KEYS` flag is on for the team, so teams without PSAK access aren't told to use a feature they can't reach.

## How did you test this code?

Ran the local dev stack, logged into a test workspace, and opened Settings > Feature flags. Confirmed the banner and "Deprecated" tag render with the flag on, the link routes to the project secret API key settings page, and the existing key still rotates as before. Confirmed in code that both the banner and tag are gated behind the feature flag so they disappear when it's off.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

SDK and local evaluation docs live in posthog.com and will be updated in a follow-up PR there.