### PR TITLE
chore(agent-proxy): log ingest request body chunk timing

### DIFF
--- a/services/agent-proxy/src/hono/ingest-handler.ts
+++ b/services/agent-proxy/src/hono/ingest-handler.ts
@@ -41,6 +41,20 @@ import {
 } from '../lib/types.js'
 import { observeStreamIngestEvents } from './metrics.js'
 
+// Diagnostic (temporary): records when request-body chunks arrive at the Node
+// process, to tell a live upload (chunks spread across the request lifetime)
+// from a body buffered upstream and delivered in one burst at request close.
+// The sandbox holds one long-lived chunked POST open for the whole turn; if
+// chunks only land when that request closes, the stall is upstream of this
+// process. Remove once the buffering hop is pinned down.
+interface IngestBodyTiming {
+    startedAt: number
+    firstChunkAt: number | null
+    lastChunkAt: number | null
+    chunks: number
+    bytes: number
+}
+
 // ---------------------------------------------------------------------------
 // Route handler (exported; wired in app.ts)
 // ---------------------------------------------------------------------------
@@ -90,9 +104,17 @@ export async function handleIngest(
     const streamKey = getStreamKey(claims.runId)
     const redisStream = new TaskRunRedisStream(streamKey, redis)
 
+    const bodyTiming: IngestBodyTiming = {
+        startedAt: Date.now(),
+        firstChunkAt: null,
+        lastChunkAt: null,
+        chunks: 0,
+        bytes: 0,
+    }
+
     let result: EventIngestResult
     try {
-        result = await ingestEventLines(redisStream, claims, token, config, c.req.raw)
+        result = await ingestEventLines(redisStream, claims, token, config, c.req.raw, bodyTiming)
     } catch (err: unknown) {
         if (err instanceof EventIngestBadRequest) {
             return c.json({ error: err.message }, 400)
@@ -119,6 +141,17 @@ export async function handleIngest(
         accepted: result.accepted,
         duplicate: result.duplicate,
         lastSeq: result.last_accepted_seq,
+        // Body-arrival timing. Live upload: firstChunkMs small, chunkSpanMs
+        // large. Buffered upstream: firstChunkMs ~= lastChunkMs, chunkSpanMs ~0
+        // (every chunk lands together when the request closes).
+        chunks: bodyTiming.chunks,
+        bodyBytes: bodyTiming.bytes,
+        firstChunkMs: bodyTiming.firstChunkAt === null ? null : bodyTiming.firstChunkAt - bodyTiming.startedAt,
+        lastChunkMs: bodyTiming.lastChunkAt === null ? null : bodyTiming.lastChunkAt - bodyTiming.startedAt,
+        chunkSpanMs:
+            bodyTiming.firstChunkAt === null || bodyTiming.lastChunkAt === null
+                ? null
+                : bodyTiming.lastChunkAt - bodyTiming.firstChunkAt,
     })
 
     return c.json(
@@ -140,7 +173,8 @@ async function ingestEventLines(
     claims: SandboxEventIngestTokenPayload,
     originalToken: string,
     config: Config,
-    rawRequest: Request
+    rawRequest: Request,
+    bodyTiming: IngestBodyTiming
 ): Promise<EventIngestResult> {
     const result: EventIngestResult = {
         accepted: 0,
@@ -152,7 +186,7 @@ async function ingestEventLines(
     let completionLineFinalSeq: number | null = null
 
     try {
-        for await (const line of iterRequestLines(rawRequest)) {
+        for await (const line of iterRequestLines(rawRequest, claims.runId, bodyTiming)) {
             const parsed = parseIngestLine(line)
 
             if (parsed.kind === 'complete') {
@@ -260,7 +294,7 @@ function parseIngestLine(line: string): IngestLine {
 // Streaming NDJSON body reader (mirrors _iter_request_lines)
 // ---------------------------------------------------------------------------
 
-async function* iterRequestLines(request: Request): AsyncGenerator<string> {
+async function* iterRequestLines(request: Request, run: string, timing: IngestBodyTiming): AsyncGenerator<string> {
     const body = request.body
     if (body === null) {
         return
@@ -276,6 +310,20 @@ async function* iterRequestLines(request: Request): AsyncGenerator<string> {
             const { done, value } = await reader.read()
 
             if (value !== undefined && value.length > 0) {
+                const chunkAt = Date.now()
+                if (timing.firstChunkAt === null) {
+                    timing.firstChunkAt = chunkAt
+                }
+                timing.lastChunkAt = chunkAt
+                timing.chunks += 1
+                timing.bytes += value.length
+                logger.debug('ingest:body_chunk', {
+                    run,
+                    chunk: timing.chunks,
+                    bytes: value.length,
+                    sinceStartMs: chunkAt - timing.startedAt,
+                })
+
                 requestSize += value.length
                 if (requestSize > MAX_REQUEST_BYTES) {
                     throw new EventIngestPayloadTooLarge('Event ingest request is too large')

--- a/services/agent-proxy/tests/hono/ingest-handler.test.ts
+++ b/services/agent-proxy/tests/hono/ingest-handler.test.ts
@@ -25,6 +25,7 @@ import {
     MAX_EVENTS_PER_REQUEST,
     HEARTBEAT_THROTTLE_SECONDS,
 } from '@/lib/constants.js'
+import { logger } from '@/lib/logging.js'
 import { TaskRunRedisStream, getStreamKey } from '@/lib/redis-stream.js'
 import { heartbeatWorkflowIfNeeded } from '@/lib/side-effects.js'
 import type { SandboxEventIngestTokenPayload } from '@/lib/types.js'
@@ -1143,6 +1144,55 @@ describe('ingest-handler', () => {
             await new Promise((r) => setTimeout(r, 0))
             expect(fetchSpy).not.toHaveBeenCalled()
             fetchSpy.mockRestore()
+        })
+    })
+
+    // -----------------------------------------------------------------------
+    // Body-arrival timing diagnostic
+    //
+    // The ingest log carries chunks/bodyBytes/firstChunkMs/lastChunkMs/chunkSpanMs
+    // so operators can tell a live upload (chunks spread over the request) from a
+    // body buffered upstream and delivered in one burst at request close. If those
+    // numbers are wrong the diagnostic misleads that investigation, so lock in that
+    // they reflect the actual body read.
+    // -----------------------------------------------------------------------
+
+    describe('body-arrival timing', () => {
+        it('reports chunk count, byte total, and a consistent span on the ingest log', async () => {
+            const infoSpy = vi.spyOn(logger, 'info')
+            const enc = new TextEncoder()
+            const chunk1 = enc.encode(JSON.stringify({ seq: 1, event: { type: 'a' } }) + '\n')
+            const chunk2 = enc.encode(JSON.stringify({ seq: 2, event: { type: 'b' } }) + '\n')
+
+            const ctx = makeContext({ body: makeChunkedBody([chunk1, chunk2]) })
+            const res = await handleIngest(ctx, fakeRedis as unknown as Redis, makeConfig(), [] as CryptoKey[])
+            expect(res.status).toBe(200)
+
+            const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest')?.[1] as Record<string, number>
+            expect(log).toBeTruthy()
+            expect(log.chunks).toBe(2)
+            expect(log.bodyBytes).toBe(chunk1.length + chunk2.length)
+            const firstChunkMs = log.firstChunkMs as number
+            const lastChunkMs = log.lastChunkMs as number
+            expect(typeof firstChunkMs).toBe('number')
+            expect(lastChunkMs).toBeGreaterThanOrEqual(firstChunkMs)
+            expect(log.chunkSpanMs as number).toBe(lastChunkMs - firstChunkMs)
+        })
+
+        it('reports zero chunks and null timing for an empty body', async () => {
+            const infoSpy = vi.spyOn(logger, 'info')
+
+            const ctx = makeContext({ body: makeStringBody('') })
+            const res = await handleIngest(ctx, fakeRedis as unknown as Redis, makeConfig(), [] as CryptoKey[])
+            expect(res.status).toBe(200)
+
+            const log = infoSpy.mock.calls.find((c) => c[0] === 'ingest')?.[1] as Record<string, unknown>
+            expect(log).toBeTruthy()
+            expect(log.chunks).toBe(0)
+            expect(log.bodyBytes).toBe(0)
+            expect(log.firstChunkMs).toBeNull()
+            expect(log.lastChunkMs).toBeNull()
+            expect(log.chunkSpanMs).toBeNull()
         })
     })
 })


### PR DESCRIPTION
## Problem

Sandbox agent runs stream their assistant output to the browser through agent-proxy's NDJSON ingest leg (`POST /v1/runs/:run/ingest`). In production the content events are not delivered live: they land in the browser SSE stream in a single burst minutes after they were generated, lined up with the sandbox's long-lived upload closing on its window roll. The read leg and the sequenced write logic are both fine, so the events simply are not reaching Redis until that upload request closes.

Reading the code, every hop we can inspect appears to stream: the sandbox client flushes each event over a chunked HTTP request as it is produced, `@hono/node-server` exposes the request body as a streaming `ReadableStream`, and the handler writes each parsed line to Redis as it reads it. The main Django app and this service also sit behind the same shared ALB and Contour/Envoy path, so the load balancer alone cannot explain why a Django-side path streams and this one does not. We need a measurement at the process boundary, not another hypothesis.

## Changes

Temporary diagnostic logging in the ingest handler that times when request-body chunks arrive at the Node process:

- A per-chunk `debug` log (`ingest:body_chunk`) with the chunk index, byte size, and milliseconds since the request started reading. Off in production by default (level is `info`); enable on a single pod with `AGENT_PROXY_LOG_LEVEL=debug`.
- Extra fields on the existing per-request `ingest` `info` log: `chunks`, `bodyBytes`, `firstChunkMs`, `lastChunkMs`, `chunkSpanMs`.

How to read it:

- Live upload: `firstChunkMs` small, `chunkSpanMs` large (chunks spread across the request lifetime).
- Buffered upstream: `firstChunkMs` and `lastChunkMs` are close and `chunkSpanMs` is near zero (every chunk lands together when the request closes).

No behavior change: logging plus an internal signature addition only. It records byte counts and timing, never event content. This is scaffolding to be reverted once the buffering hop is identified.

## How did you test this code?

I'm an agent (Claude Code). I did not exercise this against a live sandbox. Automated checks I ran locally:

- `pnpm --filter @posthog/agent-proxy typecheck` passed
- `pnpm --filter @posthog/agent-proxy exec vitest run tests/hono/ingest-handler.test.ts` passed (44/44, including 2 new cases)
- `oxlint` and `oxfmt` on the changed files: 0 warnings, formatted

New tests in `tests/hono/ingest-handler.test.ts` under `body-arrival timing`:

- "reports chunk count, byte total, and a consistent span on the ingest log" catches a refactor that miscounts chunks or bytes, or breaks the `chunkSpanMs = lastChunkMs - firstChunkMs` arithmetic. Those numbers are the whole point of the change, and a wrong value would send the buffered-versus-live investigation the wrong way. No existing test asserted the timing fields.
- "reports zero chunks and null timing for an empty body" guards the null path so an empty body logs `null` rather than `NaN`.

Operational validation still stands: deploy, set `AGENT_PROXY_LOG_LEVEL=debug` on one pod, trigger a sandbox turn, and read `firstChunkMs` / `chunkSpanMs` on the `ingest` log line.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code at the direction of @charlesvien, who is debugging why sandbox agent output reaches the browser in delayed bursts instead of live. We traced the write leg end to end and every inspectable hop (client, `@hono/node-server` body stream, Envoy defaults, the handler) appears to stream, yet the Django-side path delivers live and this one does not, despite sharing the same public ALB. Rather than commit to a load-balancer theory that the shared-LB fact undercuts, this PR adds the one measurement that localizes the stall: chunk-arrival timing at the Node process. Depending on the numbers, the fix is either in agent-proxy's body handling (read the raw request stream the way Django's ASGI ingest short-circuit does) or a client-side change to stop holding one upload open for the whole turn. The `/writing-tests` skill was invoked to scope the two added tests. No other repo skills were used.
