### PR TITLE
chore(replay): instrument ml-mirror anonymize timing breakdown

### DIFF
--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/anonymize-event.ts
@@ -5,7 +5,7 @@ import { RRWebEventSource, RRWebEventType } from '~/ingestion/pipelines/sessionr
 
 import { runBlurJobs } from './blur'
 import { scrubCanvasMutation } from './canvas'
-import { BlurJob, ScrubContext, isObject } from './config'
+import { BlurJob, ScrubContext, ScrubTiming, isObject } from './config'
 import { scrubCompressedFullSnapshot, scrubCompressedMutation } from './cv'
 import { scrubFullSnapshot, scrubMutation } from './dom'
 import { scrubText } from './text'
@@ -17,6 +17,9 @@ const CONSOLE_PLUGIN = 'rrweb/console@1'
 
 const yieldToEventLoop = (): Promise<void> => new Promise((resolve) => setImmediate(resolve))
 
+// Diagnostic: log the per-message time breakdown when a message takes longer than this to anonymize.
+const ANON_SLOW_LOG_THRESHOLD_MS = 5000
+
 /**
  * Anonymizes every event in a parsed message in place, then awaits its blur jobs.
  * Fails closed: returns `failed: true` if any event errors, so the caller can drop
@@ -27,8 +30,11 @@ export async function anonymizeParsedMessage(
     parsedMessage: ParsedMessageData
 ): Promise<{ failed: boolean }> {
     const blurJobs: BlurJob[] = []
-    const ctx: ScrubContext = { ...scrubContext, blurJobs }
+    const timing: ScrubTiming = { decompressMs: 0, recompressMs: 0 }
+    const ctx: ScrubContext = { ...scrubContext, blurJobs, timing }
 
+    const scrubStart = performance.now()
+    let eventCount = 0
     for (const events of Object.values(parsedMessage.eventsByWindowId)) {
         for (const event of events) {
             try {
@@ -40,10 +46,29 @@ export async function anonymizeParsedMessage(
                 })
                 return { failed: true }
             }
+            eventCount++
         }
     }
+    // scrubMs is synchronous (on the event loop); blurMs is the off-thread sharp work we await.
+    const scrubMs = performance.now() - scrubStart
 
+    const blurStart = performance.now()
     await runBlurJobs(blurJobs)
+    const blurMs = performance.now() - blurStart
+
+    if (scrubMs + blurMs > ANON_SLOW_LOG_THRESHOLD_MS) {
+        logger.warn('🕒', 'anonymize_slow_breakdown', {
+            totalMs: Math.round(scrubMs + blurMs),
+            scrubMs: Math.round(scrubMs),
+            blurMs: Math.round(blurMs),
+            decompressMs: Math.round(timing.decompressMs),
+            recompressMs: Math.round(timing.recompressMs),
+            walkMs: Math.round(scrubMs - timing.decompressMs - timing.recompressMs),
+            events: eventCount,
+            blurJobs: blurJobs.length,
+        })
+    }
+
     // Macrotask break so a batch of messages doesn't scrub fully synchronously and starve the loop.
     await yieldToEventLoop()
     return { failed: false }

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/config.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/config.ts
@@ -8,11 +8,19 @@ export const NUMBER_CHAR = '#'
 /** A deferred image-blur job: an async closure that blurs its image and writes the result back in place. */
 export type BlurJob = () => Promise<void>
 
+/** Diagnostic accumulator (ms) for the cv gzip de/recompression sub-steps. */
+export interface ScrubTiming {
+    decompressMs: number
+    recompressMs: number
+}
+
 /** Per-scrub context: the active allow lists plus tunables read by the scrubbers. */
 export interface ScrubContext {
     allow: AllowLists
     /** Optional collector for deferred image-blur jobs (see {@link BlurJob}). */
     blurJobs?: BlurJob[]
+    /** Optional diagnostic timing accumulator (see {@link ScrubTiming}). */
+    timing?: ScrubTiming
 }
 
 /** Shared non-null-object type guard used across the scrubbers. */

--- a/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/cv.ts
+++ b/nodejs/src/ingestion/pipelines/sessionreplay/anonymize/cv.ts
@@ -3,7 +3,7 @@ import { gunzipSync, gzipSync } from 'zlib'
 
 import { parseJSON } from '~/common/utils/json-parse'
 
-import { ScrubContext, isObject } from './config'
+import { ScrubContext, ScrubTiming, isObject } from './config'
 import { scrubFullSnapshot, scrubMutation } from './dom'
 
 function latin1ToBytes(s: string): Buffer {
@@ -18,14 +18,24 @@ function latin1ToBytes(s: string): Buffer {
     return buf
 }
 
-function decompressString(s: string): unknown {
+function decompressString(s: string, timing?: ScrubTiming): unknown {
+    const start = performance.now()
     const json = gunzipSync(latin1ToBytes(s)).toString('utf8')
-    return parseJSON(json)
+    const value = parseJSON(json)
+    if (timing) {
+        timing.decompressMs += performance.now() - start
+    }
+    return value
 }
 
-function compressToString(value: unknown): string {
+function compressToString(value: unknown, timing?: ScrubTiming): string {
+    const start = performance.now()
     // latin1 is the inverse of latin1ToBytes; JSON.stringify escapes it on serialization.
-    return gzipSync(Buffer.from(JSON.stringify(value), 'utf8')).toString('latin1')
+    const out = gzipSync(Buffer.from(JSON.stringify(value), 'utf8')).toString('latin1')
+    if (timing) {
+        timing.recompressMs += performance.now() - start
+    }
+    return out
 }
 
 /** Scrub a `cv`-compressed FullSnapshot event in place. Returns whether it changed. */
@@ -35,11 +45,11 @@ export function scrubCompressedFullSnapshot(ctx: ScrubContext, event: Record<str
         // Not actually whole-blob compressed — scrub as a plain object.
         return scrubFullSnapshot(ctx, data)
     }
-    const payload = decompressString(data)
+    const payload = decompressString(data, ctx.timing)
     if (!scrubFullSnapshot(ctx, payload)) {
         return false
     }
-    event.data = compressToString(payload)
+    event.data = compressToString(payload, ctx.timing)
     return true
 }
 
@@ -51,9 +61,9 @@ export function scrubCompressedMutation(ctx: ScrubContext, event: Record<string,
     }
 
     // Sub-fields are gzipped strings on the wire but may arrive as plain arrays; handle both.
-    const texts = readSubfield(data.texts)
-    const attributes = readSubfield(data.attributes)
-    const adds = readSubfield(data.adds)
+    const texts = readSubfield(data.texts, ctx.timing)
+    const attributes = readSubfield(data.attributes, ctx.timing)
+    const adds = readSubfield(data.adds, ctx.timing)
 
     const synthetic: Record<string, unknown> = {
         source: data.source,
@@ -69,18 +79,18 @@ export function scrubCompressedMutation(ctx: ScrubContext, event: Record<string,
 
     // Array sub-fields were mutated in place; only re-encode the ones that arrived gzipped.
     if (texts.wasCompressed) {
-        data.texts = compressToString(synthetic.texts)
+        data.texts = compressToString(synthetic.texts, ctx.timing)
     }
     if (attributes.wasCompressed) {
-        data.attributes = compressToString(synthetic.attributes)
+        data.attributes = compressToString(synthetic.attributes, ctx.timing)
     }
     if (adds.wasCompressed) {
-        data.adds = compressToString(synthetic.adds)
+        data.adds = compressToString(synthetic.adds, ctx.timing)
     }
     return true
 }
 
-function readSubfield(field: unknown): { array: unknown[]; wasCompressed: boolean } {
+function readSubfield(field: unknown, timing?: ScrubTiming): { array: unknown[]; wasCompressed: boolean } {
     if (field === undefined || field === null) {
         return { array: [], wasCompressed: false }
     }
@@ -88,7 +98,7 @@ function readSubfield(field: unknown): { array: unknown[]; wasCompressed: boolea
         if (field.length === 0) {
             return { array: [], wasCompressed: false }
         }
-        const payload = decompressString(field)
+        const payload = decompressString(field, timing)
         if (!Array.isArray(payload)) {
             // Fail closed: a decodable-but-non-array sub-field is malformed; dropping beats shipping a zeroed block.
             throw new Error('cv mutation sub-field did not decode to an array')


### PR DESCRIPTION
> Claude-written:

## Problem

The ML-mirror ingester falls behind — batches hit 11-330s to anonymize, blocking the event loop (liveness SIGKILLs) and blowing past `max.poll.interval` (rebalance churn). We know `anonymizeStep` is slow but not where the time goes inside it.

## Changes

Diagnostic-only, no behavior change. Splits each message's anonymize time into `scrubMs` (synchronous, on-loop) vs `blurMs` (awaited off-thread `sharp`), and within scrub breaks out `decompressMs`/`recompressMs` (gzip) vs `walkMs` (DOM walk + text/URL scrub). Logs `anonymize_slow_breakdown` for messages over 5s. `scrubMs` high → the liveness-killing loop block; `blurMs` high → the `max.poll` kick. Temporary — revert once we have the numbers.

## How did you test this code?

Typecheck clean; the 99-test anonymize suite passes unchanged (`timing` is optional/additive).

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted). Claude Code, at my direction.