### PR TITLE
feat(data-modeling): stamp PostHogScheduleType on v2 dag schedules

### DIFF
--- a/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
+++ b/products/data_modeling/backend/management/commands/migrate_teams_to_dag_schedules.py
@@ -15,16 +15,15 @@ from temporalio.client import (
     SchedulePolicy,
     ScheduleState,
 )
-from temporalio.common import RetryPolicy, SearchAttributePair, TypedSearchAttributes
+from temporalio.common import RetryPolicy
 
 from posthog.temporal.common.client import sync_connect
 from posthog.temporal.common.schedule import create_schedule, delete_schedule, schedule_exists
-from posthog.temporal.common.search_attributes import POSTHOG_DAG_ID_KEY, POSTHOG_ORG_ID_KEY, POSTHOG_TEAM_ID_KEY
 from posthog.temporal.data_modeling.workflows.execute_dag import ExecuteDAGInputs
 
 from products.data_modeling.backend.models import DAG, Node
 from products.data_modeling.backend.models.datawarehouse_saved_query import DataWarehouseSavedQuery
-from products.data_modeling.backend.schedule import build_schedule_spec
+from products.data_modeling.backend.schedule import build_schedule_spec, dag_schedule_search_attributes
 
 logger = structlog.get_logger(__name__)
 
@@ -167,12 +166,10 @@ class Command(BaseCommand):
                 state=ScheduleState(note=f"DAG schedule for team {team.pk}"),
                 policy=SchedulePolicy(overlap=ScheduleOverlapPolicy.SKIP),
             )
-            search_attributes = TypedSearchAttributes(
-                search_attributes=[
-                    SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team.pk),
-                    SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=str(team.organization_id)),
-                    SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=str(dag.id)),
-                ]
+            search_attributes = dag_schedule_search_attributes(
+                team_id=team.pk,
+                organization_id=str(team.organization_id),
+                dag_id=str(dag.id),
             )
             create_schedule(
                 temporal,

--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -18,9 +18,15 @@ from typing import TYPE_CHECKING
 
 from asgiref.sync import async_to_sync
 from temporalio.client import ScheduleCalendarSpec, ScheduleListActionStartWorkflow, ScheduleRange, ScheduleSpec
+from temporalio.common import SearchAttributePair, TypedSearchAttributes
 
 from posthog.temporal.common.client import async_connect
-from posthog.temporal.common.search_attributes import POSTHOG_DAG_ID_KEY
+from posthog.temporal.common.search_attributes import (
+    POSTHOG_DAG_ID_KEY,
+    POSTHOG_ORG_ID_KEY,
+    POSTHOG_SCHEDULE_TYPE_KEY,
+    POSTHOG_TEAM_ID_KEY,
+)
 
 from products.data_modeling.backend.models import Node
 
@@ -30,6 +36,17 @@ if TYPE_CHECKING:
 # v2 (DAG-based) schedules run this workflow; their schedule id is the DAG id. The v1 backend
 # (`data-modeling-run`, one schedule per saved query) is frozen and being migrated away from.
 DATA_MODELING_EXECUTE_DAG_WORKFLOW = "data-modeling-execute-dag"
+
+
+def dag_schedule_search_attributes(*, team_id: int, organization_id: str, dag_id: str) -> TypedSearchAttributes:
+    return TypedSearchAttributes(
+        search_attributes=[
+            SearchAttributePair(key=POSTHOG_TEAM_ID_KEY, value=team_id),
+            SearchAttributePair(key=POSTHOG_ORG_ID_KEY, value=organization_id),
+            SearchAttributePair(key=POSTHOG_DAG_ID_KEY, value=dag_id),
+            SearchAttributePair(key=POSTHOG_SCHEDULE_TYPE_KEY, value=DATA_MODELING_EXECUTE_DAG_WORKFLOW),
+        ]
+    )
 
 
 @async_to_sync


### PR DESCRIPTION
## Problem

Finding data modeling's v2 execute-dag schedules today means listing **every** schedule in the Temporal namespace and filtering client-side on the action's workflow name. The docstring on that path already warns a single unscoped listing can exhaust the namespace rate limit once the schedule fleet is large, and any namespace-wide reconciler pays the same cost.

There's no server-side filter we can use instead:

- `WorkflowType` is indexed for workflow executions, not for schedules, so schedule visibility rejects filtering on it.
- `PostHogDagId` doesn't discriminate: frozen v1 per-saved-query schedules stamp it too, so its presence is not a v2 signal.

## Changes

- Stamp `PostHogScheduleType = "data-modeling-execute-dag"` on each v2 execute-dag schedule at creation, through a new pure helper `dag_schedule_search_attributes()` that the migrate command now uses in place of its inline search-attributes block.
- The tag value reuses the existing execute-dag workflow-name constant, so it mirrors the value the client-side filter already checks rather than introducing a second magic string.

This is phase 1 of a deliberate multi-phase deploy. The read path (`get_v2_scheduled_dag_ids`) is unchanged here. Backfilling the tag onto existing schedules, then flipping both query paths to filter on it server-side, land in the stacked follow-up PRs — sequenced so the flip only takes effect **after** the backfill has run, since a flip against untagged schedules would silently miss already-migrated DAGs.

`PostHogScheduleType` is an existing, registered search-attribute key (added for exactly this reconciler-finds-its-own-schedules pattern, already used by replay_vision and session_replay), so no Temporal namespace admin change is needed.

## How did you test this code?

No behavior change to test in isolation — this only adds a search attribute at schedule creation, and the read path still works exactly as before. `ruff` and `ty check` pass via lint-staged. The stacked flip PR updates the existing `get_v2_scheduled_dag_ids` query-path tests, which is where the observable behavior lands. I (Claude) did no manual or prod testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @sakce, written by Claude (Claude Code).

Two decisions worth flagging for review:

- **Multi-phase split.** I deliberately shipped only the stamping here and deferred the backfill + read-path flip to stacked follow-ups, because a read that filters on the tag before existing schedules are backfilled would miss migrated DAGs and let v1 schedule commands revive them.
- **Tag value.** Chose to reuse the existing execute-dag workflow-name constant as the `PostHogScheduleType` value rather than mint a new string, so the tag and the existing client-side workflow filter agree by construction. (The other reconcilers using this key use a descriptive `-sweep` slug instead.)
