### PR TITLE
feat(replay-vision): warn before discarding unsaved scanner edits

### DIFF
--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.test.ts
@@ -1,6 +1,8 @@
 import { router } from 'kea-router'
 import { expectLogic } from 'kea-test-utils'
 
+import { urls } from 'scenes/urls'
+
 import { useMocks } from '~/mocks/jest'
 import { initKeaTests } from '~/test/init'
 
@@ -12,6 +14,7 @@ import {
     parseCsvParam,
     parseSortParam,
     replayScannerLogic,
+    shouldGuardScannerNavigation,
 } from './replayScannerLogic'
 import { defaultScannerTemplates } from './scannerTemplates'
 import { ClassifierScanner, ReplayScanner, ScorerScanner } from './types'
@@ -551,6 +554,37 @@ describe('replayScannerLogic', () => {
             await expectLogic(logic, () => logic.actions.setScannerValues({ name: 'Edited' })).toMatchValues({
                 hasUnsavedChanges: true,
             })
+        })
+    })
+
+    describe('shouldGuardScannerNavigation', () => {
+        const scannerId = 'abc-123'
+        const configure = urls.replayVisionScannerConfigure(scannerId)
+        const triggers = urls.replayVisionScannerTriggers(scannerId)
+        const template = urls.replayVisionScannerTemplate(scannerId)
+        const detail = urls.replayVision(scannerId)
+        const base = { hasUnsavedChanges: true, isSubmitting: false, scannerId, currentPathname: configure }
+
+        it.each([
+            // Nothing to lose, or the editor is mid-submit (save / step advance redirects itself).
+            ['no unsaved changes', { ...base, hasUnsavedChanges: false, nextPathname: '/insights' }, false],
+            ['mid-submit redirect to detail', { ...base, isSubmitting: true, nextPathname: detail }, false],
+            // Moving between the wizard's own steps keeps the same draft mounted.
+            ['forward to triggers step', { ...base, nextPathname: triggers }, false],
+            ['back to template step', { ...base, currentPathname: triggers, nextPathname: template }, false],
+            // Only guard while actually inside this scanner's editor.
+            ['not currently in the editor', { ...base, currentPathname: detail, nextPathname: '/insights' }, false],
+            // Genuinely leaving the editor with unsaved edits.
+            ['out to the detail page', { ...base, nextPathname: detail }, true],
+            ['out to an unrelated scene', { ...base, nextPathname: '/insights' }, true],
+            ['closing the tab (no next location)', { ...base, nextPathname: undefined }, true],
+            [
+                'over to a different scanner’s editor',
+                { ...base, nextPathname: urls.replayVisionScannerConfigure('other-id') },
+                true,
+            ],
+        ])('%s', (_label, params, expected) => {
+            expect(shouldGuardScannerNavigation(params)).toBe(expected)
         })
     })
 

--- a/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
+++ b/products/replay_vision/frontend/replay_scanners/replayScannerLogic.ts
@@ -1,7 +1,8 @@
 import equal from 'fast-deep-equal'
 import { actions, afterMount, isBreakpoint, kea, key, listeners, path, props, reducers, selectors } from 'kea'
 import { forms } from 'kea-forms'
-import { actionToUrl, router, urlToAction } from 'kea-router'
+import { actionToUrl, beforeUnload, router, urlToAction } from 'kea-router'
+import { CombinedLocation } from 'kea-router/lib/utils'
 
 import { dayjs } from 'lib/dayjs'
 import { lemonToast } from 'lib/lemon-ui/LemonToast'
@@ -1052,6 +1053,23 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
         },
     })),
 
+    beforeUnload(({ values, actions, props }) => ({
+        enabled: (newLocation?: CombinedLocation) =>
+            shouldGuardScannerNavigation({
+                hasUnsavedChanges: values.hasUnsavedChanges,
+                isSubmitting: values.isScannerSubmitting,
+                scannerId: props.id,
+                currentPathname: router.values.location.pathname,
+                nextPathname: newLocation?.pathname,
+            }),
+        message: 'Leave scanner editor?\nChanges you made will be discarded.',
+        onConfirm: () => {
+            if (values.originalScanner) {
+                actions.resetScanner(values.originalScanner)
+            }
+        },
+    })),
+
     afterMount(({ actions, props }) => {
         actions.loadScanner()
         if (props.id !== 'new') {
@@ -1062,6 +1080,42 @@ export const replayScannerLogic = kea<replayScannerLogicType>([
 ])
 
 const TABLE_URL_PARAM_KEYS = ['page', 'sort', 'status', 'triggered_by', 'verdict', 'tags', 'recording_subject'] as const
+
+/** The three step URLs of a scanner's editor wizard. */
+function scannerEditorPaths(scannerId: string): string[] {
+    return [
+        urls.replayVisionScannerTemplate(scannerId),
+        urls.replayVisionScannerConfigure(scannerId),
+        urls.replayVisionScannerTriggers(scannerId),
+    ]
+}
+
+/**
+ * Whether leaving the current location should warn about losing unsaved scanner edits.
+ * Only guards while actually inside this scanner's editor, and stays quiet for the
+ * navigation the editor triggers itself: moving between its own steps, and the
+ * programmatic redirect that a save/advance fires while submitting.
+ */
+export function shouldGuardScannerNavigation(params: {
+    hasUnsavedChanges: boolean
+    isSubmitting: boolean
+    scannerId: string
+    currentPathname: string
+    nextPathname?: string
+}): boolean {
+    const { hasUnsavedChanges, isSubmitting, scannerId, currentPathname, nextPathname } = params
+    if (!hasUnsavedChanges || isSubmitting) {
+        return false
+    }
+    const editorPaths = scannerEditorPaths(scannerId)
+    if (!editorPaths.includes(currentPathname)) {
+        return false
+    }
+    if (nextPathname && editorPaths.includes(nextPathname)) {
+        return false
+    }
+    return true
+}
 
 export function parseSortParam(value: string | undefined): ObservationsSorting | null {
     if (typeof value !== 'string' || value.length === 0) {


### PR DESCRIPTION
> Claude-written (agent-assisted, directed by @arnohillen)

## Problem

The scanner editor holds long, hand-written AI prompts. Today nothing protects that work: navigate away, close the tab, or hit refresh mid-edit and the prompt is gone with no warning. This came out of a product opportunity review flagging accidental loss of custom prompts on the scanner config page.

## Changes

Wire a `beforeUnload` guard into `replayScannerLogic` (the editor's form logic). When the form has unsaved changes and you leave the editor, you get a confirmation prompt instead of silently losing edits. It covers both in-app navigation (kea-router `confirm`) and browser tab close / refresh (native `beforeunload`).

The guard deliberately stays quiet for navigation the editor itself drives, so it never nags on the happy path:

- moving between the wizard's own steps (template → configure → triggers),
- the redirect a save or "next" fires while submitting,
- the read-only scanner detail page (where a quick enable/disable toggle briefly looks dirty).

The whole decision is a pure, exported `shouldGuardScannerNavigation()` helper, so the branching is unit tested directly rather than through router plumbing. It reuses the `hasUnsavedChanges` selector that already existed but was never wired to anything.

No new rendered UI. The only visible artifact is the browser's standard "Leave site? / Changes you made will be discarded" confirmation dialog. I did not spin up the full dev stack to screenshot a native dialog, happy to capture it if useful.

### Why not localStorage draft-saving?

The original idea was to stash drafts in `localStorage`. I went with the `beforeUnload` guard instead because it is the established PostHog pattern (feature flags, actions, notebooks, hog functions all use it), it is a small amount of code with no persistence edge cases (staleness, per-scanner keys, clear-on-submit, multi-tab conflicts), and it solves the actual reported problem of accidental loss on navigate or close. localStorage draft recovery only adds value for surviving a hard crash or an intentional "leave anyway", and can be a focused follow-up if we see that need.

## How did you test this code?

Automated (what I actually ran):

- `replayScannerLogic.test.ts`: 58/58 pass, including 9 new parameterized cases on `shouldGuardScannerNavigation` covering not-dirty, mid-submit, step-to-step nav (both directions), leaving to the detail page, leaving to an unrelated scene, tab close, "not currently in the editor", and crossing to a different scanner's editor.
- `tsgo` typecheck: no errors in the changed files.
- oxlint + oxfmt: clean.

I did not manually click through the editor in a running app.

The new tests catch the two regressions that matter: warning on the editor's own step/save navigation (a false positive that would nag users), and failing to warn when genuinely leaving with an edited prompt (a false negative, the whole point).

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted), directed by @arnohillen.

Built with Claude Code (Opus 4.8). I explored the scanner editor with a read-only search agent, confirmed the wizard's routing and the existing (unused) `hasUnsavedChanges` selector, and read the kea-router `beforeUnload` internals to get the fire semantics right: it runs on every `router.push`, and with no argument on native tab close.

Skills invoked: `/writing-tests` (test value gate).

Decisions: chose `beforeUnload` over the initially-suggested localStorage draft (rationale above). Extracted the decision into a pure helper specifically so it could be tested at the cheapest rung instead of mocking `window.confirm` and router navigation. Gated the guard on both `isScannerSubmitting` and a "currently inside this scanner's editor" check to avoid false positives on saves, step changes, and the detail-page toggle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
