### PR TITLE
feat(cdp): add job-level lifecycle metrics for batch hogflow resolver

### DIFF
--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer.ts
@@ -37,11 +37,6 @@ const counterBatchHogFlowResolverPagesProcessed = new Counter({
     labelNames: ['outcome'], // success | fetch_failure | terminal_write_failure | invalid_state
 })
 
-// Job-level lifecycle counter — one increment per job at each lifecycle event.
-// `started` fires once per job on the first dequeue; `completed`/`failed` fire
-// once per job when the terminal write is acked (or the job is abandoned via
-// job.fail()). Ratio of started vs completed+failed gives the per-day success
-// rate; drift between started and completed+failed indicates jobs still in flight.
 const counterBatchHogFlowResolverJobs = new Counter({
     name: 'cdp_batch_hog_flow_resolver_jobs',
     help: 'Batch hog flow resolver jobs by lifecycle outcome',
@@ -120,10 +115,12 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
         }
 
         // First-dequeue detection: the initial cyclotron invocation of a batch
-        // resolver job arrives with cursor=null, no pending terminal, and zero
-        // pages processed. Every subsequent dequeue of the same job has at
-        // least one of those advanced, so this fires exactly once per job.
-        if (!state.pendingTerminal && state.cursor === null && state.pagesProcessed === 0) {
+        // resolver job arrives with cursor=null, no pending terminal, zero
+        // pages processed, and zero attempts. `attempts` is required in the
+        // guard because a first-page fetch failure reschedules with the same
+        // cursor/pagesProcessed/pendingTerminal but bumps attempts — without
+        // it, `started` would fire again on every retry of the first page.
+        if (!state.pendingTerminal && state.cursor === null && state.pagesProcessed === 0 && state.attempts === 0) {
             counterBatchHogFlowResolverJobs.labels({ outcome: 'started' }).inc()
         }
 
@@ -350,7 +347,6 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
 
     private async processTerminalWrite(job: CyclotronV2DequeuedJob, state: BatchResolverState): Promise<void> {
         if (!state.pendingTerminal) {
-            counterBatchHogFlowResolverJobs.labels({ outcome: 'failed' }).inc()
             await job.fail()
             return
         }

--- a/nodejs/src/cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer.ts
+++ b/nodejs/src/cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer.ts
@@ -37,6 +37,17 @@ const counterBatchHogFlowResolverPagesProcessed = new Counter({
     labelNames: ['outcome'], // success | fetch_failure | terminal_write_failure | invalid_state
 })
 
+// Job-level lifecycle counter — one increment per job at each lifecycle event.
+// `started` fires once per job on the first dequeue; `completed`/`failed` fire
+// once per job when the terminal write is acked (or the job is abandoned via
+// job.fail()). Ratio of started vs completed+failed gives the per-day success
+// rate; drift between started and completed+failed indicates jobs still in flight.
+const counterBatchHogFlowResolverJobs = new Counter({
+    name: 'cdp_batch_hog_flow_resolver_jobs',
+    help: 'Batch hog flow resolver jobs by lifecycle outcome',
+    labelNames: ['outcome'], // started | completed | failed
+})
+
 /**
  * State machine carried in `cyclotron_jobs.state` per resolver job:
  *   cursor=null, pendingTerminal=undefined → fetch first page
@@ -93,6 +104,7 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
             // older deploy. None should happen in steady state — alert on
             // the counter so we notice fast.
             counterBatchHogFlowResolverPagesProcessed.labels({ outcome: 'invalid_state' }).inc()
+            counterBatchHogFlowResolverJobs.labels({ outcome: 'failed' }).inc()
             logger.error('🔴', `${this.name} - invalid resolver state, failing job`, {
                 jobId: job.id,
                 teamId: job.teamId,
@@ -105,6 +117,14 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
             })
             await job.fail()
             return
+        }
+
+        // First-dequeue detection: the initial cyclotron invocation of a batch
+        // resolver job arrives with cursor=null, no pending terminal, and zero
+        // pages processed. Every subsequent dequeue of the same job has at
+        // least one of those advanced, so this fires exactly once per job.
+        if (!state.pendingTerminal && state.cursor === null && state.pagesProcessed === 0) {
+            counterBatchHogFlowResolverJobs.labels({ outcome: 'started' }).inc()
         }
 
         try {
@@ -330,6 +350,7 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
 
     private async processTerminalWrite(job: CyclotronV2DequeuedJob, state: BatchResolverState): Promise<void> {
         if (!state.pendingTerminal) {
+            counterBatchHogFlowResolverJobs.labels({ outcome: 'failed' }).inc()
             await job.fail()
             return
         }
@@ -340,6 +361,7 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
             counterBatchHogFlowResolverPagesProcessed.labels({ outcome: 'terminal_write_failure' }).inc()
             const nextAttempts = state.attempts + 1
             if (nextAttempts >= MAX_RESOLVER_ATTEMPTS) {
+                counterBatchHogFlowResolverJobs.labels({ outcome: 'failed' }).inc()
                 logger.error(
                     '🔴',
                     `${this.name} - terminal status write failed permanently after ${MAX_RESOLVER_ATTEMPTS} attempts; failing job`,
@@ -365,6 +387,10 @@ export class CdpCyclotronWorkerBatchResolve extends CdpConsumerBase<PluginsServe
             })
             return
         }
+
+        counterBatchHogFlowResolverJobs
+            .labels({ outcome: state.pendingTerminal === 'completed' ? 'completed' : 'failed' })
+            .inc()
 
         // Monitoring flush happens in processResolverJob's finally block so every
         // dequeue clears its own queued logs/metrics, not just terminal writes.


### PR DESCRIPTION
## Problem

The batch hogflow resolver already exports a per-**page** counter (`cdp_batch_hog_flow_resolver_pages_processed`), but a single batch job spans many pages plus a terminal Django write. That makes it hard to answer basic operational questions from Prometheus alone:

- How many batch resolve jobs came in today?
- How many did we successfully complete?
- How many failed?

Today you have to eyeball logs or infer from downstream metrics. This PR adds a per-**job** counter so those questions become one PromQL query each.

## Changes

New counter in `cdp-cyclotron-worker-batch-resolve.consumer.ts`:

```
cdp_batch_hog_flow_resolver_jobs{outcome="started|completed|failed"}
```

- `started` — one increment per job on its first dequeue (detected via `cursor === null && !pendingTerminal && pagesProcessed === 0`, which is only true on the initial cyclotron invocation of a resolver job).
- `completed` — one increment when the terminal Django write acks successfully with `pendingTerminal === "completed"`.
- `failed` — one increment when any of the following happens:
  - terminal write acks with `pendingTerminal === "failed"` (covers missing team/hogflow, page-fetch permanent failure — both routes already flip pendingTerminal to `failed` via `transitionToFailedTerminal`)
  - resolver state deserialization throws and the job is abandoned via `job.fail()`
  - terminal Django write fails permanently after `MAX_RESOLVER_ATTEMPTS` and the job is abandoned via `job.fail()`

`started - (completed + failed)` gives the in-flight job count, and `rate(cdp_batch_hog_flow_resolver_jobs{outcome=\"failed\"}[5m]) / rate(cdp_batch_hog_flow_resolver_jobs{outcome=\"started\"}[5m])` gives the failure rate.

Existing per-page counter is untouched — the two metrics complement each other and answer different questions.

## How did you test this code?

Agent-authored, no manual runtime verification. Ran locally:

- `pnpm typescript:check` — clean
- `pnpm lint src/cdp/consumers/cdp-cyclotron-worker-batch-resolve.consumer.ts` — clean
- pre-commit hooks (format + lint) via husky — clean

No new unit tests added; each increment is a single `.inc()` call on a well-known branch, and the branches are already covered by the consumer's existing behavior tests. Happy to add explicit metric assertions if reviewers want them.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Session context: continuation of the batch hogflow resolver rollout work. During observation of a 44,998-audience run, we found we could see page-level throughput but not job-level pass/fail rates — so this PR adds the missing job-level counter.

Tool used: Claude Code (Opus 4.7, 1M context). No repo skills invoked (mandatory-skill list didn't match — this touches a Node.js CDP consumer, not DRF/migrations/tests). Decisions along the way:

- Considered splitting `failed` further (told-Django-failed vs abandoned-via-`job.fail()`) but merged them because from an operator's POV both are terminal non-successes and cardinality is already fine. If we later need to distinguish, the abandon paths are already tagged in the sibling `_pages_processed` counter (`invalid_state`, `terminal_write_failure`) so the signal isn't lost.
- Considered adding a `hog_flow_id` label but rejected it — cardinality risk, and the sibling per-page counter already goes unlabeled by flow.
- Increment sites picked to fire exactly once per job across the resolver's rescheduling lifecycle: `started` guarded by the initial-state predicate, terminal outcomes guarded by the `job.ack()` / `job.fail()` boundaries.