### PR TITLE
fix(tasks): shorten sandbox ingest stream window so live events flush

### DIFF
--- a/products/tasks/backend/logic/services/sandbox.py
+++ b/products/tasks/backend/logic/services/sandbox.py
@@ -132,6 +132,14 @@ def redact_sandbox_command(command: str) -> str:
     return SENSITIVE_AGENT_RUNTIME_ENV_PATTERN.sub(r"\g<name>=<redacted>", command)
 
 
+# Stopgap until the sandbox agent-server delivers each ingest flush as its own
+# promptly closed upload: the ingress buffers the long-lived ingest request body
+# and only forwards it when the upload rolls, so cap the roll window to keep live
+# events reaching the read stream within seconds instead of the 5-min client
+# default. Harmless once the agent-server closes per batch (window never trips).
+EVENT_INGEST_STREAM_WINDOW_MS_STOPGAP = "2000"
+
+
 def build_agent_runtime_env_prefix(
     *,
     interaction_origin: str | None = None,
@@ -150,6 +158,9 @@ def build_agent_runtime_env_prefix(
         "POSTHOG_CODE_REASONING_EFFORT": reasoning_effort,
         "POSTHOG_TASK_RUN_EVENT_INGEST_TOKEN": event_ingest_token,
         "POSTHOG_TASK_RUN_EVENT_INGEST_URL": event_ingest_url,
+        "POSTHOG_TASK_RUN_EVENT_INGEST_STREAM_WINDOW_MS": (
+            EVENT_INGEST_STREAM_WINDOW_MS_STOPGAP if event_ingest_url else None
+        ),
     }
     assignments = " ".join(
         f"{name}={shlex.quote(value)}" for name, value in env_vars.items() if value is not None and value != ""

--- a/products/tasks/backend/logic/services/test_docker_sandbox.py
+++ b/products/tasks/backend/logic/services/test_docker_sandbox.py
@@ -549,6 +549,9 @@ class TestDockerSandboxUnit:
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_TOKEN=ingest-token" in command
         # The host proxy URL is rewritten so it resolves from inside the container.
         assert "POSTHOG_TASK_RUN_EVENT_INGEST_URL=http://host.docker.internal:8003" in command
+        # Stopgap: ingest-enabled sandboxes cap the stream roll window so events
+        # reach the read stream in seconds instead of the 5-min client default.
+        assert "POSTHOG_TASK_RUN_EVENT_INGEST_STREAM_WINDOW_MS=2000" in command
 
 
 @pytest.mark.skipif(is_ci() or not docker_available(), reason="Docker sandbox tests only run locally, not in CI")


### PR DESCRIPTION
## Problem

Cloud task runs stream agent output to the browser through the agent-proxy read leg, which works in all cases. The write leg (sandbox → proxy ingest) did not deliver live: the browser received only keepalives and then the whole turn in one burst about 5 minutes later, or on refresh from persisted history.

The sandbox agent-server streams events into a single long-lived chunked ingest `POST` that only closes when its stream window rolls, defaulting to 5 minutes. The ingress in front of the proxy buffers the request body and only forwards it once the request closes, so nothing reaches the proxy until the window rolls. The proper fix — closing the upload per drained batch — lives in the agent-server (PostHog/code#3043). This PR is the stopgap for sandboxes running the currently deployed agent-server image, which already honors the stream-window env var.

## Changes

Set `POSTHOG_TASK_RUN_EVENT_INGEST_STREAM_WINDOW_MS=2000` in the sandbox runtime env when event ingest is enabled (`build_agent_runtime_env_prefix`). This caps the ingest upload roll window at 2s, so the ingress forwards buffered events every couple of seconds instead of every 5 minutes. It's gated on the ingest URL being present, so only ingest-enabled runs get it, and it's harmless once PostHog/code#3043 ships — the agent-server closes per batch well before the window ever trips.

## How did you test this code?

I'm an agent (Claude Code), human-directed. Automated tests I actually ran:

- `test_docker_sandbox.py::TestDockerSandboxUnit::test_start_agent_server_includes_runtime_environment_variables` — passes. Extended it to assert the window env is emitted when ingest is enabled.
- `ruff check` on the changed files — clean.

The Modal-equivalent env test has a pre-existing local collection import-order error that reproduces on a clean checkout (unrelated to this change); it exercises the same `build_agent_runtime_env_prefix` code path the Docker test covers. I did not run a full sandbox-to-browser flow.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code, directed by @charlesvien while debugging why cloud task-run output only appeared after a refresh. Diagnosis: the read leg (browser ← proxy SSE) works in every case; the write leg (sandbox → proxy ingest) uses a long-lived chunked upload whose request body a buffering ingress holds until the request closes, so events land only when the stream window rolls. Confirmed from proxy logs — only the bounded empty sequence-sync probe arrived; content never did until a burst that landed exactly 5 minutes after the events were generated — cross-referenced against the run's event history.

This is the stopgap half; the real fix (close the upload per batch) is PostHog/code#3043. Split this way because the deployed agent-server image already honors the window env, so shortening it unblocks current sandboxes without waiting on an agent-server image rebuild. The added test assertion guards against silently dropping the window env, which would revert ingest-enabled runs to the 5-minute buffering behavior.

Skills invoked: /writing-tests (before adding the test assertion).
