### PR TITLE
chore(data-warehouse): verify saved-query views are discoverable via information_schema

### DIFF
--- a/posthog/hogql/database/schema/test/test_information_schema.py
+++ b/posthog/hogql/database/schema/test/test_information_schema.py
@@ -307,6 +307,21 @@ class TestInformationSchema(ClickhouseTestMixin, APIBaseTest):
             columns={column: {"hogql": "StringDatabaseField", "clickhouse": "Nullable(String)", "schema_valid": True}},
         )
 
+    def _create_saved_query_view(
+        self, name: str = "revenue_view", *, table: DataWarehouseTable | None = None, is_materialized: bool = False
+    ) -> DataWarehouseSavedQuery:
+        return DataWarehouseSavedQuery.objects.create(
+            team=self.team,
+            name=name,
+            query={"query": "SELECT order_id, amount FROM events"},
+            columns={
+                "order_id": {"hogql": "StringDatabaseField", "clickhouse": "String", "schema_valid": True},
+                "amount": {"hogql": "IntegerDatabaseField", "clickhouse": "Int64", "schema_valid": True},
+            },
+            table=table,
+            is_materialized=is_materialized,
+        )
+
     def test_warehouse_tables_appear_with_row_count(self):
         self._create_warehouse_table()
         response = execute_hogql_query(
@@ -400,6 +415,52 @@ class TestInformationSchema(ClickhouseTestMixin, APIBaseTest):
         assert by_column["id"] == [0.25, "ch_001", "ch_999"]
         # Profiled stats absent for this column → all NULL.
         assert by_column["amount"] == [None, None, None]
+
+    def test_saved_query_view_appears_in_tables(self):
+        # A saved-query view must surface in the catalog as a discoverable table so PostHog AI can find
+        # it. Regression guard for the whole semantic-layer effort: if views stop being enumerated (or are
+        # misclassified as posthog/data_warehouse), descriptions wired onto them later never reach the AI.
+        self._create_saved_query_view(name="revenue_view")
+        response = execute_hogql_query(
+            "SELECT table_type, table_schema FROM system.information_schema.tables WHERE table_name = 'revenue_view'",
+            team=self.team,
+        )
+        results = response.results or []
+        assert len(results) == 1
+        assert results[0][0] == "view"
+        assert results[0][1] == "views"
+
+    def test_saved_query_view_columns_appear_with_types(self):
+        # The view's columns (built from the model's `columns` JSONField via `hogql_definition`) must be
+        # enumerated with their HogQL types — that's the surface a later phase attaches column descriptions
+        # to. Guards both the field enumeration and the JSONField→HogQL type mapping for views.
+        self._create_saved_query_view(name="revenue_view")
+        response = execute_hogql_query(
+            """
+            SELECT column_name, data_type FROM system.information_schema.columns
+            WHERE table_name = 'revenue_view'
+            """,
+            team=self.team,
+        )
+        columns = {row[0]: row[1] for row in response.results or []}
+        assert columns["order_id"] == "String"
+        assert columns["amount"] == "Integer"
+
+    def test_materialized_saved_query_view_reports_backing_table_row_count(self):
+        # A materialized view stays classified as a view but carries the row count of its backing table.
+        # Exercises the `table_type == "view"` branch of row-count resolution end-to-end (the unit test on
+        # `_warehouse_metadata` stops at the metadata dict; this proves it reaches the catalog row).
+        backing = self._create_warehouse_table(name="revenue_view_backing")
+        self._create_saved_query_view(name="revenue_view_materialized", table=backing, is_materialized=True)
+        response = execute_hogql_query(
+            "SELECT table_type, row_count FROM system.information_schema.tables "
+            "WHERE table_name = 'revenue_view_materialized'",
+            team=self.team,
+        )
+        results = response.results or []
+        assert len(results) == 1
+        assert results[0][0] == "view"
+        assert results[0][1] == 42
 
     def test_ordinal_positions_are_unique_within_a_table(self):
         # `events` exposes nested virtual-table columns (e.g. `group_0.*`); their ordinals must


### PR DESCRIPTION
## Problem

We're building a lightweight semantic layer for the data-modelling product: attach descriptions (and later semantic types) to SQL views so PostHog AI generates more accurate NL to HogQL. That work ships in phases, and every phase assumes one thing already works: saved-query views and their columns are discoverable by PostHog AI through the `system.information_schema` path. Until now that was only verified by hand. Phase 1.0 turns that manual check into an automated safety net so a regression is caught by CI, not by degraded AI answers.

## Changes

Adds three tests (and a small `_create_saved_query_view` helper) to the existing `TestInformationSchema` class in `posthog/hogql/database/schema/test/test_information_schema.py`. No production code changes.

- A saved-query view surfaces in `system.information_schema.tables` as `table_type = "view"`, `table_schema = "views"`.
- Its columns surface in `system.information_schema.columns` with correct HogQL types (built from the model's `columns` JSONField via `hogql_definition`).
- A materialized view stays classified as a view and reports its backing table's `row_count` end to end through the catalog.

## How did you test this code?

Automated only. I (Claude) ran `hogli test posthog/hogql/database/schema/test/test_information_schema.py`: 40 passed (37 pre-existing plus 3 new), no fixture breakage. `ruff check` and `ruff format --check` are clean, and lint-staged (ruff plus type check) passed on commit. I did not do manual UI testing since this is a backend test-only change.

Each test guards a distinct path no existing test covered: view enumeration and classification in the catalog, view column enumeration plus JSONField to HogQL type mapping, and the `table_type == "view"` branch of row-count resolution (the existing `_warehouse_metadata` unit test stops at the metadata dict and never reaches the catalog row). I deliberately did not assert that view descriptions are currently null, since a later phase will populate them and that assertion would be a self-inflicted breakage.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

I directed Claude Code to implement the Phase 1.0 verification tests from the semantic-layer spec. Claude explored the two discovery surfaces (the queryable `system.information_schema` virtual tables and the `read_data_warehouse_schema` AI tool), then scoped the tests to the `information_schema` path since that is where the spec says descriptions ultimately flow and where coverage was missing.

Skills invoked: `/writing-tests` (the value gate). Decisions: kept the tests at the cheapest level that catches the regression (ClickHouse-backed `TestCase`, no browser); did not duplicate the AI-tool listing path, already covered by `test_returns_view_names`; did not re-prove the `FieldOrTable.description` carrier, already covered by `test_columns_surface_seeded_descriptions`.
