### PR TITLE
perf(error-tracking): skip event serialization when no grouping rules

### DIFF
--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -125,19 +125,31 @@ impl GroupingRule {
     }
 }
 
-pub async fn evaluate_grouping_rules(
+pub async fn evaluate_grouping_rules<F>(
     con: &mut PgConnection,
     team_id: TeamId,
     team_manager: &TeamManager,
-    props: Value,
-) -> Result<Option<GroupingRule>, UnhandledError> {
+    props: F,
+) -> Result<Option<GroupingRule>, UnhandledError>
+where
+    F: FnOnce() -> Result<Value, UnhandledError>,
+{
     let timing = common_metrics::timing_guard(GROUPING_RULES_PROCESSING_TIME, &[]);
 
     let mut rules = team_manager.get_grouping_rules(&mut *con, team_id).await?;
 
     metrics::counter!(GROUPING_RULES_FOUND).increment(rules.len() as u64);
 
+    // Most teams have no grouping rules. Bail before materializing `props`, which
+    // the caller defers (serializing the event to JSON is expensive per-event work).
+    if rules.is_empty() {
+        timing.label("outcome", "no_match").fin();
+        return Ok(None);
+    }
+
     rules.sort_unstable_by_key(|r| r.order_key);
+
+    let props = props()?;
 
     for rule in rules {
         match rule.try_match(&props) {
@@ -235,10 +247,11 @@ mod test {
             .grouping_rules
             .insert(test_team_id, vec![rule]);
 
-        let matched =
-            evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props.clone())
-                .await
-                .unwrap();
+        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, || {
+            Ok(props.clone())
+        })
+        .await
+        .unwrap();
         let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
 
         assert_eq!(fingerprint.value, expected_fingerprint);
@@ -247,9 +260,10 @@ mod test {
         // tries to access an undefined global
         let props = test_props(JsonValue::from("no_match"));
 
-        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, props)
-            .await
-            .unwrap();
+        let matched =
+            evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, || Ok(props))
+                .await
+                .unwrap();
 
         assert!(matched.is_none());
     }

--- a/rust/cymbal/src/modes/processing/rules/grouping.rs
+++ b/rust/cymbal/src/modes/processing/rules/grouping.rs
@@ -3,7 +3,7 @@ use common_types::TeamId;
 use hogvm::{ExecutionContext, Program, StepOutcome, VmError};
 use serde::Serialize;
 use serde_json::Value;
-use sqlx::PgConnection;
+use sqlx::PgPool;
 use uuid::Uuid;
 
 use crate::{
@@ -126,7 +126,7 @@ impl GroupingRule {
 }
 
 pub async fn evaluate_grouping_rules<F>(
-    con: &mut PgConnection,
+    pool: &PgPool,
     team_id: TeamId,
     team_manager: &TeamManager,
     props: F,
@@ -136,7 +136,10 @@ where
 {
     let timing = common_metrics::timing_guard(GROUPING_RULES_PROCESSING_TIME, &[]);
 
-    let mut rules = team_manager.get_grouping_rules(&mut *con, team_id).await?;
+    // Pass the pool (not a checked-out connection): `get_grouping_rules` is cache-backed
+    // and only touches the DB on a miss, so nothing holds a connection across the cache
+    // lookup, `props()` serialization, or HogVM rule evaluation below.
+    let mut rules = team_manager.get_grouping_rules(pool, team_id).await?;
 
     metrics::counter!(GROUPING_RULES_FOUND).increment(rules.len() as u64);
 
@@ -171,10 +174,7 @@ where
                 );
                 continue;
             }
-            Err(err) => {
-                rule.disable(&mut *con, err.to_string(), props.clone())
-                    .await?
-            }
+            Err(err) => rule.disable(pool, err.to_string(), props.clone()).await?,
         }
     }
 
@@ -235,7 +235,6 @@ mod test {
     #[sqlx::test(migrations = "./tests/test_migrations")]
     async fn test_grouping_rules(db: PgPool) {
         let ctx = create_test_context(db).await;
-        let mut conn = ctx.posthog_pool.acquire().await.unwrap();
 
         let test_team_id = 1;
         let props = test_props(JsonValue::from("test_value"));
@@ -247,11 +246,12 @@ mod test {
             .grouping_rules
             .insert(test_team_id, vec![rule]);
 
-        let matched = evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, || {
-            Ok(props.clone())
-        })
-        .await
-        .unwrap();
+        let matched =
+            evaluate_grouping_rules(&ctx.posthog_pool, test_team_id, &ctx.team_manager, || {
+                Ok(props.clone())
+            })
+            .await
+            .unwrap();
         let fingerprint = Fingerprint::from_rule(matched.expect("rule should match"));
 
         assert_eq!(fingerprint.value, expected_fingerprint);
@@ -261,9 +261,11 @@ mod test {
         let props = test_props(JsonValue::from("no_match"));
 
         let matched =
-            evaluate_grouping_rules(&mut conn, test_team_id, &ctx.team_manager, || Ok(props))
-                .await
-                .unwrap();
+            evaluate_grouping_rules(&ctx.posthog_pool, test_team_id, &ctx.team_manager, || {
+                Ok(props)
+            })
+            .await
+            .unwrap();
 
         assert!(matched.is_none());
     }

--- a/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
+++ b/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
@@ -30,12 +30,15 @@ impl ValueOperator for FingerprintGenerator {
         mut input: ExceptionProperties,
         ctx: GroupingStage,
     ) -> OperatorResult<Self> {
-        // Generate fingerprint (uses resolved frames for hashing, or applies grouping rules)
-        let props = serde_json::to_value(&input)?;
+        // Generate fingerprint (uses resolved frames for hashing, or applies grouping rules).
+        // Serializing the event to JSON is only needed when the team has grouping rules, so
+        // defer it: `evaluate_grouping_rules` invokes this closure only when rules exist.
         let mut conn = ctx.connection.acquire().await?;
         let fingerprint: Fingerprint =
-            match evaluate_grouping_rules(&mut conn, input.team_id, &ctx.team_manager, props)
-                .await?
+            match evaluate_grouping_rules(&mut conn, input.team_id, &ctx.team_manager, || {
+                Ok(serde_json::to_value(&input)?)
+            })
+            .await?
             {
                 Some(rule) => Fingerprint::from_rule(rule),
                 None => Fingerprint::from_exception_list(&input.exception_list),

--- a/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
+++ b/rust/cymbal/src/modes/processing/stages/grouping/fingerprint.rs
@@ -33,9 +33,8 @@ impl ValueOperator for FingerprintGenerator {
         // Generate fingerprint (uses resolved frames for hashing, or applies grouping rules).
         // Serializing the event to JSON is only needed when the team has grouping rules, so
         // defer it: `evaluate_grouping_rules` invokes this closure only when rules exist.
-        let mut conn = ctx.connection.acquire().await?;
         let fingerprint: Fingerprint =
-            match evaluate_grouping_rules(&mut conn, input.team_id, &ctx.team_manager, || {
+            match evaluate_grouping_rules(&ctx.connection, input.team_id, &ctx.team_manager, || {
                 Ok(serde_json::to_value(&input)?)
             })
             .await?


### PR DESCRIPTION
## Problem

Cymbal's fingerprint stage (`FingerprintGenerator`) serialized every exception event to a `serde_json::Value` (`serde_json::to_value(&input)`) before evaluating custom grouping rules. That JSON is only consumed when a team actually has grouping rules — and most don't — so the per-event serialization was wasted work on the `POST /process` hot path.

Continuous profiling (Pyroscope) shows `serde_json` `Value` construction and `BTreeMap` churn among the dominant on-CPU costs; this is one avoidable contributor for the common case.

## Changes

- `evaluate_grouping_rules` now takes a `FnOnce() -> Result<Value, UnhandledError>` closure instead of an already-built `Value`. It fetches the team's rules first and returns early when there are none, so the closure (which serializes the event) runs only when at least one rule exists.
- `FingerprintGenerator::execute_value` passes the serialization as a closure rather than doing it eagerly.
- Grouping-rule tests updated to pass the props closure.

Notes:
- Behavior is unchanged for teams with rules. The fallback fingerprint (`Fingerprint::from_exception_list`) never used the JSON.
- Minor metric nuance: for teams *with* rules, `GROUPING_RULES_PROCESSING_TIME` now includes the props serialization (previously done in the caller, just outside the timer). For teams without rules the timer is unaffected.

## How did you test this code?

I'm an agent (Claude Code). Automated checks in a worktree:

- `cargo clippy -p cymbal --all-targets` — clean
- `cargo fmt -p cymbal` — applied

The DB-backed `test_grouping_rules` (`#[sqlx::test]`) compiles with the new signature but was not run locally (no Postgres in this environment); it will run in CI. The change is behavior-preserving — the closure yields the same `Value` that was previously passed in — so the existing match / no-match assertions still hold.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Origin: a performance pass over the cymbal / cymbal-resolution CPU flamegraphs in Grafana Pyroscope. One of three independent wins, split into separate PRs; this is the least trivial of the three.
- Tooling: Claude Code (Opus). A second model (Codex, gpt-5.5, read-only) independently validated the approach beforehand — confirming `props` is unused when a team has no rules and that the fallback fingerprint doesn't need it. The closure-based deferral (rather than passing the typed struct in) was chosen to keep the rules module decoupled from `ExceptionProperties` and to preserve the existing tests' ability to pass raw JSON.
- Rust-only change in the `cymbal` crate.
