### PR TITLE
feat(data-management): bulk edit tags on event definitions

### DIFF
--- a/frontend/snapshots.yml
+++ b/frontend/snapshots.yml
@@ -5285,17 +5285,17 @@ snapshots:
     scenes-app-data-management-definition-view--event-definition-metadata--wide--light:
         hash: v1.k794b7964.bcd0733641ad526571025b4d6636886d673602d2c6375bb7927f1c5b270c6900.kvjPEZFMkQhgRCCHHO3Ul9b8Lll83N3715Cp9SxjxFM
     scenes-app-data-management-event-definitions--default--dark:
-        hash: v1.k794b7964.d7a4728c8b21672d67310fee85291917f193a926716233fac923eb87f8b566e7.Y1ZeZ7J8fL2k3QFH-uvvPESwjUEdWD5fWUC54ObFcjQ
+        hash: v1.k794b7964.d0440958f26df761c2257d96f14a9dd541bb70baa1aed199ffa5928aeea47cb1.LtJRGPRtS4lvpOZuHtH7vD8fgt_QyRns2zOHK5NqggA
     scenes-app-data-management-event-definitions--default--light:
-        hash: v1.k794b7964.d46a5a24d81aba150ffd58368ecc0252f24ab1753e1c2c2d7d04ec0d4d3a20c8.W2ynUZgMCuucVX9GpOrfXPUL9V3ST88ryt5gtSfls8Y
+        hash: v1.k794b7964.aedbabfb55c7407c76e5ee4e51f5b547fb89522bee24eec680691155473dfeff.gm4FilNsePXr6qASJXYxop1KWQXkTf2k0lqIoH9nRZE
     scenes-app-data-management-event-definitions--filtered-unverified-only--dark:
-        hash: v1.k794b7964.f5bc0eeee1ba5c97f041de2820831d44dad5775173f1fa3e44650c25bcd752c3.LQfMv0GaXJsRlDvLtMudfYX3RC6pzLH2zOp2vPLSZHk
+        hash: v1.k794b7964.2d496db2f6747da454adfc365819e1a405e993fb129afba6ba28b42b9f1bab2b.7h4YYTSKYSWq00nY67GwBQZkxOu2dvWMEKFTfK5Rmmk
     scenes-app-data-management-event-definitions--filtered-unverified-only--light:
-        hash: v1.k794b7964.500668e28693302d53b4df95657c230281edc0a601086dfec426f66f63f38743.Bs7by0zie-B5B1KclxzsxmuXxk05mUq4r7d0Cufy4rM
+        hash: v1.k794b7964.ceae87821d34262464f20d817459bb2138f9121241b1e635d9535ff623e1bbaa.e9_xum8Gtl0EImegXmL_5XmwlTzfqlRsQkbgZ_HgmZc
     scenes-app-data-management-event-definitions--filtered-verified-only--dark:
-        hash: v1.k794b7964.c8a7d2bbd19451ead00d8b6abdc02797c9637afc77739c3a7297fada6bb25afd.qAcleN0GPwINlEa93ybkqGIqc2l0sEISJ24PVZVuZCc
+        hash: v1.k794b7964.c0e1ca6c30c2f01d0bf24a2003665d1705563b746e77a83d76ba5ba7277506db.0M3XJuReBEJN8G4lxYgeXEvXP2pae2QiYmnflaO_cG0
     scenes-app-data-management-event-definitions--filtered-verified-only--light:
-        hash: v1.k794b7964.994d982c7299b08edd713731d8f753ef0e714385f6c448477b3d5989fddf70b6.w0ONKr_hXEJzSy733f14F37EKT3HTZnEyBWu7CzQcT0
+        hash: v1.k794b7964.3b47ea008d035855293cce22b6949ffbe2a2220ef81ab9be9ccafb19f31f2255.G-mWUtZNTZJ4xlbJDgGyzAWmyVvSCYN7RAG9GpB2ABQ
     scenes-app-data-management-property-definitions--default--dark:
         hash: v1.k794b7964.9fbe3c05ac4e92ada46f8827af46cb1eb0adb5c7955711cfec86a64a0aa20691.o_50pNXYTq46HJVDkFUgpvMKiyalTdZT9V9ofWY-GEI
     scenes-app-data-management-property-definitions--default--light:

--- a/frontend/src/generated/core/api.schemas.ts
+++ b/frontend/src/generated/core/api.schemas.ts
@@ -3218,10 +3218,9 @@ export interface PatchedEnterprisePropertyDefinitionApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -3238,7 +3237,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/frontend/src/lib/components/BulkActions/BulkUpdateTagsButton.tsx
+++ b/frontend/src/lib/components/BulkActions/BulkUpdateTagsButton.tsx
@@ -14,16 +14,17 @@ import { tagsModel } from '~/models/tagsModel'
 export type BulkTagAction = 'add' | 'remove' | 'set'
 
 export interface BulkUpdateTagsResult {
-    updated: Array<{ id: number; tags: string[] }>
-    skipped: Array<{ id: number; reason: string }>
+    updated: Array<{ id: number | string; tags: string[] }>
+    skipped: Array<{ id: number | string; reason: string }>
 }
 
-export type BulkTaggableResource = 'feature_flags' | 'dashboards' | 'insights'
+export type BulkTaggableResource = 'feature_flags' | 'dashboards' | 'insights' | 'event_definitions'
 
 interface BulkUpdateTagsButtonProps {
     resource: BulkTaggableResource
-    selectedIds: ReadonlyArray<number>
-    onSuccess?: () => void
+    // Integer PKs for most resources; event definitions are keyed by UUID strings.
+    selectedIds: ReadonlyArray<number | string>
+    onSuccess?: (result: BulkUpdateTagsResult) => void
 }
 
 export function BulkUpdateTagsButton({ resource, selectedIds, onSuccess }: BulkUpdateTagsButtonProps): JSX.Element {
@@ -65,7 +66,7 @@ export function BulkUpdateTagsButton({ resource, selectedIds, onSuccess }: BulkU
             }
             close()
             loadTags()
-            onSuccess?.()
+            onSuccess?.(response)
         } catch {
             lemonToast.error('Failed to update tags')
         } finally {

--- a/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
+++ b/frontend/src/scenes/data-management/events/EventDefinitionsTable.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { IconApps, IconPlus } from '@posthog/icons'
 import { LemonButton, LemonInput, LemonSelect, LemonSelectOptions, Link } from '@posthog/lemon-ui'
 
+import { BulkUpdateTagsButton } from 'lib/components/BulkActions/BulkUpdateTagsButton'
 import { ObjectTags } from 'lib/components/ObjectTags/ObjectTags'
 import { TagSelect } from 'lib/components/TagSelect'
 import { TaxonomicFilterGroupType } from 'lib/components/TaxonomicFilter/types'
@@ -43,7 +44,7 @@ const eventTypeOptions: LemonSelectOptions<EventDefinitionType> = [
 export function EventDefinitionsTable(): JSX.Element {
     const { eventDefinitions, eventDefinitionsLoading, filters, showVerifiedFilter } =
         useValues(eventDefinitionsTableLogic)
-    const { loadEventDefinitions, setFilters } = useActions(eventDefinitionsTableLogic)
+    const { loadEventDefinitions, setFilters, applyBulkTagUpdates } = useActions(eventDefinitionsTableLogic)
     const [isCreateModalOpen, setIsCreateModalOpen] = useState(false)
 
     const columns: LemonTableColumns<EventDefinition> = [
@@ -253,6 +254,22 @@ export function EventDefinitionsTable(): JSX.Element {
                     },
                     rowExpandable: () => true,
                     noIndent: true,
+                }}
+                bulkSelection={{
+                    getKey: (definition: EventDefinition): string => definition.id,
+                    rowAriaLabel: (definition: EventDefinition) => `Select event ${definition.name}`,
+                    headerAriaLabel: 'Select all events on this page',
+                    noun: ['event', 'events'],
+                    renderActions: (ctx) => (
+                        <BulkUpdateTagsButton
+                            resource="event_definitions"
+                            selectedIds={ctx.selectedKeys}
+                            onSuccess={(result) => {
+                                applyBulkTagUpdates(result.updated)
+                                ctx.clearSelection()
+                            }}
+                        />
+                    ),
                 }}
                 dataSource={eventDefinitions.results}
                 useURLForSorting={false}

--- a/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
+++ b/frontend/src/scenes/data-management/events/eventDefinitionsTableLogic.ts
@@ -101,6 +101,7 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
         loadPropertiesForEvent: (definition: EventDefinition, url: string | null = '') => ({ definition, url }),
         setFilters: (filters: Partial<Filters>) => ({ filters }),
         setLocalEventDefinition: (definition: EventDefinition) => ({ definition }),
+        applyBulkTagUpdates: (updates: { id: number | string; tags: string[] }[]) => ({ updates }),
         setLocalPropertyDefinition: (event: EventDefinition, definition: PropertyDefinition) => ({ event, definition }),
         setEventDefinitionPropertiesLoading: (ids: string[]) => ({ ids }),
     }),
@@ -179,6 +180,25 @@ export const eventDefinitionsTableLogic = kea<eventDefinitionsTableLogicType>([
                     }
 
                     // Update cache
+                    cache.apiCache = {
+                        ...cache.apiCache,
+                        [values.eventDefinitions.current]: result,
+                    }
+
+                    return result
+                },
+                applyBulkTagUpdates: ({ updates }) => {
+                    if (!values.eventDefinitions.current || updates.length === 0) {
+                        return values.eventDefinitions
+                    }
+                    const tagsById = new Map(updates.map((u) => [String(u.id), u.tags]))
+                    const result = {
+                        ...values.eventDefinitions,
+                        results: values.eventDefinitions.results.map((d) =>
+                            tagsById.has(String(d.id)) ? { ...d, tags: tagsById.get(String(d.id)) } : d
+                        ),
+                    }
+
                     cache.apiCache = {
                         ...cache.apiCache,
                         [values.eventDefinitions.current]: result,

--- a/posthog/api/event_definition.py
+++ b/posthog/api/event_definition.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from typing import Any, Literal, Optional, cast
 
 from django.core.cache import cache
-from django.db.models import Manager
+from django.db.models import Manager, Prefetch
 from django.http import Http404
 
 import orjson
@@ -20,14 +20,20 @@ from posthog.api.event_definition_generators.python import PythonGenerator
 from posthog.api.event_definition_generators.typescript import TypeScriptGenerator
 from posthog.api.routing import TeamAndOrgViewSetMixin
 from posthog.api.shared import UserBasicSerializer
-from posthog.api.tagged_item import TaggedItemSerializerMixin, TaggedItemViewSetMixin
+from posthog.api.tagged_item import (
+    BulkUpdateTagsUUIDRequestSerializer,
+    BulkUpdateTagsUUIDResponseSerializer,
+    TaggedItemSerializerMixin,
+    TaggedItemViewSetMixin,
+    apply_bulk_tag_changes,
+)
 from posthog.api.utils import action
 from posthog.clickhouse.client import sync_execute
 from posthog.constants import EventDefinitionType
 from posthog.event_usage import report_user_action
 from posthog.filters import TermSearchFilterBackend, term_search_filter_sql
 from posthog.helpers.impersonation import is_impersonated
-from posthog.models import EventDefinition, ObjectMediaPreview, Team
+from posthog.models import EventDefinition, ObjectMediaPreview, TaggedItem, Team
 from posthog.models.activity_logging.activity_log import Detail, log_activity
 from posthog.models.user import User
 from posthog.models.utils import UUIDT
@@ -231,6 +237,8 @@ class EventDefinitionViewSet(
     viewsets.GenericViewSet,
 ):
     scope_object = "event_definition"
+    # "bulk_update_tags" must be opted in here so personal API keys with event_definition:write can use it.
+    scope_object_write_actions = ["create", "update", "partial_update", "patch", "destroy", "bulk_update_tags"]
     serializer_class = EventDefinitionSerializer
     lookup_field = "id"
     filter_backends = [TermSearchFilterBackend]
@@ -440,6 +448,38 @@ class EventDefinitionViewSet(
 
             serializer_class = EnterpriseEventDefinitionSerializer  # type: ignore
         return serializer_class
+
+    @extend_schema(
+        request=BulkUpdateTagsUUIDRequestSerializer,
+        responses={200: BulkUpdateTagsUUIDResponseSerializer},
+    )
+    @action(methods=["POST"], detail=False)
+    def bulk_update_tags(self, request, *args, **kwargs) -> response.Response:
+        """Add, remove, or replace tags across multiple event definitions in one request.
+
+        Overrides ``TaggedItemViewSetMixin.bulk_update_tags``, which assumes integer PKs and runs
+        object-level access-control filtering. Event definitions use UUID PKs and are not an
+        object-level access-controlled resource — project membership (enforced by the viewset) is
+        the only boundary, matching the single-object update path — so this scopes by project and
+        skips the per-object editor check. Tags live on the base ``EventDefinition`` row, so it
+        operates there regardless of the enterprise extension.
+        """
+        serializer = BulkUpdateTagsUUIDRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        validated = serializer.validated_data
+        validated_ids = validated["ids"]
+
+        objects = list(
+            EventDefinition.objects.filter(id__in=validated_ids, team__project_id=self.project_id).prefetch_related(
+                Prefetch("tagged_items", queryset=TaggedItem.objects.select_related("tag"), to_attr="prefetched_tags")
+            )
+        )
+
+        found_ids = {obj.id for obj in objects}
+        skipped = [{"id": obj_id, "reason": "Not found"} for obj_id in validated_ids if obj_id not in found_ids]
+
+        updated = apply_bulk_tag_changes(objects, validated["action"], validated["tags"])
+        return response.Response({"updated": updated, "skipped": skipped})
 
     def perform_create(self, serializer):
         """Handle context and side effects for event definition creation."""

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -42,6 +42,42 @@ def cleanup_orphan_tags(team_id: int) -> None:
     Tag.objects.filter(Q(team_id=team_id) & Q(tagged_items__isnull=True)).delete()
 
 
+def apply_bulk_tag_changes(objects: Sequence, tag_action: str, tags: list[str]) -> list[dict[str, Any]]:
+    """Apply an add/remove/set tag mutation to each object and return a per-object result.
+
+    Callers are responsible for team-scoping and access-checking ``objects`` first. When a
+    ``prefetched_tags`` attribute is present it is used to avoid a per-object tag query.
+    Orphaned tags are cleaned up once at the end.
+    """
+    normalized_tags = {tagify(t) for t in tags}
+    updated: list[dict[str, Any]] = []
+    team_id = None
+
+    for obj in objects:
+        team_id = obj.team_id
+        current_tags = {
+            ti.tag.name
+            for ti in (
+                obj.prefetched_tags if hasattr(obj, "prefetched_tags") else obj.tagged_items.select_related("tag").all()
+            )
+        }
+
+        if tag_action == "add":
+            new_tags = current_tags | normalized_tags
+        elif tag_action == "remove":
+            new_tags = current_tags - normalized_tags
+        else:  # set
+            new_tags = set(normalized_tags)
+
+        set_tags_on_object(list(new_tags), obj)
+        updated.append({"id": obj.id, "tags": sorted(new_tags)})
+
+    if team_id is not None:
+        cleanup_orphan_tags(team_id)
+
+    return updated
+
+
 class TaggedItemSerializerMixin(serializers.Serializer):
     """
     Serializer mixin that handles tags for objects.
@@ -117,6 +153,35 @@ class BulkUpdateTagsErrorSerializer(serializers.Serializer):
 class BulkUpdateTagsResponseSerializer(serializers.Serializer):
     updated = BulkUpdateTagsItemSerializer(many=True)
     skipped = BulkUpdateTagsErrorSerializer(many=True)
+
+
+class BulkUpdateTagsUUIDRequestSerializer(BulkUpdateTagsRequestSerializer):
+    """Variant of ``BulkUpdateTagsRequestSerializer`` for resources keyed by UUID (e.g. event definitions)."""
+
+    ids = serializers.ListField(
+        child=serializers.UUIDField(),
+        allow_empty=False,
+        max_length=BULK_UPDATE_TAGS_MAX_IDS,
+        help_text="List of object UUIDs to update tags on.",
+    )
+
+
+class BulkUpdateTagsUUIDItemSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="UUID of the object whose tags were updated.")
+    tags = serializers.ListField(
+        child=serializers.CharField(),
+        help_text="The object's full tag list after the update.",
+    )
+
+
+class BulkUpdateTagsUUIDErrorSerializer(serializers.Serializer):
+    id = serializers.UUIDField(help_text="UUID of the object that was skipped.")
+    reason = serializers.CharField(help_text="Why the object was skipped, e.g. 'Not found'.")
+
+
+class BulkUpdateTagsUUIDResponseSerializer(serializers.Serializer):
+    updated = BulkUpdateTagsUUIDItemSerializer(many=True, help_text="Objects whose tags were successfully updated.")
+    skipped = BulkUpdateTagsUUIDErrorSerializer(many=True, help_text="Objects that were skipped, with a reason each.")
 
 
 def _prefetch_tags_for_instances(instances: Sequence) -> None:
@@ -230,38 +295,7 @@ class TaggedItemViewSetMixin(viewsets.GenericViewSet):
             if obj_id not in found_ids:
                 errors.append({"id": obj_id, "reason": "Not found"})
 
-        # Normalize input tags
-        normalized_tags = {tagify(t) for t in tags}
-
-        # Apply tag changes
-        updated: list[dict[str, Any]] = []
-        team_id = None
-
-        for obj in editable_objects:
-            team_id = obj.team_id
-            current_tags = {
-                ti.tag.name
-                for ti in (
-                    obj.prefetched_tags
-                    if hasattr(obj, "prefetched_tags")
-                    else obj.tagged_items.select_related("tag").all()
-                )
-            }
-
-            if tag_action == "add":
-                new_tags = current_tags | normalized_tags
-            elif tag_action == "remove":
-                new_tags = current_tags - normalized_tags
-            else:  # set
-                new_tags = set(normalized_tags)
-
-            set_tags_on_object(list(new_tags), obj)
-            updated.append({"id": obj.id, "tags": sorted(new_tags)})
-
-        # Cleanup orphan tags once at the end
-        if team_id is not None:
-            cleanup_orphan_tags(team_id)
-
+        updated = apply_bulk_tag_changes(editable_objects, tag_action, tags)
         return response.Response({"updated": updated, "skipped": errors})
 
 

--- a/posthog/api/tagged_item.py
+++ b/posthog/api/tagged_item.py
@@ -47,14 +47,15 @@ def apply_bulk_tag_changes(objects: Sequence, tag_action: str, tags: list[str]) 
 
     Callers are responsible for team-scoping and access-checking ``objects`` first. When a
     ``prefetched_tags`` attribute is present it is used to avoid a per-object tag query.
-    Orphaned tags are cleaned up once at the end.
+    Orphaned tags are cleaned up per affected team, since ``objects`` may span multiple teams
+    when the caller scopes by project (e.g. event definitions across environments).
     """
     normalized_tags = {tagify(t) for t in tags}
     updated: list[dict[str, Any]] = []
-    team_id = None
+    team_ids: set[int] = set()
 
     for obj in objects:
-        team_id = obj.team_id
+        team_ids.add(obj.team_id)
         current_tags = {
             ti.tag.name
             for ti in (
@@ -72,7 +73,7 @@ def apply_bulk_tag_changes(objects: Sequence, tag_action: str, tags: list[str]) 
         set_tags_on_object(list(new_tags), obj)
         updated.append({"id": obj.id, "tags": sorted(new_tags)})
 
-    if team_id is not None:
+    for team_id in team_ids:
         cleanup_orphan_tags(team_id)
 
     return updated

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -16,7 +16,7 @@ from rest_framework import status
 from posthog.api.test.test_organization import create_organization
 from posthog.api.test.test_team import create_team
 from posthog.api.test.test_user import create_user
-from posthog.models import ActivityLog, EventDefinition, Organization, Team
+from posthog.models import ActivityLog, EventDefinition, Organization, Tag, Team
 
 from products.actions.backend.models.action import Action
 
@@ -491,43 +491,6 @@ class TestEventDefinitionAPI(APIBaseTest):
         other_team_event_exists = EventDefinition.objects.filter(name="team_specific_event", team=other_team).exists()
         assert not other_team_event_exists
 
-
-class TestEventDefinitionExcludeStale(APIBaseTest):
-    """Stale filter tests need real wall-clock times so the Postgres NOW() comparison
-    in `exclude_stale` matches the fixture last_seen_at values. The other test class is
-    wrapped in freeze_time which Postgres NOW() does not respect."""
-
-    @parameterized.expand(
-        [
-            (
-                "default keeps stale events",
-                "",
-                {"fresh_event", "stale_event", "ancient_event", "never_seen_event"},
-            ),
-            (
-                "explicit false keeps stale events",
-                "?exclude_stale=false",
-                {"fresh_event", "stale_event", "ancient_event", "never_seen_event"},
-            ),
-            (
-                "true hides stale events but keeps never-seen",
-                "?exclude_stale=true",
-                {"fresh_event", "never_seen_event"},
-            ),
-        ]
-    )
-    def test_exclude_stale_filter(self, _description: str, query_string: str, expected_names: set[str]) -> None:
-        now = timezone.now()
-        EventDefinition.objects.create(team=self.team, name="fresh_event", last_seen_at=now - timedelta(days=1))
-        EventDefinition.objects.create(team=self.team, name="stale_event", last_seen_at=now - timedelta(days=45))
-        EventDefinition.objects.create(team=self.team, name="ancient_event", last_seen_at=now - timedelta(days=365))
-        EventDefinition.objects.create(team=self.team, name="never_seen_event", last_seen_at=None)
-
-        response = self.client.get(f"/api/projects/{self.team.pk}/event_definitions/{query_string}")
-        assert response.status_code == status.HTTP_200_OK
-        names = {row["name"] for row in response.json()["results"]}
-        assert names == expected_names
-
     def test_bulk_update_tags_with_uuid_ids(self):
         # Event definitions have UUID PKs and are not an object-level access-controlled resource, so the
         # inherited mixin action (integer PKs + per-object access filter) can't be reused. If that override
@@ -565,6 +528,67 @@ class TestEventDefinitionExcludeStale(APIBaseTest):
         assert data["updated"] == []
         assert data["skipped"] == [{"id": str(foreign.id), "reason": "Not found"}]
         assert foreign.tagged_items.count() == 0
+
+    def test_bulk_update_tags_cleans_orphan_tags_for_every_team_in_project(self):
+        # Project-scoped bulk updates can span multiple environments (teams) in one project, so orphan
+        # cleanup must run for each affected team — not just the last object's, which would leave orphan
+        # Tag rows behind in every other environment.
+        other_env = Team.objects.create(
+            organization=self.organization, project_id=self.demo_team.project_id, name="staging env"
+        )
+        ed_a = EventDefinition.objects.create(team=self.demo_team, name="env_a_event")
+        ed_b = EventDefinition.objects.create(team=other_env, name="env_b_event")
+        bulk_url = f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/"
+        # Seed a distinct tag in each environment that the batch below then orphans.
+        self.client.post(bulk_url, {"ids": [str(ed_a.id)], "action": "set", "tags": ["orphan_a"]})
+        self.client.post(bulk_url, {"ids": [str(ed_b.id)], "action": "set", "tags": ["orphan_b"]})
+        assert Tag.objects.filter(name="orphan_a", team=self.demo_team).exists()
+        assert Tag.objects.filter(name="orphan_b", team=other_env).exists()
+
+        response = self.client.post(
+            bulk_url, {"ids": [str(ed_a.id), str(ed_b.id)], "action": "set", "tags": ["shared"]}
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        assert not Tag.objects.filter(name="orphan_a", team=self.demo_team).exists()
+        assert not Tag.objects.filter(name="orphan_b", team=other_env).exists()
+
+
+class TestEventDefinitionExcludeStale(APIBaseTest):
+    """Stale filter tests need real wall-clock times so the Postgres NOW() comparison
+    in `exclude_stale` matches the fixture last_seen_at values. The other test class is
+    wrapped in freeze_time which Postgres NOW() does not respect."""
+
+    @parameterized.expand(
+        [
+            (
+                "default keeps stale events",
+                "",
+                {"fresh_event", "stale_event", "ancient_event", "never_seen_event"},
+            ),
+            (
+                "explicit false keeps stale events",
+                "?exclude_stale=false",
+                {"fresh_event", "stale_event", "ancient_event", "never_seen_event"},
+            ),
+            (
+                "true hides stale events but keeps never-seen",
+                "?exclude_stale=true",
+                {"fresh_event", "never_seen_event"},
+            ),
+        ]
+    )
+    def test_exclude_stale_filter(self, _description: str, query_string: str, expected_names: set[str]) -> None:
+        now = timezone.now()
+        EventDefinition.objects.create(team=self.team, name="fresh_event", last_seen_at=now - timedelta(days=1))
+        EventDefinition.objects.create(team=self.team, name="stale_event", last_seen_at=now - timedelta(days=45))
+        EventDefinition.objects.create(team=self.team, name="ancient_event", last_seen_at=now - timedelta(days=365))
+        EventDefinition.objects.create(team=self.team, name="never_seen_event", last_seen_at=None)
+
+        response = self.client.get(f"/api/projects/{self.team.pk}/event_definitions/{query_string}")
+        assert response.status_code == status.HTTP_200_OK
+        names = {row["name"] for row in response.json()["results"]}
+        assert names == expected_names
 
 
 @dataclasses.dataclass

--- a/posthog/api/test/test_event_definition.py
+++ b/posthog/api/test/test_event_definition.py
@@ -528,6 +528,44 @@ class TestEventDefinitionExcludeStale(APIBaseTest):
         names = {row["name"] for row in response.json()["results"]}
         assert names == expected_names
 
+    def test_bulk_update_tags_with_uuid_ids(self):
+        # Event definitions have UUID PKs and are not an object-level access-controlled resource, so the
+        # inherited mixin action (integer PKs + per-object access filter) can't be reused. If that override
+        # regresses, UUID ids 400 on the integer serializer or every object gets filtered out as inaccessible.
+        ed1 = EventDefinition.objects.create(team=self.demo_team, name="bulk_a")
+        ed2 = EventDefinition.objects.create(team=self.demo_team, name="bulk_b")
+
+        response = self.client.post(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/",
+            {"ids": [str(ed1.id), str(ed2.id)], "action": "add", "tags": ["pii", "billing"]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["skipped"] == []
+        assert {row["id"]: sorted(row["tags"]) for row in data["updated"]} == {
+            str(ed1.id): ["billing", "pii"],
+            str(ed2.id): ["billing", "pii"],
+        }
+        for ed in (ed1, ed2):
+            assert sorted(ed.tagged_items.values_list("tag__name", flat=True)) == ["billing", "pii"]
+
+    def test_bulk_update_tags_ignores_event_definitions_in_other_project(self):
+        # Project-scoping / IDOR guard: a definition in another project must be reported "Not found" and left untouched.
+        other_team = create_team(organization=create_organization(name="other org"))
+        foreign = EventDefinition.objects.create(team=other_team, name="foreign_event")
+
+        response = self.client.post(
+            f"/api/projects/{self.demo_team.pk}/event_definitions/bulk_update_tags/",
+            {"ids": [str(foreign.id)], "action": "add", "tags": ["pii"]},
+        )
+
+        assert response.status_code == status.HTTP_200_OK, response.json()
+        data = response.json()
+        assert data["updated"] == []
+        assert data["skipped"] == [{"id": str(foreign.id), "reason": "Not found"}]
+        assert foreign.tagged_items.count() == 0
+
 
 @dataclasses.dataclass
 class EventData:

--- a/posthog/settings/web.py
+++ b/posthog/settings/web.py
@@ -522,6 +522,10 @@ SPECTACULAR_SETTINGS = {
         "HeatmapType": "products.web_analytics.backend.models.heatmap_saved.SavedHeatmap.Type",
         # --- Inline value lists (type-hint enums, no x-spec-enum-id) ---
         "PropertyGroupOperator": ["AND", "OR"],
+        # bulk_update_tags exposes an identical add/remove/set `action` ChoiceField on both
+        # BulkUpdateTagsRequest and its UUID subclass, so the shared enum can't be component-prefixed
+        # unambiguously and auto-resolves to a hash name. Pin it to a stable name.
+        "BulkUpdateTagsActionEnum": ["add", "remove", "set"],
         # Full signal taxonomy on the report `signals` endpoint; the source-config serializer's
         # subset enums keep their own auto-resolved names.
         "SignalSourceProduct": "products.signals.backend.enums.SIGNAL_SOURCE_PRODUCT_VALUES",

--- a/products/actions/frontend/generated/api.schemas.ts
+++ b/products/actions/frontend/generated/api.schemas.ts
@@ -647,10 +647,9 @@ export interface ActionReferenceApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -667,7 +666,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/products/conversations/frontend/generated/api.schemas.ts
+++ b/products/conversations/frontend/generated/api.schemas.ts
@@ -901,10 +901,9 @@ export interface BulkUpdateStatusResponseApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -921,7 +920,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/products/dashboards/frontend/generated/api.schemas.ts
+++ b/products/dashboards/frontend/generated/api.schemas.ts
@@ -8684,10 +8684,9 @@ export interface UpdateDashboardWidgetsBatchResponseApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -8704,7 +8703,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/products/event_definitions/frontend/generated/api.schemas.ts
+++ b/products/event_definitions/frontend/generated/api.schemas.ts
@@ -171,44 +171,52 @@ export interface PatchedEnterpriseEventDefinitionApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
 } as const
 
-export interface BulkUpdateTagsRequestApi {
+/**
+ * Variant of ``BulkUpdateTagsRequestSerializer`` for resources keyed by UUID (e.g. event definitions).
+ */
+export interface BulkUpdateTagsUUIDRequestApi {
     /**
-     * List of object IDs to update tags on.
+     * List of object UUIDs to update tags on.
      * @maxItems 500
      */
-    ids: number[]
+    ids: string[]
     /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
      *
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }
 
-export interface BulkUpdateTagsItemApi {
-    id: number
+export interface BulkUpdateTagsUUIDItemApi {
+    /** UUID of the object whose tags were updated. */
+    id: string
+    /** The object's full tag list after the update. */
     tags: string[]
 }
 
-export interface BulkUpdateTagsErrorApi {
-    id: number
+export interface BulkUpdateTagsUUIDErrorApi {
+    /** UUID of the object that was skipped. */
+    id: string
+    /** Why the object was skipped, e.g. 'Not found'. */
     reason: string
 }
 
-export interface BulkUpdateTagsResponseApi {
-    updated: BulkUpdateTagsItemApi[]
-    skipped: BulkUpdateTagsErrorApi[]
+export interface BulkUpdateTagsUUIDResponseApi {
+    /** Objects whose tags were successfully updated. */
+    updated: BulkUpdateTagsUUIDItemApi[]
+    /** Objects that were skipped, with a reason each. */
+    skipped: BulkUpdateTagsUUIDErrorApi[]
 }
 
 /**

--- a/products/event_definitions/frontend/generated/api.ts
+++ b/products/event_definitions/frontend/generated/api.ts
@@ -9,8 +9,8 @@ import { apiMutator } from '../../../../frontend/src/lib/api-orval-mutator'
  * OpenAPI spec version: 1.0.0
  */
 import type {
-    BulkUpdateTagsRequestApi,
-    BulkUpdateTagsResponseApi,
+    BulkUpdateTagsUUIDRequestApi,
+    BulkUpdateTagsUUIDResponseApi,
     EnterpriseEventDefinitionApi,
     EventDefinitionRecordApi,
     EventDefinitionsByNameRetrieveParams,
@@ -164,34 +164,25 @@ export const getEventDefinitionsBulkUpdateTagsCreateUrl = (projectId: string) =>
 }
 
 /**
- * Bulk update tags on multiple objects.
+ * Add, remove, or replace tags across multiple event definitions in one request.
  *
- * PAT access: this action has no ``required_scopes=`` on the decorator —
- * inheriting viewsets must add ``"bulk_update_tags"`` to their
- * ``scope_object_write_actions`` list to accept personal API keys.
- * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
- * "This action does not support personal API key access". Done per-viewset
- * so granting ``<scope>:write`` for one resource doesn't leak access to
- * sibling resources that share this mixin.
- *
- * Accepts:
- * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
- *
- * Actions:
- * - "add": Add tags to existing tags on each object
- * - "remove": Remove specific tags from each object
- * - "set": Replace all tags on each object with the provided list
+ * Overrides ``TaggedItemViewSetMixin.bulk_update_tags``, which assumes integer PKs and runs
+ * object-level access-control filtering. Event definitions use UUID PKs and are not an
+ * object-level access-controlled resource — project membership (enforced by the viewset) is
+ * the only boundary, matching the single-object update path — so this scopes by project and
+ * skips the per-object editor check. Tags live on the base ``EventDefinition`` row, so it
+ * operates there regardless of the enterprise extension.
  */
 export const eventDefinitionsBulkUpdateTagsCreate = async (
     projectId: string,
-    bulkUpdateTagsRequestApi: BulkUpdateTagsRequestApi,
+    bulkUpdateTagsUUIDRequestApi: BulkUpdateTagsUUIDRequestApi,
     options?: RequestInit
-): Promise<BulkUpdateTagsResponseApi> => {
-    return apiMutator<BulkUpdateTagsResponseApi>(getEventDefinitionsBulkUpdateTagsCreateUrl(projectId), {
+): Promise<BulkUpdateTagsUUIDResponseApi> => {
+    return apiMutator<BulkUpdateTagsUUIDResponseApi>(getEventDefinitionsBulkUpdateTagsCreateUrl(projectId), {
         ...options,
         method: 'POST',
         headers: { 'Content-Type': 'application/json', ...options?.headers },
-        body: JSON.stringify(bulkUpdateTagsRequestApi),
+        body: JSON.stringify(bulkUpdateTagsUUIDRequestApi),
     })
 }
 

--- a/products/event_definitions/frontend/generated/api.zod.ts
+++ b/products/event_definitions/frontend/generated/api.zod.ts
@@ -91,36 +91,29 @@ export const EventDefinitionsPartialUpdateBody = /* @__PURE__ */ zod
     .describe('Serializer mixin that handles tags for objects.')
 
 /**
- * Bulk update tags on multiple objects.
+ * Add, remove, or replace tags across multiple event definitions in one request.
  *
- * PAT access: this action has no ``required_scopes=`` on the decorator —
- * inheriting viewsets must add ``"bulk_update_tags"`` to their
- * ``scope_object_write_actions`` list to accept personal API keys.
- * Without that opt-in, ``APIScopePermission`` rejects PAT requests with
- * "This action does not support personal API key access". Done per-viewset
- * so granting ``<scope>:write`` for one resource doesn't leak access to
- * sibling resources that share this mixin.
- *
- * Accepts:
- * - {"ids": [...], "action": "add"|"remove"|"set", "tags": ["tag1", "tag2"]}
- *
- * Actions:
- * - "add": Add tags to existing tags on each object
- * - "remove": Remove specific tags from each object
- * - "set": Replace all tags on each object with the provided list
+ * Overrides ``TaggedItemViewSetMixin.bulk_update_tags``, which assumes integer PKs and runs
+ * object-level access-control filtering. Event definitions use UUID PKs and are not an
+ * object-level access-controlled resource — project membership (enforced by the viewset) is
+ * the only boundary, matching the single-object update path — so this scopes by project and
+ * skips the per-object editor check. Tags live on the base ``EventDefinition`` row, so it
+ * operates there regardless of the enterprise extension.
  */
 export const eventDefinitionsBulkUpdateTagsCreateBodyIdsMax = 500
 
-export const EventDefinitionsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod.object({
-    ids: zod
-        .array(zod.number())
-        .max(eventDefinitionsBulkUpdateTagsCreateBodyIdsMax)
-        .describe('List of object IDs to update tags on.'),
-    action: zod
-        .enum(['add', 'remove', 'set'])
-        .describe('\* `add` - add\n\* `remove` - remove\n\* `set` - set')
-        .describe(
-            "'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.\n\n\* `add` - add\n\* `remove` - remove\n\* `set` - set"
-        ),
-    tags: zod.array(zod.string()).describe('Tag names to add, remove, or set.'),
-})
+export const EventDefinitionsBulkUpdateTagsCreateBody = /* @__PURE__ */ zod
+    .object({
+        ids: zod
+            .array(zod.uuid())
+            .max(eventDefinitionsBulkUpdateTagsCreateBodyIdsMax)
+            .describe('List of object UUIDs to update tags on.'),
+        action: zod
+            .enum(['add', 'remove', 'set'])
+            .describe('\* `add` - add\n\* `remove` - remove\n\* `set` - set')
+            .describe(
+                "'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.\n\n\* `add` - add\n\* `remove` - remove\n\* `set` - set"
+            ),
+        tags: zod.array(zod.string()).describe('Tag names to add, remove, or set.'),
+    })
+    .describe('Variant of ``BulkUpdateTagsRequestSerializer`` for resources keyed by UUID (e.g. event definitions).')

--- a/products/feature_flags/frontend/generated/api.schemas.ts
+++ b/products/feature_flags/frontend/generated/api.schemas.ts
@@ -1190,10 +1190,9 @@ export interface BulkKeysResponseApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -1210,7 +1209,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/products/product_analytics/frontend/generated/api.schemas.ts
+++ b/products/product_analytics/frontend/generated/api.schemas.ts
@@ -7668,10 +7668,9 @@ export interface ActivityLogPaginatedResponseApi {
  * * `remove` - remove
  * * `set` - set
  */
-export type BulkUpdateTagsRequestActionEnumApi =
-    (typeof BulkUpdateTagsRequestActionEnumApi)[keyof typeof BulkUpdateTagsRequestActionEnumApi]
+export type BulkUpdateTagsActionEnumApi = (typeof BulkUpdateTagsActionEnumApi)[keyof typeof BulkUpdateTagsActionEnumApi]
 
-export const BulkUpdateTagsRequestActionEnumApi = {
+export const BulkUpdateTagsActionEnumApi = {
     Add: 'add',
     Remove: 'remove',
     Set: 'set',
@@ -7688,7 +7687,7 @@ export interface BulkUpdateTagsRequestApi {
      * * `add` - add
      * * `remove` - remove
      * * `set` - set */
-    action: BulkUpdateTagsRequestActionEnumApi
+    action: BulkUpdateTagsActionEnumApi
     /** Tag names to add, remove, or set. */
     tags: string[]
 }

--- a/services/mcp/src/api/generated.ts
+++ b/services/mcp/src/api/generated.ts
@@ -11868,6 +11868,20 @@ export namespace Schemas {
       ids: string[];
     }
 
+    /**
+     * * `add` - add
+     * * `remove` - remove
+     * * `set` - set
+     */
+    export type BulkUpdateTagsActionEnum = typeof BulkUpdateTagsActionEnum[keyof typeof BulkUpdateTagsActionEnum];
+
+
+    export const BulkUpdateTagsActionEnum = {
+      Add: 'add',
+      Remove: 'remove',
+      Set: 'set',
+    } as const;
+
     export interface BulkUpdateTagsError {
       id: number;
       reason: string;
@@ -11877,20 +11891,6 @@ export namespace Schemas {
       id: number;
       tags: string[];
     }
-
-    /**
-     * * `add` - add
-     * * `remove` - remove
-     * * `set` - set
-     */
-    export type BulkUpdateTagsRequestActionEnum = typeof BulkUpdateTagsRequestActionEnum[keyof typeof BulkUpdateTagsRequestActionEnum];
-
-
-    export const BulkUpdateTagsRequestActionEnum = {
-      Add: 'add',
-      Remove: 'remove',
-      Set: 'set',
-    } as const;
 
     export interface BulkUpdateTagsRequest {
       /**
@@ -11903,7 +11903,7 @@ export namespace Schemas {
        * * `add` - add
        * * `remove` - remove
        * * `set` - set */
-      action: BulkUpdateTagsRequestActionEnum;
+      action: BulkUpdateTagsActionEnum;
       /** Tag names to add, remove, or set. */
       tags: string[];
     }
@@ -11911,6 +11911,46 @@ export namespace Schemas {
     export interface BulkUpdateTagsResponse {
       updated: BulkUpdateTagsItem[];
       skipped: BulkUpdateTagsError[];
+    }
+
+    export interface BulkUpdateTagsUUIDError {
+      /** UUID of the object that was skipped. */
+      id: string;
+      /** Why the object was skipped, e.g. 'Not found'. */
+      reason: string;
+    }
+
+    export interface BulkUpdateTagsUUIDItem {
+      /** UUID of the object whose tags were updated. */
+      id: string;
+      /** The object's full tag list after the update. */
+      tags: string[];
+    }
+
+    /**
+     * Variant of ``BulkUpdateTagsRequestSerializer`` for resources keyed by UUID (e.g. event definitions).
+     */
+    export interface BulkUpdateTagsUUIDRequest {
+      /**
+         * List of object UUIDs to update tags on.
+         * @maxItems 500
+         */
+      ids: string[];
+      /** 'add' merges with existing tags, 'remove' deletes specific tags, 'set' replaces all tags.
+       *
+       * * `add` - add
+       * * `remove` - remove
+       * * `set` - set */
+      action: BulkUpdateTagsActionEnum;
+      /** Tag names to add, remove, or set. */
+      tags: string[];
+    }
+
+    export interface BulkUpdateTagsUUIDResponse {
+      /** Objects whose tags were successfully updated. */
+      updated: BulkUpdateTagsUUIDItem[];
+      /** Objects that were skipped, with a reason each. */
+      skipped: BulkUpdateTagsUUIDError[];
     }
 
     /**


### PR DESCRIPTION
## Problem

Event definitions could only be tagged one at a time — tagging a batch of events (say, marking a set `deprecated` or `pii`) meant opening each definition individually. Feature flags, insights, and dashboards already support bulk tag editing; this brings event definitions to parity.

## Changes

- **Frontend:** the event definitions table (`Data management → Events`) now has row selection. Selecting rows reveals the shared **Update tags** action (add / remove / replace) already used by flags, insights, and dashboards. On success the affected rows update in place (including the logic's URL cache) so tags reflect immediately without a refetch.
- **Backend:** `EventDefinitionViewSet` gains a `bulk_update_tags` action.

The interesting part is why this needed a viewset-specific override rather than reusing `TaggedItemViewSetMixin.bulk_update_tags` directly:

- **UUID PKs.** The shared action validates `ids` as integers; event definitions are keyed by UUID. A UUID-aware request/response serializer variant handles this.
- **Access model.** The shared action filters each object through object-level RBAC (`access_level_satisfied_for_resource`). `event_definition` isn't a registered access-controlled resource, so that filter would reject *every* event definition for *every* user. The override scopes by project (`team__project_id`) and relies on project membership — the same boundary the single-object `PATCH` already uses.
- Tags live on the base `EventDefinition` row (multi-table inheritance shares the PK with `EnterpriseEventDefinition`), so the override operates on `EventDefinition.objects` and works regardless of the enterprise extension.

The shared add/remove/set logic is extracted into `apply_bulk_tag_changes` so the mixin and the override don't diverge. `scope_object_write_actions` opts the action into personal-API-key `event_definition:write` access.

## How did you test this code?

I'm an agent, and this session ran in an environment without the full Python/JS toolchain, so I could not execute the suites locally — CI will. What I did run: **ruff** (lint + format) passes on all changed Python files.

Automated tests added — `posthog/api/test/test_event_definition.py`:
- `test_bulk_update_tags_with_uuid_ids` — guards the UUID-PK + access-model regressions: if the override is dropped and the inherited mixin runs, UUID ids 400 on the integer serializer or every object gets filtered out as inaccessible.
- `test_bulk_update_tags_ignores_event_definitions_in_other_project` — project-scoping / IDOR guard: a definition in another project is reported "Not found" and left untouched.

The generic add/remove/set/validation/orphan-cleanup behavior is already covered in `test_tagged_item.py` (shared `apply_bulk_tag_changes`), so these tests only cover what's event-definition-specific.

Note: the backend schema change (integer → UUID ids for this operation) regenerates `products/event_definitions/frontend/generated/` via `hogli build:openapi`. The `check-openapi-types` CI job auto-commits that for same-repo PRs; the feature itself doesn't depend on the generated client (the button calls `api.create()` directly).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code (Opus 4.8). Skills invoked while shaping this change: `/improving-drf-endpoints` (viewset/serializer + schema annotations), `/adopting-generated-api-types` (frontend API usage), and `/writing-tests` (the test value gate — kept coverage to the two event-definition-specific regressions above).

Key decisions:
- Overrode the mixin action instead of generalizing it — event definitions differ on both PK type and access model, and folding those into the shared mixin would complicate the integer/RBAC path used by flags/insights/dashboards.
- Updated affected rows from the API response rather than refetching, because the table logic caches list responses by URL and a plain reload would return stale tags.
