### PR TITLE
fix(okta): make applications endpoint full-refresh only

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/okta/settings.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/okta/settings.py
@@ -22,7 +22,7 @@ class OktaEndpointConfig:
     # on most resources and `published` on the System Log.
     default_incremental_field: Optional[str] = None
     # How the incremental filter is sent to Okta:
-    #   "filter"  -> ?filter=lastUpdated gt "<ts>"   (Users, Groups, Apps)
+    #   "filter"  -> ?filter=lastUpdated gt "<ts>"   (Users, Groups)
     #   "since"   -> ?since=<ts>                       (System Log)
     incremental_param: Optional[Literal["filter", "since"]] = None
     # Stable, immutable field to partition by. Never use lastUpdated (it mutates).
@@ -59,9 +59,9 @@ OKTA_ENDPOINTS: dict[str, OktaEndpointConfig] = {
     "applications": OktaEndpointConfig(
         name="applications",
         path="/apps",
-        incremental_fields=[_datetime_incremental_field("lastUpdated")],
-        default_incremental_field="lastUpdated",
-        incremental_param="filter",
+        # The Apps API `filter` only supports status, user.id, group.id and
+        # credentials.signing.kid — not lastUpdated — so there is no server-side time
+        # filter and this is full-refresh only.
         partition_key="created",
         page_size=200,
     ),

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/okta/tests/test_okta.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/okta/tests/test_okta.py
@@ -96,6 +96,17 @@ class TestBuildInitialParams:
         assert params["filter"] == 'lastUpdated gt "2024-01-01T00:00:00.000Z"'
         assert params["limit"] == 200
 
+    def test_applications_never_sends_filter(self):
+        # Okta's Apps API `filter` does not support lastUpdated, so an incremental run must
+        # not send a server-side filter — it would 400.
+        params = _build_initial_params(
+            OKTA_ENDPOINTS["applications"],
+            should_use_incremental_field=True,
+            db_incremental_field_last_value=datetime(2024, 1, 1, tzinfo=UTC),
+            incremental_field="lastUpdated",
+        )
+        assert params == {"limit": 200}
+
     def test_filter_endpoint_no_watermark_has_no_filter(self):
         params = _build_initial_params(
             OKTA_ENDPOINTS["users"],

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/okta/tests/test_okta_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/okta/tests/test_okta_source.py
@@ -55,7 +55,7 @@ class TestOktaSource:
         [
             ("users", True),
             ("groups", True),
-            ("applications", True),
+            ("applications", False),
             ("logs", True),
             ("group_rules", False),
             ("user_types", False),


### PR DESCRIPTION
## Problem

Error tracking surfaced a recurring `HTTPError: 400 Client Error: Bad Request` from the Okta data-warehouse import source, raised in `okta.py` at `fetch_page` (`response.raise_for_status()`).

Root cause: the `applications` endpoint (`/api/v1/apps`) was configured for server-side incremental filtering on `lastUpdated` (`incremental_param="filter"`, `default_incremental_field="lastUpdated"`). But Okta's Apps API `filter` parameter only supports `status`, `user.id`, `group.id` and `credentials.signing.kid` — **not** `lastUpdated`. So every incremental sync sent an unsupported `filter=lastUpdated gt "<ts>"` query, which Okta rejects with 400.

This is why the first sync succeeds (no watermark → no filter) but every subsequent incremental sync fails.

Error tracking issue: https://us.posthog.com/project/2/error_tracking/019f1ba3-37e6-7193-8d38-9a76acf0111c

Ref: Okta's Apps API filter only supports the four attributes above ([Okta Applications API](https://developer.okta.com/docs/reference/api/apps/)); `lastUpdated` filtering is available on Users and Groups but not Apps.

## Changes

Make the `applications` endpoint full-refresh only — drop `incremental_fields`, `default_incremental_field` and `incremental_param`. This mirrors the existing `group_rules` endpoint, which is also full-refresh because Okta offers no server-side time filter for it. Apps collections are small, so a full refresh each sync is cheap and correct. The `created` partition key is unchanged.

Decision: this is a fixable bug on our side (we send a request param Okta doesn't support), not a user/upstream error — so it's fixed rather than added to `NonRetryableErrors`. There's no way to do server-side incremental filtering on the Apps API, so full refresh is the only correct option.

## How did you test this code?

I'm an agent. I could not run the suite in my sandbox (no Python env with deps), so CI will run it. I added/updated automated tests:

- `test_applications_never_sends_filter` in `test_okta.py` — asserts an incremental run against `applications` produces only `{"limit": 200}` and no `filter`. This fails before the fix (the endpoint emitted the invalid `filter=lastUpdated gt "..."`) and is the direct regression guard for the 400.
- Updated `test_schema_incremental_support` in `test_okta_source.py` to reflect that `applications` no longer advertises incremental/append support.

I also ran `ruff check` and `ruff format --check` on the changed files (both clean).

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the failing frame is in the Okta source's `fetch_page`, traced the call path to the incremental-filter construction in `settings.py` / `_build_initial_params`, and verified against Okta's API docs that the Apps `filter` doesn't support `lastUpdated`. Chose full-refresh (matching `group_rules`) over keeping client-side incremental, since the latter offers no efficiency gain (must fetch all apps anyway) and relies on dedup behavior not worth the added risk for an ALPHA source. Kept the change scoped to the one misconfigured endpoint.

Invoked skill: `/writing-tests` guidance was followed for the added regression test.