### PR TITLE
fix(cdp): backfill teams powerplatform url support to old destinations

### DIFF
--- a/posthog/management/commands/test/test_update_hog_function_code.py
+++ b/posthog/management/commands/test/test_update_hog_function_code.py
@@ -295,7 +295,7 @@ class TestUpdateHogFunctionCode(BaseTest):
         assert POWERPLATFORM_BRANCH in function.hog
         self.assertIn("Updated: 1", out.getvalue())
         # The migrated source must be valid Hog - guards against a typo in the replacement's to_string.
-        compile_hog_for_check(function.hog, function.type)
+        compile_hog_for_check(function.hog, "destination")
 
     def test_microsoft_teams_migration_leaves_functions_without_the_stale_block_untouched(self):
         function = self._create_teams_function(COMMENTED_OUT_STALE)

--- a/posthog/management/commands/test/test_update_hog_function_code.py
+++ b/posthog/management/commands/test/test_update_hog_function_code.py
@@ -5,7 +5,43 @@ from unittest.mock import patch
 
 from django.core.management import call_command
 
+from parameterized import parameterized
+
+from posthog.cdp.validation import compile_hog as compile_hog_for_check
+
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
+
+# The powerplatform branch the migration must splice into stale Microsoft Teams functions.
+POWERPLATFORM_BRANCH = "environment.api.powerplatform.com(:443)?/powerautomate/automations/direct/workflows"
+
+# The exact tail shared by the standard 4-branch stock block and the powerplatform.com:443 variant.
+_FOUR_BRANCH_TAIL = "not match(inputs.webhookUrl, '^https://[^/]+.flow.microsoft.com/[^/]+')) {\n    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), or Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...)')"
+
+# Stale validation blocks that exist verbatim in production, each followed by a trivial send body.
+_SEND_BODY = "\n\nlet res := fetch(inputs.webhookUrl, {'method': 'POST'});\n"
+
+FOUR_BRANCH_STALE = (
+    "if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*') and\n"
+    "    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+') and\n"
+    "    not match(inputs.webhookUrl, '^https://[^/]+.powerautomate.com/[^/]+') and\n    " + _FOUR_BRANCH_TAIL + "\n}"
+) + _SEND_BODY
+
+POWERPLATFORM_COM_STALE = (
+    "if (not match(inputs.webhookUrl, '^https://[^/]+.powerplatform.com:443/[^/]+/.*') and\n"
+    "    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+') and\n"
+    "    not match(inputs.webhookUrl, '^https://[^/]+.powerautomate.com/[^/]+') and\n    " + _FOUR_BRANCH_TAIL + "\n}"
+) + _SEND_BODY
+
+ONE_BRANCH_STALE = (
+    "if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*')) {\n"
+    "    throw Error('Invalid URL. The URL should match the format: https://<region>.logic.azure.com:443/workflows/<workflowId>/triggers/manual/paths/invoke?...')\n}"
+) + _SEND_BODY
+
+# Same block but commented out - validation is disabled, so it already accepts any URL and must be left alone.
+COMMENTED_OUT_STALE = (
+    "// if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*')) {\n"
+    "//     throw Error('Invalid URL.')\n// }"
+) + _SEND_BODY
 
 
 class TestUpdateHogFunctionCode(BaseTest):
@@ -225,3 +261,48 @@ class TestUpdateHogFunctionCode(BaseTest):
         output = out.getvalue()
         self.assertIn("Found 0 destinations to process", output)
         self.assertIn("Updated: 0", output)
+
+    def _create_teams_function(self, hog: str) -> HogFunction:
+        with patch("products.cdp.backend.models.hog_functions.hog_function.reload_hog_functions_on_workers"):
+            return HogFunction.objects.create(
+                team=self.team,
+                name="Teams Function",
+                type="destination",
+                template_id="template-microsoft-teams",
+                description="Test Teams Function",
+                hog=hog,
+                enabled=True,
+            )
+
+    @parameterized.expand(
+        [
+            ("four_branch", FOUR_BRANCH_STALE),
+            ("powerplatform_com_variant", POWERPLATFORM_COM_STALE),
+            ("one_branch", ONE_BRANCH_STALE),
+        ]
+    )
+    def test_microsoft_teams_powerplatform_migration(self, _name, stale_hog):
+        function = self._create_teams_function(stale_hog)
+
+        with patch(
+            "posthog.management.commands.update_hog_function_code.compile_hog",
+            return_value="compiled_bytecode",
+        ):
+            out = StringIO()
+            call_command("update_hog_function_code", replace_key="microsoft-teams-powerplatform-url", stdout=out)
+
+        function.refresh_from_db()
+        assert POWERPLATFORM_BRANCH in function.hog
+        self.assertIn("Updated: 1", out.getvalue())
+        # The migrated source must be valid Hog - guards against a typo in the replacement's to_string.
+        compile_hog_for_check(function.hog, function.type)
+
+    def test_microsoft_teams_migration_leaves_functions_without_the_stale_block_untouched(self):
+        function = self._create_teams_function(COMMENTED_OUT_STALE)
+
+        out = StringIO()
+        call_command("update_hog_function_code", replace_key="microsoft-teams-powerplatform-url", stdout=out)
+
+        function.refresh_from_db()
+        assert POWERPLATFORM_BRANCH not in function.hog
+        self.assertIn("Updated: 0", out.getvalue())

--- a/posthog/management/commands/update_hog_function_code.py
+++ b/posthog/management/commands/update_hog_function_code.py
@@ -34,13 +34,39 @@ class Command(BaseCommand):
         replaceOptions = {
             "linked-api-version-update": {
                 "template_id": "template-linkedin-ads",
-                "from_string": "'LinkedIn-Version': '202409'",
-                "to_string": "'LinkedIn-Version': '202508'",
+                "replacements": [
+                    {
+                        "from_string": "'LinkedIn-Version': '202409'",
+                        "to_string": "'LinkedIn-Version': '202508'",
+                    },
+                ],
             },
             "meta-ads-api-version-update": {
                 "template_id": "template-meta-ads",
-                "from_string": "graph.facebook.com/v21.0/",
-                "to_string": "graph.facebook.com/v25.0/",
+                "replacements": [
+                    {
+                        "from_string": "graph.facebook.com/v21.0/",
+                        "to_string": "graph.facebook.com/v25.0/",
+                    },
+                ],
+            },
+            # Microsoft migrated Teams/Power Automate HTTP triggers to environment.api.powerplatform.com.
+            # The current template accepts that host, but functions created earlier keep their frozen code
+            # and reject the new URL. These swap the stale validation block for the current one: the
+            # standard 4-branch and the powerplatform.com:443 variant share the same tail, and the
+            # original single-branch (logic.azure.com only) block is replaced whole.
+            "microsoft-teams-powerplatform-url": {
+                "template_id": "template-microsoft-teams",
+                "replacements": [
+                    {
+                        "from_string": "not match(inputs.webhookUrl, '^https://[^/]+.flow.microsoft.com/[^/]+')) {\n    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), or Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...)')",
+                        "to_string": "not match(inputs.webhookUrl, '^https://[^/]+.flow.microsoft.com/[^/]+') and\n    not match(inputs.webhookUrl, '^https://[^/]+.environment.api.powerplatform.com(:443)?/powerautomate/automations/direct/workflows/.*')) {\n    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...), or Power Platform environment format (https://<tenant>.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/...)')",
+                    },
+                    {
+                        "from_string": "if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*')) {\n    throw Error('Invalid URL. The URL should match the format: https://<region>.logic.azure.com:443/workflows/<workflowId>/triggers/manual/paths/invoke?...')\n}",
+                        "to_string": "if (not match(inputs.webhookUrl, '^https://[^/]+.logic.azure.com:443/workflows/[^/]+/triggers/manual/paths/invoke?.*') and\n    not match(inputs.webhookUrl, '^https://[^/]+.webhook.office.com/webhookb2/[^/]+/IncomingWebhook/[^/]+/[^/]+') and\n    not match(inputs.webhookUrl, '^https://[^/]+.powerautomate.com/[^/]+') and\n    not match(inputs.webhookUrl, '^https://[^/]+.flow.microsoft.com/[^/]+') and\n    not match(inputs.webhookUrl, '^https://[^/]+.environment.api.powerplatform.com(:443)?/powerautomate/automations/direct/workflows/.*')) {\n    throw Error('Invalid URL. The URL should match either Azure Logic Apps format (https://<region>.logic.azure.com:443/workflows/...), Power Platform format (https://<tenant>.webhook.office.com/webhookb2/...), Power Automate format (https://<region>.powerautomate.com/... or https://<region>.flow.microsoft.com/...), or Power Platform environment format (https://<tenant>.environment.api.powerplatform.com:443/powerautomate/automations/direct/workflows/...)')\n}",
+                    },
+                ],
             },
         }
 
@@ -72,10 +98,17 @@ class Command(BaseCommand):
             )
 
             for destination in page.object_list:
-                if not destination.hog or replaceOption["from_string"] not in destination.hog:
+                if not destination.hog:
                     continue
 
-                new_hog = destination.hog.replace(replaceOption["from_string"], replaceOption["to_string"])
+                new_hog = destination.hog
+                for replacement in replaceOption["replacements"]:
+                    if replacement["from_string"] in new_hog:
+                        new_hog = new_hog.replace(replacement["from_string"], replacement["to_string"])
+
+                if new_hog == destination.hog:
+                    continue
+
                 # A single destination with uncompilable (e.g. hand-edited) hog must not abort the whole run.
                 try:
                     new_bytecode = compile_hog(new_hog, destination.type)

--- a/posthog/management/commands/update_hog_function_code.py
+++ b/posthog/management/commands/update_hog_function_code.py
@@ -1,4 +1,5 @@
 import time
+from typing import TypedDict
 
 from django.core.management.base import BaseCommand
 from django.core.paginator import Paginator
@@ -10,6 +11,16 @@ from posthog.cdp.validation import compile_hog
 from products.cdp.backend.models.hog_functions.hog_function import HogFunction
 
 logger = structlog.get_logger(__name__)
+
+
+class _Replacement(TypedDict):
+    from_string: str
+    to_string: str
+
+
+class _ReplaceOption(TypedDict):
+    template_id: str
+    replacements: list[_Replacement]
 
 
 class Command(BaseCommand):
@@ -31,7 +42,7 @@ class Command(BaseCommand):
         replace_key = options.get("replace_key", None)
         start_time = time.time()
 
-        replaceOptions = {
+        replaceOptions: dict[str, _ReplaceOption] = {
             "linked-api-version-update": {
                 "template_id": "template-linkedin-ads",
                 "replacements": [


### PR DESCRIPTION
## Problem

A user reported that their Power Automate destination stopped accepting its webhook URL ([Zendesk 61552](https://posthoghelp.zendesk.com/agent/tickets/61552)). Microsoft moved Power Automate and Teams HTTP trigger URLs to a new host, `environment.api.powerplatform.com`, and is retiring the older `logic.azure.com` URLs.

The Microsoft Teams destination template already accepts the new format (added in #41202), but hog functions store their own copy of the validation code at creation time and never auto-adopt template updates. Destinations created before #41202 still run the old regex and reject the new URL once Microsoft cuts their trigger over.

The one report turned out to be the tip of it. Digging into live destinations, roughly 160 are on the old code and will break as Microsoft completes the migration, and around 30 are already failing. Affected users can fix it themselves with "Reset to template", but most won't know to. This backfills the fix so a single run repairs the ones on standard code (a small number of hand-customised destinations are left untouched for manual follow-up).

## Changes

Adds a `microsoft-teams-powerplatform-url` replace key to the existing `update_hog_function_code` backfill command. It swaps the stale validation block in existing destinations for the current one.

The command previously supported a single find/replace per key. This extends each key to a list of replacements so one run can cover the different historical shapes of the block. The Teams key carries two:

- The 4-branch stock block (also shared by an older `powerplatform.com:443` variant) - a tail splice that adds the powerplatform branch.
- The original single-branch block (`logic.azure.com` only) - replaced whole with the current 5-branch block.

Both target strings match the current template exactly, so a patched destination ends up identical to a freshly created one. Functions that don't contain a known stale block (hand-edited, or with validation commented out) are left untouched, and any function whose result fails to compile is skipped and logged rather than aborting the run.

Run per region after deploy, dry-run first:

```
./manage.py update_hog_function_code --replace-key microsoft-teams-powerplatform-url --dry-run
./manage.py update_hog_function_code --replace-key microsoft-teams-powerplatform-url
```

## How did you test this code?

Added a parameterized test in `test_update_hog_function_code.py` covering the three real stale block shapes plus a commented-out (skip) case. Each case runs the migration, asserts the powerplatform branch is spliced in (or left absent for the skip case), and independently compiles the migrated source with the real Hog compiler to prove it is valid Hog.

The regression it guards: a typo in the exact-match find/replace strings would silently no-op the migration, leaving destinations broken with no error. No existing test covered the Teams key or the multi-replacement-per-key path.

I (Claude) ran the full test file locally - 11 passed. I have not run the command against any real data; that is an operator step after deploy.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Started from a support report of a rejected Power Automate URL. I traced the validator to the Microsoft Teams template, found the powerplatform format was already supported in-repo, and confirmed against production that the affected destination stored pre-fix validation code - establishing that existing hog functions freeze template code at creation and never auto-upgrade. That reframed the fix from "update the template" (already done) to "backfill existing functions".

I profiled the distinct stale block shapes to size coverage and shape the replacements, then chose to extend the existing `update_hog_function_code` command rather than add a new one. I considered a full "reset hog to the current template code" approach but rejected it: for older functions that would also rewrite the message-send body, so a targeted validation-block swap is the smaller, safer blast radius.

Skills invoked: /writing-tests. Tooling: Claude Code (Opus 4.8).

