### PR TITLE
chore(ci): build a dedicated experiments recalculation worker image

### DIFF
--- a/.github/workflows/container-images-cd.yml
+++ b/.github/workflows/container-images-cd.yml
@@ -342,7 +342,16 @@ jobs:
             - name: Check for changes that affect general purpose temporal worker
               id: check_changes_general_purpose_temporal_worker
               run: |
-                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/exports/backend/temporal/subscriptions|^products/experiments/backend/temporal/|^products/engineering_analytics/backend/logic/job_logs/|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/(ai_observability|llm_analytics)|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/delete_teams|^posthog/temporal/ingestion_acceptance_test|^posthog/temporal/backfill_group_type_created_at|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/exports/backend/temporal/subscriptions|^products/engineering_analytics/backend/logic/job_logs/|^posthog/temporal/common|^posthog/temporal/session_recordings|^posthog/temporal/proxy_service|^posthog/temporal/(ai_observability|llm_analytics)|^posthog/temporal/product_analytics|^posthog/temporal/delete_persons|^posthog/temporal/delete_teams|^posthog/temporal/ingestion_acceptance_test|^posthog/temporal/backfill_group_type_created_at|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
+                      echo "changed=true" >> $GITHUB_OUTPUT
+                  else
+                      echo "changed=false" >> $GITHUB_OUTPUT
+                  fi
+
+            - name: Check for changes that affect experiments recalculation temporal worker
+              id: check_changes_experiments_recalculation_temporal_worker
+              run: |
+                  if git diff --name-only HEAD^ HEAD | grep -qE '^products/experiments/backend/temporal/|^posthog/temporal/common|^posthog/management/commands/start_temporal_worker.py$|^pyproject.toml$|^bin/temporal-django-worker$|^posthog/clickhouse/migrations/'; then
                       echo "changed=true" >> $GITHUB_OUTPUT
                   else
                       echo "changed=false" >> $GITHUB_OUTPUT
@@ -525,6 +534,27 @@ jobs:
                           }
                         },
                         "release": "temporal-worker-replay-vision",
+                        "commit": ${{ toJson(github.event.head_commit) }},
+                        "repository": ${{ toJson(github.repository) }},
+                        "labels": ${{ steps.labels.outputs.labels }},
+                        "timestamp": "${{ github.event.head_commit.timestamp }}"
+                      }
+
+            - name: Trigger Experiments Recalculation Temporal Worker Cloud deployment
+              if: steps.check_changes_experiments_recalculation_temporal_worker.outputs.changed == 'true'
+              uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
+              with:
+                  token: ${{ steps.deployer.outputs.token }}
+                  repository: PostHog/charts
+                  event-type: commit_state_update
+                  client-payload: |
+                      {
+                        "values": {
+                          "image": {
+                            "sha": "${{ steps.build_retry.outputs.digest || steps.build.outputs.digest }}"
+                          }
+                        },
+                        "release": "temporal-worker-experiments-recalculation",
                         "commit": ${{ toJson(github.event.head_commit) }},
                         "repository": ${{ toJson(github.repository) }},
                         "labels": ${{ steps.labels.outputs.labels }},


### PR DESCRIPTION
<!-- Authoring rules (agents: read).
     Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
       ✅ feat(insights): add retention graph export
       ❌ feat: Added retention export.   (capitalized, period, no scope)
     Description: high-level rationale, not a step-by-step replay. See "Rules for agent-authored PRs" lower down.
     Public OSS repo: no internal customers, incidents, or operational metrics.
     Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
-->

## Problem

The stacked PR routes experiment metrics recalculation to a dedicated `experiments-recalculation-task-queue` served by its own worker. That worker needs its image state kept current in `PostHog/charts`, but the CD pipeline has no dispatch for it, so its deploy state would never advance past the seeded value.

## Changes

Wires the new `temporal-worker-experiments-recalculation` release into the container-images CD pipeline. There is no new image build; every temporal worker shares the `posthog-cloud` image, and each worker just gets a `repository-dispatch` to `PostHog/charts` that writes the freshly built digest into its own release state.

Adds a change-detection step scoped to the recalc worker's paths and a matching dispatch for its release. The recalc temporal path moves off the general-purpose worker's change filter, since recalc no longer runs on that worker.

- `.github/workflows/container-images-cd.yml`

## Rollback

Revert this PR. The worker keeps running on whatever image its charts state already points at; only automatic image tracking for this release stops.

## Deploy order

Stacked on top of the queue-routing PR. Order within the stack does not matter for correctness: until the dedicated worker exists in charts, this dispatch simply updates a release nothing consumes yet. It becomes load-bearing once the charts worker is live.

## How did you test this code?

Agent-run: validated that the workflow YAML parses and that the new change-detection step, its `if` gate, and the release dispatch are consistent. CI exercises the dispatch on merge.

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/container-images-cd.yml'))"
```

![cat-type-small](https://github.com/user-attachments/assets/cd8fc3d0-097e-46ec-be7c-ce8deb245d12)

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Model: Opus 4.8
Manually refactored: **no**

Skills used:

- /writing-pull-requests (local)

Relevant decisions:

- Cloned the existing single-worker dispatch pattern (change-detection step, `if` gate, `repository-dispatch` with a per-release name) rather than introducing a new image build, since all temporal workers share the `posthog-cloud` image and differ only by dispatched release.
- Removed `products/experiments/backend/temporal/` from the general-purpose worker's change filter; recalc was the only general-registered code under that path, so leaving it would rebuild the general image on every recalc change for no reason.