### PR TITLE
fix(gong): treat empty date-window 404 on calls as no data

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
@@ -128,6 +128,11 @@ def get_rows(
         if response.status_code == 429 or response.status_code >= 500:
             raise GongRetryableError(f"Gong API error (retryable): status={response.status_code}, url={url}")
 
+        # `/v2/calls` returns 404 when a date window holds no processed calls, rather than an
+        # empty list. Treat it as an empty window so a gap in call activity doesn't fail the sync.
+        if response.status_code == 404 and config.uses_date_window:
+            return {}
+
         if not response.ok:
             logger.error(f"Gong API error: status={response.status_code}, body={response.text}, url={url}")
             response.raise_for_status()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/gong.py
@@ -128,9 +128,10 @@ def get_rows(
         if response.status_code == 429 or response.status_code >= 500:
             raise GongRetryableError(f"Gong API error (retryable): status={response.status_code}, url={url}")
 
-        # `/v2/calls` returns 404 when a date window holds no processed calls, rather than an
-        # empty list. Treat it as an empty window so a gap in call activity doesn't fail the sync.
-        if response.status_code == 404 and config.uses_date_window:
+        # `/v2/calls` returns a 404 with a "no calls found" body when a date window holds no
+        # processed calls, rather than an empty list. Treat only that payload as an empty window;
+        # any other 404 is surfaced so a genuine failure isn't masked as silent data loss.
+        if response.status_code == 404 and config.uses_date_window and "no calls found" in response.text.lower():
             return {}
 
         if not response.ok:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
@@ -177,7 +177,7 @@ class TestCursorPagination:
             "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
             return_value=session,
         ):
-            with pytest.raises(Exception):
+            with pytest.raises(Exception, match="404"):
                 list(get_rows("key", "secret", "users", mock.MagicMock(), manager))
 
     def test_single_page_without_records(self) -> None:
@@ -281,6 +281,28 @@ class TestWindowedCalls:
         assert batches == []
         # The window still advances and progress is persisted, so the sync isn't aborted.
         assert len(manager.saved_states) == 1
+
+    def test_404_without_no_calls_body_raises(self) -> None:
+        last_value = datetime.now(UTC) - timedelta(days=5)
+        session = _FakeSession([_FakeResponse(status_code=404, text="not found")])
+        manager = _FakeResumableManager()
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
+            return_value=session,
+        ):
+            with pytest.raises(Exception, match="404"):
+                list(
+                    get_rows(
+                        "key",
+                        "secret",
+                        "calls",
+                        mock.MagicMock(),
+                        manager,
+                        should_use_incremental_field=True,
+                        db_incremental_field_last_value=last_value,
+                    )
+                )
 
     def test_resume_uses_saved_window_start(self) -> None:
         last_value = datetime.now(UTC) - timedelta(days=80)

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/gong/tests/test_gong.py
@@ -3,6 +3,7 @@ from datetime import UTC, date, datetime, timedelta
 from typing import Any
 from urllib.parse import unquote
 
+import pytest
 from unittest import mock
 
 from parameterized import parameterized
@@ -168,6 +169,17 @@ class TestCursorPagination:
         # Non-windowed endpoints do not persist resume state.
         assert manager.saved_states == []
 
+    def test_404_on_non_windowed_endpoint_raises(self) -> None:
+        session = _FakeSession([_FakeResponse(status_code=404, text="not found")])
+        manager = _FakeResumableManager()
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
+            return_value=session,
+        ):
+            with pytest.raises(Exception):
+                list(get_rows("key", "secret", "users", mock.MagicMock(), manager))
+
     def test_single_page_without_records(self) -> None:
         session = _FakeSession([_FakeResponse(json_data={"workspaces": [{"id": "w1"}]})])
         manager = _FakeResumableManager()
@@ -238,6 +250,37 @@ class TestWindowedCalls:
 
         assert batches == [[{"id": "c1"}], [{"id": "c2"}]]
         assert "cursor=page2" in session.requested_urls[1]
+
+    def test_404_empty_window_is_skipped(self) -> None:
+        last_value = datetime.now(UTC) - timedelta(days=5)
+        session = _FakeSession(
+            [
+                _FakeResponse(
+                    status_code=404, text='{"errors":["No calls found corresponding to the provided filters."]}'
+                )
+            ]
+        )
+        manager = _FakeResumableManager()
+
+        with mock.patch(
+            "products.warehouse_sources.backend.temporal.data_imports.sources.gong.gong.make_tracked_session",
+            return_value=session,
+        ):
+            batches = list(
+                get_rows(
+                    "key",
+                    "secret",
+                    "calls",
+                    mock.MagicMock(),
+                    manager,
+                    should_use_incremental_field=True,
+                    db_incremental_field_last_value=last_value,
+                )
+            )
+
+        assert batches == []
+        # The window still advances and progress is persisted, so the sync isn't aborted.
+        assert len(manager.saved_states) == 1
 
     def test_resume_uses_saved_window_start(self) -> None:
         last_value = datetime.now(UTC) - timedelta(days=80)


### PR DESCRIPTION
## Problem

Error tracking surfaced an `HTTPError` originating in the Gong data-warehouse import source:

> `404 Client Error: Not Found for url: https://api.gong.io/v2/calls?fromDateTime=<redacted>&toDateTime=<redacted>`

Issue: https://us.posthog.com/project/2/error_tracking/019f1c81-9ecc-7011-aa57-3da45182d6ed (7 occurrences across 7 teams).

Stack trace confirms it originates in this source's code:

```
get_rows (gong.py:138)
  → _iter_windowed_rows (gong.py:207)
    → fetch_page (gong.py:133  →  response.raise_for_status())
```

Gong's `/v2/calls` endpoint returns **404 Not Found** (body `{"errors":["No calls found corresponding to the provided filters."]}`) when a requested date window contains **zero processed calls**, rather than returning an empty list — see the [Gong developer community](https://visioneers.gong.io/developers-79/rest-api-fetch-upcoming-calls-in-gong-via-rest-api-1403). The `calls` endpoint is synced by iterating bounded date windows, and incremental windows can be only hours wide, so any team with a gap in call activity trips this on a routine sync. Our `fetch_page` treated the 404 as a hard failure and aborted the entire run.

## Changes

Decision: this is a **fixable bug**, not a user/upstream credential problem — so it stays out of `NonRetryableErrors`. A 404 on the date-windowed `calls` endpoint means "no data in this window", which is a normal outcome. `fetch_page` now returns an empty payload for a 404 on the date-windowed endpoint, so the window loop yields nothing, advances to the next window, and persists progress as usual.

The handling is scoped to `config.uses_date_window` (only `calls`). A 404 on any other endpoint still raises — those paths are fixed and correct, so a 404 there is genuinely anomalous and worth surfacing. Auth/scope failures return 401/403 and are unaffected.

## How did you test this code?

I'm an agent; I did not do manual testing. Automated tests only (run locally, all passing):

- `test_404_empty_window_is_skipped` — a 404 on a `calls` window yields no rows, advances the window, and persists resume state instead of aborting. Verified it fails without the fix. No existing windowed test exercised a non-200 response.
- `test_404_on_non_windowed_endpoint_raises` — a 404 on a non-windowed endpoint (`users`) still raises, locking in the scoping so the skip can't be broadened to swallow real errors.

## Docs update

No docs change needed.

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook. Confirmed the issue and pulled the full stack trace via the PostHog error-tracking MCP tools, read the Gong source implementation, and verified Gong's documented 404-on-empty-window behavior before deciding between `NonRetryableErrors` and a code fix. Chose the code fix because the 404 is an expected empty-result signal, not a terminal credential/config error. Checked open PRs (including the source maintainer's) for a duplicate — none. Invoked the `/writing-tests` skill before adding tests.