### PR TITLE
perf(error-tracking): drop redundant cymbal properties re-parse

### DIFF
--- a/rust/cymbal/src/modes/processing/types/exception_properties.rs
+++ b/rust/cymbal/src/modes/processing/types/exception_properties.rs
@@ -135,12 +135,9 @@ impl TryFrom<AnyEvent> for ExceptionProperties {
             return Err(EventError::WrongEventType(event.event.clone(), event.uuid));
         }
 
-        let mut properties: Value = match serde_json::from_value(event.properties) {
-            Ok(r) => r,
-            Err(e) => {
-                return Err(EventError::InvalidProperties(event.uuid, e.to_string()));
-            }
-        };
+        // `event.properties` is already a `serde_json::Value`; running it back through
+        // `from_value` only deep-rebuilds the tree. Take ownership directly instead.
+        let mut properties = event.properties;
 
         if let Some(v) = properties
             .as_object_mut()


### PR DESCRIPTION
## Problem

Cymbal's processing mode — the `POST /process` service that symbolicates, fingerprints, and groups exception events — spends a large share of CPU round-tripping event data through `serde_json::Value`. Continuous profiling (Pyroscope) shows `serde_json` (de)serialization and `BTreeMap` churn as dominant on-CPU costs on the per-event hot path.

One avoidable source: `AnyEvent::try_from` re-deserialized `event.properties` — which is *already* a `serde_json::Value` — back into another `Value` via `serde_json::from_value`. That deep-rebuilds the whole properties tree (fresh `BTreeMap` allocation) for every event, for no benefit.

## Changes

- In `rust/cymbal/src/modes/processing/types/exception_properties.rs`, take ownership of the existing `event.properties` value directly instead of running it back through `serde_json::from_value`.

The subsequent typed `from_value` into `ExceptionProperties` still validates the shape, so malformed properties are rejected exactly as before, and a null/absent properties value deserializes identically. Net effect: one fewer full per-event `Value` rebuild.

## How did you test this code?

I'm an agent (Claude Code). Automated checks run in a worktree:

- `cargo clippy -p cymbal --all-targets` — clean
- `cargo test -p cymbal --lib exception_value_truncation` — passes; this test drives the `AnyEvent` → `ExceptionProperties` conversion path that the change touches

No new test: this is a behavior-preserving change to an existing path already covered above.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Origin: a performance pass over the cymbal / cymbal-resolution CPU flamegraphs in Grafana Pyroscope. This is one of three independent, small wins, each split into its own PR.
- Tooling: Claude Code (Opus) for the investigation and edit. Before implementing, the proposed changes were independently validated by a second model (Codex, gpt-5.5, read-only), which confirmed that `from_value::<Value>(Value)` carries no validation value and that null-properties handling is unchanged.
- Rust-only change in the `cymbal` crate; no schema, API, or generated-type surface touched.
