### PR TITLE
perf(error-tracking): serialize cymbal response without a Value tree

### DIFF
--- a/rust/cymbal/src/modes/processing/router/event.rs
+++ b/rust/cymbal/src/modes/processing/router/event.rs
@@ -77,20 +77,9 @@ impl IntoResponse for ProcessEventsError {
 
 impl IntoResponse for Batch<Option<AnyEvent>> {
     fn into_response(self) -> axum::response::Response {
-        match serde_json::to_value(Vec::from(self)) {
-            Ok(value) => (StatusCode::OK, Json(value)).into_response(),
-            Err(e) => {
-                warn!("Failed to serialize response: {}", e);
-                (
-                    StatusCode::INTERNAL_SERVER_ERROR,
-                    Json(json!({
-                        "error": "Failed to serialize response",
-                        "details": e.to_string()
-                    })),
-                )
-                    .into_response()
-            }
-        }
+        // `Json` serializes straight into the response body, so hand it the events
+        // directly rather than first materializing an intermediate `serde_json::Value`.
+        (StatusCode::OK, Json(Vec::from(self))).into_response()
     }
 }
 


### PR DESCRIPTION
## Problem

Cymbal's processing mode returns processed exception events from `POST /process` as a JSON array. `Batch<Option<AnyEvent>>::into_response` built a complete `serde_json::Value` tree for the whole response batch (via `serde_json::to_value`) and then wrapped it in `Json` — which serializes to bytes anyway. So the entire `Value` tree (and its `BTreeMap` allocations) was constructed and immediately dropped for nothing.

Continuous profiling (Pyroscope) shows `serde_json` `Value` round-tripping and `BTreeMap` churn as dominant on-CPU costs; the response path is one contributor.

## Changes

- In `rust/cymbal/src/modes/processing/router/event.rs`, hand the events straight to `axum::Json`, which serializes any `T: Serialize` directly into the response body. This drops the intermediate `to_value` step.

Behavior:
- Response shape and array ordering are unchanged. The only difference: top-level passthrough keys (the `#[serde(flatten)] others` map) serialize in `HashMap` iteration order instead of sorted order. The Node consumer validates fields by name (zod `z.record`), and the documented `/process` contract (`rust/cymbal/docs/compatibility.md`) requires same array length/order and shape — not key order.
- On a response serialization failure (practically unreachable for already-deserialized events), axum returns a plain 500 rather than the previous custom JSON error body.

## How did you test this code?

I'm an agent (Claude Code). Automated checks in a worktree:

- `cargo clippy -p cymbal --all-targets` — clean (also confirms the `warn!`/`json!` helpers removed from this path are still used elsewhere in the file, so no unused imports)

No new test: the response contract is unchanged and there is no existing behavioral test for this serialization path to extend meaningfully.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Origin: a performance pass over the cymbal / cymbal-resolution CPU flamegraphs in Grafana Pyroscope. One of three independent wins, split into separate PRs.
- Tooling: Claude Code (Opus). Before implementing, a second model (Codex, gpt-5.5, read-only) independently validated the change: it confirmed axum's `Json` serializes via a direct writer (no intermediate value needed), checked the Node consumer and the `/process` compatibility doc to confirm key order is not part of the contract, and flagged the error-body behavior change noted above.
- Rust-only change in the `cymbal` crate; response JSON shape unchanged.
