### PR TITLE
fix(session-replay): yield the event loop between anonymized ml-mirror messages

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
@@ -15,6 +15,8 @@ import { scrubConsolePlugin, scrubGenericField, scrubNetworkPlugin } from './val
 const NETWORK_PLUGIN = 'rrweb/network@1'
 const CONSOLE_PLUGIN = 'rrweb/console@1'
 
+const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
+
 /**
  * Anonymizes every event in a parsed message in place, then awaits its blur jobs.
  * Fails closed: returns `failed: true` if any event errors, so the caller can drop
@@ -42,6 +44,8 @@ export async function anonymizeParsedMessage(
     }
 
     await runBlurJobs(blurJobs)
+    // Macrotask break so a batch of messages doesn't scrub fully synchronously and starve the loop.
+    await yieldToEventLoop()
     return { failed: false }
 }
 


### PR DESCRIPTION
> Claude-written:

## Problem

The ML-mirror ingester anonymizes every rrweb event synchronously on the consume loop. `anonymizeParsedMessage`'s only `await` (`runBlurJobs`) is a microtask when a message has no inline images, so a batch of image-less messages scrubs back-to-back without ever handing the loop to I/O. At large consumer-group sizes the loop stays blocked long enough that cooperative rebalances can't complete, the group wedges in `wait-join`, and the liveness probe SIGKILLs pods. The main lane runs the same group size fine because its per-message work is light.

## Changes

Yield once per message, as a macrotask (`setImmediate`, not a resolved promise), after the scrub loop. A batch of N messages now gets N breaks to service rebalances and `/_health`. Total anonymization CPU is unchanged, just interleaved with I/O.

## How did you test this code?

Output-identical (yielding doesn't change scrub results), so the existing anonymize unit tests remain the correctness gate. No live scale test run; validation at full group size is by watching the lane after deploy.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Claude Code, at my direction.