### PR TITLE
fix(agent-proxy): allow x-posthog-distinct-id header in stream CORS

### DIFF
--- a/services/agent-proxy/src/lib/constants.ts
+++ b/services/agent-proxy/src/lib/constants.ts
@@ -78,7 +78,7 @@ export const MAX_EVENTS_PER_REQUEST = 1_000
 // CORS headers (must match the Python ASGI middleware values exactly)
 export const CORS_ALLOW_METHODS = 'GET, POST, OPTIONS'
 export const CORS_ALLOW_HEADERS =
-    'authorization, last-event-id, content-type, accept, x-csrftoken, x-posthog-session-id'
+    'authorization, last-event-id, content-type, accept, x-csrftoken, x-posthog-distinct-id, x-posthog-session-id'
 export const CORS_MAX_AGE = '600'
 
 // JWT audience strings (must match Python validate_* helpers)


### PR DESCRIPTION
## Problem

The live-stream read leg (browser SSE via the standalone agent-proxy) fails with a CORS error, so Tasks runs show "Cloud stream failed" and silently fall back to REST polling.

Root cause: the browser's stream request to `agent-proxy.{us,eu}.posthog.com` sends the `x-posthog-distinct-id` request header, but the proxy's `CORS_ALLOW_HEADERS` allowlist doesn't include it. The preflight's `Access-Control-Allow-Headers` therefore omits `x-posthog-distinct-id`, so Chrome blocks the actual `GET /v1/runs/:run/stream` before it's ever sent (the proxy only ever sees the `OPTIONS` preflight, never a browser `GET`).

This was invisible until the read-via-proxy rollout: the Django-served stream is same-origin (`us.posthog.com`→`us.posthog.com`, no preflight), so the missing header never mattered. Routing the stream through the cross-origin agent-proxy is what triggers the preflight and surfaces the gap. Server-to-server ingest (the write leg) is unaffected because `node` doesn't enforce CORS.

## Changes

Add `x-posthog-distinct-id` to `CORS_ALLOW_HEADERS` in `services/agent-proxy/src/lib/constants.ts`. The browser already sends this header on every stream request; the allowlist just needs to permit it alongside the existing `x-posthog-session-id`.

## How did you test this code?

I'm an agent (Claude Code); I did not do manual browser testing. Validation:

- Ran locally against the `@posthog/agent-proxy` package: `tsc --noEmit` (typecheck), `oxlint`, and `vitest`.
- Root-caused from production agent-proxy request logs + the browser Network tab: every browser request to the stream path logged only `OPTIONS … 204` (never a `GET`), and Chrome reported `CORS error` / 0.0 kB on `GET /v1/runs/:run/stream?start=latest`, whose preflight declared `access-control-request-headers: authorization,x-posthog-distinct-id,x-posthog-session-id` — exactly the header missing from the allowlist.

No new test: this is a one-token config constant and no existing test pins the CORS header string; a unit test asserting a literal allowlist value wouldn't catch a real regression (the browser<->proxy contract is what matters, and that's an integration/deploy concern).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Not applicable — internal infra CORS config, no user-facing docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — assignee `charlesvien` is the DRI.

Tool: Claude Code. No repo skills were invoked for this change.

Root-caused live while debugging the read-leg rollout. Ruled out two earlier hypotheses before landing here: (1) a SANDBOX_JWT key/kid mismatch — disproven because ingest POSTs return 200 with `accepted:N` in the same proxy logs; (2) the `Sandbox returned HTTP 404` `stream:error` — that's the legacy `relay_sandbox_events` path (used only when the ingest leg is off) hitting a torn-down sandbox, unrelated to this CORS failure. The actual blocker was the cross-origin preflight rejecting `x-posthog-distinct-id`. Python side needs no change: the Django stream path is same-origin and its middleware reflects the requested headers rather than using a fixed allowlist.
