### PR TITLE
fix(replay-vision): remove dead space under score distribution chart

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
+++ b/products/replay_vision/frontend/replay_scanners/components/ScannerOverview.tsx
@@ -15,16 +15,18 @@ function OverviewPanel({
     title,
     subtitle,
     disabled,
+    fill,
     children,
 }: {
     title: string
     subtitle?: React.ReactNode
     disabled?: boolean
+    fill?: boolean
     children: React.ReactNode
 }): JSX.Element {
     return (
         <div
-            className={`border rounded p-4 space-y-3 ${
+            className={`border rounded p-4 space-y-3 ${fill ? 'h-full flex flex-col' : ''} ${
                 disabled ? 'bg-surface-secondary opacity-60' : 'bg-surface-primary'
             }`}
         >
@@ -184,8 +186,8 @@ function ScorerOverview({ scannerId }: { scannerId: string }): JSX.Element {
         )
     }
     return (
-        <OverviewPanel title="Score distribution" subtitle={`${scorerSummary.count} scored`}>
-            <div className="h-40 flex flex-col">
+        <OverviewPanel title="Score distribution" subtitle={`${scorerSummary.count} scored`} fill>
+            <div className="flex-1 min-h-40 flex flex-col">
                 <BarChart
                     labels={scorerHistogram.labels}
                     series={[{ key: 'count', label: 'Sessions', color: theme.colors[0], data: scorerHistogram.counts }]}
@@ -225,11 +227,12 @@ export function ScannerOverview({ scannerId }: { scannerId: string }): JSX.Eleme
     // Scorer puts its line chart and score-distribution histogram side by side to reclaim vertical space.
     if (scannerType === 'scorer') {
         return (
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 items-start">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
                 {/* min-w-0 lets the canvas charts shrink inside their grid tracks instead of overflowing */}
                 <div className="min-w-0">
                     <ScannerInsightsChart scannerId={scannerId} scannerType={scannerType} />
                 </div>
+                {/* The histogram fills to match the taller line chart, so the row has no dead space (stretch is the grid default). */}
                 <div className="min-w-0">{typeOverview}</div>
             </div>
         )


### PR DESCRIPTION
## Problem

On a scorer's Observations tab, the line chart and score-distribution histogram sit side by side. The histogram was a fixed `h-40` (160px) next to the `h-80` (320px) line chart, with the grid `items-start`, so the shorter histogram panel stranded ~150px of empty space below it — an awkward gap on the page.

## Changes

`ScannerOverview.tsx`, scorer layout only:
- Grid cells now stretch to equal height (dropped `items-start`).
- The score-distribution panel opts into filling its cell via a new `fill` prop on the shared `OverviewPanel` (`h-full flex flex-col`). Monitor and classifier panels are unaffected.
- The histogram container went from fixed `h-40` to `flex-1 min-h-40`, so it grows to match the line chart while keeping 160px as a floor.

Net: the histogram fills its panel to the same height as the line chart, so the row has no dead space and the taller bars read better.

## How did you test this code?

Agent-authored (Claude Code). `pnpm --filter=@posthog/frontend typescript:check` passes. This is a CSS/layout-only change (Tailwind classes + one optional boolean prop) with no logic change, so it's not covered by automated tests — visual verification on the scorer Observations tab is the check.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — reported from a screenshot of a live scorer.
