### PR TITLE
fix(postgres): degrade rows-to-sync count timeout on full-table syncs

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2089,17 +2089,19 @@ def _get_rows_to_sync(
         logger.debug(f"_get_rows_to_sync: rows_to_sync_int={rows_to_sync_int}")
 
         return int(rows_to_sync)
-    except psycopg.errors.QueryCanceled:
-        # On incremental syncs re-raise: this COUNT shares its WHERE with the real chunked read, so
-        # a statement_timeout here predicts the extraction will time out too — the caller maps it to
-        # the actionable "add an index on your incremental field" message. On full-table syncs the
-        # COUNT is a full scan while extraction streams sequentially via a server cursor, so a
-        # timeout here says nothing about whether extraction will succeed. Fall back to an unknown
-        # total (0) like the sibling `_get_table_chunk_size` probe rather than failing the whole
-        # sync at setup on a best-effort estimate.
+    except psycopg.errors.QueryCanceled as e:
+        # QueryCanceled means the COUNT was cancelled — usually the statement_timeout, but possibly a
+        # lock_timeout or an admin cancel (we don't inspect which). On incremental syncs re-raise:
+        # this COUNT shares its WHERE with the real chunked read, so a cancellation here predicts the
+        # extraction will hit the same wall — the caller maps it to the actionable "add an index on
+        # your incremental field" message. On full-table syncs the COUNT is a full scan while
+        # extraction streams sequentially via a server cursor, so a cancelled count says nothing
+        # about whether extraction will succeed. Fall back to an unknown total (0) like the sibling
+        # `_get_table_chunk_size` probe rather than failing the whole sync at setup on a best-effort
+        # estimate.
         if should_use_incremental_field:
             raise
-        logger.debug("_get_rows_to_sync: COUNT hit statement_timeout on a full-table sync. Using 0 as rows to sync")
+        logger.debug(f"_get_rows_to_sync: COUNT cancelled on a full-table sync ({e}). Using 0 as rows to sync")
         return 0
     except Exception as e:
         # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -2066,7 +2066,13 @@ def _role_subject_to_rls(cursor: psycopg.Cursor, schema: str, table_name: str, l
         return False
 
 
-def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger: FilteringBoundLogger) -> int:
+def _get_rows_to_sync(
+    cursor: psycopg.Cursor,
+    count_query: sql.Composed,
+    logger: FilteringBoundLogger,
+    *,
+    should_use_incremental_field: bool = False,
+) -> int:
     try:
         _explain_query(cursor, count_query, logger)
         logger.debug(f"Running query: {count_query.as_string()}")
@@ -2084,7 +2090,17 @@ def _get_rows_to_sync(cursor: psycopg.Cursor, count_query: sql.Composed, logger:
 
         return int(rows_to_sync)
     except psycopg.errors.QueryCanceled:
-        raise
+        # On incremental syncs re-raise: this COUNT shares its WHERE with the real chunked read, so
+        # a statement_timeout here predicts the extraction will time out too — the caller maps it to
+        # the actionable "add an index on your incremental field" message. On full-table syncs the
+        # COUNT is a full scan while extraction streams sequentially via a server cursor, so a
+        # timeout here says nothing about whether extraction will succeed. Fall back to an unknown
+        # total (0) like the sibling `_get_table_chunk_size` probe rather than failing the whole
+        # sync at setup on a best-effort estimate.
+        if should_use_incremental_field:
+            raise
+        logger.debug("_get_rows_to_sync: COUNT hit statement_timeout on a full-table sync. Using 0 as rows to sync")
+        return 0
     except Exception as e:
         # This COUNT(*) is a best-effort estimate for progress reporting and partition sizing.
         # It shares its FROM/WHERE with the real extraction query, so any genuine problem
@@ -2796,7 +2812,12 @@ def postgres_source(
                                 except Exception as e:
                                     logger.debug(f"Estimated row count failed, falling back to exact count: {e}")
                             if rows_to_sync is None:
-                                rows_to_sync = _get_rows_to_sync(cursor, count_query, logger)
+                                rows_to_sync = _get_rows_to_sync(
+                                    cursor,
+                                    count_query,
+                                    logger,
+                                    should_use_incremental_field=should_use_incremental_field,
+                                )
 
                             if _role_subject_to_rls(cursor, schema, table_name, logger):
                                 logger.warning(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -3923,6 +3923,52 @@ class TestGetRowsToSync:
         # The temp-file signal is actionable, so it propagates rather than being swallowed.
         mock_capture.assert_not_called()
 
+    @pytest.mark.parametrize(
+        "should_use_incremental_field,expect_raise",
+        [
+            # Full-table sync: the COUNT is a full scan while extraction streams sequentially via a
+            # server cursor, so a statement_timeout here says nothing about whether extraction will
+            # succeed. It must degrade to an unknown total (0), not fail setup with a raw, retryable
+            # QueryCanceled that floods error tracking and Temporal re-attempts forever.
+            (False, False),
+            # Incremental sync: the COUNT shares its WHERE with the chunked read, so the timeout is
+            # predictive — re-raise so the caller surfaces the "add an index" guidance.
+            (True, True),
+        ],
+    )
+    def test_statement_timeout_degrades_for_full_table_but_re_raises_for_incremental(
+        self, should_use_incremental_field, expect_raise
+    ):
+        logger = structlog.get_logger()
+
+        cursor = mock.MagicMock()
+        cursor.execute.side_effect = psycopg.errors.QueryCanceled("canceling statement due to statement timeout")
+        count_query = _build_count_query("public", "users", False, None, None, None)
+
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.capture_exception"
+        ) as mock_capture:
+            if expect_raise:
+                with pytest.raises(psycopg.errors.QueryCanceled):
+                    _get_rows_to_sync(
+                        cast(Any, cursor),
+                        count_query,
+                        logger,
+                        should_use_incremental_field=should_use_incremental_field,
+                    )
+            else:
+                assert (
+                    _get_rows_to_sync(
+                        cast(Any, cursor),
+                        count_query,
+                        logger,
+                        should_use_incremental_field=should_use_incremental_field,
+                    )
+                    == 0
+                )
+
+        mock_capture.assert_not_called()
+
 
 class TestPartitionedTableChunkSizing:
     """Incremental reads use per-child partition queries; no parent FETCH chunk cap."""


### PR DESCRIPTION
## Problem

Error tracking surfaced a `QueryCanceled` — "canceling statement due to statement timeout" — originating in `_get_rows_to_sync` (the Postgres source's best-effort rows-to-sync `COUNT`) during sync setup: [error tracking issue](https://us.posthog.com/project/2/error_tracking/019f1b5e-cedd-7a92-958f-15b36e182dab).

The `COUNT` is a best-effort progress/partition-sizing estimate. It re-raises a raw `QueryCanceled` on statement timeout so the caller can, for incremental syncs, map it to the actionable "add an index on your incremental field" message. But on full-table (non-incremental) syncs the caller fell through to a bare `raise`, leaking a raw, retryable `QueryCanceled`. That:

- floods error tracking (the raw exception is logged and re-raised through `_handle_import_error`), and
- burns the whole activity retry budget, since a deterministic timeout re-runs the same count and fails the same way.

Crucially this is **not** something to add to `NonRetryableErrors`: the message "canceling statement due to statement timeout" is generic, and non-incremental read-path timeouts are deliberately kept retryable (`_statement_timeout_as_non_retryable`) so a fresh re-sync can reorder rows safely. Widening `NonRetryableErrors` here would break that and could also catch the recovery-conflict path.

## Changes

Treat the `COUNT` timeout as the best-effort probe it already claims to be. A full-table `COUNT` is a full scan, while extraction streams sequentially via a server cursor — so a timeout on the count says nothing about whether extraction will succeed. On the non-incremental path, `_get_rows_to_sync` now falls back to an unknown total (`0`) instead of failing setup, mirroring the sibling `_get_table_chunk_size` probe. The re-raise is kept only for incremental syncs, where the count shares its `WHERE` with the chunked read and the timeout is genuinely predictive (and still yields the "add an index" guidance).

Scope is limited to the setup-phase count; the streaming read loop's own `QueryCanceled` handling is unchanged.

## How did you test this code?

I'm an agent. Automated tests only — I did not run a live sync.

- Added a parameterized case to `TestGetRowsToSync` in `test_postgres.py`: a `QueryCanceled` on the count falls back to `0` for full-table syncs and re-raises for incremental syncs, and never calls `capture_exception`. No existing case covered the `QueryCanceled` branch or the incremental/non-incremental split (existing cases cover a missing-column `ProgrammingError` and the temp-file signal).
- Ran the mock-based statement-timeout suites locally: `TestGetRowsToSync` (new cases + temp-file), `TestStatementTimeoutAsNonRetryable`, `TestServerCursorStatementTimeout`, `TestServerCursorCloseStatementTimeout` — all pass. Two pre-existing DB-backed `TestGetRowsToSync` cases require a live Postgres and only error on connection in this sandbox (unrelated to the change).
- `ruff check` and `ruff format` clean.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a webhook-delivered error-tracking issue for the Postgres data-warehouse source. Confirmed the stack originates in `_get_rows_to_sync` (setup-phase `COUNT`, routed through `_handle_import_error`), then read the source to establish the incremental vs. non-incremental split.

Decision: fixable bug (missing graceful-skip), not a `NonRetryableErrors` addition — the timeout message is too generic and non-incremental extraction timeouts are intentionally retryable, so classifying it non-retryable would be both too broad and against the existing design. Chose to make the best-effort count degrade gracefully on the non-incremental path, matching the `_get_table_chunk_size` sibling probe.

Skill invoked: `/writing-tests` (to gate the added regression test).
