### PR TITLE
fix(settings): add AI conversation scope to personal API key picker

### DIFF
--- a/frontend/src/lib/scopes.tsx
+++ b/frontend/src/lib/scopes.tsx
@@ -36,6 +36,12 @@ export const API_SCOPES: APIScope[] = [
     // `clickhouse_test_cluster_perf` is omitted — see `INTERNAL_API_SCOPE_OBJECTS` in posthog/scopes.py.
     { key: 'cohort', objectName: 'Cohort', objectPlural: 'cohorts' },
     { key: 'comment', objectName: 'Comment', objectPlural: 'comments' },
+    {
+        key: 'conversation',
+        objectName: 'AI conversation',
+        objectPlural: 'AI conversations',
+        info: 'Programmatic access to the PostHog AI (Max) chat via the conversations API.',
+    },
     { key: 'customer_analytics', objectName: 'Customer analytics', objectPlural: 'customer analytics' },
     { key: 'customer_journey', objectName: 'Customer journey', objectPlural: 'customer journeys' },
     { key: 'dashboard', objectName: 'Dashboard', objectPlural: 'dashboards' },

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -5615,6 +5615,7 @@ export type APIScopeObject =
     | 'clickhouse_test_cluster_perf'
     | 'cohort'
     | 'comment'
+    | 'conversation'
     | 'customer_analytics'
     | 'customer_journey'
     | 'customer_profile_config'


### PR DESCRIPTION
## Problem

The personal API key scope picker (Settings → Personal API keys) doesn't list the `conversation` scope, so there's no way to create a key scoped to the PostHog AI (Max) conversations API through the UI. Users have to grant an all-access `*` key or PATCH the scopes array via the API, which defeats the least-privilege guidance in our own docs.

The root cause is frontend/backend drift. The backend defines `conversation` in `posthog/scopes.py` (not internal, not OAuth-hidden), enforces it on the conversations viewset (`ee/api/conversation.py`, `scope_object = "conversation"`), documents it (`conversation:read` at [/docs/api/conversations](https://posthog.com/docs/api/conversations)), and accepts it on personal API keys. But the frontend keeps a hand-maintained scope list that never got the entry. There's even a `WARNING: keep in sync with the frontend!` comment in `scopes.py` pointing at the two files this PR touches, and nothing enforces it, so it drifted.

The conversations viewset already supports personal API key auth (it inherits the PAK-supporting default and sets `scope_object`), so this UI addition is the last piece needed to make that flow self-serve.

## Changes

- Add `conversation` to the `APIScopeObject` union in `frontend/src/types.ts`.
- Add an "AI conversation" row to `API_SCOPES` in `frontend/src/lib/scopes.tsx`, with an info note pointing at the PostHog AI (Max) conversations API.

Labeled "AI conversation" rather than the raw `conversation` key, following the file's existing product-facing naming (e.g. `llm_analytics` renders as "AI observability"). The support-inbox scope renders separately as "Ticket", so there's no in-picker name collision. The read-only and MCP-server presets derive from `API_SCOPES`, so they pick up `conversation:read` / `conversation:write` automatically.

This PR only adds `conversation` (the scope with a live user need). The broader drift in #57977 (several other backend scopes still missing from the picker, plus the suggestion to codegen the list or add a CI parity check) is left for a dedicated follow-up.

## How did you test this code?

I (the agent) did not run the app or manually exercise the UI. This was a shallow clone with no `node_modules`, so I couldn't run the JS toolchain or start the frontend locally. CI will run lint, typecheck, and jest on the PR.

What I verified by inspection:

- The change is type-safe: `'conversation'` is added to the `APIScopeObject` union before it's used as an `API_SCOPES` key.
- `frontend/src/lib/scopes.test.ts` derives everything from `API_SCOPES` at runtime (no snapshots or hardcoded counts), so it keeps passing; the `read_only_access` preset test now includes `conversation:read`.
- The backend already supports the end-to-end flow: `ee/api/conversation.py` uses `TeamAndOrgViewSetMixin` with `scope_object = "conversation"`, defines `create` / `append_message` / `open` / `cancel`, and doesn't override `authentication_classes`; `posthog/api/personal_api_key.py` validates `conversation:read` / `conversation:write` with no feature-flag gate.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Yes, it seems the conversations API docs can only be accessed directly currently; they're not in the sidebar.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Written by Claude (Opus 4.8) via PostHog Code, directed by me while working a support ticket where a user couldn't find the `conversation` scope in the key picker.

- Traced the root cause across the backend scope definitions (`posthog/scopes.py`, `personal_api_key.py`, `ee/api/conversation.py`) and the frontend picker files, confirming the scope is real and PAK-grantable but simply absent from the UI list.
- Considered and rejected two alternatives: renaming the scope to plural (would break every other singular scope and existing keys) and a full drift fix for all missing scopes (bigger, needs a parity-check or codegen decision, tracked in #57977). Chose the focused addition.
- Label wording: picked "AI conversation" over the raw key to match the file's product-facing convention and disambiguate from support tickets.
- No repo mandatory skills applied: `APIScopeObject` in `types.ts` is a hand-maintained sync target (not generated API types), and no DRF, serializer, migration, or test files changed.
