### PR TITLE
feat(conversations): link org rows to billing customer in related groups

### DIFF
--- a/frontend/src/scenes/groups/RelatedGroups.tsx
+++ b/frontend/src/scenes/groups/RelatedGroups.tsx
@@ -3,6 +3,7 @@ import { useValues } from 'kea'
 import { IconPerson } from '@posthog/icons'
 import { LemonTag, Tooltip } from '@posthog/lemon-ui'
 
+import { Link } from 'lib/lemon-ui/Link'
 import { LemonTable, LemonTableColumns } from 'lib/lemon-ui/LemonTable'
 import { capitalizeFirstLetter } from 'lib/utils/strings'
 import { relatedGroupsLogic } from 'scenes/groups/relatedGroupsLogic'
@@ -10,7 +11,7 @@ import { GroupActorDisplay } from 'scenes/persons/GroupActorDisplay'
 import { PersonDisplay } from 'scenes/persons/PersonDisplay'
 
 import { groupsModel } from '~/models/groupsModel'
-import { ActorType } from '~/types'
+import { ActorType, GroupActorType } from '~/types'
 
 export interface RelatedGroupsProps {
     groupTypeIndex: number | null
@@ -28,6 +29,8 @@ export interface RelatedGroupsProps {
     highlightStaleTooltip?: string
     /** Extra group rows to append (deduped by id), e.g. a group not in the live related list. */
     extraActors?: ActorType[]
+    /** Optional extra link rendered after a group row's display (e.g. a staff-only billing admin link). Return null for rows that shouldn't get one. */
+    groupRowLink?: (actor: GroupActorType) => { to: string; label: string } | null
 }
 
 export function RelatedGroups({
@@ -41,6 +44,7 @@ export function RelatedGroups({
     highlightStale = false,
     highlightStaleTooltip,
     extraActors,
+    groupRowLink,
 }: RelatedGroupsProps): JSX.Element {
     const { relatedActors, relatedPeople, relatedActorsLoading } = useValues(relatedGroupsLogic({ groupTypeIndex, id }))
     const { aggregationLabel } = useValues(groupsModel)
@@ -69,6 +73,7 @@ export function RelatedGroups({
             render: function RenderActor(_, actor: ActorType) {
                 if (actor.type === 'group') {
                     const isHighlighted = highlightGroupKey != null && actor.group_key === highlightGroupKey
+                    const extraLink = groupRowLink?.(actor)
                     return (
                         <div className="flex items-center gap-2">
                             <GroupActorDisplay actor={actor} />
@@ -83,6 +88,11 @@ export function RelatedGroups({
                                         Stale
                                     </LemonTag>
                                 </Tooltip>
+                            )}
+                            {extraLink && (
+                                <Link to={extraLink.to} target="_blank">
+                                    {extraLink.label}
+                                </Link>
                             )}
                         </div>
                     )

--- a/products/conversations/frontend/scenes/ticket/RelatedGroupsPanel.tsx
+++ b/products/conversations/frontend/scenes/ticket/RelatedGroupsPanel.tsx
@@ -4,6 +4,7 @@ import { LemonCollapse } from '@posthog/lemon-ui'
 
 import { RelatedGroups } from 'scenes/groups/RelatedGroups'
 import { relatedGroupsLogic } from 'scenes/groups/relatedGroupsLogic'
+import { userLogic } from 'scenes/userLogic'
 
 import { groupsModel } from '~/models/groupsModel'
 import { ActorType, GroupActorType } from '~/types'
@@ -13,6 +14,22 @@ import { creationGroupLogic } from './creationGroupLogic'
 const HIGHLIGHT_LABEL = 'Ticket origin'
 const STALE_TOOLTIP =
     "This group was active when the ticket was created, but it's no longer in the person's recent related groups."
+const BILLING_ADMIN_ORIGIN = 'https://billing.posthog.com'
+
+// Staff-only: link an organization group row to its billing customer in billing admin. The org group's key is the
+// organization UUID, so we search billing admin by org id (the same `?q=` lookup PostHog's org admin uses) — this
+// resolves the customer even when no Stripe/billing id is recorded on the account. Returns null for non-org rows
+// or non-staff users so the internal URL never renders for customers.
+export function orgBillingCustomerLink(
+    actor: GroupActorType,
+    orgGroupTypeIndex: number | null,
+    isStaff: boolean
+): { to: string; label: string } | null {
+    if (!isStaff || orgGroupTypeIndex === null || actor.group_type_index !== orgGroupTypeIndex) {
+        return null
+    }
+    return { to: `${BILLING_ADMIN_ORIGIN}/admin/billing/customer/?q=${actor.group_key}`, label: 'Billing →' }
+}
 
 interface RelatedGroupsPanelProps {
     personUuid: string
@@ -40,6 +57,7 @@ export function RelatedGroupsPanel({ personUuid, organizationId }: RelatedGroups
         relatedGroupsLogic({ groupTypeIndex: null, id: personUuid })
     )
     const { groupTypes } = useValues(groupsModel)
+    const { user } = useValues(userLogic)
 
     // `organization_id` is always a key of the "organization" group type (set that way at creation),
     // so we can resolve its index by name when the group has dropped out of the live related list.
@@ -91,6 +109,7 @@ export function RelatedGroupsPanel({ personUuid, organizationId }: RelatedGroups
                             highlightStale={showFallback}
                             highlightStaleTooltip={STALE_TOOLTIP}
                             extraActors={extraActors}
+                            groupRowLink={(actor) => orgBillingCustomerLink(actor, orgGroupTypeIndex, !!user?.is_staff)}
                         />
                     ),
                 },

--- a/products/conversations/frontend/scenes/ticket/relatedGroupsPanel.test.ts
+++ b/products/conversations/frontend/scenes/ticket/relatedGroupsPanel.test.ts
@@ -1,20 +1,43 @@
-import { ActorType } from '~/types'
+import { ActorType, GroupActorType } from '~/types'
 
-import { shouldShowCreationFallback } from './RelatedGroupsPanel'
+import { orgBillingCustomerLink, shouldShowCreationFallback } from './RelatedGroupsPanel'
 
 const group = (groupKey: string): ActorType => ({ type: 'group', group_key: groupKey }) as ActorType
 const person = (): ActorType => ({ type: 'person' }) as ActorType
+const orgGroup = (groupKey: string, groupTypeIndex: number): GroupActorType =>
+    ({ type: 'group', group_key: groupKey, group_type_index: groupTypeIndex }) as GroupActorType
 
-describe('shouldShowCreationFallback', () => {
-    it.each<[string, string | null | undefined, ActorType[], boolean, number | null, boolean]>([
-        ['no organization id', null, [], false, 0, false],
-        ['related groups still loading', 'org-1', [], true, 0, false],
-        ['organization group type not resolvable', 'org-1', [], false, null, false],
-        ['snapshot group is already in the related list', 'org-1', [group('org-1')], false, 0, false],
-        ['snapshot group is not in the related list', 'org-1', [group('other')], false, 0, true],
-        ['no related groups at all', 'org-1', [], false, 0, true],
-        ['matching group present alongside a person', 'org-1', [person(), group('org-1')], false, 0, false],
-    ])('%s', (_label, organizationId, relatedActors, loading, orgGroupTypeIndex, expected) => {
-        expect(shouldShowCreationFallback(organizationId, relatedActors, loading, orgGroupTypeIndex)).toBe(expected)
+describe('RelatedGroupsPanel', () => {
+    describe('shouldShowCreationFallback', () => {
+        it.each<[string, string | null | undefined, ActorType[], boolean, number | null, boolean]>([
+            ['no organization id', null, [], false, 0, false],
+            ['related groups still loading', 'org-1', [], true, 0, false],
+            ['organization group type not resolvable', 'org-1', [], false, null, false],
+            ['snapshot group is already in the related list', 'org-1', [group('org-1')], false, 0, false],
+            ['snapshot group is not in the related list', 'org-1', [group('other')], false, 0, true],
+            ['no related groups at all', 'org-1', [], false, 0, true],
+            ['matching group present alongside a person', 'org-1', [person(), group('org-1')], false, 0, false],
+        ])('%s', (_label, organizationId, relatedActors, loading, orgGroupTypeIndex, expected) => {
+            expect(shouldShowCreationFallback(organizationId, relatedActors, loading, orgGroupTypeIndex)).toBe(expected)
+        })
+    })
+
+    describe('orgBillingCustomerLink', () => {
+        // Guards the gating on an internal (billing.posthog.com) URL: it must render only for staff, only on
+        // organization-type rows, and must be keyed by the org id via the `?q=` search.
+        it('builds a billing-admin search link keyed by the org id for staff on an org row', () => {
+            expect(orgBillingCustomerLink(orgGroup('org-uuid', 0), 0, true)).toEqual({
+                to: 'https://billing.posthog.com/admin/billing/customer/?q=org-uuid',
+                label: 'Billing →',
+            })
+        })
+
+        it.each<[string, GroupActorType, number | null, boolean]>([
+            ['non-staff user', orgGroup('org-uuid', 0), 0, false],
+            ['org group type not resolvable', orgGroup('org-uuid', 0), null, true],
+            ['row is a different group type', orgGroup('org-uuid', 1), 0, true],
+        ])('returns null for %s', (_label, actor, orgGroupTypeIndex, isStaff) => {
+            expect(orgBillingCustomerLink(actor, orgGroupTypeIndex, isStaff)).toBeNull()
+        })
     })
 })


### PR DESCRIPTION
## Problem

When handling a support ticket, staff often need to jump from the requester's organization to that org's billing customer in billing admin. There was no direct link — you had to copy the org id and search billing admin manually, and the existing Accounts "Billing admin" link only works when a Stripe/billing id has been recorded on the account.

## Changes

Adds a staff-only **Billing →** link on organization rows in the ticket **Related groups** panel. It links to the org's billing customer in billing admin, searching by org id (`/admin/billing/customer/?q=<org_id>`) — the same `?q=` lookup PostHog's own org admin uses. Because it keys off the org id (the group key is the organization UUID), it resolves the customer even when no billing id is stored on the account.

Implementation keeps the internal billing URL out of the shared component:

- `RelatedGroups` gains a generic, opt-in `groupRowLink` render-prop that renders an extra link after a group row's display.
- The conversations `RelatedGroupsPanel` supplies that link for organization rows only, and only for staff users, so the internal URL never renders for customers on the generic Group/Person scenes.

## How did you test this code?

I'm an agent (PostHog Slack app). I could not run the JS test suite in this environment (frontend dev dependencies weren't installed), so I did not execute tests or manually exercise the UI. I added unit coverage for the new pure helper `orgBillingCustomerLink` in `relatedGroupsPanel.test.ts` — it guards the gating on the internal URL (renders only for staff, only on organization-type rows, and keyed by the org id via `?q=`), which no existing test covered. Please run `hogli test products/conversations/frontend/scenes/ticket/relatedGroupsPanel.test.ts` and typecheck before merging.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

- Authored by the PostHog Slack app (Claude Opus 4.8) from a Slack thread, directed by the assignee.
- Skills invoked: `/writing-tests` before adding the helper's unit test.
- Decisions: the request named "Related groups" as the likely home. That's the shared `RelatedGroups` table, rendered on the generic Group/Person scenes (customer-facing), the conversations ticket panel, and the customer_analytics profile sidebar. Since the billing-admin URL is PostHog-internal, putting it unconditionally in the shared component would leak it to customers. Chose a generic `groupRowLink` render-prop on the shared component, wired only from the staff-facing conversations panel and gated on `is_staff` — matching the literal "Related groups" surface while keeping the internal URL scoped. Linking by org id (rather than a stored billing id) was picked deliberately so the link works without a recorded Stripe/billing id, mirroring the existing `OrganizationAdmin.billing_link` pattern.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C08S2L0S5MZ/p1782891108867709)*
