### PR TITLE
chore(readme): add yolo

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,3 +116,5 @@ The pricing for our paid plan is completely transparent and available on [our pr
 Hey! If you're reading this, you've proven yourself as a dedicated README reader.
 
 You might also make a great addition to our team. We're growing fast [and would love for you to join us](https://posthog.com/careers).
+
+yolo


### PR DESCRIPTION
## Problem

Trivial README addition requested.

## Changes

Appends a literal `yolo` line to the end of `README.md`. No functional or code impact.

## How did you test this code?

I'm an agent. No tests are applicable — this is a README-only change. `bin/hogli format:markdown` ran via the pre-commit hook and left the file clean.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored with PostHog Code at the user's request. No skills were invoked. A stale branch (`posthog-code/readme-yolo`, closed draft PR #59745) from a prior run already existed on the remote; to avoid force-pushing over it or reopening a closed PR, this uses a fresh branch built on current master.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
