### PR TITLE
perf(dashboards): lazy-load widget UI out of the eager shell bundle

### DIFF
--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
@@ -1,6 +1,6 @@
 import clsx from 'clsx'
 import { useValues } from 'kea'
-import React, { useState } from 'react'
+import React, { Suspense, useState } from 'react'
 import { createPortal } from 'react-dom'
 
 import { CardMetaRefreshButton } from 'lib/components/Cards/CardMetaRefreshButton'
@@ -121,7 +121,9 @@ function DashboardWidgetItemBody({
             widgetId={widget.id}
             dashboardId={dashboardId}
         >
-            <WidgetComponent {...componentProps} />
+            <Suspense fallback={null}>
+                <WidgetComponent {...componentProps} />
+            </Suspense>
         </WidgetRuntimeAvailabilityGuard>
     )
 }
@@ -297,15 +299,17 @@ function DashboardWidgetItemContent({
                 onDragHandleMouseDown={onDragHandleMouseDown}
             />
             {!showSharedPlaceholder && hasProductAccess && showTileFilters && TileFilters ? (
-                <TileFilters
-                    tileId={tile.id}
-                    config={widget.config}
-                    onUpdateConfig={componentProps.onUpdateConfig}
-                    canMutateErrorTrackingIssues={componentProps.canMutateErrorTrackingIssues}
-                    disabledReason={
-                        canUpdateWidgetTileConfig ? undefined : DASHBOARD_WIDGET_TILE_FILTERS_READONLY_REASON
-                    }
-                />
+                <Suspense fallback={null}>
+                    <TileFilters
+                        tileId={tile.id}
+                        config={widget.config}
+                        onUpdateConfig={componentProps.onUpdateConfig}
+                        canMutateErrorTrackingIssues={componentProps.canMutateErrorTrackingIssues}
+                        disabledReason={
+                            canUpdateWidgetTileConfig ? undefined : DASHBOARD_WIDGET_TILE_FILTERS_READONLY_REASON
+                        }
+                    />
+                </Suspense>
             ) : null}
             {showSharedPlaceholder ? (
                 <WidgetCardSharedPlaceholderBody
@@ -338,17 +342,19 @@ function DashboardWidgetItemContent({
             {EditModal &&
                 editOpen &&
                 createPortal(
-                    <EditModal
-                        isOpen={editOpen}
-                        onClose={() => setEditOpen(false)}
-                        config={widget.config}
-                        name={title}
-                        defaultTitle={defaultTitle}
-                        description={description}
-                        onSave={async (config, metadata) => {
-                            await onUpdateWidgetTile?.({ config, ...metadata })
-                        }}
-                    />,
+                    <Suspense fallback={null}>
+                        <EditModal
+                            isOpen={editOpen}
+                            onClose={() => setEditOpen(false)}
+                            config={widget.config}
+                            name={title}
+                            defaultTitle={defaultTitle}
+                            description={description}
+                            onSave={async (config, metadata) => {
+                                await onUpdateWidgetTile?.({ config, ...metadata })
+                            }}
+                        />
+                    </Suspense>,
                     document.body
                 )}
         </>

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
@@ -10,6 +10,7 @@ import { DashboardWidgetPlacementMenus } from 'lib/components/Cards/InsightCard/
 import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
+import { Spinner } from 'lib/lemon-ui/Spinner'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { DashboardPlacement, DashboardTile, DashboardType, QueryBasedInsightModel } from '~/types'
@@ -99,6 +100,15 @@ type DashboardWidgetItemBodyProps = {
     dashboardId?: number | null
 }
 
+// While a widget's code-split chunk loads on first render, keep the tile body from flashing empty.
+function WidgetLazyChunkFallback(): JSX.Element {
+    return (
+        <div className="flex min-h-0 min-w-0 flex-1 w-full items-center justify-center">
+            <Spinner className="text-2xl" />
+        </div>
+    )
+}
+
 function DashboardWidgetItemBody({
     widget,
     definition,
@@ -121,7 +131,7 @@ function DashboardWidgetItemBody({
             widgetId={widget.id}
             dashboardId={dashboardId}
         >
-            <Suspense fallback={null}>
+            <Suspense fallback={<WidgetLazyChunkFallback />}>
                 <WidgetComponent {...componentProps} />
             </Suspense>
         </WidgetRuntimeAvailabilityGuard>

--- a/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
+++ b/products/dashboards/frontend/components/DashboardWidgetItem/DashboardWidgetItem.tsx
@@ -10,7 +10,6 @@ import { DashboardWidgetPlacementMenus } from 'lib/components/Cards/InsightCard/
 import { EditModeEdge } from 'lib/components/Cards/InsightCard/EditModeEdgeOverlay'
 import { LemonButton } from 'lib/lemon-ui/LemonButton'
 import { LemonDivider } from 'lib/lemon-ui/LemonDivider'
-import { Spinner } from 'lib/lemon-ui/Spinner'
 
 import { ErrorBoundary } from '~/layout/ErrorBoundary'
 import { DashboardPlacement, DashboardTile, DashboardType, QueryBasedInsightModel } from '~/types'
@@ -39,7 +38,7 @@ import {
     type DashboardWidgetDefinition,
 } from '../../widgets/registry'
 import { WidgetCard } from '../WidgetCard/WidgetCard'
-import { WidgetCardBody, WidgetCardSharedPlaceholderBody } from '../WidgetCard/WidgetCardBody'
+import { WidgetCardBody, WidgetCardSharedPlaceholderBody, WidgetLoadingState } from '../WidgetCard/WidgetCardBody'
 import { WidgetCardHeader, widgetCardShouldHideMoreButton } from '../WidgetCard/WidgetCardHeader'
 import { WidgetRuntimeAvailabilityGuard } from '../WidgetRuntimeAvailabilityGuard/WidgetRuntimeAvailabilityGuard'
 
@@ -100,15 +99,6 @@ type DashboardWidgetItemBodyProps = {
     dashboardId?: number | null
 }
 
-// While a widget's code-split chunk loads on first render, keep the tile body from flashing empty.
-function WidgetLazyChunkFallback(): JSX.Element {
-    return (
-        <div className="flex min-h-0 min-w-0 flex-1 w-full items-center justify-center">
-            <Spinner className="text-2xl" />
-        </div>
-    )
-}
-
 function DashboardWidgetItemBody({
     widget,
     definition,
@@ -131,7 +121,7 @@ function DashboardWidgetItemBody({
             widgetId={widget.id}
             dashboardId={dashboardId}
         >
-            <Suspense fallback={<WidgetLazyChunkFallback />}>
+            <Suspense fallback={<WidgetLoadingState />}>
                 <WidgetComponent {...componentProps} />
             </Suspense>
         </WidgetRuntimeAvailabilityGuard>

--- a/products/dashboards/frontend/components/WidgetCard/DashboardWidgetsOverview.stories.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/DashboardWidgetsOverview.stories.tsx
@@ -65,14 +65,16 @@ function DashboardWidgetOverviewTile({
                     moreButtonOverlay={mockMoreOverlay}
                 />
                 <WidgetCardBody error={demoState.cardError}>
-                    <WidgetComponent
-                        tileId={tileId}
-                        config={demoState.config}
-                        loading={demoState.loading}
-                        result={demoState.result}
-                        onUpdateConfig={() => undefined}
-                        onRefresh={() => undefined}
-                    />
+                    <React.Suspense fallback={null}>
+                        <WidgetComponent
+                            tileId={tileId}
+                            config={demoState.config}
+                            loading={demoState.loading}
+                            result={demoState.result}
+                            onUpdateConfig={() => undefined}
+                            onRefresh={() => undefined}
+                        />
+                    </React.Suspense>
                 </WidgetCardBody>
             </WidgetCard>
         </div>

--- a/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.test.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.test.tsx
@@ -2,7 +2,7 @@ import '@testing-library/jest-dom'
 
 import { cleanup, render, screen } from '@testing-library/react'
 
-import { WidgetCardHeader } from './WidgetCardHeader'
+import { WidgetCardHeader, type DashboardWidgetTopHeadingProps } from './WidgetCardHeader'
 
 describe('WidgetCardHeader', () => {
     afterEach(() => {
@@ -48,7 +48,9 @@ describe('WidgetCardHeader', () => {
                 widgetTypeLabel="Session replay"
                 config={{ dateRange: { date_from: '-14d' }, savedFilterId: 'abc123' }}
                 headerMeta={{ showWidgetType: true, showDateRange: true }}
-                TopHeading={({ widgetTypeLabel }) => <span>{widgetTypeLabel} • My saved filter</span>}
+                TopHeading={({ widgetTypeLabel }: DashboardWidgetTopHeadingProps) => (
+                    <span>{widgetTypeLabel} • My saved filter</span>
+                )}
             />
         )
 

--- a/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { type ComponentType, Suspense } from 'react'
+import React, { type ComponentType, type LazyExoticComponent, Suspense } from 'react'
 
 import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { CardTopHeadingRow } from 'lib/components/Cards/CardTopHeadingRow'
@@ -33,8 +33,11 @@ export type WidgetCardHeaderProps = {
     widgetTypeLabel?: string
     config?: Record<string, unknown>
     headerMeta?: DashboardWidgetHeaderMeta
-    /** Optional per-widget-type top heading row; falls back to the type + date range when absent. */
-    TopHeading?: ComponentType<DashboardWidgetTopHeadingProps>
+    /** Optional per-widget-type top heading row; falls back to the type + date range when absent.
+     * Accepts a lazy component so the registry can code-split it (rendered inside a Suspense below). */
+    TopHeading?:
+        | ComponentType<DashboardWidgetTopHeadingProps>
+        | LazyExoticComponent<ComponentType<DashboardWidgetTopHeadingProps>>
     description?: string
     showDescription?: boolean
     loading?: boolean

--- a/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { type ComponentType } from 'react'
+import React, { type ComponentType, Suspense } from 'react'
 
 import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { CardTopHeadingRow } from 'lib/components/Cards/CardTopHeadingRow'
@@ -191,12 +191,14 @@ export function WidgetCardHeader({
             // saved filter name in place of the now-overridden date range); otherwise fall back to the
             // type + date range.
             TopHeading ? (
-                <TopHeading
-                    config={config ?? {}}
-                    widgetTypeLabel={widgetTypeLabel}
-                    showWidgetType={showWidgetType}
-                    dateText={dateText}
-                />
+                <Suspense fallback={null}>
+                    <TopHeading
+                        config={config ?? {}}
+                        widgetTypeLabel={widgetTypeLabel}
+                        showWidgetType={showWidgetType}
+                        dateText={dateText}
+                    />
+                </Suspense>
             ) : (
                 <CardTopHeadingRow typeLabel={widgetTypeLabel} showTypeLabel={showWidgetType} dateText={dateText} />
             )

--- a/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
+++ b/products/dashboards/frontend/components/WidgetCard/WidgetCardHeader.tsx
@@ -1,5 +1,5 @@
 import clsx from 'clsx'
-import React, { type ComponentType, type LazyExoticComponent, Suspense } from 'react'
+import React, { Suspense } from 'react'
 
 import { CardMeta } from 'lib/components/Cards/CardMeta'
 import { CardTopHeadingRow } from 'lib/components/Cards/CardTopHeadingRow'
@@ -13,6 +13,7 @@ import { dateFilterToText } from 'lib/utils/dateFilters'
 import { DashboardPlacement } from '~/types'
 
 import type { DashboardWidgetHeaderLayout, DashboardWidgetHeaderMeta } from '../../widget_types/catalog'
+import type { DashboardWidgetSlot } from '../../widgets/registry'
 
 /** Props a widget type's optional TopHeading override receives so it can compose its own
  * CardTopHeadingRow — e.g. resolving a saved filter's name the generic header can't derive from config. */
@@ -34,10 +35,8 @@ export type WidgetCardHeaderProps = {
     config?: Record<string, unknown>
     headerMeta?: DashboardWidgetHeaderMeta
     /** Optional per-widget-type top heading row; falls back to the type + date range when absent.
-     * Accepts a lazy component so the registry can code-split it (rendered inside a Suspense below). */
-    TopHeading?:
-        | ComponentType<DashboardWidgetTopHeadingProps>
-        | LazyExoticComponent<ComponentType<DashboardWidgetTopHeadingProps>>
+     * A `DashboardWidgetSlot` so the registry can code-split it (rendered inside a Suspense below). */
+    TopHeading?: DashboardWidgetSlot<DashboardWidgetTopHeadingProps>
     description?: string
     showDescription?: boolean
     loading?: boolean

--- a/products/dashboards/frontend/widgets/registry.tsx
+++ b/products/dashboards/frontend/widgets/registry.tsx
@@ -143,7 +143,7 @@ function reportMissingDashboardWidgetRegistryEntry(
 }
 
 /** A widget slot reachable eagerly or via a lazy chunk — both render identically inside a <Suspense>. */
-type DashboardWidgetSlot<P> = ComponentType<P> | LazyExoticComponent<ComponentType<P>>
+export type DashboardWidgetSlot<P> = ComponentType<P> | LazyExoticComponent<ComponentType<P>>
 
 export type DashboardWidgetDefinition = {
     Component: DashboardWidgetSlot<DashboardWidgetComponentProps>

--- a/products/dashboards/frontend/widgets/registry.tsx
+++ b/products/dashboards/frontend/widgets/registry.tsx
@@ -1,5 +1,5 @@
 import posthog from 'posthog-js'
-import type { ComponentType } from 'react'
+import { type ComponentType, type LazyExoticComponent, lazy } from 'react'
 
 import type { DashboardWidgetTopHeadingProps } from '../components/WidgetCard/WidgetCardHeader'
 import type { DashboardWidgetProductAccess } from '../types'
@@ -12,36 +12,88 @@ export type DashboardWidgetTileFiltersProps = {
     disabledReason?: string | null
     canMutateErrorTrackingIssues?: boolean
 }
-import { ActivityEventsWidget } from './activity/ActivityEventsWidget'
 import { parseActivityEventsWidgetConfigApiError } from './activity/activityEventsWidgetConfigValidation'
-import { ActivityEventsWidgetTileFilters } from './activity/ActivityEventsWidgetTileFilters'
-import { EditActivityEventsWidgetModal } from './activity/EditActivityEventsWidgetModal'
 import type {
     WidgetIssueMetadataContext,
     WidgetIssueMetadataDelta,
 } from './error_tracking/applyWidgetIssueMetadataChange'
-import { EditErrorTrackingWidgetModal } from './error_tracking/EditErrorTrackingWidgetModal'
-import { ErrorTrackingWidget } from './error_tracking/ErrorTrackingWidget'
 import { parseErrorTrackingWidgetConfigApiError } from './error_tracking/errorTrackingWidgetConfigValidation'
-import { ErrorTrackingWidgetTileFilters } from './error_tracking/ErrorTrackingWidgetTileFilters'
-import { EditExperimentResultsWidgetModal } from './experiments/EditExperimentResultsWidgetModal'
-import { EditExperimentsListWidgetModal } from './experiments/EditExperimentsListWidgetModal'
-import { ExperimentResultsWidget } from './experiments/ExperimentResultsWidget'
-import { ExperimentResultsWidgetTileFilters } from './experiments/ExperimentResultsWidgetTileFilters'
-import { ExperimentsListWidget } from './experiments/ExperimentsListWidget'
-import { ExperimentsListWidgetTileFilters } from './experiments/ExperimentsListWidgetTileFilters'
 import {
     parseExperimentResultsWidgetConfigApiError,
     parseExperimentsListWidgetConfigApiError,
 } from './experiments/experimentsWidgetConfigValidation'
-import { EditLogsWidgetModal } from './logs/EditLogsWidgetModal'
-import { LogsWidget } from './logs/LogsWidget'
 import { parseLogsWidgetConfigApiError } from './logs/logsWidgetConfigValidation'
-import { LogsWidgetTileFilters } from './logs/LogsWidgetTileFilters'
-import { EditSessionReplayWidgetModal } from './session_replay/EditSessionReplayWidgetModal'
-import { SessionReplayWidget, SessionReplayWidgetTopHeading } from './session_replay/SessionReplayWidget'
 import { parseSessionReplayWidgetConfigApiError } from './session_replay/sessionReplayWidgetConfigValidation'
-import { SessionReplayWidgetTileFilters } from './session_replay/SessionReplayWidgetTileFilters'
+
+// Widget UI is code-split: the static graph keeps only config-error parsers, types, and the lazy
+// factories below, so a logged-in page no longer eagerly downloads every widget's renderer, edit
+// modal, and tile-filter bar. Each widget's subtree loads only when its tile actually renders.
+// Rendered through <Suspense> boundaries in DashboardWidgetItem and WidgetCardHeader.
+const ActivityEventsWidget = lazy(() =>
+    import('./activity/ActivityEventsWidget').then((m) => ({ default: m.ActivityEventsWidget }))
+)
+const ActivityEventsWidgetTileFilters = lazy(() =>
+    import('./activity/ActivityEventsWidgetTileFilters').then((m) => ({ default: m.ActivityEventsWidgetTileFilters }))
+)
+const EditActivityEventsWidgetModal = lazy(() =>
+    import('./activity/EditActivityEventsWidgetModal').then((m) => ({ default: m.EditActivityEventsWidgetModal }))
+)
+const ErrorTrackingWidget = lazy(() =>
+    import('./error_tracking/ErrorTrackingWidget').then((m) => ({ default: m.ErrorTrackingWidget }))
+)
+const ErrorTrackingWidgetTileFilters = lazy(() =>
+    import('./error_tracking/ErrorTrackingWidgetTileFilters').then((m) => ({
+        default: m.ErrorTrackingWidgetTileFilters,
+    }))
+)
+const EditErrorTrackingWidgetModal = lazy(() =>
+    import('./error_tracking/EditErrorTrackingWidgetModal').then((m) => ({ default: m.EditErrorTrackingWidgetModal }))
+)
+const ExperimentResultsWidget = lazy(() =>
+    import('./experiments/ExperimentResultsWidget').then((m) => ({ default: m.ExperimentResultsWidget }))
+)
+const ExperimentResultsWidgetTileFilters = lazy(() =>
+    import('./experiments/ExperimentResultsWidgetTileFilters').then((m) => ({
+        default: m.ExperimentResultsWidgetTileFilters,
+    }))
+)
+const EditExperimentResultsWidgetModal = lazy(() =>
+    import('./experiments/EditExperimentResultsWidgetModal').then((m) => ({
+        default: m.EditExperimentResultsWidgetModal,
+    }))
+)
+const ExperimentsListWidget = lazy(() =>
+    import('./experiments/ExperimentsListWidget').then((m) => ({ default: m.ExperimentsListWidget }))
+)
+const ExperimentsListWidgetTileFilters = lazy(() =>
+    import('./experiments/ExperimentsListWidgetTileFilters').then((m) => ({
+        default: m.ExperimentsListWidgetTileFilters,
+    }))
+)
+const EditExperimentsListWidgetModal = lazy(() =>
+    import('./experiments/EditExperimentsListWidgetModal').then((m) => ({ default: m.EditExperimentsListWidgetModal }))
+)
+const LogsWidget = lazy(() => import('./logs/LogsWidget').then((m) => ({ default: m.LogsWidget })))
+const LogsWidgetTileFilters = lazy(() =>
+    import('./logs/LogsWidgetTileFilters').then((m) => ({ default: m.LogsWidgetTileFilters }))
+)
+const EditLogsWidgetModal = lazy(() =>
+    import('./logs/EditLogsWidgetModal').then((m) => ({ default: m.EditLogsWidgetModal }))
+)
+const SessionReplayWidget = lazy(() =>
+    import('./session_replay/SessionReplayWidget').then((m) => ({ default: m.SessionReplayWidget }))
+)
+const SessionReplayWidgetTopHeading = lazy(() =>
+    import('./session_replay/SessionReplayWidget').then((m) => ({ default: m.SessionReplayWidgetTopHeading }))
+)
+const SessionReplayWidgetTileFilters = lazy(() =>
+    import('./session_replay/SessionReplayWidgetTileFilters').then((m) => ({
+        default: m.SessionReplayWidgetTileFilters,
+    }))
+)
+const EditSessionReplayWidgetModal = lazy(() =>
+    import('./session_replay/EditSessionReplayWidgetModal').then((m) => ({ default: m.EditSessionReplayWidgetModal }))
+)
 
 export type DashboardWidgetConfigApiErrorParser = (
     error: unknown,
@@ -90,11 +142,14 @@ function reportMissingDashboardWidgetRegistryEntry(
     })
 }
 
+/** A widget slot reachable eagerly or via a lazy chunk — both render identically inside a <Suspense>. */
+type DashboardWidgetSlot<P> = ComponentType<P> | LazyExoticComponent<ComponentType<P>>
+
 export type DashboardWidgetDefinition = {
-    Component: ComponentType<DashboardWidgetComponentProps>
-    TileFilters?: ComponentType<DashboardWidgetTileFiltersProps>
-    EditModal?: ComponentType<DashboardWidgetEditModalProps>
-    TopHeading?: ComponentType<DashboardWidgetTopHeadingProps>
+    Component: DashboardWidgetSlot<DashboardWidgetComponentProps>
+    TileFilters?: DashboardWidgetSlot<DashboardWidgetTileFiltersProps>
+    EditModal?: DashboardWidgetSlot<DashboardWidgetEditModalProps>
+    TopHeading?: DashboardWidgetSlot<DashboardWidgetTopHeadingProps>
     productAccess?: DashboardWidgetProductAccess
     /** Maps dashboard PATCH API errors to edit-modal field errors for this widget type. */
     parseConfigApiError: DashboardWidgetConfigApiErrorParser


### PR DESCRIPTION
## Problem

`DASHBOARD_WIDGET_REGISTRY` statically imported every widget's renderer, edit modal, and tile-filter bar. That registry is reachable from `AuthenticatedShell`, so all six widget types' UI sat in the authenticated-shell **eager** graph — downloaded and decoded on every logged-in page, even when no dashboard is open. Each new widget type permanently grows that bundle; the recently-added logs widget alone put ~214 KiB of source into it.

## Changes

- `registry.tsx`: the `Component` / `TileFilters` / `EditModal` / `TopHeading` slots are now `React.lazy` factories (`import('./…').then((m) => ({ default: m.X }))`), mirroring the existing `products/posthog_ai/.../toolRegistry.tsx` pattern. The static graph keeps only the config-error parsers, product-access flags, and the tiny lazy factories.
- Render seams wrapped in `<Suspense>`: `DashboardWidgetItem` (Component, TileFilters, EditModal), `WidgetCardHeader` (TopHeading), and the `DashboardWidgetsOverview` story.
- Slot field types widened to `ComponentType<P> | LazyExoticComponent<ComponentType<P>>`.

Widget renderers now load on demand when a tile of that type first renders.

## How did you test this code?

I'm an agent (PostHog Code) — automated checks only, no manual/Storybook run:

- `oxlint` + `oxfmt` on all changed files — clean.
- Local esbuild production build of `master` vs this branch, then walked the esbuild metafile's static output-chunk graph rooted at the `AuthenticatedShell` chunk to measure the real eager download.

| Metric | master | branch | Δ |
|---|---|---|---|
| Logged-in-page eager **download** (minified) | 14.42 MiB | 14.32 MiB | **−107.8 KiB** |
| AuthenticatedShell eager **input** closure | 32.59 MiB / 5,201 files | 32.25 MiB / 5,132 files | −0.34 MiB / −69 files |

19 of 21 widget UI modules move out of the eager closure into on-demand chunks (`LogsWidget` gets its own `dist/LogsWidget-*.js`).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs impact.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted) — DRI @pauldambra.

Authored with PostHog Code (Claude). Origin: while trimming an oversized integration icon we traced the authenticated-shell eager-graph drift and found the dashboard widget registry was the largest attributable recent contributor (the logs widget from #64416). This applies the lazy-load treatment the codebase already uses for `toolRegistry`.

Decisions:

- Lazy-loaded **all** widget types, not just logs, so the registry stops accreting onto the shell with each new widget — the shared render seams needed `Suspense` either way.
- Kept `parseConfigApiError` and `productAccess` eager (small, synchronous); only the UI subtrees split out.
- Confirmed this is a real download win, not just an eager-graph *metric* win, by diffing the output chunk graph across two builds. The eager-graph input figure (−0.34 MiB source) overstates it — the real downloaded saving is ~108 KiB minified.

Local `tsgo` typecheck can't run in this worktree (kea typegen absent, `@posthog/quill` unbuilt), so **type-checking relies on CI**.

Reviewer note: the `DashboardWidgetsOverview` Storybook baseline will re-snapshot (widgets now render behind a `Suspense` boundary) — expect and approve that visual diff.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
