### PR TITLE
feat(batch-import-worker): expose active jobs metric for autoscaling

### DIFF
--- a/rust/batch-import-worker/src/job/model.rs
+++ b/rust/batch-import-worker/src/job/model.rs
@@ -177,6 +177,17 @@ impl JobModel {
         }
     }
 
+    /// Count jobs that still need a worker: everything in `running` status, whether
+    /// queued (unleased) or in-flight (leased). This is the autoscaling signal — one
+    /// worker processes one job, so the count maps directly to the desired replica count.
+    pub async fn count_active_jobs(pool: &PgPool) -> Result<i64, Error> {
+        let count: i64 =
+            sqlx::query_scalar("SELECT count(*) FROM posthog_batchimport WHERE status = 'running'")
+                .fetch_one(pool)
+                .await?;
+        Ok(count)
+    }
+
     /// Schedule the job for a future retry by pushing leased_until forward and updating messages.
     /// Keeps status as 'running' so the main loop can pick it up when the lease expires.
     pub async fn schedule_backoff(

--- a/rust/batch-import-worker/src/main.rs
+++ b/rust/batch-import-worker/src/main.rs
@@ -93,7 +93,8 @@ pub async fn main() -> Result<(), Error> {
     {
         let context = context.clone();
         tokio::spawn(async move {
-            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            let start = tokio::time::Instant::now() + Duration::from_secs(60);
+            let mut interval = tokio::time::interval_at(start, Duration::from_secs(60));
             loop {
                 interval.tick().await;
                 match JobModel::count_active_jobs(&context.db).await {

--- a/rust/batch-import-worker/src/main.rs
+++ b/rust/batch-import-worker/src/main.rs
@@ -87,6 +87,23 @@ pub async fn main() -> Result<(), Error> {
 
     let context = Arc::new(AppContext::new(&config).await.unwrap());
 
+    // Periodically report the number of active jobs in the queue so the autoscaler
+    // can scale replicas to match pending + in-flight work. Every replica reports the
+    // same global count; the KEDA trigger collapses them with `max()`.
+    {
+        let context = context.clone();
+        tokio::spawn(async move {
+            let mut interval = tokio::time::interval(Duration::from_secs(60));
+            loop {
+                interval.tick().await;
+                match JobModel::count_active_jobs(&context.db).await {
+                    Ok(count) => metrics::active_jobs(count as f64),
+                    Err(e) => warn!("Failed to count active jobs for autoscaling metric: {e:#}"),
+                }
+            }
+        });
+    }
+
     let mut manager = Manager::builder("batch-import-worker").build();
 
     let job_handle = manager.register(

--- a/rust/batch-import-worker/src/metrics.rs
+++ b/rust/batch-import-worker/src/metrics.rs
@@ -3,6 +3,7 @@ pub const BACKOFF_DELAY_SECONDS: &str = "batch_import_backoff_delay_seconds";
 pub const UNPAUSE_TOTAL: &str = "batch_import_unpause_total";
 pub const STAGING_SWEEP_REMOVED: &str = "batch_import_staging_sweep_removed_total";
 pub const STAGING_DIR_BYTES: &str = "batch_import_staging_dir_bytes";
+pub const ACTIVE_JOBS: &str = "batch_import_active_jobs";
 
 use metrics::{counter, gauge, histogram};
 
@@ -21,4 +22,11 @@ pub fn staging_sweep_removed(count: u64) {
 
 pub fn staging_dir_bytes(bytes: f64) {
     gauge!(STAGING_DIR_BYTES).set(bytes);
+}
+
+/// Number of batch import jobs currently needing a worker (queued and in-flight).
+/// Reported by every replica off the shared Postgres queue; the KEDA autoscaler
+/// collapses the per-pod duplicates with `max()` to drive replica count.
+pub fn active_jobs(count: f64) {
+    gauge!(ACTIVE_JOBS).set(count);
 }


### PR DESCRIPTION
## Problem

The batch import worker processes one job at a time per pod, and its replica count is fixed. When several imports are queued, they run strictly serially behind the fixed fleet size, with no way to fan out across jobs. To drive horizontal autoscaling on queue depth, the worker needs to publish how many jobs currently need a worker.

## Changes

Add a `batch_import_active_jobs` Prometheus gauge, refreshed every 60s from a background task that counts rows in `posthog_batchimport` with `status = 'running'` (queued and in-flight — the jobs that each need a worker).

The gauge is published by every replica off the shared Postgres queue, so the value is the same global count on each pod. The autoscaler (KEDA, configured in the charts repo) collapses the per-pod series with `max()` and targets one job per replica.

## How did you test this code?

I'm an agent (Claude Code). Automated checks I actually ran in the worktree:

- `cargo fmt -p batch-import-worker` — clean.
- `cargo clippy -p batch-import-worker --all-targets -- -D warnings` — no new warnings from this change (the two remaining warnings are pre-existing workspace-level: an unused patch and a transitive `celes` future-incompat).

The count query uses a runtime `sqlx::query_scalar` (not the compile-time macro) to avoid regenerating the `.sqlx` offline cache for a trivial `count(*)`.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Built with Claude Code, directed by @jose-sequeira. The consuming autoscaler lives in a companion PR in the PostHog/charts repo (migrates the worker onto the golden chart and adds the KEDA trigger on this metric).

Metric semantics were a deliberate choice: count `status='running'` (queued **and** in-flight) rather than only unclaimed jobs. Counting only unclaimed jobs would drop the gauge to zero the moment workers claim them, thrashing the HPA mid-import; counting all active jobs keeps replicas stable at N while N jobs are being worked, then scales down as they complete.
