### PR TITLE
chore(phrocs): resolve phrocs deterministically in bin/start

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -144,6 +144,9 @@ fi
 ./bin/download-mmdb
 
 PROCESS_MANAGER="phrocs"
+# PROCESS_MANAGER is the bare name (kept for telemetry); PROCESS_MANAGER_BIN is
+# the executable to run, resolved per-manager below. For phrocs that's the
+# in-repo source build when present, so it wins over anything on PATH.
 
 # Detect detached mode early (`-d` is the shorthand, `--detach` the long
 # form). Incompatible with --mprocs since mprocs has no detached mode; only
@@ -170,19 +173,32 @@ if [[ " $* " == *" --mprocs "* ]]; then
         fi
     fi
     PROCESS_MANAGER="mprocs"
+    PROCESS_MANAGER_BIN="mprocs"
 fi
 
 if [[ "$PROCESS_MANAGER" == "phrocs" ]]; then
-    if ! command -v phrocs &>/dev/null; then
-        if command -v brew &>/dev/null; then
-            echo "🔁 Installing phrocs via Homebrew..."
-            brew tap posthog/tap && brew install phrocs
-        else
-            echo "👉 To run bin/start, install phrocs: brew tap posthog/tap && brew install phrocs"
-            exit 1
-        fi
+    # Resolve phrocs deterministically. The in-repo source build (produced by
+    # flox activation via `make -C tools/phrocs build`) is canonical: it always
+    # matches this checkout, so prefer it over anything on PATH. This stops a
+    # stray brew/curl install from silently shadowing the version your branch
+    # built. Non-flox setups have no dist binary and fall back to PATH.
+    DIST_PHROCS="$REPOSITORY_ROOT/tools/phrocs/dist/phrocs"
+    if [[ -x "$DIST_PHROCS" ]]; then
+        PROCESS_MANAGER_BIN="$DIST_PHROCS"
+    elif PATH_PHROCS="$(command -v phrocs)"; then
+        PROCESS_MANAGER_BIN="$PATH_PHROCS"
+    elif [[ -n "${FLOX_ENV_PROJECT:-}" ]]; then
+        echo "👉 phrocs isn't built yet. Re-activate your flox environment to build it"
+        echo "   (leave and re-enter the repo directory, or run: flox activate),"
+        echo "   or build it directly: hogli phrocs:build"
+        exit 1
+    else
+        echo "👉 To run bin/start, install phrocs:"
+        echo "     brew tap posthog/tap && brew install phrocs"
+        echo "   or, without Homebrew:"
+        echo "     curl -fsSL https://raw.githubusercontent.com/PostHog/posthog/master/tools/phrocs/install.sh | bash"
+        exit 1
     fi
-    PROCESS_MANAGER="phrocs"
 fi
 
 # Use custom config, if provided (e.g. bin/start --custom bin/mprocs-custom.yaml)
@@ -206,9 +222,9 @@ if [[ "$*" == *"--custom"* ]]; then
     fi
     if [[ "$DETACHED" == "1" ]]; then
         exec 9<&-
-        "$PROCESS_MANAGER" --detach --config "$config_path"
+        "$PROCESS_MANAGER_BIN" --detach --config "$config_path"
     else
-        "$PROCESS_MANAGER" --config "$config_path"
+        "$PROCESS_MANAGER_BIN" --config "$config_path"
     fi
 else
     GENERATED_CONFIG="$REPOSITORY_ROOT/.posthog/.generated/mprocs.yaml"
@@ -233,8 +249,8 @@ else
         # for the child's whole lifetime even after bin/start exits —
         # blocking the next bin/start invocation.
         exec 9<&-
-        "$PROCESS_MANAGER" --detach --config "$CONFIG_TO_USE"
+        "$PROCESS_MANAGER_BIN" --detach --config "$CONFIG_TO_USE"
     else
-        "$PROCESS_MANAGER" --config "$CONFIG_TO_USE"
+        "$PROCESS_MANAGER_BIN" --config "$CONFIG_TO_USE"
     fi
 fi

--- a/bin/start
+++ b/bin/start
@@ -185,13 +185,16 @@ if [[ "$PROCESS_MANAGER" == "phrocs" ]]; then
     DIST_PHROCS="$REPOSITORY_ROOT/tools/phrocs/dist/phrocs"
     if [[ -x "$DIST_PHROCS" ]]; then
         PROCESS_MANAGER_BIN="$DIST_PHROCS"
-    elif PATH_PHROCS="$(command -v phrocs)"; then
-        PROCESS_MANAGER_BIN="$PATH_PHROCS"
     elif [[ -n "${FLOX_ENV_PROJECT:-}" ]]; then
+        # Inside flox the source build is the only accepted binary — do NOT fall
+        # back to PATH, or a stray brew/curl phrocs would shadow the checkout
+        # build in exactly the failure mode this resolution is meant to prevent.
         echo "👉 phrocs isn't built yet. Re-activate your flox environment to build it"
         echo "   (leave and re-enter the repo directory, or run: flox activate),"
         echo "   or build it directly: hogli phrocs:build"
         exit 1
+    elif PATH_PHROCS="$(command -v phrocs)"; then
+        PROCESS_MANAGER_BIN="$PATH_PHROCS"
     else
         echo "👉 To run bin/start, install phrocs:"
         echo "     brew tap posthog/tap && brew install phrocs"

--- a/tools/phrocs/README.md
+++ b/tools/phrocs/README.md
@@ -5,6 +5,14 @@ Drop-in replacement for `mprocs` — reads the same YAML config that `hogli dev:
 
 ## Install
 
+If you develop PostHog with **flox**, you already have phrocs: activation builds
+it from source (`make -C tools/phrocs build`) and `bin/start` runs that build
+directly from `tools/phrocs/dist/phrocs`. The source build is canonical — it
+always matches your checkout, so there's nothing to install or keep up to date,
+and a stray Homebrew/curl install can't shadow it.
+
+For **non-flox** setups, install a prebuilt binary:
+
 **Homebrew** (macOS and Linux):
 
 ```sh
@@ -16,6 +24,9 @@ brew tap posthog/tap && brew install phrocs
 ```sh
 curl -fsSL https://raw.githubusercontent.com/PostHog/posthog/master/tools/phrocs/install.sh | bash
 ```
+
+`bin/start` resolves phrocs in this order: the in-repo `dist/phrocs` build if
+present, otherwise `phrocs` on `PATH`.
 
 ## Build
 


### PR DESCRIPTION
## Problem

`bin/start` resolved the phrocs binary with a bare `command -v phrocs`, so PATH order decided which binary ran. In a flox dev environment phrocs is built from source on activation and symlinked onto PATH — but a stray Homebrew or curl install earlier in PATH could silently shadow it, so you'd run a stale prebuilt binary instead of the one your checkout just built.

Two smaller annoyances rode along: the block auto-ran `brew tap && brew install phrocs` even inside flox (where phrocs is already present), and the "not found" hint was Homebrew-first even though flox is the common path.

## Changes

- Resolve phrocs deterministically: prefer the in-repo source build (`tools/phrocs/dist/phrocs`), then fall back to `phrocs` on `PATH`. The build matching the checkout always wins — nothing on `PATH` can shadow it.
- Drop the `brew` auto-install branch (dead code inside flox).
- Context-aware "not found" guidance: inside flox → re-activate / `hogli phrocs:build`; non-flox → Homebrew or the install script.
- Route execution through a new `PROCESS_MANAGER_BIN` (the resolved executable) while `PROCESS_MANAGER` stays the bare name used for telemetry.
- README: document that the flox source build is canonical, plus the resolution order.

No behavior change for the `mprocs` path.

## How did you test this code?

I'm an agent (agent-assisted); I did not run the full stack manually. I validated `bash -n bin/start` (syntax) and traced each resolution branch (dist present, PATH fallback, flox-missing, non-flox-missing). No tests were added — this is a shell launcher path with no existing test coverage, and a bespoke test here wouldn't catch a regression the diff doesn't already make obvious.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Only touches the phrocs developer README, not user-facing docs.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with Claude Code. Skill invoked: `/simplify` (fanned out four parallel cleanup agents for reuse/simplification/efficiency/altitude, then applied the survivors — a dead default assignment and a duplicated `command -v` lookup).

Decisions along the way:
- Started with a version-floor "pin" (a `tools/phrocs/.min-version` file plus a `bin/start` check that warned when a `PATH`-resolved prebuilt binary was older than the checkout expected). Dropped it as speculative — it shipped inert (`0.0.0`) with no current need. Source builds can't go stale (the checkout is their pin); if stale prebuilt binaries ever actually bite, this is small to add back with a real value.
- Considered trusting the flox `PATH` symlink alone, but the explicit `dist/phrocs` check is what guarantees the repo build wins regardless of `PATH` order — the symlink only wins if the venv bin happens to sort first.
- Rejected a shared canonical-path constant across `bin/start` and `.flox/env/on-activate.sh` as over-engineering for a small launcher script.
