### PR TITLE
fix(gong): treat empty calls window 404 as no data

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
@@ -131,7 +131,7 @@ def get_rows(
         # Gong's `/v2/calls` answers a date window with no processed calls using a 404
         # ("No calls found corresponding to the provided filters") rather than an empty 200.
         # Treat it as an empty page so the sync skips the window instead of failing.
-        if response.status_code == 404 and "no calls" in response.text.lower():
+        if config.uses_date_window and response.status_code == 404 and "no calls" in response.text.lower():
             return {}
 
         if not response.ok:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
@@ -128,6 +128,12 @@ def get_rows(
         if response.status_code == 429 or response.status_code >= 500:
             raise GongRetryableError(f"Gong API error (retryable): status={response.status_code}, url={url}")
 
+        # Gong's `/v2/calls` answers a date window with no processed calls using a 404
+        # ("No calls found corresponding to the provided filters") rather than an empty 200.
+        # Treat it as an empty page so the sync skips the window instead of failing.
+        if response.status_code == 404 and "no calls" in response.text.lower():
+            return {}
+
         if not response.ok:
             logger.error(f"Gong API error: status={response.status_code}, body={response.text}, url={url}")
             response.raise_for_status()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
@@ -239,6 +239,38 @@ class TestWindowedCalls:
         assert batches == [[{"id": "c1"}], [{"id": "c2"}]]
         assert "cursor=page2" in session.requested_urls[1]
 
+    def test_empty_window_returns_404(self) -> None:
+        # Gong returns 404 for a date window with no calls; the sync must skip it and
+        # continue to the next window rather than raising.
+        last_value = datetime.now(UTC) - timedelta(days=100)
+        responses = [
+            _FakeResponse(status_code=404, text='{"errors":["No calls found corresponding to the provided filters"]}'),
+            _FakeResponse(json_data={"calls": [{"id": "c1"}]}),
+        ]
+        session = _FakeSession(responses)
+        manager = _FakeResumableManager()
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
+            return_value=session,
+        ):
+            batches = list(
+                get_rows(
+                    "key",
+                    "secret",
+                    "calls",
+                    mock.MagicMock(),
+                    manager,
+                    should_use_incremental_field=True,
+                    db_incremental_field_last_value=last_value,
+                )
+            )
+
+        # The empty window yields nothing but does not abort the sync; both windows run.
+        assert batches == [[{"id": "c1"}]]
+        assert len(session.requested_urls) == 2
+        assert len(manager.saved_states) == 2
+
     def test_resume_uses_saved_window_start(self) -> None:
         last_value = datetime.now(UTC) - timedelta(days=80)
         resume_start = datetime.now(UTC) - timedelta(days=10)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any
 from urllib.parse import unquote
 
+import pytest
 from unittest import mock
 
 from parameterized import parameterized
@@ -239,12 +240,22 @@ class TestWindowedCalls:
         assert batches == [[{"id": "c1"}], [{"id": "c2"}]]
         assert "cursor=page2" in session.requested_urls[1]
 
-    def test_empty_window_returns_404(self) -> None:
-        # Gong returns 404 for a date window with no calls; the sync must skip it and
-        # continue to the next window rather than raising.
+    @parameterized.expand(
+        [
+            # Gong signals an empty date window with a 404; the sync skips it and continues.
+            (
+                "no_calls_body_skips_window",
+                '{"errors":["No calls found corresponding to the provided filters"]}',
+                False,
+            ),
+            # A 404 for any other reason must still surface rather than be swallowed.
+            ("unrelated_404_raises", '{"errors":["Not Found"]}', True),
+        ]
+    )
+    def test_404_handling(self, _name: str, body: str, should_raise: bool) -> None:
         last_value = datetime.now(UTC) - timedelta(days=100)
         responses = [
-            _FakeResponse(status_code=404, text='{"errors":["No calls found corresponding to the provided filters"]}'),
+            _FakeResponse(status_code=404, text=body),
             _FakeResponse(json_data={"calls": [{"id": "c1"}]}),
         ]
         session = _FakeSession(responses)
@@ -254,17 +265,20 @@ class TestWindowedCalls:
             "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
             return_value=session,
         ):
-            batches = list(
-                get_rows(
-                    "key",
-                    "secret",
-                    "calls",
-                    mock.MagicMock(),
-                    manager,
-                    should_use_incremental_field=True,
-                    db_incremental_field_last_value=last_value,
-                )
+            rows = get_rows(
+                "key",
+                "secret",
+                "calls",
+                mock.MagicMock(),
+                manager,
+                should_use_incremental_field=True,
+                db_incremental_field_last_value=last_value,
             )
+            if should_raise:
+                with pytest.raises(Exception):
+                    list(rows)
+                return
+            batches = list(rows)
 
         # The empty window yields nothing but does not abort the sync; both windows run.
         assert batches == [[{"id": "c1"}]]


### PR DESCRIPTION
## Problem

Gong data-warehouse imports were failing with an unhandled `HTTPError` raised from the source's `fetch_page` ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f1c81-9ecc-7011-aa57-3da45182d6ed)):

```
HTTPError: 404 Client Error: Not Found for url: https://api.gong.io/v2/calls?fromDateTime=<redacted>&toDateTime=<redacted>
```

Gong's `/v2/calls` endpoint answers a date window that contains **no processed calls** with a `404` (`{"errors": ["No calls found corresponding to the provided filters"]}`) rather than an empty `200`. This is documented, expected behaviour — the endpoint only returns completed calls, so a range with none returns 404.

The `calls` schema is synced by iterating bounded date windows. On incremental syncs the windows are short, so any window with no new calls hit the 404 and aborted the entire sync. The credentials are valid here (auth failures are already handled as 401/403), and the request path is a hardcoded constant — a 404 on this endpoint can only mean "no calls in this window".

## Changes

`fetch_page` now treats a `404` whose body signals no calls (`"no calls"` substring) as an empty page — it returns an empty dict so the windowed iterator yields nothing and advances to the next window, instead of calling `raise_for_status()`. Genuine 404s with a different body still surface. Retryable (429/5xx) handling is unchanged.

## How did you test this code?

I'm an agent. I added a regression test at the same layer as the fix (`test_empty_window_returns_404`): a windowed `calls` sync where the first window returns a 404 "no calls found" body and the second returns data — it asserts the sync skips the empty window, continues to the next, and returns the later window's rows rather than raising. No existing test exercised the 404-empty-window path (all windowed tests returned 200s).

Ran the source's unit suite locally: `pytest products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py` — 27 passed. Ruff check + format clean.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook for the `gong` source. Confirmed the stack originates in `gong.py` (`get_rows` → `_iter_windowed_rows` → `fetch_page` at the `raise_for_status()` call), then verified against Gong's API behaviour that a 404 on `/v2/calls` means "no calls in the requested range", not a failure. Chose to fix the code (graceful skip) rather than add to `NonRetryableErrors`, because retrying or stopping the sync are both wrong — the window is simply empty and the sync should continue. Matched on the stable `"no calls"` body substring rather than the volatile status-only signal to avoid swallowing unrelated 404s. Skill invoked: `/writing-tests`.
