### PR TITLE
fix(warehouse): correct supabase connection string instructions

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -34,11 +34,14 @@ _SourceField = (
 _SUPABASE_DIRECT_HOST_RE = re.compile(r"^db\.[a-z0-9]+\.supabase\.co$", re.IGNORECASE)
 
 _SUPABASE_POOLER_HOST_CAPTION = (
-    "For standard syncs, use the **Session pooler** host (Project settings → Database → "
-    "Connection pooling), e.g. `aws-0-<region>.pooler.supabase.com`, with username "
+    "To get your connection string, click **Connect** in the top bar of your Supabase "
+    "dashboard, open the **Direct** tab, and pick **Session pooler** or **Direct "
+    "connection** — the URL is shown at the bottom. For standard syncs use the "
+    "**Session pooler** host, e.g. `aws-0-<region>.pooler.supabase.com`, with username "
     "`postgres.<project-ref>` — the direct host `db.<ref>.supabase.co` is IPv6-only. "
-    "For **change data capture (CDC)** you must use the direct host instead and enable "
-    "Supabase's **IPv4 add-on**, because logical replication doesn't work through the pooler."
+    "For **change data capture (CDC)** you must use **Direct connection** instead and "
+    "enable Supabase's **IPv4 add-on**, because logical replication doesn't work through "
+    "the pooler."
 )
 
 _SUPABASE_DIRECT_HOST_IPV4_HINT = (


### PR DESCRIPTION
## Problem

The help caption on the host field when adding Supabase as a Data warehouse source pointed users to *Project settings → Database → Connection pooling* to find their connection details. That is not a reliable path in Supabase's current dashboard, so users struggled to locate the right host and username.

## Changes

Rewrote the host-field caption to describe the correct flow: click **Connect** in the top bar, open the **Direct** tab, and pick **Session pooler** or **Direct connection** (the URL shows at the bottom). The CDC guidance, `postgres.<project-ref>` username hint, and IPv6-only / IPv4-add-on facts are unchanged. This is a single string constant (`_SUPABASE_POOLER_HOST_CAPTION`) rendered as markdown on the source form.

## How did you test this code?

No automated tests were added or run for a copy-only change. I (Claude) confirmed the constant is still wired to the host field's `caption` and that the surrounding logic is untouched. The caption renders as markdown in the existing source form, so no codegen or migration is involved.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Thiago directed this change; I (Claude) made the edit. We first scoped where the text lived and found three related spots (the host caption, a validation error hint, a frontend CDC banner, and a dev skill doc), then deliberately limited the fix to just the host caption since that was the only one carrying the stale navigation path. No repo skills were invoked.
