### PR TITLE
fix(alerts): auto-disable misconfigured SQL alerts instead of erroring loud

### DIFF
--- a/posthog/tasks/alerts/utils.py
+++ b/posthog/tasks/alerts/utils.py
@@ -371,7 +371,13 @@ def add_alert_check(
     return alert_check, notify
 
 
-def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
+def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> AlertCheck:
+    """Auto-disable a misconfigured alert and email its subscribers.
+
+    Used for configuration problems that make the alert unevaluable as set up — a deliberate,
+    fail-loud outcome, not a bug — so the reason is surfaced to the owner rather than captured
+    as an exception. Returns the recorded ERRORED AlertCheck so callers can reference it.
+    """
     logger.warning("check_alert.auto_disabling", alert_id=alert.id, reason=reason)
     AlertConfiguration.objects.filter(pk=alert.pk).update(
         enabled=False,
@@ -381,7 +387,7 @@ def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
     alert.refresh_from_db()
 
     targets_to_notify = alert.get_subscribed_users_emails()
-    AlertCheck.objects.create(
+    alert_check = AlertCheck.objects.create(
         alert_configuration=alert,
         calculated_value=None,
         condition=alert.condition,
@@ -391,6 +397,7 @@ def disable_invalid_alert(alert: AlertConfiguration, reason: str) -> None:
     )
     if targets_to_notify:
         send_notifications_for_disabled(alert, reason, targets_to_notify)
+    return alert_check
 
 
 def send_notifications_for_disabled(alert: AlertConfiguration, reason: str, targets: list[str]) -> None:

--- a/posthog/temporal/alerts/activities.py
+++ b/posthog/temporal/alerts/activities.py
@@ -39,6 +39,7 @@ from posthog.temporal.alerts.types import (
 from posthog.temporal.common.heartbeat import Heartbeater
 
 from products.alerts.backend.evaluation import check_alert_for_insight
+from products.alerts.backend.evaluation.contract import AlertExtractionError
 from products.alerts.backend.evaluation.validation import validate_alert_config
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration
 from products.notifications.backend.facade.api import (
@@ -219,6 +220,17 @@ async def evaluate_alert(inputs: EvaluateAlertActivityInputs) -> EvaluateAlertRe
             breaches = alert_evaluation_result.breaches
         except CH_TRANSIENT_ERRORS:
             raise
+        except AlertExtractionError as err:
+            # The alert can't be evaluated as configured (wrong query shape / bad config) — a
+            # deliberate fail-loud outcome, not a bug. Auto-disable and email the owner via the
+            # existing path instead of capturing it as an exception, which would pollute error
+            # tracking with a config problem that recurs on every check until fixed.
+            alert_check = disable_invalid_alert(alert, str(err))
+            return EvaluateAlertResult(
+                alert_check_id=str(alert_check.id),
+                should_notify=False,  # disable_invalid_alert already emailed subscribers
+                new_state=AlertState.ERRORED,
+            )
         except Exception as err:
             logger.exception(f"Alert id = {alert.id}, failed to evaluate", exc_info=err)
             capture_exception(

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -381,6 +381,26 @@ class TestEvaluateAlert:
         refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
         assert refreshed.enabled is False
 
+    async def test_evaluate_emails_owner_when_auto_disabling_on_extraction_error(self, alert_with_user) -> None:
+        # The subscribed owner must be told their alert was auto-disabled. alert_with_user has a
+        # subscriber, so this exercises the send_notifications_for_disabled branch the no-subscriber
+        # fixture skips — guarding against a silent regression where owners aren't informed.
+        with (
+            patch(
+                "posthog.temporal.alerts.activities.check_alert_for_insight",
+                side_effect=AlertExtractionError("query returns a non-numeric value"),
+            ),
+            patch("posthog.tasks.alerts.utils.send_notifications_for_disabled") as mock_notify,
+        ):
+            env = ActivityEnvironment()
+            await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert_with_user.id)))
+
+        mock_notify.assert_called_once()
+        notified_alert, reason, targets = mock_notify.call_args.args
+        assert notified_alert.id == alert_with_user.id
+        assert "non-numeric" in reason
+        assert targets  # the subscribed owner's email
+
     async def test_evaluate_reraises_ch_transient_error(self, alert) -> None:
         # Transient CH errors bubble up so Temporal's retry policy handles them.
         with patch(

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -356,18 +356,21 @@ class TestEvaluateAlert:
         refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
         assert refreshed.enabled is True
 
-    async def test_evaluate_auto_disables_and_skips_error_tracking_on_extraction_error(self, alert) -> None:
+    async def test_evaluate_auto_disables_and_skips_error_tracking_on_extraction_error(self, alert_with_user) -> None:
         # A misconfigured query (wrong shape / bad config) fails loud with AlertExtractionError. That's
         # a config problem, not a bug: it must auto-disable + email the owner, not hit error tracking.
+        # alert_with_user has a subscriber, so this also exercises the send_notifications_for_disabled
+        # branch — guarding against a silent regression where the owner isn't told their alert died.
         with (
             patch(
                 "posthog.temporal.alerts.activities.check_alert_for_insight",
                 side_effect=AlertExtractionError("query returns 2 numeric columns — pick one"),
             ),
             patch("posthog.temporal.alerts.activities.capture_exception") as mock_capture,
+            patch("posthog.tasks.alerts.utils.send_notifications_for_disabled") as mock_notify,
         ):
             env = ActivityEnvironment()
-            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert_with_user.id)))
 
         assert result.new_state == AlertState.ERRORED
         assert result.should_notify is False  # disable_invalid_alert already emailed subscribers
@@ -378,27 +381,13 @@ class TestEvaluateAlert:
         assert check.error is not None
         assert "2 numeric columns" in check.error["message"]
 
-        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert_with_user.pk)
         assert refreshed.enabled is False
-
-    async def test_evaluate_emails_owner_when_auto_disabling_on_extraction_error(self, alert_with_user) -> None:
-        # The subscribed owner must be told their alert was auto-disabled. alert_with_user has a
-        # subscriber, so this exercises the send_notifications_for_disabled branch the no-subscriber
-        # fixture skips — guarding against a silent regression where owners aren't informed.
-        with (
-            patch(
-                "posthog.temporal.alerts.activities.check_alert_for_insight",
-                side_effect=AlertExtractionError("query returns a non-numeric value"),
-            ),
-            patch("posthog.tasks.alerts.utils.send_notifications_for_disabled") as mock_notify,
-        ):
-            env = ActivityEnvironment()
-            await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert_with_user.id)))
 
         mock_notify.assert_called_once()
         notified_alert, reason, targets = mock_notify.call_args.args
         assert notified_alert.id == alert_with_user.id
-        assert "non-numeric" in reason
+        assert "2 numeric columns" in reason
         assert targets  # the subscribed owner's email
 
     async def test_evaluate_reraises_ch_transient_error(self, alert) -> None:

--- a/posthog/temporal/tests/test_alerts_activities.py
+++ b/posthog/temporal/tests/test_alerts_activities.py
@@ -33,6 +33,7 @@ from posthog.temporal.alerts.types import (
     SkipReason,
 )
 
+from products.alerts.backend.evaluation.contract import AlertExtractionError
 from products.alerts.backend.evaluation.validation import THRESHOLD_BOUNDS_REQUIRED_MESSAGE
 from products.alerts.backend.models.alert import AlertCheck, AlertConfiguration, Threshold
 from products.product_analytics.backend.models.insight import Insight
@@ -354,6 +355,31 @@ class TestEvaluateAlert:
         # Only prepare-time validate_alert_config failures call disable_invalid_alert.
         refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
         assert refreshed.enabled is True
+
+    async def test_evaluate_auto_disables_and_skips_error_tracking_on_extraction_error(self, alert) -> None:
+        # A misconfigured query (wrong shape / bad config) fails loud with AlertExtractionError. That's
+        # a config problem, not a bug: it must auto-disable + email the owner, not hit error tracking.
+        with (
+            patch(
+                "posthog.temporal.alerts.activities.check_alert_for_insight",
+                side_effect=AlertExtractionError("query returns 2 numeric columns — pick one"),
+            ),
+            patch("posthog.temporal.alerts.activities.capture_exception") as mock_capture,
+        ):
+            env = ActivityEnvironment()
+            result = await env.run(evaluate_alert, EvaluateAlertActivityInputs(alert_id=str(alert.id)))
+
+        assert result.new_state == AlertState.ERRORED
+        assert result.should_notify is False  # disable_invalid_alert already emailed subscribers
+        mock_capture.assert_not_called()
+
+        check = await sync_to_async(AlertCheck.objects.get)(pk=result.alert_check_id)
+        assert check.state == AlertState.ERRORED
+        assert check.error is not None
+        assert "2 numeric columns" in check.error["message"]
+
+        refreshed = await sync_to_async(AlertConfiguration.objects.get)(pk=alert.pk)
+        assert refreshed.enabled is False
 
     async def test_evaluate_reraises_ch_transient_error(self, alert) -> None:
         # Transient CH errors bubble up so Temporal's retry policy handles them.


### PR DESCRIPTION
> Claude-written:

## Problem

Our error-tracking inbox was collecting deliberate fail-loud validation errors from misconfigured SQL alerts, not real bugs. When a SQL/HogQL alert is set up in a way the extractor can't evaluate (a non-numeric result column, two numeric columns with no pick, too many rows for the eval mode, a bad result shape), it raises `AlertExtractionError` on purpose. At evaluation time this hit the generic `except Exception` in `evaluate_alert`, which called `capture_exception`. So a user config problem showed up as an exception, and because the alert stayed enabled it re-errored and re-captured on every check.

## Changes

`evaluate_alert` now catches `AlertExtractionError` before the generic handler and routes it to the existing `disable_invalid_alert` path. That auto-disables the alert, records an ERRORED `AlertCheck`, and emails subscribers via the `alert_disabled` template, all without calling `capture_exception`. Genuine bugs (unexpected exceptions, ClickHouse errors) still flow to error tracking as before.

`disable_invalid_alert` now returns the `AlertCheck` it creates so the evaluation path can report it back in the activity result.

On catching these before they reach the DB: the alert modal already surfaces the same shape checks at configure time via the frontend preview mirror (`hogqlAlertPreview.ts` reproduces the extractor's rules). The remaining cases are data-dependent (a query returning one numeric column today, two tomorrow), so they can't be caught statically at save and the auto-disable + email path is the necessary backstop. I deliberately did not add a synchronous ClickHouse query to the save request. A server-side hard gate (run the query once at save, reject with a 400) could follow if we want the API to be authoritative for non-UI clients.

## How did you test this code?

Added `test_evaluate_auto_disables_and_skips_error_tracking_on_extraction_error` in `test_alerts_activities.py`. It catches the regression that no existing test covered: an `AlertExtractionError` at evaluation time must auto-disable the alert and stay out of error tracking. It asserts the alert ends up disabled, an ERRORED `AlertCheck` is recorded with the reason, `capture_exception` is not called, and the result reports `should_notify=False`. The existing `test_evaluate_errored_when_permanent_exception` covers the opposite case (a generic exception stays enabled and is captured), so the two are distinct.

I (Claude) could not run the DB-backed async tests in my environment (no Postgres available in the session). The changed files byte-compile cleanly and I reviewed the logic, but the suite needs to run in CI.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Authored by Claude (PostHog Slack app) from a Slack thread, directed by Vasco. Traced the alert evaluation path (`posthog/temporal/alerts/activities.py` → `products/alerts/backend/evaluation/`), found `AlertExtractionError` was the deliberate fail-loud marker being swept into `capture_exception`, and reused the already-present `disable_invalid_alert` + `alert_disabled` email system rather than building anything new.

Considered adding save-time API validation that runs the query, but rejected making it synchronous in the save request over latency/cost, and because the UI preview already gives configure-time feedback for the statically-knowable cases. Left that as an optional follow-up.

Invoked the `/writing-tests` skill before adding the test.

---
*Created with [PostHog](https://posthog.com?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09BDQLM8KA/p1782893741009949?thread_ts=1782893741.009949&cid=C09BDQLM8KA)*
