### PR TITLE
fix(mongodb): exclude reserved system.* collections from import

### DIFF
--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/mongo.py
@@ -15,6 +15,7 @@ from bson import Binary, DatetimeMS, ObjectId
 from bson.codec_options import DatetimeConversion
 from pymongo import MongoClient
 from pymongo.collection import Collection
+from pymongo.database import Database
 from pymongo.errors import PyMongoError
 from pymongo.server_description import ServerDescription
 from structlog.types import FilteringBoundLogger
@@ -430,6 +431,20 @@ def _determine_field_type_from_bson_types(bson_types: list[str]) -> str:
     return "string"
 
 
+# MongoDB reserves the `system.*` namespace for internal collections (system.keys,
+# system.views, system.profile, ...). They're never user data and reads against them fail with
+# an "Unauthorized" OperationFailure, so they must never be offered for import.
+_RESERVED_COLLECTION_PREFIX = "system."
+
+
+def _list_importable_collection_names(db: Database) -> list[str]:
+    return [
+        name
+        for name in db.list_collection_names(authorizedCollections=True)
+        if not name.startswith(_RESERVED_COLLECTION_PREFIX)
+    ]
+
+
 def get_schemas(
     config: MongoDBSourceConfig, team_id: int, names: list[str] | None = None
 ) -> dict[str, list[tuple[str, str]]]:
@@ -445,7 +460,7 @@ def get_schemas(
         schema_list: dict[str, list[tuple[str, str]]] = collections.defaultdict(list)
 
         # Get collection names
-        collection_names = db.list_collection_names(authorizedCollections=True)
+        collection_names = _list_importable_collection_names(db)
 
         if names is not None:
             names_set = set(names)
@@ -470,7 +485,7 @@ def get_collection_names(config: MongoDBSourceConfig, team_id: int) -> list[str]
         if not connection_params["database"]:
             raise ValueError(DATABASE_NAME_REQUIRED_ERROR)
         db = client[connection_params["database"]]
-        return db.list_collection_names(authorizedCollections=True)
+        return _list_importable_collection_names(db)
 
 
 def _get_primary_keys(collection: Collection, collection_name: str) -> list[str] | None:

--- a/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
+++ b/products/warehouse_sources/backend/temporal/data_imports/sources/mongodb/test_mongo.py
@@ -15,6 +15,7 @@ from pymongo.server_description import ServerDescription
 from products.warehouse_sources.backend.temporal.data_imports.sources.mongodb.mongo import (
     _build_query,
     _get_rows_to_sync,
+    _list_importable_collection_names,
     _make_safe_server_selector,
     _process_doc_with_field_logging,
     _process_nested_value,
@@ -487,3 +488,17 @@ class TestGetRowsToSync(SimpleTestCase):
         ) as capture:
             assert _get_rows_to_sync(coll, {}, MagicMock()) == 0
             capture.assert_called_once()
+
+
+class TestListImportableCollectionNames(SimpleTestCase):
+    def test_excludes_reserved_system_collections(self):
+        db = MagicMock()
+        db.list_collection_names.return_value = ["users", "system.keys", "orders", "system.views"]
+
+        assert _list_importable_collection_names(db) == ["users", "orders"]
+
+    def test_keeps_collections_that_merely_contain_system(self):
+        db = MagicMock()
+        db.list_collection_names.return_value = ["system_events", "billing.system", "systematic"]
+
+        assert _list_importable_collection_names(db) == ["system_events", "billing.system", "systematic"]


### PR DESCRIPTION
> Claude-written:

## Problem

Error tracking surfaced a permanent MongoDB import failure: an `OperationFailure` with `not authorized on admin to execute command { find: "system.keys", ... }` (code 13, `Unauthorized`). It originates in the source's own code (`mongodb/mongo.py` `get_rows`, the cursor iteration) and terminates as a non-retryable failure.

The root cause is that we offered a MongoDB internal collection for import in the first place. `system.keys` lives in MongoDB's reserved `system.*` namespace, alongside `system.views`, `system.profile`, `system.users`, and friends. These are never user data. Our schema discovery (`list_collection_names(authorizedCollections=True)`) returned them, so a user could select one to sync, and the sync then failed reading it.

The `not authorized` case is already classified as non-retryable (it's matched in `MongoDBSource.get_non_retryable_errors`), so the schema self-disables and the user gets a friendly message. This PR fixes the layer above that: the collection should never have been offered.

## Changes

Filter out the reserved `system.*` namespace during discovery. Added `_list_importable_collection_names`, used by both `get_schemas` and `get_collection_names`, so internal collections are excluded from what's offered for import. As a side benefit, a source mistakenly pointed at a database that only exposes system collections now returns the clear "No collections found in database" validation error instead of failing mid-sync.

Scoped to discovery only — no change to retry classification or the pipeline.

## How did you test this code?

Automated only (I'm Claude; I did not manually run a MongoDB sync). Added `TestListImportableCollectionNames` covering the regression: reserved `system.*` names are excluded while names that merely contain "system" (e.g. `system_events`, `billing.system`, `systematic`) are kept. This catches a revert to the bare `list_collection_names(...)` call, which no existing test covered.

Ran the full MongoDB source suite locally: `test_mongo.py` and `test_database_name.py`, 79 passed.

## Automatic notifications

- [ ] Publish to changelog?
- [ ] Alert Sales and Marketing teams?

## 🤖 Agent context

**Autonomy:** Fully autonomous

Triaged from an error tracking issue for the MongoDB data-warehouse import source. I confirmed the stack trace originates in `mongodb/mongo.py` `get_rows` (the `find` filter and `batchSize: 20000` match the source's own ObjectID incremental query and `DEFAULT_CHUNK_SIZE`), ruling out a driver-internal key-refresh read.

I considered extending `NonRetryableErrors` but rejected it: `not authorized` is already a matched pattern, so that would be a no-op. The actionable defect was offering internal `system.*` collections for import, so I fixed discovery instead. Kept the change minimal — a shared helper and a small regression test at the same layer.

Skills invoked: `/writing-tests`.
