### PR TITLE
fix(notebooks): keep migrated filters closed

### DIFF
--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.test.ts
@@ -330,7 +330,7 @@ describe('markdownNotebookDowngrade', () => {
     it('converts component tags to their v1 node type with props as attrs', () => {
         expect(convertMarkdownToNotebookContent('<Query query={{"kind":"DataTableNode"}} />')).toEqual({
             type: 'doc',
-            content: [{ type: NotebookNodeType.Query, attrs: { query: { kind: 'DataTableNode' } } }],
+            content: [{ type: NotebookNodeType.Query, attrs: { query: { kind: 'DataTableNode' }, edit: true } }],
         })
     })
 

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.ts
@@ -123,12 +123,19 @@ function convertComponentNode(node: NotebookComponentBlockNode): JSONContent | n
 
     const notebookNodeType = MARKDOWN_TAG_TO_NOTEBOOK_NODE_TYPE[node.tagName]
     if (notebookNodeType) {
-        return { type: notebookNodeType, attrs: { ...node.props } }
+        return { type: notebookNodeType, attrs: getNotebookNodeAttrsForMarkdownComponent(node) }
     }
 
     // No v1 node type for this tag — keep the serialized tag source as paragraph text so the
     // content is never silently lost.
     return makeParagraph(makeTextWithHardBreaks(serializeNode(node)))
+}
+
+function getNotebookNodeAttrsForMarkdownComponent(node: NotebookComponentBlockNode): JSONContent['attrs'] {
+    if (typeof node.props.hideFilters === 'boolean' || typeof node.props.edit === 'boolean') {
+        return { ...node.props }
+    }
+    return { ...node.props, edit: true }
 }
 
 function convertListNode(node: NotebookListBlockNode): JSONContent[] {

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts
@@ -87,6 +87,13 @@ describe('markdownNotebookV2', () => {
                     },
                 },
                 {
+                    type: NotebookNodeType.Recording,
+                    attrs: {
+                        id: '018b4205-f670-7fa8-928a-040abaaf596d',
+                        title: 'Session replay',
+                    },
+                },
+                {
                     type: NotebookNodeType.Image,
                     attrs: {
                         src: 'https://res.cloudinary.com/demo/image/upload/posthog.png',
@@ -100,9 +107,33 @@ describe('markdownNotebookV2', () => {
 
 A **bold** paragraph.
 
-<Query query={{"kind":"InsightVizNode","source":{"kind":"FunnelsQuery","series":[]}}} />
+<Query hideFilters query={{"kind":"InsightVizNode","source":{"kind":"FunnelsQuery","series":[]}}} />
+
+<Recording hideFilters id="018b4205-f670-7fa8-928a-040abaaf596d" title="Session replay" />
 
 ![PostHog engineering](https://res.cloudinary.com/demo/image/upload/posthog.png)`)
+    })
+
+    it('preserves explicitly open legacy widget filters', () => {
+        const content: JSONContent = {
+            type: 'doc',
+            content: [
+                {
+                    type: NotebookNodeType.Query,
+                    attrs: {
+                        query: {
+                            kind: 'SavedInsightNode',
+                            shortId: 'open',
+                        },
+                        edit: true,
+                    },
+                },
+            ],
+        }
+
+        expect(convertNotebookContentToMarkdown(content)).toEqual(
+            '<Query query={{"kind":"SavedInsightNode","shortId":"open"}} />'
+        )
     })
 
     it('converts raw legacy content arrays without dropping top-level text nodes', () => {
@@ -152,9 +183,9 @@ Wrapped paragraph`)
         }
 
         expect(convertNotebookContentToMarkdown(content))
-            .toEqual(`<Query query={{"kind":"SavedInsightNode","shortId":"abc123"}} />
+            .toEqual(`<Query hideFilters query={{"kind":"SavedInsightNode","shortId":"abc123"}} />
 
-<Query query={{"kind":"SavedInsightNode","shortId":"def456"}} />`)
+<Query hideFilters query={{"kind":"SavedInsightNode","shortId":"def456"}} />`)
     })
 
     it('converts remaining legacy production node shapes without unknown nodes', () => {
@@ -179,7 +210,7 @@ Wrapped paragraph`)
 
 Dashboard 123
 
-<Query query={{"kind":"DataVisualizationNode","source":{"kind":"HogQLQuery","query":"select event from events limit 1"}}} />`)
+<Query hideFilters query={{"kind":"DataVisualizationNode","source":{"kind":"HogQLQuery","query":"select event from events limit 1"}}} />`)
     })
 
     it('keeps the stable id vector for markdown query blocks without nodeId props', () => {
@@ -213,7 +244,7 @@ Dashboard 123
 
         // Nested undefined must be stripped, not cause the whole query prop to be dropped.
         expect(convertNotebookContentToMarkdown(content)).toEqual(
-            '<Query query={{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[{"kind":"EventsNode","event":"$pageview"}]}}} isDefaultFilterApplied={false} />'
+            '<Query hideFilters query={{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[{"kind":"EventsNode","event":"$pageview"}]}}} isDefaultFilterApplied={false} />'
         )
     })
 

--- a/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
+++ b/frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts
@@ -486,7 +486,7 @@ function serializeRichContentNode(
             id: '',
             type: 'component',
             tagName: markdownTagName,
-            props: getSerializableAttrs(node.attrs),
+            props: withDefaultHiddenFilters(getSerializableAttrs(node.attrs)),
         })
     }
 
@@ -516,9 +516,9 @@ function serializeLegacyInsightNode(node: JSONContent): string {
         id: '',
         type: 'component',
         tagName: 'Query',
-        props: {
+        props: withDefaultHiddenFilters({
             query: { kind: NodeKind.SavedInsightNode, shortId: insightShortId },
-        },
+        }),
     })
 }
 
@@ -542,7 +542,7 @@ function serializeLegacyQueryNode(node: JSONContent): string {
         id: '',
         type: 'component',
         tagName: 'Query',
-        props,
+        props: withDefaultHiddenFilters(props),
     })
 }
 
@@ -803,6 +803,13 @@ function getSerializableAttrs(attrs: Record<string, unknown> | undefined): Noteb
         }
         return props
     }, {})
+}
+
+function withDefaultHiddenFilters(props: NotebookComponentProps): NotebookComponentProps {
+    if (typeof props.hideFilters === 'boolean' || typeof props.edit === 'boolean') {
+        return props
+    }
+    return { ...props, hideFilters: true }
 }
 
 // Widget node attributes round-trip through HTML as JSON strings (NodeWrapper's jsonAttr), so a

--- a/frontend/src/scenes/notebooks/Notebook/notebookUpgradeDialog.test.tsx
+++ b/frontend/src/scenes/notebooks/Notebook/notebookUpgradeDialog.test.tsx
@@ -66,7 +66,7 @@ describe('notebookUpgradeDialog', () => {
         expect(isMarkdownNotebookContent(convertedContent)).toBe(true)
         expect(getMarkdownNotebookMarkdown(convertedContent)).toEqual(`# Activation
 
-<Query query={{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[]}}} />`)
+<Query hideFilters query={{"kind":"InsightVizNode","source":{"kind":"TrendsQuery","series":[]}}} />`)
     })
 
     it('embeds comment threads from range-anchored comments during conversion', () => {

--- a/products/notebooks/backend/markdown_conversion.py
+++ b/products/notebooks/backend/markdown_conversion.py
@@ -287,7 +287,9 @@ def _serialize_rich_content_node(
     if isinstance(node_type, str) and node_type in NOTEBOOK_NODE_TYPE_TO_MARKDOWN_TAG:
         return _serialize_component_node(
             NOTEBOOK_NODE_TYPE_TO_MARKDOWN_TAG[node_type],
-            _get_serializable_attrs(node.get("attrs") if isinstance(node.get("attrs"), dict) else None),
+            _with_default_hidden_filters(
+                _get_serializable_attrs(node.get("attrs") if isinstance(node.get("attrs"), dict) else None)
+            ),
         )
 
     child_markdown = "\n\n".join(
@@ -314,7 +316,10 @@ def _serialize_legacy_insight_node(node: JSONContent) -> str:
     insight_short_id = attrs.get("short_id") if isinstance(attrs.get("short_id"), str) else attrs.get("id")
     if not isinstance(insight_short_id, str) or not insight_short_id:
         return _serialize_unknown_rich_content_node(node)
-    return _serialize_component_node("Query", {"query": {"kind": "SavedInsightNode", "shortId": insight_short_id}})
+    return _serialize_component_node(
+        "Query",
+        _with_default_hidden_filters({"query": {"kind": "SavedInsightNode", "shortId": insight_short_id}}),
+    )
 
 
 def _serialize_legacy_dashboard_node(node: JSONContent) -> str:
@@ -330,7 +335,7 @@ def _serialize_legacy_query_node(node: JSONContent) -> str:
     query = props.get("query")
     if isinstance(query, dict) and query.get("kind") == "HogQLQuery":
         props["query"] = {"kind": "DataVisualizationNode", "source": query}
-    return _serialize_component_node("Query", props)
+    return _serialize_component_node("Query", _with_default_hidden_filters(props))
 
 
 def _serialize_legacy_link_node(node: JSONContent, options: NotebookMarkdownConversionOptions) -> str:
@@ -626,6 +631,12 @@ def _get_serializable_component_props(props: Mapping[str, NotebookPropValue]) ->
     if hide_results:
         next_props["hideResults"] = True
     return next_props
+
+
+def _with_default_hidden_filters(props: dict[str, NotebookPropValue]) -> dict[str, NotebookPropValue]:
+    if isinstance(props.get("hideFilters"), bool) or isinstance(props.get("edit"), bool):
+        return props
+    return {**props, "hideFilters": True}
 
 
 def _get_ordered_component_prop_entries(props: Mapping[str, NotebookPropValue]) -> list[tuple[str, NotebookPropValue]]:

--- a/products/notebooks/backend/test/test_markdown_migration.py
+++ b/products/notebooks/backend/test/test_markdown_migration.py
@@ -93,6 +93,50 @@ class TestNotebookMarkdownConversion(BaseTest):
         assert "juheapi" not in markdown
         assert "hideFilters" in markdown
 
+    def test_converts_v1_widget_nodes_with_filters_closed_by_default(self) -> None:
+        content = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "ph-query",
+                    "attrs": {
+                        "query": {"kind": "SavedInsightNode", "shortId": "ZcWG6625"},
+                        "title": "Activation",
+                    },
+                },
+                {
+                    "type": "ph-recording",
+                    "attrs": {
+                        "id": "018b4205-f670-7fa8-928a-040abaaf596d",
+                        "title": "Session replay",
+                    },
+                },
+                {
+                    "type": "ph-insight",
+                    "attrs": {
+                        "id": "legacyInsight",
+                    },
+                },
+                {
+                    "type": "ph-query",
+                    "attrs": {
+                        "query": {"kind": "SavedInsightNode", "shortId": "open"},
+                        "edit": True,
+                    },
+                },
+            ],
+        }
+
+        markdown = convert_notebook_content_to_markdown(content)
+
+        assert (
+            '<Query hideFilters query={{"kind":"SavedInsightNode","shortId":"ZcWG6625"}} title="Activation" />'
+            in markdown
+        )
+        assert '<Recording hideFilters id="018b4205-f670-7fa8-928a-040abaaf596d" title="Session replay" />' in markdown
+        assert '<Query hideFilters query={{"kind":"SavedInsightNode","shortId":"legacyInsight"}} />' in markdown
+        assert '<Query query={{"kind":"SavedInsightNode","shortId":"open"}} />' in markdown
+
     def test_converts_legacy_markdown_ast_alias_nodes_without_losing_structure(self) -> None:
         content = {
             "type": "doc",


### PR DESCRIPTION
> Codex-written:

## Problem

V1 notebook widget filters were closed by default unless a user explicitly opened a node's settings. During markdown migration, some widget node shapes did not carry an explicit `edit` flag, so the converted markdown omitted `hideFilters`. The v2 markdown renderer then treated those components as having open filters, which made migrated notebooks noisier than the original v1 view.

## Changes

The backend markdown converter now adds `hideFilters` to migrated notebook widget components by default, unless the source node explicitly persisted `hideFilters` or `edit`.

The frontend markdown converter mirrors the same rule so local conversion paths stay consistent with backend migration.

The markdown downgrade bridge marks markdown-origin widget components with `edit: true` when their filters are open. That keeps markdown -> v1 -> markdown round trips from gaining `hideFilters` by accident.

Regression tests cover v1 `ph-query`, `ph-insight`, and other widget components with closed filters by default, while preserving explicitly open legacy filters and markdown-origin open filters.

## How did you test this code?

- `hogli test products/notebooks/backend/test/test_markdown_migration.py`
- `hogli test frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts`
- `hogli test frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.test.ts`
- `hogli test frontend/src/scenes/notebooks/Notebook/notebookUpgradeDialog.test.tsx`
- `ruff check products/notebooks/backend/markdown_conversion.py products/notebooks/backend/test/test_markdown_migration.py`
- `pnpm exec oxfmt frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.ts frontend/src/scenes/notebooks/Notebook/markdownNotebookV2.test.ts`
- `pnpm exec oxfmt frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.ts frontend/src/scenes/notebooks/Notebook/markdownNotebookDowngrade.test.ts frontend/src/scenes/notebooks/Notebook/notebookUpgradeDialog.test.tsx`

The added tests catch the regression where v1 widget nodes without an explicit `edit` attribute migrated to markdown with filters open by default, plus the round-trip regression where markdown-origin query blocks gained `hideFilters` after downgrade and upgrade.

👉 _Stay up-to-date with [PostHog coding conventions](https://posthog.com/docs/contribute/coding-conventions) for a smoother review._

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## Docs update

No docs update needed. This fixes migration state preservation for existing notebook behavior.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Codex authored this change after investigating a markdown notebook migration where v1 widget filters were closed but the migrated markdown opened all filter panels. The fix keeps the behavior in the converter rather than changing renderer defaults, because the migrated markdown should explicitly preserve the old panel state.

Skills invoked: `/writing-tests`, `github:yeet`.

The full frontend format script was attempted but stopped on existing import-cycle errors in `frontend/src/toolbar/actions/*`, so Codex ran targeted `oxfmt` for the touched frontend files instead.