### PR TITLE
feat(data-modeling): filter full schedule sweep by PostHogScheduleType

### DIFF
--- a/products/data_modeling/backend/schedule.py
+++ b/products/data_modeling/backend/schedule.py
@@ -60,7 +60,8 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
     When `candidate_dag_ids` is given, the listing is scoped server-side to those DAGs via the
     `PostHogDagId` search attribute so we never paginate every schedule in the namespace — a
     single unscoped listing per saved-query operation is enough to exhaust the namespace rate
-    limit once the schedule fleet is large. Pass None only for genuine full-namespace sweeps.
+    limit once the schedule fleet is large. The None sweep filters on `PostHogScheduleType`
+    (needs schedules backfilled with the tag).
     """
     if candidate_dag_ids is not None and not candidate_dag_ids:
         return set()
@@ -72,7 +73,9 @@ async def get_v2_scheduled_dag_ids(candidate_dag_ids: Collection[str] | None = N
         quoted = ", ".join(f"'{dag_id}'" for dag_id in candidate_dag_ids)
         schedules = await temporal.list_schedules(query=f"{POSTHOG_DAG_ID_KEY.name} IN ({quoted})")
     else:
-        schedules = await temporal.list_schedules()
+        schedules = await temporal.list_schedules(
+            query=f'{POSTHOG_SCHEDULE_TYPE_KEY.name} = "{DATA_MODELING_EXECUTE_DAG_WORKFLOW}"'
+        )
 
     dag_ids: set[str] = set()
     async for listing in schedules:

--- a/products/data_modeling/backend/test/test_schedule.py
+++ b/products/data_modeling/backend/test/test_schedule.py
@@ -315,7 +315,7 @@ class TestGetV2ScheduledDagIds:
         action = mock.Mock(spec=ScheduleListActionStartWorkflow, workflow=workflow)
         return mock.Mock(id=schedule_id, schedule=mock.Mock(action=action))
 
-    def test_lists_client_side_without_workflowtype_query(self):
+    def test_full_sweep_scopes_by_schedule_type_server_side(self):
         captured: dict = {}
         listings = [
             self._listing("dag-on-v2", "data-modeling-execute-dag"),
@@ -323,7 +323,6 @@ class TestGetV2ScheduledDagIds:
         ]
 
         async def fake_list_schedules(*args, **kwargs):
-            captured["args"] = args
             captured["kwargs"] = kwargs
 
             async def gen():
@@ -340,10 +339,9 @@ class TestGetV2ScheduledDagIds:
         ):
             result = get_v2_scheduled_dag_ids()
 
-        # The schedule visibility store rejects filtering on WorkflowType, so we must not pass a
-        # server-side query and must filter the listings client-side instead.
-        assert captured["args"] == ()
-        assert "query" not in captured["kwargs"]
+        # WorkflowType isn't queryable on schedules, so the full sweep scopes server-side on the
+        # PostHogScheduleType tag instead of paginating the whole namespace.
+        assert captured["kwargs"]["query"] == 'PostHogScheduleType = "data-modeling-execute-dag"'
         assert result == {"dag-on-v2"}
 
     def test_scopes_listing_by_posthog_dag_id_when_candidates_given(self):


### PR DESCRIPTION
> Claude-written:

Stacked on #67343. **Do not deploy before the backfill (#67343) has run in prod** — see below.

## Problem

The full-namespace sweep in `get_v2_scheduled_dag_ids` (called with `candidate_dag_ids=None`) lists **every** schedule in the Temporal namespace and filters client-side on the target workflow, because Temporal can't filter schedules by the workflow they launch. That's the rate-limit risk the function's own docstring warns about. With #67336 stamping the schedules and #67343 backfilling the rest, we can finally scope this server-side.

## Changes

The full sweep now passes `PostHogScheduleType = "data-modeling-execute-dag"` as a server-side query, so Temporal only returns data modeling's own schedules instead of the whole namespace. The client-side workflow check stays as a cheap belt-and-suspenders.

The scoped path (`PostHogDagId IN (...)`) is **unchanged** — it's already bounded and already correct (its client-side workflow filter excludes v1 `n` schedules), and it's the hot production path, so I kept the tag-dependency off it entirely.

## Deploy order

This must ship **after** `backfill_dag_schedule_type` (#67343) has run in prod and coverage is confirmed. A tag-scoped sweep skips any migrated-but-untagged DAG, which would let v1 schedule commands revive its v1 schedule. Today nothing in production calls the full-sweep path, so the blast radius is limited to the future namespace-wide audit/reconciler this stack enables — but the ordering rule still holds.

## How did you test this code?

Updated the existing full-sweep unit test to assert the server-side query string (`PostHogScheduleType = "data-modeling-execute-dag"`); the scoped-path and empty-candidate tests are unchanged and still pass. `ruff` and `ty check` pass via lint-staged. I (Claude) ran the `TestGetV2ScheduledDagIds` class locally — green. No prod testing.

## 🤖 Agent context

**Autonomy:** Human-driven (agent-assisted)

Directed by @sakce, written by Claude (Claude Code). Phase 3 of 3 (stamp → backfill → flip).

Design note: I deliberately flipped **only** the full-sweep path, not the scoped path, even though the original plan flipped both. The scoped path is already server-side-bounded by `PostHogDagId` and correct, so adding the tag filter there would only push the backfill-timing hazard onto the hot production path for no real gain.
