### PR TITLE
fix(elasticsearch): raise a clear error on non-JSON index responses

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
@@ -74,7 +74,15 @@ def list_indices(host: str, auth: ElasticsearchAuth) -> list[str]:
         timeout=REQUEST_TIMEOUT_SECONDS,
     )
     response.raise_for_status()
-    body = response.json()
+    try:
+        body = response.json()
+    except requests.exceptions.JSONDecodeError:
+        # A 2xx body that isn't JSON usually means the URL points at something other than
+        # the Elasticsearch HTTP API (e.g. a browser/Kibana URL or a reverse proxy).
+        raise ValueError(
+            "Elasticsearch returned a non-JSON response. Check that the cluster URL points "
+            "at the Elasticsearch HTTP API, not a browser or Kibana URL."
+        ) from None
     indices = [row.get("index", "") for row in body if isinstance(row, dict)]
     return sorted(index for index in indices if index and not index.startswith("."))
 

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/elasticsearch.py
@@ -17,6 +17,10 @@ SCROLL_KEEPALIVE = "5m"
 REQUEST_TIMEOUT_SECONDS = 120
 MAX_RETRY_ATTEMPTS = 5
 
+# Stable prefix for the non-JSON response error. Shared so source.py can match it in
+# get_non_retryable_errors without the two strings silently drifting apart.
+NON_JSON_RESPONSE_ERROR = "Elasticsearch returned a non-JSON response"
+
 
 class ElasticsearchRetryableError(Exception):
     pass
@@ -80,7 +84,7 @@ def list_indices(host: str, auth: ElasticsearchAuth) -> list[str]:
         # A 2xx body that isn't JSON usually means the URL points at something other than
         # the Elasticsearch HTTP API (e.g. a browser/Kibana URL or a reverse proxy).
         raise ValueError(
-            "Elasticsearch returned a non-JSON response. Check that the cluster URL points "
+            f"{NON_JSON_RESPONSE_ERROR}. Check that the cluster URL points "
             "at the Elasticsearch HTTP API, not a browser or Kibana URL."
         ) from None
     indices = [row.get("index", "") for row in body if isinstance(row, dict)]

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/source.py
@@ -47,6 +47,7 @@ class ElasticsearchSource(SimpleSource[ElasticsearchSourceConfig], ValidateDatab
             "401 Client Error: Unauthorized for url": "Elasticsearch authentication failed. Please check your credentials.",
             "403 Client Error: Forbidden for url": "Elasticsearch denied access. Please check that your credentials can read this index.",
             "404 Client Error: Not Found for url": "Elasticsearch index not found. It may have been deleted or renamed.",
+            "Elasticsearch returned a non-JSON response": "Elasticsearch returned an unexpected response. Check that the cluster URL points at the Elasticsearch HTTP API, not a browser or Kibana URL.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/source.py
@@ -20,6 +20,7 @@ from products.warehouse_sources.backend.temporal.data_imports.sources.common.mix
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.registry import SourceRegistry
 from products.warehouse_sources.backend.temporal.data_imports.sources.common.schema import SourceSchema
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticsearch.elasticsearch import (
+    NON_JSON_RESPONSE_ERROR,
     ElasticsearchAuth,
     elasticsearch_source,
     hostname_of,
@@ -47,7 +48,7 @@ class ElasticsearchSource(SimpleSource[ElasticsearchSourceConfig], ValidateDatab
             "401 Client Error: Unauthorized for url": "Elasticsearch authentication failed. Please check your credentials.",
             "403 Client Error: Forbidden for url": "Elasticsearch denied access. Please check that your credentials can read this index.",
             "404 Client Error: Not Found for url": "Elasticsearch index not found. It may have been deleted or renamed.",
-            "Elasticsearch returned a non-JSON response": "Elasticsearch returned an unexpected response. Check that the cluster URL points at the Elasticsearch HTTP API, not a browser or Kibana URL.",
+            NON_JSON_RESPONSE_ERROR: "Elasticsearch returned an unexpected response. Check that the cluster URL points at the Elasticsearch HTTP API, not a browser or Kibana URL.",
         }
 
     @property

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
@@ -1,7 +1,8 @@
 from typing import Any
-from unittest import mock
 
 import pytest
+from unittest import mock
+
 import requests
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticsearch.elasticsearch import (

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import pytest
+import requests
 from unittest import mock
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticsearch.elasticsearch import (
@@ -107,6 +108,16 @@ class TestListIndices:
         )
 
         assert list_indices("https://es.example.com", ElasticsearchAuth(api_key="k")) == ["accounts", "orders"]
+
+    @mock.patch(f"{_MODULE}.make_tracked_session")
+    def test_non_json_response_raises_clear_error(self, mock_session):
+        mock_session.return_value.headers = {}
+        response = _response(None)
+        response.json.side_effect = requests.exceptions.JSONDecodeError("Expecting value", "<html>", 0)
+        mock_session.return_value.get.return_value = response
+
+        with pytest.raises(ValueError, match="non-JSON response"):
+            list_indices("https://es.example.com", ElasticsearchAuth(api_key="k"))
 
 
 class TestGetRows:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch.py
@@ -1,8 +1,8 @@
 from typing import Any
+from unittest import mock
 
 import pytest
 import requests
-from unittest import mock
 
 from products.warehouse_sources.backend.temporal.data_imports.sources.elasticsearch.elasticsearch import (
     PAGE_SIZE,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch_source.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/elasticsearch/tests/test_elasticsearch_source.py
@@ -82,6 +82,7 @@ class TestElasticsearchSource:
             "401 Client Error: Unauthorized for url: https://es.example.com:9243/orders/_search",
             "403 Client Error: Forbidden for url: https://es.example.com:9243/_cat/indices",
             "404 Client Error: Not Found for url: https://es.example.com:9243/gone/_search",
+            "ValueError: Elasticsearch returned a non-JSON response. Check that the cluster URL points at the Elasticsearch HTTP API, not a browser or Kibana URL.",
         ],
     )
     def test_non_retryable_errors_match_auth_failures(self, observed_error):


### PR DESCRIPTION
> Claude-written:

## Problem

Error tracking surfaced a `JSONDecodeError: Expecting value: line 1 column 1 (char 0)` originating in the Elasticsearch import source ([issue](https://us.posthog.com/project/2/error_tracking/019f1d03-61b1-7dc0-b84e-6a5db26815d8)).

The stack runs `database_schema` view → `get_schemas` → `list_indices` → `response.json()`. The response captured on the event was HTTP 200 with `content-type: text/html`: the configured cluster URL pointed at a web UI rather than the Elasticsearch HTTP API, so the server returned an HTML page. `list_indices` called `response.json()` on it unconditionally and blew up.

Two problems fell out of that:

- The user saw a cryptic `Expecting value: line 1 column 1 (char 0)` instead of a hint about what was actually wrong.
- The schema-fetch classifier treats an unrecognized exception as a bug, so every misconfigured setup attempt got captured to error tracking as noise.

This is our code being fragile, not an Elasticsearch outage. Retrying a wrong URL never helps.

## Changes

- `list_indices` now catches `requests.exceptions.JSONDecodeError` and raises an actionable `ValueError` explaining the cluster URL should point at the Elasticsearch HTTP API, not a browser or Kibana URL.
- Registered that stable message in `ElasticsearchSource.get_non_retryable_errors`, so `_classify_refresh_schemas_error` treats the misconfiguration as an expected user error (shown to the user, not captured as a bug) and the pipeline treats it as non-retryable.

Scoped strictly to this failure. I deliberately did not strip the path from the host in `normalize_host`, since path-prefixed Elasticsearch deployments behind reverse proxies are legitimate. The non-JSON guard is the robust catch-all regardless of what the user pastes.

## How did you test this code?

Added two regression tests. This environment had no Python runtime with deps, so I could not execute the suite locally (only `py_compile` syntax-checks passed); CI will run them.

- `test_elasticsearch.py::TestListIndices::test_non_json_response_raises_clear_error` — a 200 whose `.json()` raises `JSONDecodeError` now surfaces a `ValueError` mentioning a non-JSON response. No existing test exercised a non-JSON body; this locks in the clear error against a regression that removes the guard.
- `test_elasticsearch_source.py::test_non_retryable_errors_match_auth_failures` — added a parameterized case asserting the new message is recognized as non-retryable, guarding against the classification entry being dropped (which would re-capture the misconfiguration as a bug).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error-tracking webhook by Claude Code. Skills invoked: `/writing-tests` before adding the regression tests. I confirmed the issue via the PostHog error-tracking MCP tools (`query-error-tracking-issue`, `query-error-tracking-issue-events`), read the stack end to end, and traced it into `list_indices`.

Decision: fixable bug rather than a pure `NonRetryableErrors` addition. The root cause is our unconditional `.json()` on a 2xx body. I fixed the fragility and, because the schema-fetch classifier reuses `get_non_retryable_errors`, also registered the new stable message so the misconfiguration stops being captured as a bug. Rejected stripping the host path in `normalize_host` as too risky for path-prefixed clusters.
