### PR TITLE
fix(replay-vision): show slack channel name in actions delivery column

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -48,16 +48,19 @@ function EditorGate({ children }: { children: JSX.Element }): JSX.Element {
 }
 
 // delivery_config stores only the bare Slack channel ID (it feeds Slack delivery, see api/delivery.py),
-// so resolve the friendly name at render time via slackIntegrationLogic — the same lookup SlackChannelPicker
-// uses. Falls back to "Slack" while the lookup is in flight or if the channel can't be resolved.
+// so resolve the friendly name at render time via slackIntegrationLogic. Use loadAllSlackChannels (an
+// array) rather than the single-value by-id path: slackIntegrationLogic is keyed by integration_id, so
+// targets sharing an integration share one instance — the by-id reducer holds only one channel and would
+// leave the others showing "Slack". A valid delivery channel is always in the listing (the bot must be a
+// member to post there). Falls back to "Slack" while loading or if the channel can't be resolved.
 function DeliveryTargetLabel({ target }: { target: DeliveryTargetApi }): JSX.Element {
     const logic = slackIntegrationLogic({ id: target.integration_id })
     const { slackChannels } = useValues(logic)
-    const { loadSlackChannelById } = useActions(logic)
+    const { loadAllSlackChannels } = useActions(logic)
 
     useEffect(() => {
-        loadSlackChannelById(target.channel)
-    }, [target.channel]) // eslint-disable-line react-hooks/exhaustive-deps
+        loadAllSlackChannels()
+    }, [loadAllSlackChannels])
 
     const channel = slackChannels.find((c) => c.id === target.channel)
     return <span>{channel ? `#${channel.name}` : 'Slack'}</span>
@@ -129,8 +132,8 @@ function VisionActionsTable(): JSX.Element {
                 }
                 return (
                     <div className="flex flex-col gap-0.5 text-sm">
-                        {targets.map((t, i) => (
-                            <DeliveryTargetLabel key={i} target={t} />
+                        {targets.map((t) => (
+                            <DeliveryTargetLabel key={`${t.integration_id}-${t.channel}`} target={t} />
                         ))}
                     </div>
                 )

--- a/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/VisionActionsTab.tsx
@@ -1,4 +1,5 @@
 import { BindLogic, useActions, useValues } from 'kea'
+import { useEffect } from 'react'
 
 import { HedgehogXRay } from '@posthog/brand/hoggies'
 import { IconPencil, IconPlus, IconTrash } from '@posthog/icons'
@@ -6,6 +7,7 @@ import { LemonButton, LemonSwitch, LemonTable, Link } from '@posthog/lemon-ui'
 
 import { AccessControlAction } from 'lib/components/AccessControlAction'
 import { ProductIntroduction } from 'lib/components/ProductIntroduction/ProductIntroduction'
+import { slackIntegrationLogic } from 'lib/integrations/slackIntegrationLogic'
 import { LemonDialog } from 'lib/lemon-ui/LemonDialog'
 import { LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { ProfilePicture } from 'lib/lemon-ui/ProfilePicture'
@@ -13,7 +15,7 @@ import { urls } from 'scenes/urls'
 
 import { AccessControlLevel, AccessControlResourceType } from '~/types'
 
-import type { VisionActionApi } from '../../generated/api.schemas'
+import type { DeliveryTargetApi, VisionActionApi } from '../../generated/api.schemas'
 import { humanizeCadence, parseRruleToCadence } from '../cadence'
 import { visionActionsLogic } from '../visionActionsLogic'
 import { VisionActionForm } from './VisionActionForm'
@@ -45,9 +47,20 @@ function EditorGate({ children }: { children: JSX.Element }): JSX.Element {
     )
 }
 
-function deliverySummary(action: VisionActionApi): string {
-    const targets = action.delivery_config ?? []
-    return targets.length ? targets.map((t) => t.channel).join(', ') : '—'
+// delivery_config stores only the bare Slack channel ID (it feeds Slack delivery, see api/delivery.py),
+// so resolve the friendly name at render time via slackIntegrationLogic — the same lookup SlackChannelPicker
+// uses. Falls back to "Slack" while the lookup is in flight or if the channel can't be resolved.
+function DeliveryTargetLabel({ target }: { target: DeliveryTargetApi }): JSX.Element {
+    const logic = slackIntegrationLogic({ id: target.integration_id })
+    const { slackChannels } = useValues(logic)
+    const { loadSlackChannelById } = useActions(logic)
+
+    useEffect(() => {
+        loadSlackChannelById(target.channel)
+    }, [target.channel]) // eslint-disable-line react-hooks/exhaustive-deps
+
+    const channel = slackChannels.find((c) => c.id === target.channel)
+    return <span>{channel ? `#${channel.name}` : 'Slack'}</span>
 }
 
 export function VisionActionsTab({ scannerId }: { scannerId: string }): JSX.Element {
@@ -109,7 +122,19 @@ function VisionActionsTable(): JSX.Element {
         {
             title: 'Delivery',
             key: 'delivery',
-            render: (_, action) => <span className="text-sm">{deliverySummary(action)}</span>,
+            render: (_, action) => {
+                const targets = action.delivery_config ?? []
+                if (!targets.length) {
+                    return <span className="text-muted">—</span>
+                }
+                return (
+                    <div className="flex flex-col gap-0.5 text-sm">
+                        {targets.map((t, i) => (
+                            <DeliveryTargetLabel key={i} target={t} />
+                        ))}
+                    </div>
+                )
+            },
         },
         {
             title: 'Status',


### PR DESCRIPTION
## Problem

On a scanner's **Actions** tab, the **Delivery** column showed the raw Slack channel ID (e.g. `C0123ABC`) instead of a human-readable label. `delivery_config` intentionally persists only the bare channel ID — that ID is what the provisioned Slack HogFunction posts with (`api/delivery.py`) — so the display code was rendering it verbatim.

## Changes

Resolve the stored channel ID to its friendly `#channel-name` at render time, using the existing `slackIntegrationLogic` (`loadSlackChannelById` + `slackChannels`) — the same lookup `SlackChannelPicker` already uses. Falls back to "Slack" while the lookup is in flight or if the channel can't be resolved (e.g. private-without-access / deleted). Nothing persisted changes; Slack delivery still posts to the bare ID.

Frontend-only, single file (`VisionActionsTab.tsx`). Behind the `replay-vision-actions` flag.

## How did you test this code?

I'm an agent (agent-assisted, human-driven). I did **not** run the app manually. Automated checks run:
- `oxlint` on the changed file — clean (0 warnings, 0 errors).
- `tsgo` type check — no errors in the changed file. (Remaining type errors in the repo are pre-existing stale kea-typegen artifacts in unrelated files, present with this change reverted.)

Manual verification still needed: open a scanner with an action that has a Slack destination and confirm the Delivery column shows `#channel-name` (briefly "Slack" before the lookup resolves); actions with no destination show `—`.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Tooling: PostHog Code (Claude).
- The fix is display-only by design: the persisted `delivery_config[].channel` must stay the bare Slack ID because it feeds real delivery via the internal-destination HogFunction. Rejected the alternative of persisting the composite `id|#name` picker value (would break Slack posting) and adding a cosmetic `channel_name` serializer field (unnecessary backend surface). Chose render-time resolution through the existing `slackIntegrationLogic`, mirroring how `SlackChannelPicker` resolves a bare stored ID.
- No skills were required (no serializer/migration/DRF/test-suite changes).

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
