### PR TITLE
feat(messaging): support per-link click-tracking opt-out in emails

### DIFF
--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -113,6 +113,12 @@ describe('EmailTrackingService', () => {
             expect(out).not.toContain('target=')
         })
 
+        it('still wraps the link when the opt-out marker is on a child, not the anchor tag', () => {
+            const html = '<body><a href="https://example.com"><span data-ph-no-track>x</span></a></body>'
+            const out = addTrackingToEmail(html, invocation, signer)
+            expect(out).toContain('target=')
+        })
+
         const invocationWithDistinctId = {
             functionId: 'fn-1',
             id: 'inv-1',

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.test.ts
@@ -104,6 +104,15 @@ describe('EmailTrackingService', () => {
             expect(out).not.toContain('target=')
         })
 
+        it.each([
+            ['clicktracking="off"', '<body><a href="https://example.com" clicktracking="off">x</a></body>'],
+            ['data-ph-no-track', '<body><a href="https://example.com" data-ph-no-track>x</a></body>'],
+        ])('leaves the href untouched when the anchor opts out via %s', (_name, html) => {
+            const out = addTrackingToEmail(html, invocation, signer)
+            expect(out).toContain('href="https://example.com"')
+            expect(out).not.toContain('target=')
+        })
+
         const invocationWithDistinctId = {
             functionId: 'fn-1',
             id: 'inv-1',

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -116,7 +116,10 @@ export const addTrackingToEmail = (
         // Per-link opt-out. Leaves the href on its own domain so mobile universal links /
         // app deeplinks resolve - routing through our cross-domain redirect breaks them.
         // `clicktracking="off"` is the ESP de-facto standard; `data-ph-no-track` is our name.
-        if (LINK_TRACKING_OPT_OUT_REGEX.test(m)) {
+        // Match only the opening <a> tag so a marker in the link's inner HTML (a child
+        // element's attribute or literal link text) can't silently disable tracking.
+        const openingTag = m.match(/^<a\b[^>]*>/i)?.[0] ?? ''
+        if (LINK_TRACKING_OPT_OUT_REGEX.test(openingTag)) {
             return m
         }
         const tracked = signer.redirectUrl(trackingInvocation, href, isTest)

--- a/nodejs/src/cdp/services/messaging/email-tracking.service.ts
+++ b/nodejs/src/cdp/services/messaging/email-tracking.service.ts
@@ -22,6 +22,9 @@ export const PIXEL_GIF = Buffer.from('R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAA
 const LINK_REGEX =
     /<a\b[^>]*\bhref\s*=\s*(?:"(?!javascript:)([^"]*)"|'(?!javascript:)([^']*)'|(?!javascript:)([^'">\s]+))[^>]*>([\s\S]*?)<\/a>/gi
 
+// Anchors carrying either opt-out marker are left unwrapped (no click-tracking redirect).
+const LINK_TRACKING_OPT_OUT_REGEX = /\bclicktracking\s*=\s*["']?off["']?|\bdata-ph-no-track\b/i
+
 const trackingEventsCounter = new Counter({
     name: 'email_tracking_events_total',
     help: 'Total number of email tracking events received',
@@ -108,6 +111,12 @@ export const addTrackingToEmail = (
         // LINK_REGEX skips literal `javascript:` hrefs, but an attacker could entity-encode
         // the scheme (e.g. `java&#x73;cript:`) to slip past it; re-check after decoding.
         if (/^\s*javascript:/i.test(href)) {
+            return m
+        }
+        // Per-link opt-out. Leaves the href on its own domain so mobile universal links /
+        // app deeplinks resolve - routing through our cross-domain redirect breaks them.
+        // `clicktracking="off"` is the ESP de-facto standard; `data-ph-no-track` is our name.
+        if (LINK_TRACKING_OPT_OUT_REGEX.test(m)) {
             return m
         }
         const tracked = signer.redirectUrl(trackingInvocation, href, isTest)

--- a/products/workflows/skills/designing-email-templates/SKILL.md
+++ b/products/workflows/skills/designing-email-templates/SKILL.md
@@ -31,6 +31,16 @@ Marketing emails must include an unsubscribe link — render it with the built-i
 
 (`{{ unsubscribe_url_one_click }}` is also available for one-click list-unsubscribe flows.)
 
+## Click tracking and opt-out
+
+Every link is automatically rewritten through a click-tracking redirect. This breaks mobile universal links / app deeplinks, which only resolve when the href stays on their own domain. To keep a link untracked, mark its anchor (use an `html` block) with `clicktracking="off"` or `data-ph-no-track`:
+
+```html
+<a href="https://app.example.com/deeplink" data-ph-no-track>Open in app</a>
+```
+
+The marker must be on the `<a>` tag itself, not a child element. Opted-out links get no click metrics.
+
 ## Creating a template
 
 Call `workflows-create-email-template` with:


### PR DESCRIPTION
## Problem

A [support request](https://posthoghelp.zendesk.com/agent/tickets/61291) reported that a personalised deeplink CTA in a workflow email fails on mobile when placed inside a button or anchor, while the exact same URL works as plain auto-linked text and works everywhere on desktop.

The cause is our click tracking. Every `<a href>` in a workflow email is rewritten to a redirect on `webhooks.us.posthog.com/public/m/redirect?...&target=...`. That cross-domain 302 breaks mobile deeplinks: iOS Universal Links and Android App Links only fire when the tapped href already sits on the app's associated domain, so routing through our redirect strips the association and the link dies on mobile. As plain text the mail client auto-links the raw URL, which keeps the href on the destination's own domain, so it resolves fine - which is exactly why the "ugly" plain-text workaround was the only thing that worked.

There was no way to opt a link out. `clicktracking="off"` (which the reporter tried) was ignored, and no per-link, per-button, or per-email toggle existed.

## Changes

Adds a per-link opt-out honoured in the single choke point, `addTrackingToEmail`. An anchor carrying either marker keeps its original href and is not wrapped:

- `clicktracking="off"` - the ESP de-facto standard (SendGrid/Mailchimp lineage), and the exact attribute the reporter already tried.
- `data-ph-no-track` - our own name, matching the `data-ph-*` house convention.

Both email send paths (SES and local maildev) route through `addTrackingToEmail`, so both get the behaviour from one guard. The existing rewriter already preserves all non-href anchor attributes, so the opt-out markers survive to where they're read.

The link loses click tracking when opted out - that's the point for deeplinks that must reach the destination untouched.

Also updates the `designing-email-templates` agent skill to document the opt-out.

## Docs update

User-facing docs for this land in a companion PR: [PostHog/posthog.com#18076](https://github.com/PostHog/posthog.com/pull/18076) (adds a "Link click tracking" section to the workflows email templates doc).

## How did you test this code?

Added 2 parameterised cases to `addTrackingToEmail` in `email-tracking.service.test.ts`, one per opt-out spelling, asserting the href is left intact and no `target=` redirect is emitted. This guards the regression where the opt-out is removed or broken and a marked link gets re-wrapped. The full `addTrackingToEmail` suite passes. eslint clean.

I (Claude) did not do manual mobile-client testing. The universal-link-through-302 root cause is established behaviour of iOS/Android link handling, not something reproduced here.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Harley directed this from the support request. I traced the flow (link rewrite in `addTrackingToEmail` -> `redirectUrl` -> `handleEmailTrackingRedirect`), identified the cross-domain 302 as the mobile-deeplink breaker and the missing opt-out as the gap, then implemented the guard.

Decisions: honour both `clicktracking="off"` and `data-ph-no-track` rather than picking one - same one-regex cost, and the ESP-standard spelling means the reporter's existing attempt just works with zero new docs. Placed the check in `addTrackingToEmail` (the shared choke point) so both send paths are covered by a single guard rather than patching callers. Considered a whole-email or account-level toggle; rejected as heavier than needed for the per-link deeplink use case.

Skill invoked: `/writing-tests` (gated the two new test cases).

Tools: Claude Code (Opus 4.8).

