### PR TITLE
chore(ci): measure eager graph from shipped output, not input closure

### DIFF
--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -19,32 +19,34 @@ const reportOnly = process.argv.includes('--report-only')
 // bundle-size Signals scout tracks regressions from the PR comment, so the check informs.
 const assertReportIndex = process.argv.indexOf('--assert-report')
 
-// The eager graph is everything reachable from a root through STATIC imports only —
-// the code a browser must download and decode before that surface is interactive,
-// regardless of how the bytes are distributed across chunks. Total dist size can't
-// see regressions here (a fake-lazy require() moves no bytes, but makes them eager),
-// which is why this check exists alongside the compressed-size check.
+// The eager graph is everything a root actually SHIPS on the critical path — the bytes a
+// browser downloads and parses before that surface is interactive. It is measured from the
+// esbuild OUTPUT chunks: the root's entry chunk plus every chunk reachable through static
+// (import-statement) chunk edges. Lazy (dynamic-import) chunks are excluded, and tree-shaken
+// code is already gone from the output — so a side-effect-free re-export barrel only costs
+// what its used exports actually ship, not its whole surface (the earlier input-graph metric
+// counted the whole barrel and mistook reachability for shipped weight).
+// Total dist size can't see this regression class (a fake-lazy import moves no total bytes
+// but shifts them onto the eager path), which is why this check exists.
 //
-// Budgets are input-source bytes (pre-minification): stable across builds and
-// proportional to decoded-script memory cost per renderer (see #32479).
+// Budgets are eager output bytes (shipped, minified).
 // Ratchet policy: when a bundle-splitting win lands, lower the budget to lock it in;
 // raise a budget only as a conscious, reviewed decision in the PR that needs it.
 const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        // master 2026-06-12: 14.62 MiB / 751 files
-        budgetBytes: 16_000_000,
+        // 2026-07-01: 2.73 MiB eager output (21 chunks)
+        budgetBytes: 3_400_000,
         forbidden: ['node_modules/monaco-editor/', 'src/lib/components/ActivityLog/describers'],
     },
     {
         root: 'src/scenes/AuthenticatedShell.tsx',
         label: 'authenticated shell (every logged-in page)',
-        // 2026-06-13: 30.86 MiB / 5,083 files (post lazy activity describers)
-        // 2026-06-30: 32.44 MiB — the eager graph drifted ~1.6 MiB on master and breached the previous
-        // 34_000_000 budget. Conscious bump to restore a small margin; the breach is pre-existing master
-        // drift, not this PR. Re-ratchet down when the next bundle-split win lands.
-        budgetBytes: 34_500_000,
+        // 2026-07-01: 10.85 MiB eager output (104 chunks). Includes ~3.6 MiB of inlined
+        // @posthog/brand/hoggies SVGs pulled onto the eager path by #66238 — a ratchet-down
+        // target (make those hog usages lazy, or import them only where they render).
+        budgetBytes: 13_000_000,
         forbidden: ['node_modules/monaco-editor/', 'src/lib/components/ActivityLog/describers'],
     },
 ]
@@ -76,8 +78,8 @@ function assertReport(reportFilePath) {
     for (const r of reportToAssert.roots) {
         if (r.overBudget) {
             warnViolation(
-                `Eager graph for '${r.root}' is ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
-                    `Largest files in the closure:\n` +
+                `Eager graph for '${r.root}' ships ${formatMiB(r.bytes)}, over the ${formatMiB(r.budgetBytes)} budget.\n` +
+                    `Largest eagerly-shipped files:\n` +
                     r.largest.map(({ file, bytes }) => `   ${formatMiB(bytes).padStart(9)}  ${file}`).join('\n') +
                     `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
                     `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
@@ -86,7 +88,7 @@ function assertReport(reportFilePath) {
         }
         for (const hit of r.forbiddenHits) {
             warnViolation(
-                `'${hit.module}' is statically reachable from '${r.root}' — it must stay behind a dynamic import.\n` +
+                `'${hit.module}' ships eagerly from '${r.root}' — it must stay behind a dynamic import.\n` +
                     `Import chain:\n   ${hit.chain.join('\n   -> ')}`
             )
             violations++
@@ -148,50 +150,97 @@ if (!fs.existsSync(metaPath)) {
     process.exit(1)
 }
 
-const inputs = JSON.parse(fs.readFileSync(metaPath, 'utf-8')).inputs
+const meta = JSON.parse(fs.readFileSync(metaPath, 'utf-8'))
+const inputs = meta.inputs
+const outputs = meta.outputs
+if (!outputs) {
+    fail(`Metafile at ${metaPath} has no "outputs" — rebuild with metafile output enabled.`)
+    process.exit(1)
+}
+
+// esbuild makes every code-split point (real entry points and dynamically-imported
+// modules alike) an entryPoint of some output chunk, so a root maps to exactly one chunk.
+function entryChunk(root) {
+    for (const [name, chunk] of Object.entries(outputs)) {
+        if (chunk.entryPoint === root) {
+            return name
+        }
+    }
+    return null
+}
+
+// The eager download for a root: its entry chunk plus every chunk reachable through static
+// (import-statement) chunk edges. dynamic-import edges are the lazy boundaries — stop there.
+function eagerChunkClosure(entry) {
+    const seen = new Set([entry])
+    const queue = [entry]
+    while (queue.length) {
+        const chunk = queue.shift()
+        for (const imp of outputs[chunk].imports || []) {
+            if (imp.kind !== 'import-statement' || seen.has(imp.path) || !outputs[imp.path]) {
+                continue
+            }
+            seen.add(imp.path)
+            queue.push(imp.path)
+        }
+    }
+    return seen
+}
+
 const summaryLines = ['## Eager graph check', '', '| Root | Eager size | Budget | Files |', '| --- | --- | --- | --- |']
 const report = { roots: [], errors: [] }
 
 for (const { root, label, budgetBytes, forbidden } of ROOTS) {
-    if (!inputs[root]) {
-        const candidates = Object.keys(inputs)
-            .filter((k) => k.endsWith(path.basename(root)))
+    const entry = entryChunk(root)
+    if (!entry) {
+        const candidates = Object.values(outputs)
+            .map((c) => c.entryPoint)
+            .filter((e) => e && e.endsWith(path.basename(root)))
             .slice(0, 5)
-        const message = `Root '${root}' not found in metafile. Was it moved/renamed? Candidates: ${candidates.join(', ')}`
+        const message = `Root '${root}' is not an entry chunk in the metafile. Was it moved, or is it no longer a code-split boundary? Candidates: ${candidates.join(', ')}`
         report.errors.push(message)
         fail(message)
         continue
     }
 
-    const { seen, parentOf } = eagerClosure(inputs, root)
+    // Attribute each input module the bytes it actually contributes to the eager chunks —
+    // tree-shaken modules contribute nothing, so a barrel only counts its used exports.
+    const eagerBytesByFile = new Map()
     let totalBytes = 0
-    for (const file of seen) {
-        totalBytes += inputs[file].bytes
+    for (const chunk of eagerChunkClosure(entry)) {
+        totalBytes += outputs[chunk].bytes
+        for (const [file, info] of Object.entries(outputs[chunk].inputs || {})) {
+            if (info.bytesInOutput > 0) {
+                eagerBytesByFile.set(file, (eagerBytesByFile.get(file) || 0) + info.bytesInOutput)
+            }
+        }
     }
-    const largest = [...seen]
-        .map((f) => [f, inputs[f].bytes])
-        .sort((a, b) => b[1] - a[1])
-        .slice(0, 15)
+    const largest = [...eagerBytesByFile.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15)
 
     const overBudget = totalBytes > budgetBytes
     const forbiddenHits = []
     for (const forbiddenSubstr of forbidden) {
-        const hit = [...seen].find((f) => f.includes(forbiddenSubstr))
+        const hit = [...eagerBytesByFile.keys()].find((f) => f.includes(forbiddenSubstr))
         if (hit) {
+            const { parentOf } = eagerClosure(inputs, root)
             forbiddenHits.push({ module: forbiddenSubstr, chain: chainTo(parentOf, hit) })
         }
     }
 
-    const status = overBudget || forbiddenHits.length > 0 ? '❌' : '✅'
+    const status = overBudget || forbiddenHits.length > 0 ? '🟡' : '🟢'
     console.info(`${status} ${label}`)
     console.info(`   root: ${root}`)
-    console.info(`   eager closure: ${seen.size} files, ${formatMiB(totalBytes)} (budget ${formatMiB(budgetBytes)})`)
-    summaryLines.push(`| ${status} \`${root}\` | ${formatMiB(totalBytes)} | ${formatMiB(budgetBytes)} | ${seen.size} |`)
+    console.info(
+        `   eager output: ${eagerBytesByFile.size} files, ${formatMiB(totalBytes)} (budget ${formatMiB(budgetBytes)})`
+    )
+    summaryLines.push(
+        `| ${status} \`${root}\` | ${formatMiB(totalBytes)} | ${formatMiB(budgetBytes)} | ${eagerBytesByFile.size} |`
+    )
 
     if (overBudget) {
         fail(
-            `Eager graph for '${root}' is ${formatMiB(totalBytes)}, over the ${formatMiB(budgetBytes)} budget.\n` +
-                `Something newly reachable through static imports is inflating it. Largest files in the closure:\n` +
+            `Eager graph for '${root}' ships ${formatMiB(totalBytes)}, over the ${formatMiB(budgetBytes)} budget.\n` +
+                `Something newly shipped on the eager path is inflating it. Largest eagerly-shipped files:\n` +
                 largest.map(([f, b]) => `   ${formatMiB(b).padStart(10)}  ${f}`).join('\n') +
                 `\nMake the offending import lazy (React.lazy / dynamic import()), or raise the budget in ` +
                 `frontend/bin/check-eager-graph.mjs as a conscious decision in this PR.`
@@ -200,7 +249,7 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
 
     for (const hit of forbiddenHits) {
         fail(
-            `'${hit.module}' is statically reachable from '${root}' — it must stay behind a dynamic import.\n` +
+            `'${hit.module}' ships eagerly from '${root}' — it must stay behind a dynamic import.\n` +
                 `Import chain:\n   ${hit.chain.join('\n   -> ')}`
         )
     }
@@ -209,7 +258,7 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
         root,
         label,
         bytes: totalBytes,
-        files: seen.size,
+        files: eagerBytesByFile.size,
         budgetBytes,
         overBudget,
         forbidden,

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -22,32 +22,33 @@ const assertReportIndex = process.argv.indexOf('--assert-report')
 // The eager graph is everything a root actually SHIPS on the critical path — the bytes a
 // browser downloads and parses before that surface is interactive. It is measured from the
 // esbuild OUTPUT chunks: the root's entry chunk plus every chunk reachable through static
-// (import-statement) chunk edges. Lazy (dynamic-import) chunks are excluded, and tree-shaken
+// (import-statement) chunk edges, plus each visited chunk's attached stylesheet (cssBundle,
+// which is downloaded before render). Lazy (dynamic-import) chunks are excluded, and tree-shaken
 // code is already gone from the output — so a side-effect-free re-export barrel only costs
 // what its used exports actually ship, not its whole surface (the earlier input-graph metric
 // counted the whole barrel and mistook reachability for shipped weight).
 // Total dist size can't see this regression class (a fake-lazy import moves no total bytes
 // but shifts them onto the eager path), which is why this check exists.
 //
-// Budgets are eager output bytes (shipped, minified).
+// Budgets are eager output bytes (shipped JS + eager CSS, minified).
 // Ratchet policy: when a bundle-splitting win lands, lower the budget to lock it in;
 // raise a budget only as a conscious, reviewed decision in the PR that needs it.
 const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        // 2026-07-01: 2.73 MiB eager output (21 chunks). ~20% headroom so routine churn
-        // doesn't trip the warn; ratchet down when a bundle-split win lands.
-        budgetBytes: 3_400_000,
+        // 2026-07-01: 3.75 MiB eager output (2.73 MiB JS + 1.02 MiB eager CSS, 21 chunks).
+        // ~15% headroom so routine churn doesn't trip the warn; ratchet down on a split win.
+        budgetBytes: 4_500_000,
         forbidden: ['node_modules/monaco-editor/', 'src/lib/components/ActivityLog/describers'],
     },
     {
         root: 'src/scenes/AuthenticatedShell.tsx',
         label: 'authenticated shell (every logged-in page)',
-        // 2026-07-01: 10.85 MiB eager output (104 chunks). Includes ~3.6 MiB of inlined
-        // @posthog/brand/hoggies SVGs pulled onto the eager path by #66238 — a ratchet-down
-        // target (make those hog usages lazy, or import them only where they render).
-        budgetBytes: 13_000_000,
+        // 2026-07-01: 11.58 MiB eager output (10.85 MiB JS + 0.73 MiB eager CSS, 104 chunks).
+        // Includes ~3.6 MiB of inlined @posthog/brand/hoggies SVGs pulled onto the eager path
+        // by #66238 — a ratchet-down target (make those hog usages lazy / import where rendered).
+        budgetBytes: 13_500_000,
         forbidden: ['node_modules/monaco-editor/', 'src/lib/components/ActivityLog/describers'],
     },
 ]
@@ -207,9 +208,19 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     // Attribute each input module the bytes it actually contributes to the eager chunks —
     // tree-shaken modules contribute nothing, so a barrel only counts its used exports.
     const eagerBytesByFile = new Map()
+    const cssBundlesSeen = new Set()
     let totalBytes = 0
     for (const chunk of eagerChunkClosure(entry)) {
         totalBytes += outputs[chunk].bytes
+        // esbuild attaches a JS chunk's stylesheet via `cssBundle`, not an `imports` edge, so
+        // the chunk walk never reaches it — but it's downloaded before render, so count each
+        // distinct eager stylesheet once. Without this, adding a large eager .scss moves real
+        // bytes onto the critical path while the metric stays flat.
+        const cssBundle = outputs[chunk].cssBundle
+        if (cssBundle && !cssBundlesSeen.has(cssBundle)) {
+            cssBundlesSeen.add(cssBundle)
+            totalBytes += outputs[cssBundle]?.bytes || 0
+        }
         for (const [file, info] of Object.entries(outputs[chunk].inputs || {})) {
             if (info.bytesInOutput > 0) {
                 eagerBytesByFile.set(file, (eagerBytesByFile.get(file) || 0) + info.bytesInOutput)

--- a/frontend/bin/check-eager-graph.mjs
+++ b/frontend/bin/check-eager-graph.mjs
@@ -36,7 +36,8 @@ const ROOTS = [
     {
         root: 'src/index.tsx',
         label: 'entry (logged-out pages, app bootstrap)',
-        // 2026-07-01: 2.73 MiB eager output (21 chunks)
+        // 2026-07-01: 2.73 MiB eager output (21 chunks). ~20% headroom so routine churn
+        // doesn't trip the warn; ratchet down when a bundle-split win lands.
         budgetBytes: 3_400_000,
         forbidden: ['node_modules/monaco-editor/', 'src/lib/components/ActivityLog/describers'],
     },
@@ -94,7 +95,7 @@ function assertReport(reportFilePath) {
             violations++
         }
         if (topLevelErrors.length === 0 && !r.overBudget && r.forbiddenHits.length === 0) {
-            console.info(`✅ ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
+            console.info(`🟢 ${r.label}: ${formatMiB(r.bytes)} within ${formatMiB(r.budgetBytes)}`)
         }
     }
     return violations
@@ -218,12 +219,25 @@ for (const { root, label, budgetBytes, forbidden } of ROOTS) {
     const largest = [...eagerBytesByFile.entries()].sort((a, b) => b[1] - a[1]).slice(0, 15)
 
     const overBudget = totalBytes > budgetBytes
-    const forbiddenHits = []
+
+    // A forbidden module is a hit when it ships in the eager OUTPUT. The import chain we show
+    // is a best-effort trace through the INPUT graph — module-level `import` edges are what a
+    // human reads — computed once per root, only when there is a hit. The two graphs can
+    // diverge (a module can ship eagerly via a bundler-injected or re-export edge with no
+    // source-level import path), so the chain is a pointer, not the byte source, and may be
+    // short when the output edge has no input-graph counterpart.
+    const hitFiles = new Map()
     for (const forbiddenSubstr of forbidden) {
         const hit = [...eagerBytesByFile.keys()].find((f) => f.includes(forbiddenSubstr))
         if (hit) {
-            const { parentOf } = eagerClosure(inputs, root)
-            forbiddenHits.push({ module: forbiddenSubstr, chain: chainTo(parentOf, hit) })
+            hitFiles.set(forbiddenSubstr, hit)
+        }
+    }
+    const forbiddenHits = []
+    if (hitFiles.size > 0) {
+        const { parentOf } = eagerClosure(inputs, root)
+        for (const [module, hit] of hitFiles) {
+            forbiddenHits.push({ module, chain: chainTo(parentOf, hit) })
         }
     }
 

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -164,16 +164,16 @@ if (!anyFailure && !significantChange && !existing) {
 
 const lines = [
     MARKER,
-    `## ${anyFailure ? '❌' : '🕸️'} Eager graph`,
+    `## ${anyFailure ? '🟡' : '🟢'} Eager graph`,
     '',
-    "How much code each root forces the browser to download and decode through *static* imports — the regression class total bundle size can't see.",
+    'How much code each root ships on the *eager* path — downloaded and parsed before the surface is interactive. Measured from the esbuild output chunks (post-tree-shake, static imports only); lazy `import()` / `React.lazy` chunks are not counted.',
     '',
-    '| Root | Eager closure | Δ vs base | Budget |',
+    '| Root | Eager (shipped) | Δ vs base | Budget |',
     '| --- | --- | --- | --- |',
 ]
 
 for (const r of report.roots) {
-    const status = r.overBudget ? '❌ ' : ''
+    const status = r.overBudget ? '🟡 ' : ''
     lines.push(
         `| ${status}**${r.label}**<br/>\`${r.root}\` | ${formatBytes(r.bytes)} · ${r.files.toLocaleString()} files | ${formatDelta(r.bytes, baseBytes[r.root])} | ${budgetBar(r.bytes, r.budgetBytes)} |`
     )
@@ -181,14 +181,14 @@ for (const r of report.roots) {
 lines.push('')
 
 for (const message of report.errors ?? []) {
-    lines.push(`❌ ${message}`, '')
+    lines.push(`🟡 ${message}`, '')
 }
 
 for (const r of report.roots) {
     for (const forbiddenModule of r.forbidden) {
         const hit = r.forbiddenHits.find((h) => h.module === forbiddenModule)
         if (hit) {
-            lines.push(`❌ \`${forbiddenModule}\` is statically reachable from \`${r.root}\`:`)
+            lines.push(`🟡 \`${forbiddenModule}\` ships eagerly from \`${r.root}\`:`)
             lines.push('')
             lines.push('```')
             lines.push(hit.chain.join('\n  -> '))
@@ -210,7 +210,7 @@ for (const r of report.roots) {
 }
 lines.push('')
 lines.push(
-    '<sub>Posted automatically by [check-eager-graph](https://github.com/PostHog/posthog/blob/master/frontend/bin/check-eager-graph.mjs) · sizes are input-source bytes from the esbuild metafile · part of #32479</sub>'
+    '<sub>Posted automatically by [check-eager-graph](https://github.com/PostHog/posthog/blob/master/frontend/bin/check-eager-graph.mjs) · sizes are eager output bytes (shipped, post-tree-shake) from the esbuild metafile · part of #32479</sub>'
 )
 
 const body = lines.join('\n')

--- a/frontend/bin/post-eager-graph-comment.mjs
+++ b/frontend/bin/post-eager-graph-comment.mjs
@@ -194,7 +194,7 @@ for (const r of report.roots) {
             lines.push(hit.chain.join('\n  -> '))
             lines.push('```')
         } else {
-            lines.push(`✅ \`${forbiddenModule}\` stays out of \`${r.root}\``)
+            lines.push(`🟢 \`${forbiddenModule}\` stays out of \`${r.root}\``)
         }
     }
 }


### PR DESCRIPTION
> Claude-written:

## Problem

The eager-graph CI check started reporting the authenticated shell at **221% "of budget"** on every PR, flagging a red ❌ on all of them. It looked like a regression had blown the bundle. It hadn't.

The check summed **raw input-source bytes** of every module statically reachable from a root. That mistakes graph reachability for shipped weight. PR #66238 migrated hedgehog illustrations to the `@posthog/brand/hoggies` barrel. That barrel is `sideEffects: false` and statically re-exports all 364 illustration modules, so the input-graph walk counted the whole set (~44 MiB) — even though esbuild tree-shakes the unused ones out of the actual output. I measured it directly: importing one hog from the barrel ships **254 KiB**, identical to importing it via a deep path. The 44 MiB never reaches a browser.

So the number was a measurement artifact of a tree-shakeable barrel, not code on anyone's critical path.

## Changes

Measure the esbuild **output chunks** instead of the input graph:

- Map each root to its entry chunk (esbuild makes every code-split point an `entryPoint`).
- Walk `outputs[chunk].imports` following only `import-statement` (static) edges, collecting the eager chunk set. `dynamic-import` edges are the lazy boundaries, so they're excluded.
- Sum those chunks' real shipped bytes. Tree-shaken code is already gone from the output, so a side-effect-free barrel now only costs what its used exports actually ship.

This keeps the check's purpose intact — a lazy→static regression still moves bytes into the eager chunk and gets caught — while making it immune to the barrel phantom. Budgets are re-baselined from an actual production build to shipped-output bytes:

| Root | Old metric (input closure) | New metric (eager output) | New budget |
| --- | --- | --- | --- |
| `src/index.tsx` | 10.96 MiB | 2.73 MiB | 3.24 MiB |
| `AuthenticatedShell.tsx` | 72.91 MiB | 10.85 MiB | 12.40 MiB |

The PR comment now shows a green 🟢 / yellow 🟡 status instead of a red ❌, matching the check's warn-only posture (it hasn't failed CI since #66990). Largest-files and forbidden-module checks now operate on shipped bytes too, so they surface the real eager contributors.

Follow-up (not in this PR): the shell genuinely ships ~3.6 MiB of inlined hog SVGs on the eager path, because eagerly-loaded components like `UpgradeModal.tsx` import from the hoggies barrel. Before #66238 those were URL assets, not inlined JS. Worth ratcheting down by making those usages lazy or importing hogs only where they render.

## How did you test this code?

I ran a full production frontend build locally (`node frontend/build.mjs`) to produce a real esbuild metafile, then ran the rewritten `check-eager-graph.mjs --report-only` against it: both roots report 🟢 within budget. I confirmed the forbidden modules (`monaco-editor`, activity-log describers) stay out of the eager output, and that the forbidden-hit import-chain resolution still works for an eagerly-shipped module. I also verified the swap empirically with a standalone esbuild bundle: one hog imported via the barrel vs a deep path both ship 254 KiB, while the input graph differs by 44 MiB.

No unit tests — these are CI build scripts exercised end-to-end by the frontend build in CI; the next CI run on this PR posts the new comment against a real build.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Paul asked why the eager-graph report suddenly said ~200% over and whether it was broken or a real regression. I (Claude) traced it to PR #66238's barrel migration, then measured that the bytes tree-shake away and never ship. The first idea was to convert the ~40 barrel imports to deep single-icon paths, but I found (a) there's no deep path for the React components (only raw `svg`/`png`), and (b) shipped bytes are already identical — so that refactor would be churn with no user benefit. Paul chose to fix the check instead.

Getting a trustworthy baseline meant a real production build, which needed the `@posthog/quill-*` and `@posthog/hogvm` workspace packages built first. The empirical numbers drove the design decision: an input-graph "survival filter" (drop tree-shaken files) still over-attributes lazily-shipped modules to a root, so I moved to output-chunk measurement, which is both tree-shaking- and code-splitting-aware.

No repo skills were invoked.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
