### PR TITLE
fix(mysql): stop capturing best-effort partition-sizing errors

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/implementation.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/implementation.py
@@ -308,8 +308,13 @@ class SQLSourceImplementation(Generic[ConfigT, ConnT, CursorT], ABC):
         try:
             stats = self.fetch_table_stats(cursor, schema, table_name, logger)
         except Exception as e:
+            # Partition sizing is a best-effort optimization: returning None just falls back to
+            # default partition settings and the sync proceeds. Any genuine problem (missing table,
+            # permissions) resurfaces in the real extraction query and is classified through the
+            # normal retryable/non-retryable path, while transient connection drops here stay
+            # retryable there too. Capturing it would only flood error tracking with handled
+            # duplicates, so log at debug and fall back.
             logger.debug(f"get_partition_settings: Error fetching stats: {e}. Returning None", exc_info=e)
-            capture_exception(e)
             return None
 
         if stats is None or stats.row_count == 0:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_implementation.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_implementation.py
@@ -13,7 +13,7 @@ from contextlib import contextmanager
 from typing import Any
 
 import pytest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from products.warehouse_sources.backend.temporal.data_imports.pipelines.pipeline.typings import (
     SourceInputs,
@@ -94,9 +94,14 @@ class TestGetPartitionSettings:
 
     def test_returns_none_when_fetch_raises(self, logger):
         impl = _FakeImplementation(raises_on_stats=True)
-        assert impl.get_partition_settings(MagicMock(), "db", "t", logger) is None
+        module = "products.warehouse_sources.backend.temporal.data_imports.sources.common.sql.implementation"
+        with patch(f"{module}.capture_exception") as mock_capture:
+            assert impl.get_partition_settings(MagicMock(), "db", "t", logger) is None
         # We still called through to the driver hook.
         assert len(impl.fetch_table_stats_calls) == 1
+        # Best-effort probe: a raised stats query must not flood error tracking — it degrades to
+        # None here and resurfaces in the real extraction query if it's a genuine problem.
+        mock_capture.assert_not_called()
 
     def test_single_partition_fallback_when_partition_count_is_zero(self, logger):
         # Tiny table: 100 bytes, 2 rows → avg_row_size = 50 → partition_size huge


### PR DESCRIPTION
## Problem

Error tracking surfaced a handled `InterfaceError: (0, '')` (pymysql, raised when the connection socket is gone) originating in the MySQL import source's partition-sizing probe:

```
get_partition_settings  common/sql/implementation.py
  fetch_table_stats      mysql/mysql.py:980   → cursor.execute(...)
    pymysql ... _execute_command → InterfaceError(0, '')
```

The exception is already caught: `get_partition_settings` degrades to `None`, the sync falls back to default partition settings, and extraction proceeds. Nothing actually fails. But the shared `get_partition_settings` also called `capture_exception` on that path, so a transient connection drop during the *best-effort* stats probe was reported to error tracking as a handled exception — noise, not a real failure.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1b6e-ad5d-7a32-84e2-a36fb5ff5f08

## Changes

Drop the `capture_exception` call in the shared `SQLSourceImplementation.get_partition_settings` error path (used by MySQL, MSSQL, Redshift). Partition sizing is a best-effort optimization — returning `None` just falls back to default partitioning. Any genuine problem (missing table, permissions) resurfaces in the real extraction query and is classified through the normal retryable/non-retryable path, and transient connection drops stay retryable there too. So we log at debug and fall back without flooding error tracking with handled duplicates.

This mirrors the decision already made independently in Postgres's own `_get_partition_settings` and in MySQL's `get_rows_to_sync` override, both of which deliberately log-and-fall-back without capturing on their equivalent best-effort probes.

The transient `InterfaceError` itself is left retryable — this change is scoped to not *reporting* it from a path that already tolerates it, not to retry policy.

## How did you test this code?

I'm an agent. Automated tests only — no manual testing:

- Extended `TestGetPartitionSettings::test_returns_none_when_fetch_raises` to assert `capture_exception` is **not** called when the stats probe raises. It already covered the `None` return and the driver-hook call; nothing asserted we stay quiet in error tracking, which is exactly the behavior this PR changes. Guards against a regression that re-adds the capture and re-floods error tracking.
- Ran the suite: `products/warehouse_sources/backend/temporal/data_imports/sources/common/sql/tests/test_implementation.py` — 21 passed.
- `ruff check` / `ruff format` clean on both changed files.

## 🤖 Agent context

**Autonomy:** Fully autonomous

- Triaged from an error-tracking webhook via Claude Code, using the PostHog error-tracking MCP tools to pull the stack trace, exception, and frequency for the issue linked above.
- Invoked the `/writing-tests` skill before touching the test file; the value-gate justification is in the test-plan bullet above.
- Decision: this is neither a user/upstream error (so not a `NonRetryableErrors` addition) nor a sync-breaking bug — the sync already handles it. The `InterfaceError(0, '')` is a transient connection drop that should remain retryable. The only defect is over-eager `capture_exception` on an already-tolerated best-effort path, so the fix removes just that, following the existing Postgres/MySQL precedent rather than adding a new abstraction.