### PR TITLE
chore(signals): note manual scout runs consume the daily run budget

### DIFF
--- a/products/signals/backend/scout_harness/views.py
+++ b/products/signals/backend/scout_harness/views.py
@@ -1533,9 +1533,11 @@ class SignalScoutConfigViewSet(TeamAndOrgViewSetMixin, viewsets.GenericViewSet):
             "The run executes asynchronously on the worker and inherits every guard the scheduled "
             "path has: it is forbidden if scouts are not enabled for the project (403), and skipped "
             "if the project is over its Signals credits quota or daily run budget (429) or a run for "
-            "this scout is already in progress (409). A manual run does not change the scout's "
-            "schedule or `last_run_at`. A disabled scout can still be run this way (to test before "
-            "enabling). Returns immediately with the workflow id — poll the scout's runs for the result."
+            "this scout is already in progress (409). A manual run counts against the same daily run "
+            "budget as scheduled runs, so repeated manual runs of the same scout can exhaust the "
+            "project's daily allowance. A manual run does not change the scout's schedule or "
+            "`last_run_at`. A disabled scout can still be run this way (to test before enabling). "
+            "Returns immediately with the workflow id — poll the scout's runs for the result."
         ),
         operation_id="signals_scout_config_run",
     )

--- a/products/signals/frontend/generated/api.ts
+++ b/products/signals/frontend/generated/api.ts
@@ -504,7 +504,7 @@ export const getSignalsScoutConfigRunUrl = (projectId: string, id: string) => {
 }
 
 /**
- * Dispatch one on-demand run of this scout immediately, regardless of its schedule. Useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously on the worker and inherits every guard the scheduled path has: it is forbidden if scouts are not enabled for the project (403), and skipped if the project is over its Signals credits quota or daily run budget (429) or a run for this scout is already in progress (409). A manual run does not change the scout's schedule or `last_run_at`. A disabled scout can still be run this way (to test before enabling). Returns immediately with the workflow id — poll the scout's runs for the result.
+ * Dispatch one on-demand run of this scout immediately, regardless of its schedule. Useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously on the worker and inherits every guard the scheduled path has: it is forbidden if scouts are not enabled for the project (403), and skipped if the project is over its Signals credits quota or daily run budget (429) or a run for this scout is already in progress (409). A manual run counts against the same daily run budget as scheduled runs, so repeated manual runs of the same scout can exhaust the project's daily allowance. A manual run does not change the scout's schedule or `last_run_at`. A disabled scout can still be run this way (to test before enabling). Returns immediately with the workflow id — poll the scout's runs for the result.
  * @summary Run a scout now
  */
 export const signalsScoutConfigRun = async (

--- a/products/signals/mcp/tools.yaml
+++ b/products/signals/mcp/tools.yaml
@@ -536,10 +536,12 @@ tools:
         description: >
             Dispatch one on-demand run of a scout by its config `id`, regardless of its schedule — useful to test a
             scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously and
-            inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota and
-            409 if a run for this scout is already in progress. A manual run does not change the scout's schedule, and a
-            disabled scout can still be run this way (to test before enabling). Returns the workflow id immediately —
-            poll `signals-scout-runs-list` for the resulting run and its findings.
+            inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota or its
+            daily scout-run budget, and 409 if a run for this scout is already in progress. A manual run counts against
+            the same daily run budget the scheduled runs draw from, so avoid triggering repeated runs of the same scout
+            in a short window — each one consumes the project's scout-run allowance for the day. A manual run does not
+            change the scout's schedule, and a disabled scout can still be run this way (to test before enabling).
+            Returns the workflow id immediately — poll `signals-scout-runs-list` for the resulting run and its findings.
     signals-scout-runs-emission-reports:
         operation: signals_scout_runs_emission_reports
         enabled: true

--- a/services/mcp/schema/generated-tool-definitions.json
+++ b/services/mcp/schema/generated-tool-definitions.json
@@ -6844,7 +6844,7 @@
         }
     },
     "signals-scout-run-now": {
-        "description": "Dispatch one on-demand run of a scout by its config `id`, regardless of its schedule — useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously and inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota and 409 if a run for this scout is already in progress. A manual run does not change the scout's schedule, and a disabled scout can still be run this way (to test before enabling). Returns the workflow id immediately — poll `signals-scout-runs-list` for the resulting run and its findings.",
+        "description": "Dispatch one on-demand run of a scout by its config `id`, regardless of its schedule — useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously and inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota or its daily scout-run budget, and 409 if a run for this scout is already in progress. A manual run counts against the same daily run budget the scheduled runs draw from, so avoid triggering repeated runs of the same scout in a short window — each one consumes the project's scout-run allowance for the day. A manual run does not change the scout's schedule, and a disabled scout can still be run this way (to test before enabling). Returns the workflow id immediately — poll `signals-scout-runs-list` for the resulting run and its findings.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Run a scout now",

--- a/services/mcp/schema/tool-definitions-all.json
+++ b/services/mcp/schema/tool-definitions-all.json
@@ -7355,7 +7355,7 @@
         }
     },
     "signals-scout-run-now": {
-        "description": "Dispatch one on-demand run of a scout by its config `id`, regardless of its schedule — useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously and inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota and 409 if a run for this scout is already in progress. A manual run does not change the scout's schedule, and a disabled scout can still be run this way (to test before enabling). Returns the workflow id immediately — poll `signals-scout-runs-list` for the resulting run and its findings.",
+        "description": "Dispatch one on-demand run of a scout by its config `id`, regardless of its schedule — useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously and inherits the scheduled path's guards: it returns 429 if the project is over its Signals credits quota or its daily scout-run budget, and 409 if a run for this scout is already in progress. A manual run counts against the same daily run budget the scheduled runs draw from, so avoid triggering repeated runs of the same scout in a short window — each one consumes the project's scout-run allowance for the day. A manual run does not change the scout's schedule, and a disabled scout can still be run this way (to test before enabling). Returns the workflow id immediately — poll `signals-scout-runs-list` for the resulting run and its findings.",
         "category": "Signals",
         "feature": "signals",
         "summary": "Run a scout now",

--- a/services/mcp/src/generated/signals/api.ts
+++ b/services/mcp/src/generated/signals/api.ts
@@ -464,7 +464,7 @@ export const SignalsScoutConfigDestroyParams = /* @__PURE__ */ zod.object({
 })
 
 /**
- * Dispatch one on-demand run of this scout immediately, regardless of its schedule. Useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously on the worker and inherits every guard the scheduled path has: it is forbidden if scouts are not enabled for the project (403), and skipped if the project is over its Signals credits quota or daily run budget (429) or a run for this scout is already in progress (409). A manual run does not change the scout's schedule or `last_run_at`. A disabled scout can still be run this way (to test before enabling). Returns immediately with the workflow id — poll the scout's runs for the result.
+ * Dispatch one on-demand run of this scout immediately, regardless of its schedule. Useful to test a scout right after authoring it, or to refresh its findings on demand. The run executes asynchronously on the worker and inherits every guard the scheduled path has: it is forbidden if scouts are not enabled for the project (403), and skipped if the project is over its Signals credits quota or daily run budget (429) or a run for this scout is already in progress (409). A manual run counts against the same daily run budget as scheduled runs, so repeated manual runs of the same scout can exhaust the project's daily allowance. A manual run does not change the scout's schedule or `last_run_at`. A disabled scout can still be run this way (to test before enabling). Returns immediately with the workflow id — poll the scout's runs for the result.
  * @summary Run a scout now
  */
 export const SignalsScoutConfigRunParams = /* @__PURE__ */ zod.object({


### PR DESCRIPTION
> Claude-written:

## Problem

The on-demand scout run tool (`signals-scout-run-now`, added in #66996) didn't make it clear that a manual run counts against the same daily scout-run budget the scheduler draws from. The MCP tool description only mentioned the Signals credits quota guard and left out the daily run budget entirely, and neither the tool nor the endpoint description warned that each manual run consumes that budget. Since a manual run creates a `SignalScoutRun` row exactly like a scheduled run, `_runs_today_by_team` counts it too, so triggering repeated manual runs of the same scout can quietly exhaust the project's daily allowance. An agent (or user) refreshing findings on demand had no way to know that from the tool description.

## Changes

Description-only. No behavior change.

- `products/signals/mcp/tools.yaml`: `signals-scout-run-now` now names the daily scout-run budget alongside the credits quota in the 429 guard, and adds an explicit caution that a manual run counts against the same daily budget so repeated runs of the same scout in a short window should be avoided.
- `products/signals/backend/scout_harness/views.py`: the endpoint's `@extend_schema` description (which already mentioned the daily budget as a guard) gains the same caution about repeated manual runs exhausting the daily allowance.
- Regenerated the derived MCP/OpenAPI artifacts by hand to match: `services/mcp/schema/generated-tool-definitions.json`, `services/mcp/schema/tool-definitions-all.json`, `services/mcp/src/generated/signals/api.ts`, `products/signals/frontend/generated/api.ts`.

## How did you test this code?

No automated tests added — this is a documentation/description change with no logic change. I could not run the normal `hogli build:openapi` codegen in this environment because it needs a live database to emit the OpenAPI schema, so I updated the generated artifacts by hand and verified they exactly match the codegen output shape (single-line description strings), confirmed the JSON files still parse, and swept the repo to confirm no stale copies of the old description text remain.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Andy asked whether the `signals-scout-run-now` tool description made clear that manual runs eat into the project's allowed scout runs for the day, and whether a small follow-on to #66996 was warranted. I (Claude) traced the run endpoint and found a manual run is subject to two guards — the Signals credits quota and the per-team `max_runs_per_day` daily budget — and that `_runs_today_by_team` counts every `SignalScoutRun` row, so manual runs do consume the daily budget. The MCP tool description omitted the daily budget entirely and neither description framed the budget as something a manual run consumes. Invoked the `/implementing-mcp-tools` skill to follow the codegen workflow; the full `hogli build:openapi` couldn't run here (needs a DB), so the generated files were edited by hand to match what codegen would produce.
