### PR TITLE
fix(klaviyo): retry mid-stream chunked-encoding connection breaks

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/klaviyo.py
@@ -163,7 +163,16 @@ def _build_initial_params(
 
 
 @retry(
-    retry=retry_if_exception_type((KlaviyoRetryableError, requests.ReadTimeout, requests.ConnectionError)),
+    # ChunkedEncodingError is a mid-stream connection break (the server truncated a chunked
+    # response body); it's transient like ConnectionError/ReadTimeout, not a ConnectionError subclass.
+    retry=retry_if_exception_type(
+        (
+            KlaviyoRetryableError,
+            requests.ReadTimeout,
+            requests.ConnectionError,
+            requests.exceptions.ChunkedEncodingError,
+        )
+    ),
     stop=stop_after_attempt(5),
     wait=wait_exponential_jitter(initial=1, max=30),
     reraise=True,

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import pytest
 from freezegun import freeze_time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import requests
 from parameterized import parameterized
@@ -191,6 +191,31 @@ class TestNonRetryableErrors:
     def test_transient_errors_remain_retryable(self, _name: str, other_error: str) -> None:
         non_retryable_errors = KlaviyoSource().get_non_retryable_errors()
         assert not any(key in other_error for key in non_retryable_errors)
+
+
+class TestFetchPageRetries:
+    @parameterized.expand(
+        [
+            ("chunked_encoding", requests.exceptions.ChunkedEncodingError("Connection broken: InvalidChunkLength")),
+            ("read_timeout", requests.ReadTimeout("Read timed out.")),
+            ("connection_error", requests.ConnectionError("Connection reset by peer")),
+        ]
+    )
+    def test_transient_errors_are_retried(self, _name: str, transient_error: Exception) -> None:
+        # A transient network failure on the first attempt must retry rather than fail the whole sync.
+        good = MagicMock()
+        good.status_code = 200
+        good.ok = True
+        good.json.return_value = {"data": []}
+
+        session = MagicMock()
+        session.get.side_effect = [transient_error, good]
+
+        with patch.object(klaviyo._fetch_page.retry, "sleep", lambda *_: None):
+            result = klaviyo._fetch_page(session, "https://a.klaviyo.com/api/events", {}, MagicMock())
+
+        assert result == {"data": []}
+        assert session.get.call_count == 2
 
 
 def _response_with_status(status_code: int) -> requests.Response:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -217,6 +217,17 @@ class TestFetchPageRetries:
         assert result == {"data": []}
         assert session.get.call_count == 2
 
+    def test_transient_error_reraised_after_exhausting_attempts(self) -> None:
+        # After the 5-attempt cap the last transient error must surface (reraise=True), not be swallowed.
+        session = MagicMock()
+        session.get.side_effect = requests.exceptions.ChunkedEncodingError("Connection broken: InvalidChunkLength")
+
+        with patch.object(klaviyo._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
+            with pytest.raises(requests.exceptions.ChunkedEncodingError):
+                klaviyo._fetch_page(session, "https://a.klaviyo.com/api/events", {}, MagicMock())
+
+        assert session.get.call_count == 5
+
 
 def _response_with_status(status_code: int) -> requests.Response:
     response = requests.Response()

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/klaviyo/test_klaviyo.py
@@ -211,7 +211,7 @@ class TestFetchPageRetries:
         session = MagicMock()
         session.get.side_effect = [transient_error, good]
 
-        with patch.object(klaviyo._fetch_page.retry, "sleep", lambda *_: None):
+        with patch.object(klaviyo._fetch_page.retry, "sleep", lambda *_: None):  # type: ignore[attr-defined]
             result = klaviyo._fetch_page(session, "https://a.klaviyo.com/api/events", {}, MagicMock())
 
         assert result == {"data": []}


### PR DESCRIPTION
> Claude-written:

## Problem

Klaviyo imports were surfacing a `ValueError: invalid literal for int() with base 16: b''` in error tracking, raised from `_fetch_page` in the Klaviyo source ([error tracking issue](https://us.posthog.com/project/2/error_tracking/019f1d1a-0d52-7462-bcc0-f3a14da45bc7)).

The underlying exception chain is `ChunkedEncodingError` → `ProtocolError` → `InvalidChunkLength` → `ValueError`. In plain terms: the connection broke mid-response while `requests`/`urllib3` was reading a chunked transfer-encoded body, so the chunk-size line came back empty and `int(b'', 16)` blew up. This is a transient network failure, not a data or credential problem.

The catch: `_fetch_page` already retries transient network errors, but its retry predicate only listed `requests.ReadTimeout` and `requests.ConnectionError`. `requests.exceptions.ChunkedEncodingError` is a direct subclass of `RequestException`, not of `ConnectionError` or `ReadTimeout`, so it slipped through the predicate. A single blip failed the entire sync with zero retries.

## Changes

Add `requests.exceptions.ChunkedEncodingError` to the `_fetch_page` retry tuple, next to the existing connection/timeout errors. Same transient category, same backoff, same 5-attempt cap. No change to the global retry policy and nothing added to `NonRetryableErrors` — this stays retryable, which is the correct behavior for a transient connection break.

## How did you test this code?

Added a parameterized test (`TestFetchPageRetries`) asserting `_fetch_page` retries and recovers when the first attempt raises `ChunkedEncodingError`, `ReadTimeout`, or `ConnectionError`. The wait is patched to a no-op so the test stays fast and deterministic.

This catches a regression no existing test did: the existing `TestNonRetryableErrors` covers the separate `get_non_retryable_errors` string-matching path, not the tenacity retry predicate on `_fetch_page`. I confirmed the `chunked_encoding` case fails on `master` (the error propagates on the first attempt) and passes with the fix; the other two cases guard the pre-existing retry entries from regressing.

Ran the full Klaviyo suite locally: 36 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from a webhook-delivered error tracking alert. I (Claude) pulled the issue's raw stack trace via the PostHog error-tracking MCP tools, confirmed the failure originates in `klaviyo.py:_fetch_page`, and verified via the `requests` class hierarchy that `ChunkedEncodingError` is not a subclass of the already-retried errors. Decided this is a fixable fragility (incomplete retry predicate) rather than a `NonRetryableErrors` candidate, since a mid-stream connection break is transient and should be retried. Invoked the `/writing-tests` skill before adding the regression test. Checked open PRs (including the maintainer's) for a duplicate first; none addressed this.