### PR TITLE
fix(postgres): bound DNS resolution so stalled lookups fail fast

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -3,9 +3,15 @@ from __future__ import annotations
 import re
 import math
 import time
+import socket
+import ipaddress
 import collections
 import dataclasses
 from collections.abc import Callable, Iterator
+from concurrent.futures import (
+    ThreadPoolExecutor,
+    TimeoutError as FuturesTimeoutError,
+)
 from contextlib import ExitStack, _GeneratorContextManager, contextmanager
 from datetime import (
     UTC,
@@ -549,6 +555,54 @@ def _is_invalid_ssl_negotiation_response(error: BaseException) -> bool:
     return _INVALID_SSL_NEGOTIATION_RESPONSE_SUBSTRING in " ".join(str(arg) for arg in error.args).lower()
 
 
+def _is_ip_literal(host: str) -> bool:
+    try:
+        ipaddress.ip_address(host.strip("[]"))
+        return True
+    except ValueError:
+        return False
+
+
+def _resolve_hostaddr_with_timeout(host: str, port: int, timeout: float) -> str | None:
+    """Resolve `host` to an IP under a wall-clock `timeout`, to hand psycopg as `hostaddr`.
+
+    psycopg3 resolves hostnames in Python before libpq ever connects — `conninfo_attempts` calls
+    `socket.getaddrinfo` (see psycopg/_conninfo_attempts.py) and only then passes the resolved address
+    to libpq. `connect_timeout` bounds establishing the socket, never that name lookup, so a stalled
+    or unresponsive resolver blocks the (threaded, non-interruptible) sync activity for as long as the
+    OS resolver takes. It never trips `connect_timeout`; the activity instead runs until Temporal's
+    `start_to_close_timeout` cancels the worker thread mid-`getaddrinfo`, surfacing a misleading
+    `CancelledError` and burning the whole activity's retry budget. Resolving here and passing the
+    address via `hostaddr` (which makes psycopg skip its own lookup) turns a stalled resolver into a
+    fast, retryable error instead.
+
+    Returns None when there is nothing to bound — an empty host, a Unix-socket path, or a host that is
+    already an IP literal — and also on a genuine resolution failure, so psycopg connects (and
+    re-raises that failure) exactly as before and the existing "Name or service not known"
+    classification still applies. Only a resolver that exceeds `timeout` becomes an `OperationalError`;
+    its message deliberately avoids the non-retryable "could not translate host name" /
+    "Name or service not known" fragments because a stalled resolver is usually transient.
+    """
+    if not host or host.startswith("/") or _is_ip_literal(host):
+        return None
+
+    executor = ThreadPoolExecutor(max_workers=1)
+    try:
+        future = executor.submit(socket.getaddrinfo, host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM)
+        try:
+            addrinfo = future.result(timeout=timeout)
+        except FuturesTimeoutError:
+            raise psycopg.OperationalError(f"Timed out resolving database host name after {timeout}s")
+        except OSError:
+            return None
+    finally:
+        # Never join the lookup thread — a stalled getaddrinfo would re-block us here. Let it finish
+        # in the background; the OS resolver bounds it on its own.
+        executor.shutdown(wait=False)
+
+    return addrinfo[0][4][0] if addrinfo else None
+
+
 def _connect_with_options_fallback(**connect_kwargs: Any) -> psycopg.Connection:
     """`psycopg.connect` that retries without the libpq `options` startup parameter when the
     server rejects it.
@@ -586,6 +640,12 @@ def _connect_to_postgres(
     # cleanly. We always force UTF8 and append any caller-supplied `options` after it.
     caller_options = kwargs.pop("options", None)
     options = f"{FORCE_UTF8_CLIENT_ENCODING} {caller_options}" if caller_options else FORCE_UTF8_CLIENT_ENCODING
+    # Bound psycopg's Python-side DNS lookup in production (see `_resolve_hostaddr_with_timeout`).
+    # Dev/test connect to local or fake hosts, so skip the real lookup there — mirrors `_get_sslmode`.
+    if not (settings.TEST or settings.DEBUG or settings.E2E_TESTING):
+        hostaddr = _resolve_hostaddr_with_timeout(host, port, connect_timeout)
+        if hostaddr is not None:
+            kwargs["hostaddr"] = hostaddr
     try:
         return _connect_with_options_fallback(
             host=host,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/postgres.py
@@ -5,13 +5,10 @@ import math
 import time
 import socket
 import ipaddress
+import threading
 import collections
 import dataclasses
 from collections.abc import Callable, Iterator
-from concurrent.futures import (
-    ThreadPoolExecutor,
-    TimeoutError as FuturesTimeoutError,
-)
 from contextlib import ExitStack, _GeneratorContextManager, contextmanager
 from datetime import (
     UTC,
@@ -586,21 +583,33 @@ def _resolve_hostaddr_with_timeout(host: str, port: int, timeout: float) -> str 
     if not host or host.startswith("/") or _is_ip_literal(host):
         return None
 
-    executor = ThreadPoolExecutor(max_workers=1)
-    try:
-        future = executor.submit(socket.getaddrinfo, host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM)
-        try:
-            addrinfo = future.result(timeout=timeout)
-        except FuturesTimeoutError:
-            raise psycopg.OperationalError(f"Timed out resolving database host name after {timeout}s")
-        except OSError:
-            return None
-    finally:
-        # Never join the lookup thread — a stalled getaddrinfo would re-block us here. Let it finish
-        # in the background; the OS resolver bounds it on its own.
-        executor.shutdown(wait=False)
+    addrinfo: list[Any] = []
+    lookup_error: list[BaseException] = []
 
-    return addrinfo[0][4][0] if addrinfo else None
+    def _lookup() -> None:
+        try:
+            addrinfo.extend(socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP, type=socket.SOCK_STREAM))
+        except BaseException as e:  # noqa: BLE001 — surfaced to the caller below via lookup_error
+            lookup_error.append(e)
+
+    # Daemon thread so a stalled getaddrinfo can be abandoned without blocking worker shutdown or
+    # piling up non-daemon threads — the OS resolver bounds the orphaned lookup on its own.
+    thread = threading.Thread(target=_lookup, daemon=True)
+    thread.start()
+    thread.join(timeout)
+    if thread.is_alive():
+        raise psycopg.OperationalError(f"Timed out resolving database host name after {timeout}s")
+    # A genuine resolution failure falls through to None so psycopg connects and re-raises it,
+    # preserving the existing "Name or service not known" classification.
+    if lookup_error:
+        if isinstance(lookup_error[0], OSError):
+            return None
+        raise lookup_error[0]
+    if not addrinfo:
+        return None
+    # sockaddr[0] is the address string (getaddrinfo types it as str | int across the IPv4/IPv6
+    # tuple variants, so coerce to satisfy the str return type).
+    return str(addrinfo[0][4][0])
 
 
 def _connect_with_options_fallback(**connect_kwargs: Any) -> psycopg.Connection:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1376,6 +1376,7 @@ class TestResolveHostaddrWithTimeout:
         [
             "127.0.0.1",  # already an IP (also the SSH-tunnel local endpoint) — nothing to resolve
             "::1",
+            "[::1]",  # bracketed IPv6 literal — exercises the host.strip("[]") path in _is_ip_literal
             "/var/run/postgresql",  # Unix-socket path
             "",
         ],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/postgres/test_postgres.py
@@ -1,3 +1,5 @@
+import socket
+import threading
 from collections.abc import Generator, Iterable, Iterator
 from contextlib import contextmanager
 from datetime import UTC, date, datetime, time, timedelta, timezone
@@ -99,6 +101,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.postgres.p
     _pk_uniqueness_probe_timeout_error,
     _raise_if_setup_connection_broken,
     _recovery_conflict_abort_error,
+    _resolve_hostaddr_with_timeout,
     _rls_active_from_conn,
     _role_subject_to_rls,
     _safe_close_connection,
@@ -1361,6 +1364,66 @@ class TestConnectForcesUtf8ClientEncoding:
             )
 
         assert connect_mock.call_args.kwargs["options"] == f"{FORCE_UTF8_CLIENT_ENCODING} -c statement_timeout=5000"
+
+
+# psycopg3 resolves hostnames Python-side (`socket.getaddrinfo`) before libpq's `connect_timeout`
+# applies, so a stalled resolver hangs the threaded sync activity until Temporal's
+# `start_to_close_timeout` cancels it, surfacing a misleading `CancelledError`. We bound the lookup
+# and hand psycopg the address via `hostaddr`.
+class TestResolveHostaddrWithTimeout:
+    @pytest.mark.parametrize(
+        "host",
+        [
+            "127.0.0.1",  # already an IP (also the SSH-tunnel local endpoint) — nothing to resolve
+            "::1",
+            "/var/run/postgresql",  # Unix-socket path
+            "",
+        ],
+    )
+    def test_hosts_that_need_no_lookup_short_circuit(self, host):
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.socket.getaddrinfo"
+        ) as getaddrinfo_mock:
+            assert _resolve_hostaddr_with_timeout(host, 5432, 15) is None
+        getaddrinfo_mock.assert_not_called()
+
+    def test_resolved_hostname_returns_first_address(self):
+        addrinfo = [
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.0.0.5", 5432)),
+            (socket.AF_INET, socket.SOCK_STREAM, socket.IPPROTO_TCP, "", ("10.0.0.6", 5432)),
+        ]
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.socket.getaddrinfo",
+            return_value=addrinfo,
+        ):
+            assert _resolve_hostaddr_with_timeout("db.example.com", 5432, 15) == "10.0.0.5"
+
+    def test_genuine_resolution_failure_falls_through(self):
+        # A host that doesn't resolve must return None (not raise) so psycopg connects as before and
+        # its own "Name or service not known" error still reaches the non-retryable classifier.
+        with patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.socket.getaddrinfo",
+            side_effect=socket.gaierror(-2, "Name or service not known"),
+        ):
+            assert _resolve_hostaddr_with_timeout("does-not-exist.example.com", 5432, 15) is None
+
+    def test_stalled_resolver_raises_fast_retryable_error(self):
+        release = threading.Event()
+        try:
+            with patch(
+                "products.warehouse_sources.backend.temporal.data_imports.sources.postgres.postgres.socket.getaddrinfo",
+                side_effect=lambda *a, **k: release.wait(),
+            ):
+                with pytest.raises(psycopg.OperationalError) as exc_info:
+                    _resolve_hostaddr_with_timeout("db.example.com", 5432, 0.1)
+        finally:
+            release.set()  # let the orphaned lookup thread exit
+
+        message = str(exc_info.value)
+        assert "Timed out resolving database host name" in message
+        # Must stay retryable: it must not carry any of the non-retryable resolution fragments.
+        assert "could not translate host name" not in message
+        assert "Name or service not known" not in message
 
 
 # Transaction-mode poolers (Supabase Supavisor on :6543, PgBouncer transaction mode, AWS RDS Proxy)


### PR DESCRIPTION
## Problem

Error tracking surfaced a `CancelledError` ("Cancelled") from the Postgres import source, raised inside `socket.getaddrinfo` under `_connect_to_postgres` during schema discovery ([issue 019f1b78-af90-7ff0-8cb9-331113f491ff](https://us.posthog.com/project/2/error_tracking/019f1b78-af90-7ff0-8cb9-331113f491ff)). The failing event was `sync_new_schemas_activity` (the `discover-schemas` workflow) on **attempt 3** — a repeating failure, not a one-off cancellation.

Root cause: psycopg3 resolves hostnames itself in Python (`conninfo_attempts` → `socket.getaddrinfo`) *before* libpq ever connects. libpq's `connect_timeout` bounds establishing the socket, never that name lookup. So a stalled or unresponsive resolver blocks the worker thread for as long as the OS resolver takes. Because the data-import sync activities are threaded and non-interruptible, the lookup never trips `connect_timeout` — the activity instead runs until Temporal's `start_to_close_timeout` cancels the thread mid-`getaddrinfo`, surfacing a misleading `CancelledError` and burning the whole activity's retry budget.

## Changes

Bound the DNS lookup. `_connect_to_postgres` now resolves the host under a wall-clock timeout (reusing `connect_timeout` as the budget) and hands psycopg the resolved address via `hostaddr`, which makes psycopg skip its own unbounded lookup. A stalled resolver becomes a fast, retryable `OperationalError` instead of a hung thread.

The change is deliberately narrow and preserves existing behavior everywhere else:

- **IP literals and Unix-socket paths short-circuit** (return `None`, no lookup) — so IP hosts and the SSH-tunnel local endpoint (`127.0.0.1`) are untouched.
- **Genuine resolution failures fall through** (return `None`) — psycopg connects and re-raises as before, so the existing non-retryable "Name or service not known" / "could not translate host name" classification still applies. Only a resolver that *exceeds the timeout* is converted to a retryable error; its message avoids those non-retryable fragments so it stays retryable (a stall is usually transient).
- The lookup is gated on non-test settings (mirroring `_get_sslmode`), since dev/test connect to local or fake hosts and shouldn't do real DNS.

This is the same class of fragility already bounded for Google Sheets (request timeout) and Redshift (keepalives): an unbounded blocking network op in a threaded sync activity turning into a misleading `CancelledError`.

I considered adding `CancelledError`/`Cancelled` to the source's `NonRetryableErrors` and rejected it — a cancellation is a Temporal control-flow signal, not a user/upstream credential/config problem, and marking it non-retryable would wrongly stop retries on legitimate cancellations (worker redeploys, superseded syncs).

## How did you test this code?

I'm an agent. I could not run the Django/pytest suite in this environment (no test runner available), so CI will exercise the new tests. Locally I:

- Byte-compiled both changed files and ran `ruff check` (clean).
- Validated the resolver algorithm standalone against the real stdlib primitives (`socket`, `concurrent.futures`, `ipaddress`), confirming: IP/socket/empty hosts short-circuit without calling `getaddrinfo`; a resolved host returns the first address; a `gaierror` returns `None`; and a stalled resolver raises within the bound (~0.1s for a 0.1s timeout).

Added `TestResolveHostaddrWithTimeout` (a pure-function unit test, cheapest rung). It catches a regression where the wall-clock bound is removed or broken: without it a stalled `getaddrinfo` again hangs the threaded activity until `start_to_close_timeout` fires the misleading `CancelledError`. No existing test exercised DNS-resolution bounding. Cases cover the short-circuit (parameterized), first-address return, gaierror fall-through, and the stalled-resolver fast-fail (asserting the message stays retryable).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a PostHog error-tracking webhook for the Postgres data-warehouse source. Confirmed via the error-tracking MCP tools that the stack genuinely originates in this source's connect path (`_connect_to_postgres` → psycopg → `getaddrinfo`) and that the event was `sync_new_schemas_activity` attempt 3, indicating a repeating connect hang rather than a one-off cancellation. Decided this was a fixable fragility (not a `NonRetryableErrors` case, not a transient to leave alone), matching the Google Sheets / Redshift precedents in the same product. Invoked the `/writing-tests` skill before adding the test. Checked open PRs (including the maintainer's) for a duplicate — none touch the Postgres DNS/connect path.