### PR TITLE
fix(engineering_analytics): bypass egress proxy for OTLP log emit

### DIFF
--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -22,6 +22,7 @@ from opentelemetry.sdk._logs.export import BatchLogRecordProcessor, LogExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.trace import TraceFlags
 
+from posthog.security.outbound_proxy import internal_requests_session
 from products.engineering_analytics.backend.logic.job_logs.constants import CI_LOGS_SERVICE_NAME as _SERVICE_NAME
 from products.engineering_analytics.backend.logic.job_logs.thinning import ThinnedLine
 
@@ -79,7 +80,15 @@ class JobLogsEmitter:
     ) -> None:
         self._provider = LoggerProvider(resource=Resource.create({"service.name": _SERVICE_NAME}))
         if exporter is None and endpoint and token:
-            exporter = OTLPLogExporter(endpoint=endpoint, headers={"authorization": f"Bearer {token}"})
+            # capture-logs is in-cluster (a private ClusterIP). The worker's HTTP_PROXY/HTTPS_PROXY
+            # point at the Smokescreen egress proxy, which denies private-range hosts (407) — so the
+            # OTLP POST must bypass it. internal_requests_session sets trust_env=False; without it
+            # every batch export silently 407s and nothing lands in Logs.
+            exporter = OTLPLogExporter(
+                endpoint=endpoint,
+                headers={"authorization": f"Bearer {token}"},
+                session=internal_requests_session(),
+            )
         self._enabled = exporter is not None
         if exporter is not None:
             self._provider.add_log_record_processor(BatchLogRecordProcessor(exporter))

--- a/products/engineering_analytics/backend/logic/job_logs/emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/emitter.py
@@ -23,6 +23,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.trace import TraceFlags
 
 from posthog.security.outbound_proxy import internal_requests_session
+
 from products.engineering_analytics.backend.logic.job_logs.constants import CI_LOGS_SERVICE_NAME as _SERVICE_NAME
 from products.engineering_analytics.backend.logic.job_logs.thinning import ThinnedLine
 

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+
 from unittest.mock import patch
 
 from opentelemetry.exporter.otlp.proto.common._internal._log_encoder import encode_logs

--- a/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
+++ b/products/engineering_analytics/backend/logic/job_logs/test/test_job_logs_emitter.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from unittest.mock import patch
 
 from opentelemetry.exporter.otlp.proto.common._internal._log_encoder import encode_logs
 from opentelemetry.sdk._logs.export import InMemoryLogExporter
@@ -129,6 +130,19 @@ def test_noop_when_unconfigured():
     # With no exporter, endpoint, or token, the emitter must be a safe no-op (return 0, no crash)
     # so the worker is harmless until the Logs lane is wired in.
     assert JobLogsEmitter().emit_log_archive(_lines("2026-06-25T09:14:02.000000Z x"), attributes=_ATTRS) == 0
+
+
+def test_production_exporter_bypasses_egress_proxy():
+    # The endpoint+token path builds the real OTLP exporter, and its requests.Session must have
+    # trust_env=False: capture-logs is an in-cluster private ClusterIP, and the worker's
+    # HTTP_PROXY/HTTPS_PROXY Smokescreen egress proxy denies private-range hosts (407) — so a
+    # proxy-routed export silently drops every batch. No other test hits this branch (they all inject
+    # an in-memory exporter), which is exactly how the 407 shipped unnoticed.
+    otlp = "products.engineering_analytics.backend.logic.job_logs.emitter.OTLPLogExporter"
+    with patch(otlp) as mock_otlp:
+        with JobLogsEmitter(endpoint="http://capture-logs.posthog.svc.cluster.local:4318/i/v1/logs", token="phc_x"):
+            pass
+    assert mock_otlp.call_args.kwargs["session"].trust_env is False
 
 
 def test_noop_when_token_missing():


### PR DESCRIPTION
## Problem

CI failure logs from the engineering_analytics job-logs worker weren't landing in the Logs product, even though the worker logged `github_job_log_emitted` cleanly. Root cause: the OTLP exporter used a default `requests.Session` that honors `HTTP_PROXY`/`HTTPS_PROXY`, so the export to the in-cluster `capture-logs` service routed through the Smokescreen egress proxy — which denies private-range destinations and returned 407 ("Deny: Private Range") on every batch.

Because emit is fire-and-forget on the batch processor's background thread, the 407 only surfaced on worker stderr, never at the call site or in the consumer-side metrics (the batches never reached capture). That's why it looked like a Logs-pipeline problem when it was pure egress.

## Changes

Pass `internal_requests_session()` (`trust_env=False`) to the `OTLPLogExporter` so the in-cluster POST skips the proxy. This is the sanctioned "opt the specific code path out" pattern for reaching internal services (see charts `docs/claude/egress-proxy.md`) — not a `NO_PROXY` carveout — and mirrors the ClickHouse schema-dump hook's `curl --noproxy`. No NetworkPolicy is involved: this worker renders no egress policy, so once the proxy is bypassed the direct connection is allowed.

## How did you test this code?

Agent-authored. Ran the emitter unit tests (`hogli test .../test_job_logs_emitter.py`) and `tach check` — both green. Added one regression test asserting the endpoint+token path builds an exporter whose session has `trust_env=False`; that construction branch had zero coverage (every other test injects an in-memory exporter), which is exactly how the 407 shipped unnoticed. Not manually deployed — will confirm records land in Logs for the DevEx team once this reaches prod-us.

## Agent context

**Autonomy:** Human-driven (agent-assisted)

Diagnosed with Claude Code from a report of zero records in Logs despite a live emitter. Found the 407 in prod-us Loki (`temporal-worker-general-purpose` stderr), then cross-checked the `charts` repo to confirm the block is the Smokescreen egress proxy, not a k8s NetworkPolicy — this worker sets no `networkPolicy` and the chart default renders no egress policy. The fix matches the charts-blessed code-path opt-out and an existing prod precedent (the CH schema-dump `curl --noproxy` for a private-range host).

Invoked the `/writing-tests` skill before adding the regression test.
