### PR TITLE
fix(supabase): guide users who paste the project URL as the host

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -99,11 +99,12 @@ class SupabaseSource(PostgresSource):
     def validate_credentials(
         self, config: PostgresSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
-        project_host = _SUPABASE_PROJECT_HOST_RE.match(_strip_host_scheme(config.host or ""))
+        bare_host = _strip_host_scheme(config.host or "")
+        project_host = _SUPABASE_PROJECT_HOST_RE.match(bare_host)
         if project_host:
             ref = project_host.group("ref")
             return False, (
-                f"'{_strip_host_scheme(config.host or '')}' looks like your Supabase project URL, not a database "
+                f"'{bare_host}' looks like your Supabase project URL, not a database "
                 "host. For standard syncs use the Session pooler host (aws-0-<region>.pooler.supabase.com) with "
                 f"username postgres.{ref}; for change data capture use the direct host db.{ref}.supabase.co and "
                 "enable Supabase's IPv4 add-on."

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -102,7 +102,9 @@ class SupabaseSource(PostgresSource):
         bare_host = _strip_host_scheme(config.host or "")
         project_host = _SUPABASE_PROJECT_HOST_RE.match(bare_host)
         if project_host:
-            ref = project_host.group("ref")
+            # Project refs are lowercase, and the pooler username (postgres.<ref>) is
+            # case-sensitive — canonicalize so the suggested values are copy-pasteable.
+            ref = project_host.group("ref").lower()
             return False, (
                 f"'{bare_host}' looks like your Supabase project URL, not a database "
                 "host. For standard syncs use the Session pooler host (aws-0-<region>.pooler.supabase.com) with "

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/source.py
@@ -33,6 +33,18 @@ _SourceField = (
 # connection failures. Users need the connection pooler host instead.
 _SUPABASE_DIRECT_HOST_RE = re.compile(r"^db\.[a-z0-9]+\.supabase\.co$", re.IGNORECASE)
 
+# The Supabase dashboard shows `https://<ref>.supabase.co` as the "Project URL" — that's the
+# REST/API endpoint, not a Postgres host. Pasting it (often with the scheme) into the host field
+# just yields an opaque DNS failure, so detect it and point users at the actual database host.
+_SUPABASE_PROJECT_HOST_RE = re.compile(r"^(?P<ref>[a-z0-9]+)\.supabase\.co$", re.IGNORECASE)
+
+
+def _strip_host_scheme(host: str) -> str:
+    """Reduce a pasted value to a bare host: drop any URL scheme, path, and surrounding whitespace."""
+    stripped = re.sub(r"^[a-z][a-z0-9+.-]*://", "", (host or "").strip(), flags=re.IGNORECASE)
+    return stripped.split("/", 1)[0]
+
+
 _SUPABASE_POOLER_HOST_CAPTION = (
     "For standard syncs, use the **Session pooler** host (Project settings → Database → "
     "Connection pooling), e.g. `aws-0-<region>.pooler.supabase.com`, with username "
@@ -87,6 +99,16 @@ class SupabaseSource(PostgresSource):
     def validate_credentials(
         self, config: PostgresSourceConfig, team_id: int, schema_name: Optional[str] = None
     ) -> tuple[bool, str | None]:
+        project_host = _SUPABASE_PROJECT_HOST_RE.match(_strip_host_scheme(config.host or ""))
+        if project_host:
+            ref = project_host.group("ref")
+            return False, (
+                f"'{_strip_host_scheme(config.host or '')}' looks like your Supabase project URL, not a database "
+                "host. For standard syncs use the Session pooler host (aws-0-<region>.pooler.supabase.com) with "
+                f"username postgres.{ref}; for change data capture use the direct host db.{ref}.supabase.co and "
+                "enable Supabase's IPv4 add-on."
+            )
+
         # The direct host (IPv6-only by default) is the only host that supports logical
         # replication, so CDC users need it. We let the real connection attempt decide
         # reachability — it succeeds when the IPv4 add-on is enabled — and only swap in a

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -83,6 +83,9 @@ def test_project_url_host_is_rejected_before_connecting(host):
     assert error is not None
     assert "project url" in error.lower()
     assert "pooler.supabase.com" in error
+    # The suggested pooler username is case-sensitive, so the ref must be lowercased even when
+    # the user typed the host in caps (see the uppercase parametrized case).
+    assert "postgres.abcdefgh" in error
 
 
 @pytest.mark.parametrize(

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/supabase/test_supabase_source.py
@@ -63,6 +63,31 @@ def test_direct_host_failure_surfaces_ipv4_addon_hint(host):
 @pytest.mark.parametrize(
     "host",
     [
+        "abcdefgh.supabase.co",
+        "https://abcdefgh.supabase.co",
+        "https://abcdefgh.supabase.co/",
+        "  HTTPS://ABCDEFGH.SUPABASE.CO  ",
+    ],
+)
+def test_project_url_host_is_rejected_before_connecting(host):
+    # The dashboard's "Project URL" (`<ref>.supabase.co`) is the REST endpoint, not a database
+    # host. Pasting it (often with the scheme) must short-circuit to actionable guidance instead
+    # of attempting a doomed connection that yields an opaque DNS error.
+    config = mock.MagicMock(host=host)
+
+    with mock.patch.object(PostgresSource, "validate_credentials") as super_validate:
+        success, error = SupabaseSource().validate_credentials(config, team_id=1)
+
+    super_validate.assert_not_called()
+    assert success is False
+    assert error is not None
+    assert "project url" in error.lower()
+    assert "pooler.supabase.com" in error
+
+
+@pytest.mark.parametrize(
+    "host",
+    [
         "db.abcdefghijklmnop.supabase.co",
         "aws-0-us-east-1.pooler.supabase.com",
         "db.example.com",


### PR DESCRIPTION
> Claude-written:

## Problem

A recurring data-warehouse source-creation failure is users pasting the Supabase dashboard's "Project URL" (`<ref>.supabase.co`, often with the `https://` scheme still attached) into the database host field. That URL is the REST/API endpoint, not a Postgres host, so it can never connect. Today validation only surfaces an opaque DNS-resolution error that echoes the raw value back, which reads like a bug on our side and gives the user nothing to act on.

## Changes

Detect the project-URL host in the Supabase source's `validate_credentials`, before any connection attempt. The check strips a URL scheme and path first, so both the bare host and the pasted-with-`https://` form are caught. When matched we short-circuit with an actionable message that names the correct hosts: the Session pooler for standard syncs and the direct host for change data capture.

The existing direct-host (IPv6 / IPv4 add-on) handling and normal delegation to the Postgres source are unchanged. The project-URL pattern excludes the `db.<ref>.supabase.co` direct host and the pooler host, so neither is misclassified.

## How did you test this code?

Added 4 parameterized cases to `test_supabase_source.py` covering the project-URL host with and without a scheme, a trailing slash, and mixed case. They assert we short-circuit before attempting a connection and return guidance naming the pooler host. The existing delegation tests already guard against false positives on the direct and pooler hosts. Ran the file locally: 15 passed. I (Claude) did not do manual UI testing.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged a batch of source-creation failures across many source types. Most were clear, actionable user-misconfiguration messages that need no change. This was the one genuine gap: a known-wrong host we can validate earlier with better guidance. I invoked the `/writing-tests` skill before adding the test cases. I checked open PRs first (including #67276, which only rewrites the host-field caption) and confirmed none touch host validation, so there's no overlap.