### PR TITLE
fix(batch-exports): Handle snowflake permission error

### DIFF
--- a/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
+++ b/products/batch_exports/backend/temporal/destinations/snowflake_batch_export.py
@@ -96,6 +96,8 @@ NON_RETRYABLE_ERROR_TYPES = (
     "SnowflakeWarehouseSuspendedError",
     # Raised when the destination table schema is incompatible with the schema of the file we are trying to load.
     "SnowflakeIncompatibleSchemaError",
+    # Raised when Snowflake rejects a query because the role is missing privileges.
+    "SnowflakePermissionError",
     # Raised when we hit our self-imposed query timeout.
     # We don't want to continually retry as it could consume a lot of compute resources in the user's account and can
     # lead to a lot of queries queuing up for a given warehouse.
@@ -181,6 +183,12 @@ class SnowflakeIncompatibleSchemaError(Exception):
         )
 
 
+class SnowflakePermissionError(Exception):
+    """Raised when Snowflake rejects a query because the role is missing privileges."""
+
+    pass
+
+
 class SnowflakeQueryClientTimeoutError(TimeoutError):
     """Raised when a Snowflake query times out."""
 
@@ -258,6 +266,17 @@ class SnowflakeDestinationField(typing.NamedTuple):
     name: str
     type: SnowflakeTypeName
     is_nullable: bool
+
+
+def is_snowflake_permission_error_message(message: str) -> bool:
+    """Return whether a Snowflake error message is caused by missing privileges."""
+    normalized_message = message.lower()
+    return "sql access control error" in normalized_message or "insufficient privileges" in normalized_message
+
+
+def is_snowflake_permission_error(exc: snowflake.connector.errors.ProgrammingError) -> bool:
+    """Return whether a Snowflake programming error is caused by missing privileges."""
+    return exc.errno == 3001 or is_snowflake_permission_error_message(exc.msg or str(exc))
 
 
 def data_type_to_snowflake_type(data_type: pa.DataType) -> SnowflakeType:
@@ -1060,6 +1079,8 @@ class SnowflakeClient:
                 raise SnowflakeQueryServerTimeoutError(e.msg)
             elif e.errno == 904 and e.msg is not None and "invalid identifier" in e.msg:
                 raise SnowflakeIncompatibleSchemaError(e.msg)
+            elif is_snowflake_permission_error(e):
+                raise SnowflakePermissionError(e.msg or str(e)) from e
 
             raise SnowflakeFileNotLoadedError(
                 table.name,
@@ -1088,11 +1109,15 @@ class SnowflakeClient:
 
             if status != "LOADED":
                 errors_seen, first_error = query_result[5:7]
+                first_error_message = first_error or "NO ERROR MESSAGE"
+                if is_snowflake_permission_error_message(first_error_message):
+                    raise SnowflakePermissionError(first_error_message)
+
                 raise SnowflakeFileNotLoadedError(
                     table.name,
                     status or "NO STATUS",
                     errors_seen or 0,
-                    first_error or "NO ERROR MESSAGE",
+                    first_error_message,
                 )
 
         self.logger.info("Finished copying files into destination table")

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/test_workflow.py
@@ -14,6 +14,7 @@ import unittest.mock
 from django.conf import settings
 from django.test import override_settings
 
+import pyarrow as pa
 from temporalio import activity
 from temporalio.client import WorkflowFailureError
 from temporalio.common import RetryPolicy
@@ -27,9 +28,15 @@ from posthog.temporal.tests.utils.models import afetch_batch_export_runs
 from products.batch_exports.backend.models.batch_export import BatchExport, BatchExportRun
 from products.batch_exports.backend.temporal.batch_exports import finish_batch_export_run, start_batch_export_run
 from products.batch_exports.backend.temporal.destinations.snowflake_batch_export import (
+    NON_RETRYABLE_ERROR_TYPES,
     SnowflakeBatchExportInputs,
     SnowflakeBatchExportWorkflow,
+    SnowflakeClient,
+    SnowflakeField,
     SnowflakeInsertInputs,
+    SnowflakePermissionError,
+    SnowflakeTable,
+    SnowflakeType,
     insert_into_snowflake_activity_from_stage,
 )
 from products.batch_exports.backend.temporal.pipeline.internal_stage import insert_into_internal_stage_activity
@@ -297,6 +304,39 @@ async def test_snowflake_export_workflow_raises_error_on_copy_fail(
         assert isinstance(err.__cause__, ActivityError)
         assert isinstance(err.__cause__.__cause__, ApplicationError)
         assert err.__cause__.__cause__.type == "SnowflakeFileNotLoadedError"
+
+
+async def test_snowflake_copy_permission_error_is_non_retryable():
+    client = SnowflakeClient(
+        user="user",
+        account="account",
+        warehouse="warehouse",
+        database="POSTHOG",
+        schema="PUBLIC",
+        password="password",
+    )
+    table = SnowflakeTable(
+        name="events",
+        fields=(SnowflakeField("uuid", SnowflakeType("TEXT", False), pa.string(), True),),
+        parents=("POSTHOG", "PUBLIC"),
+    )
+
+    with (
+        unittest.mock.patch(
+            "products.batch_exports.backend.temporal.destinations.snowflake_batch_export.snowflake.connector.connect",
+            return_value=FakeSnowflakeConnection(failure_mode="copy_permission"),
+        ),
+        unittest.mock.patch(
+            "products.batch_exports.backend.temporal.destinations.snowflake_batch_export.SnowflakeClient.DEFAULT_POLL_INTERVAL",
+            0.01,
+        ),
+    ):
+        async with client.connect(use_namespace=False):
+            with pytest.raises(SnowflakePermissionError) as exc_info:
+                await client.copy_loaded_files_to_snowflake_table(table, timeout=1)
+
+    assert "SnowflakePermissionError" in NON_RETRYABLE_ERROR_TYPES
+    assert "Insufficient privileges" in str(exc_info.value)
 
 
 async def test_snowflake_export_workflow_handles_unexpected_insert_activity_errors(

--- a/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
+++ b/products/batch_exports/backend/tests/temporal/destinations/snowflake/utils.py
@@ -117,6 +117,11 @@ class FakeSnowflakeCursor:
 
     def execute_async(self, query, params=None, file_stream=None):
         self._execute_async_calls.append({"query": query, "params": params, "file_stream": file_stream})
+        if self._fail == "copy_permission" and "COPY INTO" in query:
+            raise snowflake.connector.errors.ProgrammingError(
+                msg="SQL access control error:\nInsufficient privileges to operate on table 'events'.",
+                errno=3001,
+            )
 
     def get_results_from_sfqid(self, query_id):
         pass


### PR DESCRIPTION
## Problem

Seeing Snowflake permission errors when loading files.

<!-- Who are we building for, what are their needs, why is this important? -->

<!-- Does this fix an issue? Uncomment the line below with the issue ID to automatically close it when merged -->
<!-- Closes #ISSUE_ID -->

## Changes

<!-- If there are frontend changes, please include screenshots. -->
<!-- If a reference design was involved, include a link to the relevant Figma frame! -->

## How did you test this code?

<!-- Describe steps to reproduce and verify the changes, and what the expected behavior is. -->
<!-- Include automated tests if possible, otherwise describe the manual testing routine. -->
<!-- Agents: do NOT claim manual testing you haven't done. State what the agent wasn't able to do and list only the automated tests you (the agent) actually ran. -->
<!-- Added or changed tests? Name the regression each group catches that no existing test did — if you can't name it, it probably shouldn't be in this PR. https://posthog.com/handbook/engineering/conventions/backend-coding#testing -->

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

<!-- Add the `skip-inkeep-docs` label if this PR should not trigger an automatic docs update from the Inkeep agent. -->

## 🤖 Agent context

<!-- Fill this section if an agent co-authored or authored this PR. Remove it for fully human-authored PRs. -->

<!-- Autonomy — keep one of the two options on the line below:
     - "Human-driven (agent-assisted)" when a person directed the work — assign that person as the PR assignee (the DRI).
     - "Fully autonomous" when no human drove it; leave the PR unassigned for the owning team to triage. -->

**Autonomy:** Human-driven (agent-assisted) - or - Fully autonomous

<!-- Keep this short: 1-3 short paragraphs or a handful of bullets — not an exhaustive log. Include:
     - tools/agent used and link to session. List the agent and tool names used, but do not include tool call results.
     - skills invoked: always explicitly call out any repo-provided or public skills (e.g. /django-migrations, /improving-drf-endpoints) that were invoked while producing this PR. This helps reviewers judge where and how the code was shaped by an agent.
     - decisions made along the way (what was tried, rejected, chosen, and why)
     - anything else that helps reviewers
     Write reviewer-facing prose. Do not paste user prompts verbatim — paraphrase the intent in your own words.
     This is the ONLY section that should contain descriptions of what this PR might have looked like before its present final state.
     Don't duplicate info already present in preceding sections.
     DO NOT INCLUDE sensitive data that may have been shared in an agent session.
-->

<!-- Overall PR authoring rules for agents:
- Title: <type>(<scope>): <description> — type=feat|fix|chore, scope required, lowercase, no period, <72 chars.
  ✅ feat(insights): add retention graph export
  ❌ feat: Added retention export.   (capitalized, period, no scope)
- Description: high-level rationale, not a step-by-step replay.
- Public OSS repo: no internal customers, incidents, or operational metrics.
- Labels: apply `skip-agent-review` for trivial/chore PRs that don't need Copilot or Greptile review.
- When a human directed the work, the PR must be attributable to that person, even if agent-assisted.
- If a human directed this work, assign them as the PR assignee (the DRI) — actually set the assignee, don't just name them here. Leave a PR unassigned only when it is fully autonomous with no human driver (set Autonomy to "Fully autonomous").
- Never write a GitHub @mention or username you have not verified this session. Resolve a real handle from `gh api user` (current user) or the PR's actual author/assignee via `gh pr view --json author,assignees` — never infer a handle from a display name.
- Do not add a human Co-authored-by just for the sake of attribution — if no human was involved in the changes, own it as agent-authored.
- Agent-authored PRs always require human review — do not self-merge or auto-approve.
- Do NOT claim manual testing you haven't done.
- GitHub PR descriptions render markdown, not fixed-width text. Do not hard-wrap prose at a column width or use space-aligned tables — use real markdown tables, headings, and fenced code blocks, and let GitHub flow the text.
- Write with a crisp, direct Silicon Valley communication style. Use concise language that gets straight to the point. Sentences that are easy on the reader, paragraphs that are each about one thing. Prioritize clarity and brevity over elaborate explanations. Avoid corporate jargon, buzzwords, and unnecessary embellishments. Communicate as if you're explaining a complex concept to a smart colleague over coffee, keeping the tone light but substantive. No em-dashes, only en-dashes if needed. Spare use of inline code. Limited use of the colon and semicolon.
- Write from a first person perspective of the author of a human-driven PR. Although if something was done by an agent (i.e. you), make that clear with something like "I (or, actually Claude/Codex/etc.) did blah".
- If written by agent, put in a plain blockquote before "## Problem" just saying "> Claude/Codex/etc.-written:" to set the context for readers.
- For titles, headings, or bolded parts use "Sentence case" rather than "Title Case" (i.e. only capitalize the first word of the title/heading/bold text).
-->
