### PR TITLE
chore(messaging): add mint-time metric for email tracking codes

### DIFF
--- a/nodejs/src/cdp/services/messaging/helpers/tracking-code.test.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/tracking-code.test.ts
@@ -1,6 +1,6 @@
 import { defaultConfig } from '~/common/config/config'
 
-import { EmailTrackingCodeSigner } from './tracking-code'
+import { EmailTrackingCodeSigner, trackingCodeMintCounter } from './tracking-code'
 
 const TRACKING_URL = 'http://localhost:8010'
 
@@ -280,6 +280,24 @@ describe('email tracking code', () => {
             const code = unsignedSigner.generate({ functionId: 'fn', id: 'inv', teamId: 1 })
             expect(code).not.toContain('.')
             expect(unsignedSigner.parse(code)?.format).toBe('unsigned')
+        })
+    })
+
+    describe('mint metric', () => {
+        const mintCount = async (format: string): Promise<number> => {
+            const metric = await trackingCodeMintCounter.get()
+            return metric.values.find((v) => v.labels.format === format)?.value ?? 0
+        }
+
+        // The keyless branch is silent without this counter; it is the proof that fail-closed (#62624)
+        // is safe to enable, so guard that generate() labels each minted code correctly.
+        it.each([
+            { name: 'signed when a key is configured', keys: defaultConfig.ENCRYPTION_SALT_KEYS, format: 'signed' },
+            { name: 'unsigned when no key is configured', keys: '', format: 'unsigned' },
+        ])('counts a mint as $name', async ({ keys, format }) => {
+            const before = await mintCount(format)
+            new EmailTrackingCodeSigner(keys, TRACKING_URL).generate({ functionId: 'fn', id: 'inv', teamId: 1 })
+            expect(await mintCount(format)).toBe(before + 1)
         })
     })
 })

--- a/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
+++ b/nodejs/src/cdp/services/messaging/helpers/tracking-code.ts
@@ -18,6 +18,18 @@ export const trackingCodeFormatCounter = new Counter({
     labelNames: ['format', 'source'],
 })
 
+// Mint-time signal: counts every code generate() produces, labelled by whether a signing key was
+// available. Unlike the parse-time counter above (which only sees codes that come back via the SES
+// webhook or click endpoints), this fires on the send path itself, so a sustained `unsigned` rate
+// pinpoints an email-sending deployment running without ENCRYPTION_SALT_KEYS. Watching this reach
+// zero is the prerequisite for making generate() fail closed (#62624). Note it counts per generate()
+// call (header + pixel + each redirect link), not per email, so it is a rate signal, not an email count.
+export const trackingCodeMintCounter = new Counter({
+    name: 'email_tracking_code_mint_total',
+    help: 'Count of email tracking codes minted by signature format (signed when a key is configured)',
+    labelNames: ['format'],
+})
+
 function toBase64UrlSafe(input: string | Buffer): string {
     const b64 = Buffer.isBuffer(input) ? input.toString('base64') : Buffer.from(input, 'utf8').toString('base64')
     return b64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
@@ -155,8 +167,12 @@ export class EmailTrackingCodeSigner {
         )
         if (this.signingKeys.length === 0) {
             // Fail open while signing rolls out so sends never break; tighten to throw once enforced (#62624).
+            // The mint counter makes this branch observable so we can confirm it is never hit in prod
+            // before flipping to fail-closed.
+            trackingCodeMintCounter.inc({ format: 'unsigned' })
             return payload
         }
+        trackingCodeMintCounter.inc({ format: 'signed' })
         return `${payload}.${this.signPayload(payload, this.signingKeys[0])}`
     }
 


### PR DESCRIPTION
## Problem

The email tracking code signing system has a fail-open path that returns unsigned codes when no encryption key is configured. To safely transition to fail-closed behavior (issue #62624), we need observability into whether this unsigned path is actually being hit in production.

## Changes

Added a new Prometheus counter `email_tracking_code_mint_total` that tracks every code generated by `EmailTrackingCodeSigner.generate()`, labeled by format (`signed` or `unsigned`). This provides a send-path signal that complements the existing parse-time counter, which only observes codes that return via webhooks or click endpoints.

The metric fires at code generation time (header, pixel, and each redirect link), making it a rate signal rather than an email count. A sustained `unsigned` rate in production would pinpoint deployments running without `ENCRYPTION_SALT_KEYS` configured.

## How did you test this code?

Added unit tests that verify the counter increments correctly for both signed and unsigned code generation paths. Tests confirm the metric is labeled appropriately based on key configuration.

https://claude.ai/code/session_01BqKKmiCNjd54XLub1oWq99