### PR TITLE
fix(error-tracking): harden issue merges

### DIFF
--- a/products/error_tracking/backend/facade/issues.py
+++ b/products/error_tracking/backend/facade/issues.py
@@ -9,6 +9,7 @@ from typing import Any
 from uuid import UUID
 
 from ..logic import issue_mutations as _mutations
+from ..models import ErrorTrackingIssueMergeResult
 from . import api, contracts
 
 CohortNotFoundError = _mutations.CohortNotFoundError
@@ -23,8 +24,8 @@ def update_issue(
     return api._to_issue(issue)
 
 
-def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> None:
-    _mutations.merge_issues(team_id, issue_id, source_ids)
+def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> ErrorTrackingIssueMergeResult:
+    return _mutations.merge_issues(team_id, issue_id, source_ids)
 
 
 def split_issue(team_id: int, issue_id: UUID, fingerprints: list[dict]) -> list[UUID]:

--- a/products/error_tracking/backend/logic/issue_mutations.py
+++ b/products/error_tracking/backend/logic/issue_mutations.py
@@ -21,6 +21,7 @@ from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
     ErrorTrackingIssueCohort,
+    ErrorTrackingIssueMergeResult,
     sync_issues_to_clickhouse,
 )
 from products.error_tracking.backend.notifications import dispatch_issue_assigned_realtime
@@ -107,11 +108,11 @@ def update_issue(
     return issue
 
 
-def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> None:
+def merge_issues(team_id: int, issue_id: UUID, source_ids: list[str]) -> ErrorTrackingIssueMergeResult:
     issue = _get_issue(team_id, issue_id)
     # Make sure we don't delete the issue being merged into (defensive of frontend bugs)
     ids = [x for x in source_ids if x != str(issue.id)]
-    issue.merge(issue_ids=ids)
+    return issue.merge(issue_ids=ids)
 
 
 def split_issue(team_id: int, issue_id: UUID, fingerprints: list[dict]) -> list[UUID]:

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -53,7 +53,7 @@ class ErrorTrackingIssue(UUIDTModel):
     class Meta:
         db_table = "posthog_errortrackingissue"
 
-    def merge(self, issue_ids: list[str | UUID]) -> bool:
+    def merge(self, issue_ids: list[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None) -> bool:
         team_id = self.team_id
         target_issue_id = self.id
         source_issue_ids = _normalize_source_issue_ids(issue_ids=issue_ids, target_issue_id=target_issue_id)
@@ -65,6 +65,10 @@ class ErrorTrackingIssue(UUIDTModel):
                 team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=source_issue_ids
             )
             if not existing_source_issue_ids:
+                return False
+            if expected_fingerprint_issue_ids is not None and not _lock_expected_fingerprint_issue_ids(
+                team_id=team_id, expected_fingerprint_issue_ids=expected_fingerprint_issue_ids
+            ):
                 return False
 
             locked_source_fingerprints = list(
@@ -210,14 +214,20 @@ def _lock_merge_issues(*, team_id: int, target_issue_id: UUID, source_issue_ids:
         .filter(team_id=team_id, id__in=[target_issue_id, *source_issue_ids])
         .order_by("id")
     }
-    if target_issue_id not in locked_issue_ids:
+    if target_issue_id not in locked_issue_ids or not set(source_issue_ids).issubset(locked_issue_ids):
         return []
 
-    locked_source_issue_ids = [issue_id for issue_id in source_issue_ids if issue_id in locked_issue_ids]
-    if len(locked_source_issue_ids) != len(source_issue_ids):
-        return []
+    return source_issue_ids
 
-    return locked_source_issue_ids
+
+def _lock_expected_fingerprint_issue_ids(*, team_id: int, expected_fingerprint_issue_ids: dict[str, UUID]) -> bool:
+    current_fingerprint_issue_ids = {
+        row.fingerprint: row.issue_id
+        for row in ErrorTrackingIssueFingerprintV2.objects.select_for_update()
+        .filter(team_id=team_id, fingerprint__in=list(expected_fingerprint_issue_ids))
+        .order_by("fingerprint", "id")
+    }
+    return current_fingerprint_issue_ids == expected_fingerprint_issue_ids
 
 
 def _sync_error_tracking_issue_changes_on_commit(
@@ -525,6 +535,9 @@ def resolve_fingerprints_for_issues(team_id: int, issue_ids: list[str]) -> list[
 def update_error_tracking_issue_fingerprints(
     team_id: int, issue_id: str | UUID, fingerprints: list[str]
 ) -> list[ErrorTrackingIssueFingerprintV2]:
+    if not fingerprints:
+        return []
+
     return list(
         # nosemgrep: python.django.security.audit.raw-query.avoid-raw-sql (parameterized via params list)
         ErrorTrackingIssueFingerprintV2.objects.raw(

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -214,7 +214,12 @@ def _lock_merge_issues(*, team_id: int, target_issue_id: UUID, source_issue_ids:
     }
     if target_issue_id not in locked_issue_ids:
         return []
-    return [issue_id for issue_id in source_issue_ids if issue_id in locked_issue_ids]
+
+    locked_source_issue_ids = [issue_id for issue_id in source_issue_ids if issue_id in locked_issue_ids]
+    if len(locked_source_issue_ids) != len(source_issue_ids):
+        return []
+
+    return locked_source_issue_ids
 
 
 def _sync_error_tracking_issue_changes_on_commit(

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -1,5 +1,6 @@
 import time
 from decimal import Decimal
+from enum import StrEnum
 from uuid import UUID
 
 from django.conf import settings
@@ -34,6 +35,13 @@ class ErrorTrackingIssueManager(models.Manager):
         return self.annotate(first_seen=models.Min("fingerprints__first_seen"))
 
 
+class ErrorTrackingIssueMergeResult(StrEnum):
+    MERGED = "merged"
+    NO_SOURCE_ISSUES = "no_source_issues"
+    STALE_ISSUES = "stale_issues"
+    STALE_FINGERPRINTS = "stale_fingerprints"
+
+
 class ErrorTrackingIssue(UUIDTModel):
     class Status(models.TextChoices):
         ARCHIVED = "archived", "Archived"
@@ -53,23 +61,25 @@ class ErrorTrackingIssue(UUIDTModel):
     class Meta:
         db_table = "posthog_errortrackingissue"
 
-    def merge(self, issue_ids: list[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None) -> bool:
+    def merge(
+        self, issue_ids: list[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None
+    ) -> ErrorTrackingIssueMergeResult:
         team_id = self.team_id
         target_issue_id = self.id
         source_issue_ids = _normalize_source_issue_ids(issue_ids=issue_ids, target_issue_id=target_issue_id)
         if not source_issue_ids:
-            return False
+            return ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES
 
         with transaction.atomic():
             existing_source_issue_ids = _lock_merge_issues(
                 team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=source_issue_ids
             )
             if not existing_source_issue_ids:
-                return False
+                return ErrorTrackingIssueMergeResult.STALE_ISSUES
             if expected_fingerprint_issue_ids is not None and not _lock_expected_fingerprint_issue_ids(
                 team_id=team_id, expected_fingerprint_issue_ids=expected_fingerprint_issue_ids
             ):
-                return False
+                return ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
 
             locked_source_fingerprints = list(
                 ErrorTrackingIssueFingerprintV2.objects.select_for_update()
@@ -92,7 +102,7 @@ class ErrorTrackingIssue(UUIDTModel):
             _sync_error_tracking_issue_changes_on_commit(
                 team_id=team_id, issue_ids=[target_issue_id], overrides=overrides
             )
-            return True
+            return ErrorTrackingIssueMergeResult.MERGED
 
     def split(self, fingerprints: list[dict]) -> list["ErrorTrackingIssue"]:
         team_id = self.team_id

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -1,4 +1,5 @@
 import time
+from collections.abc import Sequence
 from decimal import Decimal
 from enum import StrEnum
 from uuid import UUID
@@ -66,7 +67,7 @@ class ErrorTrackingIssue(UUIDTModel):
         db_table = "posthog_errortrackingissue"
 
     def merge(
-        self, issue_ids: list[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None
+        self, issue_ids: Sequence[str | UUID], expected_fingerprint_issue_ids: dict[str, UUID] | None = None
     ) -> ErrorTrackingIssueMergeResult:
         team_id = self.team_id
         target_issue_id = self.id
@@ -212,7 +213,7 @@ class ErrorTrackingIssueFingerprintV2(UUIDTModel):
         db_table = "posthog_errortrackingissuefingerprintv2"
 
 
-def _normalize_source_issue_ids(*, issue_ids: list[str | UUID], target_issue_id: UUID) -> list[UUID]:
+def _normalize_source_issue_ids(*, issue_ids: Sequence[str | UUID], target_issue_id: UUID) -> list[UUID]:
     source_issue_ids: set[UUID] = set()
     for issue_id in issue_ids:
         normalized_issue_id = UUID(str(issue_id))
@@ -247,14 +248,14 @@ def _lock_expected_fingerprint_issue_ids(*, team_id: int, expected_fingerprint_i
 def _sync_error_tracking_issue_changes_on_commit(
     *, team_id: int, issue_ids: list[UUID], overrides: list[ErrorTrackingIssueFingerprintV2]
 ) -> None:
-    transaction.on_commit(
-        lambda team_id=team_id, overrides=overrides: update_error_tracking_issue_fingerprint_overrides(
-            team_id=team_id, overrides=overrides
-        )
-    )
-    transaction.on_commit(
-        lambda team_id=team_id, issue_ids=issue_ids: sync_issues_to_clickhouse(issue_ids=issue_ids, team_id=team_id)
-    )
+    def sync_fingerprint_overrides() -> None:
+        update_error_tracking_issue_fingerprint_overrides(team_id=team_id, overrides=overrides)
+
+    def sync_issues() -> None:
+        sync_issues_to_clickhouse(issue_ids=issue_ids, team_id=team_id)
+
+    transaction.on_commit(sync_fingerprint_overrides)
+    transaction.on_commit(sync_issues)
 
 
 class ErrorTrackingRelease(UUIDTModel):

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -1,5 +1,6 @@
 import time
 from decimal import Decimal
+from typing import cast
 from uuid import UUID
 
 from django.conf import settings
@@ -53,18 +54,42 @@ class ErrorTrackingIssue(UUIDTModel):
     class Meta:
         db_table = "posthog_errortrackingissue"
 
-    def merge(self, issue_ids: list[str]) -> None:
-        fingerprints = resolve_fingerprints_for_issues(team_id=self.team.pk, issue_ids=issue_ids)
+    def merge(self, issue_ids: list[str | UUID]) -> bool:
+        team_id = self.team_id
+        target_issue_id = self.id
+        source_issue_ids = _normalize_source_issue_ids(issue_ids=issue_ids, target_issue_id=target_issue_id)
+        if not source_issue_ids:
+            return False
 
         with transaction.atomic():
-            overrides = update_error_tracking_issue_fingerprints(
-                team_id=self.team.pk, issue_id=self.id, fingerprints=fingerprints
+            existing_source_issue_ids = _lock_merge_issues(
+                team_id=team_id, target_issue_id=target_issue_id, source_issue_ids=source_issue_ids
             )
+            if not existing_source_issue_ids:
+                return False
+
+            locked_source_fingerprints = list(
+                ErrorTrackingIssueFingerprintV2.objects.select_for_update()
+                .filter(team_id=team_id, issue_id__in=existing_source_issue_ids)
+                .order_by("fingerprint", "id")
+            )
+
+            overrides = update_error_tracking_issue_fingerprints(
+                team_id=team_id,
+                issue_id=target_issue_id,
+                fingerprints=[fingerprint.fingerprint for fingerprint in locked_source_fingerprints],
+            )
+
             # Reassign spike events from merged issues before deleting them
-            ErrorTrackingSpikeEvent.objects.filter(team=self.team, issue_id__in=issue_ids).update(issue=self)
-            ErrorTrackingIssue.objects.filter(team=self.team, id__in=issue_ids).delete()
-            update_error_tracking_issue_fingerprint_overrides(team_id=self.team.pk, overrides=overrides)
-            sync_issues_to_clickhouse(issue_ids=[self.id], team_id=self.team_id)
+            ErrorTrackingSpikeEvent.objects.filter(team_id=team_id, issue_id__in=existing_source_issue_ids).update(
+                issue_id=target_issue_id
+            )
+            ErrorTrackingIssue.objects.filter(team_id=team_id, id__in=existing_source_issue_ids).delete()
+
+            _sync_error_tracking_issue_changes_on_commit(
+                team_id=team_id, issue_ids=[target_issue_id], overrides=overrides
+            )
+            return True
 
     def split(self, fingerprints: list[dict]) -> list["ErrorTrackingIssue"]:
         own_fingerprints = set(
@@ -92,10 +117,12 @@ class ErrorTrackingIssue(UUIDTModel):
                         team_id=self.team.pk, issue_id=new_issue.id, fingerprints=[fp]
                     )
                 )
-            update_error_tracking_issue_fingerprint_overrides(team_id=self.team.pk, overrides=overrides)
             # Spike events are no longer meaningful after splitting since the issue composition changed
             ErrorTrackingSpikeEvent.objects.filter(team=self.team, issue=self).delete()
-            sync_issues_to_clickhouse(issue_ids=[self.id] + [issue.id for issue in new_issues], team_id=self.team_id)
+            issue_ids_to_sync = [self.id] + [issue.id for issue in new_issues]
+            _sync_error_tracking_issue_changes_on_commit(
+                team_id=self.team_id, issue_ids=issue_ids_to_sync, overrides=overrides
+            )
         return new_issues
 
 
@@ -167,6 +194,40 @@ class ErrorTrackingIssueFingerprintV2(UUIDTModel):
     class Meta:
         constraints = [models.UniqueConstraint(fields=["team", "fingerprint"], name="unique_fingerprint_for_team")]
         db_table = "posthog_errortrackingissuefingerprintv2"
+
+
+def _normalize_source_issue_ids(*, issue_ids: list[str | UUID], target_issue_id: UUID) -> list[UUID]:
+    source_issue_ids: set[UUID] = set()
+    for issue_id in issue_ids:
+        normalized_issue_id = cast(UUID, UUID(str(issue_id)))
+        if normalized_issue_id != target_issue_id:
+            source_issue_ids.add(normalized_issue_id)
+    return sorted(source_issue_ids, key=lambda issue_id: issue_id.hex)
+
+
+def _lock_merge_issues(*, team_id: int, target_issue_id: UUID, source_issue_ids: list[UUID]) -> list[UUID]:
+    locked_issue_ids = {
+        issue.id
+        for issue in ErrorTrackingIssue.objects.select_for_update()
+        .filter(team_id=team_id, id__in=[target_issue_id, *source_issue_ids])
+        .order_by("id")
+    }
+    if target_issue_id not in locked_issue_ids:
+        return []
+    return [issue_id for issue_id in source_issue_ids if issue_id in locked_issue_ids]
+
+
+def _sync_error_tracking_issue_changes_on_commit(
+    *, team_id: int, issue_ids: list[UUID], overrides: list[ErrorTrackingIssueFingerprintV2]
+) -> None:
+    transaction.on_commit(
+        lambda team_id=team_id, overrides=overrides: update_error_tracking_issue_fingerprint_overrides(
+            team_id=team_id, overrides=overrides
+        )
+    )
+    transaction.on_commit(
+        lambda team_id=team_id, issue_ids=issue_ids: sync_issues_to_clickhouse(issue_ids=issue_ids, team_id=team_id)
+    )
 
 
 class ErrorTrackingRelease(UUIDTModel):
@@ -459,7 +520,7 @@ def resolve_fingerprints_for_issues(team_id: int, issue_ids: list[str]) -> list[
 
 
 def update_error_tracking_issue_fingerprints(
-    team_id: int, issue_id: str, fingerprints: list[str]
+    team_id: int, issue_id: str | UUID, fingerprints: list[str]
 ) -> list[ErrorTrackingIssueFingerprintV2]:
     return list(
         # nosemgrep: python.django.security.audit.raw-query.avoid-raw-sql (parameterized via params list)

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -36,9 +36,13 @@ class ErrorTrackingIssueManager(models.Manager):
 
 
 class ErrorTrackingIssueMergeResult(StrEnum):
+    # The merge completed and moved source fingerprints onto the target issue.
     MERGED = "merged"
+    # The request only referenced the target issue, duplicate source IDs, or no source IDs.
     NO_SOURCE_ISSUES = "no_source_issues"
+    # The target or at least one source issue disappeared before row locks were acquired.
     STALE_ISSUES = "stale_issues"
+    # A guarded fingerprint no longer belongs to the issue observed before the merge transaction.
     STALE_FINGERPRINTS = "stale_fingerprints"
 
 

--- a/products/error_tracking/backend/models.py
+++ b/products/error_tracking/backend/models.py
@@ -1,6 +1,5 @@
 import time
 from decimal import Decimal
-from typing import cast
 from uuid import UUID
 
 from django.conf import settings
@@ -92,8 +91,9 @@ class ErrorTrackingIssue(UUIDTModel):
             return True
 
     def split(self, fingerprints: list[dict]) -> list["ErrorTrackingIssue"]:
+        team_id = self.team_id
         own_fingerprints = set(
-            ErrorTrackingIssueFingerprintV2.objects.filter(team_id=self.team.pk, issue_id=self.id).values_list(
+            ErrorTrackingIssueFingerprintV2.objects.filter(team_id=team_id, issue_id=self.id).values_list(
                 "fingerprint", flat=True
             )
         )
@@ -107,21 +107,19 @@ class ErrorTrackingIssue(UUIDTModel):
                 if fp not in own_fingerprints:
                     continue
                 new_issue = ErrorTrackingIssue.objects.create(
-                    team=self.team,
+                    team_id=team_id,
                     name=entry.get("name") or "Untitled issue",
                     description=entry.get("description"),
                 )
                 new_issues.append(new_issue)
                 overrides.extend(
-                    update_error_tracking_issue_fingerprints(
-                        team_id=self.team.pk, issue_id=new_issue.id, fingerprints=[fp]
-                    )
+                    update_error_tracking_issue_fingerprints(team_id=team_id, issue_id=new_issue.id, fingerprints=[fp])
                 )
             # Spike events are no longer meaningful after splitting since the issue composition changed
-            ErrorTrackingSpikeEvent.objects.filter(team=self.team, issue=self).delete()
+            ErrorTrackingSpikeEvent.objects.filter(team_id=team_id, issue_id=self.id).delete()
             issue_ids_to_sync = [self.id] + [issue.id for issue in new_issues]
             _sync_error_tracking_issue_changes_on_commit(
-                team_id=self.team_id, issue_ids=issue_ids_to_sync, overrides=overrides
+                team_id=team_id, issue_ids=issue_ids_to_sync, overrides=overrides
             )
         return new_issues
 
@@ -199,7 +197,7 @@ class ErrorTrackingIssueFingerprintV2(UUIDTModel):
 def _normalize_source_issue_ids(*, issue_ids: list[str | UUID], target_issue_id: UUID) -> list[UUID]:
     source_issue_ids: set[UUID] = set()
     for issue_id in issue_ids:
-        normalized_issue_id = cast(UUID, UUID(str(issue_id)))
+        normalized_issue_id = UUID(str(issue_id))
         if normalized_issue_id != target_issue_id:
             source_issue_ids.add(normalized_issue_id)
     return sorted(source_issue_ids, key=lambda issue_id: issue_id.hex)

--- a/products/error_tracking/backend/presentation/views/issues.py
+++ b/products/error_tracking/backend/presentation/views/issues.py
@@ -204,10 +204,14 @@ class ErrorTrackingIssueViewSet(TeamAndOrgViewSetMixin, ForbidDestroyModel, view
     def merge(self, request: ValidatedRequest, *args: object, pk: object = None, **kwargs: object) -> Response:
         ids = [str(issue_id) for issue_id in request.validated_data["ids"]]
         try:
-            issues_facade.merge_issues(self.team.id, UUID(str(pk)), ids)
+            merge_result = issues_facade.merge_issues(self.team.id, UUID(str(pk)), ids)
         except IssueNotFoundError:
             raise NotFound("Issue not found")
-        return Response({"success": True})
+        if merge_result == issues_facade.ErrorTrackingIssueMergeResult.STALE_ISSUES:
+            raise NotFound("Issue not found")
+        if merge_result == issues_facade.ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS:
+            raise ValidationError("Issue fingerprints changed before merge. Please retry.")
+        return Response({"success": merge_result == issues_facade.ErrorTrackingIssueMergeResult.MERGED})
 
     @validated_request(
         request_serializer=ErrorTrackingIssueSplitRequestSerializer,

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -305,7 +305,13 @@ def _merge_fingerprint_into_closest_issue(
 
     source_issue_id = source_fingerprint.issue_id
     target_issue_id = target_fingerprint.issue_id
-    if not target_fingerprint.issue.merge(issue_ids=[str(source_issue_id)]):
+    if not target_fingerprint.issue.merge(
+        issue_ids=[source_issue_id],
+        expected_fingerprint_issue_ids={
+            fingerprint: source_issue_id,
+            closest_fingerprint.fingerprint: target_issue_id,
+        },
+    ):
         return 0
 
     with ph_scoped_capture() as capture:

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -18,7 +18,7 @@ from posthog.ph_client import ph_scoped_capture
 from posthog.temporal.common.utils import close_db_connections
 
 from products.error_tracking.backend.indexed_embedding import EMBEDDING_TABLES
-from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2
+from products.error_tracking.backend.models import ErrorTrackingIssueFingerprintV2, ErrorTrackingIssueMergeResult
 from products.error_tracking.backend.temporal.fingerprint_embedding_result.types import (
     FingerprintEmbeddingMergeResult,
     FingerprintEmbeddingResultInputs,
@@ -309,13 +309,16 @@ def _merge_fingerprint_into_closest_issue(
 
     source_issue_id = source_fingerprint.issue_id
     target_issue_id = target_fingerprint.issue_id
-    if not target_fingerprint.issue.merge(
+    merge_result = target_fingerprint.issue.merge(
         issue_ids=[source_issue_id],
         expected_fingerprint_issue_ids={
             fingerprint: source_issue_id,
             closest_fingerprint.fingerprint: target_issue_id,
         },
-    ):
+    )
+    if merge_result == ErrorTrackingIssueMergeResult.NO_SOURCE_ISSUES:
+        return 0
+    if merge_result != ErrorTrackingIssueMergeResult.MERGED:
         raise StaleAutoMergeStateError(f"Fingerprint issue ownership changed before auto-merge for team {team_id}")
 
     with ph_scoped_capture() as capture:

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -93,6 +93,10 @@ class FingerprintIssueNotFoundError(RuntimeError):
     pass
 
 
+class StaleAutoMergeStateError(RuntimeError):
+    pass
+
+
 def _capture_activity_exception(
     error: Exception,
     inputs: FingerprintEmbeddingResultInputs,
@@ -312,7 +316,7 @@ def _merge_fingerprint_into_closest_issue(
             closest_fingerprint.fingerprint: target_issue_id,
         },
     ):
-        return 0
+        raise StaleAutoMergeStateError(f"Fingerprint issue ownership changed before auto-merge for team {team_id}")
 
     with ph_scoped_capture() as capture:
         capture(

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py
@@ -2,7 +2,6 @@ import time
 from datetime import datetime, timedelta
 
 from django.conf import settings
-from django.db import transaction
 from django.utils.dateparse import parse_datetime
 
 import posthoganalytics
@@ -284,30 +283,30 @@ def _merge_fingerprint_into_closest_issue(
     if closest_fingerprint.distance >= AUTO_MERGE_DISTANCE_THRESHOLD:
         return 0
 
-    with transaction.atomic():
-        # Lock both fingerprints together so reciprocal auto-merge attempts re-check the post-merge state.
-        locked_fingerprints = {
-            row.fingerprint: row
-            for row in ErrorTrackingIssueFingerprintV2.objects.select_for_update()
-            .filter(team_id=team_id, fingerprint__in=[fingerprint, closest_fingerprint.fingerprint])
-            .select_related("issue")
-            .order_by("fingerprint", "id")
-        }
-        source_fingerprint = locked_fingerprints.get(fingerprint)
-        if source_fingerprint is None:
-            raise FingerprintIssueNotFoundError(f"Source fingerprint {fingerprint} not found for team {team_id}")
+    fingerprints_by_value = {
+        row.fingerprint: row
+        for row in ErrorTrackingIssueFingerprintV2.objects.filter(
+            team_id=team_id, fingerprint__in=[fingerprint, closest_fingerprint.fingerprint]
+        )
+        .select_related("issue")
+        .order_by("fingerprint", "id")
+    }
+    source_fingerprint = fingerprints_by_value.get(fingerprint)
+    if source_fingerprint is None:
+        raise FingerprintIssueNotFoundError(f"Source fingerprint {fingerprint} not found for team {team_id}")
 
-        target_fingerprint = locked_fingerprints.get(closest_fingerprint.fingerprint)
-        if target_fingerprint is None:
-            raise FingerprintIssueNotFoundError(
-                f"Target fingerprint {closest_fingerprint.fingerprint} not found for team {team_id}"
-            )
-        if source_fingerprint.issue_id == target_fingerprint.issue_id:
-            return 0
+    target_fingerprint = fingerprints_by_value.get(closest_fingerprint.fingerprint)
+    if target_fingerprint is None:
+        raise FingerprintIssueNotFoundError(
+            f"Target fingerprint {closest_fingerprint.fingerprint} not found for team {team_id}"
+        )
+    if source_fingerprint.issue_id == target_fingerprint.issue_id:
+        return 0
 
-        source_issue_id = source_fingerprint.issue_id
-        target_issue_id = target_fingerprint.issue_id
-        target_fingerprint.issue.merge(issue_ids=[str(source_issue_id)])
+    source_issue_id = source_fingerprint.issue_id
+    target_issue_id = target_fingerprint.issue_id
+    if not target_fingerprint.issue.merge(issue_ids=[str(source_issue_id)]):
+        return 0
 
     with ph_scoped_capture() as capture:
         capture(

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -18,6 +18,7 @@ from posthog.models import Team
 from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueFingerprintV2
 from products.error_tracking.backend.temporal.fingerprint_embedding_result.activities import (
     FingerprintIssueNotFoundError,
+    StaleAutoMergeStateError,
     TargetFingerprintEmbeddingNotFoundError,
     _closest_fingerprints_query,
     _merge_fingerprint_into_closest_issue,
@@ -301,15 +302,14 @@ class TestFingerprintEmbeddingResultActivity:
 
         assert result == 0
 
-    @pytest.mark.django_db
     def test_merge_fingerprint_raises_when_source_fingerprint_is_missing(self) -> None:
         fingerprint_query = MagicMock()
-        fingerprint_query.filter.return_value.select_related.return_value.order_by.return_value = []
+        fingerprint_query.select_related.return_value.order_by.return_value = []
 
         with (
             override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.select_for_update",
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.filter",
                 return_value=fingerprint_query,
             ),
             pytest.raises(FingerprintIssueNotFoundError, match="Source fingerprint test-fingerprint not found"),
@@ -320,16 +320,16 @@ class TestFingerprintEmbeddingResultActivity:
                 closest_fingerprints=[SimilarFingerprintDistance(fingerprint="fingerprint-1", distance=0.018)],
             )
 
-    @pytest.mark.django_db
     def test_merge_fingerprint_moves_source_fingerprint_to_closest_issue(self) -> None:
         source_issue_id = uuid.uuid4()
         target_issue_id = uuid.uuid4()
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         target_issue = MagicMock()
+        target_issue.merge.return_value = True
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
         team = MagicMock(id=2, uuid=uuid.uuid4())
         fingerprint_query = MagicMock()
-        fingerprint_query.filter.return_value.select_related.return_value.order_by.return_value = [
+        fingerprint_query.select_related.return_value.order_by.return_value = [
             target_fingerprint,
             source_fingerprint,
         ]
@@ -340,9 +340,9 @@ class TestFingerprintEmbeddingResultActivity:
         with (
             override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
             patch(
-                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.select_for_update",
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.filter",
                 return_value=fingerprint_query,
-            ),
+            ) as filter_fingerprints,
             patch(
                 "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ph_scoped_capture",
                 return_value=capture_context,
@@ -359,15 +359,49 @@ class TestFingerprintEmbeddingResultActivity:
             )
 
         assert result == 1
-        assert fingerprint_query.filter.call_args.kwargs == {
+        assert filter_fingerprints.call_args.kwargs == {
             "team_id": 2,
             "fingerprint__in": ["test-fingerprint", "fingerprint-1"],
         }
-        target_issue.merge.assert_called_once_with(issue_ids=[str(source_issue_id)])
+        target_issue.merge.assert_called_once_with(
+            issue_ids=[source_issue_id],
+            expected_fingerprint_issue_ids={
+                "test-fingerprint": source_issue_id,
+                "fingerprint-1": target_issue_id,
+            },
+        )
         properties = capture.call_args.kwargs["properties"]
         assert properties["merge_source"] == "auto"
         assert properties["source_issue_id"] == str(source_issue_id)
         assert properties["target_issue_id"] == str(target_issue_id)
+
+    def test_merge_fingerprint_retries_when_merge_state_is_stale(self) -> None:
+        source_issue_id = uuid.uuid4()
+        target_issue_id = uuid.uuid4()
+        source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
+        target_issue = MagicMock()
+        target_issue.merge.return_value = False
+        target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
+        team = MagicMock(id=2, uuid=uuid.uuid4())
+        fingerprint_query = MagicMock()
+        fingerprint_query.select_related.return_value.order_by.return_value = [
+            target_fingerprint,
+            source_fingerprint,
+        ]
+
+        with (
+            override_settings(ERROR_TRACKING_AUTO_MERGE_ENABLED=True),
+            patch(
+                "products.error_tracking.backend.temporal.fingerprint_embedding_result.activities.ErrorTrackingIssueFingerprintV2.objects.filter",
+                return_value=fingerprint_query,
+            ),
+            pytest.raises(StaleAutoMergeStateError, match="Fingerprint issue ownership changed"),
+        ):
+            _merge_fingerprint_into_closest_issue(
+                team=team,
+                fingerprint="test-fingerprint",
+                closest_fingerprints=[SimilarFingerprintDistance(fingerprint="fingerprint-1", distance=0.018)],
+            )
 
 
 class TestMergeFingerprintCrossTeamIsolation(BaseTest):

--- a/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
+++ b/products/error_tracking/backend/temporal/fingerprint_embedding_result/test/test_fingerprint_embedding_result.py
@@ -15,7 +15,11 @@ from temporalio.worker import UnsandboxedWorkflowRunner, Worker
 
 from posthog.models import Team
 
-from products.error_tracking.backend.models import ErrorTrackingIssue, ErrorTrackingIssueFingerprintV2
+from products.error_tracking.backend.models import (
+    ErrorTrackingIssue,
+    ErrorTrackingIssueFingerprintV2,
+    ErrorTrackingIssueMergeResult,
+)
 from products.error_tracking.backend.temporal.fingerprint_embedding_result.activities import (
     FingerprintIssueNotFoundError,
     StaleAutoMergeStateError,
@@ -325,7 +329,7 @@ class TestFingerprintEmbeddingResultActivity:
         target_issue_id = uuid.uuid4()
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         target_issue = MagicMock()
-        target_issue.merge.return_value = True
+        target_issue.merge.return_value = ErrorTrackingIssueMergeResult.MERGED
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
         team = MagicMock(id=2, uuid=uuid.uuid4())
         fingerprint_query = MagicMock()
@@ -380,7 +384,7 @@ class TestFingerprintEmbeddingResultActivity:
         target_issue_id = uuid.uuid4()
         source_fingerprint = MagicMock(issue_id=source_issue_id, fingerprint="test-fingerprint")
         target_issue = MagicMock()
-        target_issue.merge.return_value = False
+        target_issue.merge.return_value = ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
         target_fingerprint = MagicMock(issue_id=target_issue_id, issue=target_issue, fingerprint="fingerprint-1")
         team = MagicMock(id=2, uuid=uuid.uuid4())
         fingerprint_query = MagicMock()

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from django.db import close_old_connections, connection, transaction
 from django.db.utils import IntegrityError
 
+from posthog.models import Team
+
 from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
@@ -22,6 +24,8 @@ from products.error_tracking.backend.models import (
 
 
 class ErrorTrackingIssueTestMixin:
+    team: Team
+
     def create_issue(self, fingerprints: list[str]) -> ErrorTrackingIssue:
         issue = ErrorTrackingIssue.objects.create(team=self.team)
         for fingerprint in fingerprints:

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -1,11 +1,14 @@
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta
+from threading import Barrier
+from uuid import UUID
 
 import pytest
 from freezegun import freeze_time
-from posthog.test.base import BaseTest
+from posthog.test.base import BaseTest, NonAtomicBaseTest
 from unittest.mock import patch
 
-from django.db import transaction
+from django.db import close_old_connections, connection, transaction
 from django.db.utils import IntegrityError
 
 from products.error_tracking.backend.models import (
@@ -17,13 +20,15 @@ from products.error_tracking.backend.models import (
 )
 
 
-class TestErrorTracking(BaseTest):
-    def create_issue(self, fingerprints) -> ErrorTrackingIssue:
+class ErrorTrackingIssueTestMixin:
+    def create_issue(self, fingerprints: list[str]) -> ErrorTrackingIssue:
         issue = ErrorTrackingIssue.objects.create(team=self.team)
         for fingerprint in fingerprints:
             ErrorTrackingIssueFingerprintV2.objects.create(team=self.team, issue=issue, fingerprint=fingerprint)
         return issue
 
+
+class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
     def test_defaults(self):
         issue = ErrorTrackingIssue.objects.create(team=self.team)
 
@@ -257,3 +262,52 @@ class TestErrorTracking(BaseTest):
 
                 # Verify object storage delete was called with correct path
                 mock_delete.assert_called_once_with(file_name="test-storage-path")
+
+
+class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBaseTest):
+    def _run_merge(self, *, start_barrier: Barrier, target_issue_id: UUID, source_issue_ids: list[UUID]) -> bool:
+        close_old_connections()
+        try:
+            with connection.cursor() as cursor:
+                cursor.execute("SET lock_timeout = '10s'")
+                cursor.execute("SET statement_timeout = '15s'")
+            start_barrier.wait(timeout=5)
+            return ErrorTrackingIssue.objects.get(id=target_issue_id).merge(issue_ids=source_issue_ids)
+        finally:
+            close_old_connections()
+
+    def test_opposite_concurrent_merges_do_not_deadlock(self):
+        source_issue_one = self.create_issue(["source_fingerprint_one"])
+        source_issue_two = self.create_issue(["source_fingerprint_two"])
+        target_issue_one = self.create_issue(["target_fingerprint_one"])
+        target_issue_two = self.create_issue(["target_fingerprint_two"])
+        start_barrier = Barrier(2)
+
+        with (
+            patch("products.error_tracking.backend.models.update_error_tracking_issue_fingerprint_overrides"),
+            patch("products.error_tracking.backend.models.sync_issues_to_clickhouse"),
+            ThreadPoolExecutor(max_workers=2) as executor,
+        ):
+            merge_to_target_one = executor.submit(
+                self._run_merge,
+                start_barrier=start_barrier,
+                target_issue_id=target_issue_one.id,
+                source_issue_ids=[source_issue_one.id, source_issue_two.id],
+            )
+            merge_to_target_two = executor.submit(
+                self._run_merge,
+                start_barrier=start_barrier,
+                target_issue_id=target_issue_two.id,
+                source_issue_ids=[source_issue_two.id, source_issue_one.id],
+            )
+
+            merge_results = [merge_to_target_one.result(timeout=20), merge_to_target_two.result(timeout=20)]
+
+        assert sorted(merge_results) == [False, True]
+        assert not ErrorTrackingIssue.objects.filter(id__in=[source_issue_one.id, source_issue_two.id]).exists()
+        assert ErrorTrackingIssue.objects.filter(id__in=[target_issue_one.id, target_issue_two.id]).count() == 2
+
+        source_fingerprints = ErrorTrackingIssueFingerprintV2.objects.filter(
+            fingerprint__in=["source_fingerprint_one", "source_fingerprint_two"]
+        ).values_list("issue_id", flat=True)
+        assert len(set(source_fingerprints)) == 1

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -15,6 +15,7 @@ from products.error_tracking.backend.models import (
     ErrorTrackingIssue,
     ErrorTrackingIssueAssignment,
     ErrorTrackingIssueFingerprintV2,
+    ErrorTrackingIssueMergeResult,
     ErrorTrackingSpikeEvent,
     ErrorTrackingSymbolSet,
 )
@@ -87,7 +88,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         stale_issue_id = self.create_issue(["fingerprint_three"]).id
         ErrorTrackingIssue.objects.filter(id=stale_issue_id).delete()
 
-        assert issue_two.merge(issue_ids=[issue_one.id, stale_issue_id]) is False
+        assert issue_two.merge(issue_ids=[issue_one.id, stale_issue_id]) == ErrorTrackingIssueMergeResult.STALE_ISSUES
 
         assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
         assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
@@ -106,7 +107,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
                     "fingerprint_two": issue_two.id,
                 },
             )
-            is False
+            == ErrorTrackingIssueMergeResult.STALE_FINGERPRINTS
         )
 
         assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
@@ -122,7 +123,7 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
             patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse,
             self.captureOnCommitCallbacks(execute=True),
         ):
-            assert issue_two.merge(issue_ids=[issue_one.id]) is True
+            assert issue_two.merge(issue_ids=[issue_one.id]) == ErrorTrackingIssueMergeResult.MERGED
 
         sync_issues_to_clickhouse.assert_called_once_with(issue_ids=[issue_two.id], team_id=self.team.id)
 
@@ -285,7 +286,9 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
 
 
 class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBaseTest):
-    def _run_merge(self, *, start_barrier: Barrier, target_issue_id: UUID, source_issue_ids: list[UUID]) -> bool:
+    def _run_merge(
+        self, *, start_barrier: Barrier, target_issue_id: UUID, source_issue_ids: list[UUID]
+    ) -> ErrorTrackingIssueMergeResult:
         close_old_connections()
         try:
             with connection.cursor() as cursor:
@@ -323,7 +326,8 @@ class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBa
 
             merge_results = [merge_to_target_one.result(timeout=20), merge_to_target_two.result(timeout=20)]
 
-        assert sorted(merge_results) == [False, True]
+        assert merge_results.count(ErrorTrackingIssueMergeResult.MERGED) == 1
+        assert merge_results.count(ErrorTrackingIssueMergeResult.STALE_ISSUES) == 1
         assert not ErrorTrackingIssue.objects.filter(id__in=[source_issue_one.id, source_issue_two.id]).exists()
         assert ErrorTrackingIssue.objects.filter(id__in=[target_issue_one.id, target_issue_two.id]).count() == 2
 

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -76,6 +76,18 @@ class TestErrorTracking(BaseTest):
 
         assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue_three.id).count() == 3
 
+    def test_merge_missing_source_issue_is_noop(self):
+        issue_one = self.create_issue(["fingerprint_one"])
+        issue_two = self.create_issue(["fingerprint_two"])
+        stale_issue_id = self.create_issue(["fingerprint_three"]).id
+        ErrorTrackingIssue.objects.filter(id=stale_issue_id).delete()
+
+        assert issue_two.merge(issue_ids=[issue_one.id, stale_issue_id]) is False
+
+        assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
+        assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
+        assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue_two.id).count() == 1
+
     def test_merge_syncs_target_issue_to_clickhouse(self):
         issue_one = self.create_issue(["fingerprint_one"])
         issue_two = self.create_issue(["fingerprint_two"])

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 from posthog.test.base import BaseTest
 from unittest.mock import patch
 
+from django.db import transaction
 from django.db.utils import IntegrityError
 
 from products.error_tracking.backend.models import (
@@ -79,10 +80,36 @@ class TestErrorTracking(BaseTest):
         issue_one = self.create_issue(["fingerprint_one"])
         issue_two = self.create_issue(["fingerprint_two"])
 
-        with patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse:
-            issue_two.merge(issue_ids=[issue_one.id])
+        with (
+            patch("products.error_tracking.backend.models.update_error_tracking_issue_fingerprint_overrides"),
+            patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
+            assert issue_two.merge(issue_ids=[issue_one.id]) is True
 
         sync_issues_to_clickhouse.assert_called_once_with(issue_ids=[issue_two.id], team_id=self.team.id)
+
+    def test_merge_skips_clickhouse_side_effects_after_rollback(self):
+        issue_one = self.create_issue(["fingerprint_one"])
+        issue_two = self.create_issue(["fingerprint_two"])
+
+        with (
+            patch(
+                "products.error_tracking.backend.models.update_error_tracking_issue_fingerprint_overrides"
+            ) as update_overrides,
+            patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse,
+            self.captureOnCommitCallbacks(execute=True) as callbacks,
+            pytest.raises(RuntimeError),
+        ):
+            with transaction.atomic():
+                issue_two.merge(issue_ids=[issue_one.id])
+                raise RuntimeError("roll back merge")
+
+        assert callbacks == []
+        update_overrides.assert_not_called()
+        sync_issues_to_clickhouse.assert_not_called()
+        assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
+        assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
 
     def test_splitting_fingerprints(self):
         issue = self.create_issue(["fingerprint_one", "fingerprint_two", "fingerprint_three"])
@@ -120,7 +147,11 @@ class TestErrorTracking(BaseTest):
     def test_split_syncs_original_and_new_issues_to_clickhouse(self):
         issue = self.create_issue(["fingerprint_one", "fingerprint_two"])
 
-        with patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse:
+        with (
+            patch("products.error_tracking.backend.models.update_error_tracking_issue_fingerprint_overrides"),
+            patch("products.error_tracking.backend.models.sync_issues_to_clickhouse") as sync_issues_to_clickhouse,
+            self.captureOnCommitCallbacks(execute=True),
+        ):
             new_issues = issue.split(fingerprints=[{"fingerprint": "fingerprint_one"}])
 
         sync_issues_to_clickhouse.assert_called_once_with(

--- a/products/error_tracking/backend/test/test_error_tracking.py
+++ b/products/error_tracking/backend/test/test_error_tracking.py
@@ -93,6 +93,26 @@ class TestErrorTracking(ErrorTrackingIssueTestMixin, BaseTest):
         assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
         assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue_two.id).count() == 1
 
+    def test_merge_stale_expected_fingerprint_issue_is_noop(self):
+        issue_one = self.create_issue(["fingerprint_one"])
+        issue_two = self.create_issue(["fingerprint_two"])
+        issue_three = self.create_issue(["fingerprint_three"])
+
+        assert (
+            issue_two.merge(
+                issue_ids=[issue_one.id],
+                expected_fingerprint_issue_ids={
+                    "fingerprint_one": issue_three.id,
+                    "fingerprint_two": issue_two.id,
+                },
+            )
+            is False
+        )
+
+        assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
+        assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
+        assert ErrorTrackingIssueFingerprintV2.objects.filter(issue_id=issue_two.id).count() == 1
+
     def test_merge_syncs_target_issue_to_clickhouse(self):
         issue_one = self.create_issue(["fingerprint_one"])
         issue_two = self.create_issue(["fingerprint_two"])
@@ -276,7 +296,7 @@ class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBa
         finally:
             close_old_connections()
 
-    def test_opposite_concurrent_merges_do_not_deadlock(self):
+    def test_concurrent_overlapping_merges_do_not_deadlock(self):
         source_issue_one = self.create_issue(["source_fingerprint_one"])
         source_issue_two = self.create_issue(["source_fingerprint_two"])
         target_issue_one = self.create_issue(["target_fingerprint_one"])
@@ -307,7 +327,10 @@ class TestErrorTrackingMergeConcurrency(ErrorTrackingIssueTestMixin, NonAtomicBa
         assert not ErrorTrackingIssue.objects.filter(id__in=[source_issue_one.id, source_issue_two.id]).exists()
         assert ErrorTrackingIssue.objects.filter(id__in=[target_issue_one.id, target_issue_two.id]).count() == 2
 
-        source_fingerprints = ErrorTrackingIssueFingerprintV2.objects.filter(
-            fingerprint__in=["source_fingerprint_one", "source_fingerprint_two"]
-        ).values_list("issue_id", flat=True)
-        assert len(set(source_fingerprints)) == 1
+        source_fingerprint_issue_ids = list(
+            ErrorTrackingIssueFingerprintV2.objects.filter(
+                fingerprint__in=["source_fingerprint_one", "source_fingerprint_two"]
+            ).values_list("issue_id", flat=True)
+        )
+        assert len(source_fingerprint_issue_ids) == 2
+        assert len(set(source_fingerprint_issue_ids)) == 1

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -262,6 +262,20 @@ class TestErrorTracking(APIBaseTest):
         assert ErrorTrackingIssueFingerprintV2.objects.filter(fingerprint="fingerprint_two", version=1).exists()
         assert ErrorTrackingIssue.objects.count() == 1
 
+    def test_issue_merge_returns_not_found_when_source_issue_is_stale(self):
+        issue_one = self.create_issue(fingerprints=["fingerprint_one"])
+        issue_two = self.create_issue(fingerprints=["fingerprint_two"])
+        ErrorTrackingIssue.objects.filter(id=issue_two.id).delete()
+
+        response = self.client.post(
+            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_one.id}/merge",
+            data={"ids": [issue_two.id]},
+        )
+
+        assert response.status_code == 404
+        assert ErrorTrackingIssue.objects.filter(id=issue_one.id).exists()
+        assert ErrorTrackingIssueFingerprintV2.objects.get(fingerprint="fingerprint_one").issue_id == issue_one.id
+
     def test_issue_merge_requires_ids(self):
         issue = self.create_issue(fingerprints=["fingerprint_one"])
 

--- a/products/error_tracking/backend/tests/api/test_error_tracking_api.py
+++ b/products/error_tracking/backend/tests/api/test_error_tracking_api.py
@@ -1352,10 +1352,11 @@ class TestIssueStateSync(ClickhouseTestMixin, APIBaseTest):
         issue_one = self._create_issue(fingerprints=["fp_one"])
         issue_two = self._create_issue(fingerprints=["fp_two"])
 
-        self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/issues/{issue_one.id}/merge",
-            data={"ids": [str(issue_two.id)]},
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue_one.id}/merge",
+                data={"ids": [str(issue_two.id)]},
+            )
 
         rows = self._get_issue_state_rows()
         assert len(rows) == 2
@@ -1365,11 +1366,12 @@ class TestIssueStateSync(ClickhouseTestMixin, APIBaseTest):
     def test_split_syncs(self):
         issue = self._create_issue(fingerprints=["fp_keep", "fp_split"])
 
-        response = self.client.post(
-            f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
-            data={"fingerprints": [{"fingerprint": "fp_split", "name": "Split issue"}]},
-            format="json",
-        )
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(
+                f"/api/environments/{self.team.id}/error_tracking/issues/{issue.id}/split",
+                data={"fingerprints": [{"fingerprint": "fp_split", "name": "Split issue"}]},
+                format="json",
+            )
         new_issue_id = response.json()["new_issue_ids"][0]
 
         rows = self._get_issue_state_rows()


### PR DESCRIPTION
## Problem

Concurrent error tracking issue merges can deadlock when overlapping merge chains update fingerprint rows in different orders. The same code path also emitted ClickHouse/Kafka side effects inside the Postgres transaction, so a later rollback could leave downstream issue state ahead of the committed Postgres state.

## Changes

- Lock merge issue rows and source fingerprint rows in deterministic order before moving fingerprints.
- Treat stale concurrent merge state as a no-op instead of continuing with partially outdated source issues.
- Defer fingerprint override and issue-state sync side effects until `transaction.on_commit()` for merges and splits.
- Simplify the auto-merge activity so the model merge path owns locking and re-checking.
- Add regression coverage for rollback behavior so downstream sync is not emitted for an aborted merge.

## How did you test this code?

- `ruff check products/error_tracking/backend/models.py products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py products/error_tracking/backend/test/test_error_tracking.py --fix`
- `ruff format products/error_tracking/backend/models.py products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py products/error_tracking/backend/test/test_error_tracking.py`
- `uv run ty check products/error_tracking/backend/models.py products/error_tracking/backend/temporal/fingerprint_embedding_result/activities.py products/error_tracking/backend/test/test_error_tracking.py`
- `./bin/hogli test products/error_tracking/backend/test/test_error_tracking.py::TestErrorTracking::test_basic_merge products/error_tracking/backend/test/test_error_tracking.py::TestErrorTracking::test_merge_syncs_target_issue_to_clickhouse products/error_tracking/backend/test/test_error_tracking.py::TestErrorTracking::test_merge_skips_clickhouse_side_effects_after_rollback products/error_tracking/backend/test/test_error_tracking.py::TestErrorTracking::test_split_syncs_original_and_new_issues_to_clickhouse` failed during local setup because ClickHouse reset the connection at `clickhouse:9000`.

The added rollback test catches the regression where merge side effects are emitted before the enclosing transaction commits.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This is backend consistency behavior for existing error tracking merge flows.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I used Codex in the PostHog monorepo to investigate the merge deadlock path and apply the fix. Skills invoked: `/error-tracking`, `/writing-tests`, `/query-clickhouse-via-metabase`, and `/pr`.

The main design choice was to keep the existing optimized raw update for fingerprint reassignment, but make the surrounding merge path acquire deterministic locks first and defer external side effects until commit. An ORM-only update was considered, but it made the hot path less efficient.