### PR TITLE
fix(experiments): tag precompute window on the insert path builds actually use

### DIFF
--- a/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
+++ b/products/analytics_platform/backend/lazy_computation/lazy_computation_executor.py
@@ -1202,7 +1202,12 @@ def ensure_precomputed(
             base_placeholders=base_placeholders,
         )
         set_ch_query_started(job.id)
-        tag_kwargs: dict = {"client_query_id": str(job.id), "team_id": t.id}
+        tag_kwargs: dict = {
+            "client_query_id": str(job.id),
+            "team_id": t.id,
+            "precompute_window_start": str(job.time_range_start),
+            "precompute_window_end": str(job.time_range_end),
+        }
         if query_type:
             tag_kwargs["query_type"] = query_type
         with tags_context(**tag_kwargs):


### PR DESCRIPTION
The "Scan window" column added to the query-performance table is always blank for precompute-build sub-queries. The window tag was set on `_run_insert`, but precompute builds run through `ensure_precomputed()`, which executes the INSERT via `_run_manual_insert` — a separate path that never carried the tag. So build rows' `log_comment` had no window and the column rendered nothing.

Adds `precompute_window_start`/`precompute_window_end` (from the job's time range) to `_run_manual_insert`'s tag context, matching what `_run_insert` already sets.

## 🤖 Agent context

Internal staff-only tooling; forward-only tag. Fix on the shared lazy-computation executor. No new tests — the parallel path (`_run_insert`) already sets the same tags the same way, and it's a trivial passthrough. New build INSERTs will populate the window; rows logged before this ships stay blank.
